### PR TITLE
feat: add pre-built Grafana dashboards and recording rule example

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,17 @@ normal baseline (~14%), spike to ~95%, sustained high load, then recovery back t
 sonda metrics --scenario examples/csv-replay-metrics.yaml
 ```
 
+### `examples/recording-rule-test.yaml`
+
+Push a constant known value for testing Prometheus recording rules. Pair with
+`examples/recording-rule-prometheus.yml` which defines a recording rule that computes
+`sum(rate(http_requests_total[5m])) by (job)`. See the
+[Alert Testing Guide](docs/guide-alert-testing.md) Section 5 for the full walkthrough:
+
+```bash
+sonda metrics --scenario examples/recording-rule-test.yaml
+```
+
 ### `examples/victoriametrics-metrics.yaml`
 
 Push Prometheus text metrics directly to VictoriaMetrics via the HTTP import API. Requires the
@@ -1261,6 +1272,19 @@ curl "http://localhost:8428/api/v1/query?query=sonda_http_request_duration_ms"
 You can also use the VictoriaMetrics built-in UI at http://localhost:8428/vmui or open
 Grafana at http://localhost:3000, go to Explore, select the "VictoriaMetrics" datasource,
 and run PromQL queries.
+
+**Pre-built Grafana dashboards:**
+
+The compose stack auto-provisions a **Sonda Overview** dashboard in Grafana. After starting
+the stack, navigate to **Dashboards > Sonda > Sonda Overview**. The dashboard shows:
+
+- Generated metric values over time (time series graph)
+- Event rate (events per second)
+- Active scenario count (distinct metric names)
+- Gap/burst indicators (metric absence and rate spikes)
+
+The dashboard uses template variables (`$datasource` and `$job`) so it works with any
+Prometheus-compatible datasource. No manual dashboard setup is required.
 
 **vmagent relay with remote write:**
 

--- a/docker/grafana/dashboards/sonda-overview.json
+++ b/docker/grafana/dashboards/sonda-overview.json
@@ -1,0 +1,484 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Overview of Sonda-generated synthetic telemetry metrics. Shows metric values, event rates, active scenarios, and gap/burst indicators.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Time series graph of all Sonda-generated metrics matching the configured job label. Each metric name appears as a separate series.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max",
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "title": "Generated Metric Values",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "{job=\"$job\"}",
+          "legendFormat": "{{__name__}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Per-second rate of sample ingestion for Sonda-generated metrics. A drop to zero indicates a gap window; a spike indicates a burst window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "events/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "title": "Event Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (__name__) (rate({job=\"$job\"}[$__rate_interval]))",
+          "legendFormat": "{{__name__}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of distinct metric names currently being generated by Sonda scenarios with the configured job label.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Active Scenarios",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(count by (__name__) ({job=\"$job\"}))",
+          "legendFormat": "metrics",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Highlights periods where metric emission stops (gaps) or spikes (bursts). Gap windows appear as drops to zero; burst windows appear as rate spikes above the baseline. The absent() expression shows 1 when the metric disappears entirely.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bool"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "gap detected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "burst detected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "title": "Gap/Burst Indicators",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "absent({job=\"$job\"})",
+          "legendFormat": "gap detected",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_max(sum(rate({job=\"$job\"}[$__rate_interval])) > bool (2 * avg_over_time(sum(rate({job=\"$job\"}[1m]))[5m:1m])), 1)",
+          "legendFormat": "burst detected",
+          "range": true,
+          "refId": "B"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "sonda",
+    "synthetic-telemetry",
+    "observability"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "sonda",
+          "value": "sonda"
+        },
+        "description": "Job label used to filter Sonda-generated metrics",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [
+          {
+            "selected": true,
+            "text": "sonda",
+            "value": "sonda"
+          }
+        ],
+        "query": "sonda",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sonda Overview",
+  "uid": "sonda-overview",
+  "version": 1,
+  "refresh": "10s"
+}

--- a/docker/grafana/provisioning/dashboards.yml
+++ b/docker/grafana/provisioning/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+  - name: "sonda"
+    orgId: 1
+    folder: "Sonda"
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docs/guide-alert-testing.md
+++ b/docs/guide-alert-testing.md
@@ -368,6 +368,13 @@ This starts:
 | vmagent | 8429 | Metrics relay agent |
 | Grafana | 3000 | Dashboards and metric exploration |
 
+The compose stack auto-provisions a **Sonda Overview** dashboard in Grafana. After starting the
+stack, navigate to **Dashboards > Sonda > Sonda Overview** in Grafana at http://localhost:3000.
+The dashboard shows generated metric values, event rate, active scenario count, and gap/burst
+indicators -- all updated in real time as Sonda pushes data. See
+[`docker/grafana/dashboards/sonda-overview.json`](../docker/grafana/dashboards/sonda-overview.json)
+for the dashboard definition.
+
 ### Push Metrics via sonda-server
 
 Submit a scenario to sonda-server and it runs in the background:
@@ -492,6 +499,15 @@ You can also check alert state in the VictoriaMetrics UI at `http://localhost:84
 
 Recording rules pre-compute expressions and store the result as a new time series. Testing them
 requires pushing known input values and verifying the computed output.
