### PR TITLE
perf: eliminate per-tick name/labels cloning with Arc (9B.1)

### DIFF
--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -10,7 +10,7 @@ src/
 ├── lib.rs              ← public API surface, re-exports
 ├── model/
 │   ├── mod.rs          ← module declarations
-│   ├── metric.rs       ← MetricEvent, Labels
+│   ├── metric.rs       ← MetricEvent (Arc<str> name, Arc<Labels>), Labels, from_parts()
 │   └── log.rs          ← LogEvent (with Labels support for scenario-level static labels)
 ├── generator/
 │   ├── mod.rs          ← ValueGenerator trait + factory
@@ -100,6 +100,11 @@ JSON encoders pre-round the value before passing it to serde. Precision is valid
 
 - **No per-event allocations.** The hot path is: generate value → build MetricEvent → encode into
   buffer → write to sink. Each step should write into pre-allocated or caller-provided memory.
+- **Arc-wrapped MetricEvent fields.** `MetricEvent::name` is `Arc<str>` and `MetricEvent::labels`
+  is `Arc<Labels>`. Cloning a MetricEvent is O(1) — just reference-count bumps. The metric runner
+  validates the name once before the loop and uses `MetricEvent::from_parts` (no per-tick
+  validation) with `Arc::clone` (no per-tick heap allocation). Only when a cardinality spike is
+  active does the runner deep-clone the inner Labels to insert the spike key.
 - **Pre-build label strings.** Labels don't change between events for a given scenario. Build the
   serialized label prefix once at construction time.
 - **Use `BufWriter`.** Never write individual lines to stdout or files without buffering.

--- a/sonda-core/src/encoder/remote_write.rs
+++ b/sonda-core/src/encoder/remote_write.rs
@@ -140,7 +140,7 @@ impl Encoder for RemoteWriteEncoder {
         // when sorted alphabetically. We insert it and then add the rest.
         labels.push(Label {
             name: "__name__".to_string(),
-            value: event.name.clone(),
+            value: event.name.to_string(),
         });
 
         for (key, value) in event.labels.iter() {

--- a/sonda-core/src/model/metric.rs
+++ b/sonda-core/src/model/metric.rs
@@ -3,6 +3,7 @@
 //! Format-agnostic — encoding to Prometheus, Influx, or JSON is the encoder's concern.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use crate::SondaError;
@@ -111,14 +112,21 @@ impl Labels {
 ///
 /// Carries a metric name, `f64` value, a set of string label pairs, and a timestamp.
 /// The metric name is validated at construction time.
+///
+/// The `name` field uses `Arc<str>` and the `labels` field uses `Arc<Labels>` so that
+/// cloning a `MetricEvent` is O(1) — just reference-count bumps — rather than
+/// deep-copying the name string and the full label `BTreeMap`. This matters in the
+/// metric runner hot path where the name and labels are invariant across ticks and
+/// would otherwise be deep-cloned on every event.
 #[derive(Debug, Clone)]
 pub struct MetricEvent {
-    /// The metric name.
-    pub name: String,
+    /// The metric name (reference-counted for O(1) cloning in the hot path).
+    pub name: Arc<str>,
     /// The numeric value of this sample.
     pub value: f64,
-    /// The label set associated with this sample.
-    pub labels: Labels,
+    /// The label set associated with this sample (reference-counted for O(1)
+    /// cloning when no cardinality spike mutation is needed).
+    pub labels: Arc<Labels>,
     /// The time at which this sample was recorded.
     pub timestamp: SystemTime,
 }
@@ -128,6 +136,10 @@ impl MetricEvent {
     ///
     /// Validates that `name` matches `[a-zA-Z_:][a-zA-Z0-9_:]*`. Returns
     /// [`SondaError::Config`] if the name is invalid.
+    ///
+    /// The `name` is stored as `Arc<str>` and `labels` as `Arc<Labels>` for O(1)
+    /// cloning. To avoid per-event validation and allocation in hot loops, prefer
+    /// [`MetricEvent::from_parts`] with a pre-validated `Arc<str>` and `Arc<Labels>`.
     pub fn new(name: String, value: f64, labels: Labels) -> Result<Self, SondaError> {
         if !is_valid_metric_name(&name) {
             return Err(SondaError::Config(format!(
@@ -136,9 +148,9 @@ impl MetricEvent {
             )));
         }
         Ok(Self {
-            name,
+            name: Arc::from(name.as_str()),
             value,
-            labels,
+            labels: Arc::new(labels),
             timestamp: SystemTime::now(),
         })
     }
@@ -147,6 +159,10 @@ impl MetricEvent {
     ///
     /// Useful for deterministic testing and replay scenarios. Validates the metric
     /// name with the same rules as [`MetricEvent::new`].
+    ///
+    /// The `name` is stored as `Arc<str>` and `labels` as `Arc<Labels>` for O(1)
+    /// cloning. To avoid per-event validation and allocation in hot loops, prefer
+    /// [`MetricEvent::from_parts`] with a pre-validated `Arc<str>` and `Arc<Labels>`.
     pub fn with_timestamp(
         name: String,
         value: f64,
@@ -160,11 +176,36 @@ impl MetricEvent {
             )));
         }
         Ok(Self {
+            name: Arc::from(name.as_str()),
+            value,
+            labels: Arc::new(labels),
+            timestamp,
+        })
+    }
+
+    /// Construct a `MetricEvent` from pre-validated, pre-shared parts.
+    ///
+    /// This is the hot-path constructor used by the metric runner. The caller
+    /// provides a pre-validated `Arc<str>` name and a pre-built `Arc<Labels>`,
+    /// avoiding both name validation and heap allocation on every tick.
+    ///
+    /// # Safety contract (logical, not `unsafe`)
+    ///
+    /// The caller must ensure `name` is a valid Prometheus metric name. No
+    /// validation is performed. Passing an invalid name will produce events
+    /// that encoders may reject or encode incorrectly.
+    pub fn from_parts(
+        name: Arc<str>,
+        value: f64,
+        labels: Arc<Labels>,
+        timestamp: SystemTime,
+    ) -> Self {
+        Self {
             name,
             value,
             labels,
             timestamp,
-        })
+        }
     }
 }
 
