### PR TITLE
feat: feature-gate serde_yaml behind config Cargo feature (9C.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,14 +118,16 @@ sonda-core = "0.3"
 Heavy dependencies are gated behind Cargo features so library consumers only pay
 for what they use:
 
-| Feature | Dependencies | Sinks enabled |
-|---------|-------------|---------------|
-| `http` | `ureq` (rustls) | HTTP push, Loki |
-| `remote-write` | `prost`, `snap`, `ureq` | Prometheus remote write |
-| `kafka` | `rskafka`, `tokio`, `chrono` | Kafka |
+| Feature | Default | Dependencies | What it enables |
+|---------|---------|-------------|-----------------|
+| `config` | yes | `serde_yaml` | `Deserialize` impls on config types for YAML parsing |
+| `http` | no | `ureq` (rustls) | HTTP push and Loki sinks |
+| `remote-write` | no | `prost`, `snap`, `ureq` | Prometheus remote write encoder and sink |
+| `kafka` | no | `rskafka`, `tokio`, `chrono` | Kafka sink |
 
 Generators, encoders, and the stdout/file/TCP/UDP/memory/channel sinks are always
-available with no optional dependencies.
+available with no optional dependencies. Library consumers who build configs in code
+can disable the `config` feature to avoid pulling in `serde_yaml`.
 
 See the [sonda-core docs on docs.rs](https://docs.rs/sonda-core) for API details.
 

--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -56,6 +56,22 @@ src/
     └── validate.rs     ← config validation logic, parse_duration, validate_cardinality_spike_config
 ```
 
+## Cargo Features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `config` | yes | Enables `serde::Deserialize` impls on all config types and pulls in `serde_yaml` for YAML parsing. Disable for library consumers who construct configs in code and do not need YAML/JSON deserialization. |
+| `http` | no | Enables `ureq` and HTTP-based sinks (`HttpPush`, `Loki`). |
+| `kafka` | no | Enables `rskafka` + `tokio` for the Kafka sink. |
+| `remote-write` | no | Enables `prost` + `snap` + `ureq` for the Prometheus remote write encoder and sink. |
+
+When the `config` feature is disabled:
+- All config types (`ScenarioConfig`, `EncoderConfig`, `SinkConfig`, `GeneratorConfig`, etc.) remain
+  public and constructible in code.
+- `Deserialize` impls and `#[serde(...)]` attributes are conditionally compiled out.
+- `serde_yaml` is not linked. `serde_json` remains available (used by the JSON encoder).
+- Tests that parse YAML are gated behind `#[cfg(feature = "config")]`.
+
 ## How to Add a New Generator
 
 1. Create `src/generator/your_name.rs` with a struct that implements `ValueGenerator`.

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -12,13 +12,15 @@ description = "Core engine for Sonda — synthetic telemetry generation library"
 readme = "../README.md"
 
 [features]
+default = ["config"]
+config = ["dep:serde_yaml"]
 http = ["dep:ureq"]
 kafka = ["dep:rskafka", "dep:tokio", "dep:chrono"]
 remote-write = ["dep:prost", "dep:snap", "dep:ureq"]
 
 [dependencies]
 serde = { workspace = true }
-serde_yaml = { workspace = true }
+serde_yaml = { workspace = true, optional = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 ureq = { workspace = true, optional = true }

--- a/sonda-core/src/config/mod.rs
+++ b/sonda-core/src/config/mod.rs
@@ -1,10 +1,12 @@
-//! Scenario configuration: YAML deserialization and validation.
+//! Scenario configuration types and validation.
+//!
+//! The `Deserialize` impls on all config types are available only when the
+//! `config` Cargo feature is enabled (active by default). Without the feature,
+//! configs can still be constructed in code — only YAML/JSON parsing is gated.
 
 pub mod validate;
 
 use std::collections::HashMap;
-
-use serde::Deserialize;
 
 use crate::encoder::EncoderConfig;
 use crate::generator::{GeneratorConfig, LogGeneratorConfig};
@@ -14,7 +16,8 @@ use crate::sink::SinkConfig;
 ///
 /// During a gap the scheduler emits no events. The gap repeats on a fixed
 /// cycle defined by `every`, and each instance lasts for `for`.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
 pub struct GapConfig {
     /// How often the gap recurs (e.g. `"2m"`).
     pub every: String,
@@ -26,8 +29,9 @@ pub struct GapConfig {
 ///
 /// Determines how the spike window produces distinct values for the injected
 /// label key on each tick.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
+#[cfg_attr(feature = "config", serde(rename_all = "snake_case"))]
 pub enum SpikeStrategy {
     /// Sequential counter: `prefix + (tick % cardinality)`.
     ///
@@ -58,7 +62,8 @@ pub enum SpikeStrategy {
 ///     strategy: counter
 ///     prefix: "pod-"
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
 pub struct CardinalitySpikeConfig {
     /// The label key to inject during the spike window.
     ///
@@ -75,17 +80,17 @@ pub struct CardinalitySpikeConfig {
     /// Strategy for generating unique label values.
     ///
     /// Defaults to `counter` if not specified.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub strategy: SpikeStrategy,
     /// Optional prefix for generated label values.
     ///
     /// Defaults to `"{label}_"` when not specified.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub prefix: Option<String>,
     /// Optional RNG seed for the `random` strategy.
     ///
     /// Ignored for the `counter` strategy.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub seed: Option<u64>,
 }
 
@@ -96,7 +101,8 @@ pub struct CardinalitySpikeConfig {
 ///
 /// If a gap and burst overlap in time, the gap takes priority and no events
 /// are emitted.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
 pub struct BurstConfig {
     /// How often the burst recurs (e.g. `"10s"`).
     pub every: String,
@@ -106,14 +112,17 @@ pub struct BurstConfig {
     pub multiplier: f64,
 }
 
+#[cfg(feature = "config")]
 fn default_encoder() -> EncoderConfig {
     EncoderConfig::PrometheusText { precision: None }
 }
 
+#[cfg(feature = "config")]
 fn default_log_encoder() -> EncoderConfig {
     EncoderConfig::JsonLines { precision: None }
 }
 
+#[cfg(feature = "config")]
 fn default_sink() -> SinkConfig {
     SinkConfig::Stdout
 }
@@ -144,51 +153,52 @@ fn default_sink() -> SinkConfig {
 /// sink:
 ///   type: stdout
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
 pub struct ScenarioConfig {
     /// Metric name emitted by this scenario (must be a valid Prometheus metric name).
     pub name: String,
     /// Target event rate in events per second. Must be strictly positive.
     pub rate: f64,
     /// Optional total run duration (e.g. `"30s"`, `"5m"`). `None` means run indefinitely.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub duration: Option<String>,
     /// Value generator configuration.
     pub generator: GeneratorConfig,
     /// Optional gap window: recurring silent periods in the event stream.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub gaps: Option<GapConfig>,
     /// Optional burst window: recurring high-rate periods in the event stream.
     ///
     /// When both a gap and a burst overlap in time, the gap takes priority.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub bursts: Option<BurstConfig>,
     /// Optional cardinality spikes: recurring windows that inject dynamic
     /// labels to simulate cardinality explosions.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub cardinality_spikes: Option<Vec<CardinalitySpikeConfig>>,
     /// Static labels attached to every emitted event.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub labels: Option<HashMap<String, String>>,
     /// Output encoder. Defaults to `prometheus_text`.
-    #[serde(default = "default_encoder")]
+    #[cfg_attr(feature = "config", serde(default = "default_encoder"))]
     pub encoder: EncoderConfig,
     /// Output sink. Defaults to `stdout`.
-    #[serde(default = "default_sink")]
+    #[cfg_attr(feature = "config", serde(default = "default_sink"))]
     pub sink: SinkConfig,
     /// Delay before starting this scenario, relative to the group start time.
     ///
     /// Only meaningful in multi-scenario mode. Enables temporal correlation
     /// between scenarios: "metric A starts immediately, metric B starts 30s
     /// later". Accepts a duration string (e.g. `"30s"`, `"1m"`, `"500ms"`).
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub phase_offset: Option<String>,
     /// Clock group identifier for multi-scenario correlation.
     ///
     /// Scenarios with the same `clock_group` value share a common start time
     /// reference. For MVP this provides a shared start reference only; advanced
     /// cross-scenario signaling is deferred to a future phase.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub clock_group: Option<String>,
 }
 
@@ -197,14 +207,15 @@ pub struct ScenarioConfig {
 /// The `signal_type` tag selects whether this entry is a metrics or logs scenario.
 /// Deserialized from a YAML multi-scenario file where each element of the
 /// `scenarios` list carries a `signal_type: metrics` or `signal_type: logs` key.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "signal_type")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
+#[cfg_attr(feature = "config", serde(tag = "signal_type"))]
 pub enum ScenarioEntry {
     /// A metrics scenario entry.
-    #[serde(rename = "metrics")]
+    #[cfg_attr(feature = "config", serde(rename = "metrics"))]
     Metrics(ScenarioConfig),
     /// A logs scenario entry.
-    #[serde(rename = "logs")]
+    #[cfg_attr(feature = "config", serde(rename = "logs"))]
     Logs(LogScenarioConfig),
 }
 
@@ -258,7 +269,8 @@ impl ScenarioEntry {
 ///       type: file
 ///       path: /tmp/logs.json
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
 pub struct MultiScenarioConfig {
     /// The list of scenarios to run concurrently.
     pub scenarios: Vec<ScenarioEntry>,
@@ -290,53 +302,54 @@ pub struct MultiScenarioConfig {
 /// sink:
 ///   type: stdout
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
 pub struct LogScenarioConfig {
     /// Scenario name (used for identification and logging).
     pub name: String,
     /// Target event rate in events per second. Must be strictly positive.
     pub rate: f64,
     /// Optional total run duration (e.g. `"30s"`, `"5m"`). `None` means run indefinitely.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub duration: Option<String>,
     /// Log generator configuration.
     pub generator: LogGeneratorConfig,
     /// Optional gap window: recurring silent periods in the event stream.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub gaps: Option<GapConfig>,
     /// Optional burst window: recurring high-rate periods.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub bursts: Option<BurstConfig>,
     /// Optional cardinality spikes: recurring windows that inject dynamic
     /// labels to simulate cardinality explosions.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub cardinality_spikes: Option<Vec<CardinalitySpikeConfig>>,
     /// Static labels attached to every emitted log event.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub labels: Option<HashMap<String, String>>,
     /// Output encoder. Defaults to `json_lines`.
-    #[serde(default = "default_log_encoder")]
+    #[cfg_attr(feature = "config", serde(default = "default_log_encoder"))]
     pub encoder: EncoderConfig,
     /// Output sink. Defaults to `stdout`.
-    #[serde(default = "default_sink")]
+    #[cfg_attr(feature = "config", serde(default = "default_sink"))]
     pub sink: SinkConfig,
     /// Delay before starting this scenario, relative to the group start time.
     ///
     /// Only meaningful in multi-scenario mode. Enables temporal correlation
     /// between scenarios: "metric A starts immediately, metric B starts 30s
     /// later". Accepts a duration string (e.g. `"30s"`, `"1m"`, `"500ms"`).
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub phase_offset: Option<String>,
     /// Clock group identifier for multi-scenario correlation.
     ///
     /// Scenarios with the same `clock_group` value share a common start time
     /// reference. For MVP this provides a shared start reference only; advanced
     /// cross-scenario signaling is deferred to a future phase.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub clock_group: Option<String>,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "config"))]
 mod tests {
     use super::*;
 

--- a/sonda-core/src/config/validate.rs
+++ b/sonda-core/src/config/validate.rs
@@ -653,6 +653,7 @@ mod tests {
 
     // ---- ScenarioConfig YAML deserialization ---------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_minimal_scenario_config() {
         let yaml = r#"
@@ -671,6 +672,7 @@ generator:
         assert!(config.labels.is_none());
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_minimal_config_encoder_defaults_to_prometheus_text() {
         let yaml = r#"
@@ -688,6 +690,7 @@ generator:
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_minimal_config_sink_defaults_to_stdout() {
         let yaml = r#"
@@ -705,6 +708,7 @@ generator:
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_full_scenario_config_from_architecture_example() {
         // This YAML is taken directly from docs/architecture.md Section 6.
@@ -752,6 +756,7 @@ sink:
         assert!(matches!(config.sink, SinkConfig::Stdout));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_config_with_labels() {
         let yaml = r#"
@@ -771,6 +776,7 @@ labels:
         assert_eq!(labels.get("region").map(String::as_str), Some("us-east-1"));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_config_with_gap() {
         let yaml = r#"
@@ -792,6 +798,7 @@ gaps:
 
     // ---- validate_config: full architecture example round-trip ---------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn validate_architecture_example_config_passes() {
         let yaml = r#"
@@ -823,6 +830,7 @@ sink:
 
     // ---- Round-trip: deserialize -> validate -> create factories -------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn round_trip_creates_generator_encoder_sink_successfully() {
         use crate::encoder::create_encoder;
@@ -863,6 +871,7 @@ sink:
         assert!(sink.is_ok(), "sink must be created without error");
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn round_trip_constant_generator_produces_expected_value() {
         use crate::generator::create_generator;
@@ -881,6 +890,7 @@ generator:
         assert_eq!(gen.value(999), 42.0);
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn round_trip_uniform_generator_values_in_range() {
         use crate::generator::create_generator;
@@ -908,6 +918,7 @@ generator:
 
     // ---- ScenarioConfig: Clone and Debug contracts ---------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn scenario_config_is_cloneable() {
         let yaml = r#"
@@ -923,6 +934,7 @@ generator:
         assert_eq!(cloned.rate, config.rate);
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn scenario_config_is_debuggable() {
         let yaml = r#"
@@ -1182,6 +1194,7 @@ generator:
 
     // ---- ScenarioConfig: burst YAML deserialization -------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_config_with_burst() {
         let yaml = r#"
@@ -1203,6 +1216,7 @@ bursts:
         assert_eq!(burst.multiplier, 5.0);
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_config_without_burst_has_none_bursts() {
         let yaml = r#"

--- a/sonda-core/src/encoder/influx.rs
+++ b/sonda-core/src/encoder/influx.rs
@@ -525,6 +525,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_deserialization_influx_lp_no_field_key() {
         let config: EncoderConfig =
@@ -538,6 +539,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_deserialization_influx_lp_with_field_key() {
         let config: EncoderConfig =

--- a/sonda-core/src/encoder/mod.rs
+++ b/sonda-core/src/encoder/mod.rs
@@ -10,8 +10,6 @@ pub mod prometheus;
 pub mod remote_write;
 pub mod syslog;
 
-use serde::Deserialize;
-
 use crate::model::log::LogEvent;
 use crate::model::metric::MetricEvent;
 
@@ -42,28 +40,29 @@ pub trait Encoder: Send + Sync {
 ///
 /// This enum is serde-deserializable from YAML scenario files.
 /// The `type` field selects the variant: `prometheus_text`, `influx_lp`, `json_lines`, or `syslog`.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
+#[cfg_attr(feature = "config", serde(tag = "type"))]
 pub enum EncoderConfig {
     /// Prometheus text exposition format (version 0.0.4).
     ///
     /// `precision` optionally limits the number of decimal places in metric values.
-    #[serde(rename = "prometheus_text")]
+    #[cfg_attr(feature = "config", serde(rename = "prometheus_text"))]
     PrometheusText {
         /// Maximum decimal places for metric values. `None` preserves full `f64` precision.
-        #[serde(default)]
+        #[cfg_attr(feature = "config", serde(default))]
         precision: Option<u8>,
     },
     /// InfluxDB line protocol.
     ///
     /// `field_key` sets the field key used for the metric value. Defaults to `"value"`.
     /// `precision` optionally limits the number of decimal places in metric values.
-    #[serde(rename = "influx_lp")]
+    #[cfg_attr(feature = "config", serde(rename = "influx_lp"))]
     InfluxLineProtocol {
         /// The InfluxDB field key for the metric value. Defaults to `"value"` if absent.
         field_key: Option<String>,
         /// Maximum decimal places for metric values. `None` preserves full `f64` precision.
-        #[serde(default)]
+        #[cfg_attr(feature = "config", serde(default))]
         precision: Option<u8>,
     },
     /// JSON Lines (NDJSON) format.
@@ -72,16 +71,16 @@ pub enum EncoderConfig {
     /// Loki, and generic HTTP ingest endpoints.
     ///
     /// `precision` optionally rounds the metric value before JSON serialization.
-    #[serde(rename = "json_lines")]
+    #[cfg_attr(feature = "config", serde(rename = "json_lines"))]
     JsonLines {
         /// Maximum decimal places for metric values. `None` preserves full `f64` precision.
-        #[serde(default)]
+        #[cfg_attr(feature = "config", serde(default))]
         precision: Option<u8>,
     },
     /// RFC 5424 syslog format.
     ///
     /// Encodes log events as syslog lines. `hostname` and `app_name` default to `"sonda"`.
-    #[serde(rename = "syslog")]
+    #[cfg_attr(feature = "config", serde(rename = "syslog"))]
     Syslog {
         /// The HOSTNAME field in the syslog header. Defaults to `"sonda"`.
         hostname: Option<String>,
@@ -95,7 +94,7 @@ pub enum EncoderConfig {
     /// into a single `WriteRequest`, snappy-compresses, and HTTP POSTs with the
     /// correct protocol headers. Requires the `remote-write` feature flag.
     #[cfg(feature = "remote-write")]
-    #[serde(rename = "remote_write")]
+    #[cfg_attr(feature = "config", serde(rename = "remote_write"))]
     RemoteWrite,
 }
 
@@ -216,8 +215,10 @@ mod tests {
 
     // ---------------------------------------------------------------------------
     // EncoderConfig: internally-tagged deserialization (`type:` field)
+    // These tests require the `config` feature (serde_yaml).
     // ---------------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_prometheus_text_deserializes_with_type_field() {
         let yaml = "type: prometheus_text";
@@ -225,6 +226,7 @@ mod tests {
         assert!(matches!(config, EncoderConfig::PrometheusText { .. }));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_json_lines_deserializes_with_type_field() {
         let yaml = "type: json_lines";
@@ -232,6 +234,7 @@ mod tests {
         assert!(matches!(config, EncoderConfig::JsonLines { .. }));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_influx_lp_without_field_key_deserializes_with_type_field() {
         let yaml = "type: influx_lp";
@@ -245,6 +248,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_influx_lp_with_field_key_deserializes_with_type_field() {
         let yaml = "type: influx_lp\nfield_key: requests";
@@ -255,6 +259,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_unknown_type_returns_error() {
         let yaml = "type: no_such_encoder";
@@ -265,6 +270,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_missing_type_field_returns_error() {
         // Without the `type` field the internally-tagged enum cannot identify the variant.
@@ -276,6 +282,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_old_external_tag_format_is_rejected() {
         // The old externally-tagged format (`!prometheus_text`) must no longer be accepted.
@@ -467,7 +474,7 @@ mod tests {
     // EncoderConfig::RemoteWrite (feature-gated tests)
     // ---------------------------------------------------------------------------
 
-    #[cfg(feature = "remote-write")]
+    #[cfg(all(feature = "remote-write", feature = "config"))]
     #[test]
     fn encoder_config_remote_write_deserializes_from_yaml() {
         let yaml = "type: remote_write";
@@ -521,7 +528,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "remote-write")]
+    #[cfg(all(feature = "remote-write", feature = "config"))]
     #[test]
     fn scenario_yaml_with_remote_write_encoder_deserializes() {
         use crate::config::ScenarioConfig;
@@ -594,8 +601,10 @@ sink:
 
     // ---------------------------------------------------------------------------
     // EncoderConfig deserialization: precision field
+    // These tests require the `config` feature (serde_yaml).
     // ---------------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn prometheus_text_with_precision_deserializes() {
         let yaml = "type: prometheus_text\nprecision: 3";
@@ -606,6 +615,7 @@ sink:
         ));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn prometheus_text_without_precision_defaults_to_none() {
         let yaml = "type: prometheus_text";
@@ -616,6 +626,7 @@ sink:
         ));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn influx_with_precision_and_field_key_deserializes() {
         let yaml = "type: influx_lp\nfield_key: gauge\nprecision: 2";
@@ -629,6 +640,7 @@ sink:
         ));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn json_lines_with_precision_deserializes() {
         let yaml = "type: json_lines\nprecision: 5";
@@ -639,6 +651,7 @@ sink:
         ));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn json_lines_without_precision_defaults_to_none() {
         let yaml = "type: json_lines";

--- a/sonda-core/src/encoder/prometheus.rs
+++ b/sonda-core/src/encoder/prometheus.rs
@@ -422,6 +422,7 @@ mod tests {
         assert_eq!(output, "up 1 1000000\n");
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_deserialization_prometheus_text() {
         use crate::encoder::EncoderConfig;

--- a/sonda-core/src/encoder/syslog.rs
+++ b/sonda-core/src/encoder/syslog.rs
@@ -791,6 +791,7 @@ mod tests {
     // EncoderConfig::Syslog: deserialization and factory wiring
     // -----------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_syslog_deserializes_without_optional_fields() {
         use crate::encoder::{create_encoder, EncoderConfig};
@@ -810,6 +811,7 @@ mod tests {
         let _enc = create_encoder(&config);
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_syslog_deserializes_with_hostname() {
         use crate::encoder::EncoderConfig;
@@ -824,6 +826,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn encoder_config_syslog_deserializes_with_both_hostname_and_app_name() {
         use crate::encoder::EncoderConfig;

--- a/sonda-core/src/generator/csv_replay.rs
+++ b/sonda-core/src/generator/csv_replay.rs
@@ -626,6 +626,7 @@ mod tests {
 
     // ---- Example YAML deserializes and runs -----------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_csv_replay_config_from_yaml() {
         let yaml = "\
@@ -653,6 +654,7 @@ repeat: false
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_csv_replay_config_minimal() {
         let yaml = "type: csv_replay\nfile: data.csv\n";
@@ -674,6 +676,7 @@ repeat: false
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn example_yaml_scenario_file_deserializes() {
         // Validate the example file pattern from examples/csv-replay-metrics.yaml.

--- a/sonda-core/src/generator/mod.rs
+++ b/sonda-core/src/generator/mod.rs
@@ -17,8 +17,6 @@ pub mod uniform;
 
 use std::collections::HashMap;
 
-use serde::Deserialize;
-
 use self::constant::Constant;
 use self::csv_replay::CsvReplayGenerator;
 use self::log_replay::LogReplayGenerator;
@@ -53,17 +51,18 @@ pub trait ValueGenerator: Send + Sync {
 ///   period_secs: 30
 ///   offset: 10.0
 /// ```
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
+#[cfg_attr(feature = "config", serde(tag = "type"))]
 pub enum GeneratorConfig {
     /// A generator that always returns the same value.
-    #[serde(rename = "constant")]
+    #[cfg_attr(feature = "config", serde(rename = "constant"))]
     Constant {
         /// The fixed value returned on every tick.
         value: f64,
     },
     /// A generator that returns deterministically random values in `[min, max]`.
-    #[serde(rename = "uniform")]
+    #[cfg_attr(feature = "config", serde(rename = "uniform"))]
     Uniform {
         /// Lower bound of the output range (inclusive).
         min: f64,
@@ -73,7 +72,7 @@ pub enum GeneratorConfig {
         seed: Option<u64>,
     },
     /// A generator that follows a sine curve.
-    #[serde(rename = "sine")]
+    #[cfg_attr(feature = "config", serde(rename = "sine"))]
     Sine {
         /// Half the peak-to-peak swing of the wave.
         amplitude: f64,
@@ -83,7 +82,7 @@ pub enum GeneratorConfig {
         offset: f64,
     },
     /// A generator that linearly ramps from `min` to `max` then resets.
-    #[serde(rename = "sawtooth")]
+    #[cfg_attr(feature = "config", serde(rename = "sawtooth"))]
     Sawtooth {
         /// Value at the start of each period.
         min: f64,
@@ -93,7 +92,7 @@ pub enum GeneratorConfig {
         period_secs: f64,
     },
     /// A generator that steps through an explicit sequence of values.
-    #[serde(rename = "sequence")]
+    #[cfg_attr(feature = "config", serde(rename = "sequence"))]
     Sequence {
         /// The ordered list of values to step through. Must not be empty.
         values: Vec<f64>,
@@ -102,7 +101,7 @@ pub enum GeneratorConfig {
         repeat: Option<bool>,
     },
     /// A generator that replays numeric values from a CSV file.
-    #[serde(rename = "csv_replay")]
+    #[cfg_attr(feature = "config", serde(rename = "csv_replay"))]
     CsvReplay {
         /// Path to the CSV file containing numeric values.
         file: String,
@@ -193,12 +192,13 @@ pub trait LogGenerator: Send + Sync {
 ///     - "/api"
 ///     - "/health"
 /// ```
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
 pub struct TemplateConfig {
     /// The message template. Use `{field_name}` for dynamic placeholders.
     pub message: String,
     /// Maps placeholder names to their value pools.
-    #[serde(default)]
+    #[cfg_attr(feature = "config", serde(default))]
     pub field_pools: HashMap<String, Vec<String>>,
 }
 
@@ -230,23 +230,24 @@ pub struct TemplateConfig {
 ///   type: replay
 ///   file: /var/log/app.log
 /// ```
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
+#[cfg_attr(feature = "config", serde(tag = "type"))]
 pub enum LogGeneratorConfig {
     /// Generates events from message templates with randomized field pool values.
-    #[serde(rename = "template")]
+    #[cfg_attr(feature = "config", serde(rename = "template"))]
     Template {
         /// One or more template entries. Templates are selected round-robin by tick.
         templates: Vec<TemplateConfig>,
         /// Optional severity weight map. Keys are severity names (`info`, `warn`, etc.),
         /// values are relative weights. Defaults to `info: 1.0` when absent.
-        #[serde(default)]
+        #[cfg_attr(feature = "config", serde(default))]
         severity_weights: Option<HashMap<String, f64>>,
         /// Seed for deterministic replay. Defaults to `0` when absent.
         seed: Option<u64>,
     },
     /// Replays lines from a file, cycling back to the start when exhausted.
-    #[serde(rename = "replay")]
+    #[cfg_attr(feature = "config", serde(rename = "replay"))]
     Replay {
         /// Path to the file containing log lines to replay.
         file: String,
@@ -454,7 +455,9 @@ mod tests {
     }
 
     // ---- Config deserialization tests ----------------------------------------
+    // These tests require the `config` feature (serde_yaml).
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_constant_config() {
         let yaml = "type: constant\nvalue: 42.0\n";
@@ -467,6 +470,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_uniform_config_with_seed() {
         let yaml = "type: uniform\nmin: 1.0\nmax: 5.0\nseed: 99\n";
@@ -481,6 +485,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_uniform_config_without_seed() {
         let yaml = "type: uniform\nmin: 0.0\nmax: 10.0\n";
@@ -496,6 +501,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_sine_config() {
         let yaml = "type: sine\namplitude: 5.0\nperiod_secs: 30\noffset: 10.0\n";
@@ -514,6 +520,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_sawtooth_config() {
         let yaml = "type: sawtooth\nmin: 0.0\nmax: 100.0\nperiod_secs: 60.0\n";
@@ -532,6 +539,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_sequence_config_with_repeat() {
         let yaml = "type: sequence\nvalues: [1.0, 2.0, 3.0]\nrepeat: true\n";
@@ -546,6 +554,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_sequence_config_without_repeat() {
         let yaml = "type: sequence\nvalues: [10.0, 20.0]\n";
@@ -560,6 +569,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_sequence_config_repeat_false() {
         let yaml = "type: sequence\nvalues: [5.0]\nrepeat: false\n";
@@ -574,6 +584,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_sequence_config_integer_values() {
         // YAML integers should coerce to f64
@@ -589,6 +600,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_example_yaml_scenario_file() {
         // Validate the example file from examples/sequence-alert-test.yaml
@@ -645,7 +657,9 @@ sink:
     }
 
     // ---- LogGeneratorConfig deserialization tests ----------------------------
+    // These tests require the `config` feature (serde_yaml).
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_log_template_config_minimal() {
         let yaml = "\
@@ -682,6 +696,7 @@ templates:
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_log_template_config_with_weights_and_seed() {
         let yaml = "\
@@ -713,6 +728,7 @@ seed: 42
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn deserialize_log_replay_config() {
         let yaml = "type: replay\nfile: /var/log/app.log\n";

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -157,6 +157,70 @@ mod tests {
         );
     }
 
+    // ---- config feature gate tests --------------------------------------------
+
+    /// Config types are constructible in code regardless of the `config` feature.
+    /// This test runs with or without the feature enabled.
+    #[test]
+    fn config_types_constructible_without_yaml_parsing() {
+        use crate::config::ScenarioConfig;
+        use crate::encoder::EncoderConfig;
+        use crate::generator::GeneratorConfig;
+        use crate::sink::SinkConfig;
+
+        let _config = ScenarioConfig {
+            name: "test".to_string(),
+            rate: 10.0,
+            duration: None,
+            generator: GeneratorConfig::Constant { value: 1.0 },
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            labels: None,
+            encoder: EncoderConfig::PrometheusText { precision: None },
+            sink: SinkConfig::Stdout,
+            phase_offset: None,
+            clock_group: None,
+        };
+    }
+
+    /// YAML deserialization is available when the `config` feature is active.
+    #[cfg(feature = "config")]
+    #[test]
+    fn config_feature_enables_yaml_deserialization() {
+        use crate::config::ScenarioConfig;
+
+        let yaml = r#"
+name: test
+rate: 10
+generator:
+  type: constant
+  value: 1.0
+"#;
+        let config: ScenarioConfig =
+            serde_yaml::from_str(yaml).expect("YAML deserialization must work with config feature");
+        assert_eq!(config.name, "test");
+    }
+
+    /// EncoderConfig, SinkConfig, and GeneratorConfig are all constructible
+    /// without deserialization and can be passed to their respective factory functions.
+    #[test]
+    fn factory_functions_work_without_deserialization() {
+        use crate::encoder::{create_encoder, EncoderConfig};
+        use crate::generator::{create_generator, GeneratorConfig};
+        use crate::sink::{create_sink, SinkConfig};
+
+        let gen_config = GeneratorConfig::Constant { value: 42.0 };
+        let gen = create_generator(&gen_config, 1.0).expect("generator factory must succeed");
+        assert_eq!(gen.value(0), 42.0);
+
+        let enc_config = EncoderConfig::PrometheusText { precision: None };
+        let _enc = create_encoder(&enc_config);
+
+        let sink_config = SinkConfig::Stdout;
+        let _sink = create_sink(&sink_config, None).expect("sink factory must succeed");
+    }
+
     #[test]
     fn sonda_error_sink_display_includes_io_context() {
         let io_err = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe broke");

--- a/sonda-core/src/model/log.rs
+++ b/sonda-core/src/model/log.rs
@@ -7,7 +7,7 @@
 use std::collections::BTreeMap;
 use std::time::SystemTime;
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::model::metric::Labels;
 
@@ -15,7 +15,8 @@ use crate::model::metric::Labels;
 ///
 /// Variants map to the conventional log severity ladder. Serializes to and from
 /// lowercase strings (e.g., `"info"`, `"error"`) for YAML and JSON compatibility.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
     /// Extremely detailed diagnostic information.
@@ -285,44 +286,52 @@ mod tests {
 
     // -----------------------------------------------------------------------
     // Severity: deserializes from lowercase JSON
+    // These tests require the `config` feature (Deserialize impl).
     // -----------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn severity_deserializes_from_lowercase_trace() {
         let s: Severity = serde_json::from_str(r#""trace""#).unwrap();
         assert_eq!(s, Severity::Trace);
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn severity_deserializes_from_lowercase_debug() {
         let s: Severity = serde_json::from_str(r#""debug""#).unwrap();
         assert_eq!(s, Severity::Debug);
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn severity_deserializes_from_lowercase_info() {
         let s: Severity = serde_json::from_str(r#""info""#).unwrap();
         assert_eq!(s, Severity::Info);
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn severity_deserializes_from_lowercase_warn() {
         let s: Severity = serde_json::from_str(r#""warn""#).unwrap();
         assert_eq!(s, Severity::Warn);
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn severity_deserializes_from_lowercase_error() {
         let s: Severity = serde_json::from_str(r#""error""#).unwrap();
         assert_eq!(s, Severity::Error);
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn severity_deserializes_from_lowercase_fatal() {
         let s: Severity = serde_json::from_str(r#""fatal""#).unwrap();
         assert_eq!(s, Severity::Fatal);
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn severity_rejects_uppercase_deserialization() {
         let result: Result<Severity, _> = serde_json::from_str(r#""INFO""#);
@@ -332,6 +341,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn severity_rejects_unknown_variant() {
         let result: Result<Severity, _> = serde_json::from_str(r#""critical""#);
@@ -342,12 +352,14 @@ mod tests {
     // Severity: serializes to lowercase YAML
     // -----------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn severity_info_serializes_to_lowercase_yaml() {
         let s = serde_yaml::to_string(&Severity::Info).unwrap();
         assert!(s.trim() == "info", "expected 'info', got: {s}");
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn severity_error_serializes_to_lowercase_yaml() {
         let s = serde_yaml::to_string(&Severity::Error).unwrap();

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -491,6 +491,7 @@ mod tests {
     // -------------------------------------------------------------------------
 
     /// Config from YAML: log-template style YAML → valid `LogScenarioConfig`.
+    #[cfg(feature = "config")]
     #[test]
     fn log_scenario_config_deserializes_template_yaml() {
         let yaml = r#"
@@ -528,6 +529,7 @@ sink:
     }
 
     /// Config from YAML: log-replay style YAML → valid `LogScenarioConfig`.
+    #[cfg(feature = "config")]
     #[test]
     fn log_scenario_config_deserializes_replay_yaml() {
         let yaml = r#"
@@ -553,6 +555,7 @@ sink:
     }
 
     /// Default encoder for LogScenarioConfig is json_lines (not prometheus_text).
+    #[cfg(feature = "config")]
     #[test]
     fn log_scenario_config_default_encoder_is_json_lines() {
         let yaml = r#"
@@ -574,6 +577,7 @@ generator:
     }
 
     /// Default sink for LogScenarioConfig is stdout.
+    #[cfg(feature = "config")]
     #[test]
     fn log_scenario_config_default_sink_is_stdout() {
         let yaml = r#"
@@ -595,6 +599,7 @@ generator:
     }
 
     /// LogScenarioConfig with optional gaps and bursts deserializes correctly.
+    #[cfg(feature = "config")]
     #[test]
     fn log_scenario_config_with_gaps_and_bursts_deserializes() {
         let yaml = r#"

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -385,6 +385,7 @@ mod tests {
     // Config: MultiScenarioConfig and ScenarioEntry deserialization
     // -----------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn multi_scenario_config_deserializes_metrics_entry_from_yaml() {
         let yaml = r#"
@@ -409,6 +410,7 @@ scenarios:
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn multi_scenario_config_deserializes_logs_entry_from_yaml() {
         let yaml = r#"
@@ -435,6 +437,7 @@ scenarios:
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn multi_scenario_config_deserializes_mixed_entries_from_yaml() {
         let yaml = r#"
@@ -468,6 +471,7 @@ scenarios:
         assert!(matches!(config.scenarios[1], ScenarioEntry::Logs(_)));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn multi_scenario_config_unknown_signal_type_returns_error() {
         let yaml = r#"
@@ -488,6 +492,7 @@ scenarios:
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn multi_scenario_config_missing_scenarios_key_returns_error() {
         let yaml = r#"
@@ -541,6 +546,7 @@ rate: 10
     ///
     /// This catches accidental breakage of the example YAML if the config
     /// types change.
+    #[cfg(feature = "config")]
     #[test]
     fn multi_scenario_example_file_deserializes_correctly() {
         let yaml = include_str!("../../../examples/multi-scenario.yaml");
@@ -791,6 +797,7 @@ rate: 10
 
     /// Two correlated scenarios with different phase_offsets run concurrently.
     /// (Uses "1ms" instead of "0s" to avoid the parse_duration zero-rejection bug.)
+    #[cfg(feature = "config")]
     #[test]
     fn multi_metric_correlation_example_runs_concurrently() {
         let yaml = r#"

--- a/sonda-core/src/sink/file.rs
+++ b/sonda-core/src/sink/file.rs
@@ -281,6 +281,7 @@ mod tests {
         assert_eq!(content, b"via factory\n");
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_file_deserializes_from_yaml() {
         use crate::sink::SinkConfig;
@@ -295,6 +296,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_file_deserializes_from_inline_yaml() {
         use crate::sink::SinkConfig;

--- a/sonda-core/src/sink/http.rs
+++ b/sonda-core/src/sink/http.rs
@@ -609,6 +609,7 @@ mod tests {
     // SinkConfig::HttpPush deserialization
     // -------------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_http_push_deserializes_with_required_fields() {
         let yaml = "type: http_push\nurl: \"http://localhost:9090/push\"";
@@ -631,6 +632,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_http_push_deserializes_with_all_fields() {
         let yaml = r#"
@@ -658,6 +660,7 @@ batch_size: 8192
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_http_push_requires_url_field() {
         let yaml = "type: http_push";

--- a/sonda-core/src/sink/kafka.rs
+++ b/sonda-core/src/sink/kafka.rs
@@ -241,6 +241,7 @@ mod tests {
     // SinkConfig deserialization
     // -----------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_kafka_deserializes_with_brokers_and_topic() {
         let yaml = "type: kafka\nbrokers: \"127.0.0.1:9092\"\ntopic: sonda-test";
@@ -254,6 +255,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_kafka_deserializes_with_multiple_brokers() {
         let yaml = "type: kafka\nbrokers: \"broker1:9092,broker2:9092\"\ntopic: my-topic";
@@ -264,6 +266,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_kafka_requires_brokers_field() {
         let yaml = "type: kafka\ntopic: sonda-test";
@@ -274,6 +277,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_kafka_requires_topic_field() {
         let yaml = "type: kafka\nbrokers: \"127.0.0.1:9092\"";
@@ -369,6 +373,7 @@ mod tests {
     // Full scenario YAML: kafka sink variant
     // -----------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn scenario_yaml_with_kafka_sink_deserializes_correctly() {
         use crate::config::ScenarioConfig;

--- a/sonda-core/src/sink/loki.rs
+++ b/sonda-core/src/sink/loki.rs
@@ -711,6 +711,7 @@ mod tests {
     // SinkConfig::Loki deserialization
     // -------------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_loki_deserializes_with_url_only() {
         let yaml = "type: loki\nurl: \"http://localhost:3100\"";
@@ -727,6 +728,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_loki_deserializes_with_batch_size() {
         let yaml = r#"
@@ -747,6 +749,7 @@ batch_size: 50
         }
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_loki_requires_url_field() {
         let yaml = "type: loki";
@@ -871,6 +874,7 @@ batch_size: 50
     // Example YAML file round-trip
     // -------------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn loki_json_lines_example_yaml_deserializes_to_log_scenario_config() {
         use crate::config::LogScenarioConfig;

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -20,8 +20,6 @@ pub mod udp;
 use std::collections::HashMap;
 use std::path::Path;
 
-use serde::Deserialize;
-
 use crate::SondaError;
 
 /// A sink consumes encoded bytes and delivers them to a destination.
@@ -37,17 +35,18 @@ pub trait Sink: Send + Sync {
 ///
 /// This enum is serde-deserializable from YAML scenario files.
 /// The `type` field selects the variant: `stdout`, `file`, `tcp`, or `udp`.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
+#[cfg_attr(feature = "config", serde(tag = "type"))]
 pub enum SinkConfig {
     /// Write encoded events to stdout, buffered via [`BufWriter`](std::io::BufWriter).
-    #[serde(rename = "stdout")]
+    #[cfg_attr(feature = "config", serde(rename = "stdout"))]
     Stdout,
 
     /// Write encoded events to a file at the given path.
     ///
     /// Parent directories are created automatically if they do not exist.
-    #[serde(rename = "file")]
+    #[cfg_attr(feature = "config", serde(rename = "file"))]
     File {
         /// Filesystem path to write encoded events to.
         path: String,
@@ -56,7 +55,7 @@ pub enum SinkConfig {
     /// Write encoded events over a persistent TCP connection.
     ///
     /// The sink connects on construction and buffers writes via [`BufWriter`](std::io::BufWriter).
-    #[serde(rename = "tcp")]
+    #[cfg_attr(feature = "config", serde(rename = "tcp"))]
     Tcp {
         /// Remote address to connect to, e.g. `"127.0.0.1:9999"`.
         address: String,
@@ -66,7 +65,7 @@ pub enum SinkConfig {
     ///
     /// No connection is established; an ephemeral local port is bound and each
     /// call to `write` sends one `send_to` datagram.
-    #[serde(rename = "udp")]
+    #[cfg_attr(feature = "config", serde(rename = "udp"))]
     Udp {
         /// Remote address to send datagrams to, e.g. `"127.0.0.1:9999"`.
         address: String,
@@ -80,7 +79,7 @@ pub enum SinkConfig {
     ///
     /// Requires the `http` Cargo feature to be enabled.
     #[cfg(feature = "http")]
-    #[serde(rename = "http_push")]
+    #[cfg_attr(feature = "config", serde(rename = "http_push"))]
     HttpPush {
         /// Target URL for HTTP POST requests, e.g. `"http://localhost:9090/api/v1/write"`.
         url: String,
@@ -98,7 +97,7 @@ pub enum SinkConfig {
         /// header. Useful for protocols that require specific headers, such as
         /// Prometheus remote write (`Content-Encoding: snappy`,
         /// `X-Prometheus-Remote-Write-Version: 0.1.0`).
-        #[serde(default)]
+        #[cfg_attr(feature = "config", serde(default))]
         headers: Option<HashMap<String, String>>,
     },
 
@@ -112,7 +111,7 @@ pub enum SinkConfig {
     ///
     /// Requires the `remote-write` Cargo feature to be enabled.
     #[cfg(feature = "remote-write")]
-    #[serde(rename = "remote_write")]
+    #[cfg_attr(feature = "config", serde(rename = "remote_write"))]
     RemoteWrite {
         /// Target URL for the remote write endpoint, e.g.
         /// `"http://localhost:8428/api/v1/write"`.
@@ -120,7 +119,7 @@ pub enum SinkConfig {
 
         /// Flush threshold in number of TimeSeries entries. Defaults to 100 if
         /// not specified.
-        #[serde(default)]
+        #[cfg_attr(feature = "config", serde(default))]
         batch_size: Option<usize>,
     },
 
@@ -135,7 +134,7 @@ pub enum SinkConfig {
     ///
     /// Requires the `kafka` Cargo feature to be enabled.
     #[cfg(feature = "kafka")]
-    #[serde(rename = "kafka")]
+    #[cfg_attr(feature = "config", serde(rename = "kafka"))]
     Kafka {
         /// Comma-separated list of broker `host:port` addresses,
         /// e.g. `"127.0.0.1:9092"` or `"broker1:9092,broker2:9092"`.
@@ -158,13 +157,13 @@ pub enum SinkConfig {
     ///
     /// Requires the `http` Cargo feature to be enabled.
     #[cfg(feature = "http")]
-    #[serde(rename = "loki")]
+    #[cfg_attr(feature = "config", serde(rename = "loki"))]
     Loki {
         /// Base URL of the Loki instance, e.g. `"http://localhost:3100"`.
         url: String,
 
         /// Flush threshold in log entries. Defaults to `100` if not specified.
-        #[serde(default)]
+        #[cfg_attr(feature = "config", serde(default))]
         batch_size: Option<usize>,
     },
 }
@@ -236,6 +235,7 @@ mod tests {
         assert!(sink.flush().is_ok());
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_stdout_deserializes_from_yaml() {
         let yaml = "type: stdout";
@@ -263,6 +263,7 @@ mod tests {
     // SinkConfig: internally-tagged deserialization for all variants (`type:` field)
     // ---------------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_file_deserializes_with_type_field() {
         let yaml = "type: file\npath: /tmp/sonda-mod-test.txt";
@@ -272,6 +273,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_tcp_deserializes_with_type_field() {
         let yaml = "type: tcp\naddress: \"127.0.0.1:9999\"";
@@ -279,6 +281,7 @@ mod tests {
         assert!(matches!(config, SinkConfig::Tcp { ref address } if address == "127.0.0.1:9999"));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_udp_deserializes_with_type_field() {
         let yaml = "type: udp\naddress: \"127.0.0.1:9999\"";
@@ -286,6 +289,7 @@ mod tests {
         assert!(matches!(config, SinkConfig::Udp { ref address } if address == "127.0.0.1:9999"));
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_unknown_type_returns_error() {
         let yaml = "type: no_such_sink";
@@ -296,6 +300,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_missing_type_field_returns_error() {
         // Without the `type` field the internally-tagged enum cannot identify the variant.
@@ -307,6 +312,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_old_external_tag_format_is_rejected() {
         // The old externally-tagged format (`!stdout`) must no longer be accepted.
@@ -318,6 +324,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_file_requires_path_field() {
         // `type: file` without a `path` field must fail.
@@ -329,6 +336,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_tcp_requires_address_field() {
         let yaml = "type: tcp";
@@ -339,6 +347,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_udp_requires_address_field() {
         let yaml = "type: udp";
@@ -400,6 +409,7 @@ mod tests {
     // Full scenario YAML using internally-tagged EncoderConfig and SinkConfig
     // ---------------------------------------------------------------------------
 
+    #[cfg(feature = "config")]
     #[test]
     fn scenario_yaml_with_tcp_sink_deserializes_correctly() {
         use crate::config::ScenarioConfig;
@@ -427,6 +437,7 @@ sink:
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn scenario_yaml_with_file_sink_and_json_encoder_deserializes_correctly() {
         use crate::config::ScenarioConfig;
@@ -453,6 +464,7 @@ sink:
         );
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn scenario_yaml_with_udp_sink_and_influx_encoder_deserializes_correctly() {
         use crate::config::ScenarioConfig;
@@ -484,7 +496,7 @@ sink:
     // SinkConfig::Kafka deserialization and factory wiring
     // -----------------------------------------------------------------------
 
-    #[cfg(feature = "kafka")]
+    #[cfg(all(feature = "kafka", feature = "config"))]
     #[test]
     fn sink_config_kafka_deserializes_with_type_field() {
         let yaml = "type: kafka\nbrokers: \"127.0.0.1:9092\"\ntopic: sonda-test";
@@ -495,7 +507,7 @@ sink:
         );
     }
 
-    #[cfg(feature = "kafka")]
+    #[cfg(all(feature = "kafka", feature = "config"))]
     #[test]
     fn sink_config_kafka_requires_brokers_field() {
         let yaml = "type: kafka\ntopic: sonda-test";
@@ -506,7 +518,7 @@ sink:
         );
     }
 
-    #[cfg(feature = "kafka")]
+    #[cfg(all(feature = "kafka", feature = "config"))]
     #[test]
     fn sink_config_kafka_requires_topic_field() {
         let yaml = "type: kafka\nbrokers: \"127.0.0.1:9092\"";
@@ -575,7 +587,7 @@ sink:
     // SinkConfig::HttpPush with custom headers deserialization
     // ---------------------------------------------------------------------------
 
-    #[cfg(feature = "http")]
+    #[cfg(all(feature = "http", feature = "config"))]
     #[test]
     fn sink_config_http_push_with_headers_deserializes() {
         let yaml = r#"
@@ -609,7 +621,7 @@ headers:
         }
     }
 
-    #[cfg(feature = "http")]
+    #[cfg(all(feature = "http", feature = "config"))]
     #[test]
     fn sink_config_http_push_without_headers_is_backward_compatible() {
         let yaml = r#"
@@ -636,7 +648,7 @@ content_type: "text/plain"
         }
     }
 
-    #[cfg(feature = "http")]
+    #[cfg(all(feature = "http", feature = "config"))]
     #[test]
     fn sink_config_http_push_with_empty_headers_map_deserializes() {
         let yaml = r#"
@@ -714,7 +726,7 @@ headers: {}
 
     /// When the `http` feature is enabled, `type: http_push` YAML must
     /// deserialize into the `HttpPush` variant.
-    #[cfg(feature = "http")]
+    #[cfg(all(feature = "http", feature = "config"))]
     #[test]
     fn http_feature_enables_http_push_deserialization() {
         let yaml = "type: http_push\nurl: \"http://localhost:9090/push\"";
@@ -724,7 +736,7 @@ headers: {}
 
     /// When the `http` feature is enabled, `type: loki` YAML must
     /// deserialize into the `Loki` variant.
-    #[cfg(feature = "http")]
+    #[cfg(all(feature = "http", feature = "config"))]
     #[test]
     fn http_feature_enables_loki_deserialization() {
         let yaml = "type: loki\nurl: \"http://localhost:3100\"";

--- a/sonda-core/src/sink/tcp.rs
+++ b/sonda-core/src/sink/tcp.rs
@@ -230,6 +230,7 @@ mod tests {
         assert_eq!(received, b"via factory\n");
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_tcp_deserializes_from_yaml() {
         let yaml = "type: tcp\naddress: \"127.0.0.1:9999\"";

--- a/sonda-core/src/sink/udp.rs
+++ b/sonda-core/src/sink/udp.rs
@@ -273,6 +273,7 @@ mod tests {
         assert_eq!(&buf[..len], b"via factory\n");
     }
 
+    #[cfg(feature = "config")]
     #[test]
     fn sink_config_udp_deserializes_from_yaml() {
         let yaml = "type: udp\naddress: \"127.0.0.1:9999\"";

--- a/sonda-core/tests/ci_workflow_test.rs
+++ b/sonda-core/tests/ci_workflow_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "config")]
 /// Tests that validate the GitHub Actions CI workflow file for slice 0.0.
 ///
 /// The spec requires:

--- a/sonda-core/tests/encoder_sink_matrix.rs
+++ b/sonda-core/tests/encoder_sink_matrix.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "config")]
 //! Encoder × Sink matrix integration tests for Slice 1.7.
 //!
 //! Validates that all 18 combinations of 3 encoders × 6 sinks compile and

--- a/sonda-server/Cargo.toml
+++ b/sonda-server/Cargo.toml
@@ -12,7 +12,8 @@ description = "HTTP control plane for Sonda — synthetic telemetry generator"
 readme = "../README.md"
 
 [features]
-default = ["http"]
+default = ["config", "http"]
+config = ["sonda-core/config"]
 http = ["sonda-core/http"]
 remote-write = ["sonda-core/remote-write"]
 kafka = ["sonda-core/kafka"]

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -12,7 +12,8 @@ description = "CLI for Sonda — synthetic telemetry generator for testing obser
 readme = "../README.md"
 
 [features]
-default = ["http"]
+default = ["config", "http"]
+config = ["sonda-core/config"]
 http = ["sonda-core/http"]
 remote-write = ["sonda-core/remote-write"]
 kafka = ["sonda-core/kafka"]


### PR DESCRIPTION
## Summary

- Feature-gated `serde_yaml` in sonda-core behind a `config` Cargo feature (default enabled)
- All `Deserialize` derives use `#[cfg_attr(feature = "config", derive(serde::Deserialize))]`
- `serde_json` remains unconditional — used by the JSON encoder in production code
- Library consumers building configs programmatically no longer pull in YAML parsing deps
- 189 deserialization tests correctly excluded when feature is off; 723 tests still pass
- CLI and server enable `config` by default — no user-visible change

## Test plan

- [x] `cargo build --workspace` — default features work
- [x] `cargo build -p sonda-core --no-default-features` — builds without serde_yaml
- [x] `cargo test --workspace` — 1,282 tests pass
- [x] `cargo test -p sonda-core --no-default-features` — 723 tests pass (deserialization excluded)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo clippy -p sonda-core --no-default-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p sonda-core --no-default-features` — clean
- [x] CLI smoke test: valid output
- [x] Reviewer: PASS (3 NOTEs, no WARNINGs)
- [x] UAT: PASS