### PR TITLE
docs: comprehensive update for Phase 9A/9B/9C changes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,6 +173,19 @@ Sink implementations follow a natural progression of complexity:
 | **Channel** | In-memory channel sink (`mpsc::Sender<Vec<u8>>`). For testing and inter-thread communication. |
 | **Memory** | In-memory buffer sink (`Vec<Vec<u8>>`). For testing and embedding. |
 
+### 5.6 Cargo Features
+
+`sonda-core` uses Cargo features to keep the default dependency footprint minimal. Consumers who only need generators and encoders can omit heavy transitive dependencies like HTTP/TLS stacks and async runtimes.
+
+| Feature | Default | Dependencies Gated | Description |
+|---------|---------|-------------------|-------------|
+| `config` | yes | `serde_yaml_ng` | Enables `serde::Deserialize` on all config types. Disable for library consumers who construct configs in code. |
+| `http` | no | `ureq` (+ rustls, ring, webpki) | Enables `HttpPush` and `Loki` sinks. |
+| `kafka` | no | `rskafka`, `tokio` | Enables the Kafka sink. |
+| `remote-write` | no | `prost`, `snap`, `ureq` | Enables Prometheus remote write encoder and sink. |
+
+The CLI (`sonda`) and HTTP server (`sonda-server`) enable all features they need in their own `Cargo.toml`. End users of the pre-built binary or Docker image get every feature enabled.
+
 ---
 
 ## 6. Configuration

--- a/docs/phase-0-mvp.md
+++ b/docs/phase-0-mvp.md
@@ -155,7 +155,7 @@ cargo fmt --all -- --check
 - **Sine**: value(0) == offset. value at quarter-period ≈ offset + amplitude. value at half-period ≈ offset. Symmetry: value(t) + value(t + half_period) ≈ 2 * offset.
 - **Sawtooth**: value(0) == min. value(period_ticks - 1) approaches max. value(period_ticks) == min (reset).
 - **Factory**: `create_generator(Constant{value: 1.0}, _)` returns a generator where `value(0) == 1.0`. Each config variant produces the correct concrete type.
-- **Config deserialization**: `serde_yaml::from_str` with `type: sine` YAML → correct `GeneratorConfig::Sine`.
+- **Config deserialization**: `serde_yaml_ng::from_str` with `type: sine` YAML → correct `GeneratorConfig::Sine`.
 
 ### Review criteria
 - `ValueGenerator` trait is `&self` only (stateless, no `&mut self`).

--- a/docs/phase-3-server.md
+++ b/docs/phase-3-server.md
@@ -191,7 +191,7 @@ will use.
   tokio = { version = "1", features = ["full"] }
   serde = { workspace = true }
   serde_json = { workspace = true }
-  serde_yaml = { workspace = true }
+  serde_yaml_ng = { workspace = true }
   anyhow = { workspace = true }
   tower-http = { version = "0.5", features = ["cors", "trace"] }
   tracing = "0.1"

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -59,7 +59,7 @@ Error responses:
 
 - **400 Bad Request** -- body cannot be parsed as YAML or JSON.
 - **422 Unprocessable Entity** -- valid YAML/JSON but fails validation (e.g., `rate: 0`).
-- **500 Internal Server Error** -- scenario thread could not be spawned.
+- **500 Internal Server Error** -- scenario thread could not be spawned, or internal state error.
 
 !!! tip "Long-running scenarios"
     Omit the `duration` field from your scenario body to create a scenario that runs

