### PR TITLE
chore: add critical evaluation rules to implementer and reviewer agents

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -143,6 +143,11 @@ You are implementing **Slice $ARGUMENTS**. This is the only slice you work on.
 - **Docs are in scope**: Updating CLAUDE.md and README.md for your slice's changes is part of the
   deliverable, not extra work. A slice is not complete until docs reflect the new code.
 - **No TODOs in code**: Deferred work is in the phase plan, not in code comments.
+- **Question the spec**: You are a Senior Engineer, not a code typist. If a spec recommends a
+  specific dependency, tool, or approach — verify it's still the right choice. Check if
+  dependencies are maintained (GitHub archived? last commit? downloads?), if APIs have changed,
+  if better alternatives exist. If the spec is wrong or stale, note the discrepancy and choose
+  the better path.
 - **Architecture compliance**: If the spec conflicts with `docs/architecture.md`, follow the
   architecture doc and note the discrepancy.
 - **Error handling**: `thiserror` in sonda-core, `anyhow` in sonda/sonda-server. Never `unwrap()`.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -140,3 +140,8 @@ discover. Specific checks:
 - **BLOCKERs must be fixed** before the slice can proceed.
 - **Be specific.** Always reference exact file, line, and what's wrong.
 - **Architecture doc is the source of truth.**
+- **Audit the spec, not just the code.** If the implementation follows a spec that is itself
+  flawed (e.g., recommending an archived dependency), flag it as a BLOCKER. A Staff Engineer
+  doesn't just check if code matches the spec — they check if the spec is correct. Verify
+  dependency health (archived? maintained? alternatives?) independently of what the implementer
+  chose.


### PR DESCRIPTION
## Summary

Adds two new rules to the agent definitions based on the 9C.3 incident where both agents accepted an archived dependency (`serde_yml`) without verifying its maintenance status:

- **Implementer** (`implementer.md`): "Question the spec" — verify dependencies are maintained, check for alternatives, don't blindly follow stale specs
- **Reviewer** (`reviewer.md`): "Audit the spec, not just the code" — flag flawed specs as BLOCKERs, verify dependency health independently

## Motivation

In slice 9C.3, the phase plan suggested migrating to `serde_yml`. The implementer executed the migration across 34 files without checking that `serde_yml` was also archived. The reviewer approved it without catching the issue. This required a full redo to the correct crate (`serde_yaml_ng`).

Both agents are Senior/Staff Engineer personas — they should exercise independent judgment, not be code typists.