### PR TITLE
refactor: unify ScenarioConfig and LogScenarioConfig via BaseScheduleConfig (9D.2)

### DIFF
--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -54,7 +54,12 @@ src/
 │   ├── memory.rs       ← in-memory buffer sink (Vec<Vec<u8>>, for testing and embedding)
 │   └── kafka.rs        ← Kafka producer (rskafka, feature = "kafka")
 └── config/
-    ├── mod.rs          ← ScenarioConfig (with phase_offset, clock_group, cardinality_spikes), ScenarioEntry, MultiScenarioConfig, CardinalitySpikeConfig, SpikeStrategy
+    ├── mod.rs          ← BaseScheduleConfig (shared schedule/delivery fields: name, rate, duration,
+    │                      gaps, bursts, cardinality_spikes, labels, sink, phase_offset, clock_group),
+    │                      ScenarioConfig (embeds BaseScheduleConfig + generator + encoder, Deref/DerefMut),
+    │                      LogScenarioConfig (embeds BaseScheduleConfig + generator + encoder, Deref/DerefMut),
+    │                      ScenarioEntry (with base() accessor), MultiScenarioConfig,
+    │                      CardinalitySpikeConfig, SpikeStrategy
     └── validate.rs     ← config validation logic, parse_duration, validate_cardinality_spike_config
 ```
 

--- a/sonda-core/src/config/mod.rs
+++ b/sonda-core/src/config/mod.rs
@@ -127,9 +127,69 @@ fn default_sink() -> SinkConfig {
     SinkConfig::Stdout
 }
 
-/// Full configuration for a single scenario run.
+/// Shared schedule and delivery fields common to all signal types.
 ///
-/// Deserialized from a YAML scenario file. CLI flags can override any field.
+/// Both [`ScenarioConfig`] (metrics) and [`LogScenarioConfig`] (logs) embed
+/// this struct via `#[serde(flatten)]`. It contains every field that is
+/// identical across signal types — everything except the generator
+/// configuration and the encoder default.
+///
+/// New schedule-level fields (rate control, windows, labels, sink, phase
+/// offset) should be added here once and automatically propagate to both
+/// signal types.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize))]
+pub struct BaseScheduleConfig {
+    /// Scenario name (metric name for metrics, identifier for logs).
+    pub name: String,
+    /// Target event rate in events per second. Must be strictly positive.
+    pub rate: f64,
+    /// Optional total run duration (e.g. `"30s"`, `"5m"`). `None` means run indefinitely.
+    #[cfg_attr(feature = "config", serde(default))]
+    pub duration: Option<String>,
+    /// Optional gap window: recurring silent periods in the event stream.
+    #[cfg_attr(feature = "config", serde(default))]
+    pub gaps: Option<GapConfig>,
+    /// Optional burst window: recurring high-rate periods in the event stream.
+    ///
+    /// When both a gap and a burst overlap in time, the gap takes priority.
+    #[cfg_attr(feature = "config", serde(default))]
+    pub bursts: Option<BurstConfig>,
+    /// Optional cardinality spikes: recurring windows that inject dynamic
+    /// labels to simulate cardinality explosions.
+    #[cfg_attr(feature = "config", serde(default))]
+    pub cardinality_spikes: Option<Vec<CardinalitySpikeConfig>>,
+    /// Static labels attached to every emitted event.
+    #[cfg_attr(feature = "config", serde(default))]
+    pub labels: Option<HashMap<String, String>>,
+    /// Output sink. Defaults to `stdout`.
+    #[cfg_attr(feature = "config", serde(default = "default_sink"))]
+    pub sink: SinkConfig,
+    /// Delay before starting this scenario, relative to the group start time.
+    ///
+    /// Only meaningful in multi-scenario mode. Enables temporal correlation
+    /// between scenarios: "metric A starts immediately, metric B starts 30s
+    /// later". Accepts a duration string (e.g. `"30s"`, `"1m"`, `"500ms"`).
+    #[cfg_attr(feature = "config", serde(default))]
+    pub phase_offset: Option<String>,
+    /// Clock group identifier for multi-scenario correlation.
+    ///
+    /// Scenarios with the same `clock_group` value share a common start time
+    /// reference. For MVP this provides a shared start reference only; advanced
+    /// cross-scenario signaling is deferred to a future phase.
+    #[cfg_attr(feature = "config", serde(default))]
+    pub clock_group: Option<String>,
+}
+
+/// Full configuration for a single metric scenario run.
+///
+/// Embeds [`BaseScheduleConfig`] for the shared schedule and delivery fields,
+/// adding only the metric-specific value generator and a Prometheus-defaulting
+/// encoder.
+///
+/// Fields from [`BaseScheduleConfig`] are accessible directly via `Deref` (e.g.
+/// `config.name`, `config.rate`) for ergonomic read access. Struct construction
+/// uses the explicit `base` field.
 ///
 /// # Example YAML
 ///
@@ -156,50 +216,28 @@ fn default_sink() -> SinkConfig {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "config", derive(serde::Deserialize))]
 pub struct ScenarioConfig {
-    /// Metric name emitted by this scenario (must be a valid Prometheus metric name).
-    pub name: String,
-    /// Target event rate in events per second. Must be strictly positive.
-    pub rate: f64,
-    /// Optional total run duration (e.g. `"30s"`, `"5m"`). `None` means run indefinitely.
-    #[cfg_attr(feature = "config", serde(default))]
-    pub duration: Option<String>,
+    /// Shared schedule and delivery fields.
+    #[cfg_attr(feature = "config", serde(flatten))]
+    pub base: BaseScheduleConfig,
     /// Value generator configuration.
     pub generator: GeneratorConfig,
-    /// Optional gap window: recurring silent periods in the event stream.
-    #[cfg_attr(feature = "config", serde(default))]
-    pub gaps: Option<GapConfig>,
-    /// Optional burst window: recurring high-rate periods in the event stream.
-    ///
-    /// When both a gap and a burst overlap in time, the gap takes priority.
-    #[cfg_attr(feature = "config", serde(default))]
-    pub bursts: Option<BurstConfig>,
-    /// Optional cardinality spikes: recurring windows that inject dynamic
-    /// labels to simulate cardinality explosions.
-    #[cfg_attr(feature = "config", serde(default))]
-    pub cardinality_spikes: Option<Vec<CardinalitySpikeConfig>>,
-    /// Static labels attached to every emitted event.
-    #[cfg_attr(feature = "config", serde(default))]
-    pub labels: Option<HashMap<String, String>>,
     /// Output encoder. Defaults to `prometheus_text`.
     #[cfg_attr(feature = "config", serde(default = "default_encoder"))]
     pub encoder: EncoderConfig,
-    /// Output sink. Defaults to `stdout`.
-    #[cfg_attr(feature = "config", serde(default = "default_sink"))]
-    pub sink: SinkConfig,
-    /// Delay before starting this scenario, relative to the group start time.
-    ///
-    /// Only meaningful in multi-scenario mode. Enables temporal correlation
-    /// between scenarios: "metric A starts immediately, metric B starts 30s
-    /// later". Accepts a duration string (e.g. `"30s"`, `"1m"`, `"500ms"`).
-    #[cfg_attr(feature = "config", serde(default))]
-    pub phase_offset: Option<String>,
-    /// Clock group identifier for multi-scenario correlation.
-    ///
-    /// Scenarios with the same `clock_group` value share a common start time
-    /// reference. For MVP this provides a shared start reference only; advanced
-    /// cross-scenario signaling is deferred to a future phase.
-    #[cfg_attr(feature = "config", serde(default))]
-    pub clock_group: Option<String>,
+}
+
+impl std::ops::Deref for ScenarioConfig {
+    type Target = BaseScheduleConfig;
+
+    fn deref(&self) -> &BaseScheduleConfig {
+        &self.base
+    }
+}
+
+impl std::ops::DerefMut for ScenarioConfig {
+    fn deref_mut(&mut self) -> &mut BaseScheduleConfig {
+        &mut self.base
+    }
 }
 
 /// A single entry in a multi-scenario configuration.
@@ -220,20 +258,25 @@ pub enum ScenarioEntry {
 }
 
 impl ScenarioEntry {
+    /// Return a reference to the shared [`BaseScheduleConfig`].
+    ///
+    /// Useful when only schedule-level fields (name, rate, duration, gaps,
+    /// labels, sink, etc.) are needed regardless of signal type.
+    pub fn base(&self) -> &BaseScheduleConfig {
+        match self {
+            ScenarioEntry::Metrics(c) => &c.base,
+            ScenarioEntry::Logs(c) => &c.base,
+        }
+    }
+
     /// Return the `phase_offset` duration string, if set on the inner config.
     pub fn phase_offset(&self) -> Option<&str> {
-        match self {
-            ScenarioEntry::Metrics(c) => c.phase_offset.as_deref(),
-            ScenarioEntry::Logs(c) => c.phase_offset.as_deref(),
-        }
+        self.base().phase_offset.as_deref()
     }
 
     /// Return the `clock_group` identifier, if set on the inner config.
     pub fn clock_group(&self) -> Option<&str> {
-        match self {
-            ScenarioEntry::Metrics(c) => c.clock_group.as_deref(),
-            ScenarioEntry::Logs(c) => c.clock_group.as_deref(),
-        }
+        self.base().clock_group.as_deref()
     }
 }
 
