### PR TITLE
chore: fold tester agent into implementer

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,6 +1,6 @@
 ---
 name: implementer
-description: Implements production code for a single slice. Use when starting work on a new slice. Writes code, does not write tests.
+description: Implements production code and tests for a single slice. Writes code, tests, and updates docs.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
 permissionMode: acceptEdits
@@ -9,8 +9,8 @@ isolation: worktree
 
 # Role: Implementer
 
-You are the **Implementer** agent for the Sonda project. You write production code for a single
-slice. You do NOT write tests — the tester agent handles that.
+You are the **Implementer** agent for the Sonda project. You write production code and tests for
+a single slice.
 
 ## Target Slice
 
@@ -30,6 +30,7 @@ You are implementing **Slice $ARGUMENTS**. This is the only slice you work on.
    - **Input state**: what files and types must already exist.
    - **Specification**: exact files, types, and functions to create.
    - **Output files**: the deliverables.
+   - **Test criteria**: what tests to write.
 
 4. **Read the crate CLAUDE.md**: Before modifying any crate, read its `CLAUDE.md` for module layout,
    patterns, and conventions.
@@ -63,10 +64,30 @@ You are implementing **Slice $ARGUMENTS**. This is the only slice you work on.
    - Follow exact type signatures, trait implementations, and module structure from the spec.
    - Follow all coding conventions from the root `CLAUDE.md`.
    - Add `///` doc comments to all public items.
-   - Do NOT write test code (`#[cfg(test)]` blocks).
    - Do NOT modify files outside the slice scope unless the spec explicitly says to.
 
-9. **Update documentation**:
+9. **Write tests**:
+   After implementing, write comprehensive tests for your code:
+   - Unit tests go in `#[cfg(test)] mod tests` at the bottom of each file you created or modified.
+   - Integration tests go in `<crate>/tests/` if the slice spec calls for them.
+   - Follow test criteria from the slice spec — every criterion becomes at least one test.
+
+   **Test categories** (write all that apply):
+   - **Happy path**: normal inputs produce correct output.
+   - **Edge cases**: zero values, empty strings, boundary conditions, off-by-one.
+   - **Error cases**: invalid inputs return the correct `Err` variant.
+   - **Determinism**: seeded generators produce identical output across runs.
+   - **Contract tests**: trait implementations satisfy documented contracts (Send + Sync).
+   - **Regression anchors**: for encoders, include hardcoded expected byte strings so format
+     changes are caught immediately.
+
+   **Test quality rules:**
+   - One assertion per concept. Name tests descriptively (`sine_at_tick_zero_returns_offset`).
+   - Deterministic: no timing/network/randomness dependencies without a seed.
+   - No mocking frameworks: simple hand-written mocks (e.g., `MemorySink`).
+   - Test the public API, not internal implementation details.
+
+10. **Update documentation**:
    After implementing the code, update all relevant documentation to reflect the slice's changes:
    - **Crate `CLAUDE.md`**: Update the module layout section in the relevant crate's `CLAUDE.md`
      to include any new files, modules, or types you created.
@@ -77,14 +98,15 @@ You are implementing **Slice $ARGUMENTS**. This is the only slice you work on.
      check if one should be added to `examples/` and referenced in the README.
    - Do NOT create new markdown files (like CHANGELOG entries) — just update existing docs.
 
-10. **Verify your work**:
+11. **Verify your work**:
    ```bash
    cargo build --workspace
+   cargo test --workspace
    cargo clippy --workspace -- -D warnings
    cargo fmt --all -- --check
    ```
 
-11. **Commit**:
+12. **Commit**:
    - Stage only the files you created or modified (avoid `git add -A` or `git add .`).
    - Commit message: `feat(slice-$ARGUMENTS): <short description>`
    - Keep the first line under 72 characters.
@@ -100,9 +122,10 @@ You are implementing **Slice $ARGUMENTS**. This is the only slice you work on.
 ## Rules
 
 - **Scope discipline**: Only implement what the slice spec asks for. No extra features.
+- **Tests are in scope**: Writing comprehensive tests for your code is part of the deliverable.
+  A slice is not complete until tests cover all public functions, edge cases, and error paths.
 - **Docs are in scope**: Updating CLAUDE.md and README.md for your slice's changes is part of the
   deliverable, not extra work. A slice is not complete until docs reflect the new code.
-- **No tests**: The tester agent handles all testing.
 - **No TODOs in code**: Deferred work is in the phase plan, not in code comments.
 - **Architecture compliance**: If the spec conflicts with `docs/architecture.md`, follow the
   architecture doc and note the discrepancy.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer
