### PR TITLE
fix(ci): only dry-run sonda-core in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Dry run (skip actual publish)"
+        description: "Dry run (validate sonda-core packaging only, skip actual publish)"
         required: false
         type: boolean
         default: true
@@ -29,14 +29,11 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
 
+      # Dry-run only validates sonda-core. The other two crates depend on
+      # sonda-core being on crates.io at the exact version, so their dry-run
+      # will always fail until sonda-core is published first.
       - name: Dry-run publish sonda-core
         run: cargo publish --dry-run -p sonda-core
-
-      - name: Dry-run publish sonda
-        run: cargo publish --dry-run -p sonda
-
-      - name: Dry-run publish sonda-server
-        run: cargo publish --dry-run -p sonda-server
 
       - name: Publish sonda-core
         if: ${{ inputs.dry_run == false }}
@@ -53,6 +50,10 @@ jobs:
         run: cargo publish -p sonda
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io index to update
+        if: ${{ inputs.dry_run == false }}
+        run: sleep 15
 
       - name: Publish sonda-server
         if: ${{ inputs.dry_run == false }}


### PR DESCRIPTION
## Summary
Fix publish workflow that always fails on dry-run for sonda and sonda-server.

## Changes
The dry-run for `sonda` and `sonda-server` depends on `sonda-core` being on crates.io at the exact version — which it isn't until actually published. Now only dry-runs `sonda-core` (no internal deps), then publishes all three sequentially with waits between each.

## Test plan
- [x] Dry-run workflow should pass (only validates sonda-core)
- [x] Actual publish should work: sonda-core → wait → sonda → wait → sonda-server