### PR TITLE
docs: add Alertmanager integration guide and Docker Compose alerting profile

### DIFF
--- a/docs/site/docs/deployment/docker.md
+++ b/docs/site/docs/deployment/docker.md
@@ -137,3 +137,26 @@ or open Grafana and navigate to **Dashboards > Sonda > Sonda Overview**.
     The stack includes vmagent for remote write relay. You can push protobuf metrics
     through vmagent using `examples/remote-write-vm.yaml`.
     See [Encoders](../configuration/encoders.md) for details.
+
+### Alerting Profile
+
+Add vmalert, Alertmanager, and a webhook receiver to test the complete alerting loop:
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml \
+  --profile alerting up -d
+```
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `vmalert` | 8880 | Rule evaluation engine |
+| `alertmanager` | 9093 | Alert routing and notification |
+| `webhook-receiver` | 8090 | HTTP echo server (shows alert payloads) |
+
+Push a threshold-crossing metric and watch alerts flow through to the webhook:
+
+```bash
+sonda metrics --scenario examples/alertmanager/alerting-scenario.yaml
+```
+
+See the [Alerting Pipeline](../guides/alerting-pipeline.md) guide for the full walkthrough.

--- a/docs/site/docs/guides/alert-testing.md
+++ b/docs/site/docs/guides/alert-testing.md
@@ -489,6 +489,11 @@ docker compose -f examples/docker-compose-victoriametrics.yml down -v
 
 See [Docker Deployment](../deployment/docker.md) for the full stack configuration.
 
+!!! tip "Close the loop with Alertmanager"
+    This stack verifies that data arrives in VictoriaMetrics, but doesn't prove alerts fire.
+    To add vmalert, Alertmanager, and a webhook receiver to the stack, see the
+    [Alerting Pipeline](alerting-pipeline.md) guide.
+
 ---
 
 ## Quick Reference
@@ -509,6 +514,9 @@ See [Docker Deployment](../deployment/docker.md) for the full stack configuratio
 ---
 
 ## Next Steps
+
+**Verifying alerts fire end-to-end?** See [Alerting Pipeline](alerting-pipeline.md) to run
+vmalert, Alertmanager, and a webhook receiver with Docker Compose.
 
 **Validating a pipeline change?** See [Pipeline Validation](pipeline-validation.md).
 

--- a/docs/site/docs/guides/alerting-pipeline.md
+++ b/docs/site/docs/guides/alerting-pipeline.md
@@ -1,0 +1,259 @@
+# Alerting Pipeline
+
+You've written alert rules, pushed metrics to a TSDB, and checked that the data looks right. But
+does the alert actually fire? Does it reach Alertmanager? Does the notification arrive at your
+webhook? This guide closes that loop: you'll run a complete
+**Sonda -> VictoriaMetrics -> vmalert -> Alertmanager -> webhook** pipeline and watch an alert
+flow from synthetic metric to delivered notification.
+
+---
+
+## What you'll build
+
+```
+sonda (host CLI)        VictoriaMetrics        vmalert         Alertmanager     webhook-receiver
+ |                         |                    |                  |                 |
+ |-- push metrics -------->|                    |                  |                 |
+ |                         |<-- query rules ----|                  |                 |
+ |                         |--- results ------->|                  |                 |
+ |                         |                    |-- fire alert --->|                 |
+ |                         |                    |                  |-- POST JSON --->|
+ |                         |                    |                  |                 |
+```
+
+All services except Sonda run in Docker. The alerting profile adds vmalert, Alertmanager, and a
+webhook echo server to the existing VictoriaMetrics stack.
+
+---
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) with the Compose v2 plugin (`docker compose`)
+- Sonda CLI installed ([Getting Started](../getting-started.md#installation))
+- `curl` and `jq` in PATH (for verification commands)
+
+---
+
+## Start the stack
+
+The alerting services are behind a Docker Compose profile, so the base stack stays lightweight
+for users who don't need them.
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml \
+  --profile alerting up -d
+```
+
+Wait for all services to become healthy (about 15--20 seconds):
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml \
+  --profile alerting ps
+```
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| VictoriaMetrics | 8428 | Time series database |
+| vmagent | 8429 | Metrics relay agent |
+| vmalert | 8880 | Rule evaluation engine |
+| Alertmanager | 9093 | Alert routing and notification |
+| webhook-receiver | 8090 | HTTP echo server (shows alert payloads) |
+| Grafana | 3000 | Dashboards |
+| sonda-server | 8080 | Sonda HTTP API |
+
+---
+
+## Push metrics that cross alert thresholds
+
+The included alerting scenario generates a sine wave (`docker_alert_cpu`) that oscillates
+between 0 and 100 with a 30-second period. It crosses the warning threshold (70) and critical
+threshold (90) twice per cycle, and pushes directly to VictoriaMetrics.
+
+```bash
+sonda metrics --scenario examples/alertmanager/alerting-scenario.yaml
+```
+
+This runs for 5 minutes at 2 events/second. You'll see alerts fire within the first 30 seconds.
+
+??? info "What the scenario looks like"
+    ```yaml title="examples/alertmanager/alerting-scenario.yaml"
+    name: docker_alert_cpu
+    rate: 2
+    duration: 300s
+
+    generator:
+      type: sine
+      amplitude: 50.0
+      period_secs: 30
+      offset: 50.0
+
+    labels:
+      host: docker-alert-demo
+      region: us-east-1
+      service: payment-service
+      env: staging
+
+    encoder:
+      type: prometheus_text
+    sink:
+      type: http_push
+      url: "http://localhost:8428/api/v1/import/prometheus"
+      content_type: "text/plain"
+    ```
+
+---
+
+## Verify each stage
+
+Work through the pipeline one hop at a time. This is the same debugging sequence you'd use
+in production when an alert isn't firing.
+
+### 1. Data in VictoriaMetrics
+
+Confirm the metric exists and has recent values:
+
+```bash
+curl -s "http://localhost:8428/api/v1/query?query=docker_alert_cpu" | jq .
+```
+
+You should see the current value and labels. If this returns no data, Sonda isn't pushing
+successfully -- check that the VictoriaMetrics container is healthy.
+
+### 2. Rules evaluating in vmalert
+
+Check that vmalert is evaluating rules and detecting threshold breaches:
+
+```bash
+curl -s http://localhost:8880/api/v1/alerts | jq '.data.alerts[] | {alertname: .labels.alertname, state: .state, value: .value}'
+```
+
+You should see alerts in `pending` or `firing` state. The vmalert UI at
+[http://localhost:8880](http://localhost:8880) shows rule groups, evaluation results, and
+alert history.
+
+??? info "Alert rules being evaluated"
+    ```yaml title="examples/alertmanager/alert-rules.yml"
+    groups:
+      - name: sonda-alerts
+        interval: 5s
+        rules:
+          - alert: HighCpuUsage
+            expr: docker_alert_cpu > 90
+            for: 5s
+            labels:
+              severity: critical
+            annotations:
+              summary: "CPU usage is critically high"
+              description: "docker_alert_cpu on {{ $labels.host }} is {{ $value | printf \"%.1f\" }}%"
+
+          - alert: ElevatedCpuUsage
+            expr: docker_alert_cpu > 70
+            for: 5s
+            labels:
+              severity: warning
+            annotations:
+              summary: "CPU usage is elevated"
+              description: "docker_alert_cpu on {{ $labels.host }} is {{ $value | printf \"%.1f\" }}%"
+    ```
+
+### 3. Alerts in Alertmanager
+
+Verify Alertmanager received the firing alerts:
+
+```bash
+curl -s http://localhost:9093/api/v2/alerts | jq '.[].labels'
+```
+
+The Alertmanager UI at [http://localhost:9093](http://localhost:9093) shows active alerts,
+silences, and routing groups.
+
+### 4. Webhook payload delivered
+
+This is the end of the chain. Check the webhook receiver logs for the delivered notification:
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml \
+  --profile alerting logs webhook-receiver | head -50
+```
+
+You'll see the full Alertmanager notification JSON, including alert name, labels, annotations,
+and status. This is the same payload a PagerDuty/Slack/OpsGenie integration would receive.
+
+!!! tip "Follow the webhook logs in real time"
+    ```bash
+    docker compose -f examples/docker-compose-victoriametrics.yml \
+      --profile alerting logs -f webhook-receiver
+    ```
+    Keep this running in a separate terminal to watch alerts arrive as the sine wave crosses
+    thresholds.
+
+---
+
+## Customize the rules
+
+The included alert rules fire on `docker_alert_cpu > 90` (critical) and `> 70` (warning).
+To test your own rules, edit `examples/alertmanager/alert-rules.yml` and restart vmalert:
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml \
+  --profile alerting restart vmalert
+```
+
+Common adjustments:
+
+| Change | What to modify |
+|--------|---------------|
+| Different metric name | Change `expr:` in the alert rule and `name:` in the scenario |
+| Longer `for:` duration | Increase `for:` in the rule; increase `duration:` in the scenario |
+| Different thresholds | Adjust `> 90` / `> 70` in the rule; tweak `amplitude` and `offset` |
+| Route by severity | Edit `route:` in `examples/alertmanager/alertmanager.yml` |
+
+??? info "Alertmanager routing config"
+    ```yaml title="examples/alertmanager/alertmanager.yml"
+    global:
+      resolve_timeout: 1m
+
+    route:
+      receiver: webhook
+      group_by: ['alertname', 'severity']
+      group_wait: 10s
+      group_interval: 10s
+      repeat_interval: 1m
+
+    receivers:
+      - name: webhook
+        webhook_configs:
+          - url: http://webhook-receiver:8080
+            send_resolved: true
+    ```
+
+---
+
+## Tear down
+
+```bash
+docker compose -f examples/docker-compose-victoriametrics.yml \
+  --profile alerting down -v
+```
+
+---
+
+## Quick reference
+
+| File | Purpose |
+|------|---------|
+| `examples/alertmanager/alerting-scenario.yaml` | Sonda scenario: sine wave pushing to VictoriaMetrics |
+| `examples/alertmanager/alert-rules.yml` | vmalert rules: HighCpuUsage and ElevatedCpuUsage |
+| `examples/alertmanager/alertmanager.yml` | Alertmanager config: route all alerts to webhook |
+| `examples/docker-compose-victoriametrics.yml` | Docker Compose (use `--profile alerting`) |
+
+---
+
+## Next steps
+
+**Testing more alert patterns?** See [Alert Testing](alert-testing.md) for threshold, gap,
+sequence, and multi-metric scenarios.
+
+**Validating recording rules?** Check [Recording Rules](recording-rules.md).
+
+**Running automated e2e tests?** See [E2E Testing](e2e-testing.md).

--- a/docs/site/docs/guides/examples.md
+++ b/docs/site/docs/guides/examples.md
@@ -86,6 +86,17 @@ See [Docker deployment](../deployment/docker.md) for the full stack setup.
 
 See the [Alert Testing](alert-testing.md) guide for end-to-end walkthrough.
 
+## Alerting Pipeline
+
+| File | Type | Description |
+|------|------|-------------|
+| `alertmanager/alerting-scenario.yaml` | Sonda scenario | Sine wave pushing to VictoriaMetrics for alert evaluation |
+| `alertmanager/alert-rules.yml` | vmalert rules | HighCpuUsage (>90) and ElevatedCpuUsage (>70) alerts |
+| `alertmanager/alertmanager.yml` | Alertmanager config | Routes all alerts to the webhook receiver |
+
+These files are used with the `--profile alerting` Docker Compose profile. See the
+[Alerting Pipeline](alerting-pipeline.md) guide for the full walkthrough.
+
 ## Recording Rules
 
 | File | Generator | Encoder | Sink | Description |

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
   - Guides:
     - Tutorial: guides/tutorial.md
     - Alert Testing: guides/alert-testing.md
+    - Alerting Pipeline: guides/alerting-pipeline.md
     - Pipeline Validation: guides/pipeline-validation.md
     - Recording Rules: guides/recording-rules.md
     - Example Scenarios: guides/examples.md

--- a/examples/alertmanager/alert-rules.yml
+++ b/examples/alertmanager/alert-rules.yml
@@ -1,0 +1,29 @@
+# Alert rules for vmalert, designed to fire on Sonda-generated metrics.
+#
+# These rules match the docker-alerts.yaml scenario which produces a sine wave
+# metric `docker_alert_cpu` oscillating between 0 and 100 with a 30-second
+# period. The wave crosses 70 (warning) and 90 (critical) twice per cycle.
+#
+# Usage: mounted into vmalert as part of the `alerting` Docker Compose profile.
+
+groups:
+  - name: sonda-alerts
+    interval: 5s
+    rules:
+      - alert: HighCpuUsage
+        expr: docker_alert_cpu > 90
+        for: 5s
+        labels:
+          severity: critical
+        annotations:
+          summary: "CPU usage is critically high"
+          description: "docker_alert_cpu on {{ $labels.host }} is {{ $value | printf \"%.1f\" }}%"
+
+      - alert: ElevatedCpuUsage
+        expr: docker_alert_cpu > 70
+        for: 5s
+        labels:
+          severity: warning
+        annotations:
+          summary: "CPU usage is elevated"
+          description: "docker_alert_cpu on {{ $labels.host }} is {{ $value | printf \"%.1f\" }}%"

--- a/examples/alertmanager/alerting-scenario.yaml
+++ b/examples/alertmanager/alerting-scenario.yaml
@@ -1,0 +1,44 @@
+# Alerting pipeline scenario
+#
+# Produces a sine wave that crosses alert thresholds and pushes directly to
+# VictoriaMetrics via the HTTP import API. Designed for the alerting Docker
+# Compose profile: vmalert evaluates the rules, fires alerts to Alertmanager,
+# and Alertmanager routes them to the webhook receiver.
+#
+# The sine wave oscillates between 0 and 100 with a 30-second period, crossing
+# the warning threshold (70) and critical threshold (90) twice per cycle.
+#
+# Prerequisites:
+#   docker compose -f examples/docker-compose-victoriametrics.yml --profile alerting up -d
+#
+# Usage:
+#   sonda metrics --scenario examples/alertmanager/alerting-scenario.yaml
+#
+# Verify data arrived:
+#   curl "http://localhost:8428/api/v1/query?query=docker_alert_cpu"
+#
+# Check fired alerts:
+#   curl -s http://localhost:8880/api/v1/alerts | jq .
+
+name: docker_alert_cpu
+rate: 2
+duration: 300s
+
+generator:
+  type: sine
+  amplitude: 50.0
+  period_secs: 30
+  offset: 50.0
+
+labels:
+  host: docker-alert-demo
+  region: us-east-1
+  service: payment-service
+  env: staging
+
+encoder:
+  type: prometheus_text
+sink:
+  type: http_push
+  url: "http://localhost:8428/api/v1/import/prometheus"
+  content_type: "text/plain"

--- a/examples/alertmanager/alertmanager.yml
+++ b/examples/alertmanager/alertmanager.yml
@@ -1,0 +1,23 @@
+# Alertmanager configuration for the Sonda alerting example.
+#
+# Routes all alerts to a local webhook receiver so you can see the full
+# notification payload without depending on external services.
+#
+# Usage: part of the `alerting` Docker Compose profile.
+#   docker compose -f examples/docker-compose-victoriametrics.yml --profile alerting up -d
+
+global:
+  resolve_timeout: 1m
+
+route:
+  receiver: webhook
+  group_by: ['alertname', 'severity']
+  group_wait: 10s
+  group_interval: 10s
+  repeat_interval: 1m
+
+receivers:
+  - name: webhook
+    webhook_configs:
+      - url: http://webhook-receiver:8080
+        send_resolved: true

--- a/examples/docker-compose-victoriametrics.yml
+++ b/examples/docker-compose-victoriametrics.yml
@@ -21,8 +21,9 @@
 # to explore metrics with the pre-configured VictoriaMetrics datasource.
 # The "Sonda Overview" dashboard is auto-provisioned under Dashboards > Sonda.
 #
-# Optional services (Loki, Kafka) are available via Docker Compose profiles:
+# Optional services are available via Docker Compose profiles:
 #
+#   docker compose -f examples/docker-compose-victoriametrics.yml --profile alerting up -d
 #   docker compose -f examples/docker-compose-victoriametrics.yml --profile loki up -d
 #   docker compose -f examples/docker-compose-victoriametrics.yml --profile kafka up -d
 #   docker compose -f examples/docker-compose-victoriametrics.yml --profile loki --profile kafka up -d
@@ -235,6 +236,83 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
+
+  # ---------------------------------------------------------------------------
+  # vmalert: VictoriaMetrics alerting engine.
+  #
+  # Evaluates recording and alerting rules against VictoriaMetrics, then
+  # sends firing alerts to Alertmanager. Compatible with Prometheus alerting
+  # rule syntax.
+  #
+  # Alert rules are mounted from examples/alertmanager/alert-rules.yml.
+  # vmalert UI available at http://localhost:8880 to inspect rule state and
+  # active alerts.
+  #
+  # This service is only started with --profile alerting.
+  # ---------------------------------------------------------------------------
+  vmalert:
+    image: victoriametrics/vmalert:v1.108.1
+    profiles: [alerting]
+    ports:
+      - "8880:8880"
+    command:
+      - "--datasource.url=http://victoriametrics:8428"
+      - "--remoteRead.url=http://victoriametrics:8428"
+      - "--remoteWrite.url=http://victoriametrics:8428"
+      - "--notifier.url=http://alertmanager:9093"
+      - "--rule=/rules/*.yml"
+      - "--httpListenAddr=:8880"
+      - "--evaluationInterval=5s"
+    volumes:
+      - ./alertmanager/alert-rules.yml:/rules/alert-rules.yml:ro
+    depends_on:
+      victoriametrics:
+        condition: service_healthy
+
+  # ---------------------------------------------------------------------------
+  # Alertmanager: Prometheus alert notification router.
+  #
+  # Receives alerts from vmalert and routes them to configured receivers.
+  # In this stack, all alerts are sent to the webhook-receiver service so
+  # you can inspect the full notification payload.
+  #
+  # Alertmanager UI available at http://localhost:9093.
+  #
+  # This service is only started with --profile alerting.
+  # ---------------------------------------------------------------------------
+  alertmanager:
+    image: prom/alertmanager:v0.28.1
+    profiles: [alerting]
+    ports:
+      - "9093:9093"
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+
+  # ---------------------------------------------------------------------------
+  # webhook-receiver: lightweight HTTP echo server that logs request bodies.
+  #
+  # Receives alert notifications from Alertmanager and prints the full JSON
+  # payload to stdout, so you can verify end-to-end alert delivery with:
+  #
+  #   docker compose -f examples/docker-compose-victoriametrics.yml \
+  #     --profile alerting logs -f webhook-receiver
+  #
+  # Uses mendhak/http-https-echo, a well-maintained (~24M pulls) echo server
+  # that returns the request body and headers as JSON.
+  #
+  # This service is only started with --profile alerting.
+  # ---------------------------------------------------------------------------
+  webhook-receiver:
+    image: mendhak/http-https-echo:35
+    profiles: [alerting]
+    ports:
+      - "8090:8080"
+    environment:
+      - HTTP_PORT=8080
+      - LOG_WITHOUT_NEWLINE=true
 
 volumes:
   vm-data:


### PR DESCRIPTION
## Summary

- New **Alerting Pipeline** guide documenting the full loop: Sonda → VictoriaMetrics → vmalert → Alertmanager → webhook receiver
- Docker Compose `alerting` profile with 3 new services (vmalert, alertmanager, webhook-receiver) — base stack unchanged
- Alert rules for vmalert (`HighCpuUsage` >90, `ElevatedCpuUsage` >70) and Alertmanager config routing to webhook
- Cross-references added to alert-testing.md, examples.md, docker.md, and mkdocs.yml nav

Closes #78.

## Test plan

- [x] `cargo build/test/clippy/fmt` — all pass
- [x] `docker compose --profile alerting config --quiet` — valid syntax
- [x] Base stack unchanged (4 services without profile, 7 with alerting)
- [x] `sonda --dry-run metrics --scenario examples/alertmanager/alerting-scenario.yaml` — validates OK
- [x] `task site:build` with `--strict` — no warnings or broken links
- [x] All cross-references resolve in built site
- [x] Semantic consistency: metric name, alert rules, webhook URL all correctly wired
- [x] UAT: 23 scenarios tested, all PASS