### PR TITLE
perf: introduce ValidatedMetricName newtype for type-safe validation (9B.2)

### DIFF
--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -10,7 +10,8 @@ src/
 ├── lib.rs              ← public API surface, re-exports
 ├── model/
 │   ├── mod.rs          ← module declarations
-│   ├── metric.rs       ← MetricEvent (Arc<str> name, Arc<Labels>), Labels, from_parts()
+│   ├── metric.rs       ← ValidatedMetricName (newtype over Arc<str>, validates once at construction),
+│   │                      MetricEvent (ValidatedMetricName name, Arc<Labels>), Labels, from_parts()
 │   └── log.rs          ← LogEvent (with Labels support for scenario-level static labels)
 ├── generator/
 │   ├── mod.rs          ← ValueGenerator trait + factory
@@ -100,11 +101,12 @@ JSON encoders pre-round the value before passing it to serde. Precision is valid
 
 - **No per-event allocations.** The hot path is: generate value → build MetricEvent → encode into
   buffer → write to sink. Each step should write into pre-allocated or caller-provided memory.
-- **Arc-wrapped MetricEvent fields.** `MetricEvent::name` is `Arc<str>` and `MetricEvent::labels`
+- **Arc-wrapped MetricEvent fields.** `MetricEvent::name` is a `ValidatedMetricName` (newtype
+  over `Arc<str>` that validates the metric name regex once at construction) and `MetricEvent::labels`
   is `Arc<Labels>`. Cloning a MetricEvent is O(1) — just reference-count bumps. The metric runner
-  validates the name once before the loop and uses `MetricEvent::from_parts` (no per-tick
-  validation) with `Arc::clone` (no per-tick heap allocation). Only when a cardinality spike is
-  active does the runner deep-clone the inner Labels to insert the spike key.
+  constructs a `ValidatedMetricName` once before the loop and uses `MetricEvent::from_parts` (no
+  per-tick validation) with `name.clone()` (no per-tick heap allocation). Only when a cardinality
+  spike is active does the runner deep-clone the inner Labels to insert the spike key.
 - **Pre-build label strings.** Labels don't change between events for a given scenario. Build the
   serialized label prefix once at construction time.
 - **Use `BufWriter`.** Never write individual lines to stdout or files without buffering.

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -21,6 +21,7 @@ pub use model::log::LogEvent;
 pub use model::log::Severity;
 pub use model::metric::Labels;
 pub use model::metric::MetricEvent;
+pub use model::metric::ValidatedMetricName;
 pub use schedule::handle::ScenarioHandle;
 pub use schedule::launch::{launch_scenario, validate_entry};
 pub use schedule::stats::ScenarioStats;

--- a/sonda-core/src/model/metric.rs
+++ b/sonda-core/src/model/metric.rs
@@ -3,6 +3,8 @@
 //! Format-agnostic — encoding to Prometheus, Influx, or JSON is the encoder's concern.
 
 use std::collections::BTreeMap;
+use std::fmt;
+use std::ops::Deref;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -40,6 +42,63 @@ pub(crate) fn is_valid_metric_name(s: &str) -> bool {
     }
     // Remaining characters: letter, digit, underscore, or colon
     chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == ':')
+}
+
+/// A metric name that has been validated at construction time.
+///
+/// Wraps an `Arc<str>` containing a name that matches `[a-zA-Z_:][a-zA-Z0-9_:]*`.
+/// Once constructed, the name is guaranteed valid — no further validation is
+/// needed. This makes [`MetricEvent::from_parts`] safe by construction: the type
+/// system enforces the invariant instead of a doc-level safety contract.
+///
+/// Cloning is O(1) — just a reference-count bump on the inner `Arc<str>`.
+///
+/// Dereferences to `&str` for seamless use in encoders and formatting.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ValidatedMetricName(Arc<str>);
+
+impl ValidatedMetricName {
+    /// Validate and construct a `ValidatedMetricName`.
+    ///
+    /// Returns [`SondaError::Config`] if the name does not match
+    /// `[a-zA-Z_:][a-zA-Z0-9_:]*` or is empty.
+    pub fn new(name: &str) -> Result<Self, SondaError> {
+        if !is_valid_metric_name(name) {
+            return Err(SondaError::Config(format!(
+                "invalid metric name {:?}: must match [a-zA-Z_:][a-zA-Z0-9_:]*",
+                name
+            )));
+        }
+        Ok(Self(Arc::from(name)))
+    }
+
+    /// Returns the underlying `Arc<str>` for pointer-equality checks.
+    ///
+    /// This is useful in tests that verify Arc sharing semantics (e.g.,
+    /// confirming that multiple events share the same name allocation).
+    pub fn arc(&self) -> &Arc<str> {
+        &self.0
+    }
+}
+
+impl Deref for ValidatedMetricName {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for ValidatedMetricName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ValidatedMetricName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
 }
 
 /// An ordered, deduplicated set of string label key-value pairs.