+
+A ready-to-run example is provided in the repository:
+
+- [`examples/recording-rule-test.yaml`](../examples/recording-rule-test.yaml) -- Sonda scenario
+  pushing a constant value of 100 for `http_requests_total`.
+- [`examples/recording-rule-prometheus.yml`](../examples/recording-rule-prometheus.yml) -- Prometheus
+  recording rule config computing `job:http_requests_total:rate5m`.
+
+Run the scenario and load the rule file to see recording rules evaluate against known synthetic data.
 
 ### Push Known Values
 

--- a/examples/docker-compose-victoriametrics.yml
+++ b/examples/docker-compose-victoriametrics.yml
@@ -19,6 +19,7 @@
 #
 # Open Grafana at http://localhost:3000 (anonymous access, no login required)
 # to explore metrics with the pre-configured VictoriaMetrics datasource.
+# The "Sonda Overview" dashboard is auto-provisioned under Dashboards > Sonda.
 #
 # Tear down:
 #
@@ -130,6 +131,11 @@ services:
   # logging in. The VictoriaMetrics datasource is pre-provisioned -- go to
   # Explore, select "VictoriaMetrics", and run PromQL queries.
   #
+  # The "Sonda Overview" dashboard is auto-provisioned under Dashboards > Sonda.
+  # It shows generated metric values, event rate, active scenario count, and
+  # gap/burst indicators. The dashboard uses template variables ($datasource
+  # and $job) so it works with any Prometheus-compatible datasource.
+  #
   # Admin credentials (if needed): admin / admin
   # ---------------------------------------------------------------------------
   grafana:
@@ -142,6 +148,8 @@ services:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
     volumes:
       - ./grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
+      - ../docker/grafana/provisioning/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ../docker/grafana/dashboards:/var/lib/grafana/dashboards:ro
     depends_on:
       victoriametrics:
         condition: service_healthy

