### PR TITLE
feat: harden Helm chart, add OTLP to Docker build, fix docs version drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir -p sonda-core/src sonda/src sonda-server/src && \
 
 RUN RUST_TARGET=$(cat /tmp/rust-target) && \
     if [ -s /tmp/cross-env ]; then export $(cat /tmp/cross-env); fi && \
-    cargo build --release --target "${RUST_TARGET}" --features remote-write,kafka -p sonda -p sonda-server 2>/dev/null || true
+    cargo build --release --target "${RUST_TARGET}" --features remote-write,kafka,otlp -p sonda -p sonda-server 2>/dev/null || true
 
 # Copy real source and build
 COPY sonda-core/ sonda-core/
@@ -74,7 +74,7 @@ RUN touch sonda-core/src/lib.rs sonda/src/main.rs sonda-server/src/main.rs
 
 RUN RUST_TARGET=$(cat /tmp/rust-target) && \
     if [ -s /tmp/cross-env ]; then export $(cat /tmp/cross-env); fi && \
-    cargo build --release --target "${RUST_TARGET}" --features remote-write,kafka -p sonda -p sonda-server
+    cargo build --release --target "${RUST_TARGET}" --features remote-write,kafka,otlp -p sonda -p sonda-server
 
 # Copy binaries to a known location regardless of target triple
 RUN RUST_TARGET=$(cat /tmp/rust-target) && \

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -27,7 +27,7 @@ kubectl get pods -l app.kubernetes.io/name=sonda -w
 ```
 
 You should see `1/1 Running` within 15--20 seconds. The chart defaults to
-`ghcr.io/davidban77/sonda:0.4.0` (the chart's `appVersion`). Pin a different version with
+`ghcr.io/davidban77/sonda:<!--x-release-please-version-->0.6.0<!--x-release-please-end-->` (the chart's `appVersion`). Pin a different version with
 `--set image.tag=<version>`.
 
 !!! tip "Deploy to a dedicated namespace"
@@ -51,7 +51,7 @@ The chart ships with sensible defaults. Override any value with `--set` flags or
 | Value | Default | Description |
 |-------|---------|-------------|
 | `image.repository` | `ghcr.io/davidban77/sonda` | Container image registry and name |
-| `image.tag` | `""` (uses `appVersion`: `0.4.0`) | Image tag to pull |
+| `image.tag` | `""` (uses `appVersion`: <!--x-release-please-version-->`0.6.0`<!--x-release-please-end-->) | Image tag to pull |
 | `image.pullPolicy` | `IfNotPresent` | Kubernetes image pull policy |
 | `imagePullSecrets` | `[]` | Secrets for private registries |
 
@@ -91,14 +91,59 @@ helm install sonda ./helm/sonda \
   --set resources.limits.memory=512Mi
 ```
 
+### Security
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `podSecurityContext` | `{}` | Pod-level security context (e.g., `fsGroup`) |
+| `securityContext` | `{}` | Container-level security context (e.g., `runAsNonRoot`, `readOnlyRootFilesystem`, `capabilities`) |
+
 ### Scheduling
 
 | Value | Default | Description |
 |-------|---------|-------------|
-| `replicaCount` | `1` | Number of Deployment replicas |
+| `replicaCount` | `1` | Number of Deployment replicas (ignored when HPA is enabled) |
 | `nodeSelector` | `{}` | Node selector constraints |
 | `tolerations` | `[]` | Pod tolerations |
 | `affinity` | `{}` | Pod affinity/anti-affinity rules |
+
+### Autoscaling (HPA)
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `autoscaling.enabled` | `false` | Enable HorizontalPodAutoscaler |
+| `autoscaling.minReplicas` | `1` | Minimum replica count |
+| `autoscaling.maxReplicas` | `5` | Maximum replica count |
+| `autoscaling.targetCPUUtilizationPercentage` | `80` | Target CPU utilization |
+| `autoscaling.targetMemoryUtilizationPercentage` | (unset) | Target memory utilization |
+
+### Pod Disruption Budget
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `podDisruptionBudget.enabled` | `false` | Enable PodDisruptionBudget |
+| `podDisruptionBudget.minAvailable` | `1` | Minimum available pods during disruption |
+| `podDisruptionBudget.maxUnavailable` | (unset) | Maximum unavailable pods during disruption |
+
+### Ingress
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `ingress.enabled` | `false` | Enable Ingress resource |
+| `ingress.className` | `""` | Ingress class name |
+| `ingress.annotations` | `{}` | Ingress annotations |
+| `ingress.hosts` | `[{host: sonda.local, paths: [{path: /, pathType: Prefix}]}]` | Ingress host rules |
+| `ingress.tls` | `[]` | TLS configuration |
+
+### ServiceMonitor
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `serviceMonitor.enabled` | `false` | Enable Prometheus Operator ServiceMonitor |
+| `serviceMonitor.interval` | `30s` | Scrape interval |
+| `serviceMonitor.scrapeTimeout` | `10s` | Scrape timeout |
+| `serviceMonitor.path` | `/health` | Metrics endpoint path |
+| `serviceMonitor.additionalLabels` | `{}` | Extra labels on the ServiceMonitor resource |
 
 ### Scenarios (ConfigMap)
 
