### PR TITLE
docs(slice-8.2): add configuration reference pages

### DIFF
--- a/docs/site/docs/configuration/cli-reference.md
+++ b/docs/site/docs/configuration/cli-reference.md
@@ -1,0 +1,205 @@
+# CLI Reference
+
+Sonda provides three subcommands: `metrics` for metric generation, `logs` for log generation, and
+`run` for concurrent multi-scenario execution.
+
+## Global options
+
+```
+sonda [OPTIONS] <COMMAND>
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+```
+
+```bash
+sonda --version
+```
+
+```text title="Output"
+sonda 0.1.3
+```
+
+## sonda metrics
+
+Generate synthetic metrics and write them to the configured sink.
+
+```bash
+sonda metrics [OPTIONS]
+```
+
+### Scenario and identity
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--scenario <FILE>` | path | YAML scenario file. CLI flags override file values. |
+| `--name <NAME>` | string | Metric name. Required if no `--scenario`. |
+| `--rate <RATE>` | float | Events per second. Required if no `--scenario`. |
+| `--duration <DURATION>` | string | Run duration (e.g. `30s`, `5m`). Omit for indefinite. |
+
+### Generator
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--value-mode <MODE>` | string | `constant` | Generator type: `constant`, `uniform`, `sine`, `sawtooth`. |
+| `--amplitude <FLOAT>` | float | `1.0` | Sine wave amplitude. |
+| `--period-secs <FLOAT>` | float | `60.0` | Sine or sawtooth period in seconds. |
+| `--offset <FLOAT>` | float | `0.0` | Sine midpoint or constant value. |
+| `--min <FLOAT>` | float | `0.0` | Uniform or sawtooth minimum. |
+| `--max <FLOAT>` | float | `1.0` | Uniform or sawtooth maximum. |
+| `--seed <INT>` | integer | `0` | RNG seed for deterministic uniform output. |
+
+!!! note
+    The `sequence` and `csv_replay` generators are only available via scenario files. They cannot
+    be configured with CLI flags alone.
+
+### Gaps and bursts
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--gap-every <DURATION>` | string | Gap recurrence interval. Must pair with `--gap-for`. |
+| `--gap-for <DURATION>` | string | Gap duration. Must be less than `--gap-every`. |
+| `--burst-every <DURATION>` | string | Burst recurrence interval. Must pair with `--burst-for` and `--burst-multiplier`. |
+| `--burst-for <DURATION>` | string | Burst duration. Must be less than `--burst-every`. |
+| `--burst-multiplier <FLOAT>` | float | Rate multiplier during bursts. |
+
+### Labels, encoder, output
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--label <KEY=VALUE>` | string | none | Static label (repeatable). |
+| `--encoder <FORMAT>` | string | `prometheus_text` | Output format: `prometheus_text`, `influx_lp`, `json_lines`. |
+| `--output <FILE>` | path | stdout | Write to file instead of stdout. |
+
+### Examples
+
+Simplest metric:
+
+```bash
+sonda metrics --name up --rate 1 --duration 5s
+```
+
+Sine wave with labels:
+
+```bash
+sonda metrics --name cpu --rate 10 --duration 30s \
+  --value-mode sine --amplitude 50 --period-secs 60 --offset 50 \
+  --label host=web-01 --label zone=us-east-1
+```
+
+InfluxDB format to file:
+
+```bash
+sonda metrics --name cpu --rate 10 --duration 10s \
+  --encoder influx_lp --output /tmp/metrics.influx
+```
+
+Scenario file with overrides:
+
+```bash
+sonda metrics --scenario examples/basic-metrics.yaml --duration 5s --rate 2
+```
+
+## sonda logs
+
+Generate synthetic log events and write them to the configured sink.
+
+```bash
+sonda logs [OPTIONS]
+```
+
+### Scenario and rate
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--scenario <FILE>` | path | -- | YAML log scenario file. |
+| `--mode <MODE>` | string | -- | Generator mode: `template` or `replay`. Required if no `--scenario`. |
+| `--rate <RATE>` | float | `10.0` | Events per second. |
+| `--duration <DURATION>` | string | indefinite | Run duration. |
+
+### Template mode
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--message <TEXT>` | string | `"synthetic log event"` | Static message template. |
+| `--severity-weights <SPEC>` | string | `info=1.0` | Comma-separated severity weights (e.g. `info=0.7,warn=0.2,error=0.1`). |
+| `--seed <INT>` | integer | `0` | RNG seed for deterministic output. |
+
+### Replay mode
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--file <PATH>` | path | Log file to replay lines from. |
+
+### Labels, encoder, output
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--label <KEY=VALUE>` | string | none | Static label (repeatable). |
+| `--encoder <FORMAT>` | string | `json_lines` | Output format: `json_lines`, `syslog`. |
+| `--output <FILE>` | path | stdout | Write to file instead of stdout. |
+
+### Gaps and bursts
+
+The same gap and burst flags from `sonda metrics` are available for logs:
+`--gap-every`, `--gap-for`, `--burst-every`, `--burst-for`, `--burst-multiplier`.
+
+### Examples
+
+Simple template log:
+
+```bash
+sonda logs --mode template --rate 5 --duration 10s
+```
+
+Custom message with severity weights:
+
+```bash
+sonda logs --mode template --rate 5 --duration 10s \
+  --message "Connection timeout" \
+  --severity-weights "info=0.7,warn=0.2,error=0.1"
+```
+
+Syslog format:
+
+```bash
+sonda logs --mode template --rate 5 --duration 5s --encoder syslog
+```
+
+Scenario file:
+
+```bash
+sonda logs --scenario examples/log-template.yaml --duration 5s
+```
+
+## sonda run
+
+Run multiple scenarios concurrently from a multi-scenario YAML file.
+
+```bash
+sonda run --scenario <FILE>
+```
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--scenario <FILE>` | path | Multi-scenario YAML file. Required. |
+
+The file must have a top-level `scenarios:` list. Each entry includes `signal_type: metrics` or
+`signal_type: logs`. See [Scenario Files - Multi-scenario files](scenario-file.md#multi-scenario-files).
+
+```bash
+sonda run --scenario examples/multi-scenario.yaml
+```
+
+## Precedence rules
+
+Configuration values are resolved in this order (highest priority wins):
+
+1. **CLI flags** -- always win when provided.
+2. **YAML scenario file** -- base configuration loaded from disk.
+
+If neither is provided for a required field, Sonda exits with an error.
+
+For example, a YAML file sets `rate: 100` and the CLI passes `--rate 500`. The effective rate
+is 500.

--- a/docs/site/docs/configuration/encoders.md
+++ b/docs/site/docs/configuration/encoders.md
@@ -1,0 +1,128 @@
+# Encoders
+
+Encoders serialize events into a wire format before writing them to a sink. You select an encoder
+with the `encoder.type` field. If omitted, metrics default to `prometheus_text` and logs default
+to `json_lines`.
+
+## prometheus_text
+
+Prometheus text exposition format (v0.0.4). Each event becomes one line:
+
+```
+metric_name{label="value"} 42.0 1700000000000
+```
+
+No additional parameters.
+
+```yaml title="Prometheus text encoder"
+encoder:
+  type: prometheus_text
+```
+
+```text title="Wire format"
+cpu_usage{host="web-01"} 50 1774279696105
+```
+
+This encoder supports metrics only. It does not support log events.
+
+## influx_lp
+
+InfluxDB line protocol. Each event becomes one line with tags, a field, and a nanosecond
+timestamp:
+
+```
+metric_name,tag=value field_key=42.0 1700000000000000000
+```
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `field_key` | string | no | `"value"` | The InfluxDB field key for the metric value. |
+
+```yaml title="InfluxDB line protocol encoder"
+encoder:
+  type: influx_lp
+  field_key: cpu_percent
+```
+
+```text title="Wire format"
+test_influx,host=web-01 value=0 1774279709667342000
+```
+
+This encoder supports metrics only. It does not support log events.
+
+## json_lines
+
+JSON Lines (NDJSON) format. Each event is one JSON object per line.
+
+No additional parameters.
+
+```yaml title="JSON Lines encoder"
+encoder:
+  type: json_lines
+```
+
+For metrics:
+
+```json title="Metric wire format"
+{"name":"cpu_usage","value":50.0,"labels":{"host":"web-01"},"timestamp":"2026-03-23T15:28:32.321Z"}
+```
+
+For logs:
+
+```json title="Log wire format"
+{"timestamp":"2026-03-23T14:59:04.840Z","severity":"info","message":"test log","fields":{}}
+```
+
+This is the default encoder for log scenarios. It supports both metrics and logs.
+
+## syslog
+
+RFC 5424 syslog format. Encodes log events as syslog lines.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `hostname` | string | no | `"sonda"` | The HOSTNAME field in the syslog header. |
+| `app_name` | string | no | `"sonda"` | The APP-NAME field in the syslog header. |
+
+```yaml title="Syslog encoder"
+encoder:
+  type: syslog
+  hostname: web-01
+  app_name: myapp
+```
+
+```text title="Wire format"
+<14>1 2026-03-23T15:29:02.483Z sonda sonda - - - test log
+```
+
+This encoder supports logs only. It does not support metric events.
+
+## remote_write
+
+Prometheus remote write protobuf format. Encodes metrics as length-prefixed protobuf
+`TimeSeries` messages.
+
+!!! note
+    This encoder requires the `remote-write` Cargo feature flag. Pre-built release binaries
+    include this feature. If building from source: `cargo build --features remote-write -p sonda`.
+
+No additional parameters.
+
+```yaml title="Remote write encoder"
+encoder:
+  type: remote_write
+```
+
+This encoder must be paired with the `remote_write` sink, which handles batching, snappy
+compression, and HTTP POSTing with the correct protocol headers. See
+[Sinks - remote_write](sinks.md#remote_write) for details.
+
+## Encoder compatibility
+
+| Encoder | Metrics | Logs |
+|---------|---------|------|
+| `prometheus_text` | yes | no |
+| `influx_lp` | yes | no |
+| `json_lines` | yes | yes |
+| `syslog` | no | yes |
+| `remote_write` | yes | no |

--- a/docs/site/docs/configuration/generators.md
+++ b/docs/site/docs/configuration/generators.md
@@ -1,0 +1,243 @@
+# Generators
+
+Generators produce values for each tick of a scenario. For metrics, they produce `f64` values. For
+logs, they produce structured log events. You select a generator with the `generator.type` field.
+
+## Metric generators
+
+### constant
+
+Returns the same value on every tick. Use it for baseline testing or known-value verification
+(e.g. recording rule validation).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `value` | float | yes | -- | The fixed value emitted on every tick. |
+
+```yaml title="Constant generator"
+generator:
+  type: constant
+  value: 42.0
+```
+
+**Shape:** A flat horizontal line at the configured value.
+
+```bash
+sonda metrics --name up --rate 2 --duration 2s
+```
+
+```text title="Output"
+up 0 1774279693496
+up 0 1774279694001
+up 0 1774279694501
+```
+
+When no generator is configured, the default is `constant` with `value: 0.0`.
+
+### sine
+
+Produces a sine wave that oscillates between `offset - amplitude` and `offset + amplitude`.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `amplitude` | float | yes | -- | Half the peak-to-peak swing. |
+| `period_secs` | float | yes | -- | Duration of one full cycle in seconds. |
+| `offset` | float | yes | -- | Vertical midpoint of the wave. |
+
+```yaml title="Sine generator"
+generator:
+  type: sine
+  amplitude: 50.0
+  period_secs: 60
+  offset: 50.0
+```
+
+**Shape:** Oscillates smoothly between 0 and 100 with a 60-second period. At tick 0, the value
+equals the offset.
+
+```bash
+sonda metrics --name cpu --rate 2 --duration 2s \
+  --value-mode sine --amplitude 50 --period-secs 4 --offset 50
+```
+
+```text title="Output"
+cpu 50 1774279696105
+cpu 85.35533905932738 1774279696610
+cpu 100 1774279697110
+```
+
+### sawtooth
+
+Linearly ramps from `min` to `max` and resets to `min` at the start of each period.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `min` | float | yes | -- | Value at the start of each period. |
+| `max` | float | yes | -- | Value approached at the end (never reached). |
+| `period_secs` | float | yes | -- | Duration of one full ramp in seconds. |
+
+```yaml title="Sawtooth generator"
+generator:
+  type: sawtooth
+  min: 0.0
+  max: 100.0
+  period_secs: 60.0
+```
+
+**Shape:** A linear ramp from 0 to 100 over 60 seconds, then snaps back to 0.
+
+```bash
+sonda metrics --name ramp --rate 2 --duration 2s \
+  --value-mode sawtooth --min 0 --max 100 --period-secs 4
+```
+
+```text title="Output"
+ramp 0 1774279701394
+ramp 12.5 1774279701898
+ramp 25 1774279702399
+```
+
+### uniform
+
+Produces uniformly distributed random values in the range `[min, max]`. Deterministic when
+seeded.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `min` | float | yes | -- | Lower bound (inclusive). |
+| `max` | float | yes | -- | Upper bound (inclusive). |
+| `seed` | integer | no | `0` | RNG seed for deterministic replay. |
+
+```yaml title="Uniform generator"
+generator:
+  type: uniform
+  min: 10.0
+  max: 90.0
+  seed: 42
+```
+
+**Shape:** Random values scattered between 10 and 90. Same seed produces same sequence.
+
+```bash
+sonda metrics --name noise --rate 2 --duration 2s \
+  --value-mode uniform --min 10 --max 90 --seed 42
+```
+
+```text title="Output"
+noise 69.32519030174588 1774279698726
+noise 68.2543018631486 1774279699231
+noise 27.068700996215277 1774279699731
+```
+
+### sequence
+
+Steps through an explicit list of values. Use it for modeling specific incident patterns like
+threshold crossings.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `values` | list of floats | yes | -- | The ordered values to step through. Must not be empty. |
+| `repeat` | boolean | no | `true` | When true, cycles back to the start. When false, holds the last value. |
+
+```yaml title="Sequence generator"
+generator:
+  type: sequence
+  values: [10, 10, 10, 10, 10, 95, 95, 95, 95, 95, 10, 10, 10, 10, 10, 10]
+  repeat: true
+```
+
+**Shape:** Steps through the list one value per tick. With `repeat: true`, wraps around after the
+last value. With `repeat: false`, the last value is emitted for all subsequent ticks.
+
+```bash
+sonda metrics --scenario examples/sequence-alert-test.yaml --duration 5s
+```
+
+```text title="Output"
+cpu_spike_test{instance="server-01",job="node"} 10 1774279704026
+cpu_spike_test{instance="server-01",job="node"} 10 1774279705031
+cpu_spike_test{instance="server-01",job="node"} 10 1774279706031
+cpu_spike_test{instance="server-01",job="node"} 10 1774279707031
+cpu_spike_test{instance="server-01",job="node"} 10 1774279708031
+cpu_spike_test{instance="server-01",job="node"} 95 1774279709031
+```
+
+### csv_replay
+
+Replays numeric values from a CSV file. Use it to reproduce real production metric patterns
+captured from monitoring systems.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file` | string | yes | -- | Path to the CSV file. |
+| `column` | integer | no | `0` | Zero-based column index to read. |
+| `has_header` | boolean | no | `true` | Whether to skip the first row as a header. |
+| `repeat` | boolean | no | `true` | When true, cycles back to the start. When false, holds the last value. |
+
+```yaml title="CSV replay generator"
+generator:
+  type: csv_replay
+  file: examples/sample-cpu-values.csv
+  column: 1
+  has_header: true
+  repeat: true
+```
+
+**Shape:** Follows the exact pattern recorded in the CSV file -- the values are replayed verbatim,
+one per tick.
+
+!!! note
+    The CSV file path is relative to the working directory where you run `sonda`, not
+    relative to the scenario file.
+
+## Log generators
+
+Log generators produce structured log events instead of numeric values. They are used with the
+`sonda logs` subcommand.
+
+### template
+
+Generates log events from message templates with randomized field values.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `templates` | list | yes | -- | One or more template entries (round-robin selection). |
+| `templates[].message` | string | yes | -- | Message template. Use `{field}` for placeholders. |
+| `templates[].field_pools` | map | no | `{}` | Maps placeholder names to value lists. |
+| `severity_weights` | map | no | info only | Severity distribution. Keys: `trace`, `debug`, `info`, `warn`, `error`, `fatal`. |
+| `seed` | integer | no | `0` | RNG seed for deterministic field and severity selection. |
+
+```yaml title="Template log generator"
+generator:
+  type: template
+  templates:
+    - message: "Request from {ip} to {endpoint} returned {status}"
+      field_pools:
+        ip: ["10.0.0.1", "10.0.0.2"]
+        endpoint: ["/api", "/health"]
+        status: ["200", "404", "500"]
+  severity_weights:
+    info: 0.7
+    warn: 0.2
+    error: 0.1
+  seed: 42
+```
+
+Templates are selected round-robin by tick. Placeholders are resolved by randomly picking from
+the corresponding field pool.
+
+### replay
+
+Replays lines from a log file, cycling back to the start when the file is exhausted.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file` | string | yes | -- | Path to the log file to replay. |
+
+```yaml title="Replay log generator"
+generator:
+  type: replay
+  file: /var/log/app.log
+```
+
+Each line becomes the `message` field of a log event with `info` severity.

--- a/docs/site/docs/configuration/scenario-file.md
+++ b/docs/site/docs/configuration/scenario-file.md
@@ -1,0 +1,221 @@
+# Scenario Files
+
+Scenario files define everything about a Sonda run: what to generate, how to encode it, and where
+to send it. They are YAML files that you pass with `--scenario`.
+
+## Complete example
+
+This scenario touches every available field:
+
+```yaml title="full-example.yaml"
+name: cpu_usage
+rate: 100
+duration: 30s
+
+generator:
+  type: sine
+  amplitude: 50.0
+  period_secs: 60
+  offset: 50.0
+
+gaps:
+  every: 2m
+  for: 20s
+
+bursts:
+  every: 10s
+  for: 2s
+  multiplier: 5.0
+
+labels:
+  hostname: web-01
+  zone: us-east-1
+
+encoder:
+  type: prometheus_text
+
+sink:
+  type: stdout
+
+phase_offset: "5s"
+clock_group: alert-test
+```
+
+```bash
+sonda metrics --scenario full-example.yaml
+```
+
+## Field reference
+
+### Core fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | yes | -- | Metric name. Must match `[a-zA-Z_:][a-zA-Z0-9_:]*`. |
+| `rate` | float | yes | -- | Events per second. Must be positive. Fractional values allowed (e.g. `0.5`). |
+| `duration` | string | no | runs forever | Total run time. Supports `ms`, `s`, `m`, `h` units. |
+| `generator` | object | yes | -- | Value generator configuration. See [Generators](generators.md). |
+| `encoder` | object | no | `prometheus_text` | Output format. See [Encoders](encoders.md). |
+| `sink` | object | no | `stdout` | Output destination. See [Sinks](sinks.md). |
+| `labels` | map | no | none | Static key-value labels attached to every event. |
+
+### Gap window
+
+Gaps create recurring silent periods where no events are emitted. Both fields must be provided
+together.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `gaps.every` | string | yes (if gaps used) | Recurrence interval (e.g. `"2m"`). |
+| `gaps.for` | string | yes (if gaps used) | Duration of each gap. Must be less than `every`. |
+
+```yaml title="Gap example"
+gaps:
+  every: 2m
+  for: 20s
+```
+
+This emits events for 1m40s, then goes silent for 20s, then repeats.
+
+### Burst window
+
+Bursts create recurring high-rate periods. All three fields must be provided together. If a gap
+and burst overlap, the gap takes priority.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `bursts.every` | string | yes (if bursts used) | Recurrence interval (e.g. `"10s"`). |
+| `bursts.for` | string | yes (if bursts used) | Duration of each burst. Must be less than `every`. |
+| `bursts.multiplier` | float | yes (if bursts used) | Rate multiplier during burst. Must be positive. |
+
+```yaml title="Burst example"
+bursts:
+  every: 10s
+  for: 2s
+  multiplier: 5.0
+```
+
+At a base rate of 100 events/sec, this produces 500 events/sec for 2 seconds out of every 10.
+
+### Multi-scenario fields
+
+These fields are only meaningful in multi-scenario mode (via `sonda run`). They control temporal
+correlation between scenarios.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `phase_offset` | string | no | none | Delay before starting this scenario. Supports `ms`, `s`, `m`, `h`. |
+| `clock_group` | string | no | none | Scenarios with the same clock group share a start time reference. |
+
+See [Multi-scenario files](#multi-scenario-files) below for a working example.
+
+### Duration format
+
+All duration fields (`duration`, `gaps.every`, `gaps.for`, `bursts.every`, `bursts.for`,
+`phase_offset`) accept the same format:
+
+| Unit | Example | Description |
+|------|---------|-------------|
+| `ms` | `100ms` | Milliseconds |
+| `s` | `30s` | Seconds |
+| `m` | `5m` | Minutes |
+| `h` | `1h` | Hours |
+
+## Log scenario files
+
+Log scenarios use a different generator section but share the same structure for gaps, bursts,
+encoder, and sink. The key differences:
+
+- The `generator` uses log-specific types (`template` or `replay`).
+- There is no `labels` field on log scenarios.
+- The default encoder is `json_lines` instead of `prometheus_text`.
+
+```yaml title="log-scenario.yaml"
+name: app_logs
+rate: 10
+duration: 60s
+
+generator:
+  type: template
+  templates:
+    - message: "Request from {ip} to {endpoint}"
+      field_pools:
+        ip: ["10.0.0.1", "10.0.0.2"]
+        endpoint: ["/api", "/health"]
+  severity_weights:
+    info: 0.7
+    warn: 0.2
+    error: 0.1
+  seed: 42
+
+encoder:
+  type: json_lines
+sink:
+  type: stdout
+```
+
+```bash
+sonda logs --scenario log-scenario.yaml
+```
+
+## Multi-scenario files
+
+Run multiple scenarios concurrently from a single file using `sonda run`. Each entry in the
+`scenarios` list must include a `signal_type` field (`metrics` or `logs`).
+
+```yaml title="multi-scenario.yaml"
+scenarios:
+  - signal_type: metrics
+    name: cpu_usage
+    rate: 1
+    duration: 120s
+    phase_offset: "0s"
+    clock_group: alert-test
+    generator:
+      type: sequence
+      values: [20, 20, 20, 95, 95, 95, 95, 95, 20, 20]
+      repeat: true
+    labels:
+      instance: server-01
+      job: node
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+
+  - signal_type: metrics
+    name: memory_usage_percent
+    rate: 1
+    duration: 120s
+    phase_offset: "3s"
+    clock_group: alert-test
+    generator:
+      type: sequence
+      values: [40, 40, 40, 88, 88, 88, 88, 88, 40, 40]
+      repeat: true
+    labels:
+      instance: server-01
+      job: node
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+```
+
+```bash
+sonda run --scenario multi-scenario.yaml
+```
+
+The `phase_offset` on `memory_usage_percent` delays it by 3 seconds, so CPU spikes first and
+memory follows. Both scenarios share the `alert-test` clock group for synchronized timing.
+
+## CLI overrides
+
+Any field in the scenario file can be overridden from the command line. CLI flags always take
+precedence over YAML values:
+
+```bash
+sonda metrics --scenario scenario.yaml --duration 5s --rate 2
+```
+
+This loads the file but overrides `duration` and `rate` with the CLI values.

--- a/docs/site/docs/configuration/sinks.md
+++ b/docs/site/docs/configuration/sinks.md
@@ -1,0 +1,192 @@
+# Sinks
+
+Sinks deliver encoded bytes to their destination. You select a sink with the `sink.type` field. If
+omitted, the default is `stdout`.
+
+## stdout
+
+Writes events to standard output via a buffered writer. This is the default sink.
+
+No additional parameters.
+
+```yaml title="Stdout sink"
+sink:
+  type: stdout
+```
+
+## file
+
+Writes events to a file. Parent directories are created automatically.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | yes | Filesystem path to write to. |
+
+```yaml title="File sink"
+sink:
+  type: file
+  path: /tmp/sonda-output.txt
+```
+
+You can also use the `--output` CLI flag as a shorthand:
+
+```bash
+sonda metrics --name cpu --rate 10 --duration 5s --output /tmp/metrics.txt
+```
+
+## tcp
+
+Writes events over a persistent TCP connection. The connection is established when the scenario
+starts.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `address` | string | yes | Remote address in `host:port` format. |
+
+```yaml title="TCP sink"
+sink:
+  type: tcp
+  address: "127.0.0.1:9999"
+```
+
+## udp
+
+Sends each encoded event as a single UDP datagram. No connection is established -- an ephemeral
+local port is bound and each event is sent via `send_to`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `address` | string | yes | Remote address in `host:port` format. |
+
+```yaml title="UDP sink"
+sink:
+  type: udp
+  address: "127.0.0.1:9999"
+```
+
+## http_push
+
+Batches encoded events and delivers them via HTTP POST. Events accumulate in a buffer until the
+batch size is reached, then the buffer is flushed as a single POST request.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `url` | string | yes | -- | Target URL for HTTP POST requests. |
+| `content_type` | string | no | `application/octet-stream` | Value for the `Content-Type` header. |
+| `batch_size` | integer | no | `65536` (64 KiB) | Flush threshold in bytes. |
+| `headers` | map | no | none | Extra HTTP headers sent with every request. |
+
+```yaml title="HTTP push sink"
+sink:
+  type: http_push
+  url: "http://localhost:8428/api/v1/import/prometheus"
+  content_type: "text/plain"
+  batch_size: 32768
+```
+
+### Pushing to VictoriaMetrics
+
+```yaml title="VictoriaMetrics via HTTP push"
+encoder:
+  type: prometheus_text
+sink:
+  type: http_push
+  url: "http://localhost:8428/api/v1/import/prometheus"
+  content_type: "text/plain"
+```
+
+### Custom headers
+
+Use the `headers` map for protocols that require specific headers:
+
+```yaml title="HTTP push with custom headers"
+sink:
+  type: http_push
+  url: "http://localhost:8428/api/v1/write"
+  headers:
+    Content-Type: "application/x-protobuf"
+    Content-Encoding: "snappy"
+    X-Prometheus-Remote-Write-Version: "0.1.0"
+```
+
+## remote_write
+
+Batches metrics as Prometheus remote write requests. Designed to be paired with the
+`remote_write` encoder, which produces length-prefixed protobuf `TimeSeries` bytes. The sink
+accumulates entries and, on flush, wraps them in a `WriteRequest`, snappy-compresses it, and
+HTTP POSTs with the correct protocol headers.
+
+!!! note
+    This sink requires the `remote-write` Cargo feature flag. Pre-built release binaries include
+    this feature. If building from source: `cargo build --features remote-write -p sonda`.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `url` | string | yes | -- | Remote write endpoint URL. |
+| `batch_size` | integer | no | `100` | Flush threshold in number of TimeSeries entries. |
+
+```yaml title="Remote write sink"
+encoder:
+  type: remote_write
+sink:
+  type: remote_write
+  url: "http://localhost:8428/api/v1/write"
+  batch_size: 100
+```
+
+Compatible endpoints:
+
+| Backend | URL |
+|---------|-----|
+| VictoriaMetrics | `http://host:8428/api/v1/write` |
+| vmagent | `http://host:8429/api/v1/write` |
+| Prometheus | `http://host:9090/api/v1/write` |
+| Thanos Receive | `http://host:19291/api/v1/receive` |
+| Cortex / Mimir | `http://host:9009/api/v1/push` |
+
+## kafka
+
+Batches events and publishes them to a Kafka topic. Uses a pure-Rust Kafka client for static
+binary compatibility.
+
+!!! note
+    This sink requires the `kafka` Cargo feature flag. Pre-built release binaries include this
+    feature. If building from source: `cargo build --features kafka -p sonda`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `brokers` | string | yes | Comma-separated broker addresses (e.g. `"broker1:9092,broker2:9092"`). |
+| `topic` | string | yes | Kafka topic name. |
+
+```yaml title="Kafka sink"
+sink:
+  type: kafka
+  brokers: "127.0.0.1:9092"
+  topic: sonda-metrics
+```
+
+Events are buffered until 64 KiB is accumulated, then published as a single Kafka record to
+partition 0 of the configured topic.
+
+## loki
+
+Batches log lines and delivers them to Grafana Loki via HTTP POST. Each call to write appends one
+log line, and the batch is flushed when it reaches the configured size.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `url` | string | yes | -- | Base URL of the Loki instance. |
+| `labels` | map | no | `{}` | Stream labels attached to every batch. |
+| `batch_size` | integer | no | `100` | Flush threshold in number of log entries. |
+
+```yaml title="Loki sink"
+sink:
+  type: loki
+  url: "http://localhost:3100"
+  labels:
+    job: sonda
+    env: dev
+  batch_size: 50
+```
+
+The sink POSTs to `{url}/loki/api/v1/push`.

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -209,8 +209,13 @@ sonda logs --scenario examples/log-template.yaml --duration 3s
 
 ## What next
 
