### PR TITLE
feat: add VictoriaMetrics compose stack and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,6 +923,21 @@ a 10% baseline and a 95% spike, crossing a typical 90% alert threshold:
 sonda metrics --scenario examples/sequence-alert-test.yaml
 ```
 
+### `examples/victoriametrics-metrics.yaml`
+
+Push Prometheus text metrics directly to VictoriaMetrics via the HTTP import API. Requires the
+VictoriaMetrics compose stack (see [VictoriaMetrics Setup](#victoriametrics-setup)):
+
+```bash
+# Via CLI (targeting the exposed VM port on localhost)
+sonda metrics --scenario examples/victoriametrics-metrics.yaml
+
+# Via sonda-server (POST to the running container, which reaches VM on the Docker network)
+curl -X POST -H "Content-Type: text/yaml" \
+  --data-binary @examples/victoriametrics-metrics.yaml \
+  http://localhost:8080/scenarios
+```
+
 ### `examples/multi-scenario.yaml`
 
 Run both metric and log scenarios concurrently:
@@ -1115,6 +1130,87 @@ Two scenario files are provided specifically for the Docker stack:
 - **`examples/docker-alerts.yaml`** -- Sine wave (0-100) that crosses typical warning (70)
   and critical (90) thresholds. Includes bursts for spike simulation. Useful for testing
   alert rules in Prometheus or Alertmanager.
+
+### VictoriaMetrics Setup
+
+A dedicated [VictoriaMetrics compose stack](examples/docker-compose-victoriametrics.yml) is
+provided for evaluating Sonda with VictoriaMetrics as the metrics backend. It includes
+sonda-server, VictoriaMetrics (single-node), vmagent, and Grafana with a pre-provisioned
+datasource.
+
+**Start the stack:**
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml up -d
+```
+
+**Push metrics via sonda-server:**
+
+```bash
+# Verify sonda-server is running
+curl http://localhost:8080/health
+# {"status":"ok"}
+
+# Submit the VictoriaMetrics scenario
+curl -X POST -H "Content-Type: text/yaml" \
+  --data-binary @examples/victoriametrics-metrics.yaml \
+  http://localhost:8080/scenarios
+```
+
+**Push metrics via the CLI (from the host):**
+
+When running the CLI on your host machine (outside Docker), target the VictoriaMetrics port
+exposed at localhost:8428:
+
+```bash
+sonda metrics \
+  --name sonda_demo \
+  --rate 10 \
+  --duration 30s \
+  --value-mode sine \
+  --amplitude 40 \
+  --period-secs 30 \
+  --offset 60 \
+  --encoder prometheus_text \
+  --label job=sonda \
+  --label instance=local \
+  | curl -s --data-binary @- \
+    -H "Content-Type: text/plain" \
+    "http://localhost:8428/api/v1/import/prometheus"
+```
+
+**Verify data arrived in VictoriaMetrics:**
+
+```bash
+# List all Sonda-generated series
+curl "http://localhost:8428/api/v1/series?match[]={__name__=~'sonda.*'}"
+
+# Query the latest value
+curl "http://localhost:8428/api/v1/query?query=sonda_http_request_duration_ms"
+```
+
+You can also use the VictoriaMetrics built-in UI at http://localhost:8428/vmui or open
+Grafana at http://localhost:3000, go to Explore, select the "VictoriaMetrics" datasource,
+and run PromQL queries.
+
+**Known limitation -- vmagent relay:**
+
+The stack includes vmagent, which can scrape Prometheus targets and relay data to
+VictoriaMetrics. However, vmagent's remote write relay uses the Prometheus remote write
+protocol (protobuf + snappy compression). Sonda does not yet support protobuf remote write
+encoding -- this is planned for Phase 7. For now, push metrics directly to VictoriaMetrics
+using the `http_push` sink with Prometheus text format, which works without vmagent in the
+middle.
+
+**Tear down:**
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml down -v
+```
+
+See [`examples/docker-compose-victoriametrics.yml`](examples/docker-compose-victoriametrics.yml)
+and [`examples/victoriametrics-metrics.yaml`](examples/victoriametrics-metrics.yaml) for the
+full configuration.
 
 ---
 

--- a/examples/docker-compose-victoriametrics.yml
+++ b/examples/docker-compose-victoriametrics.yml
@@ -1,0 +1,145 @@
+# VictoriaMetrics + Sonda compose stack
+#
+# A self-contained setup for evaluating Sonda with VictoriaMetrics as the
+# metrics backend and Grafana for visualization.
+#
+# Quick start:
+#
+#   docker compose -f examples/docker-compose-victoriametrics.yml up -d
+#
+# Then push a scenario via the sonda-server API:
+#
+#   curl -X POST -H "Content-Type: text/yaml" \
+#     --data-binary @examples/victoriametrics-metrics.yaml \
+#     http://localhost:8080/scenarios
+#
+# Verify data arrived in VictoriaMetrics:
+#
+#   curl "http://localhost:8428/api/v1/series?match[]={__name__=~'sonda.*'}"
+#
+# Open Grafana at http://localhost:3000 (anonymous access, no login required)
+# to explore metrics with the pre-configured VictoriaMetrics datasource.
+#
+# Tear down:
+#
+#   docker compose -f examples/docker-compose-victoriametrics.yml down -v
+
+services:
+  # ---------------------------------------------------------------------------
+  # sonda-server: the Sonda HTTP control plane.
+  #
+  # Accepts scenario YAML via POST /scenarios and runs them in background
+  # threads. Scenario files in ./examples are mounted at /scenarios inside
+  # the container for reference, but scenarios are submitted via the API.
+  # ---------------------------------------------------------------------------
+  sonda-server:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./:/scenarios:ro
+    depends_on:
+      victoriametrics:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/sonda", "metrics", "--name", "healthcheck", "--rate", "1", "--duration", "1ms"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
+  # ---------------------------------------------------------------------------
+  # VictoriaMetrics: single-node time series database.
+  #
+  # Accepts Prometheus text exposition format via HTTP import:
+  #   POST http://victoriametrics:8428/api/v1/import/prometheus
+  #
+  # Also accepts InfluxDB line protocol:
+  #   POST http://victoriametrics:8428/write
+  #
+  # Query via the standard Prometheus API:
+  #   GET http://localhost:8428/api/v1/query?query=<expr>
+  #
+  # Built-in UI (vmui) available at:
+  #   http://localhost:8428/vmui
+  #
+  # Data is persisted in the vm-data volume so metrics survive container
+  # restarts. Retention is set to 7 days.
+  # ---------------------------------------------------------------------------
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:v1.108.1
+    ports:
+      - "8428:8428"
+    command:
+      - "--storageDataPath=/storage"
+      - "--httpListenAddr=:8428"
+      - "--retentionPeriod=7d"
+    volumes:
+      - vm-data:/storage
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8428/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  # ---------------------------------------------------------------------------
+  # vmagent: metrics relay agent from VictoriaMetrics.
+  #
+  # vmagent can scrape Prometheus targets and forward metrics to a remote
+  # backend. Here it is configured to relay incoming data to VictoriaMetrics.
+  #
+  # NOTE: vmagent's remote write relay uses the Prometheus remote write
+  # protocol (protobuf + snappy). Sonda does not yet support protobuf
+  # remote write encoding (planned for Phase 7). For now, push metrics
+  # directly to VictoriaMetrics using the http_push sink with Prometheus
+  # text format -- this works without vmagent in the middle.
+  #
+  # vmagent is included here so you can experiment with scrape configs
+  # and understand the architecture. It will work for scraping targets
+  # that expose /metrics endpoints in Prometheus text format.
+  # ---------------------------------------------------------------------------
+  vmagent:
+    image: victoriametrics/vmagent:v1.108.1
+    ports:
+      - "8429:8429"
+    command:
+      - "--remoteWrite.url=http://victoriametrics:8428/api/v1/write"
+      - "--httpListenAddr=:8429"
+    depends_on:
+      victoriametrics:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8429/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  # ---------------------------------------------------------------------------
+  # Grafana: dashboards and metric exploration.
+  #
+  # Anonymous access is enabled so you can open http://localhost:3000 without
+  # logging in. The VictoriaMetrics datasource is pre-provisioned -- go to
+  # Explore, select "VictoriaMetrics", and run PromQL queries.
+  #
+  # Admin credentials (if needed): admin / admin
+  # ---------------------------------------------------------------------------
+  grafana:
+    image: grafana/grafana:11.5.2
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    volumes:
+      - ./grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
+    depends_on:
+      victoriametrics:
+        condition: service_healthy
+
+volumes:
+  vm-data:

--- a/examples/grafana/datasources.yml
+++ b/examples/grafana/datasources.yml
@@ -1,0 +1,18 @@
+# Grafana datasource provisioning for the VictoriaMetrics compose stack.
+#
+# This file is mounted into Grafana at:
+#   /etc/grafana/provisioning/datasources/datasources.yml
+#
+# It pre-configures VictoriaMetrics as the default Prometheus-compatible
+# datasource so you can explore Sonda-generated metrics immediately after
+# running `docker compose up`.
+
+apiVersion: 1
+
+datasources:
+  - name: VictoriaMetrics
+    type: prometheus
+    access: proxy
+    url: http://victoriametrics:8428
+    isDefault: true
+    editable: true

--- a/examples/victoriametrics-metrics.yaml
+++ b/examples/victoriametrics-metrics.yaml
@@ -1,0 +1,53 @@
+# VictoriaMetrics metrics scenario
+#
+# Pushes Prometheus text exposition format metrics directly to VictoriaMetrics
+# using the HTTP import API. This bypasses vmagent and writes data straight
+# into the TSDB.
+#
+# Prerequisites:
+#   Start the VictoriaMetrics compose stack:
+#     docker compose -f examples/docker-compose-victoriametrics.yml up -d
+#
+# Usage with the CLI (from the host, targeting the exposed VM port):
+#   sonda metrics --scenario examples/victoriametrics-metrics.yaml
+#
+# Usage with sonda-server (POST to the running container):
+#   curl -X POST -H "Content-Type: text/yaml" \
+#     --data-binary @examples/victoriametrics-metrics.yaml \
+#     http://localhost:8080/scenarios
+#
+# Verify data arrived:
+#   curl "http://localhost:8428/api/v1/series?match[]={__name__=~'sonda.*'}"
+#
+# Query the latest value:
+#   curl "http://localhost:8428/api/v1/query?query=sonda_http_request_duration_ms"
+#
+# Explore in Grafana:
+#   Open http://localhost:3000, go to Explore, select VictoriaMetrics,
+#   and query: sonda_http_request_duration_ms
+
+name: sonda_http_request_duration_ms
+rate: 10
+duration: 120s
+
+generator:
+  type: sine
+  amplitude: 40.0
+  period_secs: 30
+  offset: 60.0
+
+labels:
+  instance: api-server-01
+  job: sonda
+  method: GET
+  service: api-gateway
+  region: us-east-1
+
+encoder:
+  type: prometheus_text
+
+sink:
+  type: http_push
+  url: "http://victoriametrics:8428/api/v1/import/prometheus"
+  content_type: "text/plain"
+  batch_size: 65536


### PR DESCRIPTION
## Summary

- Add `examples/docker-compose-victoriametrics.yml` with four services: sonda-server (built from Dockerfile), VictoriaMetrics (single-node, pinned v1.108.1), vmagent (pinned v1.108.1), and Grafana (pinned 11.5.2) with a pre-provisioned VictoriaMetrics datasource.
- Add `examples/victoriametrics-metrics.yaml` scenario that pushes Prometheus text metrics directly to VictoriaMetrics via the `http_push` sink at 10 events/sec for 120 seconds.
- Add `examples/grafana/datasources.yml` for Grafana datasource provisioning.
- Update README with a "VictoriaMetrics Setup" subsection in the Docker Deployment section covering stack startup, pushing metrics via sonda-server and CLI, querying VM to verify data, and the known vmagent protobuf limitation (Phase 7).
- Add `examples/victoriametrics-metrics.yaml` to the Example Scenarios section.

## Test plan

- [x] `docker compose -f examples/docker-compose-victoriametrics.yml config` validates successfully
- [x] Compose file includes all four services: sonda-server, victoriametrics, vmagent, grafana
- [x] `examples/victoriametrics-metrics.yaml` is valid YAML that deserializes into a ScenarioConfig
- [x] Compose file does not reference test-specific configuration or paths from `tests/e2e/`
- [x] VictoriaMetrics and Grafana versions are pinned (not `latest`)
- [x] vmagent protobuf limitation is clearly documented in both compose file comments and README
- [x] All existing tests pass: `cargo test --workspace`
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes