### PR TITLE
feat(core): defaults resolution and normalization (v2 PR 3)

### DIFF
--- a/docs/refactor/v2-progress.md
+++ b/docs/refactor/v2-progress.md
@@ -1,18 +1,18 @@
 # Sonda v2 Refactor — Progress
 
 ## Current Status
-- **Phase:** 1 — Compiler AST and parser (complete, pending merge)
+- **Phase:** 2 — Defaults resolution (complete, pending merge)
 - **Branch:** `refactor/unified-scenarios-v2`
 - **Integration PR:** #197 (targets `main`, accumulates all v2 work)
-- **Next PR:** PR 3 — Defaults resolution and normalization
+- **Next PR:** PR 4 — Pack expansion inside `scenarios:`
 
 ## Milestone Checklist
 
 | # | Milestone | Status | PR | Date |
 |---|-----------|--------|----|------|
 | 0 | Scaffolding & test foundation | Done | PR 1 | 2026-04-11 |
-| 1 | Compiler AST and parser | In Review | PR 2 (#198) | 2026-04-11 |
-| 2 | Defaults resolution | Not Started | PR 3 | |
+| 1 | Compiler AST and parser | Done | PR 2 (#198) | 2026-04-11 |
+| 2 | Defaults resolution | Done | PR 3 | 2026-04-12 |
 | 3 | Pack expansion in scenarios | Not Started | PR 4 | |
 | 4 | `after` compiler + dependency graph | Not Started | PR 5 | |
 | 5 | Runtime wiring + parity tests | Not Started | PR 6 | |
@@ -25,17 +25,20 @@
 | PR | Title | Branch | Target | Status | Date |
 |----|-------|--------|--------|--------|------|
 | 1 | Compile snapshot harness + test foundation | (direct) | integration | Merged | 2026-04-11 |
-| 2 | Compiler AST, parser, and version dispatch | `feat/v2-ast-parser` | integration (#198) | In Review | 2026-04-11 |
+| 2 | Compiler AST, parser, and version dispatch | `feat/v2-ast-parser` | integration (#198) | Merged | 2026-04-11 |
+| 3 | Defaults resolution + `parse_v2 → parse` rename | `feat/defaults-resolution` | integration | Pending Review | 2026-04-12 |
 
 ## Test Coverage
 
 | Layer | Tests | Scope |
 |-------|-------|-------|
-| Compiler parser unit tests | 45 | AST parsing, validation, shorthand, edge cases |
-| Compiler fixture integration tests | 11 | Valid/invalid YAML examples parsed from disk |
+| Compiler parser unit tests | 49 | AST parsing, validation, shorthand, edge cases |
+| Compiler normalize unit tests | 34 | Defaults inheritance, label merge (inline eager / pack deferred), built-in fallbacks, missing-rate error, defaults-labels surfacing |
+| Compiler fixture integration tests | 15 | Valid/invalid YAML examples parsed + normalized from disk |
 | Compile snapshot golden files | 12 | v1 parity baseline (6 fixtures x raw+prepared) |
-| **New in refactor** | **68** | |
-| Workspace total | 2,543 | All existing + new |
+| Normalize snapshot golden files | 3 | Resolved defaults snapshots (label merge, logs default encoder, pack entry) |
+| **New in refactor** | **113** | |
+| Workspace total | 2,585 | All existing + new |
 
 ## Validation Matrix Status
 
@@ -43,12 +46,12 @@ See [v2-validation-status.md](v2-validation-status.md) for the full 162-row chec
 
 **Every row is a mandatory merge blocker. No exceptions.**
 
-**Summary:** 4 of 162 rows addressed so far (all in section 11 — new v2 features).
+**Summary:** 11 of 162 rows addressed so far.
 
 | Section | Rows | Addressed | Notes |
 |---------|------|-----------|-------|
-| 1-10. Feature parity | 97 | 0 | Needs compilation pipeline + runtime wiring |
-| 11. New v2 features | 18 | 4 | 11.1, 11.4, 11.5, 11.10 done in PR 2 |
+| 1-10. Feature parity | 97 | 5 | 5.8 (PR 3), 10.12-10.15 (PR 3) — rest need runtime wiring |
+| 11. New v2 features | 18 | 6 | 11.1, 11.2, 11.3, 11.4, 11.5, 11.10 |
 | 12-15. CLI/Server/UX/Deploy | 47 | 0 | Later PRs (7-9) |
 | **16. Scenario parity bridge** | **12** | **0** | **v1→v2 compile + runtime for all built-ins + story** |
 | **17. Pack parity bridge** | **3** | **0** | **v1→v2 compile + runtime for all built-in packs** |
@@ -62,7 +65,7 @@ See [v2-validation-status.md](v2-validation-status.md) for the full 162-row chec
 - `KafkaSaslConfig.password` skip_serializing for security
 - Reviewer findings fixed: feature gates, trailing newlines, password masking
 
-### PR 2 — Compiler AST and parser (2026-04-11, in review)
+### PR 2 — Compiler AST and parser (2026-04-11, merged)
 - `sonda-core/src/compiler/mod.rs` — AST types: `ScenarioFile`, `Defaults`, `Entry`, `AfterClause`, `AfterOp`
 - `sonda-core/src/compiler/parse.rs` — parser with 9 validation rules, `detect_version()`
 - Single-signal shorthand wrapping (inline + pack)
@@ -72,9 +75,78 @@ See [v2-validation-status.md](v2-validation-status.md) for the full 162-row chec
 - 45 unit tests + 11 fixture integration tests (5 valid, 6 invalid YAML examples)
 - Module named `compiler` (describes function, not version number)
 
+### PR 3 — Defaults resolution and normalization (2026-04-12, pending review)
+- `sonda-core/src/compiler/normalize.rs` — `normalize()`, `NormalizedFile`, `NormalizedEntry`, `NormalizeError`
+- Precedence for `rate`/`duration`/`encoder`/`sink`: entry-level > `defaults:` > built-in fallback (eager, both inline and pack entries)
+- Built-in encoder per signal type: `prometheus_text` for metrics/histogram/summary, `json_lines` for logs
+- Built-in sink: `stdout`
+- **Label composition is asymmetric** (see PR 4 Preparation Notes below):
+  - Inline entries: eager merge — `defaults.labels ∪ entry.labels`, entry wins on key conflict
+  - Pack entries: no merge — `NormalizedEntry.labels` = entry's own labels; `NormalizedFile.defaults_labels` surfaces the source map so PR 4 can layer it correctly against pack `shared_labels` / per-metric / override labels
+- Pack entries' `pack:` and `overrides:` fields carried through untouched (pack expansion is PR 4)
+- Required-field validation: missing `rate` identifies the offending entry by index + name/id/pack
+- Rename `parse_v2 → parse` workspace-wide (module prefix carries the version)
+- 34 normalize unit tests + 4 new fixtures (3 valid with golden snapshots, 1 invalid)
+- Addresses validation matrix rows 5.8, 10.12, 10.13, 10.14, 10.15, 11.2, 11.3
+- Reviewer NOTE (pack-label precedence collision) resolved inline via Option 2 — documented in `normalize.rs` module docs and in PR 4 Preparation Notes below
+- Reviewer NITs addressed: stale `V2 AST types` comment renamed; no-op `serde(deny_unknown_fields)` dropped from `NormalizedFile`/`NormalizedEntry`; snapshot-harness `expect()` calls converted to `unwrap_or_else(panic!)` with OS error detail
+
+## PR 4 Preparation Notes
+
+These notes capture decisions and handoff context from PR 3 that PR 4 (pack expansion) must not re-litigate. A future session starting cold on PR 4 should read this section first, then the full reviewer review thread if deeper context is needed.
+
+### Label composition decision (locked)
+
+PR 3 applies **two different label strategies** depending on entry kind. This is a deliberate choice to let PR 4 interleave spec §2.2 precedence levels 4–5 (pack `shared_labels`, pack per-metric labels) at the correct position between levels 2 (`defaults.labels`) and 6 (entry-level labels).
+
+- **Inline entries** (`generator:` / `log_generator:`) → `NormalizedEntry.labels` is the eager merge `defaults.labels ∪ entry.labels`, entry wins on conflict. No downstream composition, so provenance doesn't matter.
+- **Pack entries** (`pack:`) → `NormalizedEntry.labels` is exactly the entry's own `labels` field (unchanged, possibly `None`). The file-level `defaults.labels` is carried forward separately on `NormalizedFile.defaults_labels` for PR 4 to apply at the correct precedence slot.
+
+Do not "fix" this asymmetry in PR 4 by eagerly merging. It exists because §2.2 places pack shared_labels (level 4) between defaults (2) and entry labels (6) — collapsing 2+6 loses the position where 4 and 5 need to slot in.
+
+### PR 4 expansion sketch (implementer's handoff, confirmed)
+
+1. **`NormalizedEntry` contract walk.** Before writing expansion code, walk every field of `NormalizedEntry` and classify it as either (a) propagates verbatim to each expanded child metric, or (b) participates in per-metric composition. `normalize.rs` groups fields with comments to help. Pack `overrides` definitely participates (per-metric generator/labels/after). Most schedule/delivery fields (rate, duration, encoder, sink, gaps, bursts, phase_offset, clock_group) propagate verbatim.
+
+2. **Label precedence chain for pack-expanded signals** (spec §2.2, low → high — lowest number = lowest precedence, applied first; each subsequent level overwrites on key collision):
+   1. Sonda built-in defaults (already resolved in PR 3 for non-label fields)
+   2. `NormalizedFile.defaults_labels` (new source; not yet applied to pack entries)
+   3. pack definition's top-level fields (shared rate/job, etc. — pack YAML)
+   4. pack `shared_labels`
+   5. pack per-metric `labels`
+   6. entry-level `labels` on the pack entry (already preserved on `NormalizedEntry.labels`)
+   7. override-level `labels` (from `NormalizedEntry.overrides[metric].labels`)
+   8. CLI flags (PR 7 scope)
+
+   A clean multi-level merge function with explicit precedence-named steps is preferable to nested merge calls.
+
+3. **Override key validation (matrix row 9.7).** For every key in `NormalizedEntry.overrides`, assert it matches a metric name in the pack definition. Unknown keys → `NormalizeError` or a new `PackExpansionError` with a clear message. This is a mandatory merge blocker.
+
+4. **Pack entry materialization.** One `NormalizedEntry`-equivalent (or a new `ExpandedEntry` type — PR 4's call) per metric in the pack. Synthesize:
+   - `name = <pack_metric_name>`
+   - `id = "{entry.id}.{metric}"` when `entry.id.is_some()`; otherwise an auto-generated ID from the pack name (see matrix row 11.8)
+   - `generator` = override's `generator` if present, else pack's per-metric `generator`
+   - `labels` = result of the full level-2-through-7 merge above
+   - `after` = override's `after` if present, else entry-level `after` propagated (matrix row 11.13)
+   - All other fields (rate, duration, encoder, sink, phase_offset, clock_group, gaps, bursts) copied from the parent pack entry verbatim
+
+5. **Pack search path.** Pack resolution is not yet implemented in `sonda-core::compiler`. The existing v1 engine in `src/packs/mod.rs` handles pack YAML parsing and has a search path helper; reuse `MetricPackDef` and the discovery logic. PR 4 does not need to reshape the pack definition schema (spec §7 is explicit: pack YAML on disk is unchanged). Pack YAMLs live at the repo root in `packs/` — this crate doesn't embed them.
+
+6. **Pack entries without `id`.** Spec matrix row 11.8 requires auto-generated IDs when `id` is absent. Pick a deterministic scheme (e.g., `"{pack_name}"` for the first anonymous pack entry, disambiguate subsequent ones). Decide before coding.
+
+7. **`NormalizedEntry` field evolution.** Currently carries optional serde fields for pack metadata. If PR 4 introduces a new `ExpandedEntry` type (recommended), `NormalizedEntry` can stay narrow — don't bloat it with post-expansion fields.
+
+### Target validation matrix rows for PR 4
+
+- 9.1–9.12 (pack features — run by name, run from YAML, search path, file path, overrides, unknown override key error, label merge order, dry-run, list/show, custom pack definitions)
+- 11.6 (pack inside scenarios: list)
+- 11.8 (auto-generated pack IDs)
+- 11.12 (after on pack override — partial; full `after` resolution is PR 5)
+- 11.13 (pack entry-level after propagation — partial)
+
 ## Active Risks
 - Snapshot format stability — must be deterministic and survive refactor
-- `deny_unknown_fields` on compiler types prevents forward-compatible parsing (deliberate)
+- `deny_unknown_fields` on parse-time AST prevents forward-compatible parsing (deliberate); `NormalizedFile`/`NormalizedEntry` are Serialize-only projections and intentionally do not carry that attribute
 
 ## Process Notes
 - All PRs target integration branch (`refactor/unified-scenarios-v2`), not `main`

--- a/docs/refactor/v2-validation-status.md
+++ b/docs/refactor/v2-validation-status.md
@@ -73,7 +73,7 @@ scenario and pack produces identical output in v2 format (14 rows).
 | 5.5 | remote_write | Not Tested | PR 6 | |
 | 5.6 | otlp | Not Tested | PR 6 | |
 | 5.7 | precision field | Not Tested | PR 6 | |
-| 5.8 | Default encoder per signal type | Not Tested | PR 3 | Defaults resolution |
+| 5.8 | Default encoder per signal type | Pass | PR 3 | Defaults resolution: metrics/histogram/summary → prometheus_text, logs → json_lines |
 
 ## 6. Sinks (12 rows)
 
@@ -154,18 +154,18 @@ scenario and pack produces identical output in v2 format (14 rows).
 | 10.9 | Threshold true at t=0 → error | Not Tested | PR 5 | |
 | 10.10 | sine/steady in after → error | Not Tested | PR 5 | |
 | 10.11 | Shared clock_group | Not Tested | PR 5 | |
-| 10.12 | Shared labels across signals | Not Tested | PR 3 | via defaults |
-| 10.13 | Per-signal label overrides | Not Tested | PR 3 | |
-| 10.14 | Per-signal rate/duration override | Not Tested | PR 3 | |
-| 10.15 | Per-signal encoder/sink override | Not Tested | PR 3 | |
+| 10.12 | Shared labels across signals | Pass | PR 3 | defaults.labels flows into every entry |
+| 10.13 | Per-signal label overrides | Pass | PR 3 | entry labels win on conflict, union otherwise |
+| 10.14 | Per-signal rate/duration override | Pass | PR 3 | entry rate/duration win over defaults |
+| 10.15 | Per-signal encoder/sink override | Pass | PR 3 | entry encoder/sink win over defaults |
 
 ## 11. New v2 Features (18 rows)
 
 | # | Capability | Status | PR | Notes |
 |---|-----------|--------|-----|-------|
-| 11.1 | version: 2 field | Pass | PR 2 | parse_v2 validates version |
-| 11.2 | defaults: block | Not Tested | PR 3 | Parsed in PR 2, resolution in PR 3 |
-| 11.3 | Entry-level overrides defaults | Not Tested | PR 3 | |
+| 11.1 | version: 2 field | Pass | PR 2 | parse() validates version |
+| 11.2 | defaults: block | Pass | PR 3 | resolved into every entry by normalize() |
+| 11.3 | Entry-level overrides defaults | Pass | PR 3 | entry values win over defaults across all precedence-eligible fields |
 | 11.4 | id field on entries | Pass | PR 2 | Uniqueness + format validated |
 | 11.5 | Single-signal shorthand | Pass | PR 2 | Flat files wrapped automatically |
 | 11.6 | Pack inside scenarios: list | Not Tested | PR 4 | Parsed in PR 2, expansion in PR 4 |

--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -90,9 +90,17 @@ src/
 │   │                      ScenarioFile, Defaults, Entry, AfterClause, AfterOp.
 │   │                      Pre-compilation representation of scenario YAML files.
 │   │                      No runtime integration — parsing only.
-│   └── parse.rs        ← YAML parser and structural validation.
-│                          parse_v2(), detect_version(), ParseError.
-│                          Single-signal shorthand support. Feature-gated (config).
+│   ├── parse.rs        ← YAML parser and structural validation.
+│   │                      parse(), detect_version(), ParseError.
+│   │                      Single-signal shorthand support. Feature-gated (config).
+│   └── normalize.rs    ← Phase 2 compilation: defaults resolution.
+│                          normalize(), NormalizedFile, NormalizedEntry,
+│                          NormalizeError. Flattens defaults: into every entry,
+│                          applies built-in encoder/sink fallbacks, merges
+│                          defaults.labels for inline entries (deferred for
+│                          pack entries so Phase 3 can interleave pack
+│                          shared/per-metric labels), and enforces rate
+│                          presence. Feature-gated (config).
 └── config/
     ├── mod.rs          ← BaseScheduleConfig (shared schedule/delivery fields: name, rate, duration,
     │                      gaps, bursts, cardinality_spikes, dynamic_labels, labels, sink,

--- a/sonda-core/src/compiler/mod.rs
+++ b/sonda-core/src/compiler/mod.rs
@@ -12,9 +12,13 @@
 //! # Submodules
 //!
 //! - [`parse`] — YAML deserialization, schema validation, and version detection.
+//! - [`normalize`] — `defaults:` resolution and entry-level normalization.
 
 #[cfg(feature = "config")]
 pub mod parse;
+
+#[cfg(feature = "config")]
+pub mod normalize;
 
 use std::collections::BTreeMap;
 
@@ -27,12 +31,12 @@ use crate::packs::MetricOverride;
 use crate::sink::SinkConfig;
 
 // ---------------------------------------------------------------------------
-// V2 AST types
+// Compiler AST types
 // ---------------------------------------------------------------------------
 
 /// A parsed v2 scenario file.
 ///
-/// This is the top-level AST node produced by [`parse::parse_v2`]. It captures
+/// This is the top-level AST node produced by [`parse::parse`]. It captures
 /// the exact structure of the YAML input without resolving defaults, expanding
 /// packs, or compiling after-clauses.
 #[derive(Debug, Clone)]
@@ -88,7 +92,7 @@ pub struct Defaults {
 ///
 /// All fields are optional in the struct to support flexible YAML authoring.
 /// Semantic validation (required fields, mutual exclusion) is performed by
-/// [`parse::parse_v2`].
+/// [`parse::parse`].
 #[derive(Debug, Clone)]
 #[cfg_attr(
     feature = "config",

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -1,0 +1,1277 @@
+//! Defaults resolution and entry normalization for v2 scenario files.
+//!
+//! This module implements **Phase 2** of the v2 compilation pipeline: it takes
+//! a [`ScenarioFile`] produced by [`super::parse::parse`] and flattens the
+//! shared `defaults:` block into each entry, applying the documented
+//! precedence rules.
+//!
+//! # Precedence (entry-level fields)
+//!
+//! For every entry, the resolver picks the first non-`None` value in this
+//! order:
+//!
+//! 1. the value set on the entry,
+//! 2. the value set under the file-level `defaults:` block,
+//! 3. a built-in fallback for `encoder` and `sink` (see below).
+//!
+//! The higher-precedence levels (pack `shared_labels`, pack per-metric,
+//! override labels, CLI flags) are not applied here; they belong to later
+//! compilation phases.
+//!
+//! # Built-in fallbacks
+//!
+//! When neither the entry nor `defaults:` sets an encoder, the normalizer
+//! picks one based on the entry's `signal_type`:
+//!
+//! | Signal type | Default encoder  |
+//! |-------------|------------------|
+//! | `metrics`   | `prometheus_text`|
+//! | `histogram` | `prometheus_text`|
+//! | `summary`   | `prometheus_text`|
+//! | `logs`      | `json_lines`     |
+//!
+//! The built-in fallback for `sink` is always `stdout`.
+//!
+//! # Labels merge (inline vs. pack entries)
+//!
+//! Inline entries (those with their own `generator` / `log_generator`) have
+//! no downstream label-composition steps, so their labels are merged eagerly
+//! here: `defaults.labels ∪ entry.labels`, entry keys winning on collision.
+//! If either side is `None` the merged map equals the other side; if both
+//! are `None` the entry keeps `None`.
+//!
+//! Pack entries (`pack: some_name`) behave differently. Per spec §2.2 the
+//! final label map for a pack metric is composed at eight distinct
+//! precedence levels, ordered **low → high** (lowest number is applied
+//! first, each subsequent level overwrites on key collision):
+//!
+//! 1. Sonda built-in defaults (no label default today — listed for parity
+//!    with the non-label precedence chain)
+//! 2. `defaults.labels`
+//! 3. pack definition's top-level fields (shared rate/job, etc.)
+//! 4. pack `shared_labels`
+//! 5. pack per-metric labels
+//! 6. pack entry-level labels (the entry under `scenarios:`)
+//! 7. override-level labels (`entry.overrides[metric].labels`)
+//! 8. CLI flags (applied at runtime, PR 7 scope)
+//!
+//! Eagerly merging levels 2 and 6 into a single map (as we do for inline
+//! entries) would collapse those two layers, making it impossible for pack
+//! expansion to interleave levels 3–5 at their correct precedence. A pack
+//! `shared_labels: { job: snmp }` (level 4) must be able to override a
+//! `defaults.labels: { job: web }` (level 2) while still being overridden
+//! by an entry `labels: { job: api }` (level 6) — which requires preserving
+//! the boundary.
+//!
+//! Therefore, for pack entries, [`NormalizedEntry::labels`] carries **only
+//! the entry's own labels** (unchanged, including `None`) at level 6. The
+//! file-level `defaults.labels` map is surfaced separately on
+//! [`NormalizedFile::defaults_labels`] so pack expansion (Phase 3) can
+//! apply it at precedence level 2.
+//!
+//! # Pack entries (other fields)
+//!
+//! Pack entries still inherit `rate`, `duration`, `encoder`, and `sink`
+//! eagerly — those fields do not participate in pack-level composition, so
+//! there is no benefit to deferring them.
+//!
+//! # Validation
+//!
+//! After merging, every normalized entry must have a concrete `rate`
+//! value; missing `rate` is a compile-time error identifying the entry by
+//! index plus its `name`, falling back to `id`, then to `pack`, then to
+//! `<unnamed>` when none of those are set. Range checks on `rate` (must be
+//! `> 0`) are deferred to the existing validator invoked during
+//! `prepare_entries` in Phase 5.
+
+use std::collections::BTreeMap;
+
+use super::{AfterClause, Defaults, Entry, ScenarioFile};
+use crate::config::{
+    BurstConfig, CardinalitySpikeConfig, DistributionConfig, DynamicLabelConfig, GapConfig,
+};
+use crate::encoder::EncoderConfig;
+use crate::generator::{GeneratorConfig, LogGeneratorConfig};
+use crate::packs::MetricOverride;
+use crate::sink::SinkConfig;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors produced during defaults resolution.
+#[derive(Debug, thiserror::Error)]
+pub enum NormalizeError {
+    /// An entry has no `rate` either inline or via the `defaults:` block.
+    ///
+    /// The offending entry is identified by its zero-based index and, when
+    /// available, its `name` or `id` for human-readable diagnostics.
+    #[error("entry {index} ({label}): missing required field 'rate' (set it on the entry or in defaults:)")]
+    MissingRate {
+        /// Zero-based index of the entry in the parsed `scenarios` list.
+        index: usize,
+        /// Human-readable label: the entry's `name`, falling back to `id`,
+        /// falling back to `pack`, falling back to `<unnamed>`.
+        label: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Normalized representation
+// ---------------------------------------------------------------------------
+
+/// A v2 scenario file with all defaults applied.
+///
+/// This is the output of [`normalize`]. The `defaults:` block has been
+/// flattened into each [`NormalizedEntry`] for fields that do not participate
+/// in pack-level composition (`rate`, `duration`, `encoder`, `sink`). The
+/// `defaults.labels` map is handled specially: see the module docs for the
+/// full precedence chain.
+///
+/// # Invariants
+///
+/// - Every entry has a concrete `rate`, `encoder`, and `sink`.
+/// - For **inline** entries, [`NormalizedEntry::labels`] contains the merged
+///   result of `defaults.labels` and the entry's own labels (entry wins on
+///   conflict).
+/// - For **pack** entries, [`NormalizedEntry::labels`] contains only the
+///   entry's own labels (unchanged, possibly `None`). The file-level
+///   `defaults.labels` is carried on [`Self::defaults_labels`] for Phase 3
+///   pack expansion to apply at the correct precedence slot.
+/// - Pack entries retain their `pack` and `overrides` fields untouched —
+///   pack expansion is performed in a later phase.
+/// - `after` clauses, `phase_offset`, and `clock_group` are carried through
+///   unchanged.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Serialize))]
+pub struct NormalizedFile {
+    /// Schema version. Always `2` after normalization.
+    pub version: u32,
+    /// The file-level `defaults.labels` map, carried forward verbatim for
+    /// later compilation phases to apply at the correct precedence slot.
+    ///
+    /// For pack entries this is the level-2 label layer (per spec §2.2) that
+    /// pack expansion must interleave with pack `shared_labels` (level 4),
+    /// pack per-metric labels (level 5), and entry-level labels (level 6).
+    /// For inline entries the merge is already baked into
+    /// [`NormalizedEntry::labels`] so this map is redundant — but carrying
+    /// it here for both cases keeps the type uniform.
+    ///
+    /// `None` when the source file had no `defaults:` block or when
+    /// `defaults.labels` was omitted or empty.
+    #[cfg_attr(feature = "config", serde(skip_serializing_if = "Option::is_none"))]
+    pub defaults_labels: Option<BTreeMap<String, String>>,
+    /// All entries with defaults applied, in the order they appeared in
+    /// the source file.
+    pub entries: Vec<NormalizedEntry>,
+}
+
+/// A single scenario entry with all defaults resolved.
+///
+/// Fields that could inherit from `defaults:` are now guaranteed to hold a
+/// concrete value (`rate`, `encoder`, `sink`). Fields that do not inherit
+/// (pack references, histogram/summary configuration, `after` clauses)
+/// are carried through unchanged.
+///
+/// This type is deliberately close in shape to [`Entry`] so that later
+/// compilation phases can walk the same field set without a translation
+/// step. The invariants above make the "missing rate/encoder/sink" states
+/// unrepresentable after normalization.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Serialize))]
+pub struct NormalizedEntry {
+    /// Unique identifier for causal dependency references (`after.ref`).
+    pub id: Option<String>,
+    /// Signal type: `"metrics"`, `"logs"`, `"histogram"`, or `"summary"`.
+    pub signal_type: String,
+    /// Metric or scenario name. `None` for pack-backed entries.
+    pub name: Option<String>,
+    /// Event rate in events per second. Always set after normalization.
+    pub rate: f64,
+    /// Total run duration (e.g. `"30s"`, `"5m"`). `None` means "run until
+    /// stopped" and is preserved through normalization.
+    pub duration: Option<String>,
+    /// Value generator configuration (metrics signals only).
+    pub generator: Option<GeneratorConfig>,
+    /// Log generator configuration (logs signals only).
+    pub log_generator: Option<LogGeneratorConfig>,
+    /// Static labels attached to every emitted event.
+    ///
+    /// For **inline** entries this is the merged map of `defaults.labels`
+    /// and the entry's own labels, with entry keys winning on conflict.
+    ///
+    /// For **pack** entries this is the entry's own labels **unchanged**
+    /// (possibly `None`). The file-level `defaults.labels` is NOT merged in
+    /// — it is carried separately on [`NormalizedFile::defaults_labels`] so
+    /// pack expansion can apply it at the correct precedence level. See the
+    /// module docs for the full rationale.
+    pub labels: Option<BTreeMap<String, String>>,
+    /// Dynamic (rotating) label configurations.
+    pub dynamic_labels: Option<Vec<DynamicLabelConfig>>,
+    /// Encoder configuration. Always set after normalization.
+    pub encoder: EncoderConfig,
+    /// Sink configuration. Always set after normalization.
+    pub sink: SinkConfig,
+    /// Jitter amplitude applied to generated values.
+    pub jitter: Option<f64>,
+    /// Deterministic seed for jitter RNG.
+    pub jitter_seed: Option<u64>,
+    /// Recurring silent-period configuration.
+    pub gaps: Option<GapConfig>,
+    /// Recurring high-rate burst configuration.
+    pub bursts: Option<BurstConfig>,
+    /// Cardinality spike configurations.
+    pub cardinality_spikes: Option<Vec<CardinalitySpikeConfig>>,
+    /// Phase offset for staggered start within a clock group.
+    pub phase_offset: Option<String>,
+    /// Clock group for coordinated timing across entries.
+    pub clock_group: Option<String>,
+    /// Causal dependency on another signal's value.
+    pub after: Option<AfterClause>,
+
+    // -- Pack-backed entry fields (carried through untouched) --
+    /// Pack name or file path. Mutually exclusive with `generator`.
+    pub pack: Option<String>,
+    /// Per-metric overrides within the referenced pack.
+    pub overrides: Option<BTreeMap<String, MetricOverride>>,
+
+    // -- Histogram / summary fields (carried through untouched) --
+    /// Distribution model for histogram or summary observations.
+    pub distribution: Option<DistributionConfig>,
+    /// Histogram bucket boundaries (histogram only).
+    pub buckets: Option<Vec<f64>>,
+    /// Summary quantile boundaries (summary only).
+    pub quantiles: Option<Vec<f64>>,
+    /// Number of observations sampled per tick.
+    pub observations_per_tick: Option<u32>,
+    /// Linear drift applied to the distribution mean each second.
+    pub mean_shift_per_sec: Option<f64>,
+    /// Deterministic seed for histogram/summary sampling.
+    pub seed: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Resolve the `defaults:` block into every entry of a parsed v2 scenario
+/// file.
+///
+/// The returned [`NormalizedFile`] contains a [`NormalizedEntry`] per input
+/// entry with the following fields materialized:
+///
+/// - `rate` inherits from `defaults.rate` when the entry omits it; missing
+///   on both is an error (see [`NormalizeError::MissingRate`]).
+/// - `duration` inherits from `defaults.duration`; absence is preserved as
+///   "run until stopped".
+/// - `encoder` inherits from `defaults.encoder`, otherwise defaults to
+///   `prometheus_text` for metrics/histogram/summary and `json_lines` for
+///   logs.
+/// - `sink` inherits from `defaults.sink`, otherwise defaults to `stdout`.
+/// - `labels` — **inline entries only**: the union of `defaults.labels` and
+///   the entry's labels (entry wins on conflict). **Pack entries** keep
+///   their own labels unchanged; `defaults.labels` is surfaced on
+///   [`NormalizedFile::defaults_labels`] for Phase 3 pack expansion.
+///
+/// All other fields (pack info, histogram parameters, `after` clause,
+/// `phase_offset`, `clock_group`, jitter, gaps, bursts, cardinality spikes,
+/// dynamic labels, etc.) are carried through untouched.
+///
+/// # Errors
+///
+/// Returns [`NormalizeError::MissingRate`] when an entry has no `rate`
+/// defined inline and the `defaults:` block does not supply one either.
+/// The error message identifies the entry by index and, when available,
+/// its `name`, `id`, or `pack` reference.
+pub fn normalize(file: ScenarioFile) -> Result<NormalizedFile, NormalizeError> {
+    let defaults = file.defaults;
+    let defaults_labels = defaults
+        .as_ref()
+        .and_then(|d| d.labels.as_ref())
+        .filter(|m| !m.is_empty())
+        .cloned();
+    let mut entries = Vec::with_capacity(file.scenarios.len());
+
+    for (index, entry) in file.scenarios.into_iter().enumerate() {
+        entries.push(normalize_entry(entry, index, defaults.as_ref())?);
+    }
+
+    Ok(NormalizedFile {
+        version: file.version,
+        defaults_labels,
+        entries,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/// Apply defaults to a single entry and validate required fields.
+///
+/// For inline entries, `defaults.labels` is merged into the entry's labels
+/// eagerly. For pack entries, the merge is deferred to Phase 3 pack
+/// expansion so the correct §2.2 precedence chain can be applied; see the
+/// module docs for the full rationale.
+fn normalize_entry(
+    entry: Entry,
+    index: usize,
+    defaults: Option<&Defaults>,
+) -> Result<NormalizedEntry, NormalizeError> {
+    let rate = resolve_rate(&entry, defaults, index)?;
+    let duration = entry
+        .duration
+        .or_else(|| defaults.and_then(|d| d.duration.clone()));
+    let encoder = entry
+        .encoder
+        .or_else(|| defaults.and_then(|d| d.encoder.clone()))
+        .unwrap_or_else(|| default_encoder_for(&entry.signal_type));
+    let sink = entry
+        .sink
+        .or_else(|| defaults.and_then(|d| d.sink.clone()))
+        .unwrap_or_else(default_sink);
+    let labels = if entry.pack.is_some() {
+        // Pack entries defer label composition to Phase 3 expansion; keep
+        // only the entry's own labels here so pack shared/per-metric labels
+        // can be inserted between defaults and entry levels (spec §2.2).
+        entry.labels
+    } else {
+        merge_labels(defaults.and_then(|d| d.labels.as_ref()), entry.labels)
+    };
+
+    Ok(NormalizedEntry {
+        id: entry.id,
+        signal_type: entry.signal_type,
+        name: entry.name,
+        rate,
+        duration,
+        generator: entry.generator,
+        log_generator: entry.log_generator,
+        labels,
+        dynamic_labels: entry.dynamic_labels,
+        encoder,
+        sink,
+        jitter: entry.jitter,
+        jitter_seed: entry.jitter_seed,
+        gaps: entry.gaps,
+        bursts: entry.bursts,
+        cardinality_spikes: entry.cardinality_spikes,
+        phase_offset: entry.phase_offset,
+        clock_group: entry.clock_group,
+        after: entry.after,
+        pack: entry.pack,
+        overrides: entry.overrides,
+        distribution: entry.distribution,
+        buckets: entry.buckets,
+        quantiles: entry.quantiles,
+        observations_per_tick: entry.observations_per_tick,
+        mean_shift_per_sec: entry.mean_shift_per_sec,
+        seed: entry.seed,
+    })
+}
+
+/// Resolve `rate` from the entry or defaults, producing a diagnostic error
+/// when neither is set.
+fn resolve_rate(
+    entry: &Entry,
+    defaults: Option<&Defaults>,
+    index: usize,
+) -> Result<f64, NormalizeError> {
+    if let Some(rate) = entry.rate {
+        return Ok(rate);
+    }
+    if let Some(rate) = defaults.and_then(|d| d.rate) {
+        return Ok(rate);
+    }
+    Err(NormalizeError::MissingRate {
+        index,
+        label: entry_label(entry),
+    })
+}
+
+/// Pick a human-readable label for an entry for use in error messages.
+///
+/// Preference order: `name` → `id` → `pack` → `<unnamed>`.
+fn entry_label(entry: &Entry) -> String {
+    entry
+        .name
+        .clone()
+        .or_else(|| entry.id.clone())
+        .or_else(|| entry.pack.clone())
+        .unwrap_or_else(|| "<unnamed>".to_string())
+}
+
+/// Return the built-in encoder default for a given signal type.
+///
+/// Unknown signal types fall through to `prometheus_text` as a neutral
+/// default. Parse-time validation rejects unknown signal types, so this
+/// branch is unreachable in practice; we still return a value rather than
+/// panic to keep the function total.
+fn default_encoder_for(signal_type: &str) -> EncoderConfig {
+    match signal_type {
+        "logs" => EncoderConfig::JsonLines { precision: None },
+        _ => EncoderConfig::PrometheusText { precision: None },
+    }
+}
+
+/// Return the built-in sink default (`stdout`).
+fn default_sink() -> SinkConfig {
+    SinkConfig::Stdout
+}
+
+/// Merge a file-level labels map with an entry-level labels map.
+///
+/// Entry-level keys win on conflict. If either side is `None`, the other
+/// side is returned unchanged. If both sides are `None`, returns `None`.
+fn merge_labels(
+    defaults_labels: Option<&BTreeMap<String, String>>,
+    entry_labels: Option<BTreeMap<String, String>>,
+) -> Option<BTreeMap<String, String>> {
+    match (defaults_labels, entry_labels) {
+        (None, None) => None,
+        (Some(d), None) => Some(d.clone()),
+        (None, Some(e)) => Some(e),
+        (Some(d), Some(e)) => {
+            let mut merged = d.clone();
+            for (k, v) in e {
+                merged.insert(k, v);
+            }
+            Some(merged)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::super::parse::parse;
+    use super::*;
+
+    // ======================================================================
+    // Helpers
+    // ======================================================================
+
+    fn normalize_yaml(yaml: &str) -> Result<NormalizedFile, NormalizeError> {
+        let parsed = parse(yaml).expect("parse must succeed in normalization tests");
+        normalize(parsed)
+    }
+
+    fn is_prometheus_text(encoder: &EncoderConfig) -> bool {
+        matches!(encoder, EncoderConfig::PrometheusText { .. })
+    }
+
+    fn is_json_lines(encoder: &EncoderConfig) -> bool {
+        matches!(encoder, EncoderConfig::JsonLines { .. })
+    }
+
+    fn is_stdout(sink: &SinkConfig) -> bool {
+        matches!(sink, SinkConfig::Stdout)
+    }
+
+    // ======================================================================
+    // Defaults inheritance
+    // ======================================================================
+
+    #[test]
+    fn entry_inherits_rate_and_duration_from_defaults() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  duration: 5m
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        let entry = &file.entries[0];
+        assert!((entry.rate - 1.0).abs() < f64::EPSILON);
+        assert_eq!(entry.duration.as_deref(), Some("5m"));
+    }
+
+    #[test]
+    fn entry_rate_overrides_defaults_rate() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    rate: 10
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        assert!((file.entries[0].rate - 10.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn entry_duration_overrides_defaults_duration() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  duration: 5m
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    duration: 30s
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        assert_eq!(file.entries[0].duration.as_deref(), Some("30s"));
+    }
+
+    #[test]
+    fn entry_inherits_encoder_and_sink_from_defaults() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  encoder: { type: influx_lp }
+  sink: { type: file, path: /tmp/out.txt }
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        let entry = &file.entries[0];
+        assert!(matches!(
+            entry.encoder,
+            EncoderConfig::InfluxLineProtocol { .. }
+        ));
+        assert!(matches!(entry.sink, SinkConfig::File { .. }));
+    }
+
+    #[test]
+    fn entry_encoder_overrides_defaults_encoder() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  encoder: { type: influx_lp }
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    encoder: { type: prometheus_text }
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        assert!(is_prometheus_text(&file.entries[0].encoder));
+    }
+
+    // ======================================================================
+    // Built-in defaults
+    // ======================================================================
+
+    #[test]
+    fn metrics_defaults_to_prometheus_text_and_stdout() {
+        let yaml = r#"
+version: 2
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    rate: 1
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        assert!(is_prometheus_text(&file.entries[0].encoder));
+        assert!(is_stdout(&file.entries[0].sink));
+    }
+
+    #[test]
+    fn histogram_defaults_to_prometheus_text() {
+        let yaml = r#"
+version: 2
+scenarios:
+  - signal_type: histogram
+    name: http_latency
+    rate: 1
+    distribution: { type: exponential, rate: 10.0 }
+    buckets: [0.1, 0.5, 1.0]
+    observations_per_tick: 50
+    seed: 1
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        assert!(is_prometheus_text(&file.entries[0].encoder));
+    }
+
+    #[test]
+    fn summary_defaults_to_prometheus_text() {
+        let yaml = r#"
+version: 2
+scenarios:
+  - signal_type: summary
+    name: rpc_latency
+    rate: 1
+    distribution: { type: normal, mean: 0.1, stddev: 0.02 }
+    quantiles: [0.5, 0.9, 0.99]
+    observations_per_tick: 50
+    seed: 1
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        assert!(is_prometheus_text(&file.entries[0].encoder));
+    }
+
+    #[test]
+    fn logs_defaults_to_json_lines() {
+        let yaml = r#"
+version: 2
+scenarios:
+  - signal_type: logs
+    name: app_logs
+    rate: 1
+    log_generator:
+      type: template
+      templates:
+        - message: "hello"
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        assert!(is_json_lines(&file.entries[0].encoder));
+        assert!(is_stdout(&file.entries[0].sink));
+    }
+
+    // ======================================================================
+    // Labels merge
+    // ======================================================================
+
+    #[test]
+    fn labels_merge_entry_wins_on_conflict() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  labels:
+    device: rtr-edge-01
+    region: us-west-2
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    labels:
+      region: us-east-1
+      interface: Gi0/0/0
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        let labels = file.entries[0]
+            .labels
+            .as_ref()
+            .expect("merged labels must exist");
+        assert_eq!(
+            labels.get("device").map(String::as_str),
+            Some("rtr-edge-01")
+        );
+        assert_eq!(
+            labels.get("region").map(String::as_str),
+            Some("us-east-1"),
+            "entry value must win on conflict"
+        );
+        assert_eq!(labels.get("interface").map(String::as_str), Some("Gi0/0/0"));
+    }
+
+    #[test]
+    fn labels_from_defaults_alone_are_preserved() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  labels:
+    env: staging
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        let labels = file.entries[0].labels.as_ref().expect("labels must exist");
+        assert_eq!(labels.get("env").map(String::as_str), Some("staging"));
+        assert_eq!(labels.len(), 1);
+    }
+
+    #[test]
+    fn entry_labels_preserved_when_defaults_has_no_labels() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    labels:
+      job: api
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        let labels = file.entries[0].labels.as_ref().expect("labels must exist");
+        assert_eq!(labels.get("job").map(String::as_str), Some("api"));
+        assert_eq!(labels.len(), 1);
+    }
+
+    #[test]
+    fn no_labels_anywhere_produces_none() {
+        let yaml = r#"
+version: 2
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    rate: 1
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        assert!(file.entries[0].labels.is_none());
+    }
+
+    // ======================================================================
+    // Missing rate error
+    // ======================================================================
+
+    #[test]
+    fn missing_rate_on_inline_entry_returns_error() {
+        let yaml = r#"
+version: 2
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    generator: { type: constant, value: 1.0 }
+"#;
+        let err = normalize_yaml(yaml).expect_err("missing rate must fail");
+        match err {
+            NormalizeError::MissingRate { index, label } => {
+                assert_eq!(index, 0);
+                assert_eq!(label, "cpu");
+            }
+        }
+    }
+
+    #[test]
+    fn missing_rate_error_prefers_id_over_pack_label() {
+        // When `name` is absent, the label comes from `id` next. Here we set
+        // the entry's `id` and omit `name` via a pack entry (packs need not
+        // have `name`).
+        let yaml = r#"
+version: 2
+scenarios:
+  - id: snmp_iface
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let err = normalize_yaml(yaml).expect_err("missing rate must fail");
+        match err {
+            NormalizeError::MissingRate { index, label } => {
+                assert_eq!(index, 0);
+                assert_eq!(label, "snmp_iface");
+            }
+        }
+    }
+
+    #[test]
+    fn missing_rate_error_falls_back_to_pack_label() {
+        let yaml = r#"
+version: 2
+scenarios:
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let err = normalize_yaml(yaml).expect_err("missing rate must fail");
+        match err {
+            NormalizeError::MissingRate { index, label } => {
+                assert_eq!(index, 0);
+                assert_eq!(label, "telegraf_snmp_interface");
+            }
+        }
+    }
+
+    #[test]
+    fn missing_rate_message_mentions_entry_and_hint() {
+        let yaml = r#"
+version: 2
+scenarios:
+  - signal_type: metrics
+    name: bare
+    generator: { type: constant, value: 1.0 }
+"#;
+        let err = normalize_yaml(yaml).expect_err("missing rate must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("entry 0"), "error should mention entry index");
+        assert!(msg.contains("bare"), "error should mention entry name");
+        assert!(msg.contains("rate"), "error should mention rate");
+        assert!(
+            msg.contains("defaults"),
+            "error should hint at defaults block"
+        );
+    }
+
+    // ======================================================================
+    // Shorthand normalization
+    // ======================================================================
+
+    #[test]
+    fn shorthand_single_signal_normalizes_through_wrapped_form() {
+        let yaml = r#"
+version: 2
+name: cpu_usage
+signal_type: metrics
+rate: 5
+generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize shorthand");
+        assert_eq!(file.entries.len(), 1);
+        let entry = &file.entries[0];
+        assert!((entry.rate - 5.0).abs() < f64::EPSILON);
+        assert_eq!(entry.name.as_deref(), Some("cpu_usage"));
+        assert!(is_prometheus_text(&entry.encoder));
+        assert!(is_stdout(&entry.sink));
+    }
+
+    #[test]
+    fn shorthand_logs_signal_picks_json_lines_default() {
+        let yaml = r#"
+version: 2
+name: app_logs
+signal_type: logs
+rate: 2
+log_generator:
+  type: template
+  templates:
+    - message: "hello"
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize logs shorthand");
+        assert!(is_json_lines(&file.entries[0].encoder));
+    }
+
+    // ======================================================================
+    // Pack entry normalization
+    // ======================================================================
+
+    #[test]
+    fn pack_entry_inherits_defaults_but_defers_label_merge() {
+        // Spec §2.2 reserves precedence levels 3–5 (pack shared fields,
+        // pack shared_labels, pack per-metric labels) for Phase 3 expansion
+        // between defaults (level 2) and entry labels (level 6). Eagerly
+        // merging here would collapse that chain. This test documents the
+        // asymmetry: pack entries keep their own labels verbatim, while
+        // `defaults.labels` rides on NormalizedFile::defaults_labels.
+        //
+        // Example from the user: defaults.labels = {job: web}, entry =
+        // {labels: {device: rtr-01}, pack: mypack}. Phase 3 will expand the
+        // pack's shared_labels (e.g. {job: snmp}) on top of defaults,
+        // then apply entry labels on top — yielding {job: snmp, device: rtr-01}.
+        // If we merged here the pack's job override would be unreachable.
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  duration: 10m
+  encoder: { type: prometheus_text }
+  sink: { type: stdout }
+  labels:
+    job: web
+scenarios:
+  - id: primary_uplink
+    signal_type: metrics
+    pack: mypack
+    labels:
+      device: rtr-01
+    overrides:
+      ifOperStatus:
+        generator: { type: constant, value: 0.0 }
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize pack entry");
+        let entry = &file.entries[0];
+        assert_eq!(entry.pack.as_deref(), Some("mypack"));
+        assert!(
+            entry.overrides.is_some(),
+            "overrides must be carried through untouched"
+        );
+        assert!((entry.rate - 1.0).abs() < f64::EPSILON);
+        assert_eq!(entry.duration.as_deref(), Some("10m"));
+        assert!(is_prometheus_text(&entry.encoder));
+        assert!(is_stdout(&entry.sink));
+
+        // Pack entry labels are NOT merged with defaults.labels.
+        let labels = entry.labels.as_ref().expect("entry labels must exist");
+        assert_eq!(labels.len(), 1, "only entry labels — defaults not merged");
+        assert_eq!(labels.get("device").map(String::as_str), Some("rtr-01"));
+        assert!(
+            !labels.contains_key("job"),
+            "defaults.labels must not leak into pack entry's labels"
+        );
+
+        // defaults.labels is preserved verbatim at the file level for
+        // Phase 3 pack expansion to apply.
+        let d = file
+            .defaults_labels
+            .as_ref()
+            .expect("defaults_labels must be surfaced");
+        assert_eq!(d.get("job").map(String::as_str), Some("web"));
+    }
+
+    #[test]
+    fn normalized_file_defaults_labels_matches_source() {
+        // Present when defaults.labels is set and non-empty.
+        let yaml_with = r#"
+version: 2
+defaults:
+  rate: 1
+  labels:
+    env: prod
+    region: us-east-1
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml_with).expect("must normalize");
+        let d = file
+            .defaults_labels
+            .as_ref()
+            .expect("defaults_labels must be Some when defaults.labels is set");
+        assert_eq!(d.len(), 2);
+        assert_eq!(d.get("env").map(String::as_str), Some("prod"));
+        assert_eq!(d.get("region").map(String::as_str), Some("us-east-1"));
+
+        // None when the file has no defaults block at all.
+        let yaml_no_defaults = r#"
+version: 2
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    rate: 1
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml_no_defaults).expect("must normalize");
+        assert!(file.defaults_labels.is_none());
+
+        // None when defaults exists but has no labels field.
+        let yaml_no_labels = r#"
+version: 2
+defaults:
+  rate: 1
+  duration: 5m
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    generator: { type: constant, value: 42 }
+"#;
+        let file = normalize_yaml(yaml_no_labels).expect("must normalize");
+        assert!(file.defaults_labels.is_none());
+    }
+
+    #[test]
+    fn inline_and_pack_entries_compose_defaults_labels_asymmetrically() {
+        // One file, two entries both "inheriting" defaults.labels. The
+        // inline entry gets the eager merge; the pack entry does not.
+        // defaults_labels must carry the source map verbatim for Phase 3.
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  labels:
+    job: web
+    region: us-east-1
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    labels:
+      host: node-01
+    generator: { type: constant, value: 42 }
+
+  - signal_type: metrics
+    pack: mypack
+    labels:
+      device: rtr-01
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        assert_eq!(file.entries.len(), 2);
+
+        // Inline entry: labels = defaults ∪ entry, entry wins on conflict.
+        let inline = &file.entries[0];
+        assert!(inline.pack.is_none());
+        let inline_labels = inline.labels.as_ref().expect("inline labels must exist");
+        assert_eq!(inline_labels.len(), 3, "defaults + entry merged");
+        assert_eq!(inline_labels.get("job").map(String::as_str), Some("web"));
+        assert_eq!(
+            inline_labels.get("region").map(String::as_str),
+            Some("us-east-1")
+        );
+        assert_eq!(
+            inline_labels.get("host").map(String::as_str),
+            Some("node-01")
+        );
+
+        // Pack entry: labels = entry's own labels only. No merge happened.
+        let pack = &file.entries[1];
+        assert_eq!(pack.pack.as_deref(), Some("mypack"));
+        let pack_labels = pack.labels.as_ref().expect("pack entry labels must exist");
+        assert_eq!(pack_labels.len(), 1, "only entry-level labels, no merge");
+        assert_eq!(
+            pack_labels.get("device").map(String::as_str),
+            Some("rtr-01")
+        );
+        assert!(!pack_labels.contains_key("job"));
+        assert!(!pack_labels.contains_key("region"));
+
+        // File-level defaults_labels carries the source map verbatim.
+        let d = file
+            .defaults_labels
+            .as_ref()
+            .expect("defaults_labels must be Some");
+        assert_eq!(d.len(), 2);
+        assert_eq!(d.get("job").map(String::as_str), Some("web"));
+        assert_eq!(d.get("region").map(String::as_str), Some("us-east-1"));
+    }
+
+    // ======================================================================
+    // Multi-scenario mixed entries
+    // ======================================================================
+
+    #[test]
+    fn multi_scenario_mixed_entries_all_normalize() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  duration: 5m
+  encoder: { type: prometheus_text }
+  sink: { type: stdout }
+  labels:
+    region: us-west-2
+scenarios:
+  - id: link_state
+    signal_type: metrics
+    name: interface_oper_state
+    labels:
+      interface: Gi0/0/0
+      region: us-east-1
+    generator: { type: flap, up_duration: 60s, down_duration: 30s }
+
+  - id: fast_metric
+    signal_type: metrics
+    name: cpu
+    rate: 10
+    generator: { type: constant, value: 42 }
+
+  - signal_type: logs
+    name: app_logs
+    log_generator:
+      type: template
+      templates:
+        - message: "hello"
+
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+    labels:
+      device: rtr-01
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize multi-scenario");
+        assert_eq!(file.entries.len(), 4);
+
+        // Entry 0: inline metric, inherits rate/duration/encoder/sink,
+        // labels merged with entry's region winning.
+        let e0 = &file.entries[0];
+        assert!((e0.rate - 1.0).abs() < f64::EPSILON);
+        assert_eq!(e0.duration.as_deref(), Some("5m"));
+        assert!(is_prometheus_text(&e0.encoder));
+        let labels0 = e0.labels.as_ref().expect("labels must exist");
+        assert_eq!(labels0.get("region").map(String::as_str), Some("us-east-1"));
+        assert_eq!(
+            labels0.get("interface").map(String::as_str),
+            Some("Gi0/0/0")
+        );
+
+        // Entry 1: rate override wins, inherits everything else.
+        let e1 = &file.entries[1];
+        assert!((e1.rate - 10.0).abs() < f64::EPSILON);
+        assert_eq!(e1.duration.as_deref(), Some("5m"));
+        let labels1 = e1.labels.as_ref().expect("labels must exist");
+        assert_eq!(
+            labels1.get("region").map(String::as_str),
+            Some("us-west-2"),
+            "entry has no labels.region, defaults wins"
+        );
+
+        // Entry 2: logs, picks json_lines default (defaults.encoder is
+        // prometheus_text but is overridden for logs? No — defaults.encoder
+        // is explicitly set in this file, so every entry inherits it, even
+        // logs. This is consistent with precedence: defaults wins over
+        // built-in, even when the built-in would be signal-type-aware.
+        let e2 = &file.entries[2];
+        assert!(
+            is_prometheus_text(&e2.encoder),
+            "explicit defaults.encoder applies to all entries including logs"
+        );
+
+        // Entry 3: pack entry, carries through pack field but does NOT
+        // merge defaults.labels (see module docs on the asymmetry).
+        let e3 = &file.entries[3];
+        assert_eq!(e3.pack.as_deref(), Some("telegraf_snmp_interface"));
+        let labels3 = e3.labels.as_ref().expect("labels must exist");
+        assert_eq!(labels3.len(), 1, "only entry-level labels on pack entry");
+        assert_eq!(labels3.get("device").map(String::as_str), Some("rtr-01"));
+        assert!(!labels3.contains_key("region"));
+
+        // defaults.labels still travels with the file for Phase 3 to apply.
+        let d = file
+            .defaults_labels
+            .as_ref()
+            .expect("defaults_labels must be Some");
+        assert_eq!(d.get("region").map(String::as_str), Some("us-west-2"));
+    }
+
+    // ======================================================================
+    // Fields carried through untouched
+    // ======================================================================
+
+    #[test]
+    fn after_clause_and_timing_fields_preserved() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+scenarios:
+  - id: src
+    signal_type: metrics
+    name: source
+    generator: { type: constant, value: 100.0 }
+
+  - signal_type: metrics
+    name: dependent
+    phase_offset: 5s
+    clock_group: group_a
+    generator: { type: constant, value: 1.0 }
+    after:
+      ref: src
+      op: ">"
+      value: 50.0
+      delay: 2s
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        let dep = &file.entries[1];
+        assert_eq!(dep.phase_offset.as_deref(), Some("5s"));
+        assert_eq!(dep.clock_group.as_deref(), Some("group_a"));
+        let after = dep.after.as_ref().expect("after must be preserved");
+        assert_eq!(after.ref_id, "src");
+        assert_eq!(after.delay.as_deref(), Some("2s"));
+    }
+
+    #[test]
+    fn histogram_fields_preserved() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+scenarios:
+  - signal_type: histogram
+    name: latency
+    distribution: { type: exponential, rate: 10.0 }
+    buckets: [0.1, 0.5, 1.0]
+    observations_per_tick: 100
+    mean_shift_per_sec: 0.01
+    seed: 42
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize");
+        let entry = &file.entries[0];
+        assert!(entry.distribution.is_some());
+        assert_eq!(entry.buckets.as_ref().map(Vec::len), Some(3));
+        assert_eq!(entry.observations_per_tick, Some(100));
+        assert_eq!(entry.mean_shift_per_sec, Some(0.01));
+        assert_eq!(entry.seed, Some(42));
+    }
+
+    // ======================================================================
+    // Contract tests
+    // ======================================================================
+
+    #[test]
+    fn normalize_error_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<NormalizeError>();
+    }
+
+    #[test]
+    fn normalized_types_are_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<NormalizedFile>();
+        assert_send_sync::<NormalizedEntry>();
+    }
+
+    // ======================================================================
+    // Empty scenarios
+    // ======================================================================
+
+    #[test]
+    fn empty_scenarios_list_normalizes_to_empty_entries() {
+        let yaml = r#"
+version: 2
+scenarios: []
+"#;
+        let file = normalize_yaml(yaml).expect("must normalize empty list");
+        assert_eq!(file.version, 2);
+        assert!(file.entries.is_empty());
+    }
+
+    // ======================================================================
+    // helper unit tests (internal)
+    // ======================================================================
+
+    #[test]
+    fn merge_labels_both_none_returns_none() {
+        assert!(merge_labels(None, None).is_none());
+    }
+
+    #[test]
+    fn merge_labels_only_defaults_returns_defaults_clone() {
+        let mut d = BTreeMap::new();
+        d.insert("a".to_string(), "1".to_string());
+        let merged = merge_labels(Some(&d), None).expect("must return map");
+        assert_eq!(merged.get("a").map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn merge_labels_only_entry_returns_entry() {
+        let mut e = BTreeMap::new();
+        e.insert("b".to_string(), "2".to_string());
+        let merged = merge_labels(None, Some(e)).expect("must return map");
+        assert_eq!(merged.get("b").map(String::as_str), Some("2"));
+    }
+
+    #[test]
+    fn merge_labels_entry_overrides_defaults_on_conflict() {
+        let mut d = BTreeMap::new();
+        d.insert("k".to_string(), "from_defaults".to_string());
+        let mut e = BTreeMap::new();
+        e.insert("k".to_string(), "from_entry".to_string());
+        let merged = merge_labels(Some(&d), Some(e)).expect("must return map");
+        assert_eq!(merged.get("k").map(String::as_str), Some("from_entry"));
+    }
+
+    #[test]
+    fn default_encoder_per_signal_type() {
+        assert!(matches!(
+            default_encoder_for("metrics"),
+            EncoderConfig::PrometheusText { .. }
+        ));
+        assert!(matches!(
+            default_encoder_for("histogram"),
+            EncoderConfig::PrometheusText { .. }
+        ));
+        assert!(matches!(
+            default_encoder_for("summary"),
+            EncoderConfig::PrometheusText { .. }
+        ));
+        assert!(matches!(
+            default_encoder_for("logs"),
+            EncoderConfig::JsonLines { .. }
+        ));
+    }
+
+    #[test]
+    fn default_sink_is_stdout() {
+        assert!(matches!(default_sink(), SinkConfig::Stdout));
+    }
+}

--- a/sonda-core/src/compiler/parse.rs
+++ b/sonda-core/src/compiler/parse.rs
@@ -1,6 +1,6 @@
 //! YAML parsing, schema validation, and version detection for v2 scenario files.
 //!
-//! The primary entry point is [`parse_v2`], which deserializes a YAML string
+//! The primary entry point is [`parse`], which deserializes a YAML string
 //! into a [`ScenarioFile`] and runs structural validation (version check,
 //! id uniqueness, signal type validity, generator/pack mutual exclusion).
 //!
@@ -289,8 +289,8 @@ impl FlatFile {
 /// # Errors
 ///
 /// Returns [`ParseError`] describing the first validation failure found.
-pub fn parse_v2(yaml: &str) -> Result<ScenarioFile, ParseError> {
-    let file = deserialize_v2(yaml)?;
+pub fn parse(yaml: &str) -> Result<ScenarioFile, ParseError> {
+    let file = deserialize(yaml)?;
 
     if file.version != 2 {
         return Err(ParseError::InvalidVersion(file.version));
@@ -306,7 +306,7 @@ pub fn parse_v2(yaml: &str) -> Result<ScenarioFile, ParseError> {
 /// produces confusing errors when a canonical file has a structural mistake), we
 /// peek for the `scenarios` key first. If present, we parse as canonical. If
 /// absent, we parse as flat shorthand. No fallback.
-fn deserialize_v2(yaml: &str) -> Result<ScenarioFile, ParseError> {
+fn deserialize(yaml: &str) -> Result<ScenarioFile, ParseError> {
     /// Minimal probe to detect whether the YAML contains a `scenarios` key.
     /// Intentionally does NOT use `deny_unknown_fields`.
     #[derive(serde::Deserialize)]
@@ -503,7 +503,7 @@ scenarios:
       device: rtr-01
 "#;
 
-        let file = parse_v2(yaml).expect("must parse valid multi-scenario file");
+        let file = parse(yaml).expect("must parse valid multi-scenario file");
         assert_eq!(file.version, 2);
         assert_eq!(file.scenarios.len(), 3);
         assert_eq!(file.scenarios[0].signal_type, "metrics");
@@ -530,7 +530,7 @@ generator:
   offset: 50
 "#;
 
-        let file = parse_v2(yaml).expect("must parse single-signal shorthand");
+        let file = parse(yaml).expect("must parse single-signal shorthand");
         assert_eq!(file.version, 2);
         assert!(file.defaults.is_none());
         assert_eq!(file.scenarios.len(), 1);
@@ -553,7 +553,7 @@ labels:
   device: rtr-01
 "#;
 
-        let file = parse_v2(yaml).expect("must parse pack shorthand");
+        let file = parse(yaml).expect("must parse pack shorthand");
         assert_eq!(file.version, 2);
         assert_eq!(file.scenarios.len(), 1);
 
@@ -591,7 +591,7 @@ scenarios:
       value: 90.0
 "#;
 
-        let file = parse_v2(yaml).expect("must parse after clause");
+        let file = parse(yaml).expect("must parse after clause");
         assert_eq!(file.scenarios.len(), 2);
 
         let after = file.scenarios[1]
@@ -630,7 +630,7 @@ scenarios:
       delay: "5s"
 "#;
 
-        let file = parse_v2(yaml).expect("must parse after with delay");
+        let file = parse(yaml).expect("must parse after with delay");
         let after = file.scenarios[1]
             .after
             .as_ref()
@@ -655,7 +655,7 @@ scenarios:
     seed: 42
 "#;
 
-        let file = parse_v2(yaml).expect("must parse histogram entry");
+        let file = parse(yaml).expect("must parse histogram entry");
         assert_eq!(file.scenarios.len(), 1);
 
         let entry = &file.scenarios[0];
@@ -684,7 +684,7 @@ scenarios:
     seed: 99
 "#;
 
-        let file = parse_v2(yaml).expect("must parse summary entry");
+        let file = parse(yaml).expect("must parse summary entry");
         assert_eq!(file.scenarios.len(), 1);
 
         let entry = &file.scenarios[0];
@@ -715,7 +715,7 @@ scenarios:
       value: 50.0
 "#;
 
-        let file = parse_v2(yaml).expect("must parse file with defaults");
+        let file = parse(yaml).expect("must parse file with defaults");
         let defaults = file.defaults.as_ref().expect("must have defaults");
         assert!((defaults.rate.expect("must have rate") - 10.0).abs() < f64::EPSILON);
         assert_eq!(defaults.duration.as_deref(), Some("60s"));
@@ -769,7 +769,7 @@ scenarios:
     clock_group: group_a
 "#;
 
-        let file = parse_v2(yaml).expect("must parse entry with all optional fields");
+        let file = parse(yaml).expect("must parse entry with all optional fields");
         let entry = &file.scenarios[0];
 
         assert_eq!(entry.id.as_deref(), Some("full_entry"));
@@ -806,7 +806,7 @@ scenarios:
       value: 1.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("version 1 must fail");
+        let err = parse(yaml).expect_err("version 1 must fail");
         assert!(
             matches!(err, ParseError::InvalidVersion(1)),
             "expected InvalidVersion(1), got: {err}"
@@ -824,7 +824,7 @@ scenarios:
       value: 1.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("missing version must fail");
+        let err = parse(yaml).expect_err("missing version must fail");
         assert!(
             matches!(err, ParseError::Yaml(_)),
             "expected Yaml error, got: {err}"
@@ -850,7 +850,7 @@ scenarios:
       value: 2.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("duplicate ids must fail");
+        let err = parse(yaml).expect_err("duplicate ids must fail");
         assert!(
             matches!(err, ParseError::DuplicateId(ref id) if id == "same_id"),
             "expected DuplicateId('same_id'), got: {err}"
@@ -869,7 +869,7 @@ scenarios:
       value: 1.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("invalid signal_type must fail");
+        let err = parse(yaml).expect_err("invalid signal_type must fail");
         assert!(
             matches!(err, ParseError::InvalidSignalType { index: 0, ref signal_type } if signal_type == "traces"),
             "expected InvalidSignalType at index 0, got: {err}"
@@ -889,7 +889,7 @@ scenarios:
     pack: some_pack
 "#;
 
-        let err = parse_v2(yaml).expect_err("generator + pack must fail");
+        let err = parse(yaml).expect_err("generator + pack must fail");
         assert!(
             matches!(err, ParseError::GeneratorAndPack { index: 0 }),
             "expected GeneratorAndPack at index 0, got: {err}"
@@ -905,7 +905,7 @@ scenarios:
     name: bare_entry
 "#;
 
-        let err = parse_v2(yaml).expect_err("missing generator/pack must fail");
+        let err = parse(yaml).expect_err("missing generator/pack must fail");
         assert!(
             matches!(err, ParseError::MissingGeneratorOrPack { index: 0 }),
             "expected MissingGeneratorOrPack at index 0, got: {err}"
@@ -921,7 +921,7 @@ scenarios:
     pack: some_log_pack
 "#;
 
-        let err = parse_v2(yaml).expect_err("pack + logs must fail");
+        let err = parse(yaml).expect_err("pack + logs must fail");
         assert!(
             matches!(err, ParseError::PackNotMetrics { index: 0 }),
             "expected PackNotMetrics at index 0, got: {err}"
@@ -937,7 +937,7 @@ scenarios:
     name: bare_log
 "#;
 
-        let err = parse_v2(yaml).expect_err("logs without log_generator must fail");
+        let err = parse(yaml).expect_err("logs without log_generator must fail");
         assert!(
             matches!(err, ParseError::MissingGeneratorOrPack { index: 0 }),
             "expected MissingGeneratorOrPack at index 0, got: {err}"
@@ -955,7 +955,7 @@ scenarios:
       value: 1.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("inline without name must fail");
+        let err = parse(yaml).expect_err("inline without name must fail");
         assert!(
             matches!(err, ParseError::MissingName { index: 0 }),
             "expected MissingName at index 0, got: {err}"
@@ -975,7 +975,7 @@ scenarios:
       value: 1.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("id starting with digit must fail");
+        let err = parse(yaml).expect_err("id starting with digit must fail");
         assert!(
             matches!(err, ParseError::InvalidId(ref id) if id == "123abc"),
             "expected InvalidId('123abc'), got: {err}"
@@ -995,7 +995,7 @@ scenarios:
       value: 1.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("id with dot must fail");
+        let err = parse(yaml).expect_err("id with dot must fail");
         assert!(
             matches!(err, ParseError::InvalidId(ref id) if id == "my.id"),
             "expected InvalidId('my.id'), got: {err}"
@@ -1025,7 +1025,7 @@ scenarios:
       value: 50.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("invalid after op must fail");
+        let err = parse(yaml).expect_err("invalid after op must fail");
         assert!(
             matches!(err, ParseError::Yaml(_)),
             "expected Yaml error for invalid op, got: {err}"
@@ -1156,7 +1156,7 @@ scenarios:
     buckets: [0.1, 0.5, 1.0]
 "#;
 
-        let err = parse_v2(yaml).expect_err("histogram without distribution must fail");
+        let err = parse(yaml).expect_err("histogram without distribution must fail");
         assert!(
             matches!(err, ParseError::MissingGeneratorOrPack { index: 0 }),
             "expected MissingGeneratorOrPack, got: {err}"
@@ -1184,7 +1184,7 @@ scenarios:
           alert: down
 "#;
 
-        let file = parse_v2(yaml).expect("must parse pack with overrides");
+        let file = parse(yaml).expect("must parse pack with overrides");
         let entry = &file.scenarios[0];
         let overrides = entry.overrides.as_ref().expect("must have overrides");
         assert!(overrides.contains_key("ifOperStatus"));
@@ -1207,7 +1207,7 @@ scenarios:
       value: 1.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("empty id must fail");
+        let err = parse(yaml).expect_err("empty id must fail");
         assert!(
             matches!(err, ParseError::InvalidId(ref id) if id.is_empty()),
             "expected InvalidId(''), got: {err}"
@@ -1235,7 +1235,7 @@ scenarios:
       seed: 1
 "#;
 
-        let err = parse_v2(yaml).expect_err("metrics + log_generator must fail");
+        let err = parse(yaml).expect_err("metrics + log_generator must fail");
         assert!(
             matches!(
                 err,
@@ -1262,7 +1262,7 @@ scenarios:
       stddev: 0.02
 "#;
 
-        let err = parse_v2(yaml).expect_err("metrics + distribution must fail");
+        let err = parse(yaml).expect_err("metrics + distribution must fail");
         assert!(
             matches!(
                 err,
@@ -1290,7 +1290,7 @@ scenarios:
       value: 1.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("logs + generator must fail");
+        let err = parse(yaml).expect_err("logs + generator must fail");
         assert!(
             matches!(
                 err,
@@ -1319,7 +1319,7 @@ scenarios:
       stddev: 0.02
 "#;
 
-        let err = parse_v2(yaml).expect_err("logs + distribution must fail");
+        let err = parse(yaml).expect_err("logs + distribution must fail");
         assert!(
             matches!(
                 err,
@@ -1346,7 +1346,7 @@ scenarios:
       value: 1.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("histogram + generator must fail");
+        let err = parse(yaml).expect_err("histogram + generator must fail");
         assert!(
             matches!(
                 err,
@@ -1375,7 +1375,7 @@ scenarios:
       seed: 1
 "#;
 
-        let err = parse_v2(yaml).expect_err("histogram + log_generator must fail");
+        let err = parse(yaml).expect_err("histogram + log_generator must fail");
         assert!(
             matches!(
                 err,
@@ -1403,7 +1403,7 @@ scenarios:
       value: 1.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("summary + generator must fail");
+        let err = parse(yaml).expect_err("summary + generator must fail");
         assert!(
             matches!(
                 err,
@@ -1436,7 +1436,7 @@ scenarios:
     bogus: unexpected_field
 "#;
 
-        let err = parse_v2(yaml).expect_err("malformed canonical file must fail");
+        let err = parse(yaml).expect_err("malformed canonical file must fail");
         let msg = err.to_string();
         // The error should mention the actual problem (unknown field `bogus`),
         // not the misleading "unknown field `scenarios`".
@@ -1479,7 +1479,7 @@ scenarios:
       value: 1.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("version 0 must fail");
+        let err = parse(yaml).expect_err("version 0 must fail");
         assert!(
             matches!(err, ParseError::InvalidVersion(0)),
             "expected InvalidVersion(0), got: {err}"
@@ -1495,7 +1495,7 @@ version: 2
 scenarios: []
 "#;
 
-        let file = parse_v2(yaml).expect("empty scenarios list should parse");
+        let file = parse(yaml).expect("empty scenarios list should parse");
         assert_eq!(file.version, 2);
         assert!(file.scenarios.is_empty());
     }
@@ -1514,7 +1514,7 @@ scenarios:
       value: 1.0
 "#;
 
-        let err = parse_v2(yaml).expect_err("typo in field name must fail");
+        let err = parse(yaml).expect_err("typo in field name must fail");
         assert!(
             matches!(err, ParseError::Yaml(_)),
             "expected Yaml error for unknown field, got: {err}"
@@ -1554,7 +1554,7 @@ observations_per_tick: 100
 seed: 42
 "#;
 
-        let file = parse_v2(yaml).expect("must parse histogram shorthand");
+        let file = parse(yaml).expect("must parse histogram shorthand");
         assert_eq!(file.scenarios.len(), 1);
         let entry = &file.scenarios[0];
         assert_eq!(entry.signal_type, "histogram");
@@ -1581,7 +1581,7 @@ observations_per_tick: 200
 seed: 99
 "#;
 
-        let file = parse_v2(yaml).expect("must parse summary shorthand");
+        let file = parse(yaml).expect("must parse summary shorthand");
         assert_eq!(file.scenarios.len(), 1);
         let entry = &file.scenarios[0];
         assert_eq!(entry.signal_type, "summary");
@@ -1607,7 +1607,7 @@ log_generator:
   seed: 42
 "#;
 
-        let file = parse_v2(yaml).expect("must parse logs shorthand");
+        let file = parse(yaml).expect("must parse logs shorthand");
         assert_eq!(file.scenarios.len(), 1);
         let entry = &file.scenarios[0];
         assert_eq!(entry.signal_type, "logs");
@@ -1632,7 +1632,7 @@ defaults:
   rate: 10
 "#;
 
-        let err = parse_v2(yaml).expect_err("defaults in shorthand must fail");
+        let err = parse(yaml).expect_err("defaults in shorthand must fail");
         assert!(
             matches!(err, ParseError::Yaml(_)),
             "expected Yaml error for defaults in shorthand, got: {err}"

--- a/sonda-core/tests/fixtures/v2-examples/expected/valid-defaults-label-merge.json
+++ b/sonda-core/tests/fixtures/v2-examples/expected/valid-defaults-label-merge.json
@@ -1,0 +1,93 @@
+{
+  "version": 2,
+  "defaults_labels": {
+    "device": "rtr-edge-01",
+    "region": "us-west-2"
+  },
+  "entries": [
+    {
+      "id": "link_state",
+      "signal_type": "metrics",
+      "name": "interface_oper_state",
+      "rate": 1.0,
+      "duration": "5m",
+      "generator": {
+        "type": "flap",
+        "up_duration": "60s",
+        "down_duration": "30s",
+        "up_value": null,
+        "down_value": null
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-edge-01",
+        "interface": "Gi0/0/0",
+        "region": "us-east-1"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "pack": null,
+      "overrides": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "fast_metric",
+      "signal_type": "metrics",
+      "name": "cpu",
+      "rate": 10.0,
+      "duration": "5m",
+      "generator": {
+        "type": "constant",
+        "value": 42.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-edge-01",
+        "region": "us-west-2"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "pack": null,
+      "overrides": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    }
+  ]
+}

--- a/sonda-core/tests/fixtures/v2-examples/expected/valid-defaults-logs-default-encoder.json
+++ b/sonda-core/tests/fixtures/v2-examples/expected/valid-defaults-logs-default-encoder.json
@@ -1,0 +1,49 @@
+{
+  "version": 2,
+  "entries": [
+    {
+      "id": null,
+      "signal_type": "logs",
+      "name": "app_logs",
+      "rate": 5.0,
+      "duration": null,
+      "generator": null,
+      "log_generator": {
+        "type": "template",
+        "templates": [
+          {
+            "message": "hello",
+            "field_pools": {}
+          }
+        ],
+        "severity_weights": null,
+        "seed": null
+      },
+      "labels": null,
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "json_lines",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "pack": null,
+      "overrides": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    }
+  ]
+}

--- a/sonda-core/tests/fixtures/v2-examples/expected/valid-defaults-pack-entry.json
+++ b/sonda-core/tests/fixtures/v2-examples/expected/valid-defaults-pack-entry.json
@@ -1,0 +1,53 @@
+{
+  "version": 2,
+  "defaults_labels": {
+    "env": "prod",
+    "job": "web"
+  },
+  "entries": [
+    {
+      "id": "primary_uplink",
+      "signal_type": "metrics",
+      "name": null,
+      "rate": 1.0,
+      "duration": "10m",
+      "generator": null,
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-01"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "pack": "telegraf_snmp_interface",
+      "overrides": {
+        "ifOperStatus": {
+          "generator": {
+            "type": "constant",
+            "value": 0.0
+          },
+          "labels": null
+        }
+      },
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    }
+  ]
+}

--- a/sonda-core/tests/fixtures/v2-examples/invalid-missing-rate.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-missing-rate.yaml
@@ -1,0 +1,9 @@
+# Missing `rate` — neither the entry nor `defaults:` sets it.
+# Normalization must reject this with a diagnostic identifying the entry.
+version: 2
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    generator:
+      type: constant
+      value: 1.0

--- a/sonda-core/tests/fixtures/v2-examples/valid-defaults-label-merge.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-defaults-label-merge.yaml
@@ -1,0 +1,35 @@
+# Defaults resolution with per-entry label override and rate override.
+# Every entry inherits duration, encoder, and sink from `defaults:`.
+# The first entry merges its labels with `defaults.labels`: `region` is
+# overridden by the entry, `device` and `interface` remain.
+# The second entry overrides `rate` and uses `defaults.labels` as-is.
+version: 2
+defaults:
+  rate: 1
+  duration: 5m
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+  labels:
+    device: rtr-edge-01
+    region: us-west-2
+scenarios:
+  - id: link_state
+    signal_type: metrics
+    name: interface_oper_state
+    labels:
+      interface: Gi0/0/0
+      region: us-east-1
+    generator:
+      type: flap
+      up_duration: 60s
+      down_duration: 30s
+
+  - id: fast_metric
+    signal_type: metrics
+    name: cpu
+    rate: 10
+    generator:
+      type: constant
+      value: 42

--- a/sonda-core/tests/fixtures/v2-examples/valid-defaults-logs-default-encoder.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-defaults-logs-default-encoder.yaml
@@ -1,0 +1,13 @@
+# Built-in encoder fallback for logs when `defaults:` sets no encoder.
+# `defaults.rate` flows into the entry; the encoder becomes `json_lines`
+# via the built-in signal-type default.
+version: 2
+defaults:
+  rate: 5
+scenarios:
+  - signal_type: logs
+    name: app_logs
+    log_generator:
+      type: template
+      templates:
+        - message: "hello"

--- a/sonda-core/tests/fixtures/v2-examples/valid-defaults-pack-entry.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-defaults-pack-entry.yaml
@@ -1,0 +1,40 @@
+# Defaults resolution on a pack-backed entry.
+# The pack entry inherits `rate`, `duration`, `encoder`, and `sink` from
+# `defaults:`. Its own `pack:` and `overrides:` fields are preserved for
+# pack expansion (handled in a later compilation phase).
+#
+# Note on labels: `defaults.labels` is NOT merged into a pack entry's
+# `labels` here — per spec §2.2 the final pack-metric label map must
+# interleave pack shared/per-metric labels between the defaults layer and
+# the entry layer. Phase 3 expansion does that. Until then:
+#   - the pack entry's `labels` carries only what the user wrote on the
+#     entry (so `{device: rtr-01}`, NOT `{env: prod, device: rtr-01}`),
+#   - the file-level `defaults.labels` is surfaced on the normalized
+#     file's `defaults_labels` field so Phase 3 can apply it at the
+#     correct precedence slot.
+# The non-merge is observable in the golden snapshot: the pack entry's
+# `labels` holds only `{device: rtr-01}`. If we were (incorrectly) merging,
+# those labels would also contain `job` and `env` inherited from
+# `defaults.labels`.
+version: 2
+defaults:
+  rate: 1
+  duration: 10m
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+  labels:
+    job: web
+    env: prod
+scenarios:
+  - id: primary_uplink
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+    labels:
+      device: rtr-01
+    overrides:
+      ifOperStatus:
+        generator:
+          type: constant
+          value: 0.0

--- a/sonda-core/tests/v2_fixture_examples.rs
+++ b/sonda-core/tests/v2_fixture_examples.rs
@@ -4,8 +4,13 @@
 //! Each fixture file serves dual duty: human-readable documentation of what the
 //! v2 parser accepts and rejects, and a machine-verified test that the parser
 //! actually behaves that way.
+//!
+//! Normalization fixtures go one step further and compare the resolved entries
+//! against golden JSON snapshots in `tests/fixtures/v2-examples/expected/`.
+//! Set `UPDATE_SNAPSHOTS=1` to regenerate them after a schema change.
 
-use sonda_core::compiler::parse::{parse_v2, ParseError};
+use sonda_core::compiler::normalize::{normalize, NormalizeError, NormalizedFile};
+use sonda_core::compiler::parse::{parse, ParseError};
 
 /// Helper: read a fixture file relative to the crate root.
 fn fixture(name: &str) -> String {
@@ -16,14 +21,59 @@ fn fixture(name: &str) -> String {
     std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read fixture {path}: {e}"))
 }
 
+/// Serialize a [`NormalizedFile`] as pretty-printed JSON.
+///
+/// Normalized types use `BTreeMap` for all map fields, so the output is
+/// deterministic without any post-processing. A trailing newline is appended
+/// to match the convention used by existing golden files.
+fn snapshot_normalized(file: &NormalizedFile) -> String {
+    let mut s =
+        serde_json::to_string_pretty(file).expect("serializing a NormalizedFile must not fail");
+    s.push('\n');
+    s
+}
+
+/// Assert that the snapshot matches the golden file, or regenerate it when
+/// `UPDATE_SNAPSHOTS=1` is set in the environment.
+fn assert_snapshot(actual: &str, golden_name: &str) {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/v2-examples/expected")
+        .join(golden_name);
+
+    if std::env::var("UPDATE_SNAPSHOTS").as_deref() == Ok("1") {
+        let dir = path
+            .parent()
+            .unwrap_or_else(|| panic!("golden path {} has no parent", path.display()));
+        std::fs::create_dir_all(dir)
+            .unwrap_or_else(|e| panic!("cannot create {}: {e}", dir.display()));
+        std::fs::write(&path, actual)
+            .unwrap_or_else(|e| panic!("cannot write golden {}: {e}", path.display()));
+        return;
+    }
+
+    let expected = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "cannot read golden {} (run with UPDATE_SNAPSHOTS=1 to create it): {}",
+            path.display(),
+            e
+        )
+    });
+    assert_eq!(
+        actual,
+        expected,
+        "snapshot mismatch for {}\nRun with UPDATE_SNAPSHOTS=1 to update.",
+        path.display()
+    );
+}
+
 // ======================================================================
-// Valid fixtures
+// Valid fixtures — parse only
 // ======================================================================
 
 #[test]
 fn valid_single_metric_parses() {
     let yaml = fixture("valid-single-metric.yaml");
-    let file = parse_v2(&yaml).expect("valid-single-metric.yaml must parse");
+    let file = parse(&yaml).expect("valid-single-metric.yaml must parse");
     assert_eq!(file.version, 2);
     assert_eq!(file.scenarios.len(), 1);
 
@@ -39,7 +89,7 @@ fn valid_single_metric_parses() {
 #[test]
 fn valid_multi_scenario_parses() {
     let yaml = fixture("valid-multi-scenario.yaml");
-    let file = parse_v2(&yaml).expect("valid-multi-scenario.yaml must parse");
+    let file = parse(&yaml).expect("valid-multi-scenario.yaml must parse");
     assert_eq!(file.version, 2);
     assert_eq!(file.scenarios.len(), 3);
 
@@ -74,7 +124,7 @@ fn valid_multi_scenario_parses() {
 #[test]
 fn valid_pack_shorthand_parses() {
     let yaml = fixture("valid-pack-shorthand.yaml");
-    let file = parse_v2(&yaml).expect("valid-pack-shorthand.yaml must parse");
+    let file = parse(&yaml).expect("valid-pack-shorthand.yaml must parse");
     assert_eq!(file.version, 2);
     assert_eq!(file.scenarios.len(), 1);
 
@@ -92,7 +142,7 @@ fn valid_pack_shorthand_parses() {
 #[test]
 fn valid_pack_in_scenarios_parses() {
     let yaml = fixture("valid-pack-in-scenarios.yaml");
-    let file = parse_v2(&yaml).expect("valid-pack-in-scenarios.yaml must parse");
+    let file = parse(&yaml).expect("valid-pack-in-scenarios.yaml must parse");
     assert_eq!(file.version, 2);
     assert_eq!(file.scenarios.len(), 1);
 
@@ -111,7 +161,7 @@ fn valid_pack_in_scenarios_parses() {
 #[test]
 fn valid_histogram_parses() {
     let yaml = fixture("valid-histogram.yaml");
-    let file = parse_v2(&yaml).expect("valid-histogram.yaml must parse");
+    let file = parse(&yaml).expect("valid-histogram.yaml must parse");
     assert_eq!(file.version, 2);
     assert_eq!(file.scenarios.len(), 1);
 
@@ -130,13 +180,13 @@ fn valid_histogram_parses() {
 }
 
 // ======================================================================
-// Invalid fixtures
+// Invalid fixtures — parse-time rejections
 // ======================================================================
 
 #[test]
 fn invalid_wrong_version_rejected() {
     let yaml = fixture("invalid-wrong-version.yaml");
-    let err = parse_v2(&yaml).expect_err("invalid-wrong-version.yaml must fail");
+    let err = parse(&yaml).expect_err("invalid-wrong-version.yaml must fail");
     assert!(
         matches!(err, ParseError::InvalidVersion(1)),
         "expected InvalidVersion(1), got: {err}"
@@ -146,7 +196,7 @@ fn invalid_wrong_version_rejected() {
 #[test]
 fn invalid_duplicate_ids_rejected() {
     let yaml = fixture("invalid-duplicate-ids.yaml");
-    let err = parse_v2(&yaml).expect_err("invalid-duplicate-ids.yaml must fail");
+    let err = parse(&yaml).expect_err("invalid-duplicate-ids.yaml must fail");
     assert!(
         matches!(err, ParseError::DuplicateId(ref id) if id == "my_signal"),
         "expected DuplicateId('my_signal'), got: {err}"
@@ -156,7 +206,7 @@ fn invalid_duplicate_ids_rejected() {
 #[test]
 fn invalid_generator_and_pack_rejected() {
     let yaml = fixture("invalid-generator-and-pack.yaml");
-    let err = parse_v2(&yaml).expect_err("invalid-generator-and-pack.yaml must fail");
+    let err = parse(&yaml).expect_err("invalid-generator-and-pack.yaml must fail");
     assert!(
         matches!(err, ParseError::GeneratorAndPack { index: 0 }),
         "expected GeneratorAndPack at index 0, got: {err}"
@@ -166,7 +216,7 @@ fn invalid_generator_and_pack_rejected() {
 #[test]
 fn invalid_pack_with_logs_rejected() {
     let yaml = fixture("invalid-pack-with-logs.yaml");
-    let err = parse_v2(&yaml).expect_err("invalid-pack-with-logs.yaml must fail");
+    let err = parse(&yaml).expect_err("invalid-pack-with-logs.yaml must fail");
     assert!(
         matches!(err, ParseError::PackNotMetrics { index: 0 }),
         "expected PackNotMetrics at index 0, got: {err}"
@@ -176,7 +226,7 @@ fn invalid_pack_with_logs_rejected() {
 #[test]
 fn invalid_missing_name_rejected() {
     let yaml = fixture("invalid-missing-name.yaml");
-    let err = parse_v2(&yaml).expect_err("invalid-missing-name.yaml must fail");
+    let err = parse(&yaml).expect_err("invalid-missing-name.yaml must fail");
     assert!(
         matches!(err, ParseError::MissingName { index: 0 }),
         "expected MissingName at index 0, got: {err}"
@@ -186,7 +236,7 @@ fn invalid_missing_name_rejected() {
 #[test]
 fn invalid_bad_after_op_rejected() {
     let yaml = fixture("invalid-bad-after-op.yaml");
-    let err = parse_v2(&yaml).expect_err("invalid-bad-after-op.yaml must fail");
+    let err = parse(&yaml).expect_err("invalid-bad-after-op.yaml must fail");
     assert!(
         matches!(err, ParseError::Yaml(_)),
         "expected Yaml error for invalid op, got: {err}"
@@ -196,4 +246,109 @@ fn invalid_bad_after_op_rejected() {
         msg.contains("=="),
         "error message should mention the invalid op '==', got: {msg}"
     );
+}
+
+// ======================================================================
+// Defaults normalization — valid fixtures with golden snapshots
+// ======================================================================
+
+#[test]
+fn valid_defaults_label_merge_normalizes() {
+    let yaml = fixture("valid-defaults-label-merge.yaml");
+    let parsed = parse(&yaml).expect("must parse");
+    let normalized = normalize(parsed).expect("must normalize");
+
+    // Spot-check the merged output before comparing against the golden file.
+    assert_eq!(normalized.entries.len(), 2);
+
+    let e0 = &normalized.entries[0];
+    assert!((e0.rate - 1.0).abs() < f64::EPSILON);
+    assert_eq!(e0.duration.as_deref(), Some("5m"));
+    let labels0 = e0.labels.as_ref().expect("labels must exist");
+    assert_eq!(
+        labels0.get("device").map(String::as_str),
+        Some("rtr-edge-01")
+    );
+    assert_eq!(labels0.get("region").map(String::as_str), Some("us-east-1"));
+    assert_eq!(
+        labels0.get("interface").map(String::as_str),
+        Some("Gi0/0/0")
+    );
+
+    let e1 = &normalized.entries[1];
+    assert!((e1.rate - 10.0).abs() < f64::EPSILON);
+    let labels1 = e1.labels.as_ref().expect("labels must exist");
+    assert_eq!(labels1.get("region").map(String::as_str), Some("us-west-2"));
+
+    // Golden comparison
+    let snap = snapshot_normalized(&normalized);
+    assert_snapshot(&snap, "valid-defaults-label-merge.json");
+}
+
+#[test]
+fn valid_defaults_logs_default_encoder_normalizes() {
+    let yaml = fixture("valid-defaults-logs-default-encoder.yaml");
+    let parsed = parse(&yaml).expect("must parse");
+    let normalized = normalize(parsed).expect("must normalize");
+
+    assert_eq!(normalized.entries.len(), 1);
+    let e0 = &normalized.entries[0];
+    assert!((e0.rate - 5.0).abs() < f64::EPSILON);
+    // Logs signals default to json_lines when no encoder is set anywhere.
+    assert!(matches!(
+        e0.encoder,
+        sonda_core::encoder::EncoderConfig::JsonLines { .. }
+    ));
+
+    let snap = snapshot_normalized(&normalized);
+    assert_snapshot(&snap, "valid-defaults-logs-default-encoder.json");
+}
+
+#[test]
+fn valid_defaults_pack_entry_normalizes() {
+    let yaml = fixture("valid-defaults-pack-entry.yaml");
+    let parsed = parse(&yaml).expect("must parse");
+    let normalized = normalize(parsed).expect("must normalize");
+
+    assert_eq!(normalized.entries.len(), 1);
+    let e0 = &normalized.entries[0];
+    assert_eq!(e0.pack.as_deref(), Some("telegraf_snmp_interface"));
+    assert!(e0.overrides.is_some(), "overrides must survive");
+    assert!((e0.rate - 1.0).abs() < f64::EPSILON);
+
+    // Pack entry labels are NOT merged with defaults.labels — Phase 3 pack
+    // expansion is responsible for composing levels 2–6 (see spec §2.2).
+    let labels = e0.labels.as_ref().expect("entry labels must exist");
+    assert_eq!(labels.len(), 1, "only entry labels, defaults not merged");
+    assert_eq!(labels.get("device").map(String::as_str), Some("rtr-01"));
+    assert!(!labels.contains_key("job"));
+    assert!(!labels.contains_key("env"));
+
+    // defaults.labels is surfaced at the file level for Phase 3 to apply.
+    let d = normalized
+        .defaults_labels
+        .as_ref()
+        .expect("defaults_labels must be carried forward");
+    assert_eq!(d.get("job").map(String::as_str), Some("web"));
+    assert_eq!(d.get("env").map(String::as_str), Some("prod"));
+
+    let snap = snapshot_normalized(&normalized);
+    assert_snapshot(&snap, "valid-defaults-pack-entry.json");
+}
+
+// ======================================================================
+// Defaults normalization — missing rate is rejected
+// ======================================================================
+
+#[test]
+fn invalid_missing_rate_rejected() {
+    let yaml = fixture("invalid-missing-rate.yaml");
+    let parsed = parse(&yaml).expect("parse must succeed (rate is not required at parse time)");
+    let err = normalize(parsed).expect_err("normalize must fail on missing rate");
+    match err {
+        NormalizeError::MissingRate { index, label } => {
+            assert_eq!(index, 0);
+            assert_eq!(label, "cpu");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Compile-time `normalize()` pass: folds `defaults:` into every entry, applies built-in encoder/sink fallbacks per signal type, validates rate presence.
- **Asymmetric label composition**: inline entries get eager `defaults.labels ∪ entry.labels` merge (entry wins); pack entries defer label merging so PR 4 can interleave pack `shared_labels` / per-metric labels at the correct §2.2 precedence slot. `NormalizedFile.defaults_labels` surfaces the source map for Phase 3 to consume.
- Built-in fallbacks: `prometheus_text` for metrics/histogram/summary, `json_lines` for logs, `stdout` sink.
- Workspace-wide rename: `compiler::parse::parse_v2 → parse` (the module name already implies the version).

## Validation matrix rows addressed (7)
- 5.8 — Default encoder per signal type
- 10.12 — Shared labels across signals
- 10.13 — Per-signal label overrides
- 10.14 — Per-signal rate/duration override
- 10.15 — Per-signal encoder/sink override
- 11.2 — `defaults:` block
- 11.3 — Entry-level overrides defaults

Running total: **11 of 162** rows Pass. See [`docs/refactor/v2-validation-status.md`](../blob/feat/defaults-resolution/docs/refactor/v2-validation-status.md).

## What's in the diff
- `sonda-core/src/compiler/normalize.rs` — new module (`normalize()`, `NormalizedFile`, `NormalizedEntry`, `NormalizeError`)
- `sonda-core/src/compiler/parse.rs` — `parse_v2 → parse` rename
- `sonda-core/src/compiler/mod.rs` — submodule registration + stale comment cleanup
- 4 new fixtures: 3 valid-with-golden (`valid-defaults-label-merge`, `valid-defaults-logs-default-encoder`, `valid-defaults-pack-entry`), 1 invalid (`invalid-missing-rate`)
- `docs/refactor/v2-progress.md` — gains a **PR 4 Preparation Notes** section locking in the label-asymmetry decision and 7-point expansion sketch so a cold session can pick up PR 4 without re-litigating

## Out of scope (deferred)
- Pack expansion, override key validation (PR 4)
- `after` clause resolution, phase offset computation, clock-group auto-assignment (PR 5)
- Runtime wiring into `prepare_entries()` (PR 6)
- CLI `--dry-run` changes, catalog, `sonda init` updates (PR 7)

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 2,585 tests pass
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace --no-default-features`
- [x] `cargo test -p sonda-core --no-default-features` (workspace-wide `--no-default-features` test has a pre-existing failure from PR #190 unrelated to this PR — see [`sonda/src/init/yaml_gen.rs:1379`](../blob/feat/defaults-resolution/sonda/src/init/yaml_gen.rs#L1379))
- [x] `@reviewer` (two passes), `@doc`, `@uat` all approved
- [x] Existing v1 CLI workflows verified unchanged (dry-run on every built-in scenario)
- [x] Error messages spot-checked (missing-rate identifies entry by index + name/id/pack/`<unnamed>`)

## Merge target
Integration branch `refactor/unified-scenarios-v2` — not `main`. Final merge to `main` happens only after the full 162-row validation matrix passes.