### PR TITLE
fix: add healthchecks to vmalert/alertmanager and note first-run build time

### DIFF
--- a/docs/site/docs/guides/alerting-pipeline.md
+++ b/docs/site/docs/guides/alerting-pipeline.md
@@ -44,7 +44,11 @@ docker compose -f examples/docker-compose-victoriametrics.yml \
   --profile alerting up -d
 ```
 
-Wait for all services to become healthy (about 15--20 seconds):
+Wait for all services to show `(healthy)` status (about 15--20 seconds):
+
+!!! note "First-run build time"
+    On first run, Docker builds the `sonda-server` image from source. This can take a few
+    minutes depending on your machine. Subsequent runs use the cached image and start in seconds.
 
 ```bash
 docker compose -f examples/docker-compose-victoriametrics.yml \

--- a/examples/docker-compose-victoriametrics.yml
+++ b/examples/docker-compose-victoriametrics.yml
@@ -268,6 +268,12 @@ services:
     depends_on:
       victoriametrics:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8880/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
   # ---------------------------------------------------------------------------
   # Alertmanager: Prometheus alert notification router.
@@ -290,6 +296,12 @@ services:
       - "--storage.path=/alertmanager"
     volumes:
       - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:9093/-/healthy"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
   # ---------------------------------------------------------------------------
   # webhook-receiver: lightweight HTTP echo server that logs request bodies.


### PR DESCRIPTION
## Summary

- Add `healthcheck:` to vmalert and alertmanager services in the Docker Compose alerting profile
- Add admonition to alerting pipeline guide noting first-run Docker build time for sonda-server

Both findings surfaced by the new `@smoke` agent's first live run against the alerting pipeline.

## Test plan

- [x] `docker compose --profile alerting config --quiet` — valid syntax
- [x] `task site:build` with `--strict` — no warnings or broken links
- [x] Healthcheck endpoints verified: vmalert `/health`, alertmanager `/-/healthy`