### PR TITLE
fix(docker): replace removed bitnami/kafka:3.9 with apache/kafka:4.1.2

### DIFF
--- a/examples/docker-compose-victoriametrics.yml
+++ b/examples/docker-compose-victoriametrics.yml
@@ -185,7 +185,7 @@ services:
       start_period: 15s
 
   # ---------------------------------------------------------------------------
-  # Kafka: event streaming broker (KRaft mode, no ZooKeeper).
+  # Kafka: official Apache Kafka image in KRaft mode (no ZooKeeper).
   #
   # Internal listener on port 9092 (for inter-container communication).
   # External listener on port 9094 (for host access).
@@ -194,22 +194,23 @@ services:
   # This service is only started with --profile kafka.
   # ---------------------------------------------------------------------------
   kafka:
-    image: bitnami/kafka:3.9
+    image: apache/kafka:4.1.2
     profiles: [kafka]
     environment:
-      - KAFKA_CFG_NODE_ID=0
-      - KAFKA_CFG_PROCESS_ROLES=controller,broker
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
-      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - CLUSTER_ID=MkU3OEVBNTcwNTJENDM2Qk
+      - KAFKA_NODE_ID=0
+      - KAFKA_PROCESS_ROLES=controller,broker
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      - KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
     ports:
       - "9094:9094"
     healthcheck:
-      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "127.0.0.1:9092", "--list"]
+      test: ["CMD", "/opt/kafka/bin/kafka-topics.sh", "--bootstrap-server", "127.0.0.1:9092", "--list"]
       interval: 10s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
## Summary

- Replace `bitnami/kafka:3.9` (removed from Docker Hub) with the official `apache/kafka:4.1.2` image
- Update env vars from Bitnami's `KAFKA_CFG_*` prefix to Apache's native `KAFKA_*` format
- Add required `CLUSTER_ID` for KRaft mode and fix healthcheck script path

## Test plan

- [x] `docker compose -f examples/docker-compose-victoriametrics.yml --profile kafka up -d` starts successfully
- [x] Kafka broker is healthy and accepting connections on localhost:9094