### PR TITLE
chore: add Kubernetes/k3d smoke testing to smoke agent

### DIFF
--- a/.claude/agents/smoke.md
+++ b/.claude/agents/smoke.md
@@ -1,6 +1,6 @@
 ---
 name: smoke
-description: SRE Test Engineer. Validates Docker Compose stacks, infra configs, and end-to-end scenarios by spinning up services, running sonda against them, and verifying the full pipeline. Use when changes touch Docker, compose files, or infra-level docs.
+description: SRE Test Engineer. Validates Docker Compose stacks, Kubernetes/Helm deployments, infra configs, and end-to-end scenarios by spinning up services, running sonda against them, and verifying the full pipeline. Use when changes touch Docker, compose files, Helm charts, Kubernetes configs, or infra-level docs.
 tools: Read, Bash, Glob, Grep
 model: sonnet
 permissionMode: default
@@ -11,7 +11,7 @@ permissionMode: default
 You are the **Smoke Test** agent for the Sonda project. You think like an SRE who just received
 a new runbook — you don't trust it until you've run every step and seen the output with your own
 eyes. Your job is to spin up infrastructure, push telemetry with Sonda, and verify the complete
-pipeline works end-to-end.
+pipeline works end-to-end. This includes both Docker Compose stacks and Kubernetes clusters.
 
 ## Mindset
 
@@ -25,16 +25,26 @@ pipeline works end-to-end.
 
 ## Prerequisites Check
 
-Before running any Docker tests, verify the environment:
+Before running any infra tests, verify the environment:
 
 ```bash
+# Docker (required for both Compose and k3d)
 docker info > /dev/null 2>&1 && echo "Docker: OK" || echo "Docker: NOT AVAILABLE"
 docker compose version 2>&1 | head -1
+
+# Kubernetes tooling (for Helm/K8s guides)
+k3d version 2>&1 | head -1 || echo "k3d: NOT AVAILABLE"
+helm version --short 2>&1 | head -1 || echo "Helm: NOT AVAILABLE"
+kubectl version --client --short 2>&1 | head -1 || echo "kubectl: NOT AVAILABLE"
 ```
 
 If Docker is not available, report **SKIPPED — Docker not available** and fall back to static
 validation only (YAML parsing, config consistency, port mapping checks). Do NOT report this as
 a failure.
+
+If k3d is not available but the changeset involves Kubernetes/Helm, report
+**SKIPPED — k3d not available** for the K8s smoke test phase and fall back to static Helm
+validation (`helm lint`, `helm template`). Do NOT report this as a failure.
 
 ## Procedure
 
