### PR TITLE
feat(init): non-interactive mode and --from prefill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ of raw generator types, and supports metric packs for multi-metric scenarios:
 sonda init
 ```
 
+Pre-fill from a built-in scenario or CSV file, or run fully non-interactively with flags:
+
+```bash
+sonda init --from @cpu-spike --rate 5 --duration 2m -o scenario.yaml
+sonda init --signal-type metrics --domain infrastructure --situation steady \
+  --metric cpu_usage --rate 1 --duration 60s --encoder prometheus_text \
+  --sink stdout -o cpu.yaml --run-now
+```
+
 ```text
 ? What type of signal? metrics
 ? What domain? infrastructure

--- a/docs/site/docs/configuration/cli-reference.md
+++ b/docs/site/docs/configuration/cli-reference.md
@@ -935,16 +935,123 @@ sonda import data.csv --columns 1,3,5 -o scenario.yaml
 
 ## sonda init
 
-Interactively create a new scenario YAML file. `sonda init` walks you through a guided
+Create a new scenario YAML file. By default, `sonda init` walks you through an interactive
 prompt flow -- signal type, domain, situation, parameters, labels, encoding, and sink -- and
 writes a commented, immediately-runnable YAML file.
 
+You can also supply CLI flags to skip prompts, pre-fill values from a built-in scenario or
+CSV file, or run fully non-interactively.
+
 ```bash
-sonda init
+sonda init [OPTIONS]
 ```
 