--- a/sonda-core/src/encoder/json.rs
+++ b/sonda-core/src/encoder/json.rs
@@ -133,7 +133,7 @@ impl Encoder for JsonLines {
     /// avoiding an intermediate `String` allocation.
     fn encode_metric(&self, event: &MetricEvent, buf: &mut Vec<u8>) -> Result<(), SondaError> {
         let ts_bytes = super::format_rfc3339_millis_array(event.timestamp)?;
-        // Safety: the array contains only ASCII digits, hyphens, colons, 'T', '.', 'Z'.
+        // Invariant: the array contains only ASCII digits, hyphens, colons, 'T', '.', 'Z'.
         let timestamp =
             std::str::from_utf8(&ts_bytes).expect("RFC 3339 timestamp is always valid UTF-8");
 

--- a/sonda-core/src/encoder/mod.rs
+++ b/sonda-core/src/encoder/mod.rs
@@ -205,6 +205,9 @@ pub(crate) fn format_rfc3339_millis_array(
         cursor,
         "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z",
     )
+    // Invariant: this holds for years 0000..=9999 (the 4-digit format field).
+    // Years >= 10000 would overflow the 24-byte buffer. SystemTime values
+    // from the Unix epoch (1970) cannot reach year 10000 within u64 range.
     .expect("RFC 3339 millis timestamp is always exactly 24 bytes");
     Ok(arr)
 }

--- a/sonda-core/src/model/log.rs
+++ b/sonda-core/src/model/log.rs
@@ -17,6 +17,9 @@ use crate::model::metric::Labels;
 /// lowercase strings (e.g., `"info"`, `"error"`) for YAML and JSON compatibility.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[cfg_attr(feature = "config", derive(serde::Deserialize))]
+// `rename_all` is not behind cfg_attr because it applies to both Serialize
+// (unconditional — used by the JSON encoder) and Deserialize (config-gated).
+// Splitting it would require duplicating the attribute under two cfg_attr guards.
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
     /// Extremely detailed diagnostic information.

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -322,8 +322,8 @@ pub fn run_with_sink(
                     st.in_gap = currently_in_gap;
                     st.in_burst = currently_in_burst;
                     st.in_cardinality_spike = currently_in_spike;
-                    // Buffer the metric event for scrape endpoints. The clone
-                    // cost is bounded by MAX_RECENT_METRICS (default 100).
+                    // Buffer the metric event for scrape endpoints. MetricEvent
+                    // fields are Arc-wrapped, so this move is O(1).
                     st.push_metric(event);
                 }
             }


### PR DESCRIPTION
## Summary

- Address all 7 accumulated reviewer NOTEs from Phase 9A, 9B, and 9C reviews
- Update source code comments for accuracy after Arc-wrapping (9B.1), rename "Safety:" to "Invariant:" per Rust convention (9B.4), document year invariant on timestamp buffer (9B.3), clarify ungated `serde(rename_all)` on Severity (9C.2)
- Add Cargo features subsection (5.6) to `docs/architecture.md` documenting `config`, `http`, `kafka`, and `remote-write` feature gates (9C.1/9C.2)
- Update historical phase plan references from `serde_yaml` to `serde_yaml_ng` (9C.3)
- Broaden server 500 error description to cover internal state errors from lock poisoning recovery (9A.2)
- Verify all existing user-facing docs in `docs/site/` remain accurate after Phase 9 changes (DELETE idempotency docs already correct per 9A.1)

## Changes by file

**Source code comments (4 files):**
- `sonda-core/src/schedule/runner.rs` -- stale clone-cost comment updated (Arc = O(1))
- `sonda-core/src/encoder/json.rs` -- "Safety:" renamed to "Invariant:" (no unsafe block)
- `sonda-core/src/encoder/mod.rs` -- year < 10000 invariant documented on expect()
- `sonda-core/src/model/log.rs` -- clarifying comment on ungated `#[serde(rename_all)]`

**Documentation (4 files):**
- `docs/architecture.md` -- new section 5.6 Cargo Features table
- `docs/phase-0-mvp.md` -- `serde_yaml::from_str` -> `serde_yaml_ng::from_str`
- `docs/phase-3-server.md` -- `serde_yaml` -> `serde_yaml_ng` in dep block
- `docs/site/docs/deployment/sonda-server.md` -- 500 error description broadened

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `task site:build` passes (mkdocs --strict, no warnings)
- [x] All user-facing docs pages reviewed for Phase 9 accuracy