### PR TITLE
perf: zero-allocation timestamp formatting in JSON and syslog encoders (9B.3)

### DIFF
--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -107,6 +107,10 @@ JSON encoders pre-round the value before passing it to serde. Precision is valid
   constructs a `ValidatedMetricName` once before the loop and uses `MetricEvent::from_parts` (no
   per-tick validation) with `name.clone()` (no per-tick heap allocation). Only when a cardinality
   spike is active does the runner deep-clone the inner Labels to insert the spike key.
+- **Zero-alloc timestamp formatting.** `format_rfc3339_millis_array` writes the RFC 3339 timestamp
+  into a stack-allocated `[u8; 24]` — no heap allocation. JSON and syslog encoders use this to
+  borrow a `&str` without going through `String`. The `format_rfc3339_millis(ts, buf)` variant
+  appends directly into the caller's `Vec<u8>` buffer.
 - **Pre-build label strings.** Labels don't change between events for a given scenario. Build the
   serialized label prefix once at construction time.
 - **Use `BufWriter`.** Never write individual lines to stdout or files without buffering.

--- a/sonda-core/src/encoder/json.rs
+++ b/sonda-core/src/encoder/json.rs
@@ -62,21 +62,23 @@ impl Default for JsonLines {
 /// Intermediate serde-serializable representation of a metric event.
 ///
 /// Uses `BTreeMap` for labels so the JSON field order is consistent and deterministic.
+/// The `timestamp` field borrows from a stack-allocated byte array to avoid heap allocation.
 #[derive(Serialize)]
 struct JsonMetric<'a> {
     name: &'a str,
     value: f64,
     labels: BTreeMap<&'a str, &'a str>,
-    timestamp: String,
+    timestamp: &'a str,
 }
 
 /// Intermediate serde-serializable representation of a log event.
 ///
 /// Field order matches the spec: timestamp, severity, message, labels, fields.
 /// Uses `BTreeMap` for labels and fields so the JSON field order is consistent and deterministic.
+/// The `timestamp` field borrows from a stack-allocated byte array to avoid heap allocation.
 #[derive(Serialize)]
 struct JsonLog<'a> {
-    timestamp: String,
+    timestamp: &'a str,
     severity: &'a str,
     message: &'a str,
     labels: BTreeMap<&'a str, &'a str>,