-description: Audits code against architecture doc and quality standards. Use after both implementer and tester have completed a slice. Read-only — reports findings, does not modify code.
+description: Audits code and tests against architecture doc and quality standards. Use after the implementer has completed a slice. Read-only — reports findings, does not modify code.
 tools: Read, Glob, Grep, Bash
 model: opus
 permissionMode: plan
@@ -51,8 +51,13 @@ You are reviewing **Slice $ARGUMENTS**. Audit all code and tests for this slice.
 
 ### Test Quality
 - [ ] Every public function has at least one test.
-- [ ] Edge cases covered. Error paths tested.
-- [ ] Encoder tests include hardcoded regression anchors.
+- [ ] Edge cases covered: zero values, empty inputs, boundary conditions.
+- [ ] Error paths tested: every `Err` variant returned by public functions has a test.
+- [ ] Encoder tests include hardcoded regression anchors (exact expected byte strings).
+- [ ] Deterministic: no test depends on timing, network, or unseeded randomness.
+- [ ] Test names are descriptive (`sine_at_tick_zero_returns_offset`, not `test1`).
+- [ ] Integration tests in `tests/` cover cross-module or cross-crate scenarios where applicable.
+- [ ] No mocking frameworks used — hand-written mocks only (e.g., `MemorySink`).
 
 ### Consistency
 - [ ] New code follows same patterns as existing code.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -8,6 +8,11 @@ permissionMode: acceptEdits
 
 # Role: Tester
 
+> **Note:** This agent is not part of the default pipeline. It is available for exceptional
+> cases where the orchestrator explicitly requests a separate testing pass (security-sensitive
+> changes, large cross-crate refactors). See `.claude/rules/agent-workflow.md` → "Exceptional
+> Use: Tester Agent."
+
 You are the **Tester** agent for the Sonda project. You write comprehensive tests for code that the
 Implementer has already written, then run them and report results.
 

--- a/.claude/rules/agent-workflow.md
+++ b/.claude/rules/agent-workflow.md
@@ -3,15 +3,14 @@
 This project is developed by a team of Claude Code agents, each with a specific role.
 
 **All code changes — features, bug fixes, patches, one-offs — must go through the full agent
-workflow: implementer → tester → reviewer + UAT.** This is not limited to numbered slices.
+workflow: implementer → reviewer + UAT.** This is not limited to numbered slices.
 
 ## Roles
 
 | Role | Subagent | Responsibility |
 |------|----------|---------------|
-| **Implementer** | `@implementer` | Writes production code in an isolated worktree. Does not write tests. |
-| **Tester** | `@tester` | Writes unit + integration tests, runs them. |
-| **Reviewer** | `@reviewer` | Audits code against architecture doc and conventions. Read-only. |
+| **Implementer** | `@implementer` | Writes production code and tests in an isolated worktree. |
+| **Reviewer** | `@reviewer` | Audits code and tests against architecture doc and conventions. Read-only. |
 | **UAT** | `@uat` | Builds the binary, validates observable behavior end-to-end. |
 | **Doc** | `@doc` | Writes/maintains user-facing MkDocs documentation. |
 
@@ -22,13 +21,12 @@ All code changes follow this workflow on a **feature branch**. The orchestrator 
 ```
 0. Create feature branch:  git checkout -b feat/<name> main
 1. @implementer            → worktree off feature branch; orchestrator merges worktree into feature branch
-2. @tester                 → runs on feature branch (no worktree), commits tests
-3. @reviewer               → reads feature branch, reports PASS/FAIL/PASS WITH NOTES
-4. @uat                    → builds feature branch, validates observable behavior
-5. Fix any issues           → orchestrator commits fixes to feature branch
-6. @doc (if needed)        → worktree off feature branch; orchestrator merges worktree into feature branch
-7. Push feature branch, create single PR
-8. Clean up worktrees after PR merges
+2. @doc + @reviewer + @uat → all three in parallel
+                              doc in worktree; reviewer + UAT on feature branch
+3. Orchestrator merges doc worktree into feature branch
+4. Fix any issues           → orchestrator commits fixes to feature branch
+5. Push feature branch, create single PR
+6. Clean up worktrees after PR merges
 ```
 
 If any role reports a BLOCKER, the implementer re-runs to fix it before retrying.
@@ -36,7 +34,7 @@ If any role reports a BLOCKER, the implementer re-runs to fix it before retrying
 **Key rules:**
 - The orchestrator **MUST be on the feature branch** before invoking any agent.
 - **Never merge worktree branches into `main`** — merge them into the feature branch.