@@ -309,7 +350,7 @@ mod tests {
     fn metric_event_new_with_valid_name_returns_ok() {
         let labels = Labels::from_pairs(&[]).unwrap();
         let event = MetricEvent::new("up".to_string(), 1.0, labels).unwrap();
-        assert_eq!(event.name, "up");
+        assert_eq!(&*event.name, "up");
         assert_eq!(event.value, 1.0);
     }
 
@@ -317,28 +358,28 @@ mod tests {
     fn metric_event_new_with_underscored_name_returns_ok() {
         let labels = Labels::from_pairs(&[]).unwrap();
         let event = MetricEvent::new("http_requests_total".to_string(), 42.0, labels).unwrap();
-        assert_eq!(event.name, "http_requests_total");
+        assert_eq!(&*event.name, "http_requests_total");
     }
 
     #[test]
     fn metric_event_new_with_double_underscore_prefix_returns_ok() {
         let labels = Labels::from_pairs(&[]).unwrap();
         let event = MetricEvent::new("__internal".to_string(), 0.0, labels).unwrap();
-        assert_eq!(event.name, "__internal");
+        assert_eq!(&*event.name, "__internal");
     }
 
     #[test]
     fn metric_event_new_with_colon_in_name_returns_ok() {
         let labels = Labels::from_pairs(&[]).unwrap();
         let event = MetricEvent::new("my:metric".to_string(), 0.0, labels).unwrap();
-        assert_eq!(event.name, "my:metric");
+        assert_eq!(&*event.name, "my:metric");
     }
 
     #[test]
     fn metric_event_new_with_colon_leading_name_returns_ok() {
         let labels = Labels::from_pairs(&[]).unwrap();
         let event = MetricEvent::new(":colon_first".to_string(), 0.0, labels).unwrap();
-        assert_eq!(event.name, ":colon_first");
+        assert_eq!(&*event.name, ":colon_first");
     }
 
     // --- MetricEvent::new error cases ---
@@ -417,7 +458,7 @@ mod tests {
         let ts = UNIX_EPOCH + Duration::from_millis(500);
         let labels = Labels::from_pairs(&[("env", "test")]).unwrap();
         let event = MetricEvent::with_timestamp("my_metric".to_string(), 3.14, labels, ts).unwrap();
-        assert_eq!(event.name, "my_metric");
+        assert_eq!(&*event.name, "my_metric");
         assert_eq!(event.value, 3.14);
     }
 
@@ -482,5 +523,141 @@ mod tests {
     fn metric_event_is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<MetricEvent>();
+    }
+
+    // --- MetricEvent::from_parts ---
+
+    #[test]
+    fn from_parts_constructs_event_with_given_fields() {
+        let name: Arc<str> = Arc::from("http_requests_total");
+        let labels = Arc::new(Labels::from_pairs(&[("env", "prod")]).unwrap());
+        let ts = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let event = MetricEvent::from_parts(Arc::clone(&name), 42.0, Arc::clone(&labels), ts);
+        assert_eq!(&*event.name, "http_requests_total");
+        assert_eq!(event.value, 42.0);
+        assert_eq!(event.labels.len(), 1);
+        assert_eq!(event.timestamp, ts);
+    }
+
+    #[test]
+    fn from_parts_skips_name_validation() {
+        // Deliberately pass a name that would fail is_valid_metric_name.
+        // from_parts must not reject it — validation is the caller's responsibility.
+        let name: Arc<str> = Arc::from("123-invalid!");
+        let labels = Arc::new(Labels::default());
+        let ts = UNIX_EPOCH;
+        let event = MetricEvent::from_parts(name, 0.0, labels, ts);
+        assert_eq!(&*event.name, "123-invalid!");
+    }
+
+    #[test]
+    fn from_parts_preserves_exact_timestamp() {
+        let name: Arc<str> = Arc::from("up");
+        let labels = Arc::new(Labels::default());
+        let ts = UNIX_EPOCH + Duration::from_millis(1_700_000_000_500);
+        let event = MetricEvent::from_parts(name, 1.0, labels, ts);
+        assert_eq!(event.timestamp, ts);
+    }
+
+    // --- Arc sharing semantics: clone is O(1) refcount bump ---
+
+    #[test]
+    fn name_arc_is_shared_across_cloned_events() {
+        let name: Arc<str> = Arc::from("up");
+        let labels = Arc::new(Labels::default());
+        let ts = UNIX_EPOCH;
+        let event1 = MetricEvent::from_parts(Arc::clone(&name), 1.0, Arc::clone(&labels), ts);
+        let event2 = event1.clone();
+
+        // Both events should point to the exact same heap allocation.
+        assert!(Arc::ptr_eq(&event1.name, &event2.name));
+    }
+
+    #[test]
+    fn labels_arc_is_shared_across_cloned_events() {
+        let name: Arc<str> = Arc::from("up");
+        let labels = Arc::new(Labels::from_pairs(&[("host", "srv1")]).unwrap());
+        let ts = UNIX_EPOCH;
+        let event1 = MetricEvent::from_parts(Arc::clone(&name), 1.0, Arc::clone(&labels), ts);
+        let event2 = event1.clone();
+
+        // Both events should share the same Labels allocation.
+        assert!(Arc::ptr_eq(&event1.labels, &event2.labels));
+    }
+
+    #[test]
+    fn name_arc_is_shared_between_from_parts_and_source() {
+        let name: Arc<str> = Arc::from("metric_name");
+        let labels = Arc::new(Labels::default());
+        let ts = UNIX_EPOCH;
+        let event = MetricEvent::from_parts(Arc::clone(&name), 0.0, Arc::clone(&labels), ts);
+
+        // The event's name should share the same allocation as the source Arc.
+        assert!(Arc::ptr_eq(&event.name, &name));
+    }
+
+    #[test]
+    fn labels_arc_is_shared_between_from_parts_and_source() {
+        let name: Arc<str> = Arc::from("up");
+        let labels = Arc::new(Labels::from_pairs(&[("a", "1"), ("b", "2")]).unwrap());
+        let ts = UNIX_EPOCH;
+        let event = MetricEvent::from_parts(Arc::clone(&name), 0.0, Arc::clone(&labels), ts);
+
+        // The event's labels should share the same allocation as the source Arc.
+        assert!(Arc::ptr_eq(&event.labels, &labels));
+    }
+
+    #[test]
+    fn multiple_events_from_same_arcs_share_name_allocation() {
+        let name: Arc<str> = Arc::from("shared_metric");
+        let labels = Arc::new(Labels::default());
+        let ts = UNIX_EPOCH;
+
+        let event1 = MetricEvent::from_parts(Arc::clone(&name), 1.0, Arc::clone(&labels), ts);
+        let event2 = MetricEvent::from_parts(Arc::clone(&name), 2.0, Arc::clone(&labels), ts);
+        let event3 = MetricEvent::from_parts(Arc::clone(&name), 3.0, Arc::clone(&labels), ts);
+
+        // All three events share the same name and labels allocations.
+        assert!(Arc::ptr_eq(&event1.name, &event2.name));
+        assert!(Arc::ptr_eq(&event2.name, &event3.name));
+        assert!(Arc::ptr_eq(&event1.labels, &event2.labels));
+        assert!(Arc::ptr_eq(&event2.labels, &event3.labels));
+    }
+
+    // --- Backward compatibility: new() and with_timestamp() wrap in Arc ---
+
+    #[test]
+    fn new_wraps_name_in_arc() {
+        let labels = Labels::from_pairs(&[]).unwrap();
+        let event = MetricEvent::new("up".to_string(), 1.0, labels).unwrap();
+        // The name field should be an Arc<str>, verifiable by cloning cheaply.
+        let cloned = event.clone();
+        assert!(Arc::ptr_eq(&event.name, &cloned.name));
+    }
+
+    #[test]
+    fn new_wraps_labels_in_arc() {
+        let labels = Labels::from_pairs(&[("k", "v")]).unwrap();
+        let event = MetricEvent::new("up".to_string(), 1.0, labels).unwrap();
+        let cloned = event.clone();
+        assert!(Arc::ptr_eq(&event.labels, &cloned.labels));
+    }
+
+    #[test]
+    fn with_timestamp_wraps_name_in_arc() {
+        let labels = Labels::from_pairs(&[]).unwrap();
+        let ts = UNIX_EPOCH + Duration::from_secs(1);
+        let event = MetricEvent::with_timestamp("up".to_string(), 1.0, labels, ts).unwrap();
+        let cloned = event.clone();
+        assert!(Arc::ptr_eq(&event.name, &cloned.name));
+    }
+
+    #[test]
+    fn with_timestamp_wraps_labels_in_arc() {
+        let labels = Labels::from_pairs(&[("k", "v")]).unwrap();
+        let ts = UNIX_EPOCH + Duration::from_secs(1);
+        let event = MetricEvent::with_timestamp("up".to_string(), 1.0, labels, ts).unwrap();
+        let cloned = event.clone();
+        assert!(Arc::ptr_eq(&event.labels, &cloned.labels));
     }
 }

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -136,20 +136,32 @@ pub fn run_with_sink(
     let generator = create_generator(&config.generator, config.rate)?;
     let encoder = create_encoder(&config.encoder);
 
-    // Build the label set from the config's optional HashMap.
-    let labels: Labels = if let Some(ref label_map) = config.labels {
-        let pairs: Vec<(&str, &str)> = label_map
-            .iter()
-            .map(|(k, v)| (k.as_str(), v.as_str()))
-            .collect();
-        Labels::from_pairs(&pairs)?
-    } else {
-        Labels::from_pairs(&[])?
+    // Build the label set from the config's optional HashMap, wrapped in Arc
+    // so the hot loop can share it across ticks without deep-cloning the BTreeMap.
+    let labels: Arc<Labels> = {
+        let inner = if let Some(ref label_map) = config.labels {
+            let pairs: Vec<(&str, &str)> = label_map
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            Labels::from_pairs(&pairs)?
+        } else {
+            Labels::from_pairs(&[])?
+        };
+        Arc::new(inner)
     };
 
-    // Clone the metric name once before the hot loop.
-    // The name is invariant for the lifetime of a scenario.
-    let name = config.name.clone();
+    // Validate and intern the metric name once before the hot loop.
+    // Arc<str> makes per-tick cloning O(1) — just a reference-count bump.
+    let name: Arc<str> = {
+        if !crate::model::metric::is_valid_metric_name(&config.name) {
+            return Err(SondaError::Config(format!(
+                "invalid metric name {:?}: must match [a-zA-Z_:][a-zA-Z0-9_:]*",
+                config.name
+            )));
+        }
+        Arc::from(config.name.as_str())
+    };
 
     // The base inter-event interval (at normal rate, no burst).
     let base_interval = Duration::from_secs_f64(1.0 / config.rate);
@@ -253,35 +265,40 @@ pub fn run_with_sink(
             // Timestamp the event at the start of this iteration.
             let wall_now = std::time::SystemTime::now();
 
-            // Generate the value and build the metric event.
-            // MetricEvent::with_timestamp takes owned String and Labels, so we
-            // must clone both per tick. The `name` clone is cheap (heap copy of a
-            // short string); `labels` clone is proportional to label count, which
-            // is typically small and fixed. A zero-copy API is possible post-MVP
-            // if profiling shows this to be a bottleneck.
+            // Generate the value for this tick.
             let value = generator.value(tick);
 
-            // Inject cardinality spike labels when inside a spike window.
-            // Only clone+insert when spike windows actually exist and are active,
-            // to avoid overhead for existing configs without spikes.
+            // Build the per-tick label set. In the common case (no spike windows)
+            // this is just an Arc refcount bump — O(1), zero heap allocation.
+            // Only when a cardinality spike is active do we deep-clone the inner
+            // Labels to insert the spike key.
             let currently_in_spike;
-            let tick_labels = if spike_windows.is_empty() {
+            let tick_labels: Arc<Labels> = if spike_windows.is_empty() {
                 currently_in_spike = false;
-                labels.clone()
+                Arc::clone(&labels)
             } else {
-                let mut tl = labels.clone();
                 let mut any_spike = false;
+                let mut mutated: Option<Labels> = None;
                 for sw in &spike_windows {
                     if is_in_spike(elapsed, sw) {
+                        let tl = mutated.get_or_insert_with(|| (*labels).clone());
                         tl.insert(sw.label.clone(), sw.label_value_for_tick(tick));
                         any_spike = true;
                     }
                 }
                 currently_in_spike = any_spike;
-                tl
+                match mutated {
+                    Some(tl) => Arc::new(tl),
+                    None => Arc::clone(&labels),
+                }
             };
 
-            let event = MetricEvent::with_timestamp(name.clone(), value, tick_labels, wall_now)?;
+            // Build the MetricEvent from pre-validated, pre-shared parts.
+            // name: Arc::clone is O(1) — just a refcount bump, no heap copy.
+            // tick_labels: already an Arc<Labels> from above.
+            // No metric name validation occurs here — it was validated once
+            // before the loop.
+            let event = MetricEvent::from_parts(Arc::clone(&name), value, tick_labels, wall_now);
 
             // Encode and write.
             buf.clear();
@@ -796,7 +813,7 @@ mod tests {
         let st = stats.read().expect("lock must not be poisoned");
         for event in st.recent_metrics.iter() {
             assert_eq!(
-                event.name, "up",
+                &*event.name, "up",
                 "all buffered events must have the metric name from config"
             );
         }
@@ -977,6 +994,97 @@ mod tests {
         assert!(
             st.in_cardinality_spike,
             "stats must report in_cardinality_spike=true during spike window"
+        );
+    }
+
+    // ---- Arc sharing: name and labels are reference-counted, not deep-cloned ---
+
+    /// All metric events buffered in stats must share the same Arc<str> name
+    /// allocation, proving that the runner uses Arc::clone (refcount bump)
+    /// instead of deep-cloning the name string on every tick.
+    #[test]
+    fn buffered_events_share_name_arc_allocation() {
+        use std::sync::{Arc, RwLock};
+
+        let config = make_config(200.0, "100ms", None);
+        let mut sink = MemorySink::new();
+        let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
+
+        super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
+            .expect("run must succeed");
+
+        let st = stats.read().expect("lock must not be poisoned");
+        let events: Vec<_> = st.recent_metrics.iter().collect();
+        assert!(
+            events.len() >= 2,
+            "need at least 2 events to verify sharing, got {}",
+            events.len()
+        );
+
+        // All events should share the same Arc<str> allocation for the name.
+        let first_name = &events[0].name;
+        for (i, event) in events.iter().enumerate().skip(1) {
+            assert!(
+                Arc::ptr_eq(first_name, &event.name),
+                "event[{i}].name should share Arc allocation with event[0].name"
+            );
+        }
+    }
+
+    /// When no cardinality spikes are configured, all buffered events must share
+    /// the same Arc<Labels> allocation, proving that the runner avoids
+    /// deep-cloning the BTreeMap on every tick.
+    #[test]
+    fn buffered_events_share_labels_arc_when_no_spikes() {
+        use std::sync::{Arc, RwLock};
+
+        let config = make_config(200.0, "100ms", None);
+        let mut sink = MemorySink::new();
+        let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
+
+        super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
+            .expect("run must succeed");
+
+        let st = stats.read().expect("lock must not be poisoned");
+        let events: Vec<_> = st.recent_metrics.iter().collect();
+        assert!(
+            events.len() >= 2,
+            "need at least 2 events to verify sharing, got {}",
+            events.len()
+        );
+
+        // All events should share the same Arc<Labels> allocation.
+        let first_labels = &events[0].labels;
+        for (i, event) in events.iter().enumerate().skip(1) {
+            assert!(
+                Arc::ptr_eq(first_labels, &event.labels),
+                "event[{i}].labels should share Arc allocation with event[0].labels"
+            );
+        }
+    }
+
+    /// Invalid metric name in config is caught before the hot loop, not during.
+    #[test]
+    fn invalid_metric_name_returns_config_error_before_loop() {
+        let config = ScenarioConfig {
+            name: "123-invalid".to_string(),
+            rate: 10.0,
+            duration: Some("100ms".to_string()),
+            generator: GeneratorConfig::Constant { value: 1.0 },
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            labels: None,
+            encoder: EncoderConfig::PrometheusText { precision: None },
+            sink: SinkConfig::Stdout,
+            phase_offset: None,
+            clock_group: None,
+        };
+        let mut sink = MemorySink::new();
+        let result = super::run_with_sink(&config, &mut sink, None, None);
+        assert!(
+            matches!(result, Err(crate::SondaError::Config(ref msg)) if msg.contains("123-invalid")),
+            "expected Config error for invalid name, got: {result:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- `MetricEvent` fields changed from `String`/`Labels` to `Arc<str>`/`Arc<Labels>` — cloning is now O(1) refcount bump instead of deep-copying String and BTreeMap
- New `from_parts()` constructor skips name validation for the hot loop — name is validated once before the loop
- Runner pre-wraps name and labels in Arc before the event loop; only deep-clones labels when a cardinality spike is active
- All encoders work transparently via Deref coercion (only RemoteWrite needed a `.to_string()` change)
- Backward compatible: `new()` and `with_timestamp()` still accept plain `String`/`Labels`

Note: this incidentally resolves the 9B.2 concern (per-tick regex validation) since `from_parts()` skips validation entirely.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 1,227 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] 17 new tests covering Arc sharing semantics, from_parts, backward compat, runner integration
- [x] CLI smoke tested up to 100K events/sec across all encoders
- [x] Cardinality spike labels verified (spike present during window, absent after)
- [x] Reviewer: PASS
- [x] UAT: PASS