@@ -89,7 +91,10 @@ impl Encoder for JsonLines {
     /// Uses `serde_json::to_writer` to write directly into the caller-provided buffer,
     /// avoiding an intermediate `String` allocation.
     fn encode_metric(&self, event: &MetricEvent, buf: &mut Vec<u8>) -> Result<(), SondaError> {
-        let timestamp = super::format_rfc3339_millis(event.timestamp)?;
+        let ts_bytes = super::format_rfc3339_millis_array(event.timestamp)?;
+        // Safety: the array contains only ASCII digits, hyphens, colons, 'T', '.', 'Z'.
+        let timestamp =
+            std::str::from_utf8(&ts_bytes).expect("RFC 3339 timestamp is always valid UTF-8");
 
         let labels: BTreeMap<&str, &str> = event
             .labels
@@ -126,7 +131,9 @@ impl Encoder for JsonLines {
     ///
     /// Uses `serde_json::to_writer` to write directly into the caller-provided buffer.
     fn encode_log(&self, event: &LogEvent, buf: &mut Vec<u8>) -> Result<(), SondaError> {
-        let timestamp = super::format_rfc3339_millis(event.timestamp)?;
+        let ts_bytes = super::format_rfc3339_millis_array(event.timestamp)?;
+        let timestamp =
+            std::str::from_utf8(&ts_bytes).expect("RFC 3339 timestamp is always valid UTF-8");
 
         // Serialize severity to its lowercase string representation using serde.
         let severity_str = match event.severity {
@@ -509,24 +516,35 @@ mod tests {
 
     // --- format_rfc3339_millis direct tests ---
 
+    /// Helper: format a timestamp via the buffer-based API and return as String.
+    fn fmt_ts(ts: std::time::SystemTime) -> String {
+        let mut buf = Vec::new();
+        super::super::format_rfc3339_millis(ts, &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    /// Helper: format a timestamp via the array-based API and return as String.
+    fn fmt_ts_array(ts: std::time::SystemTime) -> String {
+        let arr = super::super::format_rfc3339_millis_array(ts).unwrap();
+        std::str::from_utf8(&arr).unwrap().to_string()
+    }
+
     #[test]
     fn format_rfc3339_millis_epoch_returns_correct_string() {
-        let result = super::super::format_rfc3339_millis(UNIX_EPOCH).unwrap();
-        assert_eq!(result, "1970-01-01T00:00:00.000Z");
+        assert_eq!(fmt_ts(UNIX_EPOCH), "1970-01-01T00:00:00.000Z");
     }
 
     #[test]
     fn format_rfc3339_millis_known_timestamp_2026_03_20_returns_correct_string() {
         // 2026-03-20T12:00:00.000Z = 1774008000 Unix seconds
         let ts = UNIX_EPOCH + Duration::from_millis(1_774_008_000_000);
-        let result = super::super::format_rfc3339_millis(ts).unwrap();
-        assert_eq!(result, "2026-03-20T12:00:00.000Z");
+        assert_eq!(fmt_ts(ts), "2026-03-20T12:00:00.000Z");
     }
 
     #[test]
     fn format_rfc3339_millis_preserves_milliseconds() {
         let ts = UNIX_EPOCH + Duration::from_millis(1_700_000_000_456);
-        let result = super::super::format_rfc3339_millis(ts).unwrap();
+        let result = fmt_ts(ts);
         assert!(
             result.ends_with(".456Z"),
             "must end with .456Z but got: {result}"
@@ -537,15 +555,13 @@ mod tests {
     fn format_rfc3339_millis_midnight_boundary() {
         // End of day: 23:59:59.999
         let ts = UNIX_EPOCH + Duration::from_millis(86_399_999);
-        let result = super::super::format_rfc3339_millis(ts).unwrap();
-        assert_eq!(result, "1970-01-01T23:59:59.999Z");
+        assert_eq!(fmt_ts(ts), "1970-01-01T23:59:59.999Z");
     }
 
     #[test]
     fn format_rfc3339_millis_start_of_day_plus_one_second() {
         let ts = UNIX_EPOCH + Duration::from_secs(86400); // 1970-01-02T00:00:00.000Z
-        let result = super::super::format_rfc3339_millis(ts).unwrap();
-        assert_eq!(result, "1970-01-02T00:00:00.000Z");
+        assert_eq!(fmt_ts(ts), "1970-01-02T00:00:00.000Z");
     }
 
     #[test]
@@ -554,16 +570,42 @@ mod tests {
         // Days from epoch to 2024-02-29: calculate via known timestamp
         // 2024-02-29T00:00:00Z = 1709164800 seconds
         let ts = UNIX_EPOCH + Duration::from_secs(1_709_164_800);
-        let result = super::super::format_rfc3339_millis(ts).unwrap();
-        assert_eq!(result, "2024-02-29T00:00:00.000Z");
+        assert_eq!(fmt_ts(ts), "2024-02-29T00:00:00.000Z");
     }
 
     #[test]
     fn format_rfc3339_millis_end_of_year_dec_31() {
         // 2023-12-31T23:59:59.999Z = 1704067199.999
         let ts = UNIX_EPOCH + Duration::from_millis(1_704_067_199_999);
-        let result = super::super::format_rfc3339_millis(ts).unwrap();
-        assert_eq!(result, "2023-12-31T23:59:59.999Z");
+        assert_eq!(fmt_ts(ts), "2023-12-31T23:59:59.999Z");
+    }
+
+    #[test]
+    fn format_rfc3339_millis_array_matches_buffer_output() {
+        // Both APIs must produce identical bytes for the same timestamp.
+        let ts = UNIX_EPOCH + Duration::from_millis(1_774_008_000_456);
+        assert_eq!(fmt_ts(ts), fmt_ts_array(ts));
+    }
+
+    #[test]
+    fn format_rfc3339_millis_array_is_valid_utf8() {
+        let ts = UNIX_EPOCH + Duration::from_millis(1_700_000_000_000);
+        let arr = super::super::format_rfc3339_millis_array(ts).unwrap();
+        assert!(
+            std::str::from_utf8(&arr).is_ok(),
+            "array output must be valid UTF-8"
+        );
+    }
+
+    #[test]
+    fn format_rfc3339_millis_array_length_is_24() {
+        let ts = UNIX_EPOCH + Duration::from_millis(1_774_008_000_000);
+        let arr = super::super::format_rfc3339_millis_array(ts).unwrap();
+        assert_eq!(
+            arr.len(),
+            24,
+            "RFC 3339 millis timestamp must be exactly 24 bytes"
+        );
     }
 
     // =========================================================================

--- a/sonda-core/src/encoder/mod.rs
+++ b/sonda-core/src/encoder/mod.rs
@@ -134,16 +134,40 @@ pub(crate) fn write_value(buf: &mut Vec<u8>, value: f64, precision: Option<u8>) 
     .expect("write to Vec<u8> is infallible");
 }
 
-/// Format a [`std::time::SystemTime`] as an RFC 3339 string with millisecond precision.
+/// Fixed byte length of an RFC 3339 timestamp with millisecond precision.
 ///
-/// Produces strings of the form `2026-03-20T12:00:00.000Z`. Computed entirely from
-/// `UNIX_EPOCH` arithmetic using the Gregorian calendar algorithm from
-/// <https://howardhinnant.github.io/date_algorithms.html> — no external crate required.
+/// Format: `YYYY-MM-DDTHH:MM:SS.mmmZ` — always exactly 24 bytes.
+pub(crate) const RFC3339_MILLIS_LEN: usize = 24;
+
+/// Format a [`std::time::SystemTime`] as RFC 3339 with millisecond precision,
+/// writing directly into the caller-provided buffer.
+///
+/// Appends exactly 24 bytes of the form `2026-03-20T12:00:00.000Z` to `buf`.
+/// Computed entirely from `UNIX_EPOCH` arithmetic using the Gregorian calendar
+/// algorithm from <https://howardhinnant.github.io/date_algorithms.html> — no
+/// external crate required.
 ///
 /// Returns a [`crate::SondaError::Encoder`] if the timestamp predates the Unix epoch.
 pub(crate) fn format_rfc3339_millis(
     ts: std::time::SystemTime,
-) -> Result<String, crate::SondaError> {
+    buf: &mut Vec<u8>,
+) -> Result<(), crate::SondaError> {
+    let arr = format_rfc3339_millis_array(ts)?;
+    buf.extend_from_slice(&arr);
+    Ok(())
+}
+
+/// Format a [`std::time::SystemTime`] as RFC 3339 with millisecond precision
+/// into a stack-allocated byte array.
+///
+/// Returns a fixed-size `[u8; 24]` containing valid UTF-8 of the form
+/// `2026-03-20T12:00:00.000Z`. This avoids heap allocation entirely and is
+/// suitable for callers that need a `&str` (e.g., serde serialization structs).
+///
+/// Returns a [`crate::SondaError::Encoder`] if the timestamp predates the Unix epoch.
+pub(crate) fn format_rfc3339_millis_array(
+    ts: std::time::SystemTime,
+) -> Result<[u8; RFC3339_MILLIS_LEN], crate::SondaError> {
     use std::time::UNIX_EPOCH;
 
     let duration = ts
@@ -173,9 +197,17 @@ pub(crate) fn format_rfc3339_millis(
     let month = if mp < 10 { mp + 3 } else { mp - 9 };
     let year = if month <= 2 { y + 1 } else { y };
 
-    Ok(format!(
+    let mut arr = [0u8; RFC3339_MILLIS_LEN];
+    // write! into a &mut [u8] slice via std::io::Write.
+    // The formatted output is always exactly 24 bytes, so this cannot fail.
+    use std::io::Write as _;
+    let mut cursor = &mut arr[..];
+    write!(
+        cursor,
         "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z",
-    ))
+    )
+    .expect("RFC 3339 millis timestamp is always exactly 24 bytes");
+    Ok(arr)
 }
 
 #[cfg(test)]
@@ -615,5 +647,117 @@ sink:
             config,
             EncoderConfig::JsonLines { precision: None }
         ));
+    }
+
+    // ---------------------------------------------------------------------------
+    // format_rfc3339_millis: buffer-based API
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn format_rfc3339_millis_writes_to_buffer() {
+        use std::time::{Duration, UNIX_EPOCH};
+        let ts = UNIX_EPOCH + Duration::from_millis(1_774_008_000_000);
+        let mut buf = Vec::new();
+        format_rfc3339_millis(ts, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "2026-03-20T12:00:00.000Z");
+    }
+
+    #[test]
+    fn format_rfc3339_millis_appends_to_existing_buffer() {
+        use std::time::{Duration, UNIX_EPOCH};
+        let ts = UNIX_EPOCH + Duration::from_millis(1_774_008_000_000);
+        let mut buf = b"prefix:".to_vec();
+        format_rfc3339_millis(ts, &mut buf).unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "prefix:2026-03-20T12:00:00.000Z"
+        );
+    }
+
+    #[test]
+    fn format_rfc3339_millis_epoch_writes_correct_bytes() {
+        use std::time::UNIX_EPOCH;
+        let mut buf = Vec::new();
+        format_rfc3339_millis(UNIX_EPOCH, &mut buf).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "1970-01-01T00:00:00.000Z");
+    }
+
+    #[test]
+    fn format_rfc3339_millis_before_epoch_returns_error() {
+        use std::time::{Duration, UNIX_EPOCH};
+        let ts = UNIX_EPOCH - Duration::from_secs(1);
+        let mut buf = Vec::new();
+        let result = format_rfc3339_millis(ts, &mut buf);
+        assert!(result.is_err(), "timestamps before epoch must return error");
+        assert!(
+            buf.is_empty(),
+            "buffer must remain empty on error (nothing written before failure)"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // format_rfc3339_millis_array: stack-allocated API
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn format_rfc3339_millis_array_returns_correct_bytes() {
+        use std::time::{Duration, UNIX_EPOCH};
+        let ts = UNIX_EPOCH + Duration::from_millis(1_774_008_000_000);
+        let arr = format_rfc3339_millis_array(ts).unwrap();
+        assert_eq!(
+            std::str::from_utf8(&arr).unwrap(),
+            "2026-03-20T12:00:00.000Z"
+        );
+    }
+
+    #[test]
+    fn format_rfc3339_millis_array_epoch() {
+        use std::time::UNIX_EPOCH;
+        let arr = format_rfc3339_millis_array(UNIX_EPOCH).unwrap();
+        assert_eq!(
+            std::str::from_utf8(&arr).unwrap(),
+            "1970-01-01T00:00:00.000Z"
+        );
+    }
+
+    #[test]
+    fn format_rfc3339_millis_array_before_epoch_returns_error() {
+        use std::time::{Duration, UNIX_EPOCH};
+        let ts = UNIX_EPOCH - Duration::from_secs(1);
+        let result = format_rfc3339_millis_array(ts);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, crate::SondaError::Encoder(_)),
+            "error must be Encoder variant, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn format_rfc3339_millis_array_preserves_milliseconds() {
+        use std::time::{Duration, UNIX_EPOCH};
+        let ts = UNIX_EPOCH + Duration::from_millis(1_700_000_000_789);
+        let arr = format_rfc3339_millis_array(ts).unwrap();
+        let s = std::str::from_utf8(&arr).unwrap();
+        assert!(s.ends_with(".789Z"), "must end with .789Z but got: {s}");
+    }
+
+    #[test]
+    fn format_rfc3339_millis_array_and_buf_produce_identical_output() {
+        use std::time::{Duration, UNIX_EPOCH};
+        let ts = UNIX_EPOCH + Duration::from_millis(1_700_000_000_123);
+        let arr = format_rfc3339_millis_array(ts).unwrap();
+        let mut buf = Vec::new();
+        format_rfc3339_millis(ts, &mut buf).unwrap();
+        assert_eq!(&arr[..], &buf[..]);
+    }
+
+    #[test]
+    fn rfc3339_millis_len_constant_matches_output_size() {
+        use std::time::{Duration, UNIX_EPOCH};
+        let ts = UNIX_EPOCH + Duration::from_millis(1_774_008_000_000);
+        let mut buf = Vec::new();
+        format_rfc3339_millis(ts, &mut buf).unwrap();
+        assert_eq!(buf.len(), RFC3339_MILLIS_LEN);
     }
 }

--- a/sonda-core/src/encoder/syslog.rs
+++ b/sonda-core/src/encoder/syslog.rs
@@ -122,50 +122,57 @@ impl Encoder for Syslog {
     ///
     /// Priority = (facility * 8) + syslog_severity. Facility 1 (user-level) is used.
     fn encode_log(&self, event: &LogEvent, buf: &mut Vec<u8>) -> Result<(), SondaError> {
+        use std::io::Write;
+
         let syslog_severity = severity_to_syslog(event.severity);
         let priority = FACILITY_USER * 8 + syslog_severity;
-        let timestamp = super::format_rfc3339_millis(event.timestamp)?;
 
-        // Build structured data section: nil when no labels, [sonda k="v" ...]
-        // when labels are present.
-        let sd = if event.labels.is_empty() {
-            NILVALUE.to_string()
-        } else {
-            let mut sd_buf = String::from("[sonda");
-            for (k, v) in event.labels.iter() {
-                sd_buf.push(' ');
-                sd_buf.push_str(k);
-                sd_buf.push_str("=\"");
-                // Escape \, ], " per RFC 5424 §6.3.3
-                for ch in v.chars() {
-                    match ch {
-                        '\\' => sd_buf.push_str("\\\\"),
-                        ']' => sd_buf.push_str("\\]"),
-                        '"' => sd_buf.push_str("\\\""),
-                        _ => sd_buf.push(ch),
-                    }
-                }
-                sd_buf.push('"');
-            }
-            sd_buf.push(']');
-            sd_buf
-        };
+        // Write the priority, version, and space before timestamp.
+        write!(buf, "<{priority}>{version} ", version = SYSLOG_VERSION)
+            .expect("write to Vec<u8> is infallible");
 
-        use std::io::Write;
-        writeln!(
+        // Write the RFC 3339 timestamp directly into the output buffer (zero-alloc).
+        super::format_rfc3339_millis(event.timestamp, buf)?;
+
+        // Write the rest of the header fields.
+        write!(
             buf,
-            "<{priority}>{version} {timestamp} {hostname} {app_name} {procid} {msgid} {sd} {message}",
-            priority = priority,
-            version = SYSLOG_VERSION,
-            timestamp = timestamp,
+            " {hostname} {app_name} {procid} {msgid} ",
             hostname = self.hostname,
             app_name = self.app_name,
             procid = NILVALUE,
             msgid = NILVALUE,
-            sd = sd,
-            message = event.message,
         )
-        .map_err(|e| SondaError::Encoder(format!("syslog format error: {e}")))?;
+        .expect("write to Vec<u8> is infallible");
+
+        // Write structured data section: nil when no labels, [sonda k="v" ...]
+        // when labels are present.
+        if event.labels.is_empty() {
+            buf.extend_from_slice(NILVALUE.as_bytes());
+        } else {
+            buf.extend_from_slice(b"[sonda");
+            for (k, v) in event.labels.iter() {
+                buf.push(b' ');
+                buf.extend_from_slice(k.as_bytes());
+                buf.extend_from_slice(b"=\"");
+                // Escape \, ], " per RFC 5424 §6.3.3
+                for ch in v.bytes() {
+                    match ch {
+                        b'\\' => buf.extend_from_slice(b"\\\\"),
+                        b']' => buf.extend_from_slice(b"\\]"),
+                        b'"' => buf.extend_from_slice(b"\\\""),
+                        _ => buf.push(ch),
+                    }
+                }
+                buf.push(b'"');
+            }
+            buf.push(b']');
+        }
+
+        // Write message and trailing newline.
+        buf.push(b' ');
+        buf.extend_from_slice(event.message.as_bytes());
+        buf.push(b'\n');
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Replaced `format_rfc3339_millis` returning `String` with two zero-alloc variants:
  - `format_rfc3339_millis(ts, buf)` — writes directly into caller's `&mut Vec<u8>` (syslog encoder)
  - `format_rfc3339_millis_array(ts)` — returns stack-allocated `[u8; 24]` (JSON encoder)
- JSON encoder's `JsonMetric`/`JsonLog` timestamp field changed from `String` to `&str` (borrows from stack array)
- Syslog encoder restructured to write all output directly into buffer — no intermediate String allocations
- Added `RFC3339_MILLIS_LEN` constant and 13 new tests

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 1,240 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] JSON and syslog output validated at 100K events/sec — correct timestamps
- [x] Edge cases tested: epoch, pre-epoch error, leap year, midnight, Dec 31
- [x] Cross-API consistency test: buffer and array variants produce identical bytes
- [x] Reviewer: PASS
- [x] UAT: PASS