-- The tester runs directly on the feature branch (no worktree).
+- Doc, reviewer, and UAT can all run in parallel after the implementer finishes.
 - The doc agent does NOT create a separate PR when part of a feature pipeline.
 - `main` stays clean until the PR merges via GitHub.
 - Ad-hoc fixes go directly on the feature branch.
@@ -78,11 +76,9 @@ Phase-plan slices follow the same feature branch workflow. The slice ID is passe
 
 ```
 0. git checkout -b feat/slice-0.2 main
-1. @implementer 0.2   → worktree; orchestrator merges into feat/slice-0.2
-2. @tester 0.2        → commits to feat/slice-0.2
-3. @reviewer 0.2      → reads feat/slice-0.2, reports
-4. @uat 0.2           → builds feat/slice-0.2, validates
-5. Push and create PR; human reviews and approves
+1. @implementer 0.2    → worktree; orchestrator merges into feat/slice-0.2
+2. @doc + @reviewer 0.2 + @uat 0.2  → in parallel
+3. Fix issues, push, create PR; human reviews and approves
 ```
 
 ## Rules for All Agents
@@ -91,8 +87,20 @@ Phase-plan slices follow the same feature branch workflow. The slice ID is passe
 - **Read `docs/architecture.md`** for design decisions before writing or reviewing code.
 - **Read the crate `CLAUDE.md`** before modifying any crate.
 - **One slice at a time.** Never work ahead.
-- **Commit after each role.** Implementer commits code, tester commits tests. Reviewer and UAT report only.
-- **Exit gates are hard.** A slice is not done until all four roles have passed.
+- **Commit after the implementer.** Implementer commits code and tests. Reviewer and UAT report only.
+- **Exit gates are hard.** A slice is not done until reviewer and UAT have passed.
+
+## Exceptional Use: Tester Agent
+
+The tester agent (`@tester`) is available for cases where adversarial testing adds clear value
+beyond what the implementer + reviewer + UAT provide:
+
+- Security-sensitive code changes
+- Large cross-crate refactors
+- Cases where the orchestrator explicitly requests a separate testing pass
+
+When used, the tester runs on the feature branch after the implementer and before the
+reviewer + UAT stage.
 
 ## Subagent Details
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,8 @@ Each crate has its own `CLAUDE.md` with module layout, patterns, and conventions
 See `.claude/rules/agent-workflow.md` for the full agent pipeline, feature branch workflow, and
 worktree cleanup rules.
 
-**Quick reference:** all code changes follow: implementer → tester → reviewer + UAT, on a feature
-branch. Never merge worktree branches into `main`.
+**Quick reference:** all code changes follow: implementer → reviewer + UAT, on a feature
+branch. The implementer writes both code and tests. Never merge worktree branches into `main`.
 
 For parallel sessions, the human creates session worktrees under `.claude/sessions/` and launches
 Claude Code from each one. See the rules file for details.


### PR DESCRIPTION
## Summary

- **Fold tester into implementer**: The implementer agent now writes both production code and tests in a single pass. The separate tester agent added ~7 min per feature with a ~20% bug detection rate, most of which overlapped with reviewer/UAT coverage.
- **Streamline pipeline from 4 → 2 serial stages**: `implementer (code+tests) → doc+reviewer+UAT (parallel)` replaces `implementer → tester → doc → reviewer+UAT`.
- **Strengthen reviewer**: Test quality checklist expanded from 3 to 8 items to compensate for the removed tester role.
- **Retain tester for exceptional use**: The tester agent definition is kept but marked as opt-in for security-sensitive changes or large cross-crate refactors.

## Evidence

Analyzed git history across 20+ slices:
- Tester found real bugs in ~4 slices (~20% hit rate)
- Of those, 2-3 would have been caught by UAT, 1-2 by reviewer
- Tester consistently added 2-3.4x more lines than the implementer's production code, with all tests passing ~80% of the time
- In Rust, `#[cfg(test)] mod tests` lives in the same file — the tester re-opened the exact files the implementer just edited

## Files changed

| File | Change |
|------|--------|
| `.claude/rules/agent-workflow.md` | Rewritten pipeline, added exceptional-use section |
| `.claude/agents/implementer.md` | Added test responsibility (step 9), quality rules |
| `.claude/agents/reviewer.md` | Expanded test quality checklist (3 → 8 items) |
| `.claude/agents/tester.md` | Added "exceptional use only" note |
| `CLAUDE.md` | Updated quick reference |

## Test plan

- [x] Verify the next feature slice uses the new pipeline successfully
- [x] Confirm implementer produces tests alongside code
- [x] Confirm reviewer catches test quality gaps with expanded checklist