### PR TITLE
fix: replace .expect() with .map_err() on lock acquisitions (9A.2)

### DIFF
--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -361,11 +361,11 @@ pub async fn post_scenario(
 /// Returns a JSON object with a `scenarios` array containing each scenario's
 /// ID, name, status, and elapsed time. The list includes both running and
 /// stopped scenarios that have not been deleted.
-pub async fn list_scenarios(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn list_scenarios(State(state): State<AppState>) -> Result<impl IntoResponse, Response> {
     let scenarios = state
         .scenarios
         .read()
-        .expect("AppState RwLock must not be poisoned");
+        .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
 
     let summaries: Vec<ScenarioSummary> = scenarios
         .iter()
@@ -377,9 +377,9 @@ pub async fn list_scenarios(State(state): State<AppState>) -> impl IntoResponse 
         })
         .collect();
 
-    Json(ListScenariosResponse {
+    Ok(Json(ListScenariosResponse {
         scenarios: summaries,
-    })
+    }))
 }
 
 /// `GET /scenarios/{id}` — inspect a single scenario with full detail.
@@ -394,7 +394,7 @@ pub async fn get_scenario(
     let scenarios = state
         .scenarios
         .read()
-        .expect("AppState RwLock must not be poisoned");
+        .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
 
     let handle = scenarios
         .get(&id)
@@ -487,7 +487,7 @@ pub async fn get_scenario_stats(
     let scenarios = state
         .scenarios
         .read()
-        .expect("AppState RwLock must not be poisoned");
+        .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
 
     let handle = scenarios
         .get(&id)
@@ -551,7 +551,7 @@ pub async fn get_scenario_metrics(
     let scenarios = state
         .scenarios
         .read()
-        .expect("AppState RwLock must not be poisoned");
+        .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
 
     let handle = scenarios
         .get(&id)


### PR DESCRIPTION
## Summary

- Replaced `.expect()` with `.map_err(|e| internal_error(...))` on all `RwLock::read()` calls in server handlers
- Affected handlers: `list_scenarios`, `get_scenario`, `get_scenario_stats`, `get_scenario_metrics`
- If the internal lock is poisoned (by a panic in a write handler), read handlers now return 500 instead of crashing the server
- `list_scenarios` return type changed from `impl IntoResponse` to `Result<impl IntoResponse, Response>` to support `?`

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 254 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] All sonda-server tests pass (`cargo test -p sonda-server`)
- [x] Integration test passes (`cargo test --test integration`)
- [x] Grep confirms zero `.expect()` on lock acquisitions in handler code
- [x] Reviewer: PASS
- [x] UAT: PASS