### PR TITLE
fix(docs): make Loki/Kafka walkthrough sections self-contained

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "prost",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/docs/site/docs/guides/comprehensive-walkthrough.md
+++ b/docs/site/docs/guides/comprehensive-walkthrough.md
@@ -50,6 +50,25 @@ Verify all services:
 | vmagent | `http://localhost:8429` | Metrics relay agent |
 | Grafana | `http://localhost:3000` | Dashboards (no login required) |
 
+Additional services are available via [Docker Compose profiles](https://docs.docker.com/compose/how-tos/profiles/):
+
+| Service | URL | Profile |
+|---------|-----|---------|
+| Loki | `http://localhost:3100` | `--profile loki` |
+| Kafka (external) | `localhost:9094` | `--profile kafka` |
+| Kafka UI | `http://localhost:8081` | `--profile kafka` |
+
+```bash
+# Start with Loki:
+docker compose -f examples/docker-compose-victoriametrics.yml --profile loki up -d
+
+# Start with Kafka (requires building with the kafka feature):
+docker compose -f examples/docker-compose-victoriametrics.yml --profile kafka up -d
+
+# Start everything:
+docker compose -f examples/docker-compose-victoriametrics.yml --profile loki --profile kafka up -d
+```
+
 ```bash
 curl -s http://localhost:8080/health
 ```
@@ -564,9 +583,39 @@ sink:
   batch_size: 50
 ```
 
+Start the Loki service if you haven't already:
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml --profile loki up -d
+```
+
+Run the scenario:
+
+```bash
+sonda logs --scenario examples/loki-json-lines.yaml
+```
+
+Verify logs arrived in Loki:
+
+```bash
+curl -s 'http://localhost:3100/loki/api/v1/query?query={job="sonda"}' | python3 -m json.tool
+```
+
+You can also explore logs in Grafana at `http://localhost:3000` by selecting the **Loki** datasource in Explore.
+
 ### Kafka
 
-Publishes to a Kafka topic. Requires a running Kafka broker.
+Publishes to a Kafka topic. The Kafka sink requires the `kafka` feature flag:
+
+```bash
+cargo build --features kafka -p sonda
+```
+
+Start the Kafka service:
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml --profile kafka up -d
+```
 
 ```yaml title="examples/kafka-sink.yaml"
 name: kafka_constant
@@ -582,11 +631,44 @@ encoder:
   type: prometheus_text
 sink:
   type: kafka
-  brokers: "127.0.0.1:9092"
+  brokers: "localhost:9094"
   topic: sonda-metrics
 ```
 
-The Kafka sink is available in the e2e test stack at `tests/e2e/docker-compose.yml` (broker exposed on port 9094).
+```bash
+sonda metrics --scenario examples/kafka-sink.yaml
+```
+
+For log events over Kafka:
+
+```yaml title="examples/kafka-json-logs.yaml"
+name: app_logs_kafka
+rate: 10
+duration: 60s
+generator:
+  type: template
+  templates:
+    - message: "Event from {service} severity {level}"
+      field_pools:
+        service: ["auth", "api", "worker"]
+        level: ["INFO", "WARN", "ERROR"]
+  severity_weights:
+    info: 0.7
+    warn: 0.2
+    error: 0.1
+encoder:
+  type: json_lines
+sink:
+  type: kafka
+  brokers: "localhost:9094"
+  topic: sonda-logs
+```
+
+```bash
+sonda logs --scenario examples/kafka-json-logs.yaml
+```
+
+Inspect messages in Kafka UI at `http://localhost:8081`.
 
 ---
 
@@ -1512,6 +1594,12 @@ This starts:
 - **VictoriaMetrics** on port 8428
 - **vmagent** on port 8429
 - **Grafana** on port 3000 (with pre-provisioned VictoriaMetrics datasource and Sonda Overview dashboard)
+
+Loki and Kafka are available via profiles:
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml --profile loki --profile kafka up -d
+```
 
 Submit scenarios via the API:
 

--- a/examples/docker-compose-victoriametrics.yml
+++ b/examples/docker-compose-victoriametrics.yml
@@ -21,6 +21,12 @@
 # to explore metrics with the pre-configured VictoriaMetrics datasource.
 # The "Sonda Overview" dashboard is auto-provisioned under Dashboards > Sonda.
 #
+# Optional services (Loki, Kafka) are available via Docker Compose profiles:
+#
+#   docker compose -f examples/docker-compose-victoriametrics.yml --profile loki up -d
+#   docker compose -f examples/docker-compose-victoriametrics.yml --profile kafka up -d
+#   docker compose -f examples/docker-compose-victoriametrics.yml --profile loki --profile kafka up -d
+#
 # Tear down:
 #
 #   docker compose -f examples/docker-compose-victoriametrics.yml down -v
@@ -152,6 +158,81 @@ services:
       - ../docker/grafana/dashboards:/var/lib/grafana/dashboards:ro
     depends_on:
       victoriametrics:
+        condition: service_healthy
+
+  # ---------------------------------------------------------------------------
+  # Loki: log aggregation system.
+  #
+  # Accepts log entries via the push API:
+  #   POST http://loki:3100/loki/api/v1/push
+  #
+  # Query logs via the Loki API:
+  #   GET http://localhost:3100/loki/api/v1/query?query={job="sonda"}
+  #
+  # This service is only started with --profile loki.
+  # ---------------------------------------------------------------------------
+  loki:
+    image: grafana/loki:latest
+    profiles: [loki]
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3100/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  # ---------------------------------------------------------------------------
+  # Kafka: event streaming broker (KRaft mode, no ZooKeeper).
+  #
+  # Internal listener on port 9092 (for inter-container communication).
+  # External listener on port 9094 (for host access).
+  # Auto-creation of topics is enabled.
+  #
+  # This service is only started with --profile kafka.
+  # ---------------------------------------------------------------------------
+  kafka:
+    image: bitnami/kafka:3.9
+    profiles: [kafka]
+    environment:
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    ports:
+      - "9094:9094"
+    healthcheck:
+      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "127.0.0.1:9092", "--list"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  # ---------------------------------------------------------------------------
+  # Kafka UI: web interface for inspecting Kafka topics and messages.
+  #
+  # Available at http://localhost:8081 (port 8081 to avoid collision with
+  # sonda-server on port 8080).
+  #
+  # This service is only started with --profile kafka.
+  # ---------------------------------------------------------------------------
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    profiles: [kafka]
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=sonda
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092
+    ports:
+      - "8081:8080"
+    depends_on:
+      kafka:
         condition: service_healthy
 
 volumes:

--- a/examples/grafana/datasources.yml
+++ b/examples/grafana/datasources.yml
@@ -16,3 +16,10 @@ datasources:
     url: http://victoriametrics:8428
     isDefault: true
     editable: true
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: true

--- a/examples/kafka-sink.yaml
+++ b/examples/kafka-sink.yaml
@@ -5,7 +5,7 @@
 # Kafka record when the buffer reaches 64 KiB or when the scenario ends.
 #
 # Prerequisites:
-#   A Kafka broker must be reachable at 127.0.0.1:9092.
+#   A Kafka broker must be reachable at localhost:9094.
 #   The topic "sonda-metrics" must exist (or auto-creation must be enabled).
 #
 # Usage:
@@ -28,5 +28,5 @@ encoder:
 
 sink:
   type: kafka
-  brokers: "127.0.0.1:9092"
+  brokers: "localhost:9094"
   topic: sonda-metrics


### PR DESCRIPTION
## Summary

- Add Loki, Kafka, and Kafka UI services to `examples/docker-compose-victoriametrics.yml` using Docker Compose **profiles** (`--profile loki`, `--profile kafka`) so users can opt-in without changing the default `docker compose up` behavior
- Add run commands, infrastructure setup instructions, feature-flag prerequisites, and verification steps to the Loki and Kafka sections of the comprehensive walkthrough
- Fix Kafka broker port in `examples/kafka-sink.yaml` from `127.0.0.1:9092` to `localhost:9094` to match the compose external listener
- Add Loki datasource to `examples/grafana/datasources.yml`

## Problem

Running `sonda metrics --scenario examples/loki-json-lines.yaml` fails because Loki scenarios use the `template` log generator (requires `sonda logs`). The walkthrough documented Loki and Kafka sinks but never showed:
1. How to start the infrastructure (Loki/Kafka were missing from the compose stack)
2. Which CLI subcommand to use (`sonda logs` vs `sonda metrics`)
3. That the Kafka sink requires `--features kafka`
4. How to verify data arrived

## Test plan

- [x] `cargo build/test/clippy/fmt` all pass
- [x] `docker compose config` validates for all profile combinations (none, loki, kafka, both)
- [x] Port 9092 fully eliminated from examples and docs
- [x] Walkthrough uses correct subcommands (`sonda logs` for log scenarios)
- [x] Binary smoke tests pass for both `sonda metrics` and `sonda logs`