@@ -278,7 +321,12 @@ pub struct MultiScenarioConfig {
 
 /// Full configuration for a single log scenario run.
 ///
-/// Deserialized from a YAML scenario file. CLI flags can override any field.
+/// Embeds [`BaseScheduleConfig`] for the shared schedule and delivery fields,
+/// adding only the log-specific generator and a JSON-Lines-defaulting encoder.
+///
+/// Fields from [`BaseScheduleConfig`] are accessible directly via `Deref` (e.g.
+/// `config.name`, `config.rate`) for ergonomic read access. Struct construction
+/// uses the explicit `base` field.
 ///
 /// # Example YAML
 ///
@@ -305,48 +353,28 @@ pub struct MultiScenarioConfig {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "config", derive(serde::Deserialize))]
 pub struct LogScenarioConfig {
-    /// Scenario name (used for identification and logging).
-    pub name: String,
-    /// Target event rate in events per second. Must be strictly positive.
-    pub rate: f64,
-    /// Optional total run duration (e.g. `"30s"`, `"5m"`). `None` means run indefinitely.
-    #[cfg_attr(feature = "config", serde(default))]
-    pub duration: Option<String>,
+    /// Shared schedule and delivery fields.
+    #[cfg_attr(feature = "config", serde(flatten))]
+    pub base: BaseScheduleConfig,
     /// Log generator configuration.
     pub generator: LogGeneratorConfig,
-    /// Optional gap window: recurring silent periods in the event stream.
-    #[cfg_attr(feature = "config", serde(default))]
-    pub gaps: Option<GapConfig>,
-    /// Optional burst window: recurring high-rate periods.
-    #[cfg_attr(feature = "config", serde(default))]
-    pub bursts: Option<BurstConfig>,
-    /// Optional cardinality spikes: recurring windows that inject dynamic
-    /// labels to simulate cardinality explosions.
-    #[cfg_attr(feature = "config", serde(default))]
-    pub cardinality_spikes: Option<Vec<CardinalitySpikeConfig>>,
-    /// Static labels attached to every emitted log event.
-    #[cfg_attr(feature = "config", serde(default))]
-    pub labels: Option<HashMap<String, String>>,
     /// Output encoder. Defaults to `json_lines`.
     #[cfg_attr(feature = "config", serde(default = "default_log_encoder"))]
     pub encoder: EncoderConfig,
-    /// Output sink. Defaults to `stdout`.
-    #[cfg_attr(feature = "config", serde(default = "default_sink"))]
-    pub sink: SinkConfig,
-    /// Delay before starting this scenario, relative to the group start time.
-    ///
-    /// Only meaningful in multi-scenario mode. Enables temporal correlation
-    /// between scenarios: "metric A starts immediately, metric B starts 30s
-    /// later". Accepts a duration string (e.g. `"30s"`, `"1m"`, `"500ms"`).
-    #[cfg_attr(feature = "config", serde(default))]
-    pub phase_offset: Option<String>,
-    /// Clock group identifier for multi-scenario correlation.
-    ///
-    /// Scenarios with the same `clock_group` value share a common start time
-    /// reference. For MVP this provides a shared start reference only; advanced
-    /// cross-scenario signaling is deferred to a future phase.
-    #[cfg_attr(feature = "config", serde(default))]
-    pub clock_group: Option<String>,
+}
+
+impl std::ops::Deref for LogScenarioConfig {
+    type Target = BaseScheduleConfig;
+
+    fn deref(&self) -> &BaseScheduleConfig {
+        &self.base
+    }
+}
+
+impl std::ops::DerefMut for LogScenarioConfig {
+    fn deref_mut(&mut self) -> &mut BaseScheduleConfig {
+        &mut self.base
+    }
 }
 
 #[cfg(all(test, feature = "config"))]
@@ -636,18 +664,20 @@ clock_group: compound-alert
     #[test]
     fn scenario_entry_phase_offset_returns_value_for_metrics() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "accessor_test".to_string(),
-            rate: 10.0,
-            duration: None,
+            base: BaseScheduleConfig {
+                name: "accessor_test".to_string(),
+                rate: 10.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: Some("5s".to_string()),
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: Some("5s".to_string()),
-            clock_group: None,
         });
         assert_eq!(entry.phase_offset(), Some("5s"));
     }
@@ -656,18 +686,20 @@ clock_group: compound-alert
     #[test]
     fn scenario_entry_phase_offset_returns_none_for_metrics_without_offset() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "no_offset".to_string(),
-            rate: 10.0,
-            duration: None,
+            base: BaseScheduleConfig {
+                name: "no_offset".to_string(),
+                rate: 10.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
         assert_eq!(entry.phase_offset(), None);
     }
@@ -676,9 +708,18 @@ clock_group: compound-alert
     #[test]
     fn scenario_entry_phase_offset_returns_value_for_logs() {
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
-            name: "log_accessor".to_string(),
-            rate: 10.0,
-            duration: None,
+            base: BaseScheduleConfig {
+                name: "log_accessor".to_string(),
+                rate: 10.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: Some("10s".to_string()),
+                clock_group: None,
+            },
             generator: LogGeneratorConfig::Template {
                 templates: vec![crate::generator::TemplateConfig {
                     message: "test".to_string(),
@@ -687,14 +728,7 @@ clock_group: compound-alert
                 severity_weights: None,
                 seed: Some(0),
             },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::JsonLines { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: Some("10s".to_string()),
-            clock_group: None,
         });
         assert_eq!(entry.phase_offset(), Some("10s"));
     }
@@ -707,18 +741,20 @@ clock_group: compound-alert
     #[test]
     fn scenario_entry_clock_group_returns_value_for_metrics() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "group_accessor".to_string(),
-            rate: 10.0,
-            duration: None,
+            base: BaseScheduleConfig {
+                name: "group_accessor".to_string(),
+                rate: 10.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: Some("my-group".to_string()),
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: Some("my-group".to_string()),
         });
         assert_eq!(entry.clock_group(), Some("my-group"));
     }
@@ -727,20 +763,79 @@ clock_group: compound-alert
     #[test]
     fn scenario_entry_clock_group_returns_none_when_absent() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "no_group_acc".to_string(),