@@ -227,8 +272,17 @@ Replace `<SCENARIO_ID>` with the UUID returned by `POST /scenarios`.
 ### ServiceMonitor
 
 If you run the [Prometheus Operator](https://prometheus-operator.dev/) (typically via
-kube-prometheus-stack), create a ServiceMonitor to auto-discover Sonda. The chart does not
-include a ServiceMonitor template, so apply one manually:
+kube-prometheus-stack), the chart includes an optional ServiceMonitor template. Enable it
+with:
+
+```bash
+helm install sonda ./helm/sonda --set serviceMonitor.enabled=true
+```
+
+See the [ServiceMonitor](#servicemonitor-1) values reference for all options
+(`interval`, `scrapeTimeout`, `path`, `additionalLabels`).
+
+Alternatively, apply a custom ServiceMonitor manually for full control:
 
 ```yaml title="sonda-servicemonitor.yaml"
 apiVersion: monitoring.coreos.com/v1
@@ -267,7 +321,7 @@ Update your release after changing values or pulling a new chart version:
 helm upgrade sonda ./helm/sonda -f my-values.yaml
 
 # Upgrade to a new image version
-helm upgrade sonda ./helm/sonda --set image.tag=0.5.0
+helm upgrade sonda ./helm/sonda --set image.tag=<!--x-release-please-version-->0.6.0<!--x-release-please-end-->
 ```
 
 If your values file includes `scenarios`, the ConfigMap checksum annotation triggers an

--- a/helm/sonda/templates/deployment.yaml
+++ b/helm/sonda/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "sonda.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "sonda.selectorLabels" . | nindent 6 }}
@@ -22,10 +24,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ include "sonda.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - "--port"
             - {{ .Values.server.port | quote }}

--- a/helm/sonda/templates/hpa.yaml
+++ b/helm/sonda/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "sonda.fullname" . }}
+  labels:
+    {{- include "sonda.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "sonda.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/sonda/templates/ingress.yaml
+++ b/helm/sonda/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "sonda.fullname" . }}
+  labels:
+    {{- include "sonda.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "sonda.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/sonda/templates/pdb.yaml
+++ b/helm/sonda/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "sonda.fullname" . }}
+  labels:
+    {{- include "sonda.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "sonda.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/sonda/templates/servicemonitor.yaml
+++ b/helm/sonda/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "sonda.fullname" . }}
+  labels:
+    {{- include "sonda.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: http
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      path: {{ .Values.serviceMonitor.path }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "sonda.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/sonda/values.yaml
+++ b/helm/sonda/values.yaml
@@ -39,6 +39,18 @@ resources:
     cpu: 500m
     memory: 256Mi
 
+# Pod-level security context.
+podSecurityContext: {}
+  # fsGroup: 1000
+
+# Container-level security context.
+securityContext: {}
+  # runAsNonRoot: true
+  # readOnlyRootFilesystem: true
+  # capabilities:
+  #   drop:
+  #     - ALL
+
 # Scenario YAML files to mount as a ConfigMap.
 # Each key becomes a file under /scenarios in the container.
 # Example:
@@ -73,6 +85,40 @@ resources:
 #       sink:
 #         type: stdout
 scenarios: {}
+
+# Horizontal Pod Autoscaler configuration.
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Pod Disruption Budget configuration.
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+# Ingress configuration.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: sonda.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# ServiceMonitor for Prometheus Operator.
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  path: /health
+  additionalLabels: {}
 
 # Node selector for pod scheduling.
 nodeSelector: {}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -40,7 +40,8 @@
           "type": "yaml",
           "path": "helm/sonda/Chart.yaml",
           "jsonpath": "$.appVersion"
-        }
+        },
+        "docs/site/docs/deployment/kubernetes.md"
       ],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## Summary

Addresses low-hanging fruit from the SRE adoption review (round 2):

- **#151** — Add `otlp` to Dockerfile `--features` so the Docker image ships with OTLP/gRPC support out of the box
- **#152** — Harden Helm chart with optional templates for HPA, PDB, Ingress, and ServiceMonitor (all disabled by default). Wire `securityContext` and `podSecurityContext` into the Deployment template, defaulting to `{}` for safe upgrades
- **#153** — Fix stale version references in Kubernetes docs (`0.4.0`/`0.5.0` → `0.6.0`)

**Bonus**: Added `<!--x-release-please-version-->` markers to `kubernetes.md` and registered it in `release-please-config.json`, so future releases auto-bump version strings in the docs.

Closes #151, closes #152, closes #153.

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` — 240 tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `helm lint helm/sonda/` passes
- [x] `helm template` default render: only Deployment + Service (backwards compatible)
- [x] `helm template --set autoscaling.enabled=true` renders HPA, omits `replicas` from Deployment
- [x] `helm template --set podDisruptionBudget.enabled=true` renders PDB with `minAvailable: 1`
- [x] `helm template --set ingress.enabled=true` renders Ingress
- [x] `helm template --set serviceMonitor.enabled=true` renders ServiceMonitor
- [x] Default securityContext is `{}` (no enforcement) — safe for existing installs