-- **Configuration reference** -- learn about all generators, encoders, sinks, and CLI flags
-  (coming soon).
-- **Alert testing guide** -- use Sonda to validate your Prometheus/VictoriaMetrics alert rules
-  (coming soon).
-- **Deployment** -- run Sonda in Docker, Kubernetes, or as a long-running server (coming soon).
+- [**Scenario Files**](configuration/scenario-file.md) -- full YAML reference for all scenario
+  fields, gaps, bursts, and multi-scenario mode.
+- [**Generators**](configuration/generators.md) -- all value generators (constant, sine, sawtooth,
+  uniform, sequence, CSV replay) and log generators.
+- [**Encoders**](configuration/encoders.md) -- output formats: Prometheus text, InfluxDB, JSON,
+  syslog, remote write.
+- [**Sinks**](configuration/sinks.md) -- output destinations: stdout, file, TCP, UDP, HTTP push,
+  remote write, Kafka, Loki.
+- [**CLI Reference**](configuration/cli-reference.md) -- every flag for `metrics`, `logs`, and
+  `run` subcommands.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -47,3 +47,9 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Configuration:
+    - Scenario Files: configuration/scenario-file.md
+    - Generators: configuration/generators.md
+    - Encoders: configuration/encoders.md
+    - Sinks: configuration/sinks.md
+    - CLI Reference: configuration/cli-reference.md


