### PR TITLE
docs: document CLI status output and --quiet flag

### DIFF
--- a/docs/site/docs/configuration/cli-reference.md
+++ b/docs/site/docs/configuration/cli-reference.md
@@ -9,8 +9,23 @@ Sonda provides three subcommands: `metrics` for metric generation, `logs` for lo
 sonda [OPTIONS] <COMMAND>
 
 Options:
+  -q, --quiet    Suppress status banners (errors still print to stderr)
   -h, --help     Print help
   -V, --version  Print version
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--quiet` | `-q` | Suppress start/stop status banners. Errors still print to stderr. |
+| `--help` | `-h` | Print help information. |
+| `--version` | `-V` | Print version. |
+
+The `--quiet` flag is global and goes **before** the subcommand:
+
+```bash
+sonda -q metrics --name up --rate 1 --duration 5s
+sonda -q logs --mode template --rate 5 --duration 5s
+sonda -q run --scenario multi.yaml
 ```
 
 ```bash
@@ -20,6 +35,53 @@ sonda --version
 ```text title="Output"
 sonda 0.1.3
 ```
+
+## Status output
+
+Sonda prints colored lifecycle banners to stderr when running scenarios. These banners show you
+what is running and how it performed, without interfering with data output on stdout.
+
+### Start banner
+
+Printed when a scenario begins:
+
+```text
+▶ cpu_usage  signal_type: metrics | rate: 1000/s | encoder: prometheus_text | sink: stdout | duration: 30s
+```
+
+### Stop banner
+
+Printed when a scenario completes:
+
+```text
+■ cpu_usage  completed in 30.0s | events: 30000 | bytes: 1.2 MB | errors: 0
+```
+
+### Color behavior
+
+Colors are automatic and require no configuration:
+
+- **Interactive terminal** -- colors are enabled.
+- **Piped output** (`sonda metrics ... | grep foo`) -- colors are disabled on the piped stream. Since banners go to stderr, they stay colored if stderr is still a terminal.
+- **`NO_COLOR` environment variable** -- set `NO_COLOR=1` to disable colors everywhere. Sonda respects the [no-color.org](https://no-color.org) convention.
+- **Non-TTY stderr** -- colors are disabled when stderr is redirected to a file or pipe.
+
+### Suppressing banners
+
+Use `--quiet` / `-q` to suppress all status output. Only errors are printed:
+
+```bash
+# No banners, just data on stdout
+sonda -q metrics --name up --rate 5 --duration 5s
+
+# Useful in scripts and CI pipelines
+sonda -q metrics --name up --rate 5 --duration 5s > /tmp/data.txt
+```
+
+!!! note
+    Status banners go to stderr, data goes to stdout. Even without `--quiet`, you can
+    safely redirect stdout to a file or pipe it to another program -- banners never mix
+    with your data.
 
 ## sonda metrics
 

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -73,7 +73,13 @@ Generate a constant metric at 2 events per second for 5 seconds:
 sonda metrics --name cpu_usage --rate 2 --duration 5s
 ```
 
-```text title="Output"
+You will see a colored start banner on stderr, followed by data on stdout, then a stop banner:
+
+```text title="stderr"
+▶ cpu_usage  signal_type: metrics | rate: 2/s | encoder: prometheus_text | sink: stdout | duration: 5s
+```
+
+```text title="stdout"
 cpu_usage 0 1774277933018
 cpu_usage 0 1774277933522
 cpu_usage 0 1774277934023
@@ -81,7 +87,16 @@ cpu_usage 0 1774277934523
 ...
 ```
 
-Each line is Prometheus exposition format: `metric_name value timestamp_ms`.
+```text title="stderr"
+■ cpu_usage  completed in 5.0s | events: 10 | bytes: 240 B | errors: 0
+```
+
+Each line on stdout is Prometheus exposition format: `metric_name value timestamp_ms`.
+
+!!! tip
+    Status banners go to stderr, data goes to stdout. When you redirect or pipe stdout,
+    only data flows through. Use `--quiet` / `-q` to suppress banners entirely:
+    `sonda -q metrics --name cpu_usage --rate 2 --duration 5s`
 
 The default generator is `constant` with a value of `0.0`. To make it more interesting, use a
 sine wave:

--- a/docs/site/docs/guides/pipeline-validation.md
+++ b/docs/site/docs/guides/pipeline-validation.md
@@ -7,10 +7,10 @@ and verify it arrives correctly at the other end.
 ## Smoke Testing With the CLI
 
 The simplest validation: run Sonda with a known metric, check the exit code, and count
-the output lines.
+the output lines. Use `-q` to suppress status banners in scripts:
 
 ```bash
-sonda metrics --name smoke_test --rate 5 --duration 2s > /tmp/smoke.txt
+sonda -q metrics --name smoke_test --rate 5 --duration 2s > /tmp/smoke.txt
 echo "Exit code: $?"
 wc -l < /tmp/smoke.txt
 ```
@@ -125,7 +125,7 @@ jobs:
 
       - name: Smoke test (Prometheus text)
         run: |
-          sonda metrics --name ci_smoke --rate 10 --duration 5s \
+          sonda -q metrics --name ci_smoke --rate 10 --duration 5s \
             --output /tmp/ci-smoke-prom.txt
           LINES=$(wc -l < /tmp/ci-smoke-prom.txt)
           echo "Produced $LINES lines"
@@ -133,7 +133,7 @@ jobs:
 
       - name: Smoke test (JSON Lines)
         run: |
-          sonda metrics --name ci_smoke --rate 10 --duration 5s \
+          sonda -q metrics --name ci_smoke --rate 10 --duration 5s \
             --encoder json_lines --output /tmp/ci-smoke-json.txt
           LINES=$(wc -l < /tmp/ci-smoke-json.txt)
           echo "Produced $LINES lines"

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -67,7 +67,7 @@ sonda metrics \
   --label host=web-01
 ```
 
-```text title="Output (Prometheus exposition format)"
+```text title="Output (stdout -- Prometheus exposition format)"
 cpu_usage{host="web-01"} 50 1774278042509
 cpu_usage{host="web-01"} 85.35533905932738 1774278043013
 cpu_usage{host="web-01"} 100 1774278043513
@@ -76,7 +76,8 @@ cpu_usage{host="web-01"} 85.35533905932738 1774278044010
 ```
 
 The sine wave oscillates between 0 (`offset - amplitude`) and 100 (`offset + amplitude`) with a
-4-second period. Each line is a valid Prometheus text exposition sample.
+4-second period. Each line is a valid Prometheus text exposition sample. Sonda also prints colored
+start/stop banners to stderr -- they never mix with your data. Use `-q` to suppress them.
 
 ## Using a scenario file
 


### PR DESCRIPTION
## Summary

- Added a new **Status output** section to the CLI Reference page documenting the start/stop lifecycle banners, color behavior (NO_COLOR, TTY detection), and the `--quiet`/`-q` global flag
- Updated the **Getting Started** page to show users what the banners look like (stderr vs stdout separation) with a tip about `--quiet`
- Updated the **Pipeline Validation** guide to use `-q` in CI and scripting examples where banner suppression is appropriate
- Updated the **Home** page example to note that banners go to stderr and how to suppress them

## Test plan

- [x] `task site:build` passes with `--strict` (no broken links or warnings)
- [ ] Reviewer verifies banner format matches the actual implementation in `sonda/src/status.rs`
- [ ] Verify `--quiet` flag placement (before subcommand) is accurate