### PR TITLE
fix: prevent tick as usize truncation on 32-bit platforms (9A.4)

### DIFF
--- a/sonda-core/src/generator/csv_replay.rs
+++ b/sonda-core/src/generator/csv_replay.rs
@@ -163,10 +163,12 @@ impl ValueGenerator for CsvReplayGenerator {
     /// the last value for ticks beyond the value count.
     fn value(&self, tick: u64) -> f64 {
         let len = self.values.len();
+        // Perform modulo in u64 space to avoid truncation on 32-bit platforms
+        // where `usize` is 32 bits and ticks above u32::MAX would wrap silently.
         let index = if self.repeat {
-            (tick as usize) % len
+            (tick % len as u64) as usize
         } else {
-            (tick as usize).min(len - 1)
+            (tick.min((len - 1) as u64)) as usize
         };
         self.values[index]
     }
@@ -471,7 +473,7 @@ mod tests {
         let gen = CsvReplayGenerator::from_str(content, 0, false, true).unwrap();
         let large_tick: u64 = 1_000_000_000;
         let val = gen.value(large_tick);
-        let expected_index = (large_tick as usize) % 3;
+        let expected_index = (large_tick % 3) as usize;
         let expected = [1.0, 2.0, 3.0][expected_index];
         assert_eq!(val, expected);
     }
@@ -482,6 +484,55 @@ mod tests {
         let gen = CsvReplayGenerator::from_str(content, 0, false, false).unwrap();
         let large_tick: u64 = 1_000_000_000;
         assert_eq!(gen.value(large_tick), 3.0, "should clamp to last value");
+    }
+
+    // ---- 32-bit truncation safety (tick > u32::MAX) ----------------------------
+
+    #[test]
+    fn repeat_tick_above_u32_max_uses_u64_modulo() {
+        let content = "10.0\n20.0\n30.0\n";
+        let gen = CsvReplayGenerator::from_str(content, 0, false, true).unwrap();
+        // tick = 4_294_967_296: u64 modulo 4_294_967_296 % 3 = 1
+        let tick: u64 = u64::from(u32::MAX) + 1;
+        assert_eq!(
+            gen.value(tick),
+            20.0,
+            "tick {} mod 3 = 1, should return values[1] = 20.0",
+            tick
+        );
+    }
+
+    #[test]
+    fn repeat_tick_at_u64_max_does_not_panic() {
+        let content = "1.0\n2.0\n3.0\n";
+        let gen = CsvReplayGenerator::from_str(content, 0, false, true).unwrap();
+        let val = gen.value(u64::MAX);
+        // u64::MAX % 3 = 0
+        assert_eq!(val, 1.0, "u64::MAX % 3 = 0, should return values[0]");
+    }
+
+    #[test]
+    fn no_repeat_tick_above_u32_max_clamps_correctly() {
+        let content = "1.0\n2.0\n3.0\n";
+        let gen = CsvReplayGenerator::from_str(content, 0, false, false).unwrap();
+        let tick: u64 = u64::from(u32::MAX) + 1;
+        assert_eq!(
+            gen.value(tick),
+            3.0,
+            "tick {} beyond length should clamp to last value",
+            tick
+        );
+    }
+
+    #[test]
+    fn no_repeat_tick_at_u64_max_clamps_correctly() {
+        let content = "1.0\n2.0\n";
+        let gen = CsvReplayGenerator::from_str(content, 0, false, false).unwrap();
+        assert_eq!(
+            gen.value(u64::MAX),
+            2.0,
+            "u64::MAX should clamp to last value"
+        );
     }
 
     // ---- CsvReplayGenerator is Send + Sync ------------------------------------

--- a/sonda-core/src/generator/log_replay.rs
+++ b/sonda-core/src/generator/log_replay.rs
@@ -73,7 +73,10 @@ impl LogGenerator for LogReplayGenerator {
     /// Wraps around when `tick >= lines.len()`. The severity is always `Info`
     /// and `fields` is empty — the full log context is in the message.
     fn generate(&self, tick: u64) -> LogEvent {
-        let line = &self.lines[(tick as usize) % self.lines.len()];
+        // Perform modulo in u64 space to avoid truncation on 32-bit platforms
+        // where `usize` is 32 bits and ticks above u32::MAX would wrap silently.
+        let index = (tick % self.lines.len() as u64) as usize;
+        let line = &self.lines[index];
         LogEvent::new(
             Severity::Info,
             line.clone(),
@@ -254,7 +257,7 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------------
-    // Large tick values
+    // Large tick values and 32-bit truncation safety
     // ---------------------------------------------------------------------------
 
     #[test]
@@ -262,6 +265,30 @@ mod tests {
         let gen = five_line_generator();
         let _ = gen.generate(u64::MAX);
         let _ = gen.generate(u64::MAX - 1);
+    }
+
+    #[test]
+    fn tick_above_u32_max_uses_u64_modulo() {
+        let gen = five_line_generator();
+        // tick = 4_294_967_296: u64 modulo 4_294_967_296 % 5 = 1
+        let tick: u64 = u64::from(u32::MAX) + 1;
+        assert_eq!(
+            gen.generate(tick).message,
+            "line-1",
+            "tick {} mod 5 = 1, should return line-1",
+            tick
+        );
+    }
+
+    #[test]
+    fn tick_at_u64_max_wraps_correctly() {
+        let gen = five_line_generator();
+        let event = gen.generate(u64::MAX);
+        // u64::MAX % 5 = 0 (since 18446744073709551615 % 5 = 0)
+        assert_eq!(
+            event.message, "line-0",
+            "u64::MAX % 5 = 0, should return line-0"
+        );
     }
 
     // ---------------------------------------------------------------------------

--- a/sonda-core/src/generator/log_template.rs
+++ b/sonda-core/src/generator/log_template.rs
@@ -158,7 +158,9 @@ impl LogGenerator for LogTemplateGenerator {
             );
         }
 
-        let template = &self.templates[(tick as usize) % self.templates.len()];
+        // Perform modulo in u64 space to avoid truncation on 32-bit platforms
+        // where `usize` is 32 bits and ticks above u32::MAX would wrap silently.
+        let template = &self.templates[(tick % self.templates.len() as u64) as usize];
         let severity = self.select_severity(tick);
         let (message, fields) = self.resolve_template(template, tick);
 
@@ -450,7 +452,7 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------------
-    // Large tick values
+    // Large tick values and 32-bit truncation safety
     // ---------------------------------------------------------------------------
 
     #[test]
@@ -458,6 +460,54 @@ mod tests {
         let gen = make_simple_generator(1);
         let _ = gen.generate(u64::MAX);
         let _ = gen.generate(u64::MAX - 1);
+    }
+
+    #[test]
+    fn tick_above_u32_max_selects_correct_template() {
+        let entry_a = TemplateEntry {
+            message: "template-A".into(),
+            field_pools: HashMap::new(),
+        };
+        let entry_b = TemplateEntry {
+            message: "template-B".into(),
+            field_pools: HashMap::new(),
+        };
+        let entry_c = TemplateEntry {
+            message: "template-C".into(),
+            field_pools: HashMap::new(),
+        };
+        let gen = LogTemplateGenerator::new(vec![entry_a, entry_b, entry_c], vec![], 0);
+        // tick = 4_294_967_296: u64 modulo 4_294_967_296 % 3 = 1
+        let tick: u64 = u64::from(u32::MAX) + 1;
+        assert_eq!(
+            gen.generate(tick).message,
+            "template-B",
+            "tick {} mod 3 = 1, should select template-B",
+            tick
+        );
+    }
+
+    #[test]
+    fn tick_at_u64_max_selects_correct_template() {
+        let entry_a = TemplateEntry {
+            message: "template-A".into(),
+            field_pools: HashMap::new(),
+        };
+        let entry_b = TemplateEntry {
+            message: "template-B".into(),
+            field_pools: HashMap::new(),
+        };
+        let entry_c = TemplateEntry {
+            message: "template-C".into(),
+            field_pools: HashMap::new(),
+        };
+        let gen = LogTemplateGenerator::new(vec![entry_a, entry_b, entry_c], vec![], 0);
+        // u64::MAX % 3 = 0
+        assert_eq!(
+            gen.generate(u64::MAX).message,
+            "template-A",
+            "u64::MAX % 3 = 0, should select template-A"
+        );
     }
 
     // ---------------------------------------------------------------------------

--- a/sonda-core/src/generator/sequence.rs
+++ b/sonda-core/src/generator/sequence.rs
@@ -55,10 +55,12 @@ impl SequenceGenerator {
 impl ValueGenerator for SequenceGenerator {
     fn value(&self, tick: u64) -> f64 {
         let len = self.values.len();
+        // Perform modulo in u64 space to avoid truncation on 32-bit platforms
+        // where `usize` is 32 bits and ticks above u32::MAX would wrap silently.
         let index = if self.repeat {
-            (tick as usize) % len
+            (tick % len as u64) as usize
         } else {
-            (tick as usize).min(len - 1)
+            (tick.min((len - 1) as u64)) as usize
         };
         self.values[index]
     }
@@ -202,11 +204,9 @@ mod tests {
     #[test]
     fn repeat_large_tick_does_not_panic() {
         let gen = SequenceGenerator::new(vec![1.0, 2.0, 3.0], true).unwrap();
-        // u64::MAX would cause issues if converted to usize on 32-bit, but on 64-bit
-        // it's just a large modulo. Use a large but safe value.
         let large_tick: u64 = 1_000_000_000;
         let val = gen.value(large_tick);
-        let expected_index = (large_tick as usize) % 3;
+        let expected_index = (large_tick % 3) as usize;
         let expected = [1.0, 2.0, 3.0][expected_index];
         assert_eq!(val, expected);
     }
@@ -253,6 +253,55 @@ mod tests {
     #[test]
     fn sequence_generator_is_send_and_sync() {
         assert_send_sync::<SequenceGenerator>();
+    }
+
+    // ---- 32-bit truncation safety (tick > u32::MAX) ----------------------------
+
+    #[test]
+    fn repeat_tick_above_u32_max_uses_u64_modulo() {
+        // On a 32-bit platform, `tick as usize` would truncate to the lower 32 bits.
+        // With the fix, modulo is performed in u64 space before casting to usize.
+        let gen = SequenceGenerator::new(vec![10.0, 20.0, 30.0], true).unwrap();
+        // tick = 4_294_967_296 (u32::MAX + 1)
+        // Correct (u64):    4_294_967_296 % 3 = 1
+        // Truncated (u32):  (4_294_967_296 as u32) = 0, 0 % 3 = 0 (WRONG)
+        let tick: u64 = u64::from(u32::MAX) + 1;
+        assert_eq!(
+            gen.value(tick),
+            20.0,
+            "tick {} mod 3 = 1, should return values[1] = 20.0",
+            tick
+        );
+    }
+
+    #[test]
+    fn repeat_tick_at_u64_max_does_not_panic() {
+        let gen = SequenceGenerator::new(vec![1.0, 2.0, 3.0], true).unwrap();
+        let val = gen.value(u64::MAX);
+        // u64::MAX % 3 = 0 (since u64::MAX = 18446744073709551615, and 18446744073709551615 % 3 = 0)
+        assert_eq!(val, 1.0, "u64::MAX % 3 = 0, should return values[0]");
+    }
+
+    #[test]
+    fn no_repeat_tick_above_u32_max_clamps_correctly() {
+        let gen = SequenceGenerator::new(vec![1.0, 2.0, 3.0], false).unwrap();
+        let tick: u64 = u64::from(u32::MAX) + 1;
+        assert_eq!(
+            gen.value(tick),
+            3.0,
+            "tick {} beyond length should clamp to last value",
+            tick
+        );
+    }
+
+    #[test]
+    fn no_repeat_tick_at_u64_max_clamps_correctly() {
+        let gen = SequenceGenerator::new(vec![1.0, 2.0], false).unwrap();
+        assert_eq!(
+            gen.value(u64::MAX),
+            2.0,
+            "u64::MAX should clamp to last value"
+        );
     }
 
     // ---- Incident pattern modeling (real-world usage) -------------------------


### PR DESCRIPTION
## Summary

- Fixed `tick as usize` truncation in 4 generators: `SequenceGenerator`, `CsvReplayGenerator`, `LogReplayGenerator`, `LogTemplateGenerator`
- Modulo is now performed in u64 space before casting to usize: `(tick % len as u64) as usize`
- Prevents silent wrong results after ~50 days at 1K events/sec on 32-bit platforms
- 12 new tests verify correct behavior at `u32::MAX + 1` and `u64::MAX` tick values

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 1,212 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Zero `tick as usize` remaining in production code (grep verified)
- [x] Reviewer: PASS
- [x] UAT: PASS