@@ -111,17 +170,18 @@ impl Labels {
 /// A single timestamped metric sample.
 ///
 /// Carries a metric name, `f64` value, a set of string label pairs, and a timestamp.
-/// The metric name is validated at construction time.
+/// The metric name is validated at construction time via [`ValidatedMetricName`].
 ///
-/// The `name` field uses `Arc<str>` and the `labels` field uses `Arc<Labels>` so that
-/// cloning a `MetricEvent` is O(1) — just reference-count bumps — rather than
-/// deep-copying the name string and the full label `BTreeMap`. This matters in the
-/// metric runner hot path where the name and labels are invariant across ticks and
-/// would otherwise be deep-cloned on every event.
+/// The `name` field uses [`ValidatedMetricName`] (which wraps `Arc<str>`) and the
+/// `labels` field uses `Arc<Labels>` so that cloning a `MetricEvent` is O(1) — just
+/// reference-count bumps — rather than deep-copying the name string and the full
+/// label `BTreeMap`. This matters in the metric runner hot path where the name and
+/// labels are invariant across ticks.
 #[derive(Debug, Clone)]
 pub struct MetricEvent {
-    /// The metric name (reference-counted for O(1) cloning in the hot path).
-    pub name: Arc<str>,
+    /// The metric name, validated at construction and reference-counted for O(1)
+    /// cloning in the hot path.
+    pub name: ValidatedMetricName,
     /// The numeric value of this sample.
     pub value: f64,
     /// The label set associated with this sample (reference-counted for O(1)
@@ -137,18 +197,14 @@ impl MetricEvent {
     /// Validates that `name` matches `[a-zA-Z_:][a-zA-Z0-9_:]*`. Returns
     /// [`SondaError::Config`] if the name is invalid.
     ///
-    /// The `name` is stored as `Arc<str>` and `labels` as `Arc<Labels>` for O(1)
-    /// cloning. To avoid per-event validation and allocation in hot loops, prefer
-    /// [`MetricEvent::from_parts`] with a pre-validated `Arc<str>` and `Arc<Labels>`.
+    /// The `name` is stored as a [`ValidatedMetricName`] (wrapping `Arc<str>`) and
+    /// `labels` as `Arc<Labels>` for O(1) cloning. To avoid per-event validation
+    /// and allocation in hot loops, prefer [`MetricEvent::from_parts`] with a
+    /// pre-validated [`ValidatedMetricName`] and `Arc<Labels>`.
     pub fn new(name: String, value: f64, labels: Labels) -> Result<Self, SondaError> {
-        if !is_valid_metric_name(&name) {
-            return Err(SondaError::Config(format!(
-                "invalid metric name {:?}: must match [a-zA-Z_:][a-zA-Z0-9_:]*",
-                name
-            )));
-        }
+        let validated = ValidatedMetricName::new(&name)?;
         Ok(Self {
-            name: Arc::from(name.as_str()),
+            name: validated,
             value,
             labels: Arc::new(labels),
             timestamp: SystemTime::now(),
@@ -160,23 +216,19 @@ impl MetricEvent {
     /// Useful for deterministic testing and replay scenarios. Validates the metric
     /// name with the same rules as [`MetricEvent::new`].
     ///
-    /// The `name` is stored as `Arc<str>` and `labels` as `Arc<Labels>` for O(1)
-    /// cloning. To avoid per-event validation and allocation in hot loops, prefer
-    /// [`MetricEvent::from_parts`] with a pre-validated `Arc<str>` and `Arc<Labels>`.
+    /// The `name` is stored as a [`ValidatedMetricName`] (wrapping `Arc<str>`) and
+    /// `labels` as `Arc<Labels>` for O(1) cloning. To avoid per-event validation
+    /// and allocation in hot loops, prefer [`MetricEvent::from_parts`] with a
+    /// pre-validated [`ValidatedMetricName`] and `Arc<Labels>`.
     pub fn with_timestamp(
         name: String,
         value: f64,
         labels: Labels,
         timestamp: SystemTime,
     ) -> Result<Self, SondaError> {
-        if !is_valid_metric_name(&name) {
-            return Err(SondaError::Config(format!(
-                "invalid metric name {:?}: must match [a-zA-Z_:][a-zA-Z0-9_:]*",
-                name
-            )));
-        }
+        let validated = ValidatedMetricName::new(&name)?;
         Ok(Self {
-            name: Arc::from(name.as_str()),
+            name: validated,
             value,
             labels: Arc::new(labels),
             timestamp,
@@ -186,16 +238,14 @@ impl MetricEvent {
     /// Construct a `MetricEvent` from pre-validated, pre-shared parts.
     ///
     /// This is the hot-path constructor used by the metric runner. The caller
-    /// provides a pre-validated `Arc<str>` name and a pre-built `Arc<Labels>`,
+    /// provides a [`ValidatedMetricName`] and a pre-built `Arc<Labels>`,
     /// avoiding both name validation and heap allocation on every tick.
     ///
-    /// # Safety contract (logical, not `unsafe`)
-    ///
-    /// The caller must ensure `name` is a valid Prometheus metric name. No
-    /// validation is performed. Passing an invalid name will produce events
-    /// that encoders may reject or encode incorrectly.
+    /// Because `name` is a [`ValidatedMetricName`], the caller cannot pass an
+    /// invalid metric name — the type system enforces the invariant at compile
+    /// time.
     pub fn from_parts(
-        name: Arc<str>,
+        name: ValidatedMetricName,
         value: f64,
         labels: Arc<Labels>,
         timestamp: SystemTime,
@@ -525,14 +575,120 @@ mod tests {
         assert_send_sync::<MetricEvent>();
     }
 
+    // --- ValidatedMetricName ---
+
+    #[test]
+    fn validated_name_accepts_simple_name() {
+        let name = ValidatedMetricName::new("up").unwrap();
+        assert_eq!(&*name, "up");
+    }
+
+    #[test]
+    fn validated_name_accepts_underscored_name() {
+        let name = ValidatedMetricName::new("http_requests_total").unwrap();
+        assert_eq!(&*name, "http_requests_total");
+    }
+
+    #[test]
+    fn validated_name_accepts_colon_prefix() {
+        let name = ValidatedMetricName::new(":colon_first").unwrap();
+        assert_eq!(&*name, ":colon_first");
+    }
+
+    #[test]
+    fn validated_name_accepts_name_with_colons() {
+        let name = ValidatedMetricName::new("my:metric:name").unwrap();
+        assert_eq!(&*name, "my:metric:name");
+    }
+
+    #[test]
+    fn validated_name_rejects_digit_leading() {
+        let err = ValidatedMetricName::new("123bad").unwrap_err();
+        assert!(
+            matches!(err, SondaError::Config(ref msg) if msg.contains("123bad")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validated_name_rejects_empty_string() {
+        let err = ValidatedMetricName::new("").unwrap_err();
+        assert!(
+            matches!(err, SondaError::Config(_)),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validated_name_rejects_dash_in_name() {
+        let err = ValidatedMetricName::new("has-dash").unwrap_err();
+        assert!(
+            matches!(err, SondaError::Config(ref msg) if msg.contains("has-dash")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validated_name_deref_returns_str() {
+        let name = ValidatedMetricName::new("test_metric").unwrap();
+        let s: &str = &name;
+        assert_eq!(s, "test_metric");
+    }
+
+    #[test]
+    fn validated_name_as_ref_returns_str() {
+        let name = ValidatedMetricName::new("test_metric").unwrap();
+        let s: &str = name.as_ref();
+        assert_eq!(s, "test_metric");
+    }
+
+    #[test]
+    fn validated_name_display_shows_name() {
+        let name = ValidatedMetricName::new("cpu_usage").unwrap();
+        assert_eq!(format!("{name}"), "cpu_usage");
+    }
+
+    #[test]
+    fn validated_name_clone_shares_arc_allocation() {
+        let name = ValidatedMetricName::new("shared").unwrap();
+        let cloned = name.clone();
+        assert!(Arc::ptr_eq(name.arc(), cloned.arc()));
+    }
+
+    #[test]
+    fn validated_name_eq_compares_by_value() {
+        let name1 = ValidatedMetricName::new("up").unwrap();
+        let name2 = ValidatedMetricName::new("up").unwrap();
+        assert_eq!(name1, name2);
+    }
+
+    #[test]
+    fn validated_name_ne_for_different_values() {
+        let name1 = ValidatedMetricName::new("up").unwrap();
+        let name2 = ValidatedMetricName::new("down").unwrap();
+        assert_ne!(name1, name2);
+    }
+
+    #[test]
+    fn validated_name_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ValidatedMetricName>();
+    }
+
+    #[test]
+    fn validated_name_as_bytes_works_via_deref() {
+        let name = ValidatedMetricName::new("metric").unwrap();
+        assert_eq!(name.as_bytes(), b"metric");
+    }
+
     // --- MetricEvent::from_parts ---
 
     #[test]
     fn from_parts_constructs_event_with_given_fields() {
-        let name: Arc<str> = Arc::from("http_requests_total");
+        let name = ValidatedMetricName::new("http_requests_total").unwrap();
         let labels = Arc::new(Labels::from_pairs(&[("env", "prod")]).unwrap());
         let ts = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
-        let event = MetricEvent::from_parts(Arc::clone(&name), 42.0, Arc::clone(&labels), ts);
+        let event = MetricEvent::from_parts(name.clone(), 42.0, Arc::clone(&labels), ts);
         assert_eq!(&*event.name, "http_requests_total");
         assert_eq!(event.value, 42.0);
         assert_eq!(event.labels.len(), 1);
@@ -540,19 +696,21 @@ mod tests {
     }
 
     #[test]
-    fn from_parts_skips_name_validation() {
-        // Deliberately pass a name that would fail is_valid_metric_name.
-        // from_parts must not reject it — validation is the caller's responsibility.
-        let name: Arc<str> = Arc::from("123-invalid!");
+    fn from_parts_requires_validated_name() {
+        // ValidatedMetricName::new rejects invalid names, so from_parts
+        // cannot be called with an invalid name — the type system prevents it.
+        // This test documents that from_parts accepts ValidatedMetricName,
+        // not a raw string or Arc<str>.
+        let name = ValidatedMetricName::new("valid_metric").unwrap();
         let labels = Arc::new(Labels::default());
         let ts = UNIX_EPOCH;
         let event = MetricEvent::from_parts(name, 0.0, labels, ts);
-        assert_eq!(&*event.name, "123-invalid!");
+        assert_eq!(&*event.name, "valid_metric");
     }
 
     #[test]
     fn from_parts_preserves_exact_timestamp() {
-        let name: Arc<str> = Arc::from("up");
+        let name = ValidatedMetricName::new("up").unwrap();
         let labels = Arc::new(Labels::default());
         let ts = UNIX_EPOCH + Duration::from_millis(1_700_000_000_500);
         let event = MetricEvent::from_parts(name, 1.0, labels, ts);
@@ -563,22 +721,22 @@ mod tests {
 
     #[test]
     fn name_arc_is_shared_across_cloned_events() {
-        let name: Arc<str> = Arc::from("up");
+        let name = ValidatedMetricName::new("up").unwrap();
         let labels = Arc::new(Labels::default());
         let ts = UNIX_EPOCH;
-        let event1 = MetricEvent::from_parts(Arc::clone(&name), 1.0, Arc::clone(&labels), ts);
+        let event1 = MetricEvent::from_parts(name.clone(), 1.0, Arc::clone(&labels), ts);
         let event2 = event1.clone();
 
         // Both events should point to the exact same heap allocation.
-        assert!(Arc::ptr_eq(&event1.name, &event2.name));
+        assert!(Arc::ptr_eq(event1.name.arc(), event2.name.arc()));
     }
 
     #[test]
     fn labels_arc_is_shared_across_cloned_events() {
-        let name: Arc<str> = Arc::from("up");
+        let name = ValidatedMetricName::new("up").unwrap();
         let labels = Arc::new(Labels::from_pairs(&[("host", "srv1")]).unwrap());
         let ts = UNIX_EPOCH;
-        let event1 = MetricEvent::from_parts(Arc::clone(&name), 1.0, Arc::clone(&labels), ts);
+        let event1 = MetricEvent::from_parts(name.clone(), 1.0, Arc::clone(&labels), ts);
         let event2 = event1.clone();
 
         // Both events should share the same Labels allocation.
@@ -587,52 +745,52 @@ mod tests {
 
     #[test]
     fn name_arc_is_shared_between_from_parts_and_source() {
-        let name: Arc<str> = Arc::from("metric_name");
+        let name = ValidatedMetricName::new("metric_name").unwrap();
         let labels = Arc::new(Labels::default());
         let ts = UNIX_EPOCH;
-        let event = MetricEvent::from_parts(Arc::clone(&name), 0.0, Arc::clone(&labels), ts);
+        let event = MetricEvent::from_parts(name.clone(), 0.0, Arc::clone(&labels), ts);
 
-        // The event's name should share the same allocation as the source Arc.
-        assert!(Arc::ptr_eq(&event.name, &name));
+        // The event's name should share the same allocation as the source.
+        assert!(Arc::ptr_eq(event.name.arc(), name.arc()));
     }
 
     #[test]
     fn labels_arc_is_shared_between_from_parts_and_source() {
-        let name: Arc<str> = Arc::from("up");
+        let name = ValidatedMetricName::new("up").unwrap();
         let labels = Arc::new(Labels::from_pairs(&[("a", "1"), ("b", "2")]).unwrap());
         let ts = UNIX_EPOCH;
-        let event = MetricEvent::from_parts(Arc::clone(&name), 0.0, Arc::clone(&labels), ts);
+        let event = MetricEvent::from_parts(name, 0.0, Arc::clone(&labels), ts);
 
         // The event's labels should share the same allocation as the source Arc.
         assert!(Arc::ptr_eq(&event.labels, &labels));
     }
 
     #[test]
-    fn multiple_events_from_same_arcs_share_name_allocation() {
-        let name: Arc<str> = Arc::from("shared_metric");
+    fn multiple_events_from_same_validated_name_share_allocation() {
+        let name = ValidatedMetricName::new("shared_metric").unwrap();
         let labels = Arc::new(Labels::default());
         let ts = UNIX_EPOCH;
 
-        let event1 = MetricEvent::from_parts(Arc::clone(&name), 1.0, Arc::clone(&labels), ts);
-        let event2 = MetricEvent::from_parts(Arc::clone(&name), 2.0, Arc::clone(&labels), ts);
-        let event3 = MetricEvent::from_parts(Arc::clone(&name), 3.0, Arc::clone(&labels), ts);
+        let event1 = MetricEvent::from_parts(name.clone(), 1.0, Arc::clone(&labels), ts);
+        let event2 = MetricEvent::from_parts(name.clone(), 2.0, Arc::clone(&labels), ts);
+        let event3 = MetricEvent::from_parts(name.clone(), 3.0, Arc::clone(&labels), ts);
 
         // All three events share the same name and labels allocations.
-        assert!(Arc::ptr_eq(&event1.name, &event2.name));
-        assert!(Arc::ptr_eq(&event2.name, &event3.name));
+        assert!(Arc::ptr_eq(event1.name.arc(), event2.name.arc()));
+        assert!(Arc::ptr_eq(event2.name.arc(), event3.name.arc()));
         assert!(Arc::ptr_eq(&event1.labels, &event2.labels));
         assert!(Arc::ptr_eq(&event2.labels, &event3.labels));
     }
 
-    // --- Backward compatibility: new() and with_timestamp() wrap in Arc ---
+    // --- Backward compatibility: new() and with_timestamp() wrap in ValidatedMetricName ---
 
     #[test]
-    fn new_wraps_name_in_arc() {
+    fn new_wraps_name_in_validated_metric_name() {
         let labels = Labels::from_pairs(&[]).unwrap();
         let event = MetricEvent::new("up".to_string(), 1.0, labels).unwrap();
-        // The name field should be an Arc<str>, verifiable by cloning cheaply.
+        // The name field should be a ValidatedMetricName, verifiable by cloning cheaply.
         let cloned = event.clone();
-        assert!(Arc::ptr_eq(&event.name, &cloned.name));
+        assert!(Arc::ptr_eq(event.name.arc(), cloned.name.arc()));
     }
 
     #[test]
@@ -644,12 +802,12 @@ mod tests {
     }
 
     #[test]
-    fn with_timestamp_wraps_name_in_arc() {
+    fn with_timestamp_wraps_name_in_validated_metric_name() {
         let labels = Labels::from_pairs(&[]).unwrap();
         let ts = UNIX_EPOCH + Duration::from_secs(1);
         let event = MetricEvent::with_timestamp("up".to_string(), 1.0, labels, ts).unwrap();
         let cloned = event.clone();
-        assert!(Arc::ptr_eq(&event.name, &cloned.name));
+        assert!(Arc::ptr_eq(event.name.arc(), cloned.name.arc()));
     }
 
     #[test]

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -13,7 +13,7 @@ use crate::config::validate::parse_duration;
 use crate::config::ScenarioConfig;
 use crate::encoder::create_encoder;
 use crate::generator::create_generator;
-use crate::model::metric::{Labels, MetricEvent};
+use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
 use crate::schedule::stats::ScenarioStats;
 use crate::schedule::{
     is_in_burst, is_in_gap, is_in_spike, time_until_gap_end, BurstWindow, CardinalitySpikeWindow,
@@ -152,16 +152,9 @@ pub fn run_with_sink(
     };
 
     // Validate and intern the metric name once before the hot loop.
-    // Arc<str> makes per-tick cloning O(1) — just a reference-count bump.
-    let name: Arc<str> = {
-        if !crate::model::metric::is_valid_metric_name(&config.name) {
-            return Err(SondaError::Config(format!(
-                "invalid metric name {:?}: must match [a-zA-Z_:][a-zA-Z0-9_:]*",
-                config.name
-            )));
-        }
-        Arc::from(config.name.as_str())
-    };
+    // ValidatedMetricName wraps Arc<str> — cloning is O(1), just a refcount bump.
+    // The type system guarantees the name is valid for all subsequent uses.
+    let name = ValidatedMetricName::new(&config.name)?;
 
     // The base inter-event interval (at normal rate, no burst).
     let base_interval = Duration::from_secs_f64(1.0 / config.rate);
@@ -298,7 +291,7 @@ pub fn run_with_sink(
             // tick_labels: already an Arc<Labels> from above.
             // No metric name validation occurs here — it was validated once
             // before the loop.
-            let event = MetricEvent::from_parts(Arc::clone(&name), value, tick_labels, wall_now);
+            let event = MetricEvent::from_parts(name.clone(), value, tick_labels, wall_now);
 
             // Encode and write.
             buf.clear();
@@ -1022,10 +1015,10 @@ mod tests {
         );
 
         // All events should share the same Arc<str> allocation for the name.
-        let first_name = &events[0].name;
+        let first_name = events[0].name.arc();
         for (i, event) in events.iter().enumerate().skip(1) {
             assert!(
-                Arc::ptr_eq(first_name, &event.name),
+                Arc::ptr_eq(first_name, event.name.arc()),
                 "event[{i}].name should share Arc allocation with event[0].name"
             );
         }


### PR DESCRIPTION
## Summary

- Introduced `ValidatedMetricName` newtype wrapping `Arc<str>` — validates metric name regex once at construction, compiler enforces the invariant thereafter
- `MetricEvent::from_parts()` now requires `ValidatedMetricName` instead of raw `Arc<str>` — impossible to pass an unvalidated name
- `Deref<Target = str>` makes the type transparent to all encoders — zero changes needed in encoder code
- Eliminates duplicated validation logic that previously existed in three places
- Re-exported from `sonda-core` for library consumers

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 1,242 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] 16 new tests for `ValidatedMetricName` (validation, deref, display, clone sharing, send+sync)
- [x] CLI validated with valid names, invalid names (digit-leading, dash, empty), colons
- [x] All encoders produce correct output (Prometheus, Influx, JSON, remote-write)
- [x] Reviewer: PASS
- [x] UAT: PASS