--- a/examples/recording-rule-prometheus.yml
+++ b/examples/recording-rule-prometheus.yml
@@ -1,0 +1,39 @@
+# Prometheus recording rule config snippet for testing with Sonda.
+#
+# This file defines a recording rule that computes the per-job 5-minute rate
+# of http_requests_total. When paired with examples/recording-rule-test.yaml,
+# which pushes a constant value of 100 at 1 event/sec, the expected output is
+# a steady rate value (the rate() of a constant gauge depends on the scrape
+# interval and staleness behavior).
+#
+# How to use:
+#
+#   1. Start the VictoriaMetrics compose stack:
+#      docker compose -f examples/docker-compose-victoriametrics.yml up -d
+#
+#   2. Push known values with Sonda:
+#      sonda metrics --scenario examples/recording-rule-test.yaml
+#
+#   3. Load this rule file into Prometheus or vmalert:
+#      - Prometheus: add to the rule_files list in prometheus.yml
+#      - vmalert: pass as -rule=examples/recording-rule-prometheus.yml
+#
+#   4. Wait at least two evaluation intervals (default 1 minute each).
+#
+#   5. Query the recording rule output:
+#      curl "http://localhost:8428/api/v1/query?query=job:http_requests_total:rate5m"
+#
+#   6. Verify the result:
+#      - With a constant push at 1 event/sec, rate() measures the per-second
+#        rate of change. For a gauge metric pushed at a constant value,
+#        rate() over 5m should return a near-zero value (no change).
+#      - For a counter-like metric that increments by 100 each second,
+#        sum(rate(http_requests_total[5m])) by (job) should return ~100.
+#
+# Adjust the recording rule expression to match your alerting rules under test.
+
+groups:
+  - name: sonda-test-rules
+    rules:
+      - record: job:http_requests_total:rate5m
+        expr: sum(rate(http_requests_total[5m])) by (job)

--- a/examples/recording-rule-test.yaml
+++ b/examples/recording-rule-test.yaml
@@ -1,0 +1,35 @@
+# Recording rule test scenario.
+#
+# Pushes a constant known value (100) for http_requests_total so that
+# a recording rule computing rate() or sum() produces a predictable output.
+#
+# Pair this with examples/recording-rule-prometheus.yml which defines a
+# recording rule: job:http_requests_total:rate5m
+#
+# Workflow:
+#   1. Start the VictoriaMetrics compose stack.
+#   2. Run this scenario to push known values.
+#   3. Wait at least two evaluation intervals (default 1m each).
+#   4. Query the recording rule output and verify the computed value.
+#
+# See docs/guide-alert-testing.md Section 5 for a detailed walkthrough.
+
+name: http_requests_total
+rate: 1
+duration: 120s
+
+generator:
+  type: constant
+  value: 100.0
+
+labels:
+  method: GET
+  status: "200"
+  job: api
+
+encoder:
+  type: prometheus_text
+sink:
+  type: http_push
+  url: "http://localhost:8428/api/v1/import/prometheus"
+  content_type: "text/plain"


### PR DESCRIPTION
## Summary

- Add a **Sonda Overview** Grafana dashboard (`docker/grafana/dashboards/sonda-overview.json`) with four panels: Generated Metric Values (time series), Event Rate (events/sec), Active Scenarios (stat), and Gap/Burst Indicators (absence/rate spike detection).
- Add dashboard provisioning config (`docker/grafana/provisioning/dashboards.yml`) so dashboards auto-load on Grafana startup.
- Add recording rule test examples: `examples/recording-rule-test.yaml` (Sonda scenario pushing constant known values) and `examples/recording-rule-prometheus.yml` (Prometheus recording rule config for `job:http_requests_total:rate5m`).
- Update `examples/docker-compose-victoriametrics.yml` to mount dashboard provisioning and dashboard JSON into the Grafana container.
- Update `docs/guide-alert-testing.md` to reference the pre-built dashboard (Section 4) and recording rule examples (Section 5).
- Update `README.md` with pre-built Grafana dashboards subsection and recording rule example scenario.

## Test plan

- [x] Verify `docker/grafana/dashboards/sonda-overview.json` is valid JSON with all four panels.
- [x] Verify `docker/grafana/provisioning/dashboards.yml` is valid YAML.
- [x] Verify `examples/recording-rule-test.yaml` is valid Sonda scenario YAML.
- [x] Verify `examples/recording-rule-prometheus.yml` is valid Prometheus rule config YAML.
- [x] Start compose stack: `docker compose -f examples/docker-compose-victoriametrics.yml up -d` -- Grafana should show "Sonda Overview" under Dashboards > Sonda.
- [x] Push a metrics scenario -- dashboard panels should populate with live data.
- [x] Dashboard uses template variables (`$datasource`, `$job`) for flexibility across datasources.
- [x] All existing workspace tests continue to pass (`cargo test --workspace`).