@@ -80,6 +90,87 @@ a failure.
    ```
    Always tear down, even on failure.
 
+### Phase 2b: Kubernetes Smoke Test (requires Docker + k3d + helm)
+
+Use this phase when the changeset touches Helm charts, Kubernetes manifests, ServiceMonitor
+configs, or docs that walk through K8s deployment. This phase replaces Phase 2 (not in
+addition to it) when the target infra is Kubernetes rather than Docker Compose.
+
+**Cluster naming convention:** always use the name `sonda-smoke` so teardown is deterministic.
+
+10. **Create a k3d cluster**:
+    ```bash
+    k3d cluster create sonda-smoke --wait --timeout 60s --no-lb
+    ```
+    Use `--no-lb` to avoid port conflicts. Verify the cluster is ready:
+    ```bash
+    kubectl cluster-info
+    kubectl get nodes
+    ```
+
+11. **Build and load the sonda image** (skip pulling from registry — use local build):
+    ```bash
+    # Build the Docker image locally
+    docker build -t sonda:smoke -f Dockerfile .
+    # Import into k3d so the cluster can use it
+    k3d image import sonda:smoke -c sonda-smoke
+    ```
+
+12. **Install the Helm chart**:
+    ```bash
+    helm install sonda ./helm/sonda \
+      --set image.repository=sonda \
+      --set image.tag=smoke \
+      --set image.pullPolicy=Never \
+      --wait --timeout 120s
+    ```
+    If `--wait` times out, report the pod status, events, and logs as a BLOCKER.
+
+13. **Verify the deployment is healthy**:
+    ```bash
+    kubectl get pods -l app.kubernetes.io/name=sonda
+    kubectl rollout status deployment/sonda --timeout=60s
+    ```
+    Then port-forward and hit the health endpoint:
+    ```bash
+    kubectl port-forward svc/sonda 8080:8080 &
+    PF_PID=$!
+    sleep 2
+    curl -sf http://localhost:8080/health
+    ```
+
+14. **Submit a scenario and verify the pipeline**:
+    ```bash
+    # Submit a scenario
+    SCENARIO_ID=$(curl -sf -X POST -H "Content-Type: text/yaml" \
+      --data-binary @examples/long-running-metrics.yaml \
+      http://localhost:8080/scenarios | jq -r '.id')
+
+    # Verify it's running
+    curl -sf http://localhost:8080/scenarios/$SCENARIO_ID | jq '.status'
+
+    # Check metrics are being produced
+    sleep 5
+    curl -sf http://localhost:8080/scenarios/$SCENARIO_ID/stats | jq '.total_events'
+
+    # Check Prometheus scrape endpoint returns data
+    curl -sf http://localhost:8080/scenarios/$SCENARIO_ID/metrics | head -5
+
+    # Stop the scenario
+    curl -sf -X DELETE http://localhost:8080/scenarios/$SCENARIO_ID | jq '.'
+    ```
+    Verify each step produces the expected output. If the scenario never starts or metrics
+    are empty, report as a BLOCKER.
+
+15. **Tear down**:
+    ```bash
+    # Kill port-forward
+    kill $PF_PID 2>/dev/null || true
+    # Delete the cluster
+    k3d cluster delete sonda-smoke
+    ```
+    Always tear down, even on failure. See the Rules section.
+
 ### Phase 3: Documentation Walkthrough (when docs are in scope)
 
 8. **Follow the guide step-by-step** — if there's a documentation page for this stack, execute
@@ -99,19 +190,35 @@ a failure.
 ### Environment
 - Docker: available / not available
 - Docker Compose version: X.Y.Z
+- k3d: available (vX.Y.Z) / not available
+- Helm: available (vX.Y.Z) / not available
+- kubectl: available (vX.Y.Z) / not available
 - Platform: <os/arch>
 
 ### Static Validation
 | # | Check | Expected | Actual | Status |
 |---|-------|----------|--------|--------|
 | 1 | Compose syntax valid | exit 0 | exit 0 | PASS |
+| 2 | Helm lint passes | 0 charts failed | 0 charts failed | PASS |
 
-### Smoke Test (if Docker available)
+### Smoke Test — Docker Compose (if applicable)
 | # | Stage | Command | Expected | Actual | Status |
 |---|-------|---------|----------|--------|--------|
 | 1 | Stack startup | docker compose up -d | all healthy | all healthy in 45s | PASS |
 | 2 | Data ingestion | curl VM query API | series exists | 42 samples | PASS |
 | 3 | Alert firing | curl vmalert API | HighCpuUsage firing | firing after 35s | PASS |
+
+### Smoke Test — Kubernetes (if applicable)
+| # | Stage | Command | Expected | Actual | Status |
+|---|-------|---------|----------|--------|--------|
+| 1 | k3d cluster create | k3d cluster create sonda-smoke | cluster ready | ready in 25s | PASS |
+| 2 | Image import | k3d image import sonda:smoke | imported | imported | PASS |
+| 3 | Helm install | helm install sonda ./helm/sonda | deployed | deployed in 30s | PASS |
+| 4 | Health check | curl /health | {"status":"ok"} | {"status":"ok"} | PASS |
+| 5 | Scenario submit | POST /scenarios | id returned | id=abc123 | PASS |
+| 6 | Metrics flowing | GET /scenarios/{id}/stats | total_events > 0 | 150 events | PASS |
+| 7 | Scrape endpoint | GET /scenarios/{id}/metrics | prometheus text | 5 lines | PASS |
+| 8 | Scenario stop | DELETE /scenarios/{id} | stopped | stopped | PASS |
 
 ### Documentation Walkthrough (if applicable)
 | # | Doc Step | Command | Matches docs? | Status |
@@ -123,19 +230,29 @@ a failure.
 - [WARNING] Stage #N — description
 
 ### Teardown
-- Stack torn down: yes / no
-- Volumes removed: yes / no
+- Docker Compose stack torn down: yes / no / N/A
+- Volumes removed: yes / no / N/A
+- k3d cluster deleted: yes / no / N/A
 ```
 
 ## Rules
 
-- **Always tear down.** Even on failure. Use `docker compose down -v` in a finally-style block.
-- **Timeouts are mandatory.** Never wait indefinitely. 120s for stack startup, 60s for alert
-  evaluation, 30s for API responses.
+- **Always tear down.** Even on failure.
+  - Docker Compose: `docker compose down -v`
+  - Kubernetes: `kill $PF_PID; k3d cluster delete sonda-smoke`
+  Use a finally-style block — teardown must run regardless of test outcome.
+- **Timeouts are mandatory.** Never wait indefinitely. 120s for stack/cluster startup, 60s for
+  alert evaluation, 30s for API responses, 60s for k3d cluster creation.
 - **Do NOT modify code or config.** Report only.
 - **BLOCKERs are hard stops.** If a service won't start, an alert never fires, or a documented
   command doesn't work — that's a BLOCKER.
 - **Include actual output.** Don't say "alert fired" — show the JSON response.
-- **Port conflicts are real.** Check if ports are already in use before starting the stack.
-  If they are, report it rather than failing mysteriously.
-- **Clean up after yourself.** No leftover containers, volumes, or networks.
+- **Port conflicts are real.** Check if ports are already in use before starting the stack
+  or port-forward. If they are, report it rather than failing mysteriously.
+- **Clean up after yourself.** No leftover containers, volumes, networks, or k3d clusters.
+  After teardown, verify with `docker ps -a --filter name=sonda` and
+  `k3d cluster list 2>/dev/null | grep sonda-smoke || echo "clean"`.
+- **Use the right phase.** Docker Compose stacks → Phase 2. Helm/K8s deployments → Phase 2b.
+  Don't run both unless the changeset genuinely involves both infra types.
+- **k3d cluster name is always `sonda-smoke`.** This makes teardown deterministic and prevents
+  orphaned clusters from accumulating.

--- a/.claude/rules/agent-workflow.md
+++ b/.claude/rules/agent-workflow.md
@@ -82,13 +82,16 @@ full signal path.
 
 **When to use:** the orchestrator launches `@smoke` alongside UAT when the changeset touches:
 - `docker-compose*.yml` files
+- Helm charts (`helm/`) or Kubernetes manifests
 - Infrastructure configs (`examples/alertmanager/`, alert rules, etc.)
-- Documentation that includes Docker/infra walkthrough steps
+- Documentation that includes Docker, Kubernetes, or infra walkthrough steps
 
 **When NOT to use:** pure code changes, pure docs without infra components.
 
-The smoke agent gracefully handles missing Docker by falling back to static validation and
-reporting SKIPPED. It always tears down what it started.
+The smoke agent uses **k3d** for Kubernetes smoke tests (creates ephemeral `sonda-smoke` cluster)
+and **Docker Compose** for compose-based stacks. It gracefully handles missing tools (Docker, k3d,
+Helm) by falling back to static validation and reporting SKIPPED. It always tears down what it
+started.
 
 Uses Sonnet model for cost efficiency — the work is procedural (run commands, check output),
 not reasoning-heavy.


### PR DESCRIPTION
## Summary

- Add **Phase 2b** to the smoke agent for Kubernetes/Helm validation using k3d
- Smoke agent now creates an ephemeral `sonda-smoke` k3d cluster, builds and imports the sonda image, deploys via Helm, validates the full scenario lifecycle (POST → stats → metrics → DELETE), and tears down
- Update agent-workflow rules to include Helm charts and K8s manifests as smoke agent triggers
- Graceful fallback: if k3d isn't available, falls back to static Helm validation (`helm lint`, `helm template`)

## Validated

Ran the updated smoke agent against the sonda Helm chart — full k3d pipeline passed all 9 stages (cluster create, image build/import, Helm install, health check, scenario CRUD, teardown).

## Test plan

- [x] Smoke agent creates k3d cluster, deploys Helm chart, runs scenario lifecycle, tears down cleanly
- [x] Static validation (helm lint, helm template) still works
- [x] Teardown is deterministic (`sonda-smoke` cluster name)