### PR TITLE
docs: add deployment and guide pages from README refactor (phase 1)

### DIFF
--- a/docs/site/docs/deployment/docker.md
+++ b/docs/site/docs/deployment/docker.md
@@ -1,0 +1,137 @@
+# Docker
+
+Sonda ships as a minimal Docker image built from scratch with statically linked musl binaries.
+The image contains both the `sonda` CLI and the `sonda-server` HTTP API.
+
+## Building the Image
+
+The multi-stage Dockerfile compiles static musl binaries and copies them into a `scratch` base.
+The final image is typically under 20 MB.
+
+```bash
+docker build -t sonda .
+```
+
+For multi-arch builds (linux/amd64 and linux/arm64) using Docker Buildx:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t sonda .
+```
+
+Pre-built multi-arch images are published to GitHub Container Registry on each release.
+Docker automatically pulls the correct architecture for your host.
+
+```bash
+docker pull ghcr.io/davidban77/sonda:latest
+```
+
+## Running with Docker
+
+The default entrypoint is `sonda-server`, which starts the HTTP API on port 8080.
+
+```bash
+# Start the server
+docker run -p 8080:8080 ghcr.io/davidban77/sonda:latest
+
+# Run the CLI instead
+docker run --entrypoint /sonda ghcr.io/davidban77/sonda:latest \
+  metrics --name up --rate 10 --duration 5s
+
+# Mount scenario files from the host
+docker run -p 8080:8080 -v ./examples:/scenarios ghcr.io/davidban77/sonda:latest
+```
+
+## Docker Compose Stack
+
+A `docker-compose.yml` ships with a full observability stack for demos and testing.
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `sonda-server` | 8080 | Sonda HTTP API |
+| `prometheus` | 9090 | Prometheus (scrape or remote write) |
+| `alertmanager` | 9093 | Alertmanager for alert routing |
+| `grafana` | 3000 | Grafana dashboards (password: `admin`) |
+
+Start, use, and tear down:
+
+```bash
+# Start the stack
+docker compose up -d
+
+# Verify the server
+curl http://localhost:8080/health
+
+# Post a metrics scenario
+curl -X POST -H "Content-Type: text/yaml" \
+  --data-binary @examples/docker-metrics.yaml \
+  http://localhost:8080/scenarios
+
+# Post an alert-testing scenario
+curl -X POST -H "Content-Type: text/yaml" \
+  --data-binary @examples/docker-alerts.yaml \
+  http://localhost:8080/scenarios
+
+# List running scenarios
+curl http://localhost:8080/scenarios
+
+# Tear down
+docker compose down
+```
+
+Open Grafana at [http://localhost:3000](http://localhost:3000) and Prometheus at
+[http://localhost:9090](http://localhost:9090) to explore your data.
+
+Two scenario files are provided for this stack:
+
+- **`docker-metrics.yaml`** -- CPU sine wave (30--70%) with recurring gaps for testing gap-fill behavior.
+- **`docker-alerts.yaml`** -- Sine wave (0--100) crossing warning/critical thresholds with burst windows.
+
+See [Example Scenarios](../guides/examples.md) for the full catalog.
+
+## VictoriaMetrics Stack
+
+A dedicated compose file adds VictoriaMetrics, vmagent, and Grafana with a pre-provisioned datasource
+and auto-provisioned **Sonda Overview** dashboard.
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `sonda-server` | 8080 | Sonda HTTP API |
+| `victoriametrics` | 8428 | VictoriaMetrics single-node TSDB |
+| `vmagent` | 8429 | Metrics relay agent |
+| `grafana` | 3000 | Grafana with VictoriaMetrics datasource |
+
+```bash
+# Start the stack
+docker compose -f examples/docker-compose-victoriametrics.yml up -d
+
+# Push metrics via sonda-server
+curl -X POST -H "Content-Type: text/yaml" \
+  --data-binary @examples/victoriametrics-metrics.yaml \
+  http://localhost:8080/scenarios
+
+# Verify data arrived
+curl "http://localhost:8428/api/v1/series?match[]={__name__=~'sonda.*'}"
+
+# Tear down
+docker compose -f examples/docker-compose-victoriametrics.yml down -v
+```
+
+You can also push from the host CLI using a pipe to VictoriaMetrics:
+
+```bash
+sonda metrics \
+  --name sonda_demo --rate 10 --duration 30s \
+  --value-mode sine --amplitude 40 --period-secs 30 --offset 60 \
+  --encoder prometheus_text --label job=sonda --label instance=local \
+  | curl -s --data-binary @- \
+    -H "Content-Type: text/plain" \
+    "http://localhost:8428/api/v1/import/prometheus"
+```
+
+Explore metrics in the VictoriaMetrics UI at [http://localhost:8428/vmui](http://localhost:8428/vmui),
+or open Grafana and navigate to **Dashboards > Sonda > Sonda Overview**.
+
+!!! tip
+    The stack includes vmagent for remote write relay. If you build Sonda with
+    `--features remote-write`, you can push protobuf metrics through vmagent using
+    `examples/remote-write-vm.yaml`. See [Encoders](../configuration/encoders.md) for details.

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -1,0 +1,85 @@
+# Kubernetes
+
+Sonda includes a Helm chart for deploying `sonda-server` to Kubernetes clusters. The chart
+configures health probes, scenario injection via ConfigMap, and follows Helm best practices
+for labels and resource management.
+
+## Installing the Chart
+
+```bash
+# Default values (port 8080, 1 replica)
+helm install sonda ./helm/sonda
+
+# Custom port
+helm install sonda ./helm/sonda --set server.port=9090
+
+# Custom resource limits
+helm install sonda ./helm/sonda \
+  --set resources.requests.cpu=200m \
+  --set resources.limits.cpu=1000m
+```
+
+The chart pulls `ghcr.io/davidban77/sonda:latest` by default. Override the image tag
+with `--set image.tag=0.3.0` to pin a specific version.
+
+## Configuring Scenarios
+
+You inject scenarios as a ConfigMap mounted at `/scenarios` inside the container. Define
+them under the `scenarios` key in your values file:
+
+```yaml title="my-values.yaml"
+scenarios:
+  cpu-metrics.yaml: |
+    name: cpu_usage
+    rate: 100
+    duration: 30s
+    generator:
+      type: sine
+      amplitude: 50
+      period_secs: 60
+      offset: 50
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+```
+
+Install with your values:
+
+```bash
+helm install sonda ./helm/sonda -f my-values.yaml
+```
+
+See [Scenario Files](../configuration/scenario-file.md) for the full YAML schema.
+
+## Health Probes
+
+The Deployment configures both liveness and readiness probes using `GET /health` on the
+server port. This endpoint returns `{"status":"ok"}` with HTTP 200 when the server is
+running, so pods restart automatically if the server becomes unresponsive.
+
+## Accessing the Server
+
+Use `kubectl port-forward` to reach the API from your workstation:
+
+```bash
+export POD_NAME=$(kubectl get pods -l "app.kubernetes.io/name=sonda" \
+  -o jsonpath="{.items[0].metadata.name}")
+kubectl port-forward $POD_NAME 8080:8080
+
+# Health check
+curl http://localhost:8080/health
+
+# Start a scenario
+curl -X POST -H "Content-Type: text/yaml" \
+  --data-binary @scenario.yaml \
+  http://localhost:8080/scenarios
+```
+
+For the full API reference, see [Server API](sonda-server.md).
+
+## Uninstalling
+
+```bash
+helm uninstall sonda
+```

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -1,0 +1,98 @@
+# Server API
+
+`sonda-server` exposes a REST API for starting, inspecting, and stopping scenarios over HTTP.
+Use it to integrate Sonda into CI pipelines, test harnesses, or dashboards without shell access.
+
+## Starting the Server
+
+```bash
+# Default port (8080)
+cargo run -p sonda-server
+
+# Custom port and bind address
+cargo run -p sonda-server -- --port 9090 --bind 127.0.0.1
+```
+
+Control log verbosity with the `RUST_LOG` environment variable (default: `info`):
+
+```bash
+RUST_LOG=debug cargo run -p sonda-server -- --port 8080
+```
+
+Press Ctrl+C for graceful shutdown -- the server signals all running scenarios to stop before
+exiting.
+
+## Health Check
+
+```bash
+curl http://localhost:8080/health
+# {"status":"ok"}
+```
+
+## Start a Scenario
+
+Post a YAML or JSON scenario body to `POST /scenarios`. The server accepts both
+`text/yaml` and `application/json` content types.
+
+=== "YAML"
+
+    ```bash
+    curl -X POST \
+      -H "Content-Type: text/yaml" \
+      --data-binary @examples/basic-metrics.yaml \
+      http://localhost:8080/scenarios
+    # {"id":"<uuid>","name":"interface_oper_state","status":"running"}
+    ```
+
+=== "JSON"
+
+    ```bash
+    curl -X POST \
+      -H "Content-Type: application/json" \
+      -d '{"signal_type":"metrics","name":"up","rate":10,"generator":{"type":"constant","value":1},"encoder":{"type":"prometheus_text"},"sink":{"type":"stdout"}}' \
+      http://localhost:8080/scenarios
+    ```
+
+Error responses:
+
+- **400 Bad Request** -- body cannot be parsed as YAML or JSON.
+- **422 Unprocessable Entity** -- valid YAML/JSON but fails validation (e.g., `rate: 0`).
+- **500 Internal Server Error** -- scenario thread could not be spawned.
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Health check |
+| POST | `/scenarios` | Start a scenario from YAML/JSON body |
+| GET | `/scenarios` | List all running scenarios |
+| GET | `/scenarios/{id}` | Inspect a scenario: config, stats, elapsed |
+| DELETE | `/scenarios/{id}` | Stop and remove a running scenario |
+| GET | `/scenarios/{id}/stats` | Live stats: rate, events, gap/burst state |
+| GET | `/scenarios/{id}/metrics` | Latest metrics in Prometheus text format |
+
+## Scrape Integration
+
+The `GET /scenarios/{id}/metrics` endpoint returns recent metric events in Prometheus text
+exposition format. This enables pull-based integration: start a scenario via `POST /scenarios`,
+then configure Prometheus or vmagent to scrape the endpoint directly.
+
+```yaml title="prometheus.yml"
+scrape_configs:
+  - job_name: sonda
+    scrape_interval: 15s
+    metrics_path: /scenarios/<SCENARIO_ID>/metrics
+    static_configs:
+      - targets: ["localhost:8080"]
+```
+
+Replace `<SCENARIO_ID>` with the ID returned by `POST /scenarios`.
+
+The endpoint accepts an optional `?limit=N` query parameter (default 100, max 1000)
+to control how many recent events are returned per scrape. Each scrape drains the buffer,
+so events appear once per cycle. If no metrics are available yet, you get `204 No Content`.
+Unknown scenario IDs return `404 Not Found`.
+
+!!! note
+    The server is also available as a [Docker image](docker.md) and
+    [Helm chart](kubernetes.md) for containerized deployments.

--- a/docs/site/docs/guides/e2e-testing.md
+++ b/docs/site/docs/guides/e2e-testing.md
@@ -1,0 +1,119 @@
+# E2E Testing
+
+The `tests/e2e/` directory contains a Docker Compose-based test suite that validates Sonda
+against real observability backends and message brokers.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) with the Compose v2 plugin (`docker compose`)
+- [Task](https://taskfile.dev/) (optional, for convenient commands)
+- `curl` and `python3` in PATH
+- Rust toolchain (for `cargo build`)
+
+## Services
+
+The e2e stack runs these services:
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| VictoriaMetrics | 8428 | Push target and query endpoint |
+| Prometheus | 9090 | Remote write receiver |
+| vmagent | 8429 | Relay agent forwarding to VictoriaMetrics |
+| Kafka | 9094 | Kafka broker (KRaft mode, no Zookeeper) |
+| Kafka UI | 8080 | Browse topics and messages |
+| Grafana | 3000 | Pre-configured datasources for VM, Prometheus, and Loki |
+| Loki | 3100 | Log aggregation push target |
+
+## Test Scenarios
+
+**VictoriaMetrics** (verified by querying `/api/v1/series`):
+
+| Scenario file | Encoder | Sink target | Metric verified |
+|---------------|---------|-------------|-----------------|
+| `vm-prometheus-text.yaml` | prometheus_text | VM `/api/v1/import/prometheus` | `sonda_e2e_vm_prom_text` |
+| `vm-influx-lp.yaml` | influx_lp | VM `/write` | `sonda_e2e_vm_influx_lp_value` |
+
+**Kafka** (verified by consuming from topic):
+
+| Scenario file | Encoder | Kafka topic | Verification |
+|---------------|---------|-------------|--------------|
+| `kafka-prometheus-text.yaml` | prometheus_text | `sonda-e2e-metrics` | messages > 0 |
+| `kafka-json-lines.yaml` | json_lines | `sonda-e2e-json` | messages > 0 |
+
+## Using the Taskfile
+
+The project Taskfile provides shortcuts for common operations:
+
+```bash
+task stack:up       # Start the full e2e stack
+task stack:down     # Stop and remove everything
+task stack:status   # Show service status
+task stack:logs     # Tail all service logs
+
+task e2e            # Run automated e2e tests (starts/stops stack)
+task demo           # Start stack + send a 30s sine wave demo
+
+task run:vm-prom    # Send Prometheus text metrics to VictoriaMetrics
+task run:vm-influx  # Send InfluxDB LP metrics to VictoriaMetrics
+task run:kafka      # Send metrics to Kafka
+task run:loki       # Send log events to Loki
+```
+
+## Exploring Metrics Visually
+
+Start the stack and generate some data:
+
+```bash
+task stack:up
+task demo
+```
+
+Then open the dashboards:
+
+- **Grafana** -- [http://localhost:3000](http://localhost:3000) (anonymous access). Go to Explore,
+  select VictoriaMetrics, and query `demo_sine_wave`.
+- **Kafka UI** -- [http://localhost:8080](http://localhost:8080). Browse topics `sonda-e2e-metrics`
+  and `sonda-e2e-json`.
+- **VictoriaMetrics** -- [http://localhost:8428/vmui](http://localhost:8428/vmui) for the built-in
+  query UI.
+
+## Running Automated Tests
+
+```bash
+# Via Taskfile
+task e2e
+
+# Or directly
+./tests/e2e/run.sh
+```
+
+The script starts the Docker Compose stack, waits for all services to become healthy, builds
+Sonda in release mode, runs each scenario, verifies data arrived (VictoriaMetrics via series
+API, Kafka via consumer), and tears everything down. Exit code `0` means all passed.
+
+## Running Scenarios Manually
+
+```bash
+# Start the stack
+task stack:up
+
+# Run individual scenarios
+sonda metrics --scenario tests/e2e/scenarios/vm-prometheus-text.yaml
+sonda metrics --scenario tests/e2e/scenarios/kafka-prometheus-text.yaml
+
+# Verify VictoriaMetrics received data
+curl "http://localhost:8428/api/v1/series?match[]={__name__=%22sonda_e2e_vm_prom_text%22}"
+
+# Verify Kafka received messages
+docker exec sonda-e2e-kafka kafka-console-consumer.sh \
+    --bootstrap-server 127.0.0.1:9092 \
+    --topic sonda-e2e-metrics \
+    --from-beginning --timeout-ms 5000
+
+# Tear down
+task stack:down
+```
+
+!!! note
+    The e2e tests build Sonda in release mode. Make sure you have sufficient disk space
+    for the Rust target directory (~2 GB).

--- a/docs/site/docs/guides/examples.md
+++ b/docs/site/docs/guides/examples.md
@@ -1,0 +1,96 @@
+# Example Scenarios
+
+The `examples/` directory contains ready-to-run YAML scenario files covering every
+generator, encoder, and sink combination. Each file works as-is with the `sonda` CLI.
+
+```bash
+sonda metrics --scenario examples/basic-metrics.yaml
+```
+
+## Basic Metrics
+
+| File | Generator | Encoder | Sink | Description |
+|------|-----------|---------|------|-------------|
+| `basic-metrics.yaml` | sine | prometheus_text | stdout | 1000 evt/s sine wave with labels and a recurring gap |
+| `simple-constant.yaml` | constant | prometheus_text | stdout | Minimal `up=1` metric at 10 evt/s for 10 seconds |
+
+## Sink Types
+
+| File | Generator | Encoder | Sink | Description |
+|------|-----------|---------|------|-------------|
+| `tcp-sink.yaml` | sine | prometheus_text | tcp | Stream to a TCP listener (`nc -l 9999`) |
+| `udp-sink.yaml` | constant | json_lines | udp | Send UDP datagrams to port 9998 |
+| `file-sink.yaml` | sawtooth | influx_lp | file | Write to `/tmp/sonda-output.txt` |
+| `http-push-sink.yaml` | sine | prometheus_text | http_push | POST batches to an HTTP endpoint |
+| `kafka-sink.yaml` | constant | prometheus_text | kafka | Publish to a local Kafka broker |
+
+See [Sinks](../configuration/sinks.md) for configuration details on each sink type.
+
+## Encoding Formats
+
+| File | Generator | Encoder | Sink | Description |
+|------|-----------|---------|------|-------------|
+| `influx-file.yaml` | sawtooth | influx_lp | file | InfluxDB line protocol to a file |
+| `json-tcp.yaml` | sine | json_lines | tcp | JSON Lines over TCP |
+| `prometheus-http-push.yaml` | sine | prometheus_text | http_push | Prometheus text POSTed in batches |
+| `remote-write-vm.yaml` | sine | remote_write | remote_write | Protobuf remote write to VictoriaMetrics* |
+
+*Requires `--features remote-write`. See [Encoders](../configuration/encoders.md) for details.
+
+## Scheduling
+
+| File | Generator | Encoder | Sink | Description |
+|------|-----------|---------|------|-------------|
+| `burst-metrics.yaml` | sine | prometheus_text | stdout | Bursts to 5x rate for 2s every 10s |
+
+## Log Scenarios
+
+| File | Generator | Encoder | Sink | Description |
+|------|-----------|---------|------|-------------|
+| `log-template.yaml` | template | json_lines | stdout | Structured logs with field pools and severity weights |
+| `log-replay.yaml` | replay | json_lines | stdout | Replay lines from an existing log file |
+| `loki-json-lines.yaml` | template | json_lines | loki | Push log events to a Loki instance |
+| `kafka-json-logs.yaml` | template | json_lines | kafka | Send log events to a Kafka topic |
+
+Run log scenarios with `sonda logs`:
+
+```bash
+sonda logs --scenario examples/log-template.yaml
+```
+
+## Docker and VictoriaMetrics
+
+| File | Generator | Encoder | Sink | Description |
+|------|-----------|---------|------|-------------|
+| `docker-metrics.yaml` | sine | prometheus_text | stdout | CPU wave (30--70%) for the Docker Compose stack |
+| `docker-alerts.yaml` | sine | prometheus_text | stdout | Threshold-crossing sine for alert rule testing |
+| `victoriametrics-metrics.yaml` | sine | prometheus_text | http_push | Push directly to VictoriaMetrics |
+
+See [Docker deployment](../deployment/docker.md) for the full stack setup.
+
+## Alert Testing
+
+| File | Generator | Encoder | Sink | Description |
+|------|-----------|---------|------|-------------|
+| `sequence-alert-test.yaml` | sequence | prometheus_text | stdout | CPU spike pattern crossing a 90% threshold |
+| `csv-replay-metrics.yaml` | csv_replay | prometheus_text | stdout | Replay a real production incident from CSV |
+| `recording-rule-test.yaml` | constant | prometheus_text | http_push | Known value for recording rule validation |
+
+See the [Alert Testing](alert-testing.md) guide for end-to-end walkthrough.
+
+## Multi-Scenario
+
+| File | Signal | Description |
+|------|--------|-------------|
+| `multi-scenario.yaml` | metrics + logs | Run both signal types concurrently |
+| `multi-metric-correlation.yaml` | metrics | Correlated CPU + memory with `phase_offset` for compound alerts |
+
+Run multi-scenario files with `sonda run`:
+
+```bash
+sonda run --scenario examples/multi-scenario.yaml
+```
+
+!!! tip
+    Override any scenario field from the CLI. For example, change the duration:
+    `sonda metrics --scenario examples/basic-metrics.yaml --duration 10s`

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -53,8 +53,14 @@ nav:
     - Encoders: configuration/encoders.md
     - Sinks: configuration/sinks.md
     - CLI Reference: configuration/cli-reference.md
+  - Deployment:
+    - Docker: deployment/docker.md
+    - Kubernetes: deployment/kubernetes.md
+    - Server API: deployment/sonda-server.md
   - Guides:
     - Alert Testing: guides/alert-testing.md
-    - Comprehensive Walkthrough: guides/comprehensive-walkthrough.md
     - Pipeline Validation: guides/pipeline-validation.md
     - Recording Rules: guides/recording-rules.md
+    - Example Scenarios: guides/examples.md
+    - E2E Testing: guides/e2e-testing.md
+    - Comprehensive Walkthrough: guides/comprehensive-walkthrough.md


### PR DESCRIPTION
## Summary

- Add 3 new Deployment pages: Docker (`deployment/docker.md`), Kubernetes (`deployment/kubernetes.md`), and Server API (`deployment/sonda-server.md`)
- Add 2 new Guide pages: Example Scenarios (`guides/examples.md`) and E2E Testing (`guides/e2e-testing.md`)
- Update `mkdocs.yml` navigation with new Deployment section and expanded Guides section

Content migrated from README.md lines 806-1573, rewritten in second person active voice with proper cross-links to existing configuration reference pages. All pages verified with `mkdocs build --strict`.

## Test plan

- [x] `mkdocs build --strict` passes with zero warnings
- [x] All pages under 800 words (560, 265, 419, 614, 511)
- [x] Max 1 admonition per page (limit is 2)
- [x] Cross-links point to existing pages (configuration/generators, encoders, sinks, etc.)
- [x] All code blocks specify language
- [x] Example commands and YAML verified against actual source files
- [ ] Reviewer: verify all example commands match actual binary behavior
- [ ] UAT: build site and follow guides end-to-end