### PR TITLE
feat(story): composable multi-signal story compilation layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,19 @@ appears in `sonda scenarios list`. See the
 [CLI Reference](https://davidban77.github.io/sonda/configuration/cli-reference/#sonda-init) for
 the full prompt flow and available situations.
 
+## Stories
+
+Stories are a concise YAML format for multi-signal scenarios with temporal causality. Define
+several signals and use `after` clauses to express when one signal starts relative to another --
+Sonda resolves the timing into concrete `phase_offset` values at compile time:
+
+```bash
+sonda story --file stories/link_failover.yaml --duration 5m --sink stdout
+```
+
+Story files live in `stories/` at the repo root. CLI flags (`--duration`, `--rate`, `--sink`,
+`--endpoint`, `--encoder`) override story-level defaults.
+
 ## Documentation
 
 Full documentation is available at **https://davidban77.github.io/sonda/**.

--- a/docs/site/docs/configuration/cli-reference.md
+++ b/docs/site/docs/configuration/cli-reference.md
@@ -2,7 +2,8 @@
 
 Sonda provides subcommands for generating metrics, logs, histograms, and summaries, running
 multi-scenario files, browsing a library of built-in scenario patterns, importing CSV data
-into parameterized scenarios, and interactively scaffolding new scenario files.
+into parameterized scenarios, interactively scaffolding new scenario files, and running
+multi-signal stories with temporal causality.
 
 ## Global options
 
@@ -1328,6 +1329,49 @@ no need to copy-paste a follow-up command.
 
 The generated YAML includes inline comments and scenario metadata, so it appears in
 `sonda scenarios list` automatically.
+
+## sonda story
+
+Run a story file -- a multi-signal scenario format with temporal causality. Stories compile
+down to the existing multi-scenario infrastructure at parse time, resolving `after` clauses
+into concrete `phase_offset` values.
+
+```bash
+sonda story --file <FILE> [OPTIONS]
+```
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--file <FILE>` | path | **(required)** Path to a story YAML file. |
+| `--duration <DURATION>` | string | Override the story-level duration (e.g. `2m`, `30s`). |
+| `--rate <RATE>` | float | Override the story-level event rate (events/second). |
+| `--sink <TYPE>` | string | Override the story-level sink type (e.g. `stdout`, `http_push`). |
+| `--endpoint <URL>` | string | Sink endpoint URL (required for network sinks). |
+| `--encoder <FORMAT>` | string | Override the story-level encoder (e.g. `prometheus_text`, `json_lines`). |
+
+CLI flags override story-level shared fields. Per-signal overrides defined in the YAML take
+precedence over both.
+
+### Examples
+
+```bash
+# Run a story with defaults from the YAML
+sonda story --file stories/link-failover.yaml
+
+# Override duration and send to a backend
+sonda story --file stories/link-failover.yaml \
+  --duration 2m --sink remote_write \
+  --endpoint http://localhost:8428/api/v1/write \
+  --encoder remote_write
+
+# Validate without emitting data
+sonda --dry-run story --file stories/link-failover.yaml
+```
+
+See the [Stories guide](../guides/stories.md) for YAML format details, `after` clause syntax,
+and a worked example.
 
 ## Precedence rules
 

--- a/docs/site/docs/guides/stories.md
+++ b/docs/site/docs/guides/stories.md
@@ -1,0 +1,355 @@
+# Stories
+
+When real incidents happen, signals don't fire in isolation. A link goes down, traffic shifts
+to a backup, and latency climbs as the backup saturates. Stories let you express that causal
+chain in a single YAML file, with Sonda handling the timing math for you.
+
+A story is a compilation layer on top of Sonda's existing scenario infrastructure. You write
+signals with `after` clauses that describe temporal dependencies, and Sonda compiles them down
+to concrete `phase_offset` values at parse time. No runtime reactivity -- just deterministic
+timing based on each signal's behavior and parameters.
+
+---
+
+## Your first story
+
+Here is a minimal story with two signals -- a flapping interface and a backup link that
+saturates after the primary drops:
+
+```yaml title="my-story.yaml"
+story: link_failover
+duration: 5m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+
+signals:
+  - metric: interface_oper_state
+    behavior: flap
+    up_duration: 60s
+    down_duration: 30s
+
+  - metric: backup_link_utilization
+    behavior: saturation
+    baseline: 20
+    ceiling: 85
+    time_to_saturate: 2m
+    after: interface_oper_state < 1
+```
+
+Run it:
+
+```bash
+sonda story --file my-story.yaml
+```
+
+Sonda computes that the flap signal drops below 1 at `t=60s` (the `up_duration`), so
+`backup_link_utilization` starts with a 60-second phase offset. You get correlated,
+time-shifted signals from a single file.
+
+Use `--dry-run` to inspect the compiled timing without emitting data:
+
+```bash
+sonda --dry-run story --file my-story.yaml
+```
+
+```text title="Output (excerpt)"
+[config] [1/2] interface_oper_state
+
+  name:          interface_oper_state
+  signal:        metrics
+  rate:          1/s
+  duration:      5m
+  generator:     sequence ([1, 1, ... 90 total], repeat)
+  encoder:       prometheus_text
+  sink:          stdout
+  clock_group:   link_failover
+
+---
+[config] [2/2] backup_link_utilization
+
+  name:          backup_link_utilization
+  signal:        metrics
+  rate:          1/s
+  duration:      5m
+  generator:     sawtooth (min: 20, max: 85, period: 120s)
+  encoder:       prometheus_text
+  sink:          stdout
+  phase_offset:  1m
+  clock_group:   link_failover
+```
+
+The `phase_offset: 1m` on the second signal is the compiled result of
+`after: interface_oper_state < 1`.
+
+---
+
+## Story YAML format
+
+### Top-level fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `story` | yes | Identifier string. Used as the `clock_group` so all signals share a timeline. |
+| `description` | no | Human-readable description (not displayed at runtime, useful for documentation). |
+| `duration` | no | Shared duration for all signals (e.g., `5m`, `30s`). Per-signal overrides take precedence. |
+| `rate` | no | Shared event rate in events/second. Default: `1`. |
+| `encoder` | no | Shared encoder config. Default: `{ type: prometheus_text }`. |
+| `sink` | no | Shared sink config. Default: `{ type: stdout }`. |
+| `labels` | no | Labels applied to all signals. Per-signal labels merge in (and override on key conflict). |
+| `signals` | yes | List of signal definitions. Must contain at least one signal. |
+
+### Signal fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `metric` | yes | Metric name for this signal. Must be unique within the story. |
+| `behavior` | yes | Behavior alias (see [Supported behaviors](#supported-behaviors)). |
+| `after` | no | Temporal dependency clause (see [The after clause](#the-after-clause)). |
+| `labels` | no | Per-signal labels. Merged with story-level labels; signal wins on conflict. |
+| `rate` | no | Per-signal rate override. |
+| `duration` | no | Per-signal duration override. |
+| `encoder` | no | Per-signal encoder override. |
+| `sink` | no | Per-signal sink override. |
+| *anything else* | no | Passed through as behavior-specific parameters (e.g., `baseline`, `ceiling`, `up_duration`). |
+
+Behavior-specific parameters are written as flat keys alongside `metric` and `behavior` -- no
+nested `generator:` block needed. Sonda collects any key that isn't a reserved field and passes
+it to the generator.
+
+---
+
+## Supported behaviors
+
+Stories use Sonda's operational vocabulary aliases. Each alias maps to a generator with
+preconfigured semantics:
+
+| Alias | Generator | Parameters | What it models |
+|-------|-----------|------------|----------------|
+| `flap` | sequence | `up_duration`, `down_duration`, `up_value` (default 1), `down_value` (default 0) | Binary state toggling (link up/down, service healthy/unhealthy) |
+| `saturation` | sawtooth | `baseline`, `ceiling`, `time_to_saturate` | Resource climbing to capacity and repeating (bandwidth, CPU) |
+| `leak` | sawtooth | `baseline`, `ceiling`, `time_to_ceiling` | One-shot resource exhaustion (memory leak, disk fill) |
+| `degradation` | sawtooth + jitter | `baseline`, `ceiling`, `time_to_degrade` | Gradual performance decay with noise (latency, error rate) |
+| `spike_event` | spike | `baseline`, `spike_height`, `spike_duration`, `spike_interval` | Periodic spikes above a baseline (CPU bursts, traffic surges) |
+| `steady` | sine + jitter | `center`, `amplitude`, `period_secs`, `jitter` | Normal oscillating baseline |
+
+!!! warning "`steady` cannot be used in `after` clauses"
+    A `steady` signal (sine wave) crosses any threshold twice per period, making the crossing
+    time ambiguous. You can use `steady` as a signal *behavior*, but you cannot reference a
+    `steady` signal in another signal's `after` clause. If you need to sequence after a steady
+    signal, use explicit `phase_offset` in a regular
+    [scenario file](../configuration/scenario-file.md) instead.
+
+---
+
+## The `after` clause
+
+The `after` clause expresses "this signal starts after the referenced signal crosses a
+threshold." The syntax is:
+
+```
+after: <metric_name> <operator> <threshold>
+```
+
+Two operators are supported:
+
+| Operator | Meaning | Typical use |
+|----------|---------|-------------|
+| `<` | Signal drops below threshold | `interface_oper_state < 1` -- "after the link goes down" |
+| `>` | Signal rises above threshold | `backup_utilization > 70` -- "after backup hits 70%" |
+
+### How timing is computed
+
+Sonda resolves `after` clauses at compile time using deterministic formulas based on each
+behavior's math:
+
+- **flap**: `< threshold` resolves to `up_duration` (the moment the signal transitions from
+  up to down).
+- **saturation / leak / degradation**: `> threshold` uses linear interpolation --
+  `(threshold - baseline) / (ceiling - baseline) * period`.
+- **spike_event**: `< threshold` resolves to `spike_duration` (when the spike ends and the
+  signal returns to baseline).
+
+For transitive chains (A -> B -> C), offsets accumulate. If B depends on A with an offset of
+60s, and C depends on B with an offset of 92s, then C's total offset is 152s.
+
+!!! info "Compile-time, not runtime"
+    The `after` clause is resolved once when Sonda parses the story file. It does not watch
+    signal values at runtime. This means the timing is deterministic and reproducible, but
+    it assumes the referenced signal's behavior follows its mathematical model exactly.
+
+??? tip "Understanding the timing formulas"
+    Each behavior has a known mathematical shape. Sonda inverts that shape to find when a
+    threshold crossing occurs:
+
+    **Flap** (sequence of up/down values):
+
+    - `< threshold`: the signal drops at `t = up_duration` (when it transitions to `down_value`)
+    - `> threshold`: generally ambiguous (signal starts at `up_value`), so this is rejected
+
+    **Saturation / leak / degradation** (linear ramp from baseline to ceiling):
+
+    - `> threshold`: `t = (threshold - baseline) / (ceiling - baseline) * period_secs`
+    - `< threshold`: rejected (the ramp only goes up)
+
+    **Spike** (baseline with periodic pulses):
+
+    - `< threshold`: `t = spike_duration` (when the first spike ends)
+    - `> threshold`: rejected (spike starts immediately at t=0)
+
+### Validation rules
+
+Sonda rejects stories with:
+
+- **Unknown metric references** -- `after: nonexistent_metric < 1` fails with a clear error.
+- **Circular dependencies** -- `A after B` and `B after A` is detected and reported.
+- **Out-of-range thresholds** -- `after: utilization > 150` when ceiling is 85 tells you
+  the signal never reaches that value.
+- **Ambiguous crossings** -- conditions satisfied at t=0 (e.g., `> 0` on a signal that
+  starts at 1) are rejected.
+- **Unsupported behaviors** -- referencing a `steady` signal in `after` is rejected with
+  an explanation.
+
+---
+
+## CLI usage
+
+```
+sonda story --file <path> [--duration <d>] [--rate <r>] [--sink <type>] [--endpoint <url>] [--encoder <enc>]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--file <path>` | **(required)** Path to the story YAML file. |
+| `--duration <d>` | Override the story-level duration for all signals (e.g., `2m`, `30s`). |
+| `--rate <r>` | Override the story-level event rate (events/second). |
+| `--sink <type>` | Override the story-level sink (e.g., `stdout`, `http_push`, `remote_write`). |
+| `--endpoint <url>` | Set the sink endpoint (required for network sinks like `http_push`). |
+| `--encoder <enc>` | Override the story-level encoder (e.g., `prometheus_text`, `json_lines`). |
+
+CLI flags override story-level shared fields. Per-signal overrides defined in the YAML
+take precedence over both.
+
+Global flags (`--dry-run`, `--quiet`, `--verbose`) work as usual:
+
+```bash
+sonda --dry-run story --file stories/link-failover.yaml
+sonda -q story --file stories/link-failover.yaml
+```
+
+### Sending to a backend
+
+Override the sink to push story output to Prometheus, VictoriaMetrics, or any HTTP endpoint:
+
+```bash
+sonda story --file stories/link-failover.yaml \
+  --sink remote_write \
+  --endpoint http://localhost:8428/api/v1/write \
+  --encoder remote_write
+```
+
+---
+
+## Worked example: link failover
+
+The included `stories/link-failover.yaml` models an edge router primary link failure with
+automatic traffic shift to a backup path. Here is the full file:
+
+```yaml title="stories/link-failover.yaml"
+story: link_failover
+description: "Edge router link failure with traffic shift to backup"
+duration: 5m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+labels:
+  device: rtr-edge-01
+  job: network
+
+signals:
+  # Primary interface flaps: up for 60s, down for 30s, cycling.
+  - metric: interface_oper_state
+    behavior: flap
+    up_duration: 60s
+    down_duration: 30s
+    labels:
+      interface: GigabitEthernet0/0/0
+
+  # Backup link saturates after primary drops below 1.
+  # Ramps from 20% to 85% utilization over 2 minutes.
+  - metric: backup_link_utilization
+    behavior: saturation
+    baseline: 20
+    ceiling: 85
+    time_to_saturate: 2m
+    after: interface_oper_state < 1
+    labels:
+      interface: GigabitEthernet0/1/0
+
+  # Latency degrades after backup utilization exceeds 70%.
+  # Climbs from 5ms to 150ms over 3 minutes with noise.
+  - metric: latency_ms
+    behavior: degradation
+    baseline: 5
+    ceiling: 150
+    time_to_degrade: 3m
+    after: backup_link_utilization > 70
+    labels:
+      path: backup
+```
+
+### The causal chain
+
+Three signals form a dependency chain:
+
+1. **`interface_oper_state`** -- starts immediately. Flaps between 1 (up) and 0 (down) on a
+   60s up / 30s down cycle.
+2. **`backup_link_utilization`** -- starts after `interface_oper_state < 1`. The flap drops to
+   0 at `t=60s`, so this signal begins at `phase_offset: 1m`. It ramps from 20% to 85% over 2
+   minutes.
+3. **`latency_ms`** -- starts after `backup_link_utilization > 70`. Linear interpolation:
+   `(70 - 20) / (85 - 20) * 120s = 92.3s` after the backup starts. Total offset:
+   `60s + 92.3s = 152.3s`. Latency climbs from 5ms to 150ms over 3 minutes with jitter.
+
+The `--dry-run` output confirms these compiled offsets:
+
+```text
+[config] [2/3] backup_link_utilization
+  phase_offset:  1m
+
+[config] [3/3] latency_ms
+  phase_offset:  152.308s
+```
+
+### Timeline visualization
+
+```
+t=0s         t=60s        t=152s       t=300s
+|            |            |            |
+|-- oper_state: up=1 ---->|-- down=0 --|-- up=1 --> ...
+             |-- backup: ramps 20->85% over 2m ---->
+                          |-- latency: ramps 5->150ms over 3m -->
+```
+
+---
+
+## Limitations
+
+- **Metrics only** -- stories currently compile to `signal_type: metrics`. Log, histogram, and
+  summary signals are not yet supported.
+- **No runtime reactivity** -- `after` clauses resolve at compile time. The timing is
+  deterministic but does not react to actual signal values during execution.
+- **No `steady` in `after`** -- sine waves cross thresholds twice per period, making the
+  crossing time ambiguous. Use a different behavior or explicit `phase_offset` in a regular
+  scenario file.
+- **Single dependency per signal** -- each signal can have at most one `after` clause.
+  Transitive chains (A -> B -> C) work, but a signal cannot depend on multiple predecessors.
+- **Unique metric names** -- every signal in a story must have a unique `metric` name, since
+  that name is used for `after` references.
+
+## What next
+
+- [**Built-in Scenarios**](scenarios.md) -- pre-built single-signal patterns you can run instantly
+- [**Scenario Files**](../configuration/scenario-file.md) -- full YAML reference for scenario fields including `phase_offset` and `clock_group`
+- [**CLI Reference**](../configuration/cli-reference.md) -- every flag for all subcommands
+- [**Alert Testing**](alert-testing.md) -- use shaped signals to validate alert rules end-to-end

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -70,6 +70,7 @@ Define reusable scenarios in YAML for anything beyond quick one-offs --
 | **CSV import** | Analyze CSVs, detect patterns, generate portable scenario YAML |
 | **Interactive scaffolding** | `sonda init` -- guided wizard, non-interactive mode, `--from` prefill |
 | **Built-in scenarios** | 11 curated patterns you can run instantly -- no YAML needed |
+| **Stories** | Multi-signal scenarios with temporal causality (`after` clauses compile to phase offsets) |
 | **Deployment** | static binary, Docker, Kubernetes (Helm chart) |
 
 ## What next
@@ -80,6 +81,7 @@ Or jump straight to what you need:
 
 - [**`sonda init`**](configuration/cli-reference.md#sonda-init) -- scaffold a scenario YAML interactively, non-interactively with flags, or pre-filled from a built-in or CSV
 - [**Built-in Scenarios**](guides/scenarios.md) -- run pre-built patterns instantly, customize from there
+- [**Stories**](guides/stories.md) -- multi-signal scenarios with temporal causality (link failover, cascading failures)
 - [**CSV Import**](guides/csv-import.md) -- turn Grafana exports into portable, parameterized scenarios
 - [**Configuration**](configuration/scenario-file.md) -- scenario files, generators, encoders, sinks, CLI reference
 - [**Deployment**](deployment/docker.md) -- Docker, Kubernetes, Server API

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
   - Guides:
     - Tutorial: guides/tutorial.md
     - Built-in Scenarios: guides/scenarios.md
+    - Stories: guides/stories.md
     - Metric Packs: guides/metric-packs.md
     - Alert Testing: guides/alert-testing.md
     - CSV Import: guides/csv-import.md

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -92,6 +92,16 @@ src/
 ├── yaml_helpers.rs     ← shared YAML formatting and quoting utilities: ParamValue, needs_quoting(),
 │                          escape_yaml_double_quoted(), format_float(), format_rate().
 │                          Used by both init/yaml_gen and import/yaml_gen.
+├── story/
+│   ├── mod.rs          ← `sonda story` subcommand: StoryConfig, SignalConfig, compile_story(),
+│   │                      signal→ScenarioEntry expansion. Stories are a concise YAML format
+│   │                      for multi-signal temporal scenarios that compiles to
+│   │                      Vec<ScenarioEntry> + phase_offset at parse time.
+│   ├── after_resolve.rs ← AfterClause parsing, dependency graph, topological sort (Kahn's
+│   │                      algorithm), cycle detection, and phase_offset computation.
+│   └── timing.rs       ← Pure timing functions per behavior alias (flap, saturation, leak,
+│                          degradation, spike_event). Computes threshold-crossing time in
+│                          seconds. Rejects steady (ambiguous sine crossings).
 ├── progress.rs         ← live progress display during scenario execution (TTY/non-TTY aware,
 │                          polls ScenarioStats via shared RwLock, all output to stderr)
 └── status.rs           ← colored lifecycle banners (start/stop/config/summary) printed to stderr
@@ -121,6 +131,7 @@ sonda import <file.csv> --analyze
 sonda import <file.csv> -o <output.yaml> [--columns <1,3,5>] [--rate <r>] [--duration <d>]
 sonda [--quiet | --verbose] import <file.csv> --run [--columns <1,3,5>] [--rate <r>] [--duration <d>]
 sonda init [--from <@name | path.csv>] [--signal-type <metrics|logs|histogram|summary>] [--domain <cat>] [--situation <alias>] [--metric <name>] [--pack <name>] [--rate <r>] [--duration <d>] [--encoder <enc>] [--sink <type>] [--endpoint <url>] [-o <path>] [--label k=v]... [--run-now] [--message-template <tpl>] [--severity <preset>] [--kafka-brokers <addrs>] [--kafka-topic <topic>] [--otlp-signal-type <type>]
+sonda [--quiet | --verbose] [--dry-run] story --file <story.yaml> [--duration <d>] [--rate <r>] [--sink <type>] [--endpoint <url>] [--encoder <enc>]
 ```
 
 The `--scenario` flag accepts either a filesystem path or a `@name` shorthand that resolves
@@ -167,6 +178,15 @@ values prompt as usual (partial non-interactive mode). Situation-specific parame
 defaults when the situation is prefilled. Log-specific prompts (message template, severity)
 and sink-specific extra fields (kafka brokers/topic, OTLP signal type) are also prefillable.
 Rate and duration are validated; invalid values warn and fall through.
+
+`story` runs a story file -- a multi-signal format with temporal causality. Stories
+compile down to `Vec<ScenarioEntry>` + `phase_offset` at parse time (no runtime reactivity).
+Signals use `after` clauses (e.g., `after: metric_name < 1`) that resolve to concrete
+`phase_offset` values via deterministic timing math. Supported behaviors for `after`
+resolution: `flap`, `saturation`, `leak`, `degradation`, `spike_event`. `steady` is
+rejected (ambiguous sine crossings). Story files live in `stories/` at the repo root.
+CLI flags (`--duration`, `--rate`, `--sink`, `--endpoint`, `--encoder`) override story-level
+shared fields but not per-signal overrides.
 
 All subcommands go through the unified `sonda_core::prepare_entries` +
 `sonda_core::launch_scenario` API introduced in Slice 3.0. No per-signal-type dispatch in main.rs.

--- a/sonda/src/cli.rs
+++ b/sonda/src/cli.rs
@@ -147,6 +147,14 @@ pub enum Commands {
     ///
     /// The generated YAML can be immediately run with `sonda run --scenario`.
     Init(InitArgs),
+    /// Run a story — a multi-signal scenario with temporal causality.
+    ///
+    /// Stories are a concise YAML format that compiles down to the existing
+    /// multi-scenario infrastructure at parse time. Signals can use `after`
+    /// clauses to express temporal sequencing (e.g., "backup saturates after
+    /// primary link drops"). There is no runtime reactivity — `after` clauses
+    /// resolve to concrete `phase_offset` values via deterministic timing math.
+    Story(StoryArgs),
 }
 
 /// Arguments for the `histogram` subcommand.
@@ -1006,6 +1014,49 @@ pub struct InitArgs {
     /// OTLP signal type for `--sink otlp_grpc`: `metrics` or `logs`.
     #[arg(long, help_heading = "Sink")]
     pub otlp_signal_type: Option<String>,
+}
+
+/// Arguments for the `story` subcommand.
+///
+/// Runs a story file — a concise multi-signal format with temporal causality.
+/// CLI flags override story-level shared fields (not per-signal overrides).
+#[derive(Debug, Args)]
+pub struct StoryArgs {
+    /// Path to a story YAML file.
+    ///
+    /// The file must have a top-level `story:` field and a `signals:` list.
+    /// Each signal specifies a `metric`, `behavior`, and optional `after`
+    /// clause for temporal sequencing.
+    #[arg(long)]
+    pub file: std::path::PathBuf,
+
+    /// Override the story duration (e.g. `"2m"`, `"30s"`).
+    ///
+    /// Applies to all signals that do not have a per-signal duration override.
+    #[arg(long)]
+    pub duration: Option<String>,
+
+    /// Override the event rate in events per second.
+    ///
+    /// Applies to all signals that do not have a per-signal rate override.
+    #[arg(long)]
+    pub rate: Option<f64>,
+
+    /// Override the sink type (e.g. `stdout`, `http_push`, `file`).
+    ///
+    /// Applies to all signals that do not have a per-signal sink override.
+    #[arg(long, help_heading = "Sink")]
+    pub sink: Option<String>,
+
+    /// Override the sink endpoint (required for network sinks).
+    #[arg(long, help_heading = "Sink")]
+    pub endpoint: Option<String>,
+
+    /// Override the encoder format (e.g. `prometheus_text`, `json_lines`).
+    ///
+    /// Applies to all signals that do not have a per-signal encoder override.
+    #[arg(long, help_heading = "Encoder")]
+    pub encoder: Option<String>,
 }
 
 /// Build clap help styling for the CLI.

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -12,6 +12,7 @@ mod packs;
 mod progress;
 mod scenarios;
 mod status;
+mod story;
 mod yaml_helpers;
 
 use std::process;
@@ -168,6 +169,9 @@ fn run() -> anyhow::Result<()> {
                     &running,
                 )?;
             }