-The command has no required flags. It uses interactive terminal prompts with sensible
-defaults for every question -- press Enter to accept the default and move on.
+### Flags
+
+| Flag | Short | Type | Description |
+|------|-------|------|-------------|
+| `--from <SOURCE>` | -- | string | Pre-fill values from a built-in scenario (`@name`) or CSV file (`path.csv`). See [Pre-filling with --from](#pre-filling-with-from). |
+| `--signal-type <TYPE>` | -- | string | Signal type: `metrics` or `logs`. |
+| `--domain <DOMAIN>` | -- | string | Domain category: `infrastructure`, `network`, `application`, `custom`. |
+| `--situation <ALIAS>` | -- | string | Operational situation: `steady`, `spike_event`, `flap`, `leak`, `saturation`, `degradation`. |
+| `--metric <NAME>` | -- | string | Metric name. |
+| `--pack <NAME>` | -- | string | Use a metric pack instead of a single metric. Mutually exclusive with `--metric` and `--situation`. |
+| `--rate <RATE>` | -- | float | Events per second. |
+| `--duration <DURATION>` | -- | string | Run duration (e.g. `60s`, `5m`). |
+| `--encoder <FORMAT>` | -- | string | Encoder: `prometheus_text`, `influx_lp`, `json_lines`, `syslog`. |
+| `--sink <TYPE>` | -- | string | Sink: `stdout`, `http_push`, `file`, `remote_write`, `loki`, `otlp_grpc`, `kafka`, `tcp`, `udp`. |
+| `--endpoint <URL>` | -- | string | Sink endpoint (URL, file path, or `host:port`). |
+| `--output <PATH>` | `-o` | path | Output file path for the generated YAML. |
+| `--label <KEY=VALUE>` | -- | string | Static label (repeatable). |
+
+All flags are optional. When a flag is provided, its corresponding interactive prompt is
+skipped. When **all** required fields are supplied via flags, `sonda init` runs fully
+non-interactively -- no terminal interaction needed.
+
+### Non-interactive mode
+
+Supply enough flags to skip every prompt and `sonda init` generates the YAML without asking
+any questions. This is useful in scripts, CI pipelines, or when you already know what you want.
+
+```bash
+sonda init \
+  --signal-type metrics \
+  --domain infrastructure \
+  --metric node_cpu_seconds \
+  --situation steady \
+  --rate 1 --duration 60s \
+  --encoder prometheus_text \
+  --sink stdout \
+  -o ./scenarios/node-cpu.yaml
+```
+
+Partial flags work too -- Sonda prompts only for the missing values. For example, if you
+supply `--signal-type` and `--domain` but nothing else, the wizard starts at step 3:
+
+```bash
+sonda init --signal-type metrics --domain network
+```
+
+### Pre-filling with --from
+
+The `--from` flag loads default values from an existing source and uses them as prompt
+defaults. You can override any pre-filled value with an explicit flag.
+
+=== "--from @builtin"
+
+    Load a built-in scenario by name. Sonda extracts the signal type, domain, metric name,
+    generator type, rate, duration, encoder, and sink from the scenario YAML and uses them
+    as defaults:
+
+    ```bash
+    sonda init --from @cpu-spike
+    ```
+
+    This pre-fills the prompts with the `cpu-spike` scenario's configuration. You can
+    override individual fields:
+
+    ```bash
+    sonda init --from @cpu-spike --rate 5 --duration 2m --sink http_push \
+      --endpoint http://localhost:9090/api/v1/write
+    ```
+
+    !!! tip
+        Use `sonda scenarios list` to see available built-in scenario names.
+
+=== "--from CSV"
+
+    Point at a CSV file to detect the dominant time-series pattern and use it as the
+    situation default. Sonda reads the first numeric column, runs pattern detection
+    (the same engine as `sonda import`), and maps the result to an operational situation:
+
+    ```bash
+    sonda init --from metrics.csv
+    ```
+
+    Detected patterns map to situations: Steady becomes `steady`, Spike becomes
+    `spike_event`, Climb becomes `leak`, Sawtooth becomes `saturation`, and Flap becomes
+    `flap`. The first column name is used as the default metric name.
+
+    Combine with flags to override:
+
+    ```bash
+    sonda init --from metrics.csv --metric custom_name --rate 10
+    ```
+
+When `--from` is active, Sonda prints a summary of pre-filled values before starting the
+prompts so you can see what was loaded:
+
+```text
+  Starting from: @cpu-spike
+    signal_type: metrics
+    domain:      infrastructure
+    metric:      cpu_spike
+    situation:   spike_event
+    rate:        1
+    duration:    60s
+    encoder:     prometheus_text
+    sink:        stdout
+```
 
 ### Interactive flow
 
@@ -1149,6 +1256,48 @@ no need to copy-paste a follow-up command.
 
     ? Run it now? No
     ```
+
+=== "Non-interactive (full)"
+
+    All prompts skipped -- no terminal interaction:
+
+    ```bash
+    sonda init \
+      --signal-type metrics \
+      --domain infrastructure \
+      --metric node_memory_used_bytes \
+      --situation leak \
+      --rate 1 --duration 5m \
+      --encoder prometheus_text \
+      --sink stdout \
+      --label instance=db-01 \
+      -o ./scenarios/memory-leak.yaml
+    ```
+
+=== "--from @builtin with overrides"
+
+    Start from the built-in `cpu-spike` scenario, override the sink and rate:
+
+    ```bash
+    sonda init --from @cpu-spike \
+      --rate 5 \
+      --sink http_push --endpoint http://localhost:9090/api/v1/write \
+      -o ./scenarios/cpu-spike-fast.yaml
+    ```
+
+    Pre-filled values from the built-in are shown before prompts begin. Only
+    fields not covered by `--from` or explicit flags are prompted interactively.
+
+=== "--from CSV"
+
+    Detect patterns from a Grafana CSV export and use them as defaults:
+
+    ```bash
+    sonda init --from metrics.csv --rate 10 --duration 2m
+    ```
+
+    Sonda reads the first numeric column, detects the dominant pattern (e.g. spike,
+    steady), and maps it to a situation. The column name becomes the default metric name.
 
 The generated YAML includes inline comments and scenario metadata, so it appears in
 `sonda scenarios list` automatically.

--- a/docs/site/docs/configuration/cli-reference.md
+++ b/docs/site/docs/configuration/cli-reference.md
@@ -956,17 +956,24 @@ sonda init [OPTIONS]
 | `--situation <ALIAS>` | -- | string | Operational situation: `steady`, `spike_event`, `flap`, `leak`, `saturation`, `degradation`. |
 | `--metric <NAME>` | -- | string | Metric name. |
 | `--pack <NAME>` | -- | string | Use a metric pack instead of a single metric. Mutually exclusive with `--metric` and `--situation`. |
-| `--rate <RATE>` | -- | float | Events per second. |
-| `--duration <DURATION>` | -- | string | Run duration (e.g. `60s`, `5m`). |
+| `--rate <RATE>` | -- | float | Events per second. Must be strictly positive. |
+| `--duration <DURATION>` | -- | string | Run duration (e.g. `60s`, `5m`). Must be a valid duration with unit suffix (`ms`, `s`, `m`, `h`). |
 | `--encoder <FORMAT>` | -- | string | Encoder: `prometheus_text`, `influx_lp`, `json_lines`, `syslog`. |
 | `--sink <TYPE>` | -- | string | Sink: `stdout`, `http_push`, `file`, `remote_write`, `loki`, `otlp_grpc`, `kafka`, `tcp`, `udp`. |
 | `--endpoint <URL>` | -- | string | Sink endpoint (URL, file path, or `host:port`). |
 | `--output <PATH>` | `-o` | path | Output file path for the generated YAML. |
 | `--label <KEY=VALUE>` | -- | string | Static label (repeatable). |
+| `--run-now` | -- | bool | Run the generated scenario immediately after writing (skip the prompt). Defaults to `false` when stdin is not a TTY. |
+| `--message-template <TPL>` | -- | string | Log message template (for `--signal-type logs`). Uses `{field}` placeholders. |
+| `--severity <PRESET>` | -- | string | Severity distribution preset (for `--signal-type logs`): `mostly_info`, `balanced`, `error_heavy`. |
+| `--kafka-brokers <ADDRS>` | -- | string | Kafka broker(s) for `--sink kafka` (e.g. `localhost:9092`). |
+| `--kafka-topic <TOPIC>` | -- | string | Kafka topic for `--sink kafka`. |
+| `--otlp-signal-type <TYPE>` | -- | string | OTLP signal type for `--sink otlp_grpc`: `metrics` or `logs`. |
 
 All flags are optional. When a flag is provided, its corresponding interactive prompt is
 skipped. When **all** required fields are supplied via flags, `sonda init` runs fully
-non-interactively -- no terminal interaction needed.
+non-interactively -- no terminal interaction needed. Rate and duration values are validated;
+invalid values fall through to interactive prompts or use defaults in non-interactive mode.
 
 ### Non-interactive mode
 
@@ -984,6 +991,24 @@ sonda init \
   --sink stdout \
   -o ./scenarios/node-cpu.yaml
 ```
+
+Add `--run-now` to also execute the scenario immediately after writing:
+
+```bash
+sonda init \
+  --signal-type metrics \
+  --domain infrastructure \
+  --metric node_cpu_seconds \
+  --situation steady \
+  --rate 1 --duration 60s \
+  --encoder prometheus_text \
+  --sink stdout \
+  -o ./scenarios/node-cpu.yaml \
+  --run-now
+```
+
+When `--run-now` is not provided and stdin is not a TTY (e.g. in a CI pipeline), the
+run-now prompt is skipped and defaults to `false`.
 
 Partial flags work too -- Sonda prompts only for the missing values. For example, if you
 supply `--signal-type` and `--domain` but nothing else, the wizard starts at step 3:

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -202,7 +202,9 @@ You have the basics. The **[Tutorial](guides/tutorial.md)** walks through every 
 encoder, sink, and advanced feature step by step.
 
 Don't want to write YAML by hand? Run **`sonda init`** -- an interactive wizard that walks
-you through building a scenario step by step and writes the YAML for you (see
+you through building a scenario step by step and writes the YAML for you. Pass CLI flags
+(e.g. `--signal-type`, `--situation`, `--rate`) to skip prompts, or use
+`--from @builtin` to start from an existing scenario (see
 [CLI Reference](configuration/cli-reference.md#sonda-init)). Or try the
 **[Built-in Scenarios](guides/scenarios.md)** -- 11 curated patterns you can run instantly
 with `sonda scenarios run cpu-spike`. Explore

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -15,7 +15,8 @@ micro-bursts, cardinality spikes, and shaped value sequences.
 - **Import CSV data** -- analyze Grafana exports or plain CSVs, detect time-series patterns, and
   generate portable scenario YAML using generators instead of raw replay.
 - **Scaffold scenarios interactively** -- `sonda init` walks you through building a scenario with
-  guided prompts using operational language, no YAML knowledge required.
+  guided prompts, or run fully non-interactively with flags. Pre-fill from built-in scenarios
+  (`--from @cpu-spike`) or CSV files (`--from data.csv`).
 - **Test recording rules** -- push known constant values and verify computed outputs.
 - **Load-test backends** -- generate thousands of events per second in a static binary with zero
   runtime dependencies.
@@ -67,7 +68,7 @@ Define reusable scenarios in YAML for anything beyond quick one-offs --
 | **Scheduling** | configurable rate, duration, gap windows, burst windows, cardinality spikes, jitter |
 | **Signals** | metrics, logs (template and replay modes) |
 | **CSV import** | Analyze CSVs, detect patterns, generate portable scenario YAML |
-| **Interactive scaffolding** | `sonda init` -- guided wizard with operational vocabulary |
+| **Interactive scaffolding** | `sonda init` -- guided wizard, non-interactive mode, `--from` prefill |
 | **Built-in scenarios** | 11 curated patterns you can run instantly -- no YAML needed |
 | **Deployment** | static binary, Docker, Kubernetes (Helm chart) |
 
@@ -77,7 +78,7 @@ Ready to dive in? **[Get started in 5 minutes -->](getting-started.md)**
 
 Or jump straight to what you need:
 
-- [**`sonda init`**](configuration/cli-reference.md#sonda-init) -- interactively scaffold a scenario YAML without writing any config by hand
+- [**`sonda init`**](configuration/cli-reference.md#sonda-init) -- scaffold a scenario YAML interactively, non-interactively with flags, or pre-filled from a built-in or CSV
 - [**Built-in Scenarios**](guides/scenarios.md) -- run pre-built patterns instantly, customize from there
 - [**CSV Import**](guides/csv-import.md) -- turn Grafana exports into portable, parameterized scenarios
 - [**Configuration**](configuration/scenario-file.md) -- scenario files, generators, encoders, sinks, CLI reference

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -53,18 +53,25 @@ src/
 │   ├── mod.rs          ← `sonda init` subcommand: top-level orchestration (run_init),
 │   │                      InitResult (yaml + run_now flag + InitScenarioType for dispatch),
 │   │                      build_prefill() merges --from data with CLI flags into Prefill,
-│   │                      prefill_from_scenario() extracts fields from @name scenario YAML,
-│   │                      prefill_from_csv() detects pattern from CSV and maps to alias,
-│   │                      welcome banner, YAML preview, success summary, run-now prompt,
+│   │                      prefill_from_scenario() extracts fields from @name scenario YAML
+│   │                      (including labels), prefill_from_csv() detects pattern from CSV
+│   │                      and maps to alias (gracefully handles no-numeric-columns),
+│   │                      welcome banner, YAML preview, success summary, run-now prompt
+│   │                      (bypassed by --run-now flag or non-TTY stdin),
 │   │                      print_prefill_summary() shows pre-filled values before prompts
 │   ├── prompts.rs      ← interactive prompt logic using dialoguer: signal type, domain,
 │   │                      approach (single metric vs pack), situation selection,
-│   │                      situation-specific parameters, labels, rate, duration, encoder, sink.
-│   │                      Prefill struct carries optional pre-filled values for each prompt.
+│   │                      situation-specific parameters (bypassed with defaults when
+│   │                      situation is prefilled), labels, rate (validated > 0), duration
+│   │                      (validated via parse_duration), encoder, sink.
+│   │                      Prefill struct carries optional pre-filled values for each prompt
+│   │                      including log-specific (message_template, severity) and
+│   │                      sink-specific (kafka_brokers, kafka_topic, otlp_signal_type).
 │   │                      Each prompt fn checks prefill — valid value skips the prompt,
 │   │                      invalid value warns and falls through to interactive.
 │   │                      Two-tier sink menu (primary: stdout/http_push/file; advanced:
 │   │                      remote_write/loki/otlp_grpc/kafka/tcp/udp behind "Advanced...").
+│   │                      Prefilled advanced sinks populate extra fields from prefill.
 │   │                      Pack domain filtering (list_by_category, fallback to all).
 │   │                      enforce_encoder_for_sink() auto-overrides encoder for protocol sinks.
 │   │                      prompt_run_now() offers immediate execution after file write.
@@ -104,7 +111,7 @@ sonda [--quiet | --verbose] [--dry-run] packs run <name> [--duration <d>] [--rat
 sonda import <file.csv> --analyze
 sonda import <file.csv> -o <output.yaml> [--columns <1,3,5>] [--rate <r>] [--duration <d>]
 sonda [--quiet | --verbose] import <file.csv> --run [--columns <1,3,5>] [--rate <r>] [--duration <d>]
-sonda init [--from <@name | path.csv>] [--signal-type <metrics|logs>] [--domain <cat>] [--situation <alias>] [--metric <name>] [--pack <name>] [--rate <r>] [--duration <d>] [--encoder <enc>] [--sink <type>] [--endpoint <url>] [-o <path>] [--label k=v]...
+sonda init [--from <@name | path.csv>] [--signal-type <metrics|logs>] [--domain <cat>] [--situation <alias>] [--metric <name>] [--pack <name>] [--rate <r>] [--duration <d>] [--encoder <enc>] [--sink <type>] [--endpoint <url>] [-o <path>] [--label k=v]... [--run-now] [--message-template <tpl>] [--severity <preset>] [--kafka-brokers <addrs>] [--kafka-topic <topic>] [--otlp-signal-type <type>]
 ```
 
 The `--scenario` flag accepts either a filesystem path or a `@name` shorthand that resolves
@@ -143,10 +150,14 @@ Uses operational vocabulary aliases (steady, spike_event, flap, etc.) and suppor
 with domain-filtered selection. Two-tier sink menu (primary + advanced behind "Advanced...") with
 automatic encoder override for protocol sinks (remote_write, otlp_grpc). After writing the file,
 offers immediate execution via the run-now prompt (dispatched by InitScenarioType).
-Supports non-interactive mode via CLI flags (`--signal-type`, `--domain`, `--situation`, etc.)
-and pre-filling from built-in scenarios (`--from @name`) or CSV files (`--from path.csv`).
+Supports fully non-interactive mode via CLI flags (`--signal-type`, `--domain`, `--situation`,
+`--metric`, `--rate`, `--duration`, `--encoder`, `--sink`, `-o`, `--run-now`, etc.) and
+pre-filling from built-in scenarios (`--from @name`) or CSV files (`--from path.csv`).
 CLI flags override `--from` values. Pre-filled values skip their interactive prompts; missing
-values prompt as usual (partial non-interactive mode).
+values prompt as usual (partial non-interactive mode). Situation-specific parameters use
+defaults when the situation is prefilled. Log-specific prompts (message template, severity)
+and sink-specific extra fields (kafka brokers/topic, OTLP signal type) are also prefillable.
+Rate and duration are validated; invalid values warn and fall through.
 
 All subcommands go through the unified `sonda_core::prepare_entries` +
 `sonda_core::launch_scenario` API introduced in Slice 3.0. No per-signal-type dispatch in main.rs.

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -52,10 +52,17 @@ src/
 ├── init/
 │   ├── mod.rs          ← `sonda init` subcommand: top-level orchestration (run_init),
 │   │                      InitResult (yaml + run_now flag + InitScenarioType for dispatch),
-│   │                      welcome banner, YAML preview, success summary, run-now prompt
+│   │                      build_prefill() merges --from data with CLI flags into Prefill,
+│   │                      prefill_from_scenario() extracts fields from @name scenario YAML,
+│   │                      prefill_from_csv() detects pattern from CSV and maps to alias,
+│   │                      welcome banner, YAML preview, success summary, run-now prompt,
+│   │                      print_prefill_summary() shows pre-filled values before prompts
 │   ├── prompts.rs      ← interactive prompt logic using dialoguer: signal type, domain,
 │   │                      approach (single metric vs pack), situation selection,
 │   │                      situation-specific parameters, labels, rate, duration, encoder, sink.
+│   │                      Prefill struct carries optional pre-filled values for each prompt.
+│   │                      Each prompt fn checks prefill — valid value skips the prompt,
+│   │                      invalid value warns and falls through to interactive.
 │   │                      Two-tier sink menu (primary: stdout/http_push/file; advanced:
 │   │                      remote_write/loki/otlp_grpc/kafka/tcp/udp behind "Advanced...").
 │   │                      Pack domain filtering (list_by_category, fallback to all).
@@ -97,7 +104,7 @@ sonda [--quiet | --verbose] [--dry-run] packs run <name> [--duration <d>] [--rat
 sonda import <file.csv> --analyze
 sonda import <file.csv> -o <output.yaml> [--columns <1,3,5>] [--rate <r>] [--duration <d>]
 sonda [--quiet | --verbose] import <file.csv> --run [--columns <1,3,5>] [--rate <r>] [--duration <d>]
-sonda init
+sonda init [--from <@name | path.csv>] [--signal-type <metrics|logs>] [--domain <cat>] [--situation <alias>] [--metric <name>] [--pack <name>] [--rate <r>] [--duration <d>] [--encoder <enc>] [--sink <type>] [--endpoint <url>] [-o <path>] [--label k=v]...
 ```
 
 The `--scenario` flag accepts either a filesystem path or a `@name` shorthand that resolves
@@ -136,6 +143,10 @@ Uses operational vocabulary aliases (steady, spike_event, flap, etc.) and suppor
 with domain-filtered selection. Two-tier sink menu (primary + advanced behind "Advanced...") with
 automatic encoder override for protocol sinks (remote_write, otlp_grpc). After writing the file,
 offers immediate execution via the run-now prompt (dispatched by InitScenarioType).
+Supports non-interactive mode via CLI flags (`--signal-type`, `--domain`, `--situation`, etc.)
+and pre-filling from built-in scenarios (`--from @name`) or CSV files (`--from path.csv`).
+CLI flags override `--from` values. Pre-filled values skip their interactive prompts; missing
+values prompt as usual (partial non-interactive mode).
 
 All subcommands go through the unified `sonda_core::prepare_entries` +
 `sonda_core::launch_scenario` API introduced in Slice 3.0. No per-signal-type dispatch in main.rs.

--- a/sonda/src/cli.rs
+++ b/sonda/src/cli.rs
@@ -909,17 +909,65 @@ pub struct ImportArgs {
 
 /// Arguments for the `init` subcommand.
 ///
-/// Currently all arguments are reserved for future non-interactive mode.
-/// The struct is intentionally designed with optional fields so that
-/// `--domain`, `--situation`, etc. can be added later without restructuring.
+/// All flags are optional. When a flag is provided its value is used directly,
+/// skipping the corresponding interactive prompt. When ALL required flags are
+/// supplied, `sonda init` runs fully non-interactively.
+///
+/// The `--from` flag pre-fills values from a built-in scenario (`@name`) or a
+/// CSV file (`path.csv`). Explicit flags override `--from` values.
 #[derive(Debug, Args)]
 pub struct InitArgs {
-    // No flags for now. The interactive flow drives everything.
-    // Future non-interactive flags will go here:
-    //   --domain <domain>
-    //   --situation <alias>
-    //   --signal-type <metrics|logs>
-    //   --output <path>
+    /// Start from a built-in scenario (@name) or CSV file (path.csv).
+    #[arg(long)]
+    pub from: Option<String>,
+
+    /// Signal type: metrics or logs.
+    #[arg(long)]
+    pub signal_type: Option<String>,
+
+    /// Domain category (infrastructure, network, application, custom).
+    #[arg(long)]
+    pub domain: Option<String>,
+
+    /// Operational situation/pattern (steady, spike_event, flap, leak, saturation, degradation).
+    #[arg(long)]
+    pub situation: Option<String>,
+
+    /// Metric name.
+    #[arg(long)]
+    pub metric: Option<String>,
+
+    /// Use a metric pack instead of single metric.
+    #[arg(long)]
+    pub pack: Option<String>,
+
+    /// Events per second.
+    #[arg(long)]
+    pub rate: Option<f64>,
+
+    /// Duration (e.g., 60s, 5m).
+    #[arg(long)]
+    pub duration: Option<String>,
+
+    /// Encoder format (prometheus_text, influx_lp, json_lines, syslog).
+    #[arg(long)]
+    pub encoder: Option<String>,
+
+    /// Sink type (stdout, http_push, file, remote_write, loki, otlp_grpc, kafka, tcp, udp).
+    #[arg(long)]
+    pub sink: Option<String>,
+
+    /// Sink endpoint (URL, file path, or host:port).
+    #[arg(long)]
+    pub endpoint: Option<String>,
+
+    /// Output file path for the generated YAML.
+    #[arg(short, long)]
+    pub output: Option<String>,
+
+    /// Static labels (key=value), can be repeated.
+    #[arg(long = "label", value_name = "KEY=VALUE")]
+    pub labels: Vec<String>,
 }
 
 /// Build clap help styling for the CLI.
@@ -1682,5 +1730,119 @@ mod tests {
             Some(std::path::PathBuf::from("/custom/packs"))
         );
         assert!(matches!(cli.command, Commands::Init(_)));
+    }
+
+    #[test]
+    fn cli_init_from_builtin_scenario() {
+        let cli =
+            Cli::try_parse_from(["sonda", "init", "--from", "@cpu-spike"]).expect("should parse");
+        if let Commands::Init(ref args) = cli.command {
+            assert_eq!(args.from.as_deref(), Some("@cpu-spike"));
+        } else {
+            panic!("expected Init command");
+        }
+    }
+
+    #[test]
+    fn cli_init_from_csv_file() {
+        let cli =
+            Cli::try_parse_from(["sonda", "init", "--from", "data.csv"]).expect("should parse");
+        if let Commands::Init(ref args) = cli.command {
+            assert_eq!(args.from.as_deref(), Some("data.csv"));
+        } else {
+            panic!("expected Init command");
+        }
+    }
+
+    #[test]
+    fn cli_init_all_flags() {
+        let cli = Cli::try_parse_from([
+            "sonda",
+            "init",
+            "--signal-type",
+            "metrics",
+            "--domain",
+            "network",
+            "--situation",
+            "flap",
+            "--metric",
+            "bgp_state",
+            "--rate",
+            "2.5",
+            "--duration",
+            "5m",
+            "--encoder",
+            "prometheus_text",
+            "--sink",
+            "stdout",
+            "--endpoint",
+            "http://localhost:9090",
+            "-o",
+            "output.yaml",
+            "--label",
+            "env=prod",
+            "--label",
+            "dc=us-east",
+        ])
+        .expect("should parse");
+        if let Commands::Init(ref args) = cli.command {
+            assert_eq!(args.signal_type.as_deref(), Some("metrics"));
+            assert_eq!(args.domain.as_deref(), Some("network"));
+            assert_eq!(args.situation.as_deref(), Some("flap"));
+            assert_eq!(args.metric.as_deref(), Some("bgp_state"));
+            assert_eq!(args.rate, Some(2.5));
+            assert_eq!(args.duration.as_deref(), Some("5m"));
+            assert_eq!(args.encoder.as_deref(), Some("prometheus_text"));
+            assert_eq!(args.sink.as_deref(), Some("stdout"));
+            assert_eq!(args.endpoint.as_deref(), Some("http://localhost:9090"));
+            assert_eq!(args.output.as_deref(), Some("output.yaml"));
+            assert_eq!(args.labels, vec!["env=prod", "dc=us-east"]);
+        } else {
+            panic!("expected Init command");
+        }
+    }
+
+    #[test]
+    fn cli_init_pack_flag() {
+        let cli = Cli::try_parse_from(["sonda", "init", "--pack", "telegraf_snmp"])
+            .expect("should parse");
+        if let Commands::Init(ref args) = cli.command {
+            assert_eq!(args.pack.as_deref(), Some("telegraf_snmp"));
+        } else {
+            panic!("expected Init command");
+        }
+    }
+
+    #[test]
+    fn cli_init_no_flags_defaults_to_none() {
+        let cli = Cli::try_parse_from(["sonda", "init"]).expect("should parse");
+        if let Commands::Init(ref args) = cli.command {
+            assert!(args.from.is_none());
+            assert!(args.signal_type.is_none());
+            assert!(args.domain.is_none());
+            assert!(args.situation.is_none());
+            assert!(args.metric.is_none());
+            assert!(args.pack.is_none());
+            assert!(args.rate.is_none());
+            assert!(args.duration.is_none());
+            assert!(args.encoder.is_none());
+            assert!(args.sink.is_none());
+            assert!(args.endpoint.is_none());
+            assert!(args.output.is_none());
+            assert!(args.labels.is_empty());
+        } else {
+            panic!("expected Init command");
+        }
+    }
+
+    #[test]
+    fn cli_init_output_short_flag() {
+        let cli =
+            Cli::try_parse_from(["sonda", "init", "-o", "my-scenario.yaml"]).expect("should parse");
+        if let Commands::Init(ref args) = cli.command {
+            assert_eq!(args.output.as_deref(), Some("my-scenario.yaml"));
+        } else {
+            panic!("expected Init command");
+        }
     }
 }

--- a/sonda/src/cli.rs
+++ b/sonda/src/cli.rs
@@ -910,11 +910,17 @@ pub struct ImportArgs {
 /// Arguments for the `init` subcommand.
 ///
 /// All flags are optional. When a flag is provided its value is used directly,
-/// skipping the corresponding interactive prompt. When ALL required flags are
-/// supplied, `sonda init` runs fully non-interactively.
+/// skipping the corresponding interactive prompt. When ALL required fields are
+/// supplied via flags (signal type, domain, metric/pack, situation, rate,
+/// duration, encoder, sink, and output path), `sonda init` runs fully
+/// non-interactively — no terminal interaction needed.
 ///
 /// The `--from` flag pre-fills values from a built-in scenario (`@name`) or a
 /// CSV file (`path.csv`). Explicit flags override `--from` values.
+///
+/// For advanced sinks in non-interactive mode, supply the sink-specific flags
+/// (`--kafka-brokers`, `--kafka-topic`, `--otlp-signal-type`) alongside
+/// `--sink`.
 #[derive(Debug, Args)]
 pub struct InitArgs {
     /// Start from a built-in scenario (@name) or CSV file (path.csv).
@@ -968,6 +974,38 @@ pub struct InitArgs {
     /// Static labels (key=value), can be repeated.
     #[arg(long = "label", value_name = "KEY=VALUE")]
     pub labels: Vec<String>,
+
+    /// Run the generated scenario immediately after writing (skip the prompt).
+    ///
+    /// When absent and stdin is a TTY, prompts the user. When absent and stdin
+    /// is not a TTY, defaults to `false`.
+    #[arg(long)]
+    pub run_now: bool,
+
+    /// Log message template (for `--signal-type logs`).
+    ///
+    /// Uses `{field}` placeholders. Example:
+    /// `"Request to {endpoint} completed with status {status}"`.
+    #[arg(long, help_heading = "Logs")]
+    pub message_template: Option<String>,
+
+    /// Severity distribution preset (for `--signal-type logs`).
+    ///
+    /// Accepted values: `mostly_info`, `balanced`, `error_heavy`.
+    #[arg(long, help_heading = "Logs")]
+    pub severity: Option<String>,
+
+    /// Kafka broker(s) for `--sink kafka` (e.g. `localhost:9092`).
+    #[arg(long, help_heading = "Sink")]
+    pub kafka_brokers: Option<String>,
+
+    /// Kafka topic for `--sink kafka`.
+    #[arg(long, help_heading = "Sink")]
+    pub kafka_topic: Option<String>,
+
+    /// OTLP signal type for `--sink otlp_grpc`: `metrics` or `logs`.
+    #[arg(long, help_heading = "Sink")]
+    pub otlp_signal_type: Option<String>,
 }
 
 /// Build clap help styling for the CLI.
@@ -1830,6 +1868,12 @@ mod tests {
             assert!(args.endpoint.is_none());
             assert!(args.output.is_none());
             assert!(args.labels.is_empty());
+            assert!(!args.run_now);
+            assert!(args.message_template.is_none());
+            assert!(args.severity.is_none());
+            assert!(args.kafka_brokers.is_none());
+            assert!(args.kafka_topic.is_none());
+            assert!(args.otlp_signal_type.is_none());
         } else {
             panic!("expected Init command");
         }
@@ -1841,6 +1885,90 @@ mod tests {
             Cli::try_parse_from(["sonda", "init", "-o", "my-scenario.yaml"]).expect("should parse");
         if let Commands::Init(ref args) = cli.command {
             assert_eq!(args.output.as_deref(), Some("my-scenario.yaml"));
+        } else {
+            panic!("expected Init command");
+        }
+    }
+
+    #[test]
+    fn cli_init_run_now_flag() {
+        let cli = Cli::try_parse_from(["sonda", "init", "--run-now"]).expect("should parse");
+        if let Commands::Init(ref args) = cli.command {
+            assert!(args.run_now);
+        } else {
+            panic!("expected Init command");
+        }
+    }
+
+    #[test]
+    fn cli_init_message_template_flag() {
+        let cli = Cli::try_parse_from([
+            "sonda",
+            "init",
+            "--message-template",
+            "Connection from {ip} failed",
+        ])
+        .expect("should parse");
+        if let Commands::Init(ref args) = cli.command {
+            assert_eq!(
+                args.message_template.as_deref(),
+                Some("Connection from {ip} failed")
+            );
+        } else {
+            panic!("expected Init command");
+        }
+    }
+
+    #[test]
+    fn cli_init_severity_flag() {
+        let cli =
+            Cli::try_parse_from(["sonda", "init", "--severity", "balanced"]).expect("should parse");
+        if let Commands::Init(ref args) = cli.command {
+            assert_eq!(args.severity.as_deref(), Some("balanced"));
+        } else {
+            panic!("expected Init command");
+        }
+    }
+
+    #[test]
+    fn cli_init_kafka_flags() {
+        let cli = Cli::try_parse_from([
+            "sonda",
+            "init",
+            "--sink",
+            "kafka",
+            "--kafka-brokers",
+            "broker1:9092,broker2:9092",
+            "--kafka-topic",
+            "my-topic",
+        ])
+        .expect("should parse");
+        if let Commands::Init(ref args) = cli.command {
+            assert_eq!(args.sink.as_deref(), Some("kafka"));
+            assert_eq!(
+                args.kafka_brokers.as_deref(),
+                Some("broker1:9092,broker2:9092")
+            );
+            assert_eq!(args.kafka_topic.as_deref(), Some("my-topic"));
+        } else {
+            panic!("expected Init command");
+        }
+    }
+
+    #[test]
+    fn cli_init_otlp_signal_type_flag() {
+        let cli = Cli::try_parse_from([
+            "sonda",
+            "init",
+            "--sink",
+            "otlp_grpc",
+            "--otlp-signal-type",
+            "metrics",
+        ])
+        .expect("should parse");
+        if let Commands::Init(ref args) = cli.command {
+            assert_eq!(args.sink.as_deref(), Some("otlp_grpc"));
+            assert_eq!(args.otlp_signal_type.as_deref(), Some("metrics"));
         } else {
             panic!("expected Init command");
         }

--- a/sonda/src/init/mod.rs
+++ b/sonda/src/init/mod.rs
@@ -26,6 +26,7 @@
 pub mod prompts;
 pub mod yaml_gen;
 
+use std::io::IsTerminal;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -126,8 +127,16 @@ pub fn run_init(
     print_success(&kind, &output_path);
 
     // Offer to run immediately.
-    let theme = ColorfulTheme::default();
-    let run_now = prompts::prompt_run_now(&theme).context("run-now prompt failed")?;
+    // --run-now flag: use it directly. Otherwise, prompt if stdin is a TTY;
+    // default to false when non-interactive.
+    let run_now = if args.run_now {
+        true
+    } else if std::io::stdin().is_terminal() {
+        let theme = ColorfulTheme::default();
+        prompts::prompt_run_now(&theme).context("run-now prompt failed")?
+    } else {
+        false
+    };
 
     Ok(InitResult {
         yaml,
@@ -185,6 +194,25 @@ pub fn build_prefill(args: &InitArgs, scenario_catalog: &ScenarioCatalog) -> Res
     }
     if let Some(ref v) = args.endpoint {
         prefill.endpoint = Some(v.clone());
+    }
+
+    // Log-specific fields.
+    if let Some(ref v) = args.message_template {
+        prefill.message_template = Some(v.clone());
+    }
+    if let Some(ref v) = args.severity {
+        prefill.severity = Some(v.clone());
+    }
+
+    // Sink-specific extra fields.
+    if let Some(ref v) = args.kafka_brokers {
+        prefill.kafka_brokers = Some(v.clone());
+    }
+    if let Some(ref v) = args.kafka_topic {
+        prefill.kafka_topic = Some(v.clone());
+    }
+    if let Some(ref v) = args.otlp_signal_type {
+        prefill.otlp_signal_type = Some(v.clone());
     }
 
     // Parse --label key=value flags into the labels map.
@@ -259,6 +287,11 @@ fn prefill_from_scenario(name: &str, catalog: &ScenarioCatalog) -> Result<Prefil
             if let Some(ref p) = probe.pack {
                 prefill.pack = Some(p.clone());
             }
+            if let Some(ref l) = probe.labels {
+                for (k, v) in l {
+                    prefill.labels.insert(k.clone(), v.clone());
+                }
+            }
         }
     }
 
@@ -268,15 +301,31 @@ fn prefill_from_scenario(name: &str, catalog: &ScenarioCatalog) -> Result<Prefil
 /// Build a [`Prefill`] from a CSV file by analyzing time-series patterns.
 ///
 /// Reads the first numeric column from the CSV, detects its dominant pattern,
-/// and maps it to an operational vocabulary alias.
+/// and maps it to an operational vocabulary alias. When the CSV has no numeric
+/// columns, returns a minimal prefill with `signal_type: "metrics"` and no
+/// situation or metric name.
 ///
 /// # Errors
 ///
-/// Returns an error if the CSV file cannot be read or has no numeric columns.
+/// Returns an error if the CSV file cannot be opened or parsed.
 fn prefill_from_csv(path: &str) -> Result<Prefill> {
     let csv_path = Path::new(path);
-    let data = import::csv_reader::read_csv(csv_path, None)
-        .with_context(|| format!("failed to read CSV file: {path}"))?;
+    let data = match import::csv_reader::read_csv(csv_path, None) {
+        Ok(d) => d,
+        Err(e) => {
+            // When the CSV has no numeric columns, read_csv returns an error.
+            // We still want to produce a valid (albeit minimal) Prefill so the
+            // init flow can continue with interactive prompts.
+            let msg = e.to_string();
+            if msg.contains("no numeric data found") {
+                return Ok(Prefill {
+                    signal_type: Some("metrics".to_string()),
+                    ..Prefill::default()
+                });
+            }
+            return Err(e).with_context(|| format!("failed to read CSV file: {path}"));
+        }
+    };
 
     let mut prefill = Prefill {
         signal_type: Some("metrics".to_string()),
@@ -323,6 +372,8 @@ struct ScenarioProbe {
     encoder: Option<EncoderProbe>,
     sink: Option<SinkProbe>,
     pack: Option<String>,
+    /// Static labels from the scenario YAML.
+    labels: Option<std::collections::BTreeMap<String, String>>,
 }
 
 /// Generator section of a scenario YAML (just the type field).
@@ -354,37 +405,42 @@ fn print_prefill_summary(args: &InitArgs, prefill: &Prefill) {
     let dimmed = owo_colors::Style::new().dimmed();
     let bold_cyan = owo_colors::Style::new().bold().cyan();
 
-    // Collect fields that have values.
-    let mut fields: Vec<(&str, String)> = Vec::new();
+    // We need an owned String for the rate (formatted from f64); all other
+    // values are borrowed as &str to avoid unnecessary clones.
+    let rate_str;
+
+    // Collect fields that have values — borrows wherever possible.
+    let mut fields: Vec<(&str, &str)> = Vec::new();
     if let Some(ref v) = prefill.signal_type {
-        fields.push(("signal_type", v.clone()));
+        fields.push(("signal_type", v.as_str()));
     }
     if let Some(ref v) = prefill.domain {
-        fields.push(("domain", v.clone()));
+        fields.push(("domain", v.as_str()));
     }
     if let Some(ref v) = prefill.situation {
-        fields.push(("situation", v.clone()));
+        fields.push(("situation", v.as_str()));
     }
     if let Some(ref v) = prefill.metric {
-        fields.push(("metric", v.clone()));
+        fields.push(("metric", v.as_str()));
     }
     if let Some(ref v) = prefill.pack {
-        fields.push(("pack", v.clone()));
+        fields.push(("pack", v.as_str()));
     }
     if let Some(v) = prefill.rate {
-        fields.push(("rate", v.to_string()));
+        rate_str = v.to_string();
+        fields.push(("rate", &rate_str));
     }
     if let Some(ref v) = prefill.duration {
-        fields.push(("duration", v.clone()));
+        fields.push(("duration", v.as_str()));
     }
     if let Some(ref v) = prefill.encoder {
-        fields.push(("encoder", v.clone()));
+        fields.push(("encoder", v.as_str()));
     }
     if let Some(ref v) = prefill.sink {
-        fields.push(("sink", v.clone()));
+        fields.push(("sink", v.as_str()));
     }
     if let Some(ref v) = prefill.endpoint {
-        fields.push(("endpoint", v.clone()));
+        fields.push(("endpoint", v.as_str()));
     }
 
     if fields.is_empty() {
@@ -554,6 +610,33 @@ fn print_success(kind: &yaml_gen::ScenarioKind, output_path: &str) {
 mod tests {
     use super::*;
 
+    /// Build a default [`InitArgs`] with all fields set to their zero/None values.
+    ///
+    /// Tests override individual fields as needed.
+    fn default_init_args() -> InitArgs {
+        InitArgs {
+            from: None,
+            signal_type: None,
+            domain: None,
+            situation: None,
+            metric: None,
+            pack: None,
+            rate: None,
+            duration: None,
+            encoder: None,
+            sink: None,
+            endpoint: None,
+            output: None,
+            labels: vec![],
+            run_now: false,
+            message_template: None,
+            severity: None,
+            kafka_brokers: None,
+            kafka_topic: None,
+            otlp_signal_type: None,
+        }
+    }
+
     // -----------------------------------------------------------------------
     // YAML preview: truncation behavior
     // -----------------------------------------------------------------------
@@ -706,21 +789,7 @@ mod tests {
 
     #[test]
     fn build_prefill_no_args_produces_default() {
-        let args = InitArgs {
-            from: None,
-            signal_type: None,
-            domain: None,
-            situation: None,
-            metric: None,
-            pack: None,
-            rate: None,
-            duration: None,
-            encoder: None,
-            sink: None,
-            endpoint: None,
-            output: None,
-            labels: vec![],
-        };
+        let args = default_init_args();
         let catalog = ScenarioCatalog::discover(&[]);
         let prefill = build_prefill(&args, &catalog).expect("should succeed");
         assert!(prefill.signal_type.is_none());
@@ -731,19 +800,16 @@ mod tests {
     #[test]
     fn build_prefill_cli_flags_populate_fields() {
         let args = InitArgs {
-            from: None,
             signal_type: Some("metrics".to_string()),
             domain: Some("network".to_string()),
             situation: Some("flap".to_string()),
             metric: Some("bgp_state".to_string()),
-            pack: None,
             rate: Some(2.0),
             duration: Some("5m".to_string()),
             encoder: Some("prometheus_text".to_string()),
             sink: Some("stdout".to_string()),
-            endpoint: None,
-            output: None,
             labels: vec!["env=prod".to_string(), "region=us-east".to_string()],
+            ..default_init_args()
         };
         let catalog = ScenarioCatalog::discover(&[]);
         let prefill = build_prefill(&args, &catalog).expect("should succeed");
@@ -765,19 +831,8 @@ mod tests {
     #[test]
     fn build_prefill_labels_parse_key_value() {
         let args = InitArgs {
-            from: None,
-            signal_type: None,
-            domain: None,
-            situation: None,
-            metric: None,
-            pack: None,
-            rate: None,
-            duration: None,
-            encoder: None,
-            sink: None,
-            endpoint: None,
-            output: None,
             labels: vec!["host=web-01".to_string(), "dc=us-west-2".to_string()],
+            ..default_init_args()
         };
         let catalog = ScenarioCatalog::discover(&[]);
         let prefill = build_prefill(&args, &catalog).expect("should succeed");
@@ -795,19 +850,8 @@ mod tests {
     #[test]
     fn build_prefill_labels_skip_malformed() {
         let args = InitArgs {
-            from: None,
-            signal_type: None,
-            domain: None,
-            situation: None,
-            metric: None,
-            pack: None,
-            rate: None,
-            duration: None,
-            encoder: None,
-            sink: None,
-            endpoint: None,
-            output: None,
             labels: vec!["no_equals_sign".to_string(), "good=value".to_string()],
+            ..default_init_args()
         };
         let catalog = ScenarioCatalog::discover(&[]);
         let prefill = build_prefill(&args, &catalog).expect("should succeed");
@@ -858,18 +902,7 @@ sink:
         let catalog = ScenarioCatalog::discover(&[dir.clone()]);
         let args = InitArgs {
             from: Some("@cpu-spike".to_string()),
-            signal_type: None,
-            domain: None,
-            situation: None,
-            metric: None,
-            pack: None,
-            rate: None,
-            duration: None,
-            encoder: None,
-            sink: None,
-            endpoint: None,
-            output: None,
-            labels: vec![],
+            ..default_init_args()
         };
 
         let prefill = build_prefill(&args, &catalog).expect("should succeed");
@@ -890,18 +923,7 @@ sink:
         let catalog = ScenarioCatalog::discover(&[]);
         let args = InitArgs {
             from: Some("@nonexistent-scenario".to_string()),
-            signal_type: None,
-            domain: None,
-            situation: None,
-            metric: None,
-            pack: None,
-            rate: None,
-            duration: None,
-            encoder: None,
-            sink: None,
-            endpoint: None,
-            output: None,
-            labels: vec![],
+            ..default_init_args()
         };
 
         let result = build_prefill(&args, &catalog);
@@ -945,18 +967,10 @@ sink:
         let catalog = ScenarioCatalog::discover(&[dir.clone()]);
         let args = InitArgs {
             from: Some("@cpu-spike".to_string()),
-            signal_type: None,
             domain: Some("network".to_string()),
             situation: Some("flap".to_string()),
-            metric: None,
-            pack: None,
             rate: Some(10.0),
-            duration: None,
-            encoder: None,
-            sink: None,
-            endpoint: None,
-            output: None,
-            labels: vec![],
+            ..default_init_args()
         };
 
         let prefill = build_prefill(&args, &catalog).expect("should succeed");
@@ -1012,18 +1026,7 @@ sink:
         let catalog = ScenarioCatalog::discover(&[]);
         let args = InitArgs {
             from: Some(csv_path.to_str().unwrap().to_string()),
-            signal_type: None,
-            domain: None,
-            situation: None,
-            metric: None,
-            pack: None,
-            rate: None,
-            duration: None,
-            encoder: None,
-            sink: None,
-            endpoint: None,
-            output: None,
-            labels: vec![],
+            ..default_init_args()
         };
 
         let prefill = build_prefill(&args, &catalog).expect("should succeed");
@@ -1048,18 +1051,7 @@ sink:
         let catalog = ScenarioCatalog::discover(&[]);
         let args = InitArgs {
             from: Some("/nonexistent/path/data.csv".to_string()),
-            signal_type: None,
-            domain: None,
-            situation: None,
-            metric: None,
-            pack: None,
-            rate: None,
-            duration: None,
-            encoder: None,
-            sink: None,
-            endpoint: None,
-            output: None,
-            labels: vec![],
+            ..default_init_args()
         };
 
         let result = build_prefill(&args, &catalog);
@@ -1072,21 +1064,7 @@ sink:
 
     #[test]
     fn print_prefill_summary_does_not_panic_with_empty_prefill() {
-        let args = InitArgs {
-            from: None,
-            signal_type: None,
-            domain: None,
-            situation: None,
-            metric: None,
-            pack: None,
-            rate: None,
-            duration: None,
-            encoder: None,
-            sink: None,
-            endpoint: None,
-            output: None,
-            labels: vec![],
-        };
+        let args = default_init_args();
         let prefill = Prefill::default();
         print_prefill_summary(&args, &prefill);
     }
@@ -1095,18 +1073,7 @@ sink:
     fn print_prefill_summary_does_not_panic_with_from() {
         let args = InitArgs {
             from: Some("@cpu-spike".to_string()),
-            signal_type: None,
-            domain: None,
-            situation: None,
-            metric: None,
-            pack: None,
-            rate: None,
-            duration: None,
-            encoder: None,
-            sink: None,
-            endpoint: None,
-            output: None,
-            labels: vec![],
+            ..default_init_args()
         };
         let prefill = Prefill {
             signal_type: Some("metrics".to_string()),
@@ -1119,19 +1086,10 @@ sink:
     #[test]
     fn print_prefill_summary_does_not_panic_with_flags() {
         let args = InitArgs {
-            from: None,
             signal_type: Some("metrics".to_string()),
             domain: Some("network".to_string()),
-            situation: None,
-            metric: None,
-            pack: None,
             rate: Some(5.0),
-            duration: None,
-            encoder: None,
-            sink: None,
-            endpoint: None,
-            output: None,
-            labels: vec![],
+            ..default_init_args()
         };
         let prefill = Prefill {
             signal_type: Some("metrics".to_string()),
@@ -1140,5 +1098,151 @@ sink:
             ..Prefill::default()
         };
         print_prefill_summary(&args, &prefill);
+    }
+
+    // -----------------------------------------------------------------------
+    // build_prefill: CSV with no numeric columns
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_prefill_from_csv_no_numeric_columns() {
+        use std::fs;
+
+        let dir =
+            std::env::temp_dir().join(format!("sonda-init-csv-no-numeric-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create temp dir");
+
+        // CSV with only a timestamp column and a non-numeric column.
+        let csv_content = "timestamp,status\n\
+            1000,ok\n\
+            1001,ok\n\
+            1002,error\n";
+        let csv_path = dir.join("no-numeric.csv");
+        fs::write(&csv_path, csv_content).expect("write CSV");
+
+        let catalog = ScenarioCatalog::discover(&[]);
+        let args = InitArgs {
+            from: Some(csv_path.to_str().unwrap().to_string()),
+            ..default_init_args()
+        };
+
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        // Signal type is always set to "metrics" for CSV-based prefill.
+        assert_eq!(prefill.signal_type.as_deref(), Some("metrics"));
+        // No numeric columns means no pattern detection and no metric name.
+        assert!(
+            prefill.situation.is_none(),
+            "situation should be None when no numeric columns exist"
+        );
+        assert!(
+            prefill.metric.is_none(),
+            "metric should be None when no numeric columns exist"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // build_prefill: new fields from CLI flags
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_prefill_log_fields_from_flags() {
+        let args = InitArgs {
+            message_template: Some("Error at {line}".to_string()),
+            severity: Some("balanced".to_string()),
+            ..default_init_args()
+        };
+        let catalog = ScenarioCatalog::discover(&[]);
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        assert_eq!(prefill.message_template.as_deref(), Some("Error at {line}"));
+        assert_eq!(prefill.severity.as_deref(), Some("balanced"));
+    }
+
+    #[test]
+    fn build_prefill_kafka_fields_from_flags() {
+        let args = InitArgs {
+            sink: Some("kafka".to_string()),
+            kafka_brokers: Some("broker:9092".to_string()),
+            kafka_topic: Some("events".to_string()),
+            ..default_init_args()
+        };
+        let catalog = ScenarioCatalog::discover(&[]);
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        assert_eq!(prefill.sink.as_deref(), Some("kafka"));
+        assert_eq!(prefill.kafka_brokers.as_deref(), Some("broker:9092"));
+        assert_eq!(prefill.kafka_topic.as_deref(), Some("events"));
+    }
+
+    #[test]
+    fn build_prefill_otlp_signal_type_from_flags() {
+        let args = InitArgs {
+            sink: Some("otlp_grpc".to_string()),
+            otlp_signal_type: Some("logs".to_string()),
+            ..default_init_args()
+        };
+        let catalog = ScenarioCatalog::discover(&[]);
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        assert_eq!(prefill.otlp_signal_type.as_deref(), Some("logs"));
+    }
+
+    // -----------------------------------------------------------------------
+    // build_prefill: scenario with labels
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_prefill_from_scenario_extracts_labels() {
+        use std::fs;
+
+        let dir =
+            std::env::temp_dir().join(format!("sonda-init-labels-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create temp dir");
+
+        let scenario_yaml = r#"scenario_name: labeled-scenario
+category: network
+signal_type: metrics
+description: "Scenario with labels"
+
+name: if_traffic
+rate: 1
+duration: 30s
+
+labels:
+  device: rtr-edge-01
+  region: us-west
+
+generator:
+  type: steady
+  center: 50.0
+  amplitude: 10.0
+  period: "60s"
+
+encoder:
+  type: prometheus_text
+
+sink:
+  type: stdout
+"#;
+        fs::write(dir.join("labeled-scenario.yaml"), scenario_yaml).expect("write scenario");
+
+        let catalog = ScenarioCatalog::discover(&[dir.clone()]);
+        let args = InitArgs {
+            from: Some("@labeled-scenario".to_string()),
+            ..default_init_args()
+        };
+
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        assert_eq!(
+            prefill.labels.get("device").map(String::as_str),
+            Some("rtr-edge-01")
+        );
+        assert_eq!(
+            prefill.labels.get("region").map(String::as_str),
+            Some("us-west")
+        );
+
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/sonda/src/init/mod.rs
+++ b/sonda/src/init/mod.rs
@@ -12,6 +12,12 @@
 //! immediately. If accepted, the generated YAML is parsed and executed using
 //! the same pipeline as `sonda run --scenario`.
 //!
+//! ## Non-interactive mode
+//!
+//! When CLI flags supply values for init prompts, those prompts are skipped.
+//! The `--from` flag pre-fills values from a built-in scenario (`@name`) or a
+//! CSV file (`path.csv`). Explicit flags override `--from` values.
+//!
 //! # Module structure
 //!
 //! - [`prompts`] — interactive prompt logic using `dialoguer`.
@@ -27,7 +33,11 @@ use dialoguer::theme::ColorfulTheme;
 use owo_colors::OwoColorize;
 use owo_colors::Stream::Stderr;
 
+use crate::cli::InitArgs;
+use crate::import;
 use crate::packs::PackCatalog;
+use crate::scenarios::ScenarioCatalog;
+use prompts::Prefill;
 
 use yaml_gen::{render_scenario_yaml, suggest_filename, InitScenarioType};
 
@@ -47,26 +57,36 @@ pub struct InitResult {
     pub scenario_type: InitScenarioType,
 }
 
-/// Run the `sonda init` interactive scaffolding flow.
+/// Run the `sonda init` scaffolding flow.
 ///
-/// Walks the user through building a scenario, generates the YAML, and
-/// writes it to the chosen output path. After writing, offers to run the
+/// Builds a [`Prefill`] from CLI flags and `--from` data, then runs the
+/// interactive prompts (skipping any that have pre-filled values). Generates
+/// the YAML, writes it to the chosen output path, and offers to run the
 /// scenario immediately.
-///
-/// Returns an [`InitResult`] containing the generated YAML, output path,
-/// and whether the user chose immediate execution.
 ///
 /// # Errors
 ///
 /// Returns an error if:
+/// - `--from @name` references an unknown scenario.
+/// - `--from path.csv` cannot be read or analyzed.
 /// - Terminal interaction fails (stdin is not a TTY).
 /// - The output file cannot be written.
-pub fn run_init(pack_catalog: &PackCatalog) -> Result<InitResult> {
+pub fn run_init(
+    args: &InitArgs,
+    pack_catalog: &PackCatalog,
+    scenario_catalog: &ScenarioCatalog,
+) -> Result<InitResult> {
+    // 1. Build a Prefill from --from and/or CLI flags.
+    let prefill = build_prefill(args, scenario_catalog)?;
+
     print_welcome_banner();
 
-    // Run the interactive prompts.
+    // Show pre-fill summary if any values were loaded.
+    print_prefill_summary(args, &prefill);
+
+    // 2. Run the prompts (with prefill).
     let (kind, delivery) =
-        prompts::run_prompts(pack_catalog).context("interactive prompt failed")?;
+        prompts::run_prompts(pack_catalog, &prefill).context("interactive prompt failed")?;
 
     // Remember the scenario type before rendering.
     let scenario_type = kind.scenario_type();
@@ -80,11 +100,14 @@ pub fn run_init(pack_catalog: &PackCatalog) -> Result<InitResult> {
     // Section 4: Output.
     prompts::print_section(4, 4, "Output");
 
-    // Prompt for output path.
-    let suggested = suggest_filename(&kind);
-    let theme = ColorfulTheme::default();
-    let output_path =
-        prompts::prompt_output_path(&theme, &suggested).context("output path prompt failed")?;
+    // Use --output if provided, otherwise prompt.
+    let output_path = if let Some(ref path) = args.output {
+        path.clone()
+    } else {
+        let suggested = suggest_filename(&kind);
+        let theme = ColorfulTheme::default();
+        prompts::prompt_output_path(&theme, &suggested).context("output path prompt failed")?
+    };
 
     // Ensure parent directories exist.
     let path = Path::new(&output_path);
@@ -103,6 +126,7 @@ pub fn run_init(pack_catalog: &PackCatalog) -> Result<InitResult> {
     print_success(&kind, &output_path);
 
     // Offer to run immediately.
+    let theme = ColorfulTheme::default();
     let run_now = prompts::prompt_run_now(&theme).context("run-now prompt failed")?;
 
     Ok(InitResult {
@@ -110,6 +134,300 @@ pub fn run_init(pack_catalog: &PackCatalog) -> Result<InitResult> {
         run_now,
         scenario_type,
     })
+}
+
+/// Build a [`Prefill`] by merging `--from` data with explicit CLI flags.
+///
+/// CLI flags always take precedence over values loaded from `--from`.
+///
+/// # Errors
+///
+/// Returns an error if `--from @name` references an unknown scenario or
+/// `--from path.csv` cannot be read.
+pub fn build_prefill(args: &InitArgs, scenario_catalog: &ScenarioCatalog) -> Result<Prefill> {
+    // Start with --from data (if any).
+    let mut prefill = match args.from.as_deref() {
+        Some(from) if from.starts_with('@') => {
+            let name = &from[1..];
+            prefill_from_scenario(name, scenario_catalog)?
+        }
+        Some(from) => prefill_from_csv(from)?,
+        None => Prefill::default(),
+    };
+
+    // Overlay explicit CLI flags (they take precedence over --from).
+    if let Some(ref v) = args.signal_type {
+        prefill.signal_type = Some(v.clone());
+    }
+    if let Some(ref v) = args.domain {
+        prefill.domain = Some(v.clone());
+    }
+    if let Some(ref v) = args.situation {
+        prefill.situation = Some(v.clone());
+    }
+    if let Some(ref v) = args.metric {
+        prefill.metric = Some(v.clone());
+    }
+    if let Some(ref v) = args.pack {
+        prefill.pack = Some(v.clone());
+    }
+    if let Some(v) = args.rate {
+        prefill.rate = Some(v);
+    }
+    if let Some(ref v) = args.duration {
+        prefill.duration = Some(v.clone());
+    }
+    if let Some(ref v) = args.encoder {
+        prefill.encoder = Some(v.clone());
+    }
+    if let Some(ref v) = args.sink {
+        prefill.sink = Some(v.clone());
+    }
+    if let Some(ref v) = args.endpoint {
+        prefill.endpoint = Some(v.clone());
+    }
+
+    // Parse --label key=value flags into the labels map.
+    for label_str in &args.labels {
+        if let Some(pos) = label_str.find('=') {
+            let key = label_str[..pos].to_string();
+            let value = label_str[pos + 1..].to_string();
+            if !key.is_empty() {
+                prefill.labels.insert(key, value);
+            }
+        }
+    }
+
+    Ok(prefill)
+}
+
+/// Build a [`Prefill`] from a built-in scenario looked up by name.
+///
+/// Reads the scenario YAML and extracts metadata fields into the prefill.
+///
+/// # Errors
+///
+/// Returns an error if the scenario name is not found in the catalog.
+fn prefill_from_scenario(name: &str, catalog: &ScenarioCatalog) -> Result<Prefill> {
+    let scenario = catalog.find(name).ok_or_else(|| {
+        let available = catalog.available_names();
+        let list = if available.is_empty() {
+            "(no scenarios found in search path)".to_string()
+        } else {
+            available.join(", ")
+        };
+        anyhow::anyhow!(
+            "scenario '{}' not found. Available scenarios: {}",
+            name,
+            list
+        )
+    })?;
+
+    let mut prefill = Prefill {
+        signal_type: Some(scenario.signal_type.clone()),
+        domain: Some(scenario.category.clone()),
+        ..Prefill::default()
+    };
+
+    // Try to extract deeper fields from the YAML content.
+    if let Some(Ok(yaml_content)) = catalog.read_yaml(name) {
+        if let Ok(probe) = serde_yaml_ng::from_str::<ScenarioProbe>(&yaml_content) {
+            if let Some(ref n) = probe.name {
+                prefill.metric = Some(n.clone());
+            }
+            if let Some(ref gen) = probe.generator {
+                if let Some(ref gtype) = gen.generator_type {
+                    prefill.situation = Some(gtype.clone());
+                }
+            }
+            if let Some(v) = probe.rate {
+                prefill.rate = Some(v);
+            }
+            if let Some(ref d) = probe.duration {
+                prefill.duration = Some(d.clone());
+            }
+            if let Some(ref enc) = probe.encoder {
+                if let Some(ref etype) = enc.encoder_type {
+                    prefill.encoder = Some(etype.clone());
+                }
+            }
+            if let Some(ref s) = probe.sink {
+                if let Some(ref stype) = s.sink_type {
+                    prefill.sink = Some(stype.clone());
+                }
+            }
+            if let Some(ref p) = probe.pack {
+                prefill.pack = Some(p.clone());
+            }
+        }
+    }
+
+    Ok(prefill)
+}
+
+/// Build a [`Prefill`] from a CSV file by analyzing time-series patterns.
+///
+/// Reads the first numeric column from the CSV, detects its dominant pattern,
+/// and maps it to an operational vocabulary alias.
+///
+/// # Errors
+///
+/// Returns an error if the CSV file cannot be read or has no numeric columns.
+fn prefill_from_csv(path: &str) -> Result<Prefill> {
+    let csv_path = Path::new(path);
+    let data = import::csv_reader::read_csv(csv_path, None)
+        .with_context(|| format!("failed to read CSV file: {path}"))?;
+
+    let mut prefill = Prefill {
+        signal_type: Some("metrics".to_string()),
+        ..Prefill::default()
+    };
+
+    // Use the first column for pattern detection and metric name.
+    if let Some(col) = data.columns.first() {
+        if let Some(ref name) = col.metric_name {
+            prefill.metric = Some(name.clone());
+        }
+    }
+
+    if let Some(values) = data.values.first() {
+        let pattern = import::pattern::detect_pattern(values);
+        prefill.situation = Some(pattern_to_situation(&pattern));
+    }
+
+    Ok(prefill)
+}
+
+/// Map an import pattern to an operational vocabulary alias for the prefill.
+fn pattern_to_situation(pattern: &import::pattern::Pattern) -> String {
+    match pattern {
+        import::pattern::Pattern::Steady { .. } => "steady".to_string(),
+        import::pattern::Pattern::Spike { .. } => "spike_event".to_string(),
+        import::pattern::Pattern::Climb { .. } => "leak".to_string(),
+        import::pattern::Pattern::Sawtooth { .. } => "saturation".to_string(),
+        import::pattern::Pattern::Flap { .. } => "flap".to_string(),
+        import::pattern::Pattern::Step { .. } => "steady".to_string(),
+    }
+}
+
+/// Lightweight YAML probe for extracting init-relevant fields from a scenario.
+///
+/// Does not attempt to fully deserialize a `ScenarioConfig` — only picks out
+/// the fields that can populate a [`Prefill`].
+#[derive(serde::Deserialize)]
+struct ScenarioProbe {
+    name: Option<String>,
+    rate: Option<f64>,
+    duration: Option<String>,
+    generator: Option<GeneratorProbe>,
+    encoder: Option<EncoderProbe>,
+    sink: Option<SinkProbe>,
+    pack: Option<String>,
+}
+
+/// Generator section of a scenario YAML (just the type field).
+#[derive(serde::Deserialize)]
+struct GeneratorProbe {
+    #[serde(rename = "type")]
+    generator_type: Option<String>,
+}
+
+/// Encoder section of a scenario YAML (just the type field).
+#[derive(serde::Deserialize)]
+struct EncoderProbe {
+    #[serde(rename = "type")]
+    encoder_type: Option<String>,
+}
+
+/// Sink section of a scenario YAML (just the type field).
+#[derive(serde::Deserialize)]
+struct SinkProbe {
+    #[serde(rename = "type")]
+    sink_type: Option<String>,
+}
+
+/// Print a styled summary of pre-filled values before prompts begin.
+///
+/// Shows either "Starting from: @scenario-name" or "Starting from: path.csv"
+/// for `--from` mode, or "Pre-filled from flags:" when only flags are present.
+fn print_prefill_summary(args: &InitArgs, prefill: &Prefill) {
+    let dimmed = owo_colors::Style::new().dimmed();
+    let bold_cyan = owo_colors::Style::new().bold().cyan();
+
+    // Collect fields that have values.
+    let mut fields: Vec<(&str, String)> = Vec::new();
+    if let Some(ref v) = prefill.signal_type {
+        fields.push(("signal_type", v.clone()));
+    }
+    if let Some(ref v) = prefill.domain {
+        fields.push(("domain", v.clone()));
+    }
+    if let Some(ref v) = prefill.situation {
+        fields.push(("situation", v.clone()));
+    }
+    if let Some(ref v) = prefill.metric {
+        fields.push(("metric", v.clone()));
+    }
+    if let Some(ref v) = prefill.pack {
+        fields.push(("pack", v.clone()));
+    }
+    if let Some(v) = prefill.rate {
+        fields.push(("rate", v.to_string()));
+    }
+    if let Some(ref v) = prefill.duration {
+        fields.push(("duration", v.clone()));
+    }
+    if let Some(ref v) = prefill.encoder {
+        fields.push(("encoder", v.clone()));
+    }
+    if let Some(ref v) = prefill.sink {
+        fields.push(("sink", v.clone()));
+    }
+    if let Some(ref v) = prefill.endpoint {
+        fields.push(("endpoint", v.clone()));
+    }
+
+    if fields.is_empty() {
+        return;
+    }
+
+    // Header line.
+    let header = if let Some(ref from) = args.from {
+        format!("Starting from: {from}")
+    } else {
+        "Pre-filled from flags:".to_string()
+    };
+    eprintln!(
+        "\n  {}",
+        header.if_supports_color(Stderr, |t| t.style(dimmed))
+    );
+
+    // Individual fields.
+    for (label, value) in &fields {
+        eprintln!(
+            "    {:12} {}",
+            format!("{label}:").if_supports_color(Stderr, |t| t.style(dimmed)),
+            value.if_supports_color(Stderr, |t| t.style(bold_cyan)),
+        );
+    }
+
+    // Labels.
+    if !prefill.labels.is_empty() {
+        let pairs: Vec<String> = prefill
+            .labels
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+        eprintln!(
+            "    {:12} {}",
+            "labels:".if_supports_color(Stderr, |t| t.style(dimmed)),
+            pairs
+                .join(", ")
+                .if_supports_color(Stderr, |t| t.style(bold_cyan)),
+        );
+    }
+
+    eprintln!();
 }
 
 /// Print a styled welcome banner for the init flow.
@@ -317,5 +635,510 @@ mod tests {
             labels: BTreeMap::new(),
         });
         print_success(&kind, "./scenarios/app-logs.yaml");
+    }
+
+    // -----------------------------------------------------------------------
+    // pattern_to_situation: pattern → alias mapping
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pattern_to_situation_steady() {
+        let pattern = import::pattern::Pattern::Steady {
+            center: 50.0,
+            amplitude: 5.0,
+        };
+        assert_eq!(pattern_to_situation(&pattern), "steady");
+    }
+
+    #[test]
+    fn pattern_to_situation_spike() {
+        let pattern = import::pattern::Pattern::Spike {
+            baseline: 0.0,
+            spike_height: 100.0,
+            spike_duration_points: 5,
+            spike_interval_points: 30,
+        };
+        assert_eq!(pattern_to_situation(&pattern), "spike_event");
+    }
+
+    #[test]
+    fn pattern_to_situation_climb() {
+        let pattern = import::pattern::Pattern::Climb {
+            baseline: 0.0,
+            ceiling: 100.0,
+        };
+        assert_eq!(pattern_to_situation(&pattern), "leak");
+    }
+
+    #[test]
+    fn pattern_to_situation_sawtooth() {
+        let pattern = import::pattern::Pattern::Sawtooth {
+            min: 0.0,
+            max: 100.0,
+            period_points: 60,
+        };
+        assert_eq!(pattern_to_situation(&pattern), "saturation");
+    }
+
+    #[test]
+    fn pattern_to_situation_flap() {
+        let pattern = import::pattern::Pattern::Flap {
+            up_value: 1.0,
+            down_value: 0.0,
+            up_duration_points: 10,
+            down_duration_points: 5,
+        };
+        assert_eq!(pattern_to_situation(&pattern), "flap");
+    }
+
+    #[test]
+    fn pattern_to_situation_step() {
+        let pattern = import::pattern::Pattern::Step {
+            start: 0.0,
+            step_size: 10.0,
+        };
+        assert_eq!(pattern_to_situation(&pattern), "steady");
+    }
+
+    // -----------------------------------------------------------------------
+    // build_prefill: CLI flag overlay
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_prefill_no_args_produces_default() {
+        let args = InitArgs {
+            from: None,
+            signal_type: None,
+            domain: None,
+            situation: None,
+            metric: None,
+            pack: None,
+            rate: None,
+            duration: None,
+            encoder: None,
+            sink: None,
+            endpoint: None,
+            output: None,
+            labels: vec![],
+        };
+        let catalog = ScenarioCatalog::discover(&[]);
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        assert!(prefill.signal_type.is_none());
+        assert!(prefill.domain.is_none());
+        assert!(prefill.labels.is_empty());
+    }
+
+    #[test]
+    fn build_prefill_cli_flags_populate_fields() {
+        let args = InitArgs {
+            from: None,
+            signal_type: Some("metrics".to_string()),
+            domain: Some("network".to_string()),
+            situation: Some("flap".to_string()),
+            metric: Some("bgp_state".to_string()),
+            pack: None,
+            rate: Some(2.0),
+            duration: Some("5m".to_string()),
+            encoder: Some("prometheus_text".to_string()),
+            sink: Some("stdout".to_string()),
+            endpoint: None,
+            output: None,
+            labels: vec!["env=prod".to_string(), "region=us-east".to_string()],
+        };
+        let catalog = ScenarioCatalog::discover(&[]);
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        assert_eq!(prefill.signal_type.as_deref(), Some("metrics"));
+        assert_eq!(prefill.domain.as_deref(), Some("network"));
+        assert_eq!(prefill.situation.as_deref(), Some("flap"));
+        assert_eq!(prefill.metric.as_deref(), Some("bgp_state"));
+        assert_eq!(prefill.rate, Some(2.0));
+        assert_eq!(prefill.duration.as_deref(), Some("5m"));
+        assert_eq!(prefill.encoder.as_deref(), Some("prometheus_text"));
+        assert_eq!(prefill.sink.as_deref(), Some("stdout"));
+        assert_eq!(prefill.labels.get("env").map(String::as_str), Some("prod"));
+        assert_eq!(
+            prefill.labels.get("region").map(String::as_str),
+            Some("us-east")
+        );
+    }
+
+    #[test]
+    fn build_prefill_labels_parse_key_value() {
+        let args = InitArgs {
+            from: None,
+            signal_type: None,
+            domain: None,
+            situation: None,
+            metric: None,
+            pack: None,
+            rate: None,
+            duration: None,
+            encoder: None,
+            sink: None,
+            endpoint: None,
+            output: None,
+            labels: vec!["host=web-01".to_string(), "dc=us-west-2".to_string()],
+        };
+        let catalog = ScenarioCatalog::discover(&[]);
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        assert_eq!(prefill.labels.len(), 2);
+        assert_eq!(
+            prefill.labels.get("host").map(String::as_str),
+            Some("web-01")
+        );
+        assert_eq!(
+            prefill.labels.get("dc").map(String::as_str),
+            Some("us-west-2")
+        );
+    }
+
+    #[test]
+    fn build_prefill_labels_skip_malformed() {
+        let args = InitArgs {
+            from: None,
+            signal_type: None,
+            domain: None,
+            situation: None,
+            metric: None,
+            pack: None,
+            rate: None,
+            duration: None,
+            encoder: None,
+            sink: None,
+            endpoint: None,
+            output: None,
+            labels: vec!["no_equals_sign".to_string(), "good=value".to_string()],
+        };
+        let catalog = ScenarioCatalog::discover(&[]);
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        // "no_equals_sign" is skipped (no '=' found).
+        assert_eq!(prefill.labels.len(), 1);
+        assert_eq!(
+            prefill.labels.get("good").map(String::as_str),
+            Some("value")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // build_prefill: --from @builtin
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_prefill_from_scenario_populates_fields() {
+        use std::fs;
+
+        let dir = std::env::temp_dir().join(format!("sonda-init-from-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create temp dir");
+
+        let scenario_yaml = r#"scenario_name: cpu-spike
+category: infrastructure
+signal_type: metrics
+description: "CPU spike scenario"
+
+name: cpu_usage
+rate: 2
+duration: 5m
+
+generator:
+  type: spike_event
+  baseline: 0.0
+  spike_height: 100.0
+  spike_duration: "10s"
+  spike_interval: "30s"
+
+encoder:
+  type: prometheus_text
+
+sink:
+  type: stdout
+"#;
+        fs::write(dir.join("cpu-spike.yaml"), scenario_yaml).expect("write scenario");
+
+        let catalog = ScenarioCatalog::discover(&[dir.clone()]);
+        let args = InitArgs {
+            from: Some("@cpu-spike".to_string()),
+            signal_type: None,
+            domain: None,
+            situation: None,
+            metric: None,
+            pack: None,
+            rate: None,
+            duration: None,
+            encoder: None,
+            sink: None,
+            endpoint: None,
+            output: None,
+            labels: vec![],
+        };
+
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        assert_eq!(prefill.signal_type.as_deref(), Some("metrics"));
+        assert_eq!(prefill.domain.as_deref(), Some("infrastructure"));
+        assert_eq!(prefill.metric.as_deref(), Some("cpu_usage"));
+        assert_eq!(prefill.situation.as_deref(), Some("spike_event"));
+        assert_eq!(prefill.rate, Some(2.0));
+        assert_eq!(prefill.duration.as_deref(), Some("5m"));
+        assert_eq!(prefill.encoder.as_deref(), Some("prometheus_text"));
+        assert_eq!(prefill.sink.as_deref(), Some("stdout"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn build_prefill_from_unknown_scenario_returns_error() {
+        let catalog = ScenarioCatalog::discover(&[]);
+        let args = InitArgs {
+            from: Some("@nonexistent-scenario".to_string()),
+            signal_type: None,
+            domain: None,
+            situation: None,
+            metric: None,
+            pack: None,
+            rate: None,
+            duration: None,
+            encoder: None,
+            sink: None,
+            endpoint: None,
+            output: None,
+            labels: vec![],
+        };
+
+        let result = build_prefill(&args, &catalog);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not found"),
+            "error should mention 'not found': {err}"
+        );
+    }
+
+    #[test]
+    fn build_prefill_cli_flags_override_from() {
+        use std::fs;
+
+        let dir =
+            std::env::temp_dir().join(format!("sonda-init-override-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create temp dir");
+
+        let scenario_yaml = r#"scenario_name: cpu-spike
+category: infrastructure
+signal_type: metrics
+description: "CPU spike scenario"
+
+name: cpu_usage
+rate: 2
+duration: 5m
+
+generator:
+  type: spike_event
+
+encoder:
+  type: prometheus_text
+
+sink:
+  type: stdout
+"#;
+        fs::write(dir.join("cpu-spike.yaml"), scenario_yaml).expect("write scenario");
+
+        let catalog = ScenarioCatalog::discover(&[dir.clone()]);
+        let args = InitArgs {
+            from: Some("@cpu-spike".to_string()),
+            signal_type: None,
+            domain: Some("network".to_string()),
+            situation: Some("flap".to_string()),
+            metric: None,
+            pack: None,
+            rate: Some(10.0),
+            duration: None,
+            encoder: None,
+            sink: None,
+            endpoint: None,
+            output: None,
+            labels: vec![],
+        };
+
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        // CLI flags override --from values.
+        assert_eq!(prefill.domain.as_deref(), Some("network"));
+        assert_eq!(prefill.situation.as_deref(), Some("flap"));
+        assert_eq!(prefill.rate, Some(10.0));
+        // --from values are preserved where no CLI override.
+        assert_eq!(prefill.signal_type.as_deref(), Some("metrics"));
+        assert_eq!(prefill.metric.as_deref(), Some("cpu_usage"));
+        assert_eq!(prefill.duration.as_deref(), Some("5m"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // build_prefill: --from path.csv
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_prefill_from_csv_populates_fields() {
+        use std::fs;
+
+        let dir = std::env::temp_dir().join(format!("sonda-init-csv-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create temp dir");
+
+        // CSV with steady-ish oscillation (enough points for pattern detection).
+        let csv_content = "timestamp,cpu_usage\n\
+            1000,50.1\n\
+            1001,49.9\n\
+            1002,50.3\n\
+            1003,49.7\n\
+            1004,50.2\n\
+            1005,49.8\n\
+            1006,50.1\n\
+            1007,49.9\n\
+            1008,50.3\n\
+            1009,49.7\n\
+            1010,50.2\n\
+            1011,49.8\n\
+            1012,50.0\n\
+            1013,50.1\n\
+            1014,49.9\n\
+            1015,50.2\n\
+            1016,49.8\n\
+            1017,50.1\n\
+            1018,49.9\n\
+            1019,50.0\n";
+        let csv_path = dir.join("test-data.csv");
+        fs::write(&csv_path, csv_content).expect("write CSV");
+
+        let catalog = ScenarioCatalog::discover(&[]);
+        let args = InitArgs {
+            from: Some(csv_path.to_str().unwrap().to_string()),
+            signal_type: None,
+            domain: None,
+            situation: None,
+            metric: None,
+            pack: None,
+            rate: None,
+            duration: None,
+            encoder: None,
+            sink: None,
+            endpoint: None,
+            output: None,
+            labels: vec![],
+        };
+
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        assert_eq!(prefill.signal_type.as_deref(), Some("metrics"));
+        assert_eq!(prefill.metric.as_deref(), Some("cpu_usage"));
+        // Pattern detection produces a valid situation alias.
+        let situation = prefill
+            .situation
+            .as_deref()
+            .expect("should have a situation");
+        let valid_situations = ["steady", "spike_event", "leak", "saturation", "flap"];
+        assert!(
+            valid_situations.contains(&situation),
+            "detected situation '{situation}' must be a valid alias"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn build_prefill_from_nonexistent_csv_returns_error() {
+        let catalog = ScenarioCatalog::discover(&[]);
+        let args = InitArgs {
+            from: Some("/nonexistent/path/data.csv".to_string()),
+            signal_type: None,
+            domain: None,
+            situation: None,
+            metric: None,
+            pack: None,
+            rate: None,
+            duration: None,
+            encoder: None,
+            sink: None,
+            endpoint: None,
+            output: None,
+            labels: vec![],
+        };
+
+        let result = build_prefill(&args, &catalog);
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Prefill summary: smoke test
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn print_prefill_summary_does_not_panic_with_empty_prefill() {
+        let args = InitArgs {
+            from: None,
+            signal_type: None,
+            domain: None,
+            situation: None,
+            metric: None,
+            pack: None,
+            rate: None,
+            duration: None,
+            encoder: None,
+            sink: None,
+            endpoint: None,
+            output: None,
+            labels: vec![],
+        };
+        let prefill = Prefill::default();
+        print_prefill_summary(&args, &prefill);
+    }
+
+    #[test]
+    fn print_prefill_summary_does_not_panic_with_from() {
+        let args = InitArgs {
+            from: Some("@cpu-spike".to_string()),
+            signal_type: None,
+            domain: None,
+            situation: None,
+            metric: None,
+            pack: None,
+            rate: None,
+            duration: None,
+            encoder: None,
+            sink: None,
+            endpoint: None,
+            output: None,
+            labels: vec![],
+        };
+        let prefill = Prefill {
+            signal_type: Some("metrics".to_string()),
+            domain: Some("infrastructure".to_string()),
+            ..Prefill::default()
+        };
+        print_prefill_summary(&args, &prefill);
+    }
+
+    #[test]
+    fn print_prefill_summary_does_not_panic_with_flags() {
+        let args = InitArgs {
+            from: None,
+            signal_type: Some("metrics".to_string()),
+            domain: Some("network".to_string()),
+            situation: None,
+            metric: None,
+            pack: None,
+            rate: Some(5.0),
+            duration: None,
+            encoder: None,
+            sink: None,
+            endpoint: None,
+            output: None,
+            labels: vec![],
+        };
+        let prefill = Prefill {
+            signal_type: Some("metrics".to_string()),
+            domain: Some("network".to_string()),
+            rate: Some(5.0),
+            ..Prefill::default()
+        };
+        print_prefill_summary(&args, &prefill);
     }
 }

--- a/sonda/src/init/mod.rs
+++ b/sonda/src/init/mod.rs
@@ -320,6 +320,7 @@ fn prefill_from_csv(path: &str) -> Result<Prefill> {
             if msg.contains("no numeric data found") {
                 return Ok(Prefill {
                     signal_type: Some("metrics".to_string()),
+                    domain: Some("custom".to_string()),
                     ..Prefill::default()
                 });
             }
@@ -329,6 +330,7 @@ fn prefill_from_csv(path: &str) -> Result<Prefill> {
 
     let mut prefill = Prefill {
         signal_type: Some("metrics".to_string()),
+        domain: Some("custom".to_string()),
         ..Prefill::default()
     };
 
@@ -1241,6 +1243,93 @@ sink:
         assert_eq!(
             prefill.labels.get("region").map(String::as_str),
             Some("us-west")
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // build_prefill: CSV sets domain to "custom"
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_prefill_from_csv_sets_domain_to_custom() {
+        use std::fs;
+
+        let dir =
+            std::env::temp_dir().join(format!("sonda-init-csv-domain-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create temp dir");
+
+        let csv_content = "timestamp,cpu_usage\n\
+            1000,50.1\n\
+            1001,49.9\n\
+            1002,50.3\n\
+            1003,49.7\n\
+            1004,50.2\n\
+            1005,49.8\n\
+            1006,50.1\n\
+            1007,49.9\n\
+            1008,50.3\n\
+            1009,49.7\n\
+            1010,50.2\n\
+            1011,49.8\n\
+            1012,50.0\n\
+            1013,50.1\n\
+            1014,49.9\n\
+            1015,50.2\n\
+            1016,49.8\n\
+            1017,50.1\n\
+            1018,49.9\n\
+            1019,50.0\n";
+        let csv_path = dir.join("domain-test.csv");
+        fs::write(&csv_path, csv_content).expect("write CSV");
+
+        let catalog = ScenarioCatalog::discover(&[]);
+        let args = InitArgs {
+            from: Some(csv_path.to_str().unwrap().to_string()),
+            ..default_init_args()
+        };
+
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        assert_eq!(
+            prefill.domain.as_deref(),
+            Some("custom"),
+            "CSV-based prefill must set domain to 'custom'"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn build_prefill_from_csv_no_numeric_columns_sets_domain_to_custom() {
+        use std::fs;
+
+        let dir = std::env::temp_dir().join(format!(
+            "sonda-init-csv-no-num-domain-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create temp dir");
+
+        let csv_content = "timestamp,status\n\
+            1000,ok\n\
+            1001,ok\n\
+            1002,error\n";
+        let csv_path = dir.join("no-numeric-domain.csv");
+        fs::write(&csv_path, csv_content).expect("write CSV");
+
+        let catalog = ScenarioCatalog::discover(&[]);
+        let args = InitArgs {
+            from: Some(csv_path.to_str().unwrap().to_string()),
+            ..default_init_args()
+        };
+
+        let prefill = build_prefill(&args, &catalog).expect("should succeed");
+        assert_eq!(
+            prefill.domain.as_deref(),
+            Some("custom"),
+            "CSV-based prefill with no numeric columns must set domain to 'custom'"
         );
 
         let _ = fs::remove_dir_all(&dir);

--- a/sonda/src/init/prompts.rs
+++ b/sonda/src/init/prompts.rs
@@ -23,6 +23,7 @@
 
 use std::collections::BTreeMap;
 use std::io;
+use std::io::IsTerminal;
 
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
 use owo_colors::OwoColorize;
@@ -67,6 +68,16 @@ pub struct Prefill {
     pub endpoint: Option<String>,
     /// Static labels to attach to every event.
     pub labels: BTreeMap<String, String>,
+    /// Log message template (for logs signal type).
+    pub message_template: Option<String>,
+    /// Severity distribution preset: `"mostly_info"`, `"balanced"`, or `"error_heavy"`.
+    pub severity: Option<String>,
+    /// Kafka broker(s) for sink-specific configuration.
+    pub kafka_brokers: Option<String>,
+    /// Kafka topic for sink-specific configuration.
+    pub kafka_topic: Option<String>,
+    /// OTLP signal type (`"metrics"` or `"logs"`) for sink-specific configuration.
+    pub otlp_signal_type: Option<String>,
 }
 
 /// All valid sink type names (primary + advanced), used for prefill validation.
@@ -329,40 +340,26 @@ fn run_logs_prompts(
     };
 
     // Message template.
-    let message_template: String = Input::with_theme(theme)
-        .with_prompt("Message template (use {field} for placeholders)")
-        .default("Request to {endpoint} completed with status {status}".to_string())
-        .interact_text()?;
+    let message_template = if let Some(ref val) = prefill.message_template {
+        val.clone()
+    } else {
+        Input::with_theme(theme)
+            .with_prompt("Message template (use {field} for placeholders)")
+            .default("Request to {endpoint} completed with status {status}".to_string())
+            .interact_text()?
+    };
 
     // Severity distribution — aligned columns for readability.
-    let severity_items = &[
-        "Mostly info   info 70%  warn 20%  error 10%",
-        "Balanced      info 40%  warn 30%  error 20%  debug 10%",
-        "Error-heavy   error 60%  warn 30%  info 10%",
-    ];
-    let severity_idx = Select::with_theme(theme)
-        .with_prompt("Severity distribution")
-        .items(severity_items)
-        .default(0)
-        .interact()?;
-    let severity_weights = match severity_idx {
-        0 => vec![
-            ("info".to_string(), 0.7),
-            ("warn".to_string(), 0.2),
-            ("error".to_string(), 0.1),
-        ],
-        1 => vec![
-            ("info".to_string(), 0.4),
-            ("warn".to_string(), 0.3),
-            ("error".to_string(), 0.2),
-            ("debug".to_string(), 0.1),
-        ],
-        2 => vec![
-            ("error".to_string(), 0.6),
-            ("warn".to_string(), 0.3),
-            ("info".to_string(), 0.1),
-        ],
-        _ => unreachable!(),
+    let severity_weights = if let Some(ref val) = prefill.severity {
+        match severity_preset_weights(val) {
+            Some(weights) => weights,
+            None => {
+                print_invalid_prefill("severity", val, &["mostly_info", "balanced", "error_heavy"]);
+                prompt_severity_interactive(theme)?
+            }
+        }
+    } else {
+        prompt_severity_interactive(theme)?
     };
 
     // Merge prefill labels with interactive labels.
@@ -421,7 +418,7 @@ fn prompt_single_metric(
     let situation = prompt_situation(theme, prefill)?;
 
     // Situation-specific parameters.
-    let situation_params = prompt_situation_params(theme, &situation)?;
+    let situation_params = prompt_situation_params(theme, &situation, prefill)?;
 
     // Merge prefill labels with interactive labels.
     let mut labels = prefill.labels.clone();
@@ -569,14 +566,90 @@ fn prompt_pack_interactive(
     Ok(selected_pack.name.clone())
 }
 
+/// Return the default situation-specific parameters for a known alias.
+///
+/// These defaults match the values used as interactive prompt defaults in
+/// [`prompt_situation_params`]. When the situation is prefilled via CLI flags,
+/// these defaults are used directly without prompting.
+fn default_situation_params(situation: &str) -> Vec<(String, ParamValue)> {
+    match situation {
+        "steady" => vec![
+            ("center".to_string(), ParamValue::Float(50.0)),
+            ("amplitude".to_string(), ParamValue::Float(10.0)),
+            ("period".to_string(), ParamValue::String("60s".to_string())),
+        ],
+        "spike_event" => vec![
+            ("baseline".to_string(), ParamValue::Float(0.0)),
+            ("spike_height".to_string(), ParamValue::Float(100.0)),
+            (
+                "spike_duration".to_string(),
+                ParamValue::String("10s".to_string()),
+            ),
+            (
+                "spike_interval".to_string(),
+                ParamValue::String("30s".to_string()),
+            ),
+        ],
+        "flap" => vec![
+            ("up_value".to_string(), ParamValue::Float(1.0)),
+            ("down_value".to_string(), ParamValue::Float(0.0)),
+            (
+                "up_duration".to_string(),
+                ParamValue::String("10s".to_string()),
+            ),
+            (
+                "down_duration".to_string(),
+                ParamValue::String("5s".to_string()),
+            ),
+        ],
+        "leak" => vec![
+            ("baseline".to_string(), ParamValue::Float(0.0)),
+            ("ceiling".to_string(), ParamValue::Float(100.0)),
+            (
+                "time_to_ceiling".to_string(),
+                ParamValue::String("10m".to_string()),
+            ),
+        ],
+        "saturation" => vec![
+            ("baseline".to_string(), ParamValue::Float(0.0)),
+            ("ceiling".to_string(), ParamValue::Float(100.0)),
+            (
+                "time_to_saturate".to_string(),
+                ParamValue::String("5m".to_string()),
+            ),
+        ],
+        "degradation" => vec![
+            ("baseline".to_string(), ParamValue::Float(0.0)),
+            ("ceiling".to_string(), ParamValue::Float(100.0)),
+            (
+                "time_to_degrade".to_string(),
+                ParamValue::String("5m".to_string()),
+            ),
+            ("noise".to_string(), ParamValue::Float(1.0)),
+        ],
+        _ => vec![],
+    }
+}
+
 /// Prompt for situation-specific parameters with sensible defaults.
 ///
 /// Each alias has its own set of parameters matching the fields in
 /// `sonda-core/src/config/aliases.rs`.
+///
+/// When the situation was prefilled (i.e., it came from CLI flags or `--from`),
+/// the defaults are used directly without prompting. This enables fully
+/// non-interactive operation when the caller already chose a situation.
 fn prompt_situation_params(
     theme: &ColorfulTheme,
     situation: &str,
+    prefill: &Prefill,
 ) -> Result<Vec<(String, ParamValue)>, io::Error> {
+    // When the situation was prefilled, use defaults silently so we never
+    // touch the terminal for situation parameters.
+    if prefill.situation.is_some() {
+        return Ok(default_situation_params(situation));
+    }
+
     let params = match situation {
         "steady" => {
             let center: f64 = Input::with_theme(theme)
@@ -731,6 +804,68 @@ fn prompt_situation_params(
     Ok(params)
 }
 
+/// Return severity weights for a named preset, or `None` if the name is invalid.
+///
+/// Supported presets:
+/// - `"mostly_info"`: info 70%, warn 20%, error 10%
+/// - `"balanced"`: info 40%, warn 30%, error 20%, debug 10%
+/// - `"error_heavy"`: error 60%, warn 30%, info 10%
+fn severity_preset_weights(preset: &str) -> Option<Vec<(String, f64)>> {
+    match preset {
+        "mostly_info" => Some(vec![
+            ("info".to_string(), 0.7),
+            ("warn".to_string(), 0.2),
+            ("error".to_string(), 0.1),
+        ]),
+        "balanced" => Some(vec![
+            ("info".to_string(), 0.4),
+            ("warn".to_string(), 0.3),
+            ("error".to_string(), 0.2),
+            ("debug".to_string(), 0.1),
+        ]),
+        "error_heavy" => Some(vec![
+            ("error".to_string(), 0.6),
+            ("warn".to_string(), 0.3),
+            ("info".to_string(), 0.1),
+        ]),
+        _ => None,
+    }
+}
+
+/// Interactive severity distribution prompt (extracted for prefill fallthrough).
+fn prompt_severity_interactive(theme: &ColorfulTheme) -> Result<Vec<(String, f64)>, io::Error> {
+    let severity_items = &[
+        "Mostly info   info 70%  warn 20%  error 10%",
+        "Balanced      info 40%  warn 30%  error 20%  debug 10%",
+        "Error-heavy   error 60%  warn 30%  info 10%",
+    ];
+    let severity_idx = Select::with_theme(theme)
+        .with_prompt("Severity distribution")
+        .items(severity_items)
+        .default(0)
+        .interact()?;
+    let weights = match severity_idx {
+        0 => vec![
+            ("info".to_string(), 0.7),
+            ("warn".to_string(), 0.2),
+            ("error".to_string(), 0.1),
+        ],
+        1 => vec![
+            ("info".to_string(), 0.4),
+            ("warn".to_string(), 0.3),
+            ("error".to_string(), 0.2),
+            ("debug".to_string(), 0.1),
+        ],
+        2 => vec![
+            ("error".to_string(), 0.6),
+            ("warn".to_string(), 0.3),
+            ("info".to_string(), 0.1),
+        ],
+        _ => unreachable!(),
+    };
+    Ok(weights)
+}
+
 /// Prompt for key=value labels, one at a time.
 ///
 /// The user enters labels as `key=value` strings. An empty input ends the
@@ -775,10 +910,25 @@ fn format_label_summary(labels: &BTreeMap<String, String>) -> String {
 
 /// Prompt for events-per-second rate.
 ///
-/// When `prefill.rate` is set, returns it without prompting.
+/// When `prefill.rate` is set and strictly positive, returns it without
+/// prompting. Invalid values (zero or negative) print a warning and fall
+/// through to the interactive prompt; in non-interactive mode the default
+/// `1.0` is used.
 fn prompt_rate(theme: &ColorfulTheme, prefill: &Prefill) -> Result<f64, io::Error> {
     if let Some(val) = prefill.rate {
-        return Ok(val);
+        if val > 0.0 {
+            return Ok(val);
+        }
+        let warning = format!(
+            "Invalid --rate value '{}': must be strictly positive. Using default 1.0.",
+            val
+        );
+        eprintln!("  {}", warning.if_supports_color(Stderr, |t| t.dimmed()));
+        // In non-interactive mode (all fields prefilled), use the default
+        // rather than trying to prompt.
+        if !std::io::stdin().is_terminal() {
+            return Ok(1.0);
+        }
     }
     let rate: f64 = Input::with_theme(theme)
         .with_prompt("Events per second (rate)")
@@ -789,10 +939,23 @@ fn prompt_rate(theme: &ColorfulTheme, prefill: &Prefill) -> Result<f64, io::Erro
 
 /// Prompt for scenario duration.
 ///
-/// When `prefill.duration` is set, returns it without prompting.
+/// When `prefill.duration` is set and passes basic validation (recognized by
+/// `sonda_core::config::validate::parse_duration`), returns it without
+/// prompting. Invalid values print a warning and fall through to the
+/// interactive prompt; in non-interactive mode the default `"60s"` is used.
 fn prompt_duration(theme: &ColorfulTheme, prefill: &Prefill) -> Result<String, io::Error> {
     if let Some(ref val) = prefill.duration {
-        return Ok(val.clone());
+        if sonda_core::config::validate::parse_duration(val).is_ok() {
+            return Ok(val.clone());
+        }
+        let warning = format!(
+            "Invalid --duration value '{}': expected format like 30s, 5m, 1h. Using default 60s.",
+            val
+        );
+        eprintln!("  {}", warning.if_supports_color(Stderr, |t| t.dimmed()));
+        if !std::io::stdin().is_terminal() {
+            return Ok("60s".to_string());
+        }
     }
     let duration: String = Input::with_theme(theme)
         .with_prompt("Duration (e.g., 30s, 5m, 1h)")
@@ -835,12 +998,55 @@ fn prompt_encoder(
 /// When `prefill.endpoint` is set, skips the endpoint prompt for sinks that
 /// require one.
 fn prompt_sink(theme: &ColorfulTheme, prefill: &Prefill) -> Result<SinkPromptResult, io::Error> {
-    // If prefill has a valid sink, use it directly.
+    // If prefill has a valid sink, use it directly — but handle sinks that
+    // need extra fields by populating them from prefill or falling through to
+    // interactive prompts for just those fields.
     if let Some(ref val) = prefill.sink {
         if ALL_SINKS.contains(&val.as_str()) {
             let sink = val.clone();
-            let extra = BTreeMap::new();
             let endpoint = prefill.endpoint.clone();
+            let mut extra = BTreeMap::new();
+
+            match sink.as_str() {
+                "kafka" => {
+                    let brokers = if let Some(ref b) = prefill.kafka_brokers {
+                        b.clone()
+                    } else {
+                        Input::with_theme(theme)
+                            .with_prompt("Kafka broker(s) (host:port)")
+                            .default("localhost:9092".to_string())
+                            .interact_text()?
+                    };
+                    let topic = if let Some(ref t) = prefill.kafka_topic {
+                        t.clone()
+                    } else {
+                        Input::with_theme(theme)
+                            .with_prompt("Kafka topic")
+                            .default("sonda-events".to_string())
+                            .interact_text()?
+                    };
+                    extra.insert("brokers".to_string(), brokers);
+                    extra.insert("topic".to_string(), topic);
+                }
+                "otlp_grpc" => {
+                    if let Some(ref st) = prefill.otlp_signal_type {
+                        extra.insert("signal_type".to_string(), st.clone());
+                    } else {
+                        let signal_items = &["metrics", "logs"];
+                        let signal_idx = Select::with_theme(theme)
+                            .with_prompt("OTLP signal type")
+                            .items(signal_items)
+                            .default(0)
+                            .interact()?;
+                        extra.insert(
+                            "signal_type".to_string(),
+                            signal_items[signal_idx].to_string(),
+                        );
+                    }
+                }
+                _ => {}
+            }
+
             return Ok((sink, endpoint, extra));
         }
         print_invalid_prefill("sink", val, ALL_SINKS);
@@ -1265,6 +1471,11 @@ mod tests {
         assert!(pf.sink.is_none());
         assert!(pf.endpoint.is_none());
         assert!(pf.labels.is_empty());
+        assert!(pf.message_template.is_none());
+        assert!(pf.severity.is_none());
+        assert!(pf.kafka_brokers.is_none());
+        assert!(pf.kafka_topic.is_none());
+        assert!(pf.otlp_signal_type.is_none());
     }
 
     #[test]
@@ -1324,5 +1535,127 @@ mod tests {
                 "log encoder '{e}' must be in ALL_ENCODERS"
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // default_situation_params: returns correct defaults for each alias
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn default_situation_params_steady_has_three_params() {
+        let params = default_situation_params("steady");
+        assert_eq!(params.len(), 3);
+        assert_eq!(params[0].0, "center");
+        assert_eq!(params[1].0, "amplitude");
+        assert_eq!(params[2].0, "period");
+    }
+
+    #[test]
+    fn default_situation_params_spike_event_has_four_params() {
+        let params = default_situation_params("spike_event");
+        assert_eq!(params.len(), 4);
+        assert_eq!(params[0].0, "baseline");
+        assert_eq!(params[1].0, "spike_height");
+        assert_eq!(params[2].0, "spike_duration");
+        assert_eq!(params[3].0, "spike_interval");
+    }
+
+    #[test]
+    fn default_situation_params_flap_has_four_params() {
+        let params = default_situation_params("flap");
+        assert_eq!(params.len(), 4);
+        assert_eq!(params[0].0, "up_value");
+        assert_eq!(params[1].0, "down_value");
+        assert_eq!(params[2].0, "up_duration");
+        assert_eq!(params[3].0, "down_duration");
+    }
+
+    #[test]
+    fn default_situation_params_leak_has_three_params() {
+        let params = default_situation_params("leak");
+        assert_eq!(params.len(), 3);
+        assert_eq!(params[0].0, "baseline");
+        assert_eq!(params[1].0, "ceiling");
+        assert_eq!(params[2].0, "time_to_ceiling");
+    }
+
+    #[test]
+    fn default_situation_params_saturation_has_three_params() {
+        let params = default_situation_params("saturation");
+        assert_eq!(params.len(), 3);
+        assert_eq!(params[0].0, "baseline");
+        assert_eq!(params[1].0, "ceiling");
+        assert_eq!(params[2].0, "time_to_saturate");
+    }
+
+    #[test]
+    fn default_situation_params_degradation_has_four_params() {
+        let params = default_situation_params("degradation");
+        assert_eq!(params.len(), 4);
+        assert_eq!(params[0].0, "baseline");
+        assert_eq!(params[1].0, "ceiling");
+        assert_eq!(params[2].0, "time_to_degrade");
+        assert_eq!(params[3].0, "noise");
+    }
+
+    #[test]
+    fn default_situation_params_unknown_returns_empty() {
+        let params = default_situation_params("nonexistent");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn default_situation_params_covers_all_situations() {
+        // Every known situation must produce a non-empty params list.
+        for &sit in SITUATIONS {
+            let params = default_situation_params(sit);
+            assert!(
+                !params.is_empty(),
+                "default_situation_params({sit}) must return non-empty"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // severity_preset_weights: preset name → weights mapping
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn severity_preset_mostly_info_returns_three_weights() {
+        let weights = severity_preset_weights("mostly_info").expect("should be valid");
+        assert_eq!(weights.len(), 3);
+        assert_eq!(weights[0].0, "info");
+    }
+
+    #[test]
+    fn severity_preset_balanced_returns_four_weights() {
+        let weights = severity_preset_weights("balanced").expect("should be valid");
+        assert_eq!(weights.len(), 4);
+    }
+
+    #[test]
+    fn severity_preset_error_heavy_returns_three_weights() {
+        let weights = severity_preset_weights("error_heavy").expect("should be valid");
+        assert_eq!(weights.len(), 3);
+        assert_eq!(weights[0].0, "error");
+    }
+
+    #[test]
+    fn severity_preset_invalid_returns_none() {
+        assert!(severity_preset_weights("unknown_preset").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Prefill: new fields default to None
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn prefill_default_has_new_fields_none() {
+        let pf = Prefill::default();
+        assert!(pf.message_template.is_none());
+        assert!(pf.severity.is_none());
+        assert!(pf.kafka_brokers.is_none());
+        assert!(pf.kafka_topic.is_none());
+        assert!(pf.otlp_signal_type.is_none());
     }
 }

--- a/sonda/src/init/prompts.rs
+++ b/sonda/src/init/prompts.rs
@@ -16,6 +16,10 @@
 //!   loki, otlp_grpc, kafka, tcp, udp) behind an "Advanced..." option.
 //! - **Run-now prompt**: after writing the scenario file, asks the user whether
 //!   to execute the scenario immediately.
+//! - **Prefill support**: when CLI flags or `--from` supply values, each prompt
+//!   checks its [`Prefill`] field and uses the value directly when present,
+//!   skipping the interactive prompt. Invalid prefill values fall through to
+//!   the interactive prompt with a warning.
 
 use std::collections::BTreeMap;
 use std::io;
@@ -30,6 +34,63 @@ use super::yaml_gen::{
     required_encoder_for_sink, DeliveryAnswers, LogAnswers, MetricAnswers, PackAnswers, ParamValue,
     ScenarioKind,
 };
+
+/// Optional pre-filled values for the init prompts.
+///
+/// When a field is `Some`, it serves as the answer for the corresponding
+/// prompt, skipping the interactive question entirely. When a field is `None`,
+/// the prompt runs interactively as usual.
+///
+/// CLI flags and `--from` data are merged into a single `Prefill` before
+/// prompts begin. Explicit CLI flags take precedence over `--from` values.
+#[derive(Debug, Default, Clone)]
+pub struct Prefill {
+    /// Signal type: `"metrics"` or `"logs"`.
+    pub signal_type: Option<String>,
+    /// Domain category (infrastructure, network, application, custom).
+    pub domain: Option<String>,
+    /// Operational situation/pattern alias.
+    pub situation: Option<String>,
+    /// Metric name (or log scenario name).
+    pub metric: Option<String>,
+    /// Metric pack name (mutually exclusive with `metric` + `situation`).
+    pub pack: Option<String>,
+    /// Events per second.
+    pub rate: Option<f64>,
+    /// Scenario duration string (e.g. `"60s"`, `"5m"`).
+    pub duration: Option<String>,
+    /// Encoder format name.
+    pub encoder: Option<String>,
+    /// Sink type name.
+    pub sink: Option<String>,
+    /// Sink endpoint (URL, file path, or host:port).
+    pub endpoint: Option<String>,
+    /// Static labels to attach to every event.
+    pub labels: BTreeMap<String, String>,
+}
+
+/// All valid sink type names (primary + advanced), used for prefill validation.
+const ALL_SINKS: &[&str] = &[
+    "stdout",
+    "http_push",
+    "file",
+    "remote_write",
+    "loki",
+    "otlp_grpc",
+    "kafka",
+    "tcp",
+    "udp",
+];
+
+/// All valid encoder names (metric + log), used for prefill validation.
+const ALL_ENCODERS: &[&str] = &[
+    "prometheus_text",
+    "influx_lp",
+    "json_lines",
+    "syslog",
+    "remote_write",
+    "otlp",
+];
 
 /// Available operational vocabulary aliases for metric scenarios.
 ///
@@ -127,30 +188,43 @@ pub fn print_section(step: usize, total: usize, title: &str) {
 
 /// Run the full interactive prompt flow and return the collected answers.
 ///
+/// Pre-filled values in `prefill` skip their corresponding prompts. When a
+/// prefill value is invalid for its prompt (e.g., an unknown domain), a
+/// warning is printed and the prompt falls through to interactive mode.
+///
 /// # Errors
 ///
 /// Returns an I/O error if terminal interaction fails (e.g., stdin is not a TTY).
 pub fn run_prompts(
     pack_catalog: &PackCatalog,
+    prefill: &Prefill,
 ) -> Result<(ScenarioKind, DeliveryAnswers), io::Error> {
     let theme = ColorfulTheme::default();
 
     // Section 1: Signal.
     print_section(1, 4, "Signal");
 
-    let signal_type = prompt_signal_type(&theme)?;
-    let domain = prompt_domain(&theme)?;
+    let signal_type = prompt_signal_type(&theme, prefill)?;
+    let domain = prompt_domain(&theme, prefill)?;
 
     match signal_type.as_str() {
-        "metrics" => run_metrics_prompts(&theme, &domain, pack_catalog),
-        "logs" => run_logs_prompts(&theme, &domain),
+        "metrics" => run_metrics_prompts(&theme, &domain, pack_catalog, prefill),
+        "logs" => run_logs_prompts(&theme, &domain, prefill),
         _ => unreachable!("signal type is constrained by prompt"),
     }
 }
 
 /// Prompt for signal type: metrics or logs.
-fn prompt_signal_type(theme: &ColorfulTheme) -> Result<String, io::Error> {
+///
+/// When `prefill.signal_type` is a valid value, returns it without prompting.
+fn prompt_signal_type(theme: &ColorfulTheme, prefill: &Prefill) -> Result<String, io::Error> {
     let items = &["metrics", "logs"];
+    if let Some(ref val) = prefill.signal_type {
+        if items.contains(&val.as_str()) {
+            return Ok(val.clone());
+        }
+        print_invalid_prefill("signal_type", val, items);
+    }
     let selection = Select::with_theme(theme)
         .with_prompt("What type of signal?")
         .items(items)
@@ -160,7 +234,15 @@ fn prompt_signal_type(theme: &ColorfulTheme) -> Result<String, io::Error> {
 }
 
 /// Prompt for domain category.
-fn prompt_domain(theme: &ColorfulTheme) -> Result<String, io::Error> {
+///
+/// When `prefill.domain` is a valid value, returns it without prompting.
+fn prompt_domain(theme: &ColorfulTheme, prefill: &Prefill) -> Result<String, io::Error> {
+    if let Some(ref val) = prefill.domain {
+        if DOMAINS.contains(&val.as_str()) {
+            return Ok(val.clone());
+        }
+        print_invalid_prefill("domain", val, DOMAINS);
+    }
     let selection = Select::with_theme(theme)
         .with_prompt("What domain?")
         .items(DOMAINS)
@@ -174,13 +256,20 @@ fn run_metrics_prompts(
     theme: &ColorfulTheme,
     domain: &str,
     pack_catalog: &PackCatalog,
+    prefill: &Prefill,
 ) -> Result<(ScenarioKind, DeliveryAnswers), io::Error> {
     let available_packs = pack_catalog.list();
 
     // Section 2: Metric.
     print_section(2, 4, "Metric");
 
-    let kind = if !available_packs.is_empty() {
+    // If prefill has a pack name, go directly to pack flow.
+    let kind = if prefill.pack.is_some() {
+        prompt_pack(theme, pack_catalog, domain, prefill)?
+    } else if !available_packs.is_empty() && prefill.metric.is_none() && prefill.situation.is_none()
+    {
+        // Only ask the approach question when packs are available and neither
+        // metric name nor situation has been pre-filled.
         let approach_items = &["Single metric", "Use a metric pack"];
         let approach = Select::with_theme(theme)
             .with_prompt("How would you like to define metrics?")
@@ -189,21 +278,21 @@ fn run_metrics_prompts(
             .interact()?;
 
         match approach {
-            0 => prompt_single_metric(theme)?,
-            1 => prompt_pack(theme, pack_catalog, domain)?,
+            0 => prompt_single_metric(theme, prefill)?,
+            1 => prompt_pack(theme, pack_catalog, domain, prefill)?,
             _ => unreachable!(),
         }
     } else {
-        prompt_single_metric(theme)?
+        prompt_single_metric(theme, prefill)?
     };
 
     // Section 3: Delivery.
     print_section(3, 4, "Delivery");
 
-    let rate = prompt_rate(theme)?;
-    let duration = prompt_duration(theme)?;
-    let encoder = prompt_encoder(theme, METRIC_ENCODERS)?;
-    let (sink, endpoint, sink_extra) = prompt_sink(theme)?;
+    let rate = prompt_rate(theme, prefill)?;
+    let duration = prompt_duration(theme, prefill)?;
+    let encoder = prompt_encoder(theme, METRIC_ENCODERS, prefill)?;
+    let (sink, endpoint, sink_extra) = prompt_sink(theme, prefill)?;
 
     // Enforce encoder/sink pairing: some sinks require a specific encoder.
     let encoder = enforce_encoder_for_sink(encoder, &sink);
@@ -225,14 +314,19 @@ fn run_metrics_prompts(
 fn run_logs_prompts(
     theme: &ColorfulTheme,
     domain: &str,
+    prefill: &Prefill,
 ) -> Result<(ScenarioKind, DeliveryAnswers), io::Error> {
     // Section 2: Log.
     print_section(2, 4, "Log");
 
-    let name: String = Input::with_theme(theme)
-        .with_prompt("Log scenario name")
-        .default("app_logs".to_string())
-        .interact_text()?;
+    let name = if let Some(ref val) = prefill.metric {
+        val.clone()
+    } else {
+        Input::with_theme(theme)
+            .with_prompt("Log scenario name")
+            .default("app_logs".to_string())
+            .interact_text()?
+    };
 
     // Message template.
     let message_template: String = Input::with_theme(theme)
@@ -271,16 +365,19 @@ fn run_logs_prompts(
         _ => unreachable!(),
     };
 
-    // Labels.
-    let labels = prompt_labels(theme)?;
+    // Merge prefill labels with interactive labels.
+    let mut labels = prefill.labels.clone();
+    if labels.is_empty() {
+        labels = prompt_labels(theme)?;
+    }
 
     // Section 3: Delivery.
     print_section(3, 4, "Delivery");
 
-    let rate = prompt_rate(theme)?;
-    let duration = prompt_duration(theme)?;
-    let encoder = prompt_encoder(theme, LOG_ENCODERS)?;
-    let (sink, endpoint, sink_extra) = prompt_sink(theme)?;
+    let rate = prompt_rate(theme, prefill)?;
+    let duration = prompt_duration(theme, prefill)?;
+    let encoder = prompt_encoder(theme, LOG_ENCODERS, prefill)?;
+    let (sink, endpoint, sink_extra) = prompt_sink(theme, prefill)?;
 
     // Enforce encoder/sink pairing: some sinks require a specific encoder.
     let encoder = enforce_encoder_for_sink(encoder, &sink);
@@ -306,26 +403,31 @@ fn run_logs_prompts(
 }
 
 /// Prompt for a single metric: name, situation, parameters, labels.
-fn prompt_single_metric(theme: &ColorfulTheme) -> Result<ScenarioKind, io::Error> {
+fn prompt_single_metric(
+    theme: &ColorfulTheme,
+    prefill: &Prefill,
+) -> Result<ScenarioKind, io::Error> {
     // Metric name.
-    let name: String = Input::with_theme(theme)
-        .with_prompt("Metric name")
-        .default("my_metric".to_string())
-        .interact_text()?;
+    let name = if let Some(ref val) = prefill.metric {
+        val.clone()
+    } else {
+        Input::with_theme(theme)
+            .with_prompt("Metric name")
+            .default("my_metric".to_string())
+            .interact_text()?
+    };
 
     // Situation (operational vocabulary).
-    let situation_idx = Select::with_theme(theme)
-        .with_prompt("What situation should this metric simulate?")
-        .items(SITUATION_DESCRIPTIONS)
-        .default(0)
-        .interact()?;
-    let situation = SITUATIONS[situation_idx].to_string();
+    let situation = prompt_situation(theme, prefill)?;
 
     // Situation-specific parameters.
     let situation_params = prompt_situation_params(theme, &situation)?;
 
-    // Labels.
-    let labels = prompt_labels(theme)?;
+    // Merge prefill labels with interactive labels.
+    let mut labels = prefill.labels.clone();
+    if labels.is_empty() {
+        labels = prompt_labels(theme)?;
+    }
 
     Ok(ScenarioKind::SingleMetric(MetricAnswers {
         name,
@@ -335,20 +437,104 @@ fn prompt_single_metric(theme: &ColorfulTheme) -> Result<ScenarioKind, io::Error
     }))
 }
 
+/// Prompt for an operational situation alias.
+///
+/// When `prefill.situation` is a valid alias, returns it without prompting.
+fn prompt_situation(theme: &ColorfulTheme, prefill: &Prefill) -> Result<String, io::Error> {
+    if let Some(ref val) = prefill.situation {
+        if SITUATIONS.contains(&val.as_str()) {
+            return Ok(val.clone());
+        }
+        print_invalid_prefill("situation", val, SITUATIONS);
+    }
+    let situation_idx = Select::with_theme(theme)
+        .with_prompt("What situation should this metric simulate?")
+        .items(SITUATION_DESCRIPTIONS)
+        .default(0)
+        .interact()?;
+    Ok(SITUATIONS[situation_idx].to_string())
+}
+
 /// Prompt for pack selection and pack-specific labels.
 ///
 /// Filters the pack list to show only packs whose `category` matches the
 /// selected domain. If no packs match the domain, falls back to showing all
 /// packs so the user is never dead-ended.
+///
+/// When `prefill.pack` names a pack that exists in the catalog, its
+/// interactive prompt is skipped.
 fn prompt_pack(
     theme: &ColorfulTheme,
     catalog: &PackCatalog,
     domain: &str,
+    prefill: &Prefill,
 ) -> Result<ScenarioKind, io::Error> {
+    // If prefill has a pack name, validate it exists in the catalog.
+    let pack_name = if let Some(ref prefill_pack) = prefill.pack {
+        if catalog.find(prefill_pack).is_some() {
+            prefill_pack.clone()
+        } else {
+            let warning = format!(
+                "Pack '{}' not found in catalog, falling through to prompt.",
+                prefill_pack
+            );
+            eprintln!("  {}", warning.if_supports_color(Stderr, |t| t.dimmed()));
+            prompt_pack_interactive(theme, catalog, domain)?
+        }
+    } else {
+        prompt_pack_interactive(theme, catalog, domain)?
+    };
+
+    // Read the pack YAML to find shared_labels with empty values.
+    let mut labels = prefill.labels.clone();
+
+    if let Some(Ok(yaml_content)) = catalog.read_yaml(&pack_name) {
+        // Parse shared_labels to find required values.
+        if let Ok(pack_def) =
+            serde_yaml_ng::from_str::<sonda_core::packs::MetricPackDef>(&yaml_content)
+        {
+            if let Some(shared_labels) = &pack_def.shared_labels {
+                for (key, value) in shared_labels {
+                    // Skip keys already provided via prefill.
+                    if labels.contains_key(key) {
+                        continue;
+                    }
+                    if value.is_empty() {
+                        // Prompt the user for this label value.
+                        let label_value: String = Input::with_theme(theme)
+                            .with_prompt(format!("Value for label '{key}'"))
+                            .default(format!("my-{key}"))
+                            .interact_text()?;
+                        labels.insert(key.clone(), label_value);
+                    } else {
+                        // Carry forward the default value from the pack.
+                        labels.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    // Ask for any additional labels (skip if we already have prefilled labels).
+    if prefill.labels.is_empty() {
+        let extra_labels = prompt_labels(theme)?;
+        for (k, v) in extra_labels {
+            labels.insert(k, v);
+        }
+    }
+
+    Ok(ScenarioKind::Pack(PackAnswers { pack_name, labels }))
+}
+
+/// Interactive pack selection prompt (extracted for prefill fallthrough).
+fn prompt_pack_interactive(
+    theme: &ColorfulTheme,
+    catalog: &PackCatalog,
+    domain: &str,
+) -> Result<String, io::Error> {
     let domain_packs = catalog.list_by_category(domain);
 
     let packs_to_show = if domain_packs.is_empty() {
-        // Fallback: show all packs when none match the domain.
         eprintln!(
             "  {}",
             format!("No packs found for domain \"{domain}\", showing all packs.")
@@ -380,41 +566,7 @@ fn prompt_pack(
         .interact()?;
 
     let selected_pack = packs_to_show[pack_idx];
-    let pack_name = selected_pack.name.clone();
-
-    // Read the pack YAML to find shared_labels with empty values.
-    let mut labels = BTreeMap::new();
-
-    if let Some(Ok(yaml_content)) = catalog.read_yaml(&pack_name) {
-        // Parse shared_labels to find required values.
-        if let Ok(pack_def) =
-            serde_yaml_ng::from_str::<sonda_core::packs::MetricPackDef>(&yaml_content)
-        {
-            if let Some(shared_labels) = &pack_def.shared_labels {
-                for (key, value) in shared_labels {
-                    if value.is_empty() {
-                        // Prompt the user for this label value.
-                        let label_value: String = Input::with_theme(theme)
-                            .with_prompt(format!("Value for label '{key}'"))
-                            .default(format!("my-{key}"))
-                            .interact_text()?;
-                        labels.insert(key.clone(), label_value);
-                    } else {
-                        // Carry forward the default value from the pack.
-                        labels.insert(key.clone(), value.clone());
-                    }
-                }
-            }
-        }
-    }
-
-    // Ask for any additional labels.
-    let extra_labels = prompt_labels(theme)?;
-    for (k, v) in extra_labels {
-        labels.insert(k, v);
-    }
-
-    Ok(ScenarioKind::Pack(PackAnswers { pack_name, labels }))
+    Ok(selected_pack.name.clone())
 }
 
 /// Prompt for situation-specific parameters with sensible defaults.
@@ -622,7 +774,12 @@ fn format_label_summary(labels: &BTreeMap<String, String>) -> String {
 }
 
 /// Prompt for events-per-second rate.
-fn prompt_rate(theme: &ColorfulTheme) -> Result<f64, io::Error> {
+///
+/// When `prefill.rate` is set, returns it without prompting.
+fn prompt_rate(theme: &ColorfulTheme, prefill: &Prefill) -> Result<f64, io::Error> {
+    if let Some(val) = prefill.rate {
+        return Ok(val);
+    }
     let rate: f64 = Input::with_theme(theme)
         .with_prompt("Events per second (rate)")
         .default(1.0)
@@ -631,7 +788,12 @@ fn prompt_rate(theme: &ColorfulTheme) -> Result<f64, io::Error> {
 }
 
 /// Prompt for scenario duration.
-fn prompt_duration(theme: &ColorfulTheme) -> Result<String, io::Error> {
+///
+/// When `prefill.duration` is set, returns it without prompting.
+fn prompt_duration(theme: &ColorfulTheme, prefill: &Prefill) -> Result<String, io::Error> {
+    if let Some(ref val) = prefill.duration {
+        return Ok(val.clone());
+    }
     let duration: String = Input::with_theme(theme)
         .with_prompt("Duration (e.g., 30s, 5m, 1h)")
         .default("60s".to_string())
@@ -640,7 +802,22 @@ fn prompt_duration(theme: &ColorfulTheme) -> Result<String, io::Error> {
 }
 
 /// Prompt for encoder format.
-fn prompt_encoder(theme: &ColorfulTheme, options: &[&str]) -> Result<String, io::Error> {
+///
+/// When `prefill.encoder` is a valid encoder name, returns it without
+/// prompting. The value is validated against [`ALL_ENCODERS`], not just the
+/// provided `options` slice, because the encoder may be overridden later by
+/// sink constraints (e.g., `remote_write`, `otlp`).
+fn prompt_encoder(
+    theme: &ColorfulTheme,
+    options: &[&str],
+    prefill: &Prefill,
+) -> Result<String, io::Error> {
+    if let Some(ref val) = prefill.encoder {
+        if ALL_ENCODERS.contains(&val.as_str()) {
+            return Ok(val.clone());
+        }
+        print_invalid_prefill("encoder", val, ALL_ENCODERS);
+    }
     let selection = Select::with_theme(theme)
         .with_prompt("Output encoding format")
         .items(options)
@@ -653,7 +830,22 @@ fn prompt_encoder(theme: &ColorfulTheme, options: &[&str]) -> Result<String, io:
 ///
 /// Returns `(sink_type, endpoint, extra_fields)` where `extra_fields` carries
 /// additional sink-specific configuration (e.g., kafka topic).
-fn prompt_sink(theme: &ColorfulTheme) -> Result<SinkPromptResult, io::Error> {
+///
+/// When `prefill.sink` is a valid sink name, skips the sink selection prompt.
+/// When `prefill.endpoint` is set, skips the endpoint prompt for sinks that
+/// require one.
+fn prompt_sink(theme: &ColorfulTheme, prefill: &Prefill) -> Result<SinkPromptResult, io::Error> {
+    // If prefill has a valid sink, use it directly.
+    if let Some(ref val) = prefill.sink {
+        if ALL_SINKS.contains(&val.as_str()) {
+            let sink = val.clone();
+            let extra = BTreeMap::new();
+            let endpoint = prefill.endpoint.clone();
+            return Ok((sink, endpoint, extra));
+        }
+        print_invalid_prefill("sink", val, ALL_SINKS);
+    }
+
     let sink_idx = Select::with_theme(theme)
         .with_prompt("Where should output be sent?")
         .items(SINKS)
@@ -815,6 +1007,18 @@ pub fn prompt_output_path(theme: &ColorfulTheme, suggested: &str) -> Result<Stri
         .default(default_path)
         .interact_text()?;
     Ok(path)
+}
+
+/// Print a dimmed warning when a prefill value is not in the allowed set.
+///
+/// Informs the user that the provided value was ignored and the interactive
+/// prompt will be used instead. Lists the valid options for reference.
+fn print_invalid_prefill(field: &str, value: &str, valid: &[&str]) {
+    let warning = format!(
+        "Invalid --{field} value '{value}', valid options: {}. Falling through to prompt.",
+        valid.join(", ")
+    );
+    eprintln!("  {}", warning.if_supports_color(Stderr, |t| t.dimmed()));
 }
 
 #[cfg(test)]
@@ -1041,5 +1245,84 @@ mod tests {
     fn enforce_encoder_no_op_for_kafka_sink() {
         let result = enforce_encoder_for_sink("json_lines".to_string(), "kafka");
         assert_eq!(result, "json_lines");
+    }
+
+    // -----------------------------------------------------------------------
+    // Prefill struct: defaults
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn prefill_default_has_all_none_fields() {
+        let pf = Prefill::default();
+        assert!(pf.signal_type.is_none());
+        assert!(pf.domain.is_none());
+        assert!(pf.situation.is_none());
+        assert!(pf.metric.is_none());
+        assert!(pf.pack.is_none());
+        assert!(pf.rate.is_none());
+        assert!(pf.duration.is_none());
+        assert!(pf.encoder.is_none());
+        assert!(pf.sink.is_none());
+        assert!(pf.endpoint.is_none());
+        assert!(pf.labels.is_empty());
+    }
+
+    #[test]
+    fn prefill_clone_preserves_values() {
+        let mut pf = Prefill::default();
+        pf.signal_type = Some("metrics".to_string());
+        pf.rate = Some(5.0);
+        pf.labels.insert("env".to_string(), "staging".to_string());
+        let clone = pf.clone();
+        assert_eq!(clone.signal_type.as_deref(), Some("metrics"));
+        assert_eq!(clone.rate, Some(5.0));
+        assert_eq!(clone.labels.get("env").map(String::as_str), Some("staging"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Validation constants: ALL_SINKS and ALL_ENCODERS
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn all_sinks_contains_primary_sinks() {
+        for &s in SINKS {
+            if s == "Advanced..." {
+                continue;
+            }
+            assert!(
+                ALL_SINKS.contains(&s),
+                "primary sink '{s}' must be in ALL_SINKS"
+            );
+        }
+    }
+
+    #[test]
+    fn all_sinks_contains_advanced_sinks() {
+        for &s in ADVANCED_SINKS {
+            assert!(
+                ALL_SINKS.contains(&s),
+                "advanced sink '{s}' must be in ALL_SINKS"
+            );
+        }
+    }
+
+    #[test]
+    fn all_encoders_contains_metric_encoders() {
+        for &e in METRIC_ENCODERS {
+            assert!(
+                ALL_ENCODERS.contains(&e),
+                "metric encoder '{e}' must be in ALL_ENCODERS"
+            );
+        }
+    }
+
+    #[test]
+    fn all_encoders_contains_log_encoders() {
+        for &e in LOG_ENCODERS {
+            assert!(
+                ALL_ENCODERS.contains(&e),
+                "log encoder '{e}' must be in ALL_ENCODERS"
+            );
+        }
     }
 }

--- a/sonda/src/init/prompts.rs
+++ b/sonda/src/init/prompts.rs
@@ -363,10 +363,7 @@ fn run_logs_prompts(
     };
 
     // Merge prefill labels with interactive labels.
-    let mut labels = prefill.labels.clone();
-    if labels.is_empty() {
-        labels = prompt_labels(theme)?;
-    }
+    let labels = prompt_labels(theme, &prefill.labels)?;
 
     // Section 3: Delivery.
     print_section(3, 4, "Delivery");
@@ -421,10 +418,7 @@ fn prompt_single_metric(
     let situation_params = prompt_situation_params(theme, &situation, prefill)?;
 
     // Merge prefill labels with interactive labels.
-    let mut labels = prefill.labels.clone();
-    if labels.is_empty() {
-        labels = prompt_labels(theme)?;
-    }
+    let labels = prompt_labels(theme, &prefill.labels)?;
 
     Ok(ScenarioKind::SingleMetric(MetricAnswers {
         name,
@@ -512,9 +506,12 @@ fn prompt_pack(
         }
     }
 
-    // Ask for any additional labels (skip if we already have prefilled labels).
+    // Ask for any additional labels. When prefill already has labels, pass
+    // them through so prompt_labels returns immediately. Otherwise the TTY
+    // guard inside prompt_labels handles non-interactive mode.
     if prefill.labels.is_empty() {
-        let extra_labels = prompt_labels(theme)?;
+        let empty = BTreeMap::new();
+        let extra_labels = prompt_labels(theme, &empty)?;
         for (k, v) in extra_labels {
             labels.insert(k, v);
         }
@@ -871,7 +868,24 @@ fn prompt_severity_interactive(theme: &ColorfulTheme) -> Result<Vec<(String, f64
 /// The user enters labels as `key=value` strings. An empty input ends the
 /// label collection. After each successful addition, the accumulated labels
 /// are shown in dimmed text so the user can see what has been collected.
-fn prompt_labels(theme: &ColorfulTheme) -> Result<BTreeMap<String, String>, io::Error> {
+///
+/// When `prefilled` is non-empty, those labels are returned directly without
+/// prompting. When stdin is not a TTY and no labels are prefilled, returns
+/// an empty map (non-interactive mode).
+fn prompt_labels(
+    theme: &ColorfulTheme,
+    prefilled: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>, io::Error> {
+    // If the caller already has labels (from --label flags or --from), use them.
+    if !prefilled.is_empty() {
+        return Ok(prefilled.clone());
+    }
+
+    // Non-interactive: no prefilled labels and no TTY — return empty.
+    if !io::stdin().is_terminal() {
+        return Ok(BTreeMap::new());
+    }
+
     let mut labels = BTreeMap::new();
 
     loop {
@@ -1657,5 +1671,42 @@ mod tests {
         assert!(pf.kafka_brokers.is_none());
         assert!(pf.kafka_topic.is_none());
         assert!(pf.otlp_signal_type.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // prompt_labels: prefill and TTY guard
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn prompt_labels_returns_prefilled_labels_immediately() {
+        let theme = ColorfulTheme::default();
+        let mut prefilled = BTreeMap::new();
+        prefilled.insert("env".to_string(), "prod".to_string());
+        prefilled.insert("region".to_string(), "us-west".to_string());
+
+        let result = prompt_labels(&theme, &prefilled).expect("should succeed");
+        assert_eq!(result.len(), 2);
+        assert_eq!(result.get("env").map(String::as_str), Some("prod"));
+        assert_eq!(result.get("region").map(String::as_str), Some("us-west"));
+    }
+
+    #[test]
+    fn prompt_labels_with_empty_prefill_returns_empty_in_non_tty() {
+        // In CI / test harness, stdin is not a TTY.
+        // When prefilled labels are empty AND stdin is not a TTY,
+        // prompt_labels must return an empty map without attempting
+        // to read from the terminal.
+        let theme = ColorfulTheme::default();
+        let prefilled = BTreeMap::new();
+
+        // This test only verifies behavior when stdin is NOT a TTY,
+        // which is the case in test harnesses and CI environments.
+        if !std::io::stdin().is_terminal() {
+            let result = prompt_labels(&theme, &prefilled).expect("should succeed");
+            assert!(
+                result.is_empty(),
+                "non-TTY stdin with no prefilled labels must return empty map"
+            );
+        }
     }
 }

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -156,8 +156,8 @@ fn run() -> anyhow::Result<()> {
         Commands::Import(ref args) => {
             run_import_command(args, &cli, verbosity, &running)?;
         }
-        Commands::Init(ref _args) => {
-            let result = init::run_init(&pack_catalog)?;
+        Commands::Init(ref args) => {
+            let result = init::run_init(args, &pack_catalog, &scenario_catalog)?;
             if result.run_now {
                 run_init_scenario(
                     result.yaml,


### PR DESCRIPTION
## Summary

Adds non-interactive mode and `--from` prefill support to `sonda init` (#189, PR 2 of 3).

- **Non-interactive mode**: CLI flags (`--signal-type`, `--domain`, `--situation`, `--metric`, `--pack`, `--rate`, `--duration`, `--encoder`, `--sink`, `--endpoint`, `-o`, `--label`, `--run-now`, `--message-template`, `--severity`, `--kafka-brokers`, `--kafka-topic`, `--otlp-signal-type`) skip their corresponding prompts. When all required fields are provided, runs fully non-interactively — no terminal needed.
- **`--from @builtin`**: `sonda init --from @cpu-spike` loads a built-in scenario and uses its fields (metric, situation, rate, duration, encoder, sink, labels) as prompt defaults. CLI flags override `--from` values.
- **`--from path.csv`**: `sonda init --from metrics.csv` runs CSV pattern detection and maps detected patterns to operational vocabulary aliases as situation defaults.

### Key design decisions

- `Prefill` struct in `prompts.rs` carries optional pre-filled values through every prompt function. Each prompt checks its prefill field — valid value skips the prompt, invalid value warns and falls through to interactive.
- TTY detection (`std::io::IsTerminal`) on stdin for `prompt_labels`, `prompt_rate`, `prompt_duration`, and `prompt_run_now` — non-TTY defaults to safe values (empty labels, default rate/duration, no run).
- `ScenarioProbe` lightweight deserialization for `--from @name` (avoids full config parsing).
- Rate validation (> 0.0) and duration validation (via `sonda_core::config::validate::parse_duration`).

Closes enhancements #1, #2, #3 from #189.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — 2340+ tests, 0 failures
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Fully non-interactive single metric (no prompts, exit 0)
- [x] Fully non-interactive logs with `--message-template` and `--severity`
- [x] `--from @cpu-spike --sink stdout` (builtin prefill, fully non-interactive)
- [x] `--from metrics.csv` (CSV pattern detection, domain defaults to "custom")
- [x] `--sink kafka --kafka-brokers --kafka-topic` (extra fields in YAML)
- [x] `--sink otlp_grpc --otlp-signal-type` (encoder auto-override to otlp)
- [x] `--run-now` runs scenario after creation
- [x] Rate/duration validation (warns, defaults in non-TTY)
- [x] `< /dev/null` explicit no-TTY test — no blocking
- [x] `--help` shows all new flags