### PR DESCRIPTION
## Summary

- Add five configuration reference pages under `docs/site/docs/configuration/`:
  - **Scenario Files** -- full YAML field reference including gaps, bursts, multi-scenario mode, phase_offset, and clock_group
  - **Generators** -- all six metric generators (constant, sine, sawtooth, uniform, sequence, csv_replay) and two log generators (template, replay)
  - **Encoders** -- all five encoders (prometheus_text, influx_lp, json_lines, syslog, remote_write) with compatibility matrix
  - **Sinks** -- all eight sinks (stdout, file, tcp, udp, http_push, remote_write, kafka, loki) with parameter tables
  - **CLI Reference** -- every flag for `metrics`, `logs`, and `run` subcommands with working examples
- Update `mkdocs.yml` navigation to include the Configuration section
- Update getting-started.md "What next" links to point to the new reference pages

## Verification

- Every YAML and CLI example tested against the actual binary
- Every generator, encoder, and sink in source code is documented
- No references to features that don't exist
- `mkdocs build --strict` passes with zero warnings
- Cross-links from getting-started.md resolve correctly

## Test plan

- [x] `task site:build` passes with zero warnings
- [x] Navigation renders correctly in the site
- [x] Every YAML example is valid and produces expected output
- [x] CLI reference matches actual `--help` output
- [x] All cross-links resolve (no 404s)