### PR TITLE
docs(slice-8.4): add pipeline validation and recording rules guides

### DIFF
--- a/docs/site/docs/guides/pipeline-validation.md
+++ b/docs/site/docs/guides/pipeline-validation.md
@@ -1,0 +1,271 @@
+# Pipeline Validation
+
+You changed your ingest pipeline, added an encoder, or modified a routing rule. How do you know
+nothing broke? Sonda gives you a fast, repeatable way to push known data through your pipeline
+and verify it arrives correctly at the other end.
+
+## Smoke Testing With the CLI
+
+The simplest validation: run Sonda with a known metric, check the exit code, and count
+the output lines.
+
+```bash
+sonda metrics --name smoke_test --rate 5 --duration 2s > /tmp/smoke.txt
+echo "Exit code: $?"
+wc -l < /tmp/smoke.txt
+```
+
+A successful run exits with code `0` and produces approximately `rate * duration` lines
+(roughly 10 for rate=5 and duration=2s). A non-zero exit code means something went wrong:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Success -- all events emitted. |
+| `1` | Error -- missing required flags, bad scenario file, sink connection failure. |
+
+```bash
+# Missing required --name flag: exits 1
+sonda metrics 2>/dev/null; echo $?
+# 1
+
+# Bad scenario path: exits 1
+sonda metrics --scenario /nonexistent.yaml 2>/dev/null; echo $?
+# 1
+```
+
+## Multi-Format Validation
+
+Run the same metric through each encoder to verify that every format arrives at its destination.
+This catches encoding regressions and misconfigured parsers.
+
+=== "Prometheus text"
+
+    ```bash
+    sonda metrics --name pipeline_test --rate 2 --duration 2s
+    ```
+
+    ```
+    pipeline_test 0 1700000000000
+    pipeline_test 0 1700000000500
+    ```
+
+=== "InfluxDB line protocol"
+
+    ```bash
+    sonda metrics --name pipeline_test --rate 2 --duration 2s --encoder influx_lp
+    ```
+
+    ```
+    pipeline_test value=0 1700000000000000000
+    pipeline_test value=0 1700000000500000000
+    ```
+
+=== "JSON Lines"
+
+    ```bash
+    sonda metrics --name pipeline_test --rate 2 --duration 2s --encoder json_lines
+    ```
+
+    ```json
+    {"name":"pipeline_test","value":0.0,"labels":{},"timestamp":"2026-03-23T12:00:00.000Z"}
+    {"name":"pipeline_test","value":0.0,"labels":{},"timestamp":"2026-03-23T12:00:00.500Z"}
+    ```
+
+To push each format to a different backend, combine the encoder with an
+[`http_push` sink](../configuration/sinks.md#http_push) or a
+[file sink](../configuration/sinks.md#file):
+
+```yaml title="multi-format-test.yaml"
+name: pipeline_test
+rate: 2
+duration: 10s
+
+generator:
+  type: constant
+  value: 42.0
+
+labels:
+  env: test
+
+encoder:
+  type: influx_lp
+sink:
+  type: file
+  path: /tmp/pipeline-influx.txt
+```
+
+```bash
+sonda metrics --scenario multi-format-test.yaml
+wc -l < /tmp/pipeline-influx.txt
+```
+
+See [Encoders](../configuration/encoders.md) and [Sinks](../configuration/sinks.md) for the
+full list of supported formats and destinations.
+
+## CI Integration
+
+Add Sonda as a step in your GitHub Actions workflow to validate your pipeline on every push.
+The `--duration` flag ensures the step finishes in bounded time.
+
+```yaml title=".github/workflows/pipeline-test.yml"
+name: Pipeline Smoke Test
+on: [push, pull_request]
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Sonda
+        run: cargo install sonda
+
+      - name: Smoke test (Prometheus text)
+        run: |
+          sonda metrics --name ci_smoke --rate 10 --duration 5s \
+            --output /tmp/ci-smoke-prom.txt
+          LINES=$(wc -l < /tmp/ci-smoke-prom.txt)
+          echo "Produced $LINES lines"
+          [ "$LINES" -ge 40 ] || { echo "FAIL: too few lines"; exit 1; }
+
+      - name: Smoke test (JSON Lines)
+        run: |
+          sonda metrics --name ci_smoke --rate 10 --duration 5s \
+            --encoder json_lines --output /tmp/ci-smoke-json.txt
+          LINES=$(wc -l < /tmp/ci-smoke-json.txt)
+          echo "Produced $LINES lines"
+          [ "$LINES" -ge 40 ] || { echo "FAIL: too few lines"; exit 1; }
+```
+
+!!! tip "Pre-built binaries"
+    If a Sonda release binary is available for your platform, download it instead of building
+    from source to save CI time. Check the
+    [GitHub Releases](https://github.com/davidban77/sonda/releases) page.
+
+## E2E Testing With Docker Compose
+
+For full end-to-end validation, use Docker Compose to spin up Sonda alongside a backend
+(VictoriaMetrics, Prometheus, Kafka) and verify data arrives.
+
+The project includes a ready-to-use e2e test suite in `tests/e2e/`. The stack starts
+Prometheus, VictoriaMetrics, vmagent, Kafka, Loki, and Grafana:
+
+```bash
+# Run the full e2e suite
+./tests/e2e/run.sh
+```
+
+The script performs these steps:
+
+1. Starts the Docker Compose stack and waits for all services to become healthy.
+2. Builds Sonda in release mode.
+3. Runs each test scenario for a short duration (5 seconds).
+4. Queries VictoriaMetrics (or Kafka) to verify data arrived.
+5. Reports PASS/FAIL for each scenario.
+6. Tears down the stack and exits with code `0` (all pass) or `1` (any failure).
+
+### Writing Your Own E2E Test
+
+Create a scenario YAML that pushes to your backend, run it with a bounded duration, then
+query the backend to verify:
+
+```yaml title="e2e-scenario.yaml"
+name: e2e_pipeline_check
+rate: 1
+duration: 10s
+
+generator:
+  type: constant
+  value: 99.0
+
+labels:
+  test: pipeline
+  env: ci
+
+encoder:
+  type: prometheus_text
+sink:
+  type: http_push
+  url: "http://localhost:8428/api/v1/import/prometheus"
+  content_type: "text/plain"
+```
+
+```bash
+# Push data
+sonda metrics --scenario e2e-scenario.yaml
+
+# Wait for ingestion
+sleep 5
+
+# Verify the metric exists
+curl -s "http://localhost:8428/api/v1/query?query=e2e_pipeline_check" \
+  | jq '.data.result | length'
+# Expected: 1 (at least one series)
+```
+
+### Docker Compose for a Minimal Backend
+
+If you only need VictoriaMetrics for validation, use the provided compose file:
+
+```bash
+# Start the stack (includes VictoriaMetrics, vmagent, Grafana, sonda-server)
+docker compose -f examples/docker-compose-victoriametrics.yml up -d
+
+# Run your scenario
+sonda metrics --scenario e2e-scenario.yaml
+
+# Query and verify
+curl -s "http://localhost:8428/api/v1/query?query=e2e_pipeline_check"
+
+# Tear down
+docker compose -f examples/docker-compose-victoriametrics.yml down -v
+```
+
+## Multi-Scenario Validation
+
+Use the `sonda run` subcommand to push metrics and logs concurrently from a single YAML file.
+This validates that your pipeline handles multiple signal types at the same time:
+
+```yaml title="multi-pipeline-test.yaml"
+scenarios:
+  - signal_type: metrics
+    name: pipeline_metrics
+    rate: 5
+    duration: 10s
+    generator:
+      type: constant
+      value: 1.0
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+
+  - signal_type: logs
+    name: pipeline_logs
+    rate: 5
+    duration: 10s
+    generator:
+      type: template
+      templates:
+        - message: "Pipeline validation event"
+      severity_weights:
+        info: 1.0
+      seed: 42
+    encoder:
+      type: json_lines
+    sink:
+      type: file
+      path: /tmp/pipeline-logs.json
+```
+
+```bash
+sonda run --scenario multi-pipeline-test.yaml
+echo "Exit: $?"
+wc -l < /tmp/pipeline-logs.json
+```
+
+See [Scenario Files](../configuration/scenario-file.md) for the full multi-scenario YAML
+reference.

--- a/docs/site/docs/guides/recording-rules.md
+++ b/docs/site/docs/guides/recording-rules.md
@@ -1,0 +1,174 @@
+# Testing Recording Rules
+
+You have Prometheus recording rules that pre-compute expressions and store results as new time
+series. You need to verify they compute correctly against known input before deploying to
+production.
+
+## The Approach
+
+1. Push a metric with a **known, constant value** using Sonda.
+2. Wait for at least **two evaluation intervals** (default: 1 minute each).
+3. Query the recording rule output and verify the computed value matches your expectation.
+
+This works because a constant input produces a predictable output: `sum()` of one instance
+pushing `42.0` equals `42.0`.
+
+## Working Example
+
+The repository includes a ready-to-use recording rule test:
+
+- `examples/recording-rule-test.yaml` -- Sonda scenario pushing a constant value of 100 for
+  `http_requests_total`.
+- `examples/recording-rule-prometheus.yml` -- Prometheus recording rule config computing
+  `job:http_requests_total:rate5m`.
+
+### Step 1: Start VictoriaMetrics
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml up -d
+```
+
+Wait for the service to become healthy:
+
+```bash
+curl -sf http://localhost:8428/health && echo "VM is ready"
+```
+
+### Step 2: Push Known Values
+
+Use the constant [generator](../configuration/generators.md#constant) to push a known value:
+
+```yaml title="recording-rule-input.yaml"
+name: http_requests_total
+rate: 1
+duration: 300s
+
+generator:
+  type: constant
+  value: 42.0
+
+labels:
+  instance: api-01
+  job: web
+
+encoder:
+  type: prometheus_text
+sink:
+  type: http_push
+  url: "http://localhost:8428/api/v1/import/prometheus"
+  content_type: "text/plain"
+```
+
+```bash
+sonda metrics --scenario recording-rule-input.yaml &
+```
+
+### Step 3: Wait for Evaluation
+
+Recording rules evaluate on a fixed interval (default 1 minute in Prometheus, configurable in
+vmalert). Wait at least two intervals:
+
+```bash
+sleep 120
+```
+
+### Step 4: Verify the Computed Value
+
+Suppose your recording rule computes a sum per job:
+
+```yaml title="recording-rule.yml"
+groups:
+  - name: test_rules
+    rules:
+      - record: job:http_requests_total:sum
+        expr: sum(http_requests_total) by (job)
+```
+
+With one instance pushing `42.0`, query the result:
+
+```bash
+curl -s "http://localhost:8428/api/v1/query?query=job:http_requests_total:sum" \
+  | jq '.data.result'
+```
+
+Expected output:
+
+```json
+[
+  {
+    "metric": {"job": "web"},
+    "value": [1700000000, "42"]
+  }
+]
+```
+
+If the value matches, your recording rule is correct.
+
+## Testing Rate-Based Rules
+
+For `rate()` or `irate()` rules, you need a metric whose value increases over time. Use the
+[sawtooth generator](../configuration/generators.md#sawtooth), which ramps linearly and resets:
+
+```yaml title="rate-rule-input.yaml"
+name: http_requests_total
+rate: 1
+duration: 300s
+
+generator:
+  type: sawtooth
+  min: 0.0
+  max: 1000.0
+  period_secs: 60
+
+labels:
+  instance: api-01
+  job: web
+
+encoder:
+  type: prometheus_text
+sink:
+  type: http_push
+  url: "http://localhost:8428/api/v1/import/prometheus"
+  content_type: "text/plain"
+```
+
+The sawtooth ramps from 0 to 1000 over 60 seconds, then resets. After sufficient data,
+`rate(http_requests_total[1m])` should return approximately `16.67` (1000 / 60 seconds).
+
+```bash
+# After pushing for at least 2 minutes
+curl -s "http://localhost:8428/api/v1/query?query=rate(http_requests_total[1m])" \
+  | jq '.data.result[0].value[1]'
+```
+
+## Loading Rules Into Your Stack
+
+You can load recording rules into Prometheus or vmalert:
+
+**Prometheus**: Add the rule file to `rule_files` in `prometheus.yml`:
+
+```yaml title="prometheus.yml (snippet)"
+rule_files:
+  - recording-rule.yml
+```
+
+**vmalert**: Pass the rule file as a flag:
+
+```bash
+vmalert -rule=recording-rule.yml \
+  -datasource.url=http://localhost:8428 \
+  -remoteWrite.url=http://localhost:8428
+```
+
+## Tear Down
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml down -v
+```
+
+## What Next
+
+- [Pipeline Validation](pipeline-validation.md) -- verify your ingest pipeline handles all
+  encoders correctly.
+- [Generators reference](../configuration/generators.md) -- full list of available generators.
+- [Sinks reference](../configuration/sinks.md) -- all available sink destinations.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -55,3 +55,5 @@ nav:
     - CLI Reference: configuration/cli-reference.md
   - Guides:
     - Alert Testing: guides/alert-testing.md
+    - Pipeline Validation: guides/pipeline-validation.md
+    - Recording Rules: guides/recording-rules.md


### PR DESCRIPTION
## Summary

- Add **Pipeline Validation** guide (`docs/site/docs/guides/pipeline-validation.md`): covers CLI smoke testing, exit code behavior, multi-format validation (Prometheus text / InfluxDB LP / JSON Lines), CI integration with a GitHub Actions example, e2e testing with Docker Compose, and multi-scenario validation using `sonda run`.
- Add **Recording Rules** guide (`docs/site/docs/guides/recording-rules.md`): covers testing Prometheus recording rules by pushing known constant values with Sonda, waiting for evaluation, and verifying computed output. Includes a rate-based rule example using the sawtooth generator.
- Update `mkdocs.yml` nav to add the new Guides section with both pages.

All CLI commands and YAML examples were tested against the actual binary. `mkdocs build --strict` passes with zero warnings.

## Test plan

- [x] `task site:build` passes with zero warnings in strict mode
- [x] Every CLI command in the pipeline validation guide produces the documented output format
- [x] Every YAML scenario in both guides runs successfully with `sonda metrics --scenario`
- [x] Exit code behavior (0 for success, 1 for error) matches documentation
- [x] Cross-links to configuration reference pages resolve correctly
- [x] No references to features that do not exist in the codebase