### PR TITLE
fix: make kafka an opt-in feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "prost",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/sonda-server/Cargo.toml
+++ b/sonda-server/Cargo.toml
@@ -13,6 +13,7 @@ readme = "../README.md"
 
 [features]
 remote-write = ["sonda-core/remote-write"]
+kafka = ["sonda-core/kafka"]
 
 [[bin]]
 name = "sonda-server"

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -13,13 +13,14 @@ readme = "../README.md"
 
 [features]
 remote-write = ["sonda-core/remote-write"]
+kafka = ["sonda-core/kafka"]
 
 [[bin]]
 name = "sonda"
 path = "src/main.rs"
 
 [dependencies]
-sonda-core = { workspace = true, features = ["kafka"] }
+sonda-core = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }


### PR DESCRIPTION
## Summary
- Kafka was hardcoded as always-enabled in the `sonda` CLI crate (`sonda-core = { workspace = true, features = ["kafka"] }`), making it impossible to build without it
- Changed kafka to an opt-in feature flag (`--features kafka`) consistent with how `remote-write` is already handled
- Added the `kafka` feature passthrough to `sonda-server` as well for parity

## Test plan
- [x] `cargo build --workspace` compiles without optional features
- [x] `cargo build -p sonda --features kafka,remote-write` compiles with both features enabled
- [x] `cargo install --path sonda --features kafka` works as expected