-            rate: 10.0,
-            duration: None,
+            base: BaseScheduleConfig {
+                name: "no_group_acc".to_string(),
+                rate: 10.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
         assert_eq!(entry.clock_group(), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // ScenarioEntry::base() accessor
+    // -----------------------------------------------------------------------
+
+    /// ScenarioEntry::base() returns the shared config for a Metrics entry.
+    #[test]
+    fn scenario_entry_base_returns_shared_config_for_metrics() {
+        let entry = ScenarioEntry::Metrics(ScenarioConfig {
+            base: BaseScheduleConfig {
+                name: "base_test".to_string(),
+                rate: 42.0,
+                duration: Some("5s".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
+            generator: GeneratorConfig::Constant { value: 1.0 },
+            encoder: EncoderConfig::PrometheusText { precision: None },
+        });
+        assert_eq!(entry.base().name, "base_test");
+        assert_eq!(entry.base().rate, 42.0);
+    }
+
+    /// ScenarioEntry::base() returns the shared config for a Logs entry.
+    #[test]
+    fn scenario_entry_base_returns_shared_config_for_logs() {
+        let entry = ScenarioEntry::Logs(LogScenarioConfig {
+            base: BaseScheduleConfig {
+                name: "log_base".to_string(),
+                rate: 99.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
+            generator: LogGeneratorConfig::Template {
+                templates: vec![crate::generator::TemplateConfig {
+                    message: "test".to_string(),
+                    field_pools: HashMap::new(),
+                }],
+                severity_weights: None,
+                seed: Some(0),
+            },
+            encoder: EncoderConfig::JsonLines { precision: None },
+        });
+        assert_eq!(entry.base().name, "log_base");
+        assert_eq!(entry.base().rate, 99.0);
     }
 
     // -----------------------------------------------------------------------
@@ -955,7 +1050,7 @@ cardinality_spikes:
     cardinality: 10
 "#;
         let config: ScenarioConfig = serde_yaml_ng::from_str(yaml).unwrap();
-        let spikes = config.cardinality_spikes.unwrap();
+        let spikes = config.base.cardinality_spikes.unwrap();
         assert_eq!(spikes[0].strategy, SpikeStrategy::Counter);
     }
 
@@ -977,7 +1072,7 @@ cardinality_spikes:
     cardinality: 100
 "#;
         let config: LogScenarioConfig = serde_yaml_ng::from_str(yaml).unwrap();
-        let spikes = config.cardinality_spikes.unwrap();
+        let spikes = config.base.cardinality_spikes.unwrap();
         assert_eq!(spikes.len(), 1);
         assert_eq!(spikes[0].label, "pod_name");
     }
@@ -1003,5 +1098,253 @@ gaps:
         assert!(config.cardinality_spikes.is_none());
         assert!(config.gaps.is_some());
         assert_eq!(config.name, "compat_test");
+    }
+
+    // -----------------------------------------------------------------------
+    // BaseScheduleConfig: Clone + Debug contract
+    // -----------------------------------------------------------------------
+
+    /// BaseScheduleConfig is Clone and Debug.
+    #[test]
+    fn base_schedule_config_is_clone_and_debug() {
+        let base = BaseScheduleConfig {
+            name: "test".to_string(),
+            rate: 42.0,
+            duration: Some("10s".to_string()),
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            labels: None,
+            sink: SinkConfig::Stdout,
+            phase_offset: None,
+            clock_group: None,
+        };
+        let cloned = base.clone();
+        assert_eq!(cloned.name, "test");
+        assert_eq!(cloned.rate, 42.0);
+        let dbg = format!("{base:?}");
+        assert!(
+            dbg.contains("BaseScheduleConfig"),
+            "Debug output must contain type name"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Deref: ScenarioConfig fields accessible directly
+    // -----------------------------------------------------------------------
+
+    /// ScenarioConfig fields from BaseScheduleConfig are accessible via Deref.
+    #[test]
+    fn scenario_config_deref_accesses_base_fields() {
+        let config = ScenarioConfig {
+            base: BaseScheduleConfig {
+                name: "deref_test".to_string(),
+                rate: 99.0,
+                duration: Some("5s".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: Some("1s".to_string()),
+                clock_group: Some("group-a".to_string()),
+            },
+            generator: GeneratorConfig::Constant { value: 1.0 },
+            encoder: EncoderConfig::PrometheusText { precision: None },
+        };
+        // All these access via Deref — no explicit `.base.` needed.
+        assert_eq!(config.name, "deref_test");
+        assert_eq!(config.rate, 99.0);
+        assert_eq!(config.duration.as_deref(), Some("5s"));
+        assert!(config.gaps.is_none());
+        assert_eq!(config.phase_offset.as_deref(), Some("1s"));
+        assert_eq!(config.clock_group.as_deref(), Some("group-a"));
+    }
+
+    /// LogScenarioConfig fields from BaseScheduleConfig are accessible via Deref.
+    #[test]
+    fn log_scenario_config_deref_accesses_base_fields() {
+        let config = LogScenarioConfig {
+            base: BaseScheduleConfig {
+                name: "log_deref".to_string(),
+                rate: 50.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
+            generator: LogGeneratorConfig::Template {
+                templates: vec![crate::generator::TemplateConfig {
+                    message: "test".to_string(),
+                    field_pools: HashMap::new(),
+                }],
+                severity_weights: None,
+                seed: Some(0),
+            },
+            encoder: EncoderConfig::JsonLines { precision: None },
+        };
+        assert_eq!(config.name, "log_deref");
+        assert_eq!(config.rate, 50.0);
+        assert!(config.duration.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // DerefMut: ScenarioConfig base fields mutable via DerefMut
+    // -----------------------------------------------------------------------
+
+    /// ScenarioConfig base fields can be mutated via DerefMut.
+    #[test]
+    fn scenario_config_deref_mut_allows_base_field_mutation() {
+        let mut config = ScenarioConfig {
+            base: BaseScheduleConfig {
+                name: "original".to_string(),
+                rate: 10.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
+            generator: GeneratorConfig::Constant { value: 1.0 },
+            encoder: EncoderConfig::PrometheusText { precision: None },
+        };
+        config.name = "mutated".to_string();
+        config.rate = 999.0;
+        config.duration = Some("30s".to_string());
+        assert_eq!(config.name, "mutated");
+        assert_eq!(config.rate, 999.0);
+        assert_eq!(config.duration.as_deref(), Some("30s"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Flatten: YAML with base fields and generator deserializes correctly
+    // -----------------------------------------------------------------------
+
+    /// ScenarioConfig deserializes with all fields at the top level (serde flatten).
+    #[test]
+    fn scenario_config_flatten_deserializes_all_fields() {
+        let yaml = r#"
+name: flatten_test
+rate: 100
+duration: 30s
+generator:
+  type: sine
+  amplitude: 5.0
+  period_secs: 30
+  offset: 10.0
+gaps:
+  every: 2m
+  for: 20s
+bursts:
+  every: 10s
+  for: 2s
+  multiplier: 5.0
+labels:
+  hostname: t0-a1
+  zone: eu1
+encoder:
+  type: prometheus_text
+sink:
+  type: stdout
+phase_offset: "5s"
+clock_group: correlation
+"#;
+        let config: ScenarioConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.name, "flatten_test");
+        assert_eq!(config.rate, 100.0);
+        assert_eq!(config.duration.as_deref(), Some("30s"));
+        assert!(config.gaps.is_some());
+        assert!(config.bursts.is_some());
+        let labels = config.labels.as_ref().unwrap();
+        assert_eq!(labels.get("hostname").map(String::as_str), Some("t0-a1"));
+        assert!(matches!(
+            config.encoder,
+            EncoderConfig::PrometheusText { .. }
+        ));
+        assert!(matches!(config.base.sink, SinkConfig::Stdout));
+        assert_eq!(config.phase_offset.as_deref(), Some("5s"));
+        assert_eq!(config.clock_group.as_deref(), Some("correlation"));
+    }
+
+    /// LogScenarioConfig deserializes with all fields at the top level (serde flatten).
+    #[test]
+    fn log_scenario_config_flatten_deserializes_all_fields() {
+        let yaml = r#"
+name: log_flatten
+rate: 20
+duration: 60s
+generator:
+  type: template
+  templates:
+    - message: "hello"
+      field_pools: {}
+labels:
+  env: prod
+encoder:
+  type: syslog
+  hostname: myhost
+  app_name: myapp
+sink:
+  type: stdout
+phase_offset: "2s"
+clock_group: log-group
+"#;
+        let config: LogScenarioConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.name, "log_flatten");
+        assert_eq!(config.rate, 20.0);
+        assert_eq!(config.duration.as_deref(), Some("60s"));
+        let labels = config.labels.as_ref().unwrap();
+        assert_eq!(labels.get("env").map(String::as_str), Some("prod"));
+        assert_eq!(config.phase_offset.as_deref(), Some("2s"));
+        assert_eq!(config.clock_group.as_deref(), Some("log-group"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Encoder defaults remain correct per signal type
+    // -----------------------------------------------------------------------
+
+    /// ScenarioConfig defaults encoder to prometheus_text.
+    #[test]
+    fn scenario_config_encoder_defaults_to_prometheus_text() {
+        let yaml = r#"
+name: enc_default
+rate: 10
+generator:
+  type: constant
+  value: 1.0
+"#;
+        let config: ScenarioConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(
+            matches!(config.encoder, EncoderConfig::PrometheusText { .. }),
+            "ScenarioConfig encoder default must be prometheus_text, got {:?}",
+            config.encoder
+        );
+    }
+
+    /// LogScenarioConfig defaults encoder to json_lines.
+    #[test]
+    fn log_scenario_config_encoder_defaults_to_json_lines() {
+        let yaml = r#"
+name: log_enc_default
+rate: 10
+generator:
+  type: template
+  templates:
+    - message: "test"
+      field_pools: {}
+"#;
+        let config: LogScenarioConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(
+            matches!(config.encoder, EncoderConfig::JsonLines { .. }),
+            "LogScenarioConfig encoder default must be json_lines, got {:?}",
+            config.encoder
+        );
     }
 }

--- a/sonda-core/src/config/validate.rs
+++ b/sonda-core/src/config/validate.rs
@@ -776,7 +776,7 @@ labels:
 "#;
         let config: ScenarioConfig =
             serde_yaml_ng::from_str(yaml).expect("YAML with labels must deserialize");
-        let labels = config.labels.expect("labels must be present");
+        let labels = config.base.labels.expect("labels must be present");
         assert_eq!(labels.get("env").map(String::as_str), Some("prod"));
         assert_eq!(labels.get("region").map(String::as_str), Some("us-east-1"));
     }
@@ -796,7 +796,7 @@ gaps:
 "#;
         let config: ScenarioConfig =
             serde_yaml_ng::from_str(yaml).expect("YAML with gaps must deserialize");
-        let gap = config.gaps.expect("gaps must be present");
+        let gap = config.base.gaps.expect("gaps must be present");
         assert_eq!(gap.every, "2m");
         assert_eq!(gap.r#for, "20s");
     }
@@ -1215,7 +1215,7 @@ bursts:
 "#;
         let config: ScenarioConfig =
             serde_yaml_ng::from_str(yaml).expect("YAML with bursts must deserialize");
-        let burst = config.bursts.expect("bursts must be present");
+        let burst = config.base.bursts.expect("bursts must be present");
         assert_eq!(burst.every, "10s");
         assert_eq!(burst.r#for, "2s");
         assert_eq!(burst.multiplier, 5.0);
@@ -1281,18 +1281,20 @@ generator:
     /// Build a minimal valid ScenarioConfig overriding only the rate.
     fn minimal_config_with_rate(rate: f64) -> ScenarioConfig {
         ScenarioConfig {
-            name: "up".to_string(),
-            rate,
-            duration: None,
+            base: crate::config::BaseScheduleConfig {
+                name: "up".to_string(),
+                rate,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         }
     }
 

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod schedule;
 pub mod sink;
 pub(crate) mod util;
 
+pub use config::BaseScheduleConfig;
 pub use config::BurstConfig;
 pub use config::CardinalitySpikeConfig;
 pub use config::LogScenarioConfig;
@@ -532,24 +533,26 @@ mod tests {
     /// This test runs with or without the feature enabled.
     #[test]
     fn config_types_constructible_without_yaml_parsing() {
-        use crate::config::ScenarioConfig;
+        use crate::config::{BaseScheduleConfig, ScenarioConfig};
         use crate::encoder::EncoderConfig;
         use crate::generator::GeneratorConfig;
         use crate::sink::SinkConfig;
 
         let _config = ScenarioConfig {
-            name: "test".to_string(),
-            rate: 10.0,
-            duration: None,
+            base: BaseScheduleConfig {
+                name: "test".to_string(),
+                rate: 10.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         };
     }
 

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -150,7 +150,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-    use crate::config::{LogScenarioConfig, ScenarioConfig, ScenarioEntry};
+    use crate::config::{BaseScheduleConfig, LogScenarioConfig, ScenarioConfig, ScenarioEntry};
     use crate::encoder::EncoderConfig;
     use crate::generator::{GeneratorConfig, LogGeneratorConfig, TemplateConfig};
     use crate::sink::SinkConfig;
@@ -160,27 +160,38 @@ mod tests {
     /// Build a short-lived metrics `ScenarioEntry` (runs for 200ms then stops).
     fn metrics_entry(name: &str) -> ScenarioEntry {
         ScenarioEntry::Metrics(ScenarioConfig {
-            name: name.to_string(),
-            rate: 50.0,
-            duration: Some("200ms".to_string()),
+            base: BaseScheduleConfig {
+                name: name.to_string(),
+                rate: 50.0,
+                duration: Some("200ms".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         })
     }
 
     /// Build a short-lived logs `ScenarioEntry` (runs for 200ms then stops).
     fn logs_entry(name: &str) -> ScenarioEntry {
         ScenarioEntry::Logs(LogScenarioConfig {
-            name: name.to_string(),
-            rate: 50.0,
-            duration: Some("200ms".to_string()),
+            base: BaseScheduleConfig {
+                name: name.to_string(),
+                rate: 50.0,
+                duration: Some("200ms".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: LogGeneratorConfig::Template {
                 templates: vec![TemplateConfig {
                     message: "test log".to_string(),
@@ -189,41 +200,45 @@ mod tests {
                 severity_weights: None,
                 seed: Some(0),
             },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::JsonLines { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         })
     }
 
     /// Build an indefinitely-running metrics entry (no duration).
     fn metrics_entry_indefinite(name: &str) -> ScenarioEntry {
         ScenarioEntry::Metrics(ScenarioConfig {
-            name: name.to_string(),
-            rate: 100.0,
-            duration: None,
+            base: BaseScheduleConfig {
+                name: name.to_string(),
+                rate: 100.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         })
     }
 
     /// Build an indefinitely-running logs entry (no duration).
     fn logs_entry_indefinite(name: &str) -> ScenarioEntry {
         ScenarioEntry::Logs(LogScenarioConfig {
-            name: name.to_string(),
-            rate: 100.0,
-            duration: None,
+            base: BaseScheduleConfig {
+                name: name.to_string(),
+                rate: 100.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: LogGeneratorConfig::Template {
                 templates: vec![TemplateConfig {
                     message: "indefinite log".to_string(),
@@ -232,14 +247,7 @@ mod tests {
                 severity_weights: None,
                 seed: Some(1),
             },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::JsonLines { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         })
     }
 
@@ -271,18 +279,20 @@ mod tests {
     #[test]
     fn validate_entry_rejects_metrics_entry_with_zero_rate() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "bad_metrics".to_string(),
-            rate: 0.0, // invalid
-            duration: Some("1s".to_string()),
+            base: BaseScheduleConfig {
+                name: "bad_metrics".to_string(),
+                rate: 0.0, // invalid
+                duration: Some("1s".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
         let result = validate_entry(&entry);
         assert!(
@@ -295,18 +305,20 @@ mod tests {
     #[test]
     fn validate_entry_rejects_metrics_entry_with_negative_rate() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "neg_rate".to_string(),
-            rate: -5.0,
-            duration: Some("1s".to_string()),
+            base: BaseScheduleConfig {
+                name: "neg_rate".to_string(),
+                rate: -5.0,
+                duration: Some("1s".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
         let result = validate_entry(&entry);
         assert!(
@@ -319,9 +331,18 @@ mod tests {
     #[test]
     fn validate_entry_rejects_logs_entry_with_zero_rate() {
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
-            name: "bad_logs".to_string(),
-            rate: 0.0, // invalid
-            duration: Some("1s".to_string()),
+            base: BaseScheduleConfig {
+                name: "bad_logs".to_string(),
+                rate: 0.0, // invalid
+                duration: Some("1s".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: LogGeneratorConfig::Template {
                 templates: vec![TemplateConfig {
                     message: "msg".to_string(),
@@ -330,14 +351,7 @@ mod tests {
                 severity_weights: None,
                 seed: Some(0),
             },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::JsonLines { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
         let result = validate_entry(&entry);
         assert!(
@@ -350,18 +364,20 @@ mod tests {
     #[test]
     fn validate_entry_rejects_metrics_entry_with_bad_duration() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "bad_dur".to_string(),
-            rate: 10.0,
-            duration: Some("not_a_duration".to_string()),
+            base: BaseScheduleConfig {
+                name: "bad_dur".to_string(),
+                rate: 10.0,
+                duration: Some("not_a_duration".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
         let result = validate_entry(&entry);
         assert!(
@@ -485,18 +501,20 @@ mod tests {
         let shutdown = Arc::new(AtomicBool::new(true));
         // High rate so events accumulate quickly.
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "stats_test".to_string(),
-            rate: 500.0,
-            duration: None, // indefinite — we stop it manually
+            base: BaseScheduleConfig {
+                name: "stats_test".to_string(),
+                rate: 500.0,
+                duration: None, // indefinite — we stop it manually
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
 
         let mut handle =
@@ -529,9 +547,18 @@ mod tests {
 
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
-            name: "logs_stats_test".to_string(),
-            rate: 500.0,
-            duration: None,
+            base: BaseScheduleConfig {
+                name: "logs_stats_test".to_string(),
+                rate: 500.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: LogGeneratorConfig::Template {
                 templates: vec![TemplateConfig {
                     message: "stat tracking log".to_string(),
@@ -540,14 +567,7 @@ mod tests {
                 severity_weights: None,
                 seed: Some(42),
             },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::JsonLines { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
 
         let mut handle = launch_scenario(
@@ -622,18 +642,20 @@ mod tests {
 
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "no_delay_test".to_string(),
-            rate: 500.0,
-            duration: None,
+            base: BaseScheduleConfig {
+                name: "no_delay_test".to_string(),
+                rate: 500.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
 
         let mut handle =
@@ -663,18 +685,20 @@ mod tests {
 
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "delay_test".to_string(),
-            rate: 500.0,
-            duration: Some("1s".to_string()),
+            base: BaseScheduleConfig {
+                name: "delay_test".to_string(),
+                rate: 500.0,
+                duration: Some("1s".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
 
         let delay = Duration::from_millis(500);
@@ -767,9 +791,18 @@ mod tests {
 
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
-            name: "log_delay_test".to_string(),
-            rate: 500.0,
-            duration: Some("1s".to_string()),
+            base: BaseScheduleConfig {
+                name: "log_delay_test".to_string(),
+                rate: 500.0,
+                duration: Some("1s".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: LogGeneratorConfig::Template {
                 templates: vec![TemplateConfig {
                     message: "delayed log".to_string(),
@@ -778,14 +811,7 @@ mod tests {
                 severity_weights: None,
                 seed: Some(0),
             },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::JsonLines { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
 
         let delay = Duration::from_millis(500);

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -320,7 +320,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::config::{GapConfig, LogScenarioConfig};
+    use crate::config::{BaseScheduleConfig, GapConfig, LogScenarioConfig};
     use crate::encoder::EncoderConfig;
     use crate::generator::{LogGeneratorConfig, TemplateConfig};
     use crate::sink::memory::MemorySink;
@@ -333,9 +333,18 @@ mod tests {
     /// call `run_logs_with_sink` directly).
     fn make_config(rate: f64, duration: Option<&str>) -> LogScenarioConfig {
         LogScenarioConfig {
-            name: "test_logs".to_string(),
-            rate,
-            duration: duration.map(|s| s.to_string()),
+            base: BaseScheduleConfig {
+                name: "test_logs".to_string(),
+                rate,
+                duration: duration.map(|s| s.to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: LogGeneratorConfig::Template {
                 templates: vec![TemplateConfig {
                     message: "synthetic log event".to_string(),
@@ -344,14 +353,7 @@ mod tests {
                 severity_weights: None,
                 seed: Some(0),
             },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::JsonLines { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         }
     }
 

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -97,7 +97,9 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant};
 
-    use crate::config::{LogScenarioConfig, MultiScenarioConfig, ScenarioConfig, ScenarioEntry};
+    use crate::config::{
+        BaseScheduleConfig, LogScenarioConfig, MultiScenarioConfig, ScenarioConfig, ScenarioEntry,
+    };
     use crate::encoder::EncoderConfig;
     use crate::generator::{GeneratorConfig, LogGeneratorConfig, TemplateConfig};
     use crate::sink::SinkConfig;
@@ -108,18 +110,20 @@ mod tests {
     /// Duration of "100ms" ensures the thread exits quickly.
     fn metrics_entry_stdout(name: &str) -> ScenarioEntry {
         ScenarioEntry::Metrics(ScenarioConfig {
-            name: name.to_string(),
-            rate: 10.0,
-            duration: Some("100ms".to_string()),
+            base: BaseScheduleConfig {
+                name: name.to_string(),
+                rate: 10.0,
+                duration: Some("100ms".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         })
     }
 
@@ -127,9 +131,18 @@ mod tests {
     /// Duration of "100ms" ensures the thread exits quickly.
     fn logs_entry_stdout(name: &str) -> ScenarioEntry {
         ScenarioEntry::Logs(LogScenarioConfig {
-            name: name.to_string(),
-            rate: 10.0,
-            duration: Some("100ms".to_string()),
+            base: BaseScheduleConfig {
+                name: name.to_string(),
+                rate: 10.0,
+                duration: Some("100ms".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: LogGeneratorConfig::Template {
                 templates: vec![TemplateConfig {
                     message: "test log event".to_string(),
@@ -138,14 +151,7 @@ mod tests {
                 severity_weights: None,
                 seed: Some(42),
             },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::JsonLines { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         })
     }
 
@@ -234,23 +240,34 @@ mod tests {
         let config = MultiScenarioConfig {
             scenarios: vec![
                 ScenarioEntry::Metrics(ScenarioConfig {
-                    name: "shutdown_test_metric".to_string(),
-                    rate: 10.0,
-                    duration: None, // indefinite
+                    base: BaseScheduleConfig {
+                        name: "shutdown_test_metric".to_string(),
+                        rate: 10.0,
+                        duration: None, // indefinite
+                        gaps: None,
+                        bursts: None,
+                        cardinality_spikes: None,
+                        labels: None,
+                        sink: SinkConfig::Stdout,
+                        phase_offset: None,
+                        clock_group: None,
+                    },
                     generator: GeneratorConfig::Constant { value: 1.0 },
-                    gaps: None,
-                    bursts: None,
-                    cardinality_spikes: None,
-                    labels: None,
                     encoder: EncoderConfig::PrometheusText { precision: None },
-                    sink: SinkConfig::Stdout,
-                    phase_offset: None,
-                    clock_group: None,
                 }),
                 ScenarioEntry::Logs(LogScenarioConfig {
-                    name: "shutdown_test_logs".to_string(),
-                    rate: 10.0,
-                    duration: None, // indefinite
+                    base: BaseScheduleConfig {
+                        name: "shutdown_test_logs".to_string(),
+                        rate: 10.0,
+                        duration: None, // indefinite
+                        gaps: None,
+                        bursts: None,
+                        cardinality_spikes: None,
+                        labels: None,
+                        sink: SinkConfig::Stdout,
+                        phase_offset: None,
+                        clock_group: None,
+                    },
                     generator: LogGeneratorConfig::Template {
                         templates: vec![TemplateConfig {
                             message: "shutdown test".to_string(),
@@ -259,14 +276,7 @@ mod tests {
                         severity_weights: None,
                         seed: Some(0),
                     },
-                    gaps: None,
-                    bursts: None,
-                    cardinality_spikes: None,
-                    labels: None,
                     encoder: EncoderConfig::JsonLines { precision: None },
-                    sink: SinkConfig::Stdout,
-                    phase_offset: None,
-                    clock_group: None,
                 }),
             ],
         };
@@ -312,21 +322,22 @@ mod tests {
         // during sink construction inside the thread.
         let config = MultiScenarioConfig {
             scenarios: vec![ScenarioEntry::Metrics(ScenarioConfig {
-                name: "error_test".to_string(),
-                rate: 10.0,
-                duration: Some("100ms".to_string()),
-                generator: GeneratorConfig::Constant { value: 1.0 },
-                gaps: None,
-                bursts: None,
-                cardinality_spikes: None,
-                labels: None,
-                encoder: EncoderConfig::PrometheusText { precision: None },
-                // /proc is read-only on Linux and not writable on macOS either
-                sink: SinkConfig::File {
-                    path: "/proc/sonda_test_cannot_create_this_file_27.txt".to_string(),
+                base: BaseScheduleConfig {
+                    name: "error_test".to_string(),
+                    rate: 10.0,
+                    duration: Some("100ms".to_string()),
+                    gaps: None,
+                    bursts: None,
+                    cardinality_spikes: None,
+                    labels: None,
+                    sink: SinkConfig::File {
+                        path: "/proc/sonda_test_cannot_create_this_file_27.txt".to_string(),
+                    },
+                    phase_offset: None,
+                    clock_group: None,
                 },
-                phase_offset: None,
-                clock_group: None,
+                generator: GeneratorConfig::Constant { value: 1.0 },
+                encoder: EncoderConfig::PrometheusText { precision: None },
             })],
         };
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -348,36 +359,40 @@ mod tests {
         let config = MultiScenarioConfig {
             scenarios: vec![
                 ScenarioEntry::Metrics(ScenarioConfig {
-                    name: "err_a".to_string(),
-                    rate: 10.0,
-                    duration: Some("100ms".to_string()),
-                    generator: GeneratorConfig::Constant { value: 1.0 },
-                    gaps: None,
-                    bursts: None,
-                    cardinality_spikes: None,
-                    labels: None,
-                    encoder: EncoderConfig::PrometheusText { precision: None },
-                    sink: SinkConfig::File {
-                        path: "/proc/sonda_err_a_27.txt".to_string(),
+                    base: BaseScheduleConfig {
+                        name: "err_a".to_string(),
+                        rate: 10.0,
+                        duration: Some("100ms".to_string()),
+                        gaps: None,
+                        bursts: None,
+                        cardinality_spikes: None,
+                        labels: None,
+                        sink: SinkConfig::File {
+                            path: "/proc/sonda_err_a_27.txt".to_string(),
+                        },
+                        phase_offset: None,
+                        clock_group: None,
                     },
-                    phase_offset: None,
-                    clock_group: None,
+                    generator: GeneratorConfig::Constant { value: 1.0 },
+                    encoder: EncoderConfig::PrometheusText { precision: None },
                 }),
                 ScenarioEntry::Metrics(ScenarioConfig {
-                    name: "err_b".to_string(),
-                    rate: 10.0,
-                    duration: Some("100ms".to_string()),
-                    generator: GeneratorConfig::Constant { value: 1.0 },
-                    gaps: None,
-                    bursts: None,
-                    cardinality_spikes: None,
-                    labels: None,
-                    encoder: EncoderConfig::PrometheusText { precision: None },
-                    sink: SinkConfig::File {
-                        path: "/proc/sonda_err_b_27.txt".to_string(),
+                    base: BaseScheduleConfig {
+                        name: "err_b".to_string(),
+                        rate: 10.0,
+                        duration: Some("100ms".to_string()),
+                        gaps: None,
+                        bursts: None,
+                        cardinality_spikes: None,
+                        labels: None,
+                        sink: SinkConfig::File {
+                            path: "/proc/sonda_err_b_27.txt".to_string(),
+                        },
+                        phase_offset: None,
+                        clock_group: None,
                     },
-                    phase_offset: None,
-                    clock_group: None,
+                    generator: GeneratorConfig::Constant { value: 1.0 },
+                    encoder: EncoderConfig::PrometheusText { precision: None },
                 }),
             ],
         };
@@ -398,20 +413,22 @@ mod tests {
         // The collected error must be Runtime::ScenariosFailed, not Config.
         let config = MultiScenarioConfig {
             scenarios: vec![ScenarioEntry::Metrics(ScenarioConfig {
-                name: "variant_test".to_string(),
-                rate: 10.0,
-                duration: Some("100ms".to_string()),
-                generator: GeneratorConfig::Constant { value: 1.0 },
-                gaps: None,
-                bursts: None,
-                cardinality_spikes: None,
-                labels: None,
-                encoder: EncoderConfig::PrometheusText { precision: None },
-                sink: SinkConfig::File {
-                    path: "/proc/sonda_variant_test_27.txt".to_string(),
+                base: BaseScheduleConfig {
+                    name: "variant_test".to_string(),
+                    rate: 10.0,
+                    duration: Some("100ms".to_string()),
+                    gaps: None,
+                    bursts: None,
+                    cardinality_spikes: None,
+                    labels: None,
+                    sink: SinkConfig::File {
+                        path: "/proc/sonda_variant_test_27.txt".to_string(),
+                    },
+                    phase_offset: None,
+                    clock_group: None,
                 },
-                phase_offset: None,
-                clock_group: None,
+                generator: GeneratorConfig::Constant { value: 1.0 },
+                encoder: EncoderConfig::PrometheusText { precision: None },
             })],
         };
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -621,18 +638,20 @@ rate: 10
     fn run_multi_with_minimal_phase_offset_emits_almost_immediately() {
         let config = MultiScenarioConfig {
             scenarios: vec![ScenarioEntry::Metrics(ScenarioConfig {
-                name: "minimal_offset".to_string(),
-                rate: 10.0,
-                duration: Some("200ms".to_string()),
+                base: BaseScheduleConfig {
+                    name: "minimal_offset".to_string(),
+                    rate: 10.0,
+                    duration: Some("200ms".to_string()),
+                    gaps: None,
+                    bursts: None,
+                    cardinality_spikes: None,
+                    labels: None,
+                    sink: SinkConfig::Stdout,
+                    phase_offset: Some("1ms".to_string()),
+                    clock_group: None,
+                },
                 generator: GeneratorConfig::Constant { value: 1.0 },
-                gaps: None,
-                bursts: None,
-                cardinality_spikes: None,
-                labels: None,
                 encoder: EncoderConfig::PrometheusText { precision: None },
-                sink: SinkConfig::Stdout,
-                phase_offset: Some("1ms".to_string()),
-                clock_group: None,
             })],
         };
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -657,18 +676,20 @@ rate: 10
     fn run_multi_accepts_zero_phase_offset() {
         let config = MultiScenarioConfig {
             scenarios: vec![ScenarioEntry::Metrics(ScenarioConfig {
-                name: "zero_offset".to_string(),
-                rate: 10.0,
-                duration: Some("200ms".to_string()),
+                base: BaseScheduleConfig {
+                    name: "zero_offset".to_string(),
+                    rate: 10.0,
+                    duration: Some("200ms".to_string()),
+                    gaps: None,
+                    bursts: None,
+                    cardinality_spikes: None,
+                    labels: None,
+                    sink: SinkConfig::Stdout,
+                    phase_offset: Some("0s".to_string()),
+                    clock_group: None,
+                },
                 generator: GeneratorConfig::Constant { value: 1.0 },
-                gaps: None,
-                bursts: None,
-                cardinality_spikes: None,
-                labels: None,
                 encoder: EncoderConfig::PrometheusText { precision: None },
-                sink: SinkConfig::Stdout,
-                phase_offset: Some("0s".to_string()),
-                clock_group: None,
             })],
         };
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -702,32 +723,36 @@ rate: 10
         let config = MultiScenarioConfig {
             scenarios: vec![
                 ScenarioEntry::Metrics(ScenarioConfig {
-                    name: "first_immediate".to_string(),
-                    rate: 10.0,
-                    duration: Some("100ms".to_string()),
+                    base: BaseScheduleConfig {
+                        name: "first_immediate".to_string(),
+                        rate: 10.0,
+                        duration: Some("100ms".to_string()),
+                        gaps: None,
+                        bursts: None,
+                        cardinality_spikes: None,
+                        labels: None,
+                        sink: SinkConfig::Stdout,
+                        phase_offset: None,
+                        clock_group: None,
+                    },
                     generator: GeneratorConfig::Constant { value: 1.0 },
-                    gaps: None,
-                    bursts: None,
-                    cardinality_spikes: None,
-                    labels: None,
                     encoder: EncoderConfig::PrometheusText { precision: None },
-                    sink: SinkConfig::Stdout,
-                    phase_offset: None,
-                    clock_group: None,
                 }),
                 ScenarioEntry::Metrics(ScenarioConfig {
-                    name: "second_delayed".to_string(),
-                    rate: 10.0,
-                    duration: Some("100ms".to_string()),
+                    base: BaseScheduleConfig {
+                        name: "second_delayed".to_string(),
+                        rate: 10.0,
+                        duration: Some("100ms".to_string()),
+                        gaps: None,
+                        bursts: None,
+                        cardinality_spikes: None,
+                        labels: None,
+                        sink: SinkConfig::Stdout,
+                        phase_offset: Some("500ms".to_string()),
+                        clock_group: None,
+                    },
                     generator: GeneratorConfig::Constant { value: 2.0 },
-                    gaps: None,
-                    bursts: None,
-                    cardinality_spikes: None,
-                    labels: None,
                     encoder: EncoderConfig::PrometheusText { precision: None },
-                    sink: SinkConfig::Stdout,
-                    phase_offset: Some("500ms".to_string()),
-                    clock_group: None,
                 }),
             ],
         };
@@ -753,33 +778,37 @@ rate: 10
             scenarios: vec![
                 // First scenario runs indefinitely.
                 ScenarioEntry::Metrics(ScenarioConfig {
-                    name: "immediate_indef".to_string(),
-                    rate: 10.0,
-                    duration: None,
+                    base: BaseScheduleConfig {
+                        name: "immediate_indef".to_string(),
+                        rate: 10.0,
+                        duration: None,
+                        gaps: None,
+                        bursts: None,
+                        cardinality_spikes: None,
+                        labels: None,
+                        sink: SinkConfig::Stdout,
+                        phase_offset: None,
+                        clock_group: None,
+                    },
                     generator: GeneratorConfig::Constant { value: 1.0 },
-                    gaps: None,
-                    bursts: None,
-                    cardinality_spikes: None,
-                    labels: None,
                     encoder: EncoderConfig::PrometheusText { precision: None },
-                    sink: SinkConfig::Stdout,
-                    phase_offset: None,
-                    clock_group: None,
                 }),
                 // Second scenario has a long delay — we'll shut down before it starts.
                 ScenarioEntry::Metrics(ScenarioConfig {
-                    name: "long_delay".to_string(),
-                    rate: 10.0,
-                    duration: None,
+                    base: BaseScheduleConfig {
+                        name: "long_delay".to_string(),
+                        rate: 10.0,
+                        duration: None,
+                        gaps: None,
+                        bursts: None,
+                        cardinality_spikes: None,
+                        labels: None,
+                        sink: SinkConfig::Stdout,
+                        phase_offset: Some("10s".to_string()),
+                        clock_group: None,
+                    },
                     generator: GeneratorConfig::Constant { value: 2.0 },
-                    gaps: None,
-                    bursts: None,
-                    cardinality_spikes: None,
-                    labels: None,
                     encoder: EncoderConfig::PrometheusText { precision: None },
-                    sink: SinkConfig::Stdout,
-                    phase_offset: Some("10s".to_string()),
-                    clock_group: None,
                 }),
             ],
         };
@@ -814,18 +843,20 @@ rate: 10
     fn run_multi_rejects_invalid_phase_offset() {
         let config = MultiScenarioConfig {
             scenarios: vec![ScenarioEntry::Metrics(ScenarioConfig {
-                name: "bad_offset".to_string(),
-                rate: 10.0,
-                duration: Some("100ms".to_string()),
+                base: BaseScheduleConfig {
+                    name: "bad_offset".to_string(),
+                    rate: 10.0,
+                    duration: Some("100ms".to_string()),
+                    gaps: None,
+                    bursts: None,
+                    cardinality_spikes: None,
+                    labels: None,
+                    sink: SinkConfig::Stdout,
+                    phase_offset: Some("not_a_duration".to_string()),
+                    clock_group: None,
+                },
                 generator: GeneratorConfig::Constant { value: 1.0 },
-                gaps: None,
-                bursts: None,
-                cardinality_spikes: None,
-                labels: None,
                 encoder: EncoderConfig::PrometheusText { precision: None },
-                sink: SinkConfig::Stdout,
-                phase_offset: Some("not_a_duration".to_string()),
-                clock_group: None,
             })],
         };
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -890,32 +921,36 @@ scenarios:
         let config = MultiScenarioConfig {
             scenarios: vec![
                 ScenarioEntry::Metrics(ScenarioConfig {
-                    name: "grouped_a".to_string(),
-                    rate: 10.0,
-                    duration: Some("100ms".to_string()),
+                    base: BaseScheduleConfig {
+                        name: "grouped_a".to_string(),
+                        rate: 10.0,
+                        duration: Some("100ms".to_string()),
+                        gaps: None,
+                        bursts: None,
+                        cardinality_spikes: None,
+                        labels: None,
+                        sink: SinkConfig::Stdout,
+                        phase_offset: None,
+                        clock_group: Some("test-group".to_string()),
+                    },
                     generator: GeneratorConfig::Constant { value: 1.0 },
-                    gaps: None,
-                    bursts: None,
-                    cardinality_spikes: None,
-                    labels: None,
                     encoder: EncoderConfig::PrometheusText { precision: None },
-                    sink: SinkConfig::Stdout,
-                    phase_offset: None,
-                    clock_group: Some("test-group".to_string()),
                 }),
                 ScenarioEntry::Metrics(ScenarioConfig {
-                    name: "grouped_b".to_string(),
-                    rate: 10.0,
-                    duration: Some("100ms".to_string()),
+                    base: BaseScheduleConfig {
+                        name: "grouped_b".to_string(),
+                        rate: 10.0,
+                        duration: Some("100ms".to_string()),
+                        gaps: None,
+                        bursts: None,
+                        cardinality_spikes: None,
+                        labels: None,
+                        sink: SinkConfig::Stdout,
+                        phase_offset: Some("200ms".to_string()),
+                        clock_group: Some("test-group".to_string()),
+                    },
                     generator: GeneratorConfig::Constant { value: 2.0 },
-                    gaps: None,
-                    bursts: None,
-                    cardinality_spikes: None,
-                    labels: None,
                     encoder: EncoderConfig::PrometheusText { precision: None },
-                    sink: SinkConfig::Stdout,
-                    phase_offset: Some("200ms".to_string()),
-                    clock_group: Some("test-group".to_string()),
                 }),
             ],
         };

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -348,7 +348,7 @@ pub fn run_with_sink(
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{GapConfig, ScenarioConfig};
+    use crate::config::{BaseScheduleConfig, GapConfig, ScenarioConfig};
     use crate::encoder::EncoderConfig;
     use crate::generator::GeneratorConfig;
     use crate::sink::memory::MemorySink;
@@ -357,18 +357,20 @@ mod tests {
     /// Build a minimal ScenarioConfig suitable for a short integration run.
     fn make_config(rate: f64, duration: &str, gaps: Option<GapConfig>) -> ScenarioConfig {
         ScenarioConfig {
-            name: "up".to_string(),
-            rate,
-            duration: Some(duration.to_string()),
+            base: BaseScheduleConfig {
+                name: "up".to_string(),
+                rate,
+                duration: Some(duration.to_string()),
+                gaps,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout, // not used — tests use run_with_sink directly
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout, // not used — tests use run_with_sink directly
-            phase_offset: None,
-            clock_group: None,
         }
     }
 
@@ -516,18 +518,20 @@ mod tests {
         bursts: Option<crate::config::BurstConfig>,
     ) -> crate::config::ScenarioConfig {
         crate::config::ScenarioConfig {
-            name: "up".to_string(),
-            rate,
-            duration: Some(duration.to_string()),
+            base: crate::config::BaseScheduleConfig {
+                name: "up".to_string(),
+                rate,
+                duration: Some(duration.to_string()),
+                gaps,
+                bursts,
+                cardinality_spikes: None,
+                labels: None,
+                sink: crate::sink::SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: crate::generator::GeneratorConfig::Constant { value: 1.0 },
-            gaps,
-            bursts,
-            cardinality_spikes: None,
-            labels: None,
             encoder: crate::encoder::EncoderConfig::PrometheusText { precision: None },
-            sink: crate::sink::SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         }
     }
 
@@ -862,18 +866,20 @@ mod tests {
         spike: crate::config::CardinalitySpikeConfig,
     ) -> crate::config::ScenarioConfig {
         crate::config::ScenarioConfig {
-            name: "up".to_string(),
-            rate,
-            duration: Some(duration.to_string()),
+            base: crate::config::BaseScheduleConfig {
+                name: "up".to_string(),
+                rate,
+                duration: Some(duration.to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: Some(vec![spike]),
+                labels: None,
+                sink: crate::sink::SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: crate::generator::GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: Some(vec![spike]),
-            labels: None,
             encoder: crate::encoder::EncoderConfig::PrometheusText { precision: None },
-            sink: crate::sink::SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         }
     }
 
@@ -1060,18 +1066,20 @@ mod tests {
     #[test]
     fn invalid_metric_name_returns_config_error_before_loop() {
         let config = ScenarioConfig {
-            name: "123-invalid".to_string(),
-            rate: 10.0,
-            duration: Some("100ms".to_string()),
+            base: BaseScheduleConfig {
+                name: "123-invalid".to_string(),
+                rate: 10.0,
+                duration: Some("100ms".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         };
         let mut sink = MemorySink::new();
         let result = super::run_with_sink(&config, &mut sink, None, None);

--- a/sonda/src/config.rs
+++ b/sonda/src/config.rs
@@ -13,8 +13,8 @@ use std::fs;
 
 use anyhow::{bail, Context, Result};
 use sonda_core::config::{
-    BurstConfig, CardinalitySpikeConfig, GapConfig, LogScenarioConfig, MultiScenarioConfig,
-    ScenarioConfig, SpikeStrategy,
+    BaseScheduleConfig, BurstConfig, CardinalitySpikeConfig, GapConfig, LogScenarioConfig,
+    MultiScenarioConfig, ScenarioConfig, SpikeStrategy,
 };
 use sonda_core::encoder::EncoderConfig;
 use sonda_core::generator::{GeneratorConfig, LogGeneratorConfig, TemplateConfig};
@@ -53,21 +53,23 @@ pub fn load_config(args: &MetricsArgs) -> Result<ScenarioConfig> {
         })?;
 
         ScenarioConfig {
-            name,
-            rate,
-            duration: args.duration.clone(),
+            base: BaseScheduleConfig {
+                name,
+                rate,
+                duration: args.duration.clone(),
+                gaps: build_gap_config(args)?,
+                bursts: build_burst_config(args)?,
+                cardinality_spikes: build_spike_config(args)?,
+                labels: build_labels(args),
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: build_generator_config(args)?,
-            gaps: build_gap_config(args)?,
-            bursts: build_burst_config(args)?,
-            cardinality_spikes: build_spike_config(args)?,
-            labels: build_labels(args),
             encoder: parse_encoder_config(
                 args.encoder.as_deref().unwrap_or("prometheus_text"),
                 args.precision,
             )?,
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         }
     };
 
@@ -363,21 +365,23 @@ pub fn load_log_config(args: &LogsArgs) -> Result<LogScenarioConfig> {
         let rate = args.rate.unwrap_or(10.0);
 
         LogScenarioConfig {
-            name: "logs".to_string(),
-            rate,
-            duration: args.duration.clone(),
+            base: BaseScheduleConfig {
+                name: "logs".to_string(),
+                rate,
+                duration: args.duration.clone(),
+                gaps: build_gap_config_for_logs(args)?,
+                bursts: build_log_burst_config(args)?,
+                cardinality_spikes: build_log_spike_config(args)?,
+                labels: build_log_labels(args),
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator,
-            gaps: build_gap_config_for_logs(args)?,
-            bursts: build_log_burst_config(args)?,
-            cardinality_spikes: build_log_spike_config(args)?,
-            labels: build_log_labels(args),
             encoder: parse_log_encoder_config(
                 args.encoder.as_deref().unwrap_or("json_lines"),
                 args.precision,
             )?,
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         }
     };
 
@@ -1089,7 +1093,7 @@ mod tests {
             ..default_args()
         };
         let config = load_config(&args).expect("output flag should produce valid config");
-        match config.sink {
+        match &config.sink {
             SinkConfig::File { path } => {
                 assert_eq!(path, "/tmp/sonda-output-test.txt");
             }
@@ -1140,7 +1144,7 @@ mod tests {
             ..default_args()
         };
         let config = load_config(&args).expect("output override on YAML should succeed");
-        match config.sink {
+        match &config.sink {
             SinkConfig::File { path } => {
                 assert_eq!(path, "/tmp/sonda-yaml-override.txt");
             }
@@ -1159,7 +1163,7 @@ mod tests {
             ..default_args()
         };
         let config = load_config(&args).expect("nested output path should succeed");
-        match config.sink {
+        match &config.sink {
             SinkConfig::File { path } => {
                 assert_eq!(path, "/tmp/sonda/nested/dir/test.txt");
             }
@@ -1631,7 +1635,7 @@ mod tests {
         };
 
         let config = load_log_config(&args).expect("output flag must produce valid config");
-        match config.sink {
+        match &config.sink {
             SinkConfig::File { path } => {
                 assert_eq!(path, "/tmp/sonda-logs-test.json");
             }

--- a/sonda/src/status.rs
+++ b/sonda/src/status.rs
@@ -435,7 +435,7 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
 
-    use sonda_core::config::{LogScenarioConfig, ScenarioConfig};
+    use sonda_core::config::{BaseScheduleConfig, LogScenarioConfig, ScenarioConfig};
     use sonda_core::encoder::EncoderConfig;
     use sonda_core::generator::{GeneratorConfig, LogGeneratorConfig, TemplateConfig};
     use sonda_core::schedule::stats::ScenarioStats;
@@ -858,27 +858,38 @@ mod tests {
     /// Helper: build a minimal ScenarioEntry::Metrics for testing.
     fn make_metrics_entry() -> ScenarioEntry {
         ScenarioEntry::Metrics(ScenarioConfig {
-            name: "test_metric".to_string(),
-            rate: 10.0,
-            duration: Some("10s".to_string()),
+            base: BaseScheduleConfig {
+                name: "test_metric".to_string(),
+                rate: 10.0,
+                duration: Some("10s".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         })
     }
 
     /// Helper: build a minimal ScenarioEntry::Logs for testing.
     fn make_logs_entry() -> ScenarioEntry {
         ScenarioEntry::Logs(LogScenarioConfig {
-            name: "test_logs".to_string(),
-            rate: 5.0,
-            duration: Some("5s".to_string()),
+            base: BaseScheduleConfig {
+                name: "test_logs".to_string(),
+                rate: 5.0,
+                duration: Some("5s".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: LogGeneratorConfig::Template {
                 templates: vec![TemplateConfig {
                     message: "test message".to_string(),
@@ -887,14 +898,7 @@ mod tests {
                 severity_weights: None,
                 seed: Some(0),
             },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::JsonLines { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         })
     }
 
@@ -939,18 +943,20 @@ mod tests {
     #[test]
     fn print_start_metrics_without_duration_does_not_panic() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "no_dur".to_string(),
-            rate: 1.0,
-            duration: None,
+            base: BaseScheduleConfig {
+                name: "no_dur".to_string(),
+                rate: 1.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Constant { value: 0.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
         print_start(&entry, Verbosity::Normal);
     }
@@ -1045,37 +1051,39 @@ mod tests {
         labels.insert("region".to_string(), "us-east-1".to_string());
 
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "full_config".to_string(),
-            rate: 1000.0,
-            duration: Some("30s".to_string()),
+            base: BaseScheduleConfig {
+                name: "full_config".to_string(),
+                rate: 1000.0,
+                duration: Some("30s".to_string()),
+                gaps: Some(GapConfig {
+                    every: "2m".to_string(),
+                    r#for: "20s".to_string(),
+                }),
+                bursts: Some(BurstConfig {
+                    every: "10s".to_string(),
+                    r#for: "1s".to_string(),
+                    multiplier: 5.0,
+                }),
+                cardinality_spikes: Some(vec![CardinalitySpikeConfig {
+                    label: "pod_name".to_string(),
+                    every: "2m".to_string(),
+                    r#for: "30s".to_string(),
+                    cardinality: 100,
+                    strategy: SpikeStrategy::Counter,
+                    prefix: None,
+                    seed: None,
+                }]),
+                labels: Some(labels),
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: GeneratorConfig::Sine {
                 amplitude: 50.0,
                 period_secs: 60.0,
                 offset: 50.0,
             },
-            gaps: Some(GapConfig {
-                every: "2m".to_string(),
-                r#for: "20s".to_string(),
-            }),
-            bursts: Some(BurstConfig {
-                every: "10s".to_string(),
-                r#for: "1s".to_string(),
-                multiplier: 5.0,
-            }),
-            cardinality_spikes: Some(vec![CardinalitySpikeConfig {
-                label: "pod_name".to_string(),
-                every: "2m".to_string(),
-                r#for: "30s".to_string(),
-                cardinality: 100,
-                strategy: SpikeStrategy::Counter,
-                prefix: None,
-                seed: None,
-            }]),
-            labels: Some(labels),
             encoder: EncoderConfig::PrometheusText { precision: Some(2) },
-            sink: SinkConfig::Stdout,
-            phase_offset: None,
-            clock_group: None,
         });
         print_config(&entry);
     }
@@ -1083,25 +1091,27 @@ mod tests {
     #[test]
     fn print_config_logs_with_replay_generator_does_not_panic() {
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
-            name: "replay_logs".to_string(),
-            rate: 100.0,
-            duration: None,
+            base: BaseScheduleConfig {
+                name: "replay_logs".to_string(),
+                rate: 100.0,
+                duration: None,
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::File {
+                    path: "/tmp/out.log".to_string(),
+                },
+                phase_offset: None,
+                clock_group: None,
+            },
             generator: LogGeneratorConfig::Replay {
                 file: "/var/log/app.log".to_string(),
             },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::Syslog {
                 hostname: None,
                 app_name: None,
             },
-            sink: SinkConfig::File {
-                path: "/tmp/out.log".to_string(),
-            },
-            phase_offset: None,
-            clock_group: None,
         });
         print_config(&entry);
     }
@@ -1201,18 +1211,20 @@ mod tests {
     #[test]
     fn print_config_metrics_with_phase_offset_and_clock_group_does_not_panic() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
-            name: "correlated_metric".to_string(),
-            rate: 10.0,
-            duration: Some("30s".to_string()),
+            base: BaseScheduleConfig {
+                name: "correlated_metric".to_string(),
+                rate: 10.0,
+                duration: Some("30s".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: Some("5s".to_string()),
+                clock_group: Some("alert-group".to_string()),
+            },
             generator: GeneratorConfig::Constant { value: 1.0 },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: Some("5s".to_string()),
-            clock_group: Some("alert-group".to_string()),
         });
         print_config(&entry);
     }
@@ -1220,9 +1232,18 @@ mod tests {
     #[test]
     fn print_config_logs_with_phase_offset_and_clock_group_does_not_panic() {
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
-            name: "correlated_logs".to_string(),
-            rate: 5.0,
-            duration: Some("10s".to_string()),
+            base: BaseScheduleConfig {
+                name: "correlated_logs".to_string(),
+                rate: 5.0,
+                duration: Some("10s".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: Some("2s".to_string()),
+                clock_group: Some("log-sync".to_string()),
+            },
             generator: LogGeneratorConfig::Template {
                 templates: vec![TemplateConfig {
                     message: "test".to_string(),
@@ -1231,14 +1252,7 @@ mod tests {
                 severity_weights: None,
                 seed: None,
             },
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            labels: None,
             encoder: EncoderConfig::JsonLines { precision: None },
-            sink: SinkConfig::Stdout,
-            phase_offset: Some("2s".to_string()),
-            clock_group: Some("log-sync".to_string()),
         });
         print_config(&entry);
     }


### PR DESCRIPTION
## Summary

- Extracted `BaseScheduleConfig` with the 10 shared fields from `ScenarioConfig` and `LogScenarioConfig`
- Both configs embed it via `#[serde(flatten)]` — YAML schema is unchanged
- `Deref<Target = BaseScheduleConfig>` + `DerefMut` for transparent field access
- New `ScenarioEntry::base()` accessor for signal-type-agnostic config access
- Encoder defaults remain signal-specific (prometheus_text for metrics, json_lines for logs)
- 10 new tests covering Deref, DerefMut, flatten deserialization, encoder defaults, base accessor

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 1,363 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build -p sonda-core --no-default-features` — works
- [x] All 22 YAML example files parse correctly via `--dry-run`
- [x] Multi-scenario, phase_offset, clock_group all work
- [x] Reviewer: PASS (zero WARNINGs)
- [x] UAT: PASS