### PR TITLE
fix(ci): add deps to allowed commit types and ignore major dep bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
       prefix: "deps"
     open-pull-requests-limit: 5
     target-branch: "main"
+    ignore:
+      # Major version bumps require code changes — handle manually
+      - dependency-name: "axum"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "tower-http"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "reqwest"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -30,4 +30,5 @@ jobs:
             ci
             perf
             build
+            deps
           requireScope: false


### PR DESCRIPTION
## Summary
- Add `deps` to commitlint allowed types so dependabot PRs pass title validation
- Ignore major version bumps for axum, tower-http, and reqwest in dependabot config — these require code changes and will be handled as dedicated upgrade tasks

## Changes
- `.github/workflows/commitlint.yml` — added `deps` to allowed types
- `.github/dependabot.yml` — added ignore rules for major bumps on axum, tower-http, reqwest

## Test plan
- Dependabot PRs with `deps:` prefix should pass conventional commit check
- Major version bump PRs for ignored packages should no longer be opened by dependabot