+        }
+        Commands::Story(ref args) => {
+            run_story_command(args, &cli, verbosity, &running)?;
         }
     }
 
@@ -590,6 +594,45 @@ fn run_init_scenario(
         run_single_scenario("init".to_string(), p, running, verbosity)?;
     } else {
         launch_and_join_prepared("init", prepared, running, verbosity)?;
+    }
+
+    Ok(())
+}
+
+/// Execute a story file: load, compile, and run all signals.
+fn run_story_command(
+    args: &cli::StoryArgs,
+    cli_opts: &Cli,
+    verbosity: Verbosity,
+    running: &Arc<AtomicBool>,
+) -> anyhow::Result<()> {
+    let yaml = story::load_story_yaml(&args.file)?;
+    let config = story::parse_story(&yaml)?;
+    let overrides = story::StoryOverrides {
+        duration: args.duration.clone(),
+        rate: args.rate,
+        sink: args.sink.clone(),
+        endpoint: args.endpoint.clone(),
+        encoder: args.encoder.clone(),
+    };
+    let entries = story::compile_story(&config, &overrides)?;
+
+    let prepared = sonda_core::prepare_entries(entries).map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    if handle_pre_launch(&prepared, verbosity, cli_opts.dry_run) {
+        return Ok(());
+    }
+
+    if prepared.len() == 1 {
+        let p = prepared.into_iter().next().expect("len checked above");
+        run_single_scenario(format!("story-{}", config.story), p, running, verbosity)?;
+    } else {
+        launch_and_join_prepared(
+            &format!("story-{}", config.story),
+            prepared,
+            running,
+            verbosity,
+        )?;
     }
 
     Ok(())

--- a/sonda/src/story/after_resolve.rs
+++ b/sonda/src/story/after_resolve.rs
@@ -322,9 +322,13 @@ fn get_duration_param(
 }
 
 /// Extract an f64 parameter from the signal params. Returns `default` if absent.
+///
+/// Handles both `Value::Number` and `Value::String` (e.g., `baseline: "20"`),
+/// matching the pattern used by [`get_duration_param`].
 fn get_f64_param(params: &HashMap<String, serde_yaml_ng::Value>, key: &str, default: f64) -> f64 {
     match params.get(key) {
         Some(serde_yaml_ng::Value::Number(n)) => n.as_f64().unwrap_or(default),
+        Some(serde_yaml_ng::Value::String(s)) => s.parse().unwrap_or(default),
         _ => default,
     }
 }
@@ -683,6 +687,82 @@ mod tests {
         assert!(
             err.contains("150") && (err.contains("ceiling") || err.contains("exceeds")),
             "got: {err}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // get_f64_param string fallback (Fix 4)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_f64_param_handles_number() {
+        let params = HashMap::from([("baseline".to_string(), nv(20.0))]);
+        let val = get_f64_param(&params, "baseline", 0.0);
+        assert!((val - 20.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn get_f64_param_handles_string() {
+        let params = HashMap::from([("baseline".to_string(), sv("20"))]);
+        let val = get_f64_param(&params, "baseline", 0.0);
+        assert!(
+            (val - 20.0).abs() < f64::EPSILON,
+            "string \"20\" should parse to 20.0, got {val}"
+        );
+    }
+
+    #[test]
+    fn get_f64_param_string_unparseable_returns_default() {
+        let params = HashMap::from([("baseline".to_string(), sv("not_a_number"))]);
+        let val = get_f64_param(&params, "baseline", 42.0);
+        assert!(
+            (val - 42.0).abs() < f64::EPSILON,
+            "unparseable string should return default 42.0, got {val}"
+        );
+    }
+
+    #[test]
+    fn get_f64_param_missing_key_returns_default() {
+        let params: HashMap<String, serde_yaml_ng::Value> = HashMap::new();
+        let val = get_f64_param(&params, "baseline", 99.0);
+        assert!((val - 99.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn resolve_offsets_with_string_baseline() {
+        // Regression: baseline: "20" (YAML string) must be parsed correctly
+        // instead of silently using 0.0.
+        let signals = vec![
+            (
+                "util".to_string(),
+                None,
+                make_params(
+                    "saturation",
+                    &[
+                        ("baseline", sv("20")),
+                        ("ceiling", nv(85.0)),
+                        ("time_to_saturate", sv("120s")),
+                    ],
+                ),
+            ),
+            (
+                "dependent".to_string(),
+                Some(AfterClause {
+                    metric_ref: "util".to_string(),
+                    operator: Operator::GreaterThan,
+                    threshold: 70.0,
+                }),
+                make_params("flap", &[]),
+            ),
+        ];
+
+        let offsets = resolve_offsets(&signals).expect("should succeed");
+        // With baseline=20 (from string): (70-20)/(85-20)*120 = 92.307...s
+        let expected = (70.0 - 20.0) / (85.0 - 20.0) * 120.0;
+        assert!(
+            (offsets["dependent"] - expected).abs() < 1e-9,
+            "expected ~{expected}s with baseline=\"20\", got {}s",
+            offsets["dependent"]
         );
     }
 }

--- a/sonda/src/story/after_resolve.rs
+++ b/sonda/src/story/after_resolve.rs
@@ -1,0 +1,688 @@
+//! `after` clause parsing, dependency graph construction, topological sort,
+//! and offset computation.
+//!
+//! An `after` clause like `"interface_oper_state < 1"` is parsed into an
+//! [`AfterClause`] struct, then resolved against the signal definitions in
+//! the story to compute a concrete `phase_offset` in seconds. Signals are
+//! processed in topological order so that transitive dependencies accumulate
+//! correctly.
+
+use std::collections::HashMap;
+
+use super::timing::{
+    self, flap_crossing_secs, sawtooth_crossing_secs, spike_crossing_secs, Operator, TimingError,
+};
+
+/// A parsed `after` clause from a story signal.
+///
+/// Represents `"<metric_ref> <operator> <threshold>"`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AfterClause {
+    /// The metric name this clause references.
+    pub metric_ref: String,
+    /// The comparison operator.
+    pub operator: Operator,
+    /// The numeric threshold value.
+    pub threshold: f64,
+}
+
+/// Parse an `after` clause string into an [`AfterClause`].
+///
+/// Expected format: `"metric_name < 1"` or `"metric_name > 70"`.
+/// Only `<` and `>` operators are supported.
+///
+/// # Errors
+///
+/// Returns an error string if the clause cannot be parsed.
+pub fn parse_after_clause(s: &str) -> Result<AfterClause, String> {
+    let s = s.trim();
+
+    // Find the operator position. We scan for standalone `<` or `>`.
+    let (op_pos, op) = find_operator(s)?;
+
+    let metric_ref = s[..op_pos].trim().to_string();
+    if metric_ref.is_empty() {
+        return Err("after clause has no metric name before the operator".to_string());
+    }
+
+    let threshold_str = s[op_pos + 1..].trim();
+    if threshold_str.is_empty() {
+        return Err("after clause has no threshold value after the operator".to_string());
+    }
+
+    let threshold: f64 = threshold_str
+        .parse()
+        .map_err(|_| format!("invalid threshold value {threshold_str:?} in after clause"))?;
+
+    Ok(AfterClause {
+        metric_ref,
+        operator: op,
+        threshold,
+    })
+}
+
+/// Find the operator (`<` or `>`) in an after clause string.
+///
+/// Returns `(position, Operator)`. Rejects ambiguous or missing operators.
+fn find_operator(s: &str) -> Result<(usize, Operator), String> {
+    let mut found: Option<(usize, Operator)> = None;
+
+    for (i, ch) in s.char_indices() {
+        let op = match ch {
+            '<' => Some(Operator::LessThan),
+            '>' => Some(Operator::GreaterThan),
+            _ => None,
+        };
+        if let Some(op) = op {
+            if found.is_some() {
+                return Err(format!(
+                    "after clause {s:?} contains multiple operators; \
+                     only a single '<' or '>' is allowed"
+                ));
+            }
+            found = Some((i, op));
+        }
+    }
+
+    found.ok_or_else(|| {
+        format!(
+            "after clause {s:?} has no operator; \
+             expected format: \"metric_name < threshold\" or \"metric_name > threshold\""
+        )
+    })
+}
+
+/// Parameters extracted from a signal definition, needed for timing computation.
+#[derive(Debug, Clone)]
+pub struct SignalParams {
+    /// The behavior alias (e.g., "flap", "saturation", "leak", "degradation",
+    /// "spike_event", "steady").
+    pub behavior: String,
+    /// Flat key-value parameters from the signal definition.
+    pub params: HashMap<String, serde_yaml_ng::Value>,
+}
+
+/// Resolve all `after` clauses in a story into concrete offsets (in seconds).
+///
+/// Takes a list of `(metric_name, optional_after_clause, signal_params)` tuples
+/// and returns a map from metric name to resolved phase offset in seconds.
+///
+/// Signals without an `after` clause get offset 0.0. Signals with an `after`
+/// clause get the referenced signal's offset plus the timing computation result.
+///
+/// # Errors
+///
+/// Returns a descriptive error string for:
+/// - Unknown metric references
+/// - Circular dependencies
+/// - Unsupported behavior aliases (e.g., "steady")
+/// - Out-of-range thresholds
+pub fn resolve_offsets(
+    signals: &[(String, Option<AfterClause>, SignalParams)],
+) -> Result<HashMap<String, f64>, String> {
+    let name_to_idx: HashMap<&str, usize> = signals
+        .iter()
+        .enumerate()
+        .map(|(i, (name, _, _))| (name.as_str(), i))
+        .collect();
+
+    // Validate all metric references exist.
+    for (name, after, _) in signals {
+        if let Some(clause) = after {
+            if !name_to_idx.contains_key(clause.metric_ref.as_str()) {
+                return Err(format!(
+                    "signal {:?}: after clause references {:?} which is not defined in this story",
+                    name, clause.metric_ref
+                ));
+            }
+        }
+    }
+
+    // Build adjacency list: edges go from dependency -> dependent.
+    // in_degree[i] = number of signals that signal i depends on (0 or 1).
+    let n = signals.len();
+    let mut in_degree = vec![0u32; n];
+    let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); n];
+
+    for (i, (_, after, _)) in signals.iter().enumerate() {
+        if let Some(clause) = after {
+            let dep_idx = name_to_idx[clause.metric_ref.as_str()];
+            in_degree[i] = 1;
+            dependents[dep_idx].push(i);
+        }
+    }
+
+    // Kahn's algorithm for topological sort.
+    let mut queue: Vec<usize> = Vec::new();
+    for (i, &deg) in in_degree.iter().enumerate() {
+        if deg == 0 {
+            queue.push(i);
+        }
+    }
+
+    let mut sorted: Vec<usize> = Vec::with_capacity(n);
+    let mut offsets = vec![0.0_f64; n];
+
+    while let Some(idx) = queue.pop() {
+        sorted.push(idx);
+
+        for &dep_idx in &dependents[idx] {
+            in_degree[dep_idx] -= 1;
+            if in_degree[dep_idx] == 0 {
+                queue.push(dep_idx);
+            }
+        }
+    }
+
+    if sorted.len() < n {
+        // Cycle detected — find the cycle for error reporting.
+        let cycle = find_cycle(signals, &name_to_idx);
+        return Err(format!("circular dependency: {cycle}"));
+    }
+
+    // Process in topological order.
+    for &idx in &sorted {
+        let (name, after, params) = &signals[idx];
+        if let Some(clause) = after {
+            let dep_idx = name_to_idx[clause.metric_ref.as_str()];
+            let dep_offset = offsets[dep_idx];
+            let dep_params = &signals[dep_idx].2;
+
+            let crossing_secs = compute_crossing(name, clause, dep_params).map_err(|e| {
+                format!(
+                    "signal {:?}: after {:?} {} {}: {}",
+                    name, clause.metric_ref, clause.operator, clause.threshold, e
+                )
+            })?;
+
+            offsets[idx] = dep_offset + crossing_secs;
+        }
+        // else: offset remains 0.0
+        let _ = params; // suppress unused warning
+    }
+
+    let mut result = HashMap::with_capacity(n);
+    for (i, (name, _, _)) in signals.iter().enumerate() {
+        result.insert(name.clone(), offsets[i]);
+    }
+
+    Ok(result)
+}
+
+/// Compute the crossing time for a single `after` clause against a signal's
+/// parameters.
+fn compute_crossing(
+    _signal_name: &str,
+    clause: &AfterClause,
+    dep_params: &SignalParams,
+) -> Result<f64, TimingError> {
+    match dep_params.behavior.as_str() {
+        "flap" => {
+            let up_duration_secs = get_duration_param(&dep_params.params, "up_duration", 10.0)?;
+            let down_duration_secs = get_duration_param(&dep_params.params, "down_duration", 5.0)?;
+            let up_value = get_f64_param(&dep_params.params, "up_value", 1.0);
+            let down_value = get_f64_param(&dep_params.params, "down_value", 0.0);
+
+            flap_crossing_secs(
+                clause.operator,
+                clause.threshold,
+                up_duration_secs,
+                down_duration_secs,
+                up_value,
+                down_value,
+            )
+        }
+        "saturation" => {
+            let baseline = get_f64_param(&dep_params.params, "baseline", 0.0);
+            let ceiling = get_f64_param(&dep_params.params, "ceiling", 100.0);
+            let period_secs = get_duration_param(&dep_params.params, "time_to_saturate", 300.0)?;
+
+            sawtooth_crossing_secs(
+                clause.operator,
+                clause.threshold,
+                baseline,
+                ceiling,
+                period_secs,
+            )
+        }
+        "leak" => {
+            let baseline = get_f64_param(&dep_params.params, "baseline", 0.0);
+            let ceiling = get_f64_param(&dep_params.params, "ceiling", 100.0);
+            let period_secs = get_duration_param(&dep_params.params, "time_to_ceiling", 600.0)?;
+
+            sawtooth_crossing_secs(
+                clause.operator,
+                clause.threshold,
+                baseline,
+                ceiling,
+                period_secs,
+            )
+        }
+        "degradation" => {
+            let baseline = get_f64_param(&dep_params.params, "baseline", 0.0);
+            let ceiling = get_f64_param(&dep_params.params, "ceiling", 100.0);
+            let period_secs = get_duration_param(&dep_params.params, "time_to_degrade", 300.0)?;
+
+            sawtooth_crossing_secs(
+                clause.operator,
+                clause.threshold,
+                baseline,
+                ceiling,
+                period_secs,
+            )
+        }
+        "spike_event" => {
+            let baseline = get_f64_param(&dep_params.params, "baseline", 0.0);
+            let spike_height = get_f64_param(&dep_params.params, "spike_height", 100.0);
+            let spike_duration_secs =
+                get_duration_param(&dep_params.params, "spike_duration", 10.0)?;
+
+            spike_crossing_secs(
+                clause.operator,
+                clause.threshold,
+                baseline,
+                spike_height,
+                spike_duration_secs,
+            )
+        }
+        "steady" => timing::steady_crossing_secs(),
+        other => Err(TimingError::Unsupported {
+            message: format!(
+                "behavior {:?} does not support after-clause threshold crossing computation",
+                other
+            ),
+        }),
+    }
+}
+
+/// Extract a duration parameter from the signal params, parsing the duration
+/// string to seconds. Returns `default_secs` if the key is absent.
+fn get_duration_param(
+    params: &HashMap<String, serde_yaml_ng::Value>,
+    key: &str,
+    default_secs: f64,
+) -> Result<f64, TimingError> {
+    match params.get(key) {
+        Some(serde_yaml_ng::Value::String(s)) => {
+            let dur = sonda_core::config::validate::parse_duration(s).map_err(|e| {
+                TimingError::OutOfRange {
+                    message: format!("invalid duration {:?} for {key}: {e}", s),
+                }
+            })?;
+            Ok(dur.as_secs_f64())
+        }
+        Some(serde_yaml_ng::Value::Number(n)) => {
+            // Treat bare numbers as seconds.
+            n.as_f64().ok_or_else(|| TimingError::OutOfRange {
+                message: format!("{key}: numeric value is not a valid f64"),
+            })
+        }
+        _ => Ok(default_secs),
+    }
+}
+
+/// Extract an f64 parameter from the signal params. Returns `default` if absent.
+fn get_f64_param(params: &HashMap<String, serde_yaml_ng::Value>, key: &str, default: f64) -> f64 {
+    match params.get(key) {
+        Some(serde_yaml_ng::Value::Number(n)) => n.as_f64().unwrap_or(default),
+        _ => default,
+    }
+}
+
+/// Find a cycle in the dependency graph for error reporting.
+///
+/// Returns a string like `"A -> B -> C -> A"`.
+fn find_cycle(
+    signals: &[(String, Option<AfterClause>, SignalParams)],
+    name_to_idx: &HashMap<&str, usize>,
+) -> String {
+    let n = signals.len();
+    let mut visited = vec![0u8; n]; // 0=white, 1=gray, 2=black
+    let mut parent = vec![usize::MAX; n];
+
+    for start in 0..n {
+        if visited[start] != 0 {
+            continue;
+        }
+        // DFS from `start`.
+        let mut stack = vec![(start, false)];
+        while let Some((node, returning)) = stack.pop() {
+            if returning {
+                visited[node] = 2;
+                continue;
+            }
+            if visited[node] == 1 {
+                // Found a back-edge to a gray node while revisiting — skip.
+                continue;
+            }
+            visited[node] = 1;
+            stack.push((node, true)); // return marker
+
+            if let Some(ref clause) = signals[node].1 {
+                if let Some(&dep_idx) = name_to_idx.get(clause.metric_ref.as_str()) {
+                    if visited[dep_idx] == 1 {
+                        // Cycle found: trace back from node to dep_idx.
+                        let mut cycle = vec![signals[dep_idx].0.clone()];
+                        let mut cur = node;
+                        while cur != dep_idx {
+                            cycle.push(signals[cur].0.clone());
+                            cur = parent[cur];
+                            if cur == usize::MAX {
+                                break;
+                            }
+                        }
+                        cycle.push(signals[dep_idx].0.clone());
+                        cycle.reverse();
+                        return cycle.join(" -> ");
+                    }
+                    if visited[dep_idx] == 0 {
+                        parent[dep_idx] = node;
+                        stack.push((dep_idx, false));
+                    }
+                }
+            }
+        }
+    }
+
+    "unknown cycle".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // AfterClause parsing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_less_than() {
+        let clause = parse_after_clause("interface_oper_state < 1").expect("should parse");
+        assert_eq!(clause.metric_ref, "interface_oper_state");
+        assert_eq!(clause.operator, Operator::LessThan);
+        assert!((clause.threshold - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_greater_than() {
+        let clause = parse_after_clause("backup_link_utilization > 70").expect("should parse");
+        assert_eq!(clause.metric_ref, "backup_link_utilization");
+        assert_eq!(clause.operator, Operator::GreaterThan);
+        assert!((clause.threshold - 70.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_with_extra_whitespace() {
+        let clause =
+            parse_after_clause("  metric_name   >   42.5  ").expect("should parse with spaces");
+        assert_eq!(clause.metric_ref, "metric_name");
+        assert_eq!(clause.operator, Operator::GreaterThan);
+        assert!((clause.threshold - 42.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_negative_threshold() {
+        let clause = parse_after_clause("temp < -10").expect("should parse negative");
+        assert_eq!(clause.metric_ref, "temp");
+        assert_eq!(clause.operator, Operator::LessThan);
+        assert!((clause.threshold - (-10.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_missing_operator() {
+        let err = parse_after_clause("metric_name 70").expect_err("should fail");
+        assert!(err.contains("no operator"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_missing_metric() {
+        let err = parse_after_clause("< 70").expect_err("should fail");
+        assert!(err.contains("no metric name"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_missing_threshold() {
+        let err = parse_after_clause("metric >").expect_err("should fail");
+        assert!(err.contains("no threshold"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_invalid_threshold() {
+        let err = parse_after_clause("metric > abc").expect_err("should fail");
+        assert!(err.contains("invalid threshold"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_multiple_operators() {
+        let err = parse_after_clause("a < b > c").expect_err("should fail");
+        assert!(err.contains("multiple operators"), "got: {err}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Offset resolution
+    // -----------------------------------------------------------------------
+
+    fn make_params(behavior: &str, kvs: &[(&str, serde_yaml_ng::Value)]) -> SignalParams {
+        let mut params = HashMap::new();
+        for (k, v) in kvs {
+            params.insert(k.to_string(), v.clone());
+        }
+        SignalParams {
+            behavior: behavior.to_string(),
+            params,
+        }
+    }
+
+    fn sv(s: &str) -> serde_yaml_ng::Value {
+        serde_yaml_ng::Value::String(s.to_string())
+    }
+
+    fn nv(n: f64) -> serde_yaml_ng::Value {
+        serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(n))
+    }
+
+    #[test]
+    fn no_after_clauses_all_zero() {
+        let signals = vec![
+            ("metric_a".to_string(), None, make_params("flap", &[])),
+            ("metric_b".to_string(), None, make_params("saturation", &[])),
+        ];
+
+        let offsets = resolve_offsets(&signals).expect("should succeed");
+        assert!((offsets["metric_a"]).abs() < f64::EPSILON);
+        assert!((offsets["metric_b"]).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn simple_dependency_chain() {
+        // A (flap, up_duration=60s) -> B depends on "A < 1" -> offset = 60s
+        let signals = vec![
+            (
+                "interface_oper_state".to_string(),
+                None,
+                make_params("flap", &[("up_duration", sv("60s"))]),
+            ),
+            (
+                "backup_link_utilization".to_string(),
+                Some(AfterClause {
+                    metric_ref: "interface_oper_state".to_string(),
+                    operator: Operator::LessThan,
+                    threshold: 1.0,
+                }),
+                make_params(
+                    "saturation",
+                    &[
+                        ("baseline", nv(20.0)),
+                        ("ceiling", nv(85.0)),
+                        ("time_to_saturate", sv("2m")),
+                    ],
+                ),
+            ),
+        ];
+
+        let offsets = resolve_offsets(&signals).expect("should succeed");
+        assert!((offsets["interface_oper_state"]).abs() < f64::EPSILON);
+        assert!((offsets["backup_link_utilization"] - 60.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn transitive_dependency() {
+        // A (flap, up_duration=60s) at t=0
+        // B depends on "A < 1" -> offset = 60s
+        // B (saturation, baseline=20, ceiling=85, period=120s)
+        // C depends on "B > 70" -> offset = 60 + (70-20)/(85-20)*120 = 60 + 92.307...
+        let signals = vec![
+            (
+                "interface_oper_state".to_string(),
+                None,
+                make_params("flap", &[("up_duration", sv("60s"))]),
+            ),
+            (
+                "backup_link_utilization".to_string(),
+                Some(AfterClause {
+                    metric_ref: "interface_oper_state".to_string(),
+                    operator: Operator::LessThan,
+                    threshold: 1.0,
+                }),
+                make_params(
+                    "saturation",
+                    &[
+                        ("baseline", nv(20.0)),
+                        ("ceiling", nv(85.0)),
+                        ("time_to_saturate", sv("120s")),
+                    ],
+                ),
+            ),
+            (
+                "latency_ms".to_string(),
+                Some(AfterClause {
+                    metric_ref: "backup_link_utilization".to_string(),
+                    operator: Operator::GreaterThan,
+                    threshold: 70.0,
+                }),
+                make_params(
+                    "degradation",
+                    &[
+                        ("baseline", nv(5.0)),
+                        ("ceiling", nv(150.0)),
+                        ("time_to_degrade", sv("3m")),
+                    ],
+                ),
+            ),
+        ];
+
+        let offsets = resolve_offsets(&signals).expect("should succeed");
+        let expected_b = 60.0;
+        let expected_c = 60.0 + (70.0 - 20.0) / (85.0 - 20.0) * 120.0;
+        assert!((offsets["interface_oper_state"]).abs() < f64::EPSILON);
+        assert!(
+            (offsets["backup_link_utilization"] - expected_b).abs() < f64::EPSILON,
+            "B: got {}, expected {expected_b}",
+            offsets["backup_link_utilization"]
+        );
+        assert!(
+            (offsets["latency_ms"] - expected_c).abs() < 1e-9,
+            "C: got {}, expected {expected_c}",
+            offsets["latency_ms"]
+        );
+    }
+
+    #[test]
+    fn unknown_metric_reference() {
+        let signals = vec![(
+            "metric_a".to_string(),
+            Some(AfterClause {
+                metric_ref: "nonexistent".to_string(),
+                operator: Operator::LessThan,
+                threshold: 1.0,
+            }),
+            make_params("flap", &[]),
+        )];
+
+        let err = resolve_offsets(&signals).expect_err("should fail");
+        assert!(
+            err.contains("nonexistent") && err.contains("not defined"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn cycle_detection() {
+        let signals = vec![
+            (
+                "a".to_string(),
+                Some(AfterClause {
+                    metric_ref: "b".to_string(),
+                    operator: Operator::LessThan,
+                    threshold: 1.0,
+                }),
+                make_params("flap", &[]),
+            ),
+            (
+                "b".to_string(),
+                Some(AfterClause {
+                    metric_ref: "a".to_string(),
+                    operator: Operator::LessThan,
+                    threshold: 1.0,
+                }),
+                make_params("flap", &[]),
+            ),
+        ];
+
+        let err = resolve_offsets(&signals).expect_err("should fail");
+        assert!(err.contains("circular dependency"), "got: {err}");
+    }
+
+    #[test]
+    fn steady_behavior_rejected() {
+        let signals = vec![
+            (
+                "baseline_metric".to_string(),
+                None,
+                make_params("steady", &[]),
+            ),
+            (
+                "dependent".to_string(),
+                Some(AfterClause {
+                    metric_ref: "baseline_metric".to_string(),
+                    operator: Operator::GreaterThan,
+                    threshold: 50.0,
+                }),
+                make_params("saturation", &[]),
+            ),
+        ];
+
+        let err = resolve_offsets(&signals).expect_err("should fail");
+        assert!(err.contains("steady"), "got: {err}");
+    }
+
+    #[test]
+    fn out_of_range_threshold() {
+        // saturation: baseline=20, ceiling=85. Threshold 150 is out of range.
+        let signals = vec![
+            (
+                "util".to_string(),
+                None,
+                make_params(
+                    "saturation",
+                    &[("baseline", nv(20.0)), ("ceiling", nv(85.0))],
+                ),
+            ),
+            (
+                "dependent".to_string(),
+                Some(AfterClause {
+                    metric_ref: "util".to_string(),
+                    operator: Operator::GreaterThan,
+                    threshold: 150.0,
+                }),
+                make_params("flap", &[]),
+            ),
+        ];
+
+        let err = resolve_offsets(&signals).expect_err("should fail");
+        assert!(
+            err.contains("150") && (err.contains("ceiling") || err.contains("exceeds")),
+            "got: {err}"
+        );
+    }
+}

--- a/sonda/src/story/mod.rs
+++ b/sonda/src/story/mod.rs
@@ -257,7 +257,13 @@ pub fn compile_story(
     // When a wall-clock duration cap is set, warn about signals that will be
     // skipped or truncated, and compute the effective per-signal duration.
     if let Some(cap_secs) = total_duration_secs {
-        print_duration_cap_warnings(config, &offsets, cap_secs, effective_duration.unwrap_or(""));
+        print_duration_cap_warnings(
+            config,
+            &offsets,
+            cap_secs,
+            effective_duration.unwrap_or(""),
+            effective_duration,
+        );
     }
 
     // Expand each signal into a ScenarioEntry.
@@ -386,11 +392,16 @@ fn compute_signal_duration(
 
 /// Print warnings to stderr when the story duration cap causes signals to be
 /// skipped or truncated.
+///
+/// `effective_duration_str` is the duration as resolved after CLI overrides,
+/// so truncation detection uses the actual cap rather than the story's
+/// configured duration.
 fn print_duration_cap_warnings(
     config: &StoryConfig,
     offsets: &HashMap<String, f64>,
     cap_secs: f64,
     duration_str: &str,
+    effective_duration_str: Option<&str>,
 ) {
     let mut skipped: Vec<(&str, f64)> = Vec::new();
     let mut truncated: Vec<(&str, f64, f64)> = Vec::new();
@@ -401,11 +412,13 @@ fn print_duration_cap_warnings(
             skipped.push((&sig.metric, offset));
         } else {
             // Check if the signal's emission time would be truncated.
+            // Use the per-signal duration if set, otherwise the effective
+            // (possibly CLI-overridden) duration, not the story config duration.
             let remaining = cap_secs - offset;
             let sig_dur = sig
                 .duration
                 .as_deref()
-                .or(config.duration.as_deref())
+                .or(effective_duration_str)
                 .and_then(|d| sonda_core::config::validate::parse_duration(d).ok())
                 .map(|d| d.as_secs_f64());
             if let Some(dur_secs) = sig_dur {
@@ -498,7 +511,8 @@ fn format_yaml_value(value: &Value) -> String {
         Value::String(s) => {
             // Quote strings that might be misinterpreted by YAML.
             if needs_quoting(s) {
-                format!("{s:?}")
+                let escaped = escape_yaml_double_quoted(s);
+                format!("\"{escaped}\"")
             } else {
                 s.clone()
             }
@@ -1495,5 +1509,129 @@ signals:
         // No per-signal or story duration string, but cap is 90s, offset 30s.
         let result = compute_signal_duration(None, None, Some(90.0), 30.0);
         assert_eq!(result.as_deref(), Some("1m"));
+    }
+
+    // -----------------------------------------------------------------------
+    // NOTE 4: format_yaml_value uses escape_yaml_double_quoted consistently
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn format_yaml_value_quotes_duration_strings() {
+        let val = Value::String("60s".to_string());
+        let result = format_yaml_value(&val);
+        // "60s" parses as a number would NOT (it doesn't), but it is a
+        // plain string. Confirm it is not quoted.
+        assert_eq!(result, "60s");
+    }
+
+    #[test]
+    fn format_yaml_value_quotes_string_with_colon() {
+        let val = Value::String("http://example.com".to_string());
+        let result = format_yaml_value(&val);
+        // Must be double-quoted, using escape_yaml_double_quoted.
+        assert_eq!(result, "\"http://example.com\"");
+    }
+
+    #[test]
+    fn format_yaml_value_quotes_string_with_backslash_and_quote() {
+        // This is the key regression test: Rust debug formatting would
+        // produce different escaping than escape_yaml_double_quoted.
+        let val = Value::String(r#"a\b"c"#.to_string());
+        let result = format_yaml_value(&val);
+        // escape_yaml_double_quoted: backslash -> \\, quote -> \"
+        assert_eq!(result, r#""a\\b\"c""#);
+    }
+
+    #[test]
+    fn format_yaml_value_number() {
+        let val = Value::Number(serde_yaml_ng::Number::from(42));
+        assert_eq!(format_yaml_value(&val), "42");
+    }
+
+    #[test]
+    fn format_yaml_value_bool() {
+        let val = Value::Bool(true);
+        assert_eq!(format_yaml_value(&val), "true");
+    }
+
+    // -----------------------------------------------------------------------
+    // NOTE 1: all signals skipped returns an error, not empty Vec
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compile_story_all_signals_skipped_returns_error() {
+        // A sub-microsecond duration like 0.0001ms truncates to Duration::ZERO
+        // when converted via `Duration::from_micros((0.0001 * 1000.0) as u64)`.
+        // This makes cap_secs = 0.0 so every signal's offset >= 0.0 is true
+        // and all are skipped. compile_story must return Err, not Ok(vec![]).
+        let yaml = r#"
+story: all_skipped
+duration: 10m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+signals:
+  - metric: interface_oper_state
+    behavior: flap
+    up_duration: 60s
+    down_duration: 30s
+  - metric: backup_utilization
+    behavior: saturation
+    baseline: 20
+    ceiling: 85
+    time_to_saturate: 120s
+    after: interface_oper_state < 1
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let overrides = StoryOverrides {
+            duration: Some("0.0001ms".to_string()),
+            ..Default::default()
+        };
+        let err = compile_story(&config, &overrides).expect_err("should fail when all skipped");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("all signals were skipped"),
+            "expected 'all signals were skipped' error, got: {msg}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // NOTE 2: offset exactly equals duration cap is skipped (>= boundary)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compile_story_offset_exactly_equals_cap_is_skipped() {
+        // Signal B has an after clause that resolves to offset = 60s.
+        // With --duration 60s the cap is exactly 60s, so offset >= cap
+        // holds and B is skipped (0s remaining = nothing to emit).
+        let yaml = r#"
+story: exact_boundary
+duration: 10m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+signals:
+  - metric: interface_oper_state
+    behavior: flap
+    up_duration: 60s
+    down_duration: 30s
+  - metric: backup_utilization
+    behavior: saturation
+    baseline: 20
+    ceiling: 85
+    time_to_saturate: 120s
+    after: interface_oper_state < 1
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        // Set cap to exactly 60s — matching the flap up_duration offset.
+        let overrides = StoryOverrides {
+            duration: Some("60s".to_string()),
+            ..Default::default()
+        };
+        let entries = compile_story(&config, &overrides).expect("should compile");
+        // Only the first signal (offset=0) should be included.
+        // The second signal has offset=60s which exactly equals the cap.
+        assert_eq!(entries.len(), 1, "signal at offset==cap should be skipped");
+        assert_eq!(entries[0].base().name, "interface_oper_state");
     }
 }

--- a/sonda/src/story/mod.rs
+++ b/sonda/src/story/mod.rs
@@ -55,6 +55,8 @@ use anyhow::{bail, Context, Result};
 use serde_yaml_ng::Value;
 use sonda_core::config::ScenarioEntry;
 
+use crate::yaml_helpers::{escape_yaml_double_quoted, needs_quoting};
+
 use self::after_resolve::{parse_after_clause, resolve_offsets, AfterClause, SignalParams};
 
 /// Top-level story configuration, parsed from YAML.
@@ -217,6 +219,15 @@ pub fn compile_story(
     let effective_encoder = build_effective_encoder(overrides, config);
     let effective_sink = build_effective_sink(overrides, config);
 
+    // Parse the total wall-clock cap (if any).
+    let total_duration_secs = effective_duration
+        .map(|d| {
+            sonda_core::config::validate::parse_duration(d)
+                .map(|dur| dur.as_secs_f64())
+                .map_err(|e| anyhow::anyhow!("invalid story duration {:?}: {e}", d))
+        })
+        .transpose()?;
+
     // Build the signal list for after-clause resolution.
     let signal_tuples: Vec<(String, Option<AfterClause>, SignalParams)> = config
         .signals
@@ -243,22 +254,41 @@ pub fn compile_story(
     // Resolve all offsets.
     let offsets = resolve_offsets(&signal_tuples).map_err(|e| anyhow::anyhow!("{e}"))?;
 
+    // When a wall-clock duration cap is set, warn about signals that will be
+    // skipped or truncated, and compute the effective per-signal duration.
+    if let Some(cap_secs) = total_duration_secs {
+        print_duration_cap_warnings(config, &offsets, cap_secs, effective_duration.unwrap_or(""));
+    }
+
     // Expand each signal into a ScenarioEntry.
     let mut entries = Vec::with_capacity(config.signals.len());
 
     for sig in &config.signals {
         let offset_secs = offsets[&sig.metric];
 
+        // When a wall-clock cap is active, skip signals whose phase_offset
+        // meets or exceeds the total duration.
+        if let Some(cap_secs) = total_duration_secs {
+            if offset_secs >= cap_secs {
+                continue;
+            }
+        }
+
         // Build merged labels: story-level + signal-level (signal wins on conflict).
         let merged_labels = merge_labels(config.labels.as_ref(), sig.labels.as_ref());
 
         // Determine per-signal rate, duration, encoder, sink.
         let sig_rate = sig.rate.unwrap_or(effective_rate);
-        let sig_duration = sig
-            .duration
-            .as_deref()
-            .or(effective_duration)
-            .map(|s| s.to_string());
+
+        // Compute the per-signal emission duration. When a wall-clock cap is
+        // active the effective duration is capped to (total_duration - offset).
+        let sig_duration = compute_signal_duration(
+            sig.duration.as_deref(),
+            effective_duration,
+            total_duration_secs,
+            offset_secs,
+        );
+
         let sig_encoder = sig.encoder.as_ref().unwrap_or(&effective_encoder);
         let sig_sink = sig.sink.as_ref().unwrap_or(&effective_sink);
 
@@ -295,7 +325,147 @@ pub fn compile_story(
         entries.push(entry);
     }
 
+    if entries.is_empty() {
+        bail!(
+            "all signals were skipped because their phase offsets exceed \
+             the story duration ({})",
+            effective_duration.unwrap_or("0s")
+        );
+    }
+
     Ok(entries)
+}
+
+/// Compute the effective per-signal emission duration, respecting the
+/// wall-clock duration cap when set.
+///
+/// When `total_duration_secs` is `Some`, each signal's effective duration is
+/// capped to `total_duration - offset_secs`. If the signal has its own
+/// per-signal duration, the effective value is the minimum of that duration
+/// and the remaining wall-clock budget.
+fn compute_signal_duration(
+    per_signal_duration: Option<&str>,
+    story_duration: Option<&str>,
+    total_duration_secs: Option<f64>,
+    offset_secs: f64,
+) -> Option<String> {
+    let base_duration_str = per_signal_duration.or(story_duration);
+
+    let Some(cap_secs) = total_duration_secs else {
+        // No wall-clock cap — use the signal or story duration as-is.
+        return base_duration_str.map(|s| s.to_string());
+    };
+
+    let remaining = cap_secs - offset_secs;
+    if remaining <= 0.0 {
+        // Should not happen (caller filters these out), but be defensive.
+        return Some("0s".to_string());
+    }
+
+    match base_duration_str {
+        Some(dur_str) => {
+            // Parse the per-signal duration and cap it.
+            if let Ok(dur) = sonda_core::config::validate::parse_duration(dur_str) {
+                let dur_secs = dur.as_secs_f64();
+                if dur_secs > remaining {
+                    Some(format_duration_secs(remaining))
+                } else {
+                    Some(dur_str.to_string())
+                }
+            } else {
+                // Unparseable duration — pass through and let validation catch it.
+                Some(dur_str.to_string())
+            }
+        }
+        None => {
+            // No explicit duration but there is a wall-clock cap — set one.
+            Some(format_duration_secs(remaining))
+        }
+    }
+}
+
+/// Print warnings to stderr when the story duration cap causes signals to be
+/// skipped or truncated.
+fn print_duration_cap_warnings(
+    config: &StoryConfig,
+    offsets: &HashMap<String, f64>,
+    cap_secs: f64,
+    duration_str: &str,
+) {
+    let mut skipped: Vec<(&str, f64)> = Vec::new();
+    let mut truncated: Vec<(&str, f64, f64)> = Vec::new();
+
+    for sig in &config.signals {
+        let offset = offsets[&sig.metric];
+        if offset >= cap_secs {
+            skipped.push((&sig.metric, offset));
+        } else {
+            // Check if the signal's emission time would be truncated.
+            let remaining = cap_secs - offset;
+            let sig_dur = sig
+                .duration
+                .as_deref()
+                .or(config.duration.as_deref())
+                .and_then(|d| sonda_core::config::validate::parse_duration(d).ok())
+                .map(|d| d.as_secs_f64());
+            if let Some(dur_secs) = sig_dur {
+                if dur_secs > remaining {
+                    truncated.push((&sig.metric, offset, remaining));
+                }
+            }
+        }
+    }
+
+    if skipped.is_empty() && truncated.is_empty() {
+        return;
+    }
+
+    eprintln!("warning: story duration ({duration_str}) is shorter than some phase offsets:");
+    for (name, offset) in &skipped {
+        eprintln!(
+            "  - {:?} needs {} before it starts -- skipped",
+            name,
+            format_duration_human(*offset),
+        );
+    }
+    for (name, _offset, remaining) in &truncated {
+        eprintln!(
+            "  - {:?} will run for {} instead of its full duration",
+            name,
+            format_duration_human(*remaining),
+        );
+    }
+
+    // Suggest the minimum duration needed to include all signals.
+    let max_offset = offsets.values().cloned().fold(0.0_f64, f64::max);
+    eprintln!(
+        "  hint: use --duration {} or longer to include all signals",
+        format_duration_human(max_offset + 60.0),
+    );
+}
+
+/// Format a duration in seconds as a human-readable string for warning messages.
+///
+/// Uses minutes and seconds notation (e.g., "2m32s") for values >= 60s.
+fn format_duration_human(secs: f64) -> String {
+    if secs < 0.0 {
+        return "0s".to_string();
+    }
+    let total_secs = secs.round() as u64;
+    if total_secs == 0 {
+        // Sub-second: use milliseconds.
+        let ms = (secs * 1000.0).round() as u64;
+        return format!("{ms}ms");
+    }
+    let m = total_secs / 60;
+    let s = total_secs % 60;
+    if m == 0 {
+        format!("{s}s")
+    } else if s == 0 {
+        format!("{m}m")
+    } else {
+        format!("{m}m{s}s")
+    }
 }
 
 /// Build a YAML snippet for the generator from a behavior alias and flat params.
@@ -340,25 +510,6 @@ fn format_yaml_value(value: &Value) -> String {
     }
 }
 
-/// Check if a string value needs YAML quoting.
-fn needs_quoting(s: &str) -> bool {
-    // Quote if it contains special chars, looks like a number, or is a YAML keyword.
-    s.is_empty()
-        || s.contains(':')
-        || s.contains('#')
-        || s.contains('{')
-        || s.contains('}')
-        || s.contains('[')
-        || s.contains(']')
-        || s.contains('\'')
-        || s.contains('"')
-        || s.contains('\n')
-        || s.starts_with(' ')
-        || s.ends_with(' ')
-        || matches!(s, "true" | "false" | "null" | "yes" | "no" | "on" | "off")
-        || s.parse::<f64>().is_ok()
-}
-
 /// Parameters for building a ScenarioEntry YAML string.
 struct EntryYamlParams<'a> {
     name: &'a str,
@@ -377,7 +528,12 @@ fn build_entry_yaml(p: &EntryYamlParams<'_>) -> Result<String> {
     let mut lines = Vec::new();
 
     lines.push("signal_type: metrics".to_string());
-    lines.push(format!("name: {}", p.name));
+    if needs_quoting(p.name) {
+        let escaped = escape_yaml_double_quoted(p.name);
+        lines.push(format!("name: \"{escaped}\""));
+    } else {
+        lines.push(format!("name: {}", p.name));
+    }
     lines.push(format!("rate: {}", p.rate));
 
     if let Some(dur) = p.duration {
@@ -412,7 +568,12 @@ fn build_entry_yaml(p: &EntryYamlParams<'_>) -> Result<String> {
             let mut sorted_labels: Vec<_> = lbl.iter().collect();
             sorted_labels.sort_by_key(|(k, _)| *k);
             for (k, v) in sorted_labels {
-                lines.push(format!("  {k}: {v}"));
+                if needs_quoting(v) {
+                    let escaped = escape_yaml_double_quoted(v);
+                    lines.push(format!("  {k}: \"{escaped}\""));
+                } else {
+                    lines.push(format!("  {k}: {v}"));
+                }
             }
         }
     }
@@ -480,10 +641,14 @@ fn build_effective_sink(overrides: &StoryOverrides, config: &StoryConfig) -> Val
             Value::String(sink_type.clone()),
         );
         if let Some(ref endpoint) = overrides.endpoint {
-            // Different sinks use different endpoint field names.
+            // Different sinks use different endpoint field names,
+            // matching the SinkConfig variant fields in sonda-core.
             let field = match sink_type.as_str() {
                 "http_push" | "remote_write" | "loki" => "url",
                 "tcp" | "udp" => "address",
+                "otlp_grpc" => "endpoint",
+                "file" => "path",
+                "kafka" => "brokers",
                 _ => "url",
             };
             map.insert(
@@ -984,5 +1149,351 @@ signals:
         let result = merge_labels(Some(&story), Some(&signal)).unwrap();
         assert_eq!(result.get("a").unwrap(), "override");
         assert_eq!(result.get("b").unwrap(), "2");
+    }
+
+    // -----------------------------------------------------------------------
+    // Duration cap (Fix 1)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn duration_cap_skips_signals_beyond_cap() {
+        // Story has 3 signals: A at t=0, B at t=60s, C at ~152s.
+        // With --duration 30s, only A should survive.
+        let yaml = r#"
+story: cap_test
+duration: 10m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+signals:
+  - metric: interface_oper_state
+    behavior: flap
+    up_duration: 60s
+    down_duration: 30s
+  - metric: backup_utilization
+    behavior: saturation
+    baseline: 20
+    ceiling: 85
+    time_to_saturate: 120s
+    after: interface_oper_state < 1
+  - metric: latency_ms
+    behavior: degradation
+    baseline: 5
+    ceiling: 150
+    time_to_degrade: 3m
+    after: backup_utilization > 70
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let overrides = StoryOverrides {
+            duration: Some("30s".to_string()),
+            ..Default::default()
+        };
+        let entries = compile_story(&config, &overrides).expect("should compile");
+        // Only the first signal (offset=0) fits within 30s.
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].base().name, "interface_oper_state");
+        // Its duration should be capped to 30s.
+        assert_eq!(entries[0].base().duration.as_deref(), Some("30s"));
+    }
+
+    #[test]
+    fn duration_cap_truncates_signal_duration() {
+        // Signal A starts at t=0 with a 5m story duration, but cap is 2m.
+        // Signal A's effective duration should be capped to 2m.
+        let yaml = r#"
+story: truncate_test
+duration: 5m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+signals:
+  - metric: cpu_usage
+    behavior: steady
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let overrides = StoryOverrides {
+            duration: Some("2m".to_string()),
+            ..Default::default()
+        };
+        let entries = compile_story(&config, &overrides).expect("should compile");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].base().duration.as_deref(), Some("2m"));
+    }
+
+    #[test]
+    fn duration_cap_keeps_signals_within_budget() {
+        // Signal A at t=0, B at t=60s. Cap is 3m.
+        // Both should be included: A gets 3m, B gets 2m.
+        let yaml = r#"
+story: budget_test
+duration: 10m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+signals:
+  - metric: interface_oper_state
+    behavior: flap
+    up_duration: 60s
+    down_duration: 30s
+  - metric: backup_utilization
+    behavior: saturation
+    baseline: 20
+    ceiling: 85
+    time_to_saturate: 120s
+    after: interface_oper_state < 1
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let overrides = StoryOverrides {
+            duration: Some("3m".to_string()),
+            ..Default::default()
+        };
+        let entries = compile_story(&config, &overrides).expect("should compile");
+        assert_eq!(entries.len(), 2);
+        // A: duration = min(10m, 3m - 0) = 3m
+        assert_eq!(entries[0].base().duration.as_deref(), Some("3m"));
+        // B: duration = min(10m, 3m - 60s) = 2m
+        assert_eq!(entries[1].base().duration.as_deref(), Some("2m"));
+    }
+
+    #[test]
+    fn duration_cap_skips_dependent_signals_only() {
+        // Story: A at offset=0, B at offset=60s. Cap=30s.
+        // B should be skipped, A survives with truncated duration.
+        let yaml = r#"
+story: skip_dependent
+duration: 10m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+signals:
+  - metric: interface_oper_state
+    behavior: flap
+    up_duration: 60s
+    down_duration: 30s
+  - metric: backup_utilization
+    behavior: saturation
+    baseline: 20
+    ceiling: 85
+    time_to_saturate: 120s
+    after: interface_oper_state < 1
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let overrides = StoryOverrides {
+            duration: Some("30s".to_string()),
+            ..Default::default()
+        };
+        let entries = compile_story(&config, &overrides).expect("should compile");
+        // Only A (offset=0) survives.
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].base().name, "interface_oper_state");
+    }
+
+    #[test]
+    fn duration_cap_no_cap_passes_duration_through() {
+        // Without a duration cap, signal gets the story duration unchanged.
+        let yaml = r#"
+story: no_cap_test
+duration: 5m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+signals:
+  - metric: cpu_usage
+    behavior: steady
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let entries = compile_story(&config, &StoryOverrides::default()).expect("should compile");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].base().duration.as_deref(), Some("5m"));
+    }
+
+    #[test]
+    fn duration_cap_per_signal_duration_respected_if_shorter() {
+        // Signal has its own duration (10s) which is shorter than cap (2m).
+        // Per-signal duration should be kept as-is.
+        let yaml = r#"
+story: per_signal_dur
+duration: 5m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+signals:
+  - metric: cpu_usage
+    behavior: steady
+    duration: 10s
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let overrides = StoryOverrides {
+            duration: Some("2m".to_string()),
+            ..Default::default()
+        };
+        let entries = compile_story(&config, &overrides).expect("should compile");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].base().duration.as_deref(), Some("10s"));
+    }
+
+    // -----------------------------------------------------------------------
+    // YAML label quoting (Fix 5)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn label_values_with_special_chars_are_quoted() {
+        let yaml = r#"
+story: quote_test
+rate: 1
+duration: 10s
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+labels:
+  url: "http://example.com:8080"
+  flag: "true"
+signals:
+  - metric: cpu_usage
+    behavior: steady
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let entries = compile_story(&config, &StoryOverrides::default()).expect("should compile");
+        assert_eq!(entries.len(), 1);
+        let base = entries[0].base();
+        let labels = base.labels.as_ref().expect("should have labels");
+        assert_eq!(labels.get("url").unwrap(), "http://example.com:8080");
+        assert_eq!(labels.get("flag").unwrap(), "true");
+    }
+
+    // -----------------------------------------------------------------------
+    // Sink endpoint field mapping (Fix 3)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_effective_sink_otlp_grpc_uses_endpoint_field() {
+        let config = StoryConfig {
+            story: "test".to_string(),
+            description: None,
+            duration: None,
+            rate: None,
+            encoder: None,
+            sink: None,
+            labels: None,
+            signals: vec![],
+        };
+        let overrides = StoryOverrides {
+            sink: Some("otlp_grpc".to_string()),
+            endpoint: Some("http://localhost:4317".to_string()),
+            ..Default::default()
+        };
+        let sink = build_effective_sink(&overrides, &config);
+        let map = sink.as_mapping().expect("should be a mapping");
+        // otlp_grpc should use "endpoint" field, not "url".
+        assert!(map.get(Value::String("endpoint".to_string())).is_some());
+        assert!(map.get(Value::String("url".to_string())).is_none());
+    }
+
+    #[test]
+    fn build_effective_sink_file_uses_path_field() {
+        let config = StoryConfig {
+            story: "test".to_string(),
+            description: None,
+            duration: None,
+            rate: None,
+            encoder: None,
+            sink: None,
+            labels: None,
+            signals: vec![],
+        };
+        let overrides = StoryOverrides {
+            sink: Some("file".to_string()),
+            endpoint: Some("/tmp/output.txt".to_string()),
+            ..Default::default()
+        };
+        let sink = build_effective_sink(&overrides, &config);
+        let map = sink.as_mapping().expect("should be a mapping");
+        assert!(map.get(Value::String("path".to_string())).is_some());
+        assert!(map.get(Value::String("url".to_string())).is_none());
+    }
+
+    #[test]
+    fn build_effective_sink_kafka_uses_brokers_field() {
+        let config = StoryConfig {
+            story: "test".to_string(),
+            description: None,
+            duration: None,
+            rate: None,
+            encoder: None,
+            sink: None,
+            labels: None,
+            signals: vec![],
+        };
+        let overrides = StoryOverrides {
+            sink: Some("kafka".to_string()),
+            endpoint: Some("localhost:9092".to_string()),
+            ..Default::default()
+        };
+        let sink = build_effective_sink(&overrides, &config);
+        let map = sink.as_mapping().expect("should be a mapping");
+        assert!(map.get(Value::String("brokers".to_string())).is_some());
+        assert!(map.get(Value::String("url".to_string())).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // format_duration_human
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn format_duration_human_seconds() {
+        assert_eq!(format_duration_human(30.0), "30s");
+    }
+
+    #[test]
+    fn format_duration_human_minutes_and_seconds() {
+        assert_eq!(format_duration_human(152.0), "2m32s");
+    }
+
+    #[test]
+    fn format_duration_human_exact_minutes() {
+        assert_eq!(format_duration_human(60.0), "1m");
+    }
+
+    #[test]
+    fn format_duration_human_zero() {
+        // Sub-second rounding to 0.
+        assert_eq!(format_duration_human(0.0), "0ms");
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_signal_duration
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compute_signal_duration_no_cap() {
+        let result = compute_signal_duration(None, Some("5m"), None, 0.0);
+        assert_eq!(result.as_deref(), Some("5m"));
+    }
+
+    #[test]
+    fn compute_signal_duration_cap_truncates() {
+        // Story duration 5m, cap 2m, offset 0 -> effective = 2m.
+        let result = compute_signal_duration(Some("5m"), Some("5m"), Some(120.0), 0.0);
+        assert_eq!(result.as_deref(), Some("2m"));
+    }
+
+    #[test]
+    fn compute_signal_duration_cap_with_offset() {
+        // Cap 3m, offset 60s -> remaining = 2m.
+        let result = compute_signal_duration(Some("5m"), Some("5m"), Some(180.0), 60.0);
+        assert_eq!(result.as_deref(), Some("2m"));
+    }
+
+    #[test]
+    fn compute_signal_duration_per_signal_shorter_than_cap() {
+        // Per-signal 10s, cap 2m, offset 0 -> keep 10s.
+        let result = compute_signal_duration(Some("10s"), Some("5m"), Some(120.0), 0.0);
+        assert_eq!(result.as_deref(), Some("10s"));
+    }
+
+    #[test]
+    fn compute_signal_duration_no_explicit_uses_remaining() {
+        // No per-signal or story duration string, but cap is 90s, offset 30s.
+        let result = compute_signal_duration(None, None, Some(90.0), 30.0);
+        assert_eq!(result.as_deref(), Some("1m"));
     }
 }

--- a/sonda/src/story/mod.rs
+++ b/sonda/src/story/mod.rs
@@ -1,0 +1,988 @@
+//! Story compilation layer for multi-signal temporal scenarios.
+//!
+//! Stories are a concise YAML format that expresses multi-signal scenarios
+//! with temporal causality. A story compiles down to the existing
+//! `Vec<ScenarioEntry>` + `phase_offset` infrastructure at parse time —
+//! there is no runtime reactivity.
+//!
+//! # Example Story YAML
+//!
+//! ```yaml
+//! story: link_failover
+//! description: "Edge router link failure with traffic shift to backup"
+//! duration: 5m
+//! rate: 1
+//! encoder: { type: prometheus_text }
+//! sink: { type: stdout }
+//! labels:
+//!   device: rtr-edge-01
+//!   job: network
+//!
+//! signals:
+//!   - metric: interface_oper_state
+//!     behavior: flap
+//!     up_duration: 60s
+//!     down_duration: 30s
+//!     labels:
+//!       interface: GigabitEthernet0/0/0
+//!
+//!   - metric: backup_link_utilization
+//!     behavior: saturation
+//!     baseline: 20
+//!     ceiling: 85
+//!     time_to_saturate: 2m
+//!     after: interface_oper_state < 1
+//!     labels:
+//!       interface: GigabitEthernet0/1/0
+//! ```
+//!
+//! # Compilation Flow
+//!
+//! 1. Parse YAML into [`StoryConfig`]
+//! 2. Resolve `after` clauses (topological sort + timing formulas)
+//! 3. Expand each signal into a [`ScenarioEntry`] with shared fields,
+//!    `phase_offset`, and `clock_group` injected
+//! 4. Return `Vec<ScenarioEntry>` for the existing `prepare_entries` pipeline
+
+pub mod after_resolve;
+pub mod timing;
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use serde_yaml_ng::Value;
+use sonda_core::config::ScenarioEntry;
+
+use self::after_resolve::{parse_after_clause, resolve_offsets, AfterClause, SignalParams};
+
+/// Top-level story configuration, parsed from YAML.
+///
+/// Contains shared fields that apply to all signals (unless overridden)
+/// and the list of signal definitions.
+#[derive(Debug)]
+pub struct StoryConfig {
+    /// Story identifier (used as `clock_group`).
+    pub story: String,
+    /// Human-readable description (currently parsed but not displayed).
+    #[allow(dead_code)]
+    pub description: Option<String>,
+    /// Shared duration for all signals (e.g., `"5m"`).
+    pub duration: Option<String>,
+    /// Shared event rate in events per second.
+    pub rate: Option<f64>,
+    /// Shared encoder configuration (raw YAML value).
+    pub encoder: Option<Value>,
+    /// Shared sink configuration (raw YAML value).
+    pub sink: Option<Value>,
+    /// Shared labels applied to all signals.
+    pub labels: Option<HashMap<String, String>>,
+    /// The signal definitions.
+    pub signals: Vec<SignalConfig>,
+}
+
+/// A single signal definition within a story.
+///
+/// Each signal maps to one `ScenarioEntry` after compilation.
+#[derive(Debug)]
+pub struct SignalConfig {
+    /// Metric name for this signal.
+    pub metric: String,
+    /// Behavior alias (e.g., `"flap"`, `"saturation"`, `"degradation"`).
+    pub behavior: String,
+    /// Optional `after` clause for temporal sequencing.
+    pub after: Option<String>,
+    /// Per-signal labels (merged with story-level labels).
+    pub labels: Option<HashMap<String, String>>,
+    /// Per-signal rate override.
+    pub rate: Option<f64>,
+    /// Per-signal duration override.
+    pub duration: Option<String>,
+    /// Per-signal encoder override (raw YAML value).
+    pub encoder: Option<Value>,
+    /// Per-signal sink override (raw YAML value).
+    pub sink: Option<Value>,
+    /// All remaining flat parameters (behavior-specific).
+    pub params: HashMap<String, Value>,
+}
+
+/// CLI overrides that can be applied to a story.
+///
+/// These override the story-level shared fields, not per-signal fields.
+#[derive(Debug, Default)]
+pub struct StoryOverrides {
+    /// Override the story duration.
+    pub duration: Option<String>,
+    /// Override the story rate.
+    pub rate: Option<f64>,
+    /// Override the story sink type.
+    pub sink: Option<String>,
+    /// Override the sink endpoint.
+    pub endpoint: Option<String>,
+    /// Override the encoder format.
+    pub encoder: Option<String>,
+}
+
+/// Load a story YAML file from disk and return its raw content.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read.
+pub fn load_story_yaml(path: &Path) -> Result<String> {
+    fs::read_to_string(path)
+        .with_context(|| format!("failed to read story file {}", path.display()))
+}
+
+/// Parse a story YAML string into a [`StoryConfig`].
+///
+/// # Errors
+///
+/// Returns an error if the YAML structure is invalid or required fields
+/// are missing.
+pub fn parse_story(yaml: &str) -> Result<StoryConfig> {
+    let root: Value = serde_yaml_ng::from_str(yaml).context("invalid YAML in story file")?;
+
+    let mapping = root
+        .as_mapping()
+        .ok_or_else(|| anyhow::anyhow!("story file must be a YAML mapping at the top level"))?;
+
+    let story = get_string(mapping, "story")
+        .ok_or_else(|| anyhow::anyhow!("story file must have a 'story' field (string)"))?;
+
+    let description = get_string(mapping, "description");
+    let duration = get_string(mapping, "duration");
+    let rate = get_f64(mapping, "rate");
+    let encoder = mapping.get(Value::String("encoder".to_string())).cloned();
+    let sink = mapping.get(Value::String("sink".to_string())).cloned();
+    let labels = parse_labels(mapping.get(Value::String("labels".to_string())));
+
+    let signals_val = mapping
+        .get(Value::String("signals".to_string()))
+        .ok_or_else(|| anyhow::anyhow!("story file must have a 'signals' list"))?;
+
+    let signals_seq = signals_val
+        .as_sequence()
+        .ok_or_else(|| anyhow::anyhow!("'signals' must be a YAML sequence"))?;
+
+    if signals_seq.is_empty() {
+        bail!("'signals' list must not be empty");
+    }
+
+    let mut signals = Vec::with_capacity(signals_seq.len());
+    for (i, val) in signals_seq.iter().enumerate() {
+        let sig = parse_signal(val).with_context(|| format!("error in signal[{i}]"))?;
+        signals.push(sig);
+    }
+
+    // Check for duplicate metric names.
+    let mut seen = HashMap::new();
+    for (i, sig) in signals.iter().enumerate() {
+        if let Some(prev) = seen.insert(&sig.metric, i) {
+            bail!(
+                "duplicate metric name {:?} in signals[{prev}] and signals[{i}]",
+                sig.metric
+            );
+        }
+    }
+
+    Ok(StoryConfig {
+        story,
+        description,
+        duration,
+        rate,
+        encoder,
+        sink,
+        labels,
+        signals,
+    })
+}
+
+/// Compile a [`StoryConfig`] into a `Vec<ScenarioEntry>`, resolving `after`
+/// clauses into `phase_offset` values.
+///
+/// Applies `overrides` to story-level shared fields before expanding signals.
+///
+/// # Errors
+///
+/// Returns an error if `after` clause resolution fails (unknown references,
+/// cycles, unsupported behaviors, out-of-range thresholds).
+pub fn compile_story(
+    config: &StoryConfig,
+    overrides: &StoryOverrides,
+) -> Result<Vec<ScenarioEntry>> {
+    // Resolve effective shared fields (CLI overrides > story fields).
+    let effective_rate = overrides.rate.or(config.rate).unwrap_or(1.0);
+    let effective_duration = overrides.duration.as_deref().or(config.duration.as_deref());
+    let effective_encoder = build_effective_encoder(overrides, config);
+    let effective_sink = build_effective_sink(overrides, config);
+
+    // Build the signal list for after-clause resolution.
+    let signal_tuples: Vec<(String, Option<AfterClause>, SignalParams)> = config
+        .signals
+        .iter()
+        .map(|sig| {
+            let after_clause = sig
+                .after
+                .as_deref()
+                .map(parse_after_clause)
+                .transpose()
+                .map_err(|e| {
+                    anyhow::anyhow!("signal {:?}: invalid after clause: {e}", sig.metric)
+                })?;
+
+            let params = SignalParams {
+                behavior: sig.behavior.clone(),
+                params: sig.params.clone(),
+            };
+
+            Ok((sig.metric.clone(), after_clause, params))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // Resolve all offsets.
+    let offsets = resolve_offsets(&signal_tuples).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    // Expand each signal into a ScenarioEntry.
+    let mut entries = Vec::with_capacity(config.signals.len());
+
+    for sig in &config.signals {
+        let offset_secs = offsets[&sig.metric];
+
+        // Build merged labels: story-level + signal-level (signal wins on conflict).
+        let merged_labels = merge_labels(config.labels.as_ref(), sig.labels.as_ref());
+
+        // Determine per-signal rate, duration, encoder, sink.
+        let sig_rate = sig.rate.unwrap_or(effective_rate);
+        let sig_duration = sig
+            .duration
+            .as_deref()
+            .or(effective_duration)
+            .map(|s| s.to_string());
+        let sig_encoder = sig.encoder.as_ref().unwrap_or(&effective_encoder);
+        let sig_sink = sig.sink.as_ref().unwrap_or(&effective_sink);
+
+        // Build the phase_offset string.
+        let phase_offset = if offset_secs > 0.0 {
+            Some(format_duration_secs(offset_secs))
+        } else {
+            None
+        };
+
+        // Build a YAML snippet for the generator config from behavior + flat params.
+        let generator_yaml = build_generator_yaml(&sig.behavior, &sig.params);
+
+        // Build the full scenario entry YAML and deserialize it.
+        let entry_yaml = build_entry_yaml(&EntryYamlParams {
+            name: &sig.metric,
+            rate: sig_rate,
+            duration: sig_duration.as_deref(),
+            generator_yaml: &generator_yaml,
+            encoder: sig_encoder,
+            sink: sig_sink,
+            labels: &merged_labels,
+            phase_offset: phase_offset.as_deref(),
+            clock_group: &config.story,
+        })?;
+
+        let entry: ScenarioEntry = serde_yaml_ng::from_str(&entry_yaml).with_context(|| {
+            format!(
+                "failed to deserialize compiled scenario for signal {:?}:\n{}",
+                sig.metric, entry_yaml
+            )
+        })?;
+
+        entries.push(entry);
+    }
+
+    Ok(entries)
+}
+
+/// Build a YAML snippet for the generator from a behavior alias and flat params.
+///
+/// This produces something like:
+/// ```yaml
+/// type: flap
+/// up_duration: "60s"
+/// down_duration: "30s"
+/// ```
+fn build_generator_yaml(behavior: &str, params: &HashMap<String, Value>) -> String {
+    let mut lines = Vec::with_capacity(params.len() + 1);
+    lines.push(format!("type: {behavior}"));
+
+    // Sort keys for deterministic output.
+    let mut sorted: Vec<(&String, &Value)> = params.iter().collect();
+    sorted.sort_by_key(|(k, _)| *k);
+
+    for (key, value) in sorted {
+        let val_str = format_yaml_value(value);
+        lines.push(format!("{key}: {val_str}"));
+    }
+
+    lines.join("\n")
+}
+
+/// Format a serde_yaml_ng::Value for inline YAML output.
+fn format_yaml_value(value: &Value) -> String {
+    match value {
+        Value::String(s) => {
+            // Quote strings that might be misinterpreted by YAML.
+            if needs_quoting(s) {
+                format!("{s:?}")
+            } else {
+                s.clone()
+            }
+        }
+        Value::Number(n) => format!("{n}"),
+        Value::Bool(b) => format!("{b}"),
+        Value::Null => "null".to_string(),
+        _ => serde_yaml_ng::to_string(value).unwrap_or_else(|_| "null".to_string()),
+    }
+}
+
+/// Check if a string value needs YAML quoting.
+fn needs_quoting(s: &str) -> bool {
+    // Quote if it contains special chars, looks like a number, or is a YAML keyword.
+    s.is_empty()
+        || s.contains(':')
+        || s.contains('#')
+        || s.contains('{')
+        || s.contains('}')
+        || s.contains('[')
+        || s.contains(']')
+        || s.contains('\'')
+        || s.contains('"')
+        || s.contains('\n')
+        || s.starts_with(' ')
+        || s.ends_with(' ')
+        || matches!(s, "true" | "false" | "null" | "yes" | "no" | "on" | "off")
+        || s.parse::<f64>().is_ok()
+}
+
+/// Parameters for building a ScenarioEntry YAML string.
+struct EntryYamlParams<'a> {
+    name: &'a str,
+    rate: f64,
+    duration: Option<&'a str>,
+    generator_yaml: &'a str,
+    encoder: &'a Value,
+    sink: &'a Value,
+    labels: &'a Option<HashMap<String, String>>,
+    phase_offset: Option<&'a str>,
+    clock_group: &'a str,
+}
+
+/// Build a full ScenarioEntry YAML string from compiled signal fields.
+fn build_entry_yaml(p: &EntryYamlParams<'_>) -> Result<String> {
+    let mut lines = Vec::new();
+
+    lines.push("signal_type: metrics".to_string());
+    lines.push(format!("name: {}", p.name));
+    lines.push(format!("rate: {}", p.rate));
+
+    if let Some(dur) = p.duration {
+        lines.push(format!("duration: {dur}"));
+    }
+
+    // Generator block.
+    lines.push("generator:".to_string());
+    for gen_line in p.generator_yaml.lines() {
+        lines.push(format!("  {gen_line}"));
+    }
+
+    // Encoder.
+    let encoder_str =
+        serde_yaml_ng::to_string(p.encoder).context("failed to serialize encoder config")?;
+    lines.push("encoder:".to_string());
+    for enc_line in encoder_str.trim().lines() {
+        lines.push(format!("  {enc_line}"));
+    }
+
+    // Sink.
+    let sink_str = serde_yaml_ng::to_string(p.sink).context("failed to serialize sink config")?;
+    lines.push("sink:".to_string());
+    for sink_line in sink_str.trim().lines() {
+        lines.push(format!("  {sink_line}"));
+    }
+
+    // Labels.
+    if let Some(ref lbl) = p.labels {
+        if !lbl.is_empty() {
+            lines.push("labels:".to_string());
+            let mut sorted_labels: Vec<_> = lbl.iter().collect();
+            sorted_labels.sort_by_key(|(k, _)| *k);
+            for (k, v) in sorted_labels {
+                lines.push(format!("  {k}: {v}"));
+            }
+        }
+    }
+
+    // Phase offset.
+    if let Some(offset) = p.phase_offset {
+        lines.push(format!("phase_offset: {offset}"));
+    }
+
+    // Clock group.
+    lines.push(format!("clock_group: {}", p.clock_group));
+
+    Ok(lines.join("\n"))
+}
+
+/// Merge story-level labels with signal-level labels.
+///
+/// Signal labels override story labels on key conflict.
+fn merge_labels(
+    story_labels: Option<&HashMap<String, String>>,
+    signal_labels: Option<&HashMap<String, String>>,
+) -> Option<HashMap<String, String>> {
+    match (story_labels, signal_labels) {
+        (None, None) => None,
+        (Some(s), None) => Some(s.clone()),
+        (None, Some(s)) => Some(s.clone()),
+        (Some(story), Some(signal)) => {
+            let mut merged = story.clone();
+            for (k, v) in signal {
+                merged.insert(k.clone(), v.clone());
+            }
+            Some(merged)
+        }
+    }
+}
+
+/// Build the effective encoder value from overrides and config.
+fn build_effective_encoder(overrides: &StoryOverrides, config: &StoryConfig) -> Value {
+    if let Some(ref enc) = overrides.encoder {
+        // Build a simple encoder YAML value from the string.
+        let mut map = serde_yaml_ng::Mapping::new();
+        map.insert(
+            Value::String("type".to_string()),
+            Value::String(enc.clone()),
+        );
+        Value::Mapping(map)
+    } else {
+        config.encoder.clone().unwrap_or_else(|| {
+            let mut map = serde_yaml_ng::Mapping::new();
+            map.insert(
+                Value::String("type".to_string()),
+                Value::String("prometheus_text".to_string()),
+            );
+            Value::Mapping(map)
+        })
+    }
+}
+
+/// Build the effective sink value from overrides and config.
+fn build_effective_sink(overrides: &StoryOverrides, config: &StoryConfig) -> Value {
+    if let Some(ref sink_type) = overrides.sink {
+        let mut map = serde_yaml_ng::Mapping::new();
+        map.insert(
+            Value::String("type".to_string()),
+            Value::String(sink_type.clone()),
+        );
+        if let Some(ref endpoint) = overrides.endpoint {
+            // Different sinks use different endpoint field names.
+            let field = match sink_type.as_str() {
+                "http_push" | "remote_write" | "loki" => "url",
+                "tcp" | "udp" => "address",
+                _ => "url",
+            };
+            map.insert(
+                Value::String(field.to_string()),
+                Value::String(endpoint.clone()),
+            );
+        }
+        Value::Mapping(map)
+    } else {
+        config.sink.clone().unwrap_or_else(|| {
+            let mut map = serde_yaml_ng::Mapping::new();
+            map.insert(
+                Value::String("type".to_string()),
+                Value::String("stdout".to_string()),
+            );
+            Value::Mapping(map)
+        })
+    }
+}
+
+/// Format a duration in seconds as a human-readable string.
+///
+/// Uses the largest whole unit that divides evenly, otherwise falls back
+/// to fractional seconds with millisecond precision.
+fn format_duration_secs(secs: f64) -> String {
+    if secs <= 0.0 {
+        return "0s".to_string();
+    }
+
+    // Try whole seconds first.
+    let ms = (secs * 1000.0).round() as u64;
+    if ms.is_multiple_of(1000) {
+        let whole_secs = ms / 1000;
+        if whole_secs.is_multiple_of(3600) && whole_secs > 0 {
+            return format!("{}h", whole_secs / 3600);
+        }
+        if whole_secs.is_multiple_of(60) && whole_secs > 0 {
+            return format!("{}m", whole_secs / 60);
+        }
+        return format!("{whole_secs}s");
+    }
+
+    // Fractional seconds — use milliseconds if sub-second, else fractional seconds.
+    if ms < 1000 {
+        return format!("{ms}ms");
+    }
+
+    // Use fractional seconds with up to 3 decimal places.
+    let rounded = (secs * 1000.0).round() / 1000.0;
+    format!("{rounded}s")
+}
+
+/// Parse a signal definition from a YAML value.
+fn parse_signal(val: &Value) -> Result<SignalConfig> {
+    let mapping = val
+        .as_mapping()
+        .ok_or_else(|| anyhow::anyhow!("each signal must be a YAML mapping"))?;
+
+    let metric = get_string(mapping, "metric")
+        .ok_or_else(|| anyhow::anyhow!("signal must have a 'metric' field"))?;
+
+    let behavior = get_string(mapping, "behavior")
+        .ok_or_else(|| anyhow::anyhow!("signal must have a 'behavior' field"))?;
+
+    let after = get_string(mapping, "after");
+    let labels = parse_labels(mapping.get(Value::String("labels".to_string())));
+    let rate = get_f64(mapping, "rate");
+    let duration = get_string(mapping, "duration");
+    let encoder = mapping.get(Value::String("encoder".to_string())).cloned();
+    let sink = mapping.get(Value::String("sink".to_string())).cloned();
+
+    // Collect all remaining keys as behavior params.
+    let reserved = [
+        "metric",
+        "behavior",
+        "after",
+        "labels",
+        "rate",
+        "duration",
+        "encoder",
+        "sink",
+        "signal_type",
+    ];
+    let mut params = HashMap::new();
+    for (k, v) in mapping {
+        if let Value::String(key) = k {
+            if !reserved.contains(&key.as_str()) {
+                params.insert(key.clone(), v.clone());
+            }
+        }
+    }
+
+    Ok(SignalConfig {
+        metric,
+        behavior,
+        after,
+        labels,
+        rate,
+        duration,
+        encoder,
+        sink,
+        params,
+    })
+}
+
+/// Extract a string value from a YAML mapping.
+fn get_string(mapping: &serde_yaml_ng::Mapping, key: &str) -> Option<String> {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(|v| match v {
+            Value::String(s) => Some(s.clone()),
+            // Handle bare numbers/bools that YAML might auto-parse.
+            Value::Number(n) => Some(format!("{n}")),
+            Value::Bool(b) => Some(format!("{b}")),
+            _ => None,
+        })
+}
+
+/// Extract an f64 value from a YAML mapping.
+fn get_f64(mapping: &serde_yaml_ng::Mapping, key: &str) -> Option<f64> {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(|v| match v {
+            Value::Number(n) => n.as_f64(),
+            Value::String(s) => s.parse().ok(),
+            _ => None,
+        })
+}
+
+/// Parse a labels YAML value into a `HashMap<String, String>`.
+fn parse_labels(val: Option<&Value>) -> Option<HashMap<String, String>> {
+    val.and_then(|v| v.as_mapping()).map(|m| {
+        m.iter()
+            .filter_map(|(k, v)| {
+                let key = match k {
+                    Value::String(s) => s.clone(),
+                    _ => return None,
+                };
+                let value = match v {
+                    Value::String(s) => s.clone(),
+                    Value::Number(n) => format!("{n}"),
+                    Value::Bool(b) => format!("{b}"),
+                    _ => return None,
+                };
+                Some((key, value))
+            })
+            .collect()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // parse_story
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_minimal_story() {
+        let yaml = r#"
+story: test_story
+signals:
+  - metric: cpu_usage
+    behavior: steady
+"#;
+        let config = parse_story(yaml).expect("should parse minimal story");
+        assert_eq!(config.story, "test_story");
+        assert_eq!(config.signals.len(), 1);
+        assert_eq!(config.signals[0].metric, "cpu_usage");
+        assert_eq!(config.signals[0].behavior, "steady");
+    }
+
+    #[test]
+    fn parse_story_with_all_shared_fields() {
+        let yaml = r#"
+story: link_failover
+description: "Edge router link failure"
+duration: 5m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+labels:
+  device: rtr-edge-01
+  job: network
+signals:
+  - metric: interface_oper_state
+    behavior: flap
+    up_duration: 60s
+    down_duration: 30s
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        assert_eq!(config.story, "link_failover");
+        assert_eq!(
+            config.description.as_deref(),
+            Some("Edge router link failure")
+        );
+        assert_eq!(config.duration.as_deref(), Some("5m"));
+        assert!((config.rate.unwrap() - 1.0).abs() < f64::EPSILON);
+        assert!(config.labels.is_some());
+        let labels = config.labels.as_ref().unwrap();
+        assert_eq!(labels.get("device").unwrap(), "rtr-edge-01");
+        assert_eq!(labels.get("job").unwrap(), "network");
+    }
+
+    #[test]
+    fn parse_story_missing_story_field() {
+        let yaml = r#"
+signals:
+  - metric: cpu
+    behavior: steady
+"#;
+        let err = parse_story(yaml).expect_err("should fail");
+        assert!(err.to_string().contains("story"), "got: {}", err);
+    }
+
+    #[test]
+    fn parse_story_empty_signals() {
+        let yaml = r#"
+story: test
+signals: []
+"#;
+        let err = parse_story(yaml).expect_err("should fail");
+        assert!(err.to_string().contains("empty"), "got: {}", err);
+    }
+
+    #[test]
+    fn parse_story_duplicate_metrics() {
+        let yaml = r#"
+story: test
+signals:
+  - metric: cpu_usage
+    behavior: steady
+  - metric: cpu_usage
+    behavior: flap
+"#;
+        let err = parse_story(yaml).expect_err("should fail");
+        assert!(err.to_string().contains("duplicate"), "got: {}", err);
+    }
+
+    #[test]
+    fn parse_signal_flat_params() {
+        let yaml = r#"
+story: test
+signals:
+  - metric: interface_oper_state
+    behavior: flap
+    up_duration: 60s
+    down_duration: 30s
+    up_value: 1.0
+    down_value: 0.0
+    labels:
+      interface: GigabitEthernet0/0/0
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let sig = &config.signals[0];
+        assert_eq!(sig.params.len(), 4);
+        assert!(sig.labels.is_some());
+        let labels = sig.labels.as_ref().unwrap();
+        assert_eq!(labels.get("interface").unwrap(), "GigabitEthernet0/0/0");
+    }
+
+    // -----------------------------------------------------------------------
+    // compile_story
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compile_story_no_after_clauses() {
+        let yaml = r#"
+story: test_compile
+duration: 30s
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+signals:
+  - metric: cpu_usage
+    behavior: steady
+    center: 75.0
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let entries = compile_story(&config, &StoryOverrides::default()).expect("should compile");
+        assert_eq!(entries.len(), 1);
+
+        // Verify the entry has the correct clock_group.
+        assert_eq!(entries[0].clock_group(), Some("test_compile"));
+        // No phase_offset since no after clause.
+        assert!(entries[0].phase_offset().is_none());
+    }
+
+    #[test]
+    fn compile_story_with_after_clause() {
+        let yaml = r#"
+story: failover
+duration: 5m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+signals:
+  - metric: interface_oper_state
+    behavior: flap
+    up_duration: 60s
+    down_duration: 30s
+  - metric: backup_link_utilization
+    behavior: saturation
+    baseline: 20
+    ceiling: 85
+    time_to_saturate: 2m
+    after: interface_oper_state < 1
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let entries = compile_story(&config, &StoryOverrides::default()).expect("should compile");
+        assert_eq!(entries.len(), 2);
+
+        // First signal: no offset.
+        assert!(entries[0].phase_offset().is_none());
+        // Second signal: offset = 60s (up_duration of flap).
+        // format_duration_secs(60.0) produces "1m".
+        assert!(entries[1].phase_offset().is_some());
+        let offset = entries[1].phase_offset().unwrap();
+        assert_eq!(offset, "1m", "expected 1m offset, got {offset}");
+
+        // Both should share the same clock_group.
+        assert_eq!(entries[0].clock_group(), Some("failover"));
+        assert_eq!(entries[1].clock_group(), Some("failover"));
+    }
+
+    #[test]
+    fn compile_story_with_label_merging() {
+        let yaml = r#"
+story: label_test
+rate: 1
+duration: 10s
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+labels:
+  device: rtr-01
+  job: network
+signals:
+  - metric: cpu_usage
+    behavior: steady
+    labels:
+      interface: eth0
+      device: rtr-02
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let entries = compile_story(&config, &StoryOverrides::default()).expect("should compile");
+        assert_eq!(entries.len(), 1);
+
+        // Check the labels on the entry.
+        let base = entries[0].base();
+        let labels = base.labels.as_ref().expect("should have labels");
+        // Signal's device=rtr-02 should override story's device=rtr-01.
+        assert_eq!(labels.get("device").unwrap(), "rtr-02");
+        // Story's job=network should be present.
+        assert_eq!(labels.get("job").unwrap(), "network");
+        // Signal's interface=eth0 should be present.
+        assert_eq!(labels.get("interface").unwrap(), "eth0");
+    }
+
+    #[test]
+    fn compile_story_with_cli_overrides() {
+        let yaml = r#"
+story: test_override
+duration: 5m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+signals:
+  - metric: cpu_usage
+    behavior: steady
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let overrides = StoryOverrides {
+            duration: Some("2m".to_string()),
+            rate: Some(10.0),
+            ..Default::default()
+        };
+        let entries = compile_story(&config, &overrides).expect("should compile");
+        assert_eq!(entries.len(), 1);
+
+        let base = entries[0].base();
+        assert!((base.rate - 10.0).abs() < f64::EPSILON);
+        assert_eq!(base.duration.as_deref(), Some("2m"));
+    }
+
+    #[test]
+    fn compile_story_with_transitive_after() {
+        let yaml = r#"
+story: transitive
+duration: 10m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+signals:
+  - metric: interface_oper_state
+    behavior: flap
+    up_duration: 60s
+    down_duration: 30s
+  - metric: backup_utilization
+    behavior: saturation
+    baseline: 20
+    ceiling: 85
+    time_to_saturate: 120s
+    after: interface_oper_state < 1
+  - metric: latency_ms
+    behavior: degradation
+    baseline: 5
+    ceiling: 150
+    time_to_degrade: 3m
+    after: backup_utilization > 70
+"#;
+        let config = parse_story(yaml).expect("should parse");
+        let entries = compile_story(&config, &StoryOverrides::default()).expect("should compile");
+        assert_eq!(entries.len(), 3);
+
+        // Verify offsets: A=0, B=60s (formatted as 1m), C=60s + (70-20)/(85-20)*120s
+        assert!(entries[0].phase_offset().is_none());
+        assert_eq!(entries[1].phase_offset().unwrap(), "1m");
+        // C offset = 60 + 92.307... = 152.307...s
+        let c_offset = entries[2].phase_offset().expect("should have offset");
+        // Parse it back to verify.
+        let c_dur =
+            sonda_core::config::validate::parse_duration(c_offset).expect("should parse offset");
+        let expected_c = 60.0 + (70.0 - 20.0) / (85.0 - 20.0) * 120.0;
+        assert!(
+            (c_dur.as_secs_f64() - expected_c).abs() < 0.01,
+            "expected ~{expected_c}s, got {}s from {:?}",
+            c_dur.as_secs_f64(),
+            c_offset
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // format_duration_secs
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn format_duration_whole_seconds() {
+        assert_eq!(format_duration_secs(30.0), "30s");
+    }
+
+    #[test]
+    fn format_duration_whole_minutes() {
+        assert_eq!(format_duration_secs(120.0), "2m");
+    }
+
+    #[test]
+    fn format_duration_whole_hours() {
+        assert_eq!(format_duration_secs(3600.0), "1h");
+    }
+
+    #[test]
+    fn format_duration_fractional_seconds() {
+        let result = format_duration_secs(92.307);
+        // Should produce a parseable duration string.
+        let dur = sonda_core::config::validate::parse_duration(&result)
+            .expect("formatted duration should be parseable");
+        assert!(
+            (dur.as_secs_f64() - 92.307).abs() < 0.01,
+            "got {}, expected ~92.307",
+            dur.as_secs_f64()
+        );
+    }
+
+    #[test]
+    fn format_duration_zero() {
+        assert_eq!(format_duration_secs(0.0), "0s");
+    }
+
+    #[test]
+    fn format_duration_sub_second() {
+        assert_eq!(format_duration_secs(0.5), "500ms");
+    }
+
+    // -----------------------------------------------------------------------
+    // merge_labels
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn merge_labels_both_none() {
+        assert!(merge_labels(None, None).is_none());
+    }
+
+    #[test]
+    fn merge_labels_story_only() {
+        let story = HashMap::from([("a".to_string(), "1".to_string())]);
+        let result = merge_labels(Some(&story), None).unwrap();
+        assert_eq!(result.get("a").unwrap(), "1");
+    }
+
+    #[test]
+    fn merge_labels_signal_overrides() {
+        let story = HashMap::from([
+            ("a".to_string(), "1".to_string()),
+            ("b".to_string(), "2".to_string()),
+        ]);
+        let signal = HashMap::from([("a".to_string(), "override".to_string())]);
+        let result = merge_labels(Some(&story), Some(&signal)).unwrap();
+        assert_eq!(result.get("a").unwrap(), "override");
+        assert_eq!(result.get("b").unwrap(), "2");
+    }
+}

--- a/sonda/src/story/timing.rs
+++ b/sonda/src/story/timing.rs
@@ -1,0 +1,584 @@
+//! Pure timing functions for computing when a signal crosses a threshold.
+//!
+//! Each supported behavior alias has a deterministic formula that computes
+//! the time (in seconds) at which the signal first crosses the given
+//! threshold. These functions are pure — no I/O, no side effects, no
+//! allocations.
+//!
+//! The formulas mirror the generator math from `sonda-core`:
+//!
+//! | Alias | Generator | Formula |
+//! |-------|-----------|---------|
+//! | **flap** | Sequence (up/down) | `<` threshold: `up_duration_secs` |
+//! | **saturation** | Sawtooth (baseline→ceiling, repeating) | linear interpolation |
+//! | **leak** | Sawtooth (baseline→ceiling, one-shot) | same as saturation |
+//! | **degradation** | Sawtooth + jitter | same as saturation |
+//! | **spike_event** | Spike (baseline + magnitude pulses) | spike start or end |
+//! | **steady** | Sine + jitter | **not supported** (ambiguous) |
+
+use std::fmt;
+
+/// Error from threshold-crossing computation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TimingError {
+    /// The threshold falls outside the signal's output range.
+    OutOfRange {
+        /// Human-readable description of the problem.
+        message: String,
+    },
+    /// The behavior alias does not support threshold-crossing computation.
+    Unsupported {
+        /// Human-readable description of the problem.
+        message: String,
+    },
+    /// The crossing condition is ambiguous or trivially satisfied at t=0.
+    Ambiguous {
+        /// Human-readable description of the problem.
+        message: String,
+    },
+}
+
+impl fmt::Display for TimingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TimingError::OutOfRange { message } => write!(f, "{message}"),
+            TimingError::Unsupported { message } => write!(f, "{message}"),
+            TimingError::Ambiguous { message } => write!(f, "{message}"),
+        }
+    }
+}
+
+/// Comparison operator parsed from an `after` clause.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operator {
+    /// `<` — signal drops below threshold.
+    LessThan,
+    /// `>` — signal rises above threshold.
+    GreaterThan,
+}
+
+impl fmt::Display for Operator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Operator::LessThan => write!(f, "<"),
+            Operator::GreaterThan => write!(f, ">"),
+        }
+    }
+}
+
+/// Compute the time offset (in seconds) at which a **flap** signal first
+/// crosses the given threshold.
+///
+/// A flap signal alternates between `up_value` (default 1.0) and `down_value`
+/// (default 0.0). The `<` operator detects the transition to the down state
+/// (at `up_duration_secs`). The `>` operator on a standard flap (up_value=1,
+/// down_value=0) is satisfied at t=0 which is ambiguous.
+///
+/// # Errors
+///
+/// - `Ambiguous` when the condition is satisfied at t=0.
+/// - `OutOfRange` when the threshold is outside `[down_value, up_value]`.
+pub fn flap_crossing_secs(
+    op: Operator,
+    threshold: f64,
+    up_duration_secs: f64,
+    _down_duration_secs: f64,
+    up_value: f64,
+    down_value: f64,
+) -> Result<f64, TimingError> {
+    let (lo, hi) = if up_value >= down_value {
+        (down_value, up_value)
+    } else {
+        (up_value, down_value)
+    };
+
+    match op {
+        Operator::LessThan => {
+            // "< threshold" — we want the signal to drop below threshold.
+            // The flap signal starts at up_value for up_duration, then drops to down_value.
+            if threshold <= lo {
+                return Err(TimingError::OutOfRange {
+                    message: format!(
+                        "threshold {threshold} is at or below the down_value {down_value}; \
+                         the flap signal never goes below it"
+                    ),
+                });
+            }
+            if threshold > hi {
+                // Signal starts below threshold — satisfied at t=0.
+                return Err(TimingError::Ambiguous {
+                    message: format!(
+                        "threshold {threshold} is above up_value {up_value}; \
+                         the flap signal is always below it (satisfied at t=0)"
+                    ),
+                });
+            }
+            // The drop happens at the transition from up to down phase.
+            // If down_value < threshold, that's at up_duration_secs.
+            if down_value < threshold {
+                Ok(up_duration_secs)
+            } else {
+                Err(TimingError::OutOfRange {
+                    message: format!(
+                        "down_value {down_value} is not less than threshold {threshold}; \
+                         the flap signal never drops below {threshold}"
+                    ),
+                })
+            }
+        }
+        Operator::GreaterThan => {
+            // "> threshold" — we want the signal to rise above threshold.
+            if threshold >= hi {
+                return Err(TimingError::OutOfRange {
+                    message: format!(
+                        "threshold {threshold} is at or above up_value {up_value}; \
+                         the flap signal never exceeds it"
+                    ),
+                });
+            }
+            if threshold < lo {
+                // Signal starts above threshold at t=0.
+                return Err(TimingError::Ambiguous {
+                    message: format!(
+                        "threshold {threshold} is below down_value {down_value}; \
+                         the flap signal is always above it (satisfied at t=0)"
+                    ),
+                });
+            }
+            // If up_value > threshold, the signal starts in the up state which
+            // already satisfies the condition at t=0.
+            if up_value > threshold {
+                return Err(TimingError::Ambiguous {
+                    message: format!(
+                        "\"{} > {threshold}\" is satisfied at t=0 \
+                         (starts at up_value {up_value}). \
+                         Use \"<\" to detect the down event",
+                        "flap_signal"
+                    ),
+                });
+            }
+            // up_value == threshold but down_value < threshold:
+            // the signal returns to up_value after down phase, but up_value
+            // is not strictly greater than threshold. This is not satisfiable.
+            Err(TimingError::OutOfRange {
+                message: format!(
+                    "up_value {up_value} equals threshold {threshold}; \
+                     the signal never strictly exceeds it"
+                ),
+            })
+        }
+    }
+}
+
+/// Compute the time offset (in seconds) at which a **sawtooth-based** signal
+/// (saturation, leak, degradation) first crosses the given threshold.
+///
+/// These aliases all desugar to a sawtooth that ramps linearly from `baseline`
+/// to `ceiling` over `period_secs`. The crossing time is computed via linear
+/// interpolation.
+///
+/// # Errors
+///
+/// - `OutOfRange` when the threshold is outside `[baseline, ceiling]`.
+/// - `Ambiguous` when the condition is trivially satisfied at t=0.
+pub fn sawtooth_crossing_secs(
+    op: Operator,
+    threshold: f64,
+    baseline: f64,
+    ceiling: f64,
+    period_secs: f64,
+) -> Result<f64, TimingError> {
+    let range = ceiling - baseline;
+    if range.abs() < f64::EPSILON {
+        return Err(TimingError::OutOfRange {
+            message: format!(
+                "baseline ({baseline}) equals ceiling ({ceiling}); \
+                 the signal is constant and cannot cross any threshold"
+            ),
+        });
+    }
+
+    // Normalize so we always think of baseline < ceiling.
+    let (lo, hi) = if baseline <= ceiling {
+        (baseline, ceiling)
+    } else {
+        (ceiling, baseline)
+    };
+
+    match op {
+        Operator::GreaterThan => {
+            // "> threshold" — signal ramps from baseline toward ceiling.
+            if threshold >= hi {
+                return Err(TimingError::OutOfRange {
+                    message: format!(
+                        "threshold {threshold} is at or above ceiling {ceiling}; \
+                         the signal never exceeds it"
+                    ),
+                });
+            }
+            if threshold < lo {
+                return Err(TimingError::Ambiguous {
+                    message: format!(
+                        "threshold {threshold} is below baseline {baseline}; \
+                         the signal starts above it (satisfied at t=0)"
+                    ),
+                });
+            }
+            // Linear interpolation: t = (threshold - baseline) / (ceiling - baseline) * period
+            let fraction = (threshold - baseline) / range;
+            Ok(fraction * period_secs)
+        }
+        Operator::LessThan => {
+            // "< threshold" — the sawtooth starts at baseline and ramps up.
+            // It only goes below baseline after a reset (which is a saturation
+            // behavior). For a single ramp, the signal never goes below baseline.
+            if threshold <= lo {
+                return Err(TimingError::OutOfRange {
+                    message: format!(
+                        "threshold {threshold} is at or below baseline {baseline}; \
+                         the signal never drops below it"
+                    ),
+                });
+            }
+            if threshold > hi {
+                // Signal is always below threshold (starts at baseline < threshold).
+                return Err(TimingError::Ambiguous {
+                    message: format!(
+                        "threshold {threshold} is above ceiling {ceiling}; \
+                         the signal is always below it (satisfied at t=0)"
+                    ),
+                });
+            }
+            // For a ramp from baseline to ceiling, the signal starts below
+            // threshold if baseline < threshold. That means it's satisfied at t=0.
+            if baseline < threshold {
+                return Err(TimingError::Ambiguous {
+                    message: format!(
+                        "signal starts at baseline {baseline} which is already \
+                         below threshold {threshold} (satisfied at t=0)"
+                    ),
+                });
+            }
+            Err(TimingError::OutOfRange {
+                message: format!(
+                    "the sawtooth ramps from {baseline} toward {ceiling}; \
+                     it does not cross below {threshold} during the ramp"
+                ),
+            })
+        }
+    }
+}
+
+/// Compute the time offset (in seconds) at which a **spike_event** signal
+/// first crosses the given threshold.
+///
+/// A spike_event produces `baseline` normally, then spikes to
+/// `baseline + spike_height` for `spike_duration_secs` every
+/// `spike_interval_secs`. The first spike starts at t=0.
+///
+/// - `> threshold`: satisfied at t=0 if baseline + spike_height > threshold
+/// - `< threshold`: satisfied at `spike_duration_secs` when spike ends
+///
+/// # Errors
+///
+/// - `OutOfRange` when the threshold is outside the signal's range.
+/// - `Ambiguous` when satisfied at t=0.
+pub fn spike_crossing_secs(
+    op: Operator,
+    threshold: f64,
+    baseline: f64,
+    spike_height: f64,
+    spike_duration_secs: f64,
+) -> Result<f64, TimingError> {
+    let peak = baseline + spike_height;
+    let lo = baseline.min(peak);
+    let hi = baseline.max(peak);
+
+    match op {
+        Operator::GreaterThan => {
+            if threshold >= hi {
+                return Err(TimingError::OutOfRange {
+                    message: format!(
+                        "threshold {threshold} is at or above peak value {peak}; \
+                         the signal never exceeds it"
+                    ),
+                });
+            }
+            if threshold < lo {
+                return Err(TimingError::Ambiguous {
+                    message: format!(
+                        "threshold {threshold} is below baseline {baseline}; \
+                         the signal is always above it (satisfied at t=0)"
+                    ),
+                });
+            }
+            // The spike starts at t=0, so if baseline + spike_height > threshold,
+            // it's satisfied immediately.
+            if peak > threshold {
+                // Signal starts at peak at t=0 — crossing happens at the spike start.
+                // This is t=0 for the first spike.
+                return Err(TimingError::Ambiguous {
+                    message: format!(
+                        "\"> {threshold}\" is satisfied at t=0 (spike starts immediately \
+                         at peak {peak}). Use \"<\" to detect when the spike ends"
+                    ),
+                });
+            }
+            Err(TimingError::OutOfRange {
+                message: format!("peak {peak} does not exceed threshold {threshold}"),
+            })
+        }
+        Operator::LessThan => {
+            if threshold <= lo {
+                return Err(TimingError::OutOfRange {
+                    message: format!(
+                        "threshold {threshold} is at or below baseline {baseline}; \
+                         the signal never drops below it"
+                    ),
+                });
+            }
+            if threshold > hi {
+                return Err(TimingError::Ambiguous {
+                    message: format!(
+                        "threshold {threshold} is above peak {peak}; \
+                         the signal is always below it (satisfied at t=0)"
+                    ),
+                });
+            }
+            // The spike ends after spike_duration_secs, returning to baseline.
+            // If baseline < threshold and peak >= threshold, the crossing
+            // happens when the spike ends.
+            if baseline < threshold {
+                Ok(spike_duration_secs)
+            } else {
+                Err(TimingError::OutOfRange {
+                    message: format!(
+                        "baseline {baseline} is not below threshold {threshold}; \
+                         the signal does not cross below it when the spike ends"
+                    ),
+                })
+            }
+        }
+    }
+}
+
+/// Reject threshold-crossing computation for the **steady** behavior.
+///
+/// Steady desugars to a sine wave, which crosses any threshold twice per
+/// period — the crossing direction is ambiguous. Stories should use a
+/// different behavior or explicit `phase_offset`.
+///
+/// # Errors
+///
+/// Always returns `TimingError::Unsupported`.
+pub fn steady_crossing_secs() -> Result<f64, TimingError> {
+    Err(TimingError::Unsupported {
+        message: "cannot compute crossing for \"steady\" behavior \
+                  -- sine waves cross any threshold twice per period, \
+                  making the result ambiguous. Use explicit phase_offset instead"
+            .to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // Flap crossing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn flap_less_than_one_returns_up_duration() {
+        // Standard flap: up_value=1.0, down_value=0.0, up_duration=60s, down_duration=30s
+        // "interface_oper_state < 1" -> 60s (when it drops to 0)
+        let t = flap_crossing_secs(Operator::LessThan, 1.0, 60.0, 30.0, 1.0, 0.0)
+            .expect("should succeed");
+        assert!((t - 60.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn flap_less_than_half_returns_up_duration() {
+        // "oper_state < 0.5" with up=1.0, down=0.0 -> crossing at up_duration
+        let t = flap_crossing_secs(Operator::LessThan, 0.5, 10.0, 5.0, 1.0, 0.0)
+            .expect("should succeed");
+        assert!((t - 10.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn flap_greater_than_zero_is_ambiguous() {
+        // "oper_state > 0" starts at up_value=1.0 which is > 0 at t=0
+        let err = flap_crossing_secs(Operator::GreaterThan, 0.0, 10.0, 5.0, 1.0, 0.0)
+            .expect_err("should be ambiguous");
+        assert!(matches!(err, TimingError::Ambiguous { .. }));
+    }
+
+    #[test]
+    fn flap_less_than_zero_is_out_of_range() {
+        // threshold=0 with down_value=0 -> signal never goes below 0
+        let err = flap_crossing_secs(Operator::LessThan, 0.0, 10.0, 5.0, 1.0, 0.0)
+            .expect_err("should be out of range");
+        assert!(matches!(err, TimingError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn flap_threshold_above_up_value_less_than_is_ambiguous() {
+        // threshold=2.0 with up_value=1.0 -> signal is always below 2.0
+        let err = flap_crossing_secs(Operator::LessThan, 2.0, 10.0, 5.0, 1.0, 0.0)
+            .expect_err("should be ambiguous");
+        assert!(matches!(err, TimingError::Ambiguous { .. }));
+    }
+
+    #[test]
+    fn flap_threshold_above_up_value_greater_than_is_out_of_range() {
+        // threshold=2.0 with up_value=1.0 -> signal never exceeds 2.0
+        let err = flap_crossing_secs(Operator::GreaterThan, 2.0, 10.0, 5.0, 1.0, 0.0)
+            .expect_err("should be out of range");
+        assert!(matches!(err, TimingError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn flap_custom_values() {
+        // up_value=100, down_value=50, "< 75" -> triggers at up_duration when
+        // signal drops to 50
+        let t = flap_crossing_secs(Operator::LessThan, 75.0, 20.0, 10.0, 100.0, 50.0)
+            .expect("should succeed");
+        assert!((t - 20.0).abs() < f64::EPSILON);
+    }
+
+    // -----------------------------------------------------------------------
+    // Sawtooth crossing (saturation / leak / degradation)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn sawtooth_greater_than_at_midpoint() {
+        // baseline=20, ceiling=85, period=120s
+        // "> 70" -> (70-20)/(85-20) * 120 = 50/65 * 120 = 92.307...s
+        let t = sawtooth_crossing_secs(Operator::GreaterThan, 70.0, 20.0, 85.0, 120.0)
+            .expect("should succeed");
+        let expected = (70.0 - 20.0) / (85.0 - 20.0) * 120.0;
+        assert!((t - expected).abs() < 1e-9, "got {t}, expected {expected}");
+    }
+
+    #[test]
+    fn sawtooth_greater_than_near_ceiling() {
+        // "> 84" with baseline=20, ceiling=85, period=120
+        let t = sawtooth_crossing_secs(Operator::GreaterThan, 84.0, 20.0, 85.0, 120.0)
+            .expect("should succeed");
+        let expected = (84.0 - 20.0) / (85.0 - 20.0) * 120.0;
+        assert!((t - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn sawtooth_greater_than_at_ceiling_is_out_of_range() {
+        let err = sawtooth_crossing_secs(Operator::GreaterThan, 85.0, 20.0, 85.0, 120.0)
+            .expect_err("should be out of range");
+        assert!(matches!(err, TimingError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn sawtooth_greater_than_below_baseline_is_ambiguous() {
+        let err = sawtooth_crossing_secs(Operator::GreaterThan, 10.0, 20.0, 85.0, 120.0)
+            .expect_err("should be ambiguous");
+        assert!(matches!(err, TimingError::Ambiguous { .. }));
+    }
+
+    #[test]
+    fn sawtooth_less_than_above_ceiling_is_ambiguous() {
+        // threshold > ceiling -> signal is always below
+        let err = sawtooth_crossing_secs(Operator::LessThan, 100.0, 20.0, 85.0, 120.0)
+            .expect_err("should be ambiguous");
+        assert!(matches!(err, TimingError::Ambiguous { .. }));
+    }
+
+    #[test]
+    fn sawtooth_less_than_at_baseline_is_out_of_range() {
+        // threshold == baseline -> signal never drops below
+        let err = sawtooth_crossing_secs(Operator::LessThan, 20.0, 20.0, 85.0, 120.0)
+            .expect_err("should be out of range");
+        assert!(matches!(err, TimingError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn sawtooth_less_than_midpoint_is_ambiguous_at_t0() {
+        // Signal starts at baseline=20 which is < 50, so "< 50" is satisfied at t=0.
+        let err = sawtooth_crossing_secs(Operator::LessThan, 50.0, 20.0, 85.0, 120.0)
+            .expect_err("should be ambiguous");
+        assert!(matches!(err, TimingError::Ambiguous { .. }));
+    }
+
+    #[test]
+    fn sawtooth_equal_baseline_ceiling_is_out_of_range() {
+        let err = sawtooth_crossing_secs(Operator::GreaterThan, 50.0, 50.0, 50.0, 120.0)
+            .expect_err("should be out of range");
+        assert!(matches!(err, TimingError::OutOfRange { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // Spike crossing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn spike_less_than_returns_spike_duration() {
+        // baseline=0, spike_height=100, spike_duration=10s
+        // "< 50" -> when spike ends at t=10s, returns to baseline=0 which is < 50
+        let t = spike_crossing_secs(Operator::LessThan, 50.0, 0.0, 100.0, 10.0)
+            .expect("should succeed");
+        assert!((t - 10.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn spike_greater_than_is_ambiguous_at_t0() {
+        // Spike starts immediately at peak=100 > 50 at t=0
+        let err = spike_crossing_secs(Operator::GreaterThan, 50.0, 0.0, 100.0, 10.0)
+            .expect_err("should be ambiguous");
+        assert!(matches!(err, TimingError::Ambiguous { .. }));
+    }
+
+    #[test]
+    fn spike_less_than_at_baseline_is_out_of_range() {
+        // threshold=0 with baseline=0 -> signal never drops below 0
+        let err = spike_crossing_secs(Operator::LessThan, 0.0, 0.0, 100.0, 10.0)
+            .expect_err("should be out of range");
+        assert!(matches!(err, TimingError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn spike_greater_than_at_peak_is_out_of_range() {
+        // threshold=100 with peak=100 -> signal never exceeds 100
+        let err = spike_crossing_secs(Operator::GreaterThan, 100.0, 0.0, 100.0, 10.0)
+            .expect_err("should be out of range");
+        assert!(matches!(err, TimingError::OutOfRange { .. }));
+    }
+
+    #[test]
+    fn spike_less_than_above_peak_is_ambiguous() {
+        // threshold=150 with peak=100 -> always below
+        let err = spike_crossing_secs(Operator::LessThan, 150.0, 0.0, 100.0, 10.0)
+            .expect_err("should be ambiguous");
+        assert!(matches!(err, TimingError::Ambiguous { .. }));
+    }
+
+    #[test]
+    fn spike_greater_than_below_baseline_is_ambiguous() {
+        // threshold=-10 with baseline=0 -> always above
+        let err = spike_crossing_secs(Operator::GreaterThan, -10.0, 0.0, 100.0, 10.0)
+            .expect_err("should be ambiguous");
+        assert!(matches!(err, TimingError::Ambiguous { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // Steady (always rejected)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn steady_always_unsupported() {
+        let err = steady_crossing_secs().expect_err("steady should be unsupported");
+        assert!(matches!(err, TimingError::Unsupported { .. }));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("steady"),
+            "error message should mention steady, got: {msg}"
+        );
+    }
+}

--- a/sonda/src/yaml_helpers.rs
+++ b/sonda/src/yaml_helpers.rs
@@ -20,9 +20,10 @@ pub enum ParamValue {
 /// Check if a YAML scalar value needs double-quoting to be parsed correctly.
 ///
 /// Returns `true` for values that a YAML parser would interpret as something
-/// other than a plain string: empty strings, numbers, boolean keywords,
+/// other than a plain string: empty strings, numbers, boolean keywords
+/// (including YAML 1.1 `on`/`off`), values with leading/trailing whitespace,
 /// and values containing characters that are syntactically significant in
-/// YAML (`:`  `#`  `{`  `}`  `"`  `\`).
+/// YAML (`:`  `#`  `{`  `}`  `[`  `]`  `"`  `'`  `\`  newlines).
 pub fn needs_quoting(value: &str) -> bool {
     if value.is_empty() {
         return true;
@@ -30,16 +31,32 @@ pub fn needs_quoting(value: &str) -> bool {
     if value.parse::<f64>().is_ok() {
         return true;
     }
+    // Leading/trailing whitespace changes semantics in YAML flow scalars.
+    if value != value.trim() {
+        return true;
+    }
     let lower = value.to_lowercase();
-    if lower == "true" || lower == "false" || lower == "null" || lower == "yes" || lower == "no" {
+    // Standard YAML booleans plus YAML 1.1 `on`/`off`.
+    if lower == "true"
+        || lower == "false"
+        || lower == "null"
+        || lower == "yes"
+        || lower == "no"
+        || lower == "on"
+        || lower == "off"
+    {
         return true;
     }
     if value.contains(':')
         || value.contains('#')
         || value.contains('{')
         || value.contains('}')
+        || value.contains('[')
+        || value.contains(']')
         || value.contains('"')
+        || value.contains('\'')
         || value.contains('\\')
+        || value.contains('\n')
     {
         return true;
     }
@@ -133,6 +150,37 @@ mod tests {
     #[test]
     fn needs_quoting_backslash() {
         assert!(needs_quoting(r"C:\Users\admin"));
+    }
+
+    #[test]
+    fn needs_quoting_square_brackets() {
+        assert!(needs_quoting("[item]"));
+        assert!(needs_quoting("value]"));
+    }
+
+    #[test]
+    fn needs_quoting_single_quote() {
+        assert!(needs_quoting("it's"));
+    }
+
+    #[test]
+    fn needs_quoting_newline() {
+        assert!(needs_quoting("line1\nline2"));
+    }
+
+    #[test]
+    fn needs_quoting_leading_trailing_whitespace() {
+        assert!(needs_quoting(" leading"));
+        assert!(needs_quoting("trailing "));
+        assert!(needs_quoting("  both  "));
+    }
+
+    #[test]
+    fn needs_quoting_yaml_11_booleans() {
+        assert!(needs_quoting("on"));
+        assert!(needs_quoting("off"));
+        assert!(needs_quoting("On"));
+        assert!(needs_quoting("OFF"));
     }
 
     #[test]

--- a/stories/link-failover.yaml
+++ b/stories/link-failover.yaml
@@ -1,0 +1,54 @@
+# Link Failover Story
+#
+# Models an edge router primary link failure with automatic traffic shift
+# to a backup link. The causal chain:
+#
+#   1. Primary interface flaps down (interface_oper_state < 1)
+#   2. Backup link saturates as traffic shifts (after primary drops)
+#   3. Latency degrades as backup approaches capacity (after backup > 70%)
+#
+# Run with:
+#   sonda story --file stories/link-failover.yaml
+#   sonda story --file stories/link-failover.yaml --dry-run
+#   sonda story --file stories/link-failover.yaml --duration 2m
+
+story: link_failover
+description: "Edge router link failure with traffic shift to backup"
+duration: 5m
+rate: 1
+encoder: { type: prometheus_text }
+sink: { type: stdout }
+labels:
+  device: rtr-edge-01
+  job: network
+
+signals:
+  # Primary interface flaps: up for 60s, down for 30s, cycling.
+  - metric: interface_oper_state
+    behavior: flap
+    up_duration: 60s
+    down_duration: 30s
+    labels:
+      interface: GigabitEthernet0/0/0
+
+  # Backup link saturates after primary drops below 1.
+  # Ramps from 20% to 85% utilization over 2 minutes.
+  - metric: backup_link_utilization
+    behavior: saturation
+    baseline: 20
+    ceiling: 85
+    time_to_saturate: 2m
+    after: interface_oper_state < 1
+    labels:
+      interface: GigabitEthernet0/1/0
+
+  # Latency degrades after backup utilization exceeds 70%.
+  # Climbs from 5ms to 150ms over 3 minutes with noise.
+  - metric: latency_ms
+    behavior: degradation
+    baseline: 5
+    ceiling: 150
+    time_to_degrade: 3m
+    after: backup_link_utilization > 70
+    labels:
+      path: backup


### PR DESCRIPTION
## Summary

Closes #179 (parent: #177)

- Adds `sonda story` subcommand — a concise YAML format for expressing multi-signal scenarios with temporal causality (`after` clauses) that compile to `Vec<ScenarioEntry>` + `phase_offset` at parse time. No runtime reactivity.
- `after` resolution engine: parses `after: metric_name < threshold`, builds a dependency graph, topological sorts via Kahn's algorithm with cycle detection, and computes concrete `phase_offset` values using per-behavior timing formulas (flap, saturation, leak, degradation, spike_event).
- `--duration` caps total wall-clock time with clear warnings when signals are skipped or truncated.
- Ships one built-in example: `stories/link-failover.yaml` (edge router link failure → backup saturation → latency degradation).

All story logic lives in the CLI crate (`sonda/src/story/`). Zero sonda-core changes.

## Changes

| File | What |
|------|------|
| `sonda/src/story/mod.rs` | StoryConfig, SignalConfig, compile_story(), duration capping, YAML expansion |
| `sonda/src/story/after_resolve.rs` | AfterClause parsing, dependency graph, topo sort, offset computation |
| `sonda/src/story/timing.rs` | Pure timing functions per behavior alias |
| `sonda/src/cli.rs` | `Story(StoryArgs)` variant + flags |
| `sonda/src/main.rs` | `mod story` + `Commands::Story` match arm |
| `sonda/src/yaml_helpers.rs` | Hardened `needs_quoting()` for YAML-significant chars |
| `stories/link-failover.yaml` | Built-in example |
| `README.md` | Stories section |
| `docs/site/docs/guides/stories.md` | Full user guide |
| `docs/site/docs/configuration/cli-reference.md` | CLI reference for `sonda story` |
| `docs/site/docs/index.md` + `mkdocs.yml` | Nav + feature table |

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 2,450+ tests, 0 failures
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `sonda story --file stories/link-failover.yaml --dry-run` — shows compiled config
- [x] `sonda story --file stories/link-failover.yaml --duration 5s --sink stdout` — runs ~5s, warns about skipped signals
- [x] `sonda story --file stories/link-failover.yaml --duration 2m --sink stdout` — runs ~2m, includes 2 of 3 signals
- [x] Error handling: missing file, invalid YAML, cycles, out-of-range thresholds all produce actionable messages
- [x] Staff engineer review: PASS
- [x] UAT: PASS