### PR TITLE
feat(core): pack expansion inside scenarios: (v2 PR 4)

### DIFF
--- a/docs/refactor/v2-progress.md
+++ b/docs/refactor/v2-progress.md
@@ -1,10 +1,10 @@
 # Sonda v2 Refactor — Progress
 
 ## Current Status
-- **Phase:** 2 — Defaults resolution (complete, pending merge)
+- **Phase:** 3 — Pack expansion (complete, pending merge)
 - **Branch:** `refactor/unified-scenarios-v2`
 - **Integration PR:** #197 (targets `main`, accumulates all v2 work)
-- **Next PR:** PR 4 — Pack expansion inside `scenarios:`
+- **Next PR:** PR 5 — `after` compiler + dependency graph
 
 ## Milestone Checklist
 
@@ -12,8 +12,8 @@
 |---|-----------|--------|----|------|
 | 0 | Scaffolding & test foundation | Done | PR 1 | 2026-04-11 |
 | 1 | Compiler AST and parser | Done | PR 2 (#198) | 2026-04-11 |
-| 2 | Defaults resolution | Done | PR 3 | 2026-04-12 |
-| 3 | Pack expansion in scenarios | Not Started | PR 4 | |
+| 2 | Defaults resolution | Done | PR 3 (#199) | 2026-04-12 |
+| 3 | Pack expansion in scenarios | Done | PR 4 | 2026-04-12 |
 | 4 | `after` compiler + dependency graph | Not Started | PR 5 | |
 | 5 | Runtime wiring + parity tests | Not Started | PR 6 | |
 | 6 | CLI unification | Not Started | PR 7 | |
@@ -26,7 +26,8 @@
 |----|-------|--------|--------|--------|------|
 | 1 | Compile snapshot harness + test foundation | (direct) | integration | Merged | 2026-04-11 |
 | 2 | Compiler AST, parser, and version dispatch | `feat/v2-ast-parser` | integration (#198) | Merged | 2026-04-11 |
-| 3 | Defaults resolution + `parse_v2 → parse` rename | `feat/defaults-resolution` | integration | Pending Review | 2026-04-12 |
+| 3 | Defaults resolution + `parse_v2 → parse` rename | `feat/defaults-resolution` | integration (#199) | Merged | 2026-04-12 |
+| 4 | Pack expansion inside `scenarios:` | `feat/pack-expansion` | integration | Pending Review | 2026-04-12 |
 
 ## Test Coverage
 
@@ -34,11 +35,15 @@
 |-------|-------|-------|
 | Compiler parser unit tests | 49 | AST parsing, validation, shorthand, edge cases |
 | Compiler normalize unit tests | 34 | Defaults inheritance, label merge (inline eager / pack deferred), built-in fallbacks, missing-rate error, defaults-labels surfacing |
+| Compiler expand unit tests | 28 | Pack expansion, label precedence, auto-IDs, override validation, after propagation, resolver trait |
 | Compiler fixture integration tests | 15 | Valid/invalid YAML examples parsed + normalized from disk |
+| Compiler expand fixture integration tests | 5 | Pack expansion fixtures with golden snapshots + invalid-override rejection |
+| Pack parity bridge integration tests | 3 | Built-in pack compile parity (telegraf_snmp_interface, node_exporter_cpu, node_exporter_memory) |
 | Compile snapshot golden files | 12 | v1 parity baseline (6 fixtures x raw+prepared) |
 | Normalize snapshot golden files | 3 | Resolved defaults snapshots (label merge, logs default encoder, pack entry) |
-| **New in refactor** | **113** | |
-| Workspace total | 2,585 | All existing + new |
+| Expand snapshot golden files | 4 | Phase 3 snapshots (overrides, file-path, multi-pack, anonymous pack) |
+| **New in refactor** | **149** | |
+| Workspace total | 2,621 | All existing + new |
 
 ## Validation Matrix Status
 
@@ -46,15 +51,15 @@ See [v2-validation-status.md](v2-validation-status.md) for the full 162-row chec
 
 **Every row is a mandatory merge blocker. No exceptions.**
 
-**Summary:** 11 of 162 rows addressed so far.
+**Summary:** 25 of 162 rows addressed so far.
 
 | Section | Rows | Addressed | Notes |
 |---------|------|-----------|-------|
-| 1-10. Feature parity | 97 | 5 | 5.8 (PR 3), 10.12-10.15 (PR 3) — rest need runtime wiring |
-| 11. New v2 features | 18 | 6 | 11.1, 11.2, 11.3, 11.4, 11.5, 11.10 |
+| 1-10. Feature parity | 97 | 14 | 5.8 (PR 3), 9.1–9.8, 9.12 (PR 4), 10.12–10.15 (PR 3) — rest need runtime wiring |
+| 11. New v2 features | 18 | 8 | 11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.8, 11.10; 11.12/11.13 partial (PR 5 resolves `after`) |
 | 12-15. CLI/Server/UX/Deploy | 47 | 0 | Later PRs (7-9) |
 | **16. Scenario parity bridge** | **12** | **0** | **v1→v2 compile + runtime for all built-ins + story** |
-| **17. Pack parity bridge** | **3** | **0** | **v1→v2 compile + runtime for all built-in packs** |
+| **17. Pack parity bridge** | **3** | **3** | **compile parity passes for all three built-in packs; runtime parity is PR 6** |
 
 ## Completed Work
 
@@ -75,6 +80,19 @@ See [v2-validation-status.md](v2-validation-status.md) for the full 162-row chec
 - 45 unit tests + 11 fixture integration tests (5 valid, 6 invalid YAML examples)
 - Module named `compiler` (describes function, not version number)
 
+### PR 4 — Pack expansion inside `scenarios:` (2026-04-12, pending review)
+- `sonda-core/src/compiler/expand.rs` — `expand()`, `ExpandedFile`, `ExpandedEntry`, `ExpandError`
+- `PackResolver` trait with classification helper (`classify_pack_reference`) and `PackResolveOrigin` (Name | FilePath); `InMemoryPackResolver` test/embedded impl
+- Five-level label precedence chain applied per spec §2.2 (defaults → pack shared → pack per-metric → entry → override) using `BTreeMap<String, String>` for determinism
+- Entry-level `after` propagated to every expanded metric; override-level `after` replaces entry-level for that specific metric (resolution deferred to PR 5)
+- Auto-ID scheme: anonymous pack entries receive `"{pack_def_name}_{entry_index}"`; sub-signal IDs are always `"{effective_entry_id}.{metric_name}"`
+- Override key validation — unknown override keys produce `ExpandError::UnknownOverrideKey` with pack name and valid metric list, matching v1 `expand_pack` diagnostic shape
+- `MetricOverride` gained an optional `after: Option<AfterClause>` field (backward-compatible `#[serde(default)]`); v1 `expand_pack` ignores it
+- 28 expand unit tests + 5 new fixture integration tests (4 valid with golden snapshots, 1 invalid) + 3 pack parity bridge tests (matrix rows 17.1–17.3 compile parity)
+- Addresses validation matrix rows 9.1–9.8, 9.12, 11.6, 11.8, 17.1, 17.2, 17.3 (compile-parity only); 11.12 and 11.13 Pass for the carry-through portion — actual `after` resolution is PR 5
+- `parse_v2 → parse` alignment from PR 3 reused; no v1/v2 prefix on any symbol inside `sonda-core::compiler`
+- Snapshot golden `valid-defaults-pack-entry.json` updated because `MetricOverride` now serializes with `after: null`
+
 ### PR 3 — Defaults resolution and normalization (2026-04-12, pending review)
 - `sonda-core/src/compiler/normalize.rs` — `normalize()`, `NormalizedFile`, `NormalizedEntry`, `NormalizeError`
 - Precedence for `rate`/`duration`/`encoder`/`sink`: entry-level > `defaults:` > built-in fallback (eager, both inline and pack entries)
@@ -91,58 +109,62 @@ See [v2-validation-status.md](v2-validation-status.md) for the full 162-row chec
 - Reviewer NOTE (pack-label precedence collision) resolved inline via Option 2 — documented in `normalize.rs` module docs and in PR 4 Preparation Notes below
 - Reviewer NITs addressed: stale `V2 AST types` comment renamed; no-op `serde(deny_unknown_fields)` dropped from `NormalizedFile`/`NormalizedEntry`; snapshot-harness `expect()` calls converted to `unwrap_or_else(panic!)` with OS error detail
 
-## PR 4 Preparation Notes
+## PR 5 Preparation Notes
 
-These notes capture decisions and handoff context from PR 3 that PR 4 (pack expansion) must not re-litigate. A future session starting cold on PR 4 should read this section first, then the full reviewer review thread if deeper context is needed.
+These notes capture decisions and handoff context from PR 4 that PR 5 (the `after` compiler + dependency graph) must not re-litigate. A future session starting cold on PR 5 should read this section first, then the reviewer thread on PR 4 if deeper context is needed.
 
-### Label composition decision (locked)
+### What PR 4 already hands off
 
-PR 3 applies **two different label strategies** depending on entry kind. This is a deliberate choice to let PR 4 interleave spec §2.2 precedence levels 4–5 (pack `shared_labels`, pack per-metric labels) at the correct position between levels 2 (`defaults.labels`) and 6 (entry-level labels).
+PR 4 produces `ExpandedFile { version, entries: Vec<ExpandedEntry> }` — a fully resolved, flat list of concrete signals. Every entry has:
+- a **concrete `id`** for pack-expanded signals (`"{effective_entry_id}.{metric_name}"`); inline entries may still have `id: None` if the source YAML omitted it.
+- a concrete `generator`, `rate`, `encoder`, `sink` (inherited from PR 3).
+- labels already merged through the full spec §2.2 precedence chain.
+- the raw `after: Option<AfterClause>` that the user wrote, after PR 4's propagation:
+  - entry-level `after` on a pack entry is copied onto every expanded metric,
+  - override-level `after` replaces the entry-level value for that specific metric.
+- no `pack` or `overrides` field — the type itself doesn't carry them.
 
-- **Inline entries** (`generator:` / `log_generator:`) → `NormalizedEntry.labels` is the eager merge `defaults.labels ∪ entry.labels`, entry wins on conflict. No downstream composition, so provenance doesn't matter.
-- **Pack entries** (`pack:`) → `NormalizedEntry.labels` is exactly the entry's own `labels` field (unchanged, possibly `None`). The file-level `defaults.labels` is carried forward separately on `NormalizedFile.defaults_labels` for PR 4 to apply at the correct precedence slot.
+PR 5 can treat every `ExpandedEntry` uniformly; inline vs. pack-origin is no longer observable at this layer.
 
-Do not "fix" this asymmetry in PR 4 by eagerly merging. It exists because §2.2 places pack shared_labels (level 4) between defaults (2) and entry labels (6) — collapsing 2+6 loses the position where 4 and 5 need to slot in.
+### What PR 5 must build
 
-### PR 4 expansion sketch (implementer's handoff, confirmed)
+1. **Reference index.** Map every signal id (both user-declared on inline entries and auto-generated on pack entries) to the concrete `ExpandedEntry`. Spec §3.2: references target signal IDs, not metric names. Because `ExpandedEntry.id` is a flat `Option<String>`, the reference index is just a pass over the entries collecting `entry.id.clone()` as key → `&entry` as value. Reject entries with `after.ref` pointing to a missing id (matrix row 10.7).
 
-1. **`NormalizedEntry` contract walk.** Before writing expansion code, walk every field of `NormalizedEntry` and classify it as either (a) propagates verbatim to each expanded child metric, or (b) participates in per-metric composition. `normalize.rs` groups fields with comments to help. Pack `overrides` definitely participates (per-metric generator/labels/after). Most schedule/delivery fields (rate, duration, encoder, sink, gaps, bursts, phase_offset, clock_group) propagate verbatim.
+2. **`after` resolution per signal.** For each signal with `after: Some(_)`:
+   - validate the target generator supports the given operator (spec §3.3);
+   - validate the threshold is in range for the target generator's output;
+   - compute the crossing time on the target;
+   - accumulate transitive offsets (walk the chain);
+   - detect cycles with topological sort and report the full cycle path (matrix row 10.6).
 
-2. **Label precedence chain for pack-expanded signals** (spec §2.2, low → high — lowest number = lowest precedence, applied first; each subsequent level overwrites on key collision):
-   1. Sonda built-in defaults (already resolved in PR 3 for non-label fields)
-   2. `NormalizedFile.defaults_labels` (new source; not yet applied to pack entries)
-   3. pack definition's top-level fields (shared rate/job, etc. — pack YAML)
-   4. pack `shared_labels`
-   5. pack per-metric `labels`
-   6. entry-level `labels` on the pack entry (already preserved on `NormalizedEntry.labels`)
-   7. override-level `labels` (from `NormalizedEntry.overrides[metric].labels`)
-   8. CLI flags (PR 7 scope)
+3. **Clock group derivation.** For each connected component in the after-dependency graph, assign a shared `clock_group` when none is set. If users set `clock_group` explicitly on multiple entries in one chain, assert consistency (matrix row 11.16). Signals with no `after` and no explicit `clock_group` stay independent. PR 4 left `clock_group` untouched on `ExpandedEntry` — it is `Option<String>` exactly as the user wrote it.
 
-   A clean multi-level merge function with explicit precedence-named steps is preferable to nested merge calls.
+4. **`phase_offset` application.** Set `phase_offset` on each signal to its computed total offset. If a signal already had an explicit `phase_offset`, add the computed offset to it (matrix row 11.14).
 
-3. **Override key validation (matrix row 9.7).** For every key in `NormalizedEntry.overrides`, assert it matches a metric name in the pack definition. Unknown keys → `NormalizeError` or a new `PackExpansionError` with a clear message. This is a mandatory merge blocker.
+### Supported generators for `after` (per spec §3.3)
 
-4. **Pack entry materialization.** One `NormalizedEntry`-equivalent (or a new `ExpandedEntry` type — PR 4's call) per metric in the pack. Synthesize:
-   - `name = <pack_metric_name>`
-   - `id = "{entry.id}.{metric}"` when `entry.id.is_some()`; otherwise an auto-generated ID from the pack name (see matrix row 11.8)
-   - `generator` = override's `generator` if present, else pack's per-metric `generator`
-   - `labels` = result of the full level-2-through-7 merge above
-   - `after` = override's `after` if present, else entry-level `after` propagated (matrix row 11.13)
-   - All other fields (rate, duration, encoder, sink, phase_offset, clock_group, gaps, bursts) copied from the parent pack entry verbatim
+PR 5 must validate operator/threshold compatibility against the generator's analytical form. The generators that can participate as targets are: `sine`, `sawtooth`, `step`, `spike`, `flap`, `saturation`, `leak`, `degradation`, `steady`, `spike_event`, `sequence`. The aliases desugar to core generators before PR 5 runs — use the desugared form for math.
 
-5. **Pack search path.** Pack resolution is not yet implemented in `sonda-core::compiler`. The existing v1 engine in `src/packs/mod.rs` handles pack YAML parsing and has a search path helper; reuse `MetricPackDef` and the discovery logic. PR 4 does not need to reshape the pack definition schema (spec §7 is explicit: pack YAML on disk is unchanged). Pack YAMLs live at the repo root in `packs/` — this crate doesn't embed them.
+Generators that do not support `after` as targets (noise-dominated or constant, per matrix row 10.10): `constant`, `uniform`, `csv_replay`, and `jitter`-wrapped generators whose underlying type is `sine`/`steady` (spec §3.3 rejects `sine` and `steady` specifically as causal targets). Surface a clear error when an `after.ref` resolves to an unsupported generator.
 
-6. **Pack entries without `id`.** Spec matrix row 11.8 requires auto-generated IDs when `id` is absent. Pick a deterministic scheme (e.g., `"{pack_name}"` for the first anonymous pack entry, disambiguate subsequent ones). Decide before coding.
+### Data contract between PR 4 output and PR 5 input
 
-7. **`NormalizedEntry` field evolution.** Currently carries optional serde fields for pack metadata. If PR 4 introduces a new `ExpandedEntry` type (recommended), `NormalizedEntry` can stay narrow — don't bloat it with post-expansion fields.
+- `ExpandedEntry.id` is the only identity PR 5 should key off. Do not reconstruct ids from `pack + metric` — that information is gone after PR 4 for a reason.
+- `ExpandedEntry.after: Option<AfterClause>` is the source of truth for each signal. There is no parent-entry context to reach back to.
+- `AfterClause` lives in `sonda-core::compiler` (`super::AfterClause` from `expand.rs`). `MetricOverride` in `sonda-core::packs` now also has an optional `after` field, but by the time PR 5 runs, overrides have been expanded into per-signal `AfterClause`s — PR 5 does not touch `MetricOverride`.
+- `GeneratorConfig` aliases (`flap`, `saturation`, …) are still present in `ExpandedEntry.generator` because PR 4 does no desugaring. Run `config::aliases::desugar_*` (or equivalent) before generator-shape analysis.
 
-### Target validation matrix rows for PR 4
+### Scope for PR 5 (target matrix rows)
 
-- 9.1–9.12 (pack features — run by name, run from YAML, search path, file path, overrides, unknown override key error, label merge order, dry-run, list/show, custom pack definitions)
-- 11.6 (pack inside scenarios: list)
-- 11.8 (auto-generated pack IDs)
-- 11.12 (after on pack override — partial; full `after` resolution is PR 5)
-- 11.13 (pack entry-level after propagation — partial)
+- 10.1–10.11 (`after` semantics and validation)
+- 11.7 (dotted `after.ref` into pack sub-signals — works for free because PR 4 already assigns sub-signal ids of the form `{entry}.{metric}`)
+- 11.9 (`delay` in after clause)
+- 11.11 (cross-signal-type `after`)
+- 11.14 (`after + phase_offset` sum)
+- 11.15 (clock group auto-assignment)
+- 11.16 (conflicting `clock_group` in a chain → error)
+- 11.17, 11.18 (`after` with step and sequence generators)
+- Promote 11.12 and 11.13 from "partial" to "Pass" once full resolution works.
 
 ## Active Risks
 - Snapshot format stability — must be deterministic and survive refactor

--- a/docs/refactor/v2-progress.md
+++ b/docs/refactor/v2-progress.md
@@ -35,15 +35,15 @@
 |-------|-------|-------|
 | Compiler parser unit tests | 49 | AST parsing, validation, shorthand, edge cases |
 | Compiler normalize unit tests | 34 | Defaults inheritance, label merge (inline eager / pack deferred), built-in fallbacks, missing-rate error, defaults-labels surfacing |
-| Compiler expand unit tests | 28 | Pack expansion, label precedence, auto-IDs, override validation, after propagation, resolver trait |
+| Compiler expand unit tests | 33 | Pack expansion, label precedence, auto-IDs (including duplicate-name disambiguation), post-expansion id uniqueness, override validation, after propagation, resolver trait |
 | Compiler fixture integration tests | 15 | Valid/invalid YAML examples parsed + normalized from disk |
 | Compiler expand fixture integration tests | 5 | Pack expansion fixtures with golden snapshots + invalid-override rejection |
 | Pack parity bridge integration tests | 3 | Built-in pack compile parity (telegraf_snmp_interface, node_exporter_cpu, node_exporter_memory) |
 | Compile snapshot golden files | 12 | v1 parity baseline (6 fixtures x raw+prepared) |
 | Normalize snapshot golden files | 3 | Resolved defaults snapshots (label merge, logs default encoder, pack entry) |
 | Expand snapshot golden files | 4 | Phase 3 snapshots (overrides, file-path, multi-pack, anonymous pack) |
-| **New in refactor** | **149** | |
-| Workspace total | 2,621 | All existing + new |
+| **New in refactor** | **154** | |
+| Workspace total | 2,626 | All existing + new |
 
 ## Validation Matrix Status
 
@@ -51,12 +51,12 @@ See [v2-validation-status.md](v2-validation-status.md) for the full 162-row chec
 
 **Every row is a mandatory merge blocker. No exceptions.**
 
-**Summary:** 25 of 162 rows addressed so far.
+**Summary:** 27 of 162 rows addressed so far.
 
 | Section | Rows | Addressed | Notes |
 |---------|------|-----------|-------|
 | 1-10. Feature parity | 97 | 14 | 5.8 (PR 3), 9.1–9.8, 9.12 (PR 4), 10.12–10.15 (PR 3) — rest need runtime wiring |
-| 11. New v2 features | 18 | 8 | 11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.8, 11.10; 11.12/11.13 partial (PR 5 resolves `after`) |
+| 11. New v2 features | 18 | 10 | 11.1–11.6, 11.8, 11.10, 11.12, 11.13 — 11.12/11.13 cover carry-through; `after` resolution itself lands in PR 5 |
 | 12-15. CLI/Server/UX/Deploy | 47 | 0 | Later PRs (7-9) |
 | **16. Scenario parity bridge** | **12** | **0** | **v1→v2 compile + runtime for all built-ins + story** |
 | **17. Pack parity bridge** | **3** | **3** | **compile parity passes for all three built-in packs; runtime parity is PR 6** |
@@ -85,10 +85,11 @@ See [v2-validation-status.md](v2-validation-status.md) for the full 162-row chec
 - `PackResolver` trait with classification helper (`classify_pack_reference`) and `PackResolveOrigin` (Name | FilePath); `InMemoryPackResolver` test/embedded impl
 - Five-level label precedence chain applied per spec §2.2 (defaults → pack shared → pack per-metric → entry → override) using `BTreeMap<String, String>` for determinism
 - Entry-level `after` propagated to every expanded metric; override-level `after` replaces entry-level for that specific metric (resolution deferred to PR 5)
-- Auto-ID scheme: anonymous pack entries receive `"{pack_def_name}_{entry_index}"`; sub-signal IDs are always `"{effective_entry_id}.{metric_name}"`
+- Auto-ID scheme: anonymous pack entries receive `"{pack_def_name}_{entry_index}"`; sub-signal IDs are `"{effective_entry_id}.{metric_name}"` for unique-by-name packs and `"{effective_entry_id}.{metric_name}#{spec_index}"` for packs shipping multiple `MetricSpec`s under the same name (e.g. `node_exporter_cpu`)
+- Post-expansion id uniqueness check: `ExpandError::DuplicateEntryId` fires when a user-authored inline id collides with an auto-synthesized pack-entry id (the parser's id check only sees user-provided ids, so this pass closes the gap)
 - Override key validation — unknown override keys produce `ExpandError::UnknownOverrideKey` with pack name and valid metric list, matching v1 `expand_pack` diagnostic shape
 - `MetricOverride` gained an optional `after: Option<AfterClause>` field (backward-compatible `#[serde(default)]`); v1 `expand_pack` ignores it
-- 28 expand unit tests + 5 new fixture integration tests (4 valid with golden snapshots, 1 invalid) + 3 pack parity bridge tests (matrix rows 17.1–17.3 compile parity)
+- 33 expand unit tests + 5 new fixture integration tests (4 valid with golden snapshots, 1 invalid) + 3 pack parity bridge tests (matrix rows 17.1–17.3 compile parity, plus v2-only sub-signal id uniqueness assertion)
 - Addresses validation matrix rows 9.1–9.8, 9.12, 11.6, 11.8, 17.1, 17.2, 17.3 (compile-parity only); 11.12 and 11.13 Pass for the carry-through portion — actual `after` resolution is PR 5
 - `parse_v2 → parse` alignment from PR 3 reused; no v1/v2 prefix on any symbol inside `sonda-core::compiler`
 - Snapshot golden `valid-defaults-pack-entry.json` updated because `MetricOverride` now serializes with `after: null`
@@ -98,15 +99,15 @@ See [v2-validation-status.md](v2-validation-status.md) for the full 162-row chec
 - Precedence for `rate`/`duration`/`encoder`/`sink`: entry-level > `defaults:` > built-in fallback (eager, both inline and pack entries)
 - Built-in encoder per signal type: `prometheus_text` for metrics/histogram/summary, `json_lines` for logs
 - Built-in sink: `stdout`
-- **Label composition is asymmetric** (see PR 4 Preparation Notes below):
+- **Label composition is asymmetric** (rationale in `normalize.rs` module docs under "Labels merge"):
   - Inline entries: eager merge — `defaults.labels ∪ entry.labels`, entry wins on key conflict
-  - Pack entries: no merge — `NormalizedEntry.labels` = entry's own labels; `NormalizedFile.defaults_labels` surfaces the source map so PR 4 can layer it correctly against pack `shared_labels` / per-metric / override labels
+  - Pack entries: no merge — `NormalizedEntry.labels` = entry's own labels; `NormalizedFile.defaults_labels` surfaces the source map so pack expansion can layer it correctly against pack `shared_labels` / per-metric / override labels
 - Pack entries' `pack:` and `overrides:` fields carried through untouched (pack expansion is PR 4)
 - Required-field validation: missing `rate` identifies the offending entry by index + name/id/pack
 - Rename `parse_v2 → parse` workspace-wide (module prefix carries the version)
 - 34 normalize unit tests + 4 new fixtures (3 valid with golden snapshots, 1 invalid)
 - Addresses validation matrix rows 5.8, 10.12, 10.13, 10.14, 10.15, 11.2, 11.3
-- Reviewer NOTE (pack-label precedence collision) resolved inline via Option 2 — documented in `normalize.rs` module docs and in PR 4 Preparation Notes below
+- Reviewer NOTE (pack-label precedence collision) resolved inline via Option 2 — documented in `normalize.rs` module docs (see "Labels merge")
 - Reviewer NITs addressed: stale `V2 AST types` comment renamed; no-op `serde(deny_unknown_fields)` dropped from `NormalizedFile`/`NormalizedEntry`; snapshot-harness `expect()` calls converted to `unwrap_or_else(panic!)` with OS error detail
 
 ## PR 5 Preparation Notes
@@ -116,7 +117,7 @@ These notes capture decisions and handoff context from PR 4 that PR 5 (the `afte
 ### What PR 4 already hands off
 
 PR 4 produces `ExpandedFile { version, entries: Vec<ExpandedEntry> }` — a fully resolved, flat list of concrete signals. Every entry has:
-- a **concrete `id`** for pack-expanded signals (`"{effective_entry_id}.{metric_name}"`); inline entries may still have `id: None` if the source YAML omitted it.
+- a **concrete `id`** for pack-expanded signals (shape documented below); inline entries may still have `id: None` if the source YAML omitted it.
 - a concrete `generator`, `rate`, `encoder`, `sink` (inherited from PR 3).
 - labels already merged through the full spec §2.2 precedence chain.
 - the raw `after: Option<AfterClause>` that the user wrote, after PR 4's propagation:
@@ -126,9 +127,19 @@ PR 4 produces `ExpandedFile { version, entries: Vec<ExpandedEntry> }` — a full
 
 PR 5 can treat every `ExpandedEntry` uniformly; inline vs. pack-origin is no longer observable at this layer.
 
+#### Pack sub-signal id shape (what the reference index will see)
+
+Pack-expanded entries carry sub-signal ids composed from the effective pack-entry id and the metric name:
+
+- **Default (unique-by-name packs):** `"{effective_entry_id}.{metric_name}"` — e.g. `net.ifOperStatus`, `net.ifHCInOctets`.
+- **Duplicate-name packs:** when two or more `MetricSpec` entries in a single pack share a `name` (e.g. `node_exporter_cpu` ships eight `node_cpu_seconds_total` specs differentiated by `labels.mode`), each colliding spec gets an extra `"#{spec_index}"` suffix — e.g. `cpu.node_cpu_seconds_total#0`, `cpu.node_cpu_seconds_total#1`. Unique-named metrics in such a pack keep the clean form.
+- **Effective pack-entry id:** either the user-provided `id:` on the entry, or the auto-generated `{pack_def_name}_{entry_index}` when `id:` is absent.
+
+The uniqueness of *all* ids is enforced by PR 4 via a post-expansion `ExpandError::DuplicateEntryId`, including collisions between user-authored inline ids and auto-synthesized pack-entry ids. PR 5's reference index can therefore assume no two entries share an id.
+
 ### What PR 5 must build
 
-1. **Reference index.** Map every signal id (both user-declared on inline entries and auto-generated on pack entries) to the concrete `ExpandedEntry`. Spec §3.2: references target signal IDs, not metric names. Because `ExpandedEntry.id` is a flat `Option<String>`, the reference index is just a pass over the entries collecting `entry.id.clone()` as key → `&entry` as value. Reject entries with `after.ref` pointing to a missing id (matrix row 10.7).
+1. **Reference index.** Map every signal id (both user-declared on inline entries and auto-generated on pack entries) to the concrete `ExpandedEntry`. Spec §3.2: references target signal IDs, not metric names. Because `ExpandedEntry.id` is a flat `Option<String>`, the reference index is just a pass over the entries collecting `entry.id.clone()` as key → `&entry` as value. Reject entries with `after.ref` pointing to a missing id (matrix row 10.7). Note that `after.ref` targeting a duplicate-name pack metric must use the `{entry}.{metric}#{spec_index}` form; surface a helpful diagnostic when a bare `{entry}.{metric}` ref is used against a collided metric.
 
 2. **`after` resolution per signal.** For each signal with `after: Some(_)`:
    - validate the target generator supports the given operator (spec §3.3);
@@ -157,14 +168,14 @@ Generators that do not support `after` as targets (noise-dominated or constant, 
 ### Scope for PR 5 (target matrix rows)
 
 - 10.1–10.11 (`after` semantics and validation)
-- 11.7 (dotted `after.ref` into pack sub-signals — works for free because PR 4 already assigns sub-signal ids of the form `{entry}.{metric}`)
+- 11.7 (dotted `after.ref` into pack sub-signals — works for free because PR 4 already assigns sub-signal ids; see "Pack sub-signal id shape" above for the `{entry}.{metric}` / `{entry}.{metric}#{spec_index}` forms)
 - 11.9 (`delay` in after clause)
 - 11.11 (cross-signal-type `after`)
 - 11.14 (`after + phase_offset` sum)
 - 11.15 (clock group auto-assignment)
 - 11.16 (conflicting `clock_group` in a chain → error)
 - 11.17, 11.18 (`after` with step and sequence generators)
-- Promote 11.12 and 11.13 from "partial" to "Pass" once full resolution works.
+- Complete 11.12 and 11.13: PR 4 already marks them Pass for carry-through; PR 5 must extend the same tests to assert the resolved `after` offsets.
 
 ## Active Risks
 - Snapshot format stability — must be deterministic and survive refactor

--- a/docs/refactor/v2-validation-status.md
+++ b/docs/refactor/v2-validation-status.md
@@ -170,7 +170,7 @@ scenario and pack produces identical output in v2 format (14 rows).
 | 11.5 | Single-signal shorthand | Pass | PR 2 | Flat files wrapped automatically |
 | 11.6 | Pack inside scenarios: list | Pass | PR 4 | Parsed in PR 2, expansion in PR 4 with one ExpandedEntry per pack metric |
 | 11.7 | Dotted after ref into pack | Not Tested | PR 5 | Sub-signal IDs of form `{entry_id}.{metric}` already assigned in PR 4 |
-| 11.8 | Auto-generated pack IDs | Pass | PR 4 | Deterministic `{pack_def_name}_{entry_index}` when `id` absent |
+| 11.8 | Auto-generated pack IDs | Pass | PR 4 | Deterministic `{pack_def_name}_{entry_index}` when `id` absent; duplicate metric names receive `"#{spec_index}"` suffix on the sub-signal id; post-expansion uniqueness check guards against user/auto id collisions |
 | 11.9 | delay in after clause | Not Tested | PR 5 | Parsed in PR 2 |
 | 11.10 | Structured after validation | Pass | PR 2 | AfterOp enum, serde validation |
 | 11.11 | Cross-signal-type after | Not Tested | PR 5 | |

--- a/docs/refactor/v2-validation-status.md
+++ b/docs/refactor/v2-validation-status.md
@@ -123,18 +123,18 @@ scenario and pack produces identical output in v2 format (14 rows).
 
 | # | Capability | Status | PR | Notes |
 |---|-----------|--------|-----|-------|
-| 9.1 | Run pack by name | Not Tested | PR 4/7 | |
-| 9.2 | Run pack from YAML | Not Tested | PR 4/6 | |
-| 9.3 | Pack search path | Not Tested | PR 4 | |
-| 9.4 | Pack by file path | Not Tested | PR 4 | |
-| 9.5 | Per-metric overrides (generator) | Not Tested | PR 4 | |
-| 9.6 | Per-metric overrides (labels) | Not Tested | PR 4 | |
-| 9.7 | Unknown override key → error | Not Tested | PR 4 | |
-| 9.8 | Label merge order | Not Tested | PR 4 | |
+| 9.1 | Run pack by name | Pass | PR 4 | Compile-level: name lookup via PackResolver; CLI wiring lands in PR 7 |
+| 9.2 | Run pack from YAML | Pass | PR 4 | Compile-level: v2 YAML with `scenarios: - pack:` parses and expands |
+| 9.3 | Pack search path | Pass | PR 4 | PackResolver trait abstraction; filesystem search path wiring lands in PR 7 CLI |
+| 9.4 | Pack by file path | Pass | PR 4 | classify_pack_reference routes `./x.yaml` or `/abs/x.yaml` to FilePath origin |
+| 9.5 | Per-metric overrides (generator) | Pass | PR 4 | expand::select_pack_metric_generator picks override > spec > constant(0) |
+| 9.6 | Per-metric overrides (labels) | Pass | PR 4 | Override labels sit at precedence level 7 in the merge |
+| 9.7 | Unknown override key → error | Pass | PR 4 | ExpandError::UnknownOverrideKey lists key + pack + valid metrics |
+| 9.8 | Label merge order | Pass | PR 4 | Five-level precedence chain validated by `label_precedence_chain_applied_in_order` |
 | 9.9 | Pack --dry-run | Not Tested | PR 7 | Enhanced |
 | 9.10 | List packs | Not Tested | PR 7 | |
 | 9.11 | Show pack YAML | Not Tested | PR 7 | |
-| 9.12 | Custom pack definitions | Not Tested | PR 4 | |
+| 9.12 | Custom pack definitions | Pass | PR 4 | InMemoryPackResolver accepts any MetricPackDef; classify_pack_reference supports file paths |
 | 9.13 | Built-in: telegraf_snmp_interface | Not Tested | PR 8 | |
 | 9.14 | Built-in: node_exporter_cpu | Not Tested | PR 8 | |
 | 9.15 | Built-in: node_exporter_memory | Not Tested | PR 8 | |
@@ -168,14 +168,14 @@ scenario and pack produces identical output in v2 format (14 rows).
 | 11.3 | Entry-level overrides defaults | Pass | PR 3 | entry values win over defaults across all precedence-eligible fields |
 | 11.4 | id field on entries | Pass | PR 2 | Uniqueness + format validated |
 | 11.5 | Single-signal shorthand | Pass | PR 2 | Flat files wrapped automatically |
-| 11.6 | Pack inside scenarios: list | Not Tested | PR 4 | Parsed in PR 2, expansion in PR 4 |
-| 11.7 | Dotted after ref into pack | Not Tested | PR 5 | |
-| 11.8 | Auto-generated pack IDs | Not Tested | PR 4 | |
+| 11.6 | Pack inside scenarios: list | Pass | PR 4 | Parsed in PR 2, expansion in PR 4 with one ExpandedEntry per pack metric |
+| 11.7 | Dotted after ref into pack | Not Tested | PR 5 | Sub-signal IDs of form `{entry_id}.{metric}` already assigned in PR 4 |
+| 11.8 | Auto-generated pack IDs | Pass | PR 4 | Deterministic `{pack_def_name}_{entry_index}` when `id` absent |
 | 11.9 | delay in after clause | Not Tested | PR 5 | Parsed in PR 2 |
 | 11.10 | Structured after validation | Pass | PR 2 | AfterOp enum, serde validation |
 | 11.11 | Cross-signal-type after | Not Tested | PR 5 | |
-| 11.12 | after on pack override | Not Tested | PR 4/5 | |
-| 11.13 | Pack entry-level after propagation | Not Tested | PR 4/5 | |
+| 11.12 | after on pack override | Pass | PR 4/5 | Carry-through Pass (PR 4); `after` resolution lands in PR 5 |
+| 11.13 | Pack entry-level after propagation | Pass | PR 4/5 | Propagation Pass (PR 4); `after` resolution lands in PR 5 |
 | 11.14 | after + phase_offset sum | Not Tested | PR 5 | |
 | 11.15 | Clock group auto-assignment | Not Tested | PR 5 | |
 | 11.16 | Conflicting clock_group → error | Not Tested | PR 5 | |
@@ -290,6 +290,6 @@ For each built-in pack, a v2 scenario file is created that uses the pack inside
 
 | # | Pack | Compile Parity | Runtime Parity | PR | Notes |
 |---|------|----------------|----------------|-----|-------|
-| 17.1 | telegraf-snmp-interface.yaml | Not Tested | Not Tested | PR 4/6 | 5 metrics, network category |
-| 17.2 | node-exporter-cpu.yaml | Not Tested | Not Tested | PR 4/6 | 8 metrics, step sizes sum to 1.0 |
-| 17.3 | node-exporter-memory.yaml | Not Tested | Not Tested | PR 4/6 | 5 metrics, 16 GiB defaults |
+| 17.1 | telegraf-snmp-interface.yaml | Pass | Not Tested | PR 4/6 | v1 `expand_pack` and v2 pipeline yield the same concrete signals including flap override; runtime parity lands in PR 6 |
+| 17.2 | node-exporter-cpu.yaml | Pass | Not Tested | PR 4/6 | Eight per-mode metrics of `node_cpu_seconds_total` compile identically; runtime parity lands in PR 6 |
+| 17.3 | node-exporter-memory.yaml | Pass | Not Tested | PR 4/6 | Five memory gauge metrics + override labels compile identically; runtime parity lands in PR 6 |

--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -93,14 +93,24 @@ src/
 │   ├── parse.rs        ← YAML parser and structural validation.
 │   │                      parse(), detect_version(), ParseError.
 │   │                      Single-signal shorthand support. Feature-gated (config).
-│   └── normalize.rs    ← Phase 2 compilation: defaults resolution.
-│                          normalize(), NormalizedFile, NormalizedEntry,
-│                          NormalizeError. Flattens defaults: into every entry,
-│                          applies built-in encoder/sink fallbacks, merges
-│                          defaults.labels for inline entries (deferred for
-│                          pack entries so Phase 3 can interleave pack
-│                          shared/per-metric labels), and enforces rate
-│                          presence. Feature-gated (config).
+│   ├── normalize.rs    ← Phase 2 compilation: defaults resolution.
+│   │                      normalize(), NormalizedFile, NormalizedEntry,
+│   │                      NormalizeError. Flattens defaults: into every entry,
+│   │                      applies built-in encoder/sink fallbacks, merges
+│   │                      defaults.labels for inline entries (deferred for
+│   │                      pack entries so Phase 3 can interleave pack
+│   │                      shared/per-metric labels), and enforces rate
+│   │                      presence. Feature-gated (config).
+│   └── expand.rs       ← Phase 3 compilation: pack expansion inside scenarios:.
+│                          expand(), ExpandedFile, ExpandedEntry, ExpandError.
+│                          PackResolver trait (name vs file-path classification)
+│                          plus InMemoryPackResolver test impl. Pack entries are
+│                          materialized into one signal per pack metric with the
+│                          spec §2.2 five-level label precedence chain
+│                          (defaults → shared → per-metric → entry → override)
+│                          and entry-level after propagation. Auto-ID scheme is
+│                          `{pack_def_name}_{entry_index}` for anonymous pack
+│                          entries. Feature-gated (config).
 └── config/
     ├── mod.rs          ← BaseScheduleConfig (shared schedule/delivery fields: name, rate, duration,
     │                      gaps, bursts, cardinality_spikes, dynamic_labels, labels, sink,

--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -110,7 +110,12 @@ src/
 │                          (defaults → shared → per-metric → entry → override)
 │                          and entry-level after propagation. Auto-ID scheme is
 │                          `{pack_def_name}_{entry_index}` for anonymous pack
-│                          entries. Feature-gated (config).
+│                          entries; sub-signal IDs are `{entry_id}.{metric}`
+│                          (bare) or `{entry_id}.{metric}#{spec_index}` when
+│                          the pack ships duplicate metric names. Post-
+│                          expansion uniqueness check rejects user/auto id
+│                          collisions via ExpandError::DuplicateEntryId.
+│                          Feature-gated (config).
 └── config/
     ├── mod.rs          ← BaseScheduleConfig (shared schedule/delivery fields: name, rate, duration,
     │                      gaps, bursts, cardinality_spikes, dynamic_labels, labels, sink,

--- a/sonda-core/src/compiler/expand.rs
+++ b/sonda-core/src/compiler/expand.rs
@@ -24,13 +24,13 @@
 //!
 //! Levels 1 (built-in defaults) and 3 (entry non-label fields) do not
 //! contribute labels. Level 8 (CLI flags) is applied later and is out of
-//! scope here. PR 3 deliberately left pack entry labels *unmerged* with
+//! scope here. Phase 2 deliberately left pack entry labels *unmerged* with
 //! `defaults.labels` so this pass can interleave levels 4 and 5 between
 //! them.
 //!
-//! Inline entries do **not** re-apply `defaults_labels`: PR 3 already merged
-//! them eagerly and we must not double-apply. Inline entries are copied
-//! through with their label map intact.
+//! Inline entries do **not** re-apply `defaults_labels`: Phase 2 already
+//! merged them eagerly and we must not double-apply. Inline entries are
+//! copied through with their label map intact.
 //!
 //! # Auto-generated pack entry IDs
 //!
@@ -42,9 +42,83 @@
 //! appended (even for the first anonymous pack entry) so two anonymous pack
 //! entries referencing the same pack never collide.
 //!
-//! The per-metric sub-signal IDs always take the form
-//! `"{effective_entry_id}.{metric_name}"`, where `effective_entry_id` is
-//! either the user-provided `id` or the auto-generated one above.
+//! After synthesis, a post-expansion uniqueness check runs over every
+//! effective pack-entry id *and* every emitted [`ExpandedEntry::id`]:
+//! collisions between user-authored ids and auto-generated ids (or between
+//! two pack sub-signals) are rejected via
+//! [`ExpandError::DuplicateEntryId`]. The parser's id uniqueness pass only
+//! sees user-provided ids, so this pass closes the gap.
+//!
+//! ## Sub-signal IDs and duplicate metric names
+//!
+//! When a pack's metrics are unique by name (the common case), the per-metric
+//! sub-signal id takes the form `"{effective_entry_id}.{metric_name}"` —
+//! e.g. the `telegraf_snmp_interface` pack produces
+//! `net.ifOperStatus`, `net.ifHCInOctets`, etc.
+//!
+//! When two or more [`MetricSpec`][crate::packs::MetricSpec] entries in a
+//! single pack share a `name` (the `node_exporter_cpu` pack ships eight
+//! `node_cpu_seconds_total` specs differentiated only by `labels.mode`), the
+//! bare `{effective_entry_id}.{metric_name}` id would collide. This pass
+//! appends `"#{spec_index}"` **only to the colliding specs**, producing ids
+//! such as `cpu.node_cpu_seconds_total#0`, `cpu.node_cpu_seconds_total#1`,
+//! etc., where `spec_index` is the metric's zero-based position in
+//! [`MetricPackDef::metrics`]. Unique metric names keep their clean form so
+//! dotted `after.ref` into a pack sub-signal (matrix row 11.7) is still
+//! ergonomic for the majority of packs.
+//!
+//! ## Worked example
+//!
+//! Given a pack entry written as:
+//!
+//! ```yaml
+//! scenarios:
+//!   - signal_type: metrics      # no `id:`, anonymous entry at index 0
+//!     pack: telegraf_snmp_interface
+//! ```
+//!
+//! and assuming `telegraf_snmp_interface` contains four metrics
+//! (`ifOperStatus`, `ifHCInOctets`, `ifHCOutOctets`, `ifInErrors`), this pass
+//! emits four [`ExpandedEntry`]s with the following ids:
+//!
+//! | `id` | derivation |
+//! |------|------------|
+//! | `telegraf_snmp_interface_0.ifOperStatus` | auto pack-entry id + metric name |
+//! | `telegraf_snmp_interface_0.ifHCInOctets` | auto pack-entry id + metric name |
+//! | `telegraf_snmp_interface_0.ifHCOutOctets` | auto pack-entry id + metric name |
+//! | `telegraf_snmp_interface_0.ifInErrors` | auto pack-entry id + metric name |
+//!
+//! If the same pack entry had a user-provided `id: primary`, the ids above
+//! would instead read `primary.ifOperStatus`, `primary.ifHCInOctets`, and so
+//! on.
+//!
+//! # Field propagation (parent pack entry → expanded metric)
+//!
+//! Spec §4.3 step 7 lists the fields that propagate from a pack entry to
+//! each expanded signal. The full set is wider than the spec's illustrative
+//! list; this pass copies the following fields from the parent
+//! [`NormalizedEntry`] onto every emitted [`ExpandedEntry`]:
+//!
+//! | Field | Propagation rule |
+//! |-------|------------------|
+//! | `rate` | copied verbatim (inherited from defaults in Phase 2) |
+//! | `duration` | copied verbatim |
+//! | `encoder` | copied verbatim |
+//! | `sink` | copied verbatim |
+//! | `jitter`, `jitter_seed` | copied verbatim |
+//! | `gaps` | cloned verbatim |
+//! | `bursts` | cloned verbatim |
+//! | `cardinality_spikes` | cloned verbatim |
+//! | `dynamic_labels` | cloned verbatim |
+//! | `phase_offset` | cloned verbatim |
+//! | `clock_group` | cloned verbatim |
+//! | `after` | per-metric override `after` wins, else parent entry `after` (see below) |
+//!
+//! Per-metric override fields in [`MetricOverride`] (`generator`, `labels`,
+//! `after`) replace or layer on top of the parent's values as documented
+//! above and in the label precedence chain. No other fields on a
+//! [`MetricOverride`] exist today; adding one requires both extending
+//! [`MetricOverride`] and teaching this pass to propagate it.
 //!
 //! # No pack references survive
 //!
@@ -59,7 +133,10 @@
 //!
 //! - unknown override keys in a pack entry,
 //! - pack resolver failures (name lookup, file IO, YAML parse),
-//! - pack definitions with no metrics.
+//! - pack definitions with no metrics,
+//! - duplicate entry ids after synthesis (user-authored id colliding with
+//!   an auto-generated pack-entry id, or sub-signal ids colliding with one
+//!   another).
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -114,6 +191,31 @@ pub enum ExpandError {
     EmptyPack {
         /// The pack definition name that was being expanded.
         pack_name: String,
+    },
+
+    /// Two entries ended up with the same identifier after pack expansion.
+    ///
+    /// The parser already rejects duplicate **user-provided** ids, but this
+    /// pass synthesizes ids for anonymous pack entries (see the module docs'
+    /// "Auto-generated pack entry IDs" section) and composes sub-signal ids
+    /// of the form `"{effective_entry_id}.{metric_name}"`. Those synthesized
+    /// ids can clash with user-authored ids or with one another; such
+    /// collisions are detected here so later phases (e.g. the Phase 4
+    /// reference index) see a unique id space.
+    ///
+    /// The `first_source` / `second_source` fields describe where each
+    /// collider originated so the diagnostic points at both contributors.
+    #[error(
+        "duplicate entry id '{id}' after pack expansion: \
+         {first_source} conflicts with {second_source}"
+    )]
+    DuplicateEntryId {
+        /// The colliding identifier.
+        id: String,
+        /// Description of the first source that produced the id.
+        first_source: String,
+        /// Description of the second source that produced the same id.
+        second_source: String,
     },
 }
 
@@ -341,8 +443,7 @@ pub struct ExpandedEntry {
     ///
     /// For pack-expanded signals, an override-level `after` replaces the
     /// parent pack entry's `after`; otherwise the parent's `after` is
-    /// propagated verbatim. Resolution into timing offsets is Phase 4
-    /// (PR 5).
+    /// propagated verbatim. Resolution into timing offsets is Phase 4's job.
     pub after: Option<AfterClause>,
 
     // -- Histogram / summary fields (inline entries only) --
@@ -377,6 +478,10 @@ pub struct ExpandedEntry {
 /// the resolved pack, with labels composed according to the module-level
 /// precedence chain and fields propagated per spec §4.3.
 ///
+/// Id uniqueness — including collisions between user-provided ids and
+/// auto-synthesized pack-entry ids — is enforced after expansion; the parser
+/// only validates user-provided ids.
+///
 /// # Errors
 ///
 /// - [`ExpandError::ResolveFailed`] when the resolver cannot produce a
@@ -384,12 +489,20 @@ pub struct ExpandedEntry {
 /// - [`ExpandError::UnknownOverrideKey`] when an override targets a metric
 ///   that is not present in the resolved pack definition.
 /// - [`ExpandError::EmptyPack`] when the resolved pack has no metrics.
+/// - [`ExpandError::DuplicateEntryId`] when two entries end up with the
+///   same identifier after synthesis (e.g. a user-authored inline id
+///   colliding with an auto-generated pack-entry id, or two sub-signal
+///   ids composing to the same string).
 pub fn expand<R: PackResolver>(
     file: NormalizedFile,
     resolver: &R,
 ) -> Result<ExpandedFile, ExpandError> {
     let defaults_labels = file.defaults_labels;
     let mut entries: Vec<ExpandedEntry> = Vec::with_capacity(file.entries.len());
+    // Collects every id that occupies the signal-id namespace so we can
+    // catch collisions between user-authored ids, synthesized pack-entry
+    // ids, and pack sub-signal ids in a single pass.
+    let mut id_registry: BTreeMap<String, String> = BTreeMap::new();
 
     for (index, entry) in file.entries.into_iter().enumerate() {
         if entry.pack.is_some() {
@@ -399,9 +512,14 @@ pub fn expand<R: PackResolver>(
                 defaults_labels.as_ref(),
                 resolver,
                 &mut entries,
+                &mut id_registry,
             )?;
         } else {
-            entries.push(expand_inline_entry(entry));
+            let expanded = expand_inline_entry(entry);
+            if let Some(id) = expanded.id.as_ref() {
+                record_id(&mut id_registry, id, format!("inline entry '{id}'"))?;
+            }
+            entries.push(expanded);
         }
     }
 
@@ -409,6 +527,27 @@ pub fn expand<R: PackResolver>(
         version: file.version,
         entries,
     })
+}
+
+/// Insert an identifier into the post-expansion uniqueness registry.
+///
+/// Returns [`ExpandError::DuplicateEntryId`] if `id` was already registered,
+/// tagging both the previous and current source so the diagnostic points at
+/// both contributors.
+fn record_id(
+    registry: &mut BTreeMap<String, String>,
+    id: &str,
+    source: String,
+) -> Result<(), ExpandError> {
+    if let Some(prior) = registry.get(id) {
+        return Err(ExpandError::DuplicateEntryId {
+            id: id.to_string(),
+            first_source: prior.clone(),
+            second_source: source,
+        });
+    }
+    registry.insert(id.to_string(), source);
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -456,13 +595,15 @@ fn expand_inline_entry(entry: NormalizedEntry) -> ExpandedEntry {
 // ---------------------------------------------------------------------------
 
 /// Expand a single pack-backed [`NormalizedEntry`] into one [`ExpandedEntry`]
-/// per metric in the resolved pack, appending to `out`.
+/// per metric in the resolved pack, appending to `out` and tracking every
+/// produced id in `id_registry` for the post-expansion uniqueness check.
 fn expand_pack_entry<R: PackResolver>(
     entry: NormalizedEntry,
     entry_index: usize,
     defaults_labels: Option<&BTreeMap<String, String>>,
     resolver: &R,
     out: &mut Vec<ExpandedEntry>,
+    id_registry: &mut BTreeMap<String, String>,
 ) -> Result<(), ExpandError> {
     // `entry.pack` is Some() by the caller's check; unwrap defensively.
     let reference = entry
@@ -485,12 +626,38 @@ fn expand_pack_entry<R: PackResolver>(
 
     validate_override_keys(&pack, entry.overrides.as_ref())?;
 
-    let effective_entry_id = match entry.id.clone() {
-        Some(id) => id,
-        None => format!("{}_{}", pack.name, entry_index),
+    let (effective_entry_id, effective_id_source) = match entry.id.clone() {
+        Some(id) => (id.clone(), format!("pack entry '{id}' (user-provided id)")),
+        None => {
+            let synthesized = format!("{}_{}", pack.name, entry_index);
+            (
+                synthesized.clone(),
+                format!(
+                    "pack entry at index {entry_index} (auto-generated id '{synthesized}' \
+                     from pack '{}')",
+                    pack.name
+                ),
+            )
+        }
     };
 
-    for metric in &pack.metrics {
+    // The effective pack-entry id occupies the signal-id namespace even
+    // though no single `ExpandedEntry` carries it verbatim: its sub-signal
+    // ids live underneath (e.g. `{effective_entry_id}.{metric_name}`) and a
+    // future `after.ref` targeting `effective_entry_id` would resolve into
+    // this namespace. Register it so user-authored ids cannot silently
+    // shadow an auto-generated pack-entry id and vice versa.
+    record_id(id_registry, &effective_entry_id, effective_id_source)?;
+
+    // Per the module docs, sub-signal ids default to
+    // `"{effective_entry_id}.{metric_name}"` but metrics whose name collides
+    // with another spec in the same pack receive an additional
+    // `"#{spec_index}"` suffix. This keeps the common case clean while
+    // preventing id collisions for packs like `node_exporter_cpu` where
+    // multiple `MetricSpec`s share a metric name.
+    let duplicate_metric_names = duplicate_metric_names(&pack);
+
+    for (spec_index, metric) in pack.metrics.iter().enumerate() {
         let override_for_metric = entry
             .overrides
             .as_ref()
@@ -509,13 +676,27 @@ fn expand_pack_entry<R: PackResolver>(
         // Override-level `after` replaces entry-level `after` for this
         // specific expanded metric; otherwise propagate the parent's
         // `after` verbatim. We do NOT resolve `after.ref` here — that is
-        // PR 5's job.
+        // Phase 4's job.
         let after = override_for_metric
             .and_then(|o| o.after.clone())
             .or_else(|| entry.after.clone());
 
+        let sub_signal_id = if duplicate_metric_names.contains(metric.name.as_str()) {
+            format!("{}.{}#{}", effective_entry_id, metric.name, spec_index)
+        } else {
+            format!("{}.{}", effective_entry_id, metric.name)
+        };
+        record_id(
+            id_registry,
+            &sub_signal_id,
+            format!(
+                "pack sub-signal '{sub_signal_id}' (pack '{}', metric '{}' at index {spec_index})",
+                pack.name, metric.name
+            ),
+        )?;
+
         out.push(ExpandedEntry {
-            id: Some(format!("{}.{}", effective_entry_id, metric.name)),
+            id: Some(sub_signal_id),
             signal_type: "metrics".to_string(),
             name: metric.name.clone(),
             rate: entry.rate,
@@ -544,6 +725,23 @@ fn expand_pack_entry<R: PackResolver>(
     }
 
     Ok(())
+}
+
+/// Return the set of metric names that appear more than once in `pack`.
+///
+/// Used by [`expand_pack_entry`] to decide which sub-signal ids need a
+/// `"#{spec_index}"` disambiguator per the scheme documented in the module
+/// docs. Unique metric names stay out of this set and keep their clean
+/// `{effective_entry_id}.{metric_name}` form.
+fn duplicate_metric_names(pack: &MetricPackDef) -> BTreeSet<&str> {
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    let mut duplicates: BTreeSet<&str> = BTreeSet::new();
+    for metric in &pack.metrics {
+        if !seen.insert(metric.name.as_str()) {
+            duplicates.insert(metric.name.as_str());
+        }
+    }
+    duplicates
 }
 
 /// Reject overrides whose keys do not match any metric name in the pack.
@@ -1027,7 +1225,7 @@ scenarios:
 
     #[test]
     fn inline_entry_labels_pass_through_unchanged() {
-        // Inline entries must NOT re-apply defaults_labels; PR 3 already
+        // Inline entries must NOT re-apply defaults_labels; Phase 2 already
         // merged them. Verify that exactly the merged set from normalize
         // shows up here — not doubled, not missing a defaults key.
         let yaml = r#"
@@ -1424,6 +1622,203 @@ scenarios:
                 .get("mode")
                 .unwrap(),
             "system"
+        );
+    }
+
+    #[test]
+    fn repeated_metric_names_produce_unique_sub_signal_ids() {
+        // Regression anchor: every ExpandedEntry.id must be unique even
+        // when a pack ships multiple MetricSpec entries under one name
+        // (e.g. node_exporter_cpu). Duplicate names receive a
+        // "#{spec_index}" suffix per the module-level auto-ID docs.
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    pack: node_exporter_cpu
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("node_exporter_cpu", node_cpu_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+
+        let ids: Vec<&str> = expanded
+            .entries
+            .iter()
+            .map(|e| {
+                e.id.as_deref()
+                    .expect("pack-expanded entries always carry an id")
+            })
+            .collect();
+        let mut unique = ids.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            ids.len(),
+            "sub-signal ids must be unique; saw {ids:?}"
+        );
+
+        // Exact id shape: first two node_cpu_seconds_total specs live at
+        // pack metric indices 0 and 1.
+        assert_eq!(ids[0], "cpu.node_cpu_seconds_total#0");
+        assert_eq!(ids[1], "cpu.node_cpu_seconds_total#1");
+    }
+
+    #[test]
+    fn unique_metric_names_keep_clean_sub_signal_ids() {
+        // The `#{spec_index}` disambiguator is applied only when a metric
+        // name collides with another spec in the same pack. Packs whose
+        // metrics are unique by name (like telegraf_snmp_interface) keep
+        // the clean `{effective_entry_id}.{metric_name}` form so dotted
+        // `after.ref` into a pack sub-signal stays ergonomic.
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - id: net
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+
+        let ids: Vec<&str> = expanded
+            .entries
+            .iter()
+            .filter_map(|e| e.id.as_deref())
+            .collect();
+        assert_eq!(ids, vec!["net.ifOperStatus", "net.ifHCInOctets"]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Post-expansion id uniqueness (user-provided vs. auto-synthesized)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn user_id_colliding_with_auto_pack_entry_id_is_an_error() {
+        // Reviewer-described case: the user writes an inline id that
+        // equals what the anonymous pack entry at the next position would
+        // synthesize. The parser's id uniqueness pass never sees the
+        // synthesized id, so this pass must catch the collision.
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - id: telegraf_snmp_interface_1
+    signal_type: metrics
+    name: cpu
+    generator: { type: constant, value: 1 }
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let parsed = parse(yaml).expect("parse");
+        let normalized = normalize(parsed).expect("normalize");
+        let err = expand(normalized, &resolver).expect_err("must fail");
+        match err {
+            ExpandError::DuplicateEntryId {
+                id,
+                first_source,
+                second_source,
+            } => {
+                assert_eq!(id, "telegraf_snmp_interface_1");
+                assert!(
+                    first_source.contains("inline entry"),
+                    "unexpected first source: {first_source}"
+                );
+                assert!(
+                    second_source.contains("auto-generated"),
+                    "unexpected second source: {second_source}"
+                );
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn auto_pack_entry_id_colliding_with_later_user_id_is_an_error() {
+        // Reverse ordering: anonymous pack entry comes first, user-written
+        // id collides with the synthesized name afterward. The registry
+        // must flag the collision regardless of source order.
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+  - id: telegraf_snmp_interface_0
+    signal_type: metrics
+    name: cpu
+    generator: { type: constant, value: 1 }
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let parsed = parse(yaml).expect("parse");
+        let normalized = normalize(parsed).expect("normalize");
+        let err = expand(normalized, &resolver).expect_err("must fail");
+        match err {
+            ExpandError::DuplicateEntryId {
+                id,
+                first_source,
+                second_source,
+            } => {
+                assert_eq!(id, "telegraf_snmp_interface_0");
+                assert!(
+                    first_source.contains("auto-generated"),
+                    "unexpected first source: {first_source}"
+                );
+                assert!(
+                    second_source.contains("inline entry"),
+                    "unexpected second source: {second_source}"
+                );
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_entry_id_error_preserves_both_sources() {
+        // The diagnostic must name both contributors so users can locate
+        // each side of the collision. Parser-level id validation rejects
+        // `.` and `#` in user ids, so the only reachable collisions travel
+        // between inline ids and synthesized pack-entry ids; both sources
+        // appear in the error regardless of document order.
+        //
+        // The pack entry here sits at index 1, so its auto-id is
+        // `telegraf_snmp_interface_1`; the inline entry claims that id
+        // first.
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - id: telegraf_snmp_interface_1
+    signal_type: metrics
+    name: cpu
+    generator: { type: constant, value: 1 }
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let parsed = parse(yaml).expect("parse");
+        let normalized = normalize(parsed).expect("normalize");
+        let err = expand(normalized, &resolver).expect_err("must fail");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("'telegraf_snmp_interface_1'"),
+            "error must name the colliding id: {rendered}"
+        );
+        assert!(
+            rendered.contains("inline entry"),
+            "error must name the inline source: {rendered}"
+        );
+        assert!(
+            rendered.contains("auto-generated"),
+            "error must name the auto-generated source: {rendered}"
         );
     }
 

--- a/sonda-core/src/compiler/expand.rs
+++ b/sonda-core/src/compiler/expand.rs
@@ -1,0 +1,1460 @@
+//! Pack expansion for v2 scenario files.
+//!
+//! This module implements **Phase 3** of the v2 compilation pipeline. It takes
+//! a [`NormalizedFile`] (the output of [`super::normalize::normalize`]) and
+//! expands every pack-backed entry into one concrete per-metric signal while
+//! preserving the full label precedence chain from spec §2.2. After expansion,
+//! the returned [`ExpandedFile`] contains no unresolved pack references —
+//! every entry is a concrete signal that later phases can reason about in
+//! isolation.
+//!
+//! # Label precedence chain (for pack-expanded signals)
+//!
+//! For each metric produced by a pack expansion the final label map is
+//! composed from five layers, applied **low → high** (each subsequent level
+//! overwrites on key collision):
+//!
+//! | Level | Source |
+//! |------:|--------|
+//! | 2 | [`NormalizedFile::defaults_labels`] |
+//! | 4 | pack [`MetricPackDef::shared_labels`] |
+//! | 5 | pack per-metric [`MetricSpec::labels`] |
+//! | 6 | pack entry [`NormalizedEntry::labels`] |
+//! | 7 | override [`MetricOverride::labels`] |
+//!
+//! Levels 1 (built-in defaults) and 3 (entry non-label fields) do not
+//! contribute labels. Level 8 (CLI flags) is applied later and is out of
+//! scope here. PR 3 deliberately left pack entry labels *unmerged* with
+//! `defaults.labels` so this pass can interleave levels 4 and 5 between
+//! them.
+//!
+//! Inline entries do **not** re-apply `defaults_labels`: PR 3 already merged
+//! them eagerly and we must not double-apply. Inline entries are copied
+//! through with their label map intact.
+//!
+//! # Auto-generated pack entry IDs
+//!
+//! Spec §2.4 allows pack entries to omit `id`; spec matrix row 11.8 still
+//! requires sub-signal IDs to be addressable. When a pack entry has no `id`
+//! set, this pass synthesizes a deterministic identifier of the form
+//! `"{pack_def_name}_{entry_index}"` where `entry_index` is the pack entry's
+//! zero-based position in [`NormalizedFile::entries`]. The suffix is always
+//! appended (even for the first anonymous pack entry) so two anonymous pack
+//! entries referencing the same pack never collide.
+//!
+//! The per-metric sub-signal IDs always take the form
+//! `"{effective_entry_id}.{metric_name}"`, where `effective_entry_id` is
+//! either the user-provided `id` or the auto-generated one above.
+//!
+//! # No pack references survive
+//!
+//! After [`expand`] returns successfully, none of the entries in
+//! [`ExpandedFile::entries`] carry a `pack` reference. Subsequent compilation
+//! phases (after-clause resolution, clock group assignment, runtime wiring)
+//! can operate on a flat list of concrete signals.
+//!
+//! # Error surface
+//!
+//! All failure modes flow through [`ExpandError`]:
+//!
+//! - unknown override keys in a pack entry,
+//! - pack resolver failures (name lookup, file IO, YAML parse),
+//! - pack definitions with no metrics.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::normalize::{NormalizedEntry, NormalizedFile};
+use super::AfterClause;
+use crate::config::{
+    BurstConfig, CardinalitySpikeConfig, DistributionConfig, DynamicLabelConfig, GapConfig,
+};
+use crate::encoder::EncoderConfig;
+use crate::generator::{GeneratorConfig, LogGeneratorConfig};
+use crate::packs::{MetricOverride, MetricPackDef};
+use crate::sink::SinkConfig;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors produced during pack expansion.
+#[derive(Debug, thiserror::Error)]
+pub enum ExpandError {
+    /// The pack reference could not be resolved — either unknown name or a
+    /// file path load failure. The wrapped message includes the pack
+    /// reference and an indication of whether the resolver treated it as a
+    /// name lookup or a file path load.
+    #[error("pack '{reference}' could not be resolved: {message}")]
+    ResolveFailed {
+        /// The pack reference as written in the scenario file.
+        reference: String,
+        /// Diagnostic detail from the underlying resolver.
+        message: String,
+    },
+
+    /// An override in a pack entry referenced a metric name that does not
+    /// exist in the resolved pack definition.
+    ///
+    /// The error lists the pack's available metric names so the user can see
+    /// what was expected.
+    #[error(
+        "override references unknown metric '{key}'; pack '{pack_name}' contains: {available}"
+    )]
+    UnknownOverrideKey {
+        /// The offending override key.
+        key: String,
+        /// The pack definition name that was being expanded.
+        pack_name: String,
+        /// Comma-separated list of valid metric names from the pack.
+        available: String,
+    },
+
+    /// The pack definition has no metrics, so expansion has nothing to emit.
+    #[error("pack '{pack_name}' contains no metrics")]
+    EmptyPack {
+        /// The pack definition name that was being expanded.
+        pack_name: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Pack resolver trait
+// ---------------------------------------------------------------------------
+
+/// Resolves a pack reference into a [`MetricPackDef`].
+///
+/// The trait is intentionally narrow: implementations receive the raw
+/// reference string exactly as it appeared in the scenario file, decide
+/// whether to treat it as a pack name (catalog lookup) or a file path (when
+/// the string contains `/` or starts with `.`, per spec §2.4), and return
+/// the parsed definition.
+///
+/// Implementations must be pure with respect to the inputs they receive —
+/// the compiler does not cache results, so callers that want memoization
+/// should wrap their resolver.
+///
+/// The [`sonda`] CLI crate adapts its filesystem `PackCatalog` to this
+/// trait. Tests use [`InMemoryPackResolver`].
+pub trait PackResolver {
+    /// Resolve `reference` to a pack definition.
+    ///
+    /// `reference` is the string the user wrote under `pack:`. Per spec
+    /// §2.4, values containing `/` or starting with `.` are treated as file
+    /// paths; everything else is treated as a pack name and looked up on
+    /// the caller's search path.
+    ///
+    /// Errors must include enough context (path, underlying OS error, YAML
+    /// parse diagnostic) for the compiler to surface a useful diagnostic
+    /// without further decoration.
+    fn resolve(&self, reference: &str) -> Result<MetricPackDef, PackResolveError>;
+}
+
+/// Error produced by a [`PackResolver`] implementation.
+///
+/// Carries a human-readable message plus a classification of how the
+/// resolver interpreted the reference. The compiler folds this into
+/// [`ExpandError::ResolveFailed`] so users see a consistent diagnostic.
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct PackResolveError {
+    /// Diagnostic message describing the failure.
+    pub message: String,
+    /// Origin kind the resolver decided to use for the reference.
+    pub origin: PackResolveOrigin,
+}
+
+/// How a resolver interpreted a pack reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackResolveOrigin {
+    /// Interpreted as a pack name looked up on the catalog search path.
+    Name,
+    /// Interpreted as a filesystem path to a pack YAML file.
+    FilePath,
+}
+
+impl PackResolveError {
+    /// Construct a resolver error from a reference and a message.
+    ///
+    /// `origin` should reflect the path the resolver took to interpret the
+    /// reference so error messages can disambiguate "unknown pack name"
+    /// from "pack file not found".
+    pub fn new(message: impl Into<String>, origin: PackResolveOrigin) -> Self {
+        Self {
+            message: message.into(),
+            origin,
+        }
+    }
+}
+
+/// Classify a pack reference as a file path or a catalog name per spec §2.4.
+///
+/// Returns [`PackResolveOrigin::FilePath`] when `reference` contains a `/`
+/// or starts with a `.`; otherwise [`PackResolveOrigin::Name`].
+pub fn classify_pack_reference(reference: &str) -> PackResolveOrigin {
+    if reference.contains('/') || reference.starts_with('.') {
+        PackResolveOrigin::FilePath
+    } else {
+        PackResolveOrigin::Name
+    }
+}
+
+/// An in-memory [`PackResolver`] backed by a `BTreeMap`.
+///
+/// Useful for unit tests, embedded integrations, and any caller that
+/// constructs pack definitions in code rather than loading them from disk.
+/// Both pack names (catalog lookup) and file-path strings can be inserted —
+/// lookup is a direct key match.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryPackResolver {
+    packs: BTreeMap<String, MetricPackDef>,
+}
+
+impl InMemoryPackResolver {
+    /// Create an empty resolver.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a pack definition keyed by `reference`.
+    ///
+    /// The key is matched verbatim against the pack reference string in
+    /// the scenario file. Callers that need to support both "pack by name"
+    /// and "pack by file path" for the same definition should insert it
+    /// under both keys.
+    pub fn insert(&mut self, reference: impl Into<String>, pack: MetricPackDef) {
+        self.packs.insert(reference.into(), pack);
+    }
+}
+
+impl PackResolver for InMemoryPackResolver {
+    fn resolve(&self, reference: &str) -> Result<MetricPackDef, PackResolveError> {
+        match self.packs.get(reference) {
+            Some(pack) => Ok(pack.clone()),
+            None => Err(PackResolveError::new(
+                format!("pack reference '{reference}' not found in resolver"),
+                classify_pack_reference(reference),
+            )),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Expanded representation
+// ---------------------------------------------------------------------------
+
+/// A v2 scenario file whose pack entries have been fully expanded.
+///
+/// This is the output of [`expand`]. Every entry is a concrete signal —
+/// there are no unresolved pack references. Inline entries from the
+/// [`NormalizedFile`] pass through verbatim; pack entries are replaced by
+/// one [`ExpandedEntry`] per metric in the pack.
+///
+/// # Invariants
+///
+/// - No entry has a `pack` or `overrides` field — those have been resolved.
+/// - Every entry has a concrete `rate`, `encoder`, and `sink` (inherited
+///   from [`NormalizedEntry`]).
+/// - Entry IDs remain unique across the file, including auto-generated
+///   IDs synthesized for anonymous pack entries.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Serialize))]
+pub struct ExpandedFile {
+    /// Schema version. Always `2` after expansion.
+    pub version: u32,
+    /// All entries with pack expansion applied, in source order.
+    ///
+    /// Pack entries contribute one entry per metric, in the order metrics
+    /// appear in the resolved pack definition. Inline entries contribute
+    /// one entry each, unchanged from the normalized input.
+    pub entries: Vec<ExpandedEntry>,
+}
+
+/// A single concrete scenario entry after pack expansion.
+///
+/// This is the fully-resolved form of a signal that later compilation
+/// phases (`after` compiler, clock group assignment, runtime launcher)
+/// consume. The type deliberately drops pack-related fields
+/// (`pack`, `overrides`) because they cannot appear here, and drops
+/// histogram/summary fields because spec §2.4 forbids pack entries from
+/// carrying them — inline histogram/summary entries still flow through but
+/// pack expansion never produces them.
+///
+/// Sub-signal IDs produced by pack expansion have the form
+/// `"{effective_entry_id}.{metric_name}"`; see the module docs for the
+/// auto-ID scheme used when the pack entry lacks an explicit `id`.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Serialize))]
+pub struct ExpandedEntry {
+    /// Signal identifier. Concrete for every expanded entry: either the
+    /// user-provided inline id, or a pack-expansion sub-signal id of the
+    /// form `"{effective_entry_id}.{metric_name}"`.
+    ///
+    /// Inline entries without an `id` in the source carry `None` here (that
+    /// survives verbatim from the normalized input). Pack-expanded entries
+    /// always have `Some(_)`: if the parent pack entry lacked an id, one
+    /// was synthesized (see module docs).
+    pub id: Option<String>,
+    /// Signal type: `"metrics"`, `"logs"`, `"histogram"`, or `"summary"`.
+    pub signal_type: String,
+    /// Metric or scenario name. Always populated after expansion: inline
+    /// entries carried their own name through normalization; pack-expanded
+    /// entries use the pack metric's name.
+    pub name: String,
+    /// Event rate in events per second. Inherited from the parent
+    /// normalized entry.
+    pub rate: f64,
+    /// Total run duration (e.g. `"30s"`, `"5m"`).
+    pub duration: Option<String>,
+    /// Value generator configuration (metrics signals only).
+    pub generator: Option<GeneratorConfig>,
+    /// Log generator configuration (logs signals only).
+    pub log_generator: Option<LogGeneratorConfig>,
+    /// Static labels after the full precedence chain has been applied.
+    ///
+    /// For pack-expanded entries this is the level-2-through-7 merge
+    /// described in the module docs. For inline entries it is the
+    /// already-merged map produced by Phase 2 normalization (unchanged).
+    ///
+    /// `None` when no source contributed any labels.
+    pub labels: Option<BTreeMap<String, String>>,
+    /// Dynamic (rotating) label configurations.
+    pub dynamic_labels: Option<Vec<DynamicLabelConfig>>,
+    /// Encoder configuration.
+    pub encoder: EncoderConfig,
+    /// Sink configuration.
+    pub sink: SinkConfig,
+    /// Jitter amplitude applied to generated values.
+    pub jitter: Option<f64>,
+    /// Deterministic seed for jitter RNG.
+    pub jitter_seed: Option<u64>,
+    /// Recurring silent-period configuration.
+    pub gaps: Option<GapConfig>,
+    /// Recurring high-rate burst configuration.
+    pub bursts: Option<BurstConfig>,
+    /// Cardinality spike configurations.
+    pub cardinality_spikes: Option<Vec<CardinalitySpikeConfig>>,
+    /// Phase offset for staggered start within a clock group.
+    pub phase_offset: Option<String>,
+    /// Clock group for coordinated timing across entries.
+    pub clock_group: Option<String>,
+    /// Causal dependency on another signal's value.
+    ///
+    /// For pack-expanded signals, an override-level `after` replaces the
+    /// parent pack entry's `after`; otherwise the parent's `after` is
+    /// propagated verbatim. Resolution into timing offsets is Phase 4
+    /// (PR 5).
+    pub after: Option<AfterClause>,
+
+    // -- Histogram / summary fields (inline entries only) --
+    //
+    // Pack entries cannot carry these (spec §2.4: pack entries must have
+    // signal_type: metrics, parse-time validation enforces that). They
+    // survive here purely as carry-through for inline histogram/summary
+    // signals.
+    /// Distribution model for histogram or summary observations.
+    pub distribution: Option<DistributionConfig>,
+    /// Histogram bucket boundaries (histogram only).
+    pub buckets: Option<Vec<f64>>,
+    /// Summary quantile boundaries (summary only).
+    pub quantiles: Option<Vec<f64>>,
+    /// Number of observations sampled per tick.
+    pub observations_per_tick: Option<u32>,
+    /// Linear drift applied to the distribution mean each second.
+    pub mean_shift_per_sec: Option<f64>,
+    /// Deterministic seed for histogram/summary sampling.
+    pub seed: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Expand every pack entry in a normalized v2 scenario file.
+///
+/// Inline entries in [`NormalizedFile::entries`] are copied through
+/// verbatim (without re-applying `defaults_labels` — Phase 2 handled that).
+/// Pack entries are materialized into one [`ExpandedEntry`] per metric in
+/// the resolved pack, with labels composed according to the module-level
+/// precedence chain and fields propagated per spec §4.3.
+///
+/// # Errors
+///
+/// - [`ExpandError::ResolveFailed`] when the resolver cannot produce a
+///   [`MetricPackDef`] for a pack reference.
+/// - [`ExpandError::UnknownOverrideKey`] when an override targets a metric
+///   that is not present in the resolved pack definition.
+/// - [`ExpandError::EmptyPack`] when the resolved pack has no metrics.
+pub fn expand<R: PackResolver>(
+    file: NormalizedFile,
+    resolver: &R,
+) -> Result<ExpandedFile, ExpandError> {
+    let defaults_labels = file.defaults_labels;
+    let mut entries: Vec<ExpandedEntry> = Vec::with_capacity(file.entries.len());
+
+    for (index, entry) in file.entries.into_iter().enumerate() {
+        if entry.pack.is_some() {
+            expand_pack_entry(
+                entry,
+                index,
+                defaults_labels.as_ref(),
+                resolver,
+                &mut entries,
+            )?;
+        } else {
+            entries.push(expand_inline_entry(entry));
+        }
+    }
+
+    Ok(ExpandedFile {
+        version: file.version,
+        entries,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Inline pass-through
+// ---------------------------------------------------------------------------
+
+/// Convert an inline [`NormalizedEntry`] into an [`ExpandedEntry`].
+///
+/// Labels are preserved verbatim — Phase 2 normalization already merged
+/// `defaults_labels` into inline entries. Re-applying them here would
+/// double-merge a map the user already sees in the normalized output.
+fn expand_inline_entry(entry: NormalizedEntry) -> ExpandedEntry {
+    ExpandedEntry {
+        id: entry.id,
+        signal_type: entry.signal_type,
+        // Inline entries always have `name` by parse-time validation.
+        name: entry.name.unwrap_or_default(),
+        rate: entry.rate,
+        duration: entry.duration,
+        generator: entry.generator,
+        log_generator: entry.log_generator,
+        labels: entry.labels,
+        dynamic_labels: entry.dynamic_labels,
+        encoder: entry.encoder,
+        sink: entry.sink,
+        jitter: entry.jitter,
+        jitter_seed: entry.jitter_seed,
+        gaps: entry.gaps,
+        bursts: entry.bursts,
+        cardinality_spikes: entry.cardinality_spikes,
+        phase_offset: entry.phase_offset,
+        clock_group: entry.clock_group,
+        after: entry.after,
+        distribution: entry.distribution,
+        buckets: entry.buckets,
+        quantiles: entry.quantiles,
+        observations_per_tick: entry.observations_per_tick,
+        mean_shift_per_sec: entry.mean_shift_per_sec,
+        seed: entry.seed,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pack expansion
+// ---------------------------------------------------------------------------
+
+/// Expand a single pack-backed [`NormalizedEntry`] into one [`ExpandedEntry`]
+/// per metric in the resolved pack, appending to `out`.
+fn expand_pack_entry<R: PackResolver>(
+    entry: NormalizedEntry,
+    entry_index: usize,
+    defaults_labels: Option<&BTreeMap<String, String>>,
+    resolver: &R,
+    out: &mut Vec<ExpandedEntry>,
+) -> Result<(), ExpandError> {
+    // `entry.pack` is Some() by the caller's check; unwrap defensively.
+    let reference = entry
+        .pack
+        .as_deref()
+        .expect("expand_pack_entry called with non-pack entry; caller must check");
+
+    let pack = resolver
+        .resolve(reference)
+        .map_err(|e| ExpandError::ResolveFailed {
+            reference: reference.to_string(),
+            message: e.message,
+        })?;
+
+    if pack.metrics.is_empty() {
+        return Err(ExpandError::EmptyPack {
+            pack_name: pack.name,
+        });
+    }
+
+    validate_override_keys(&pack, entry.overrides.as_ref())?;
+
+    let effective_entry_id = match entry.id.clone() {
+        Some(id) => id,
+        None => format!("{}_{}", pack.name, entry_index),
+    };
+
+    for metric in &pack.metrics {
+        let override_for_metric = entry
+            .overrides
+            .as_ref()
+            .and_then(|map| map.get(&metric.name));
+
+        let labels = compose_pack_metric_labels(
+            defaults_labels,
+            pack.shared_labels.as_ref(),
+            metric.labels.as_ref(),
+            entry.labels.as_ref(),
+            override_for_metric.and_then(|o| o.labels.as_ref()),
+        );
+
+        let generator = select_pack_metric_generator(metric, override_for_metric);
+
+        // Override-level `after` replaces entry-level `after` for this
+        // specific expanded metric; otherwise propagate the parent's
+        // `after` verbatim. We do NOT resolve `after.ref` here — that is
+        // PR 5's job.
+        let after = override_for_metric
+            .and_then(|o| o.after.clone())
+            .or_else(|| entry.after.clone());
+
+        out.push(ExpandedEntry {
+            id: Some(format!("{}.{}", effective_entry_id, metric.name)),
+            signal_type: "metrics".to_string(),
+            name: metric.name.clone(),
+            rate: entry.rate,
+            duration: entry.duration.clone(),
+            generator: Some(generator),
+            log_generator: None,
+            labels,
+            dynamic_labels: entry.dynamic_labels.clone(),
+            encoder: entry.encoder.clone(),
+            sink: entry.sink.clone(),
+            jitter: entry.jitter,
+            jitter_seed: entry.jitter_seed,
+            gaps: entry.gaps.clone(),
+            bursts: entry.bursts.clone(),
+            cardinality_spikes: entry.cardinality_spikes.clone(),
+            phase_offset: entry.phase_offset.clone(),
+            clock_group: entry.clock_group.clone(),
+            after,
+            distribution: None,
+            buckets: None,
+            quantiles: None,
+            observations_per_tick: None,
+            mean_shift_per_sec: None,
+            seed: None,
+        });
+    }
+
+    Ok(())
+}
+
+/// Reject overrides whose keys do not match any metric name in the pack.
+///
+/// Matches the message shape produced by
+/// [`crate::packs::expand_pack`] so v1 and v2 surfaces stay consistent.
+fn validate_override_keys(
+    pack: &MetricPackDef,
+    overrides: Option<&BTreeMap<String, MetricOverride>>,
+) -> Result<(), ExpandError> {
+    let Some(overrides) = overrides else {
+        return Ok(());
+    };
+    if overrides.is_empty() {
+        return Ok(());
+    }
+
+    let metric_names: BTreeSet<&str> = pack.metrics.iter().map(|m| m.name.as_str()).collect();
+    for key in overrides.keys() {
+        if !metric_names.contains(key.as_str()) {
+            let available: Vec<&str> = pack.metrics.iter().map(|m| m.name.as_str()).collect();
+            return Err(ExpandError::UnknownOverrideKey {
+                key: key.clone(),
+                pack_name: pack.name.clone(),
+                available: available.join(", "),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Compose the final label map for a single pack-expanded metric.
+///
+/// Applies the five label layers in the precedence order documented at
+/// the module level. `None` maps are skipped. Uses [`BTreeMap`] for
+/// deterministic iteration order so snapshot tests are stable.
+fn compose_pack_metric_labels(
+    defaults_labels: Option<&BTreeMap<String, String>>,
+    pack_shared_labels: Option<&std::collections::HashMap<String, String>>,
+    pack_metric_labels: Option<&std::collections::HashMap<String, String>>,
+    entry_labels: Option<&BTreeMap<String, String>>,
+    override_labels: Option<&BTreeMap<String, String>>,
+) -> Option<BTreeMap<String, String>> {
+    let mut merged: BTreeMap<String, String> = BTreeMap::new();
+
+    // Level 2: file-level defaults labels.
+    if let Some(src) = defaults_labels {
+        for (k, v) in src {
+            merged.insert(k.clone(), v.clone());
+        }
+    }
+
+    // Level 4: pack shared_labels.
+    if let Some(src) = pack_shared_labels {
+        for (k, v) in src {
+            merged.insert(k.clone(), v.clone());
+        }
+    }
+
+    // Level 5: pack per-metric labels.
+    if let Some(src) = pack_metric_labels {
+        for (k, v) in src {
+            merged.insert(k.clone(), v.clone());
+        }
+    }
+
+    // Level 6: entry-level labels on the pack entry.
+    if let Some(src) = entry_labels {
+        for (k, v) in src {
+            merged.insert(k.clone(), v.clone());
+        }
+    }
+
+    // Level 7: override-level labels.
+    if let Some(src) = override_labels {
+        for (k, v) in src {
+            merged.insert(k.clone(), v.clone());
+        }
+    }
+
+    if merged.is_empty() {
+        None
+    } else {
+        Some(merged)
+    }
+}
+
+/// Choose the generator for a pack-expanded metric.
+///
+/// Precedence: override generator > pack metric generator > `constant(0.0)`.
+/// Matches the fallback used by [`crate::packs::expand_pack`] so v1 and v2
+/// behave identically when a pack metric has no generator declared.
+fn select_pack_metric_generator(
+    metric: &crate::packs::MetricSpec,
+    metric_override: Option<&MetricOverride>,
+) -> GeneratorConfig {
+    if let Some(over) = metric_override {
+        if let Some(gen) = over.generator.clone() {
+            return gen;
+        }
+    }
+    metric
+        .generator
+        .clone()
+        .unwrap_or(GeneratorConfig::Constant { value: 0.0 })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler::normalize::normalize;
+    use crate::compiler::parse::parse;
+    use crate::compiler::AfterOp;
+    use crate::packs::MetricSpec;
+    use std::collections::HashMap;
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    fn telegraf_pack() -> MetricPackDef {
+        let mut shared = HashMap::new();
+        shared.insert("device".to_string(), String::new());
+        shared.insert("job".to_string(), "snmp".to_string());
+
+        MetricPackDef {
+            name: "telegraf_snmp_interface".to_string(),
+            description: "test".to_string(),
+            category: "network".to_string(),
+            shared_labels: Some(shared),
+            metrics: vec![
+                MetricSpec {
+                    name: "ifOperStatus".to_string(),
+                    labels: None,
+                    generator: Some(GeneratorConfig::Constant { value: 1.0 }),
+                },
+                MetricSpec {
+                    name: "ifHCInOctets".to_string(),
+                    labels: None,
+                    generator: Some(GeneratorConfig::Step {
+                        start: Some(0.0),
+                        step_size: 125_000.0,
+                        max: None,
+                    }),
+                },
+            ],
+        }
+    }
+
+    fn node_cpu_pack() -> MetricPackDef {
+        let mut shared = HashMap::new();
+        shared.insert("job".to_string(), "node_exporter".to_string());
+
+        let mut user_labels = HashMap::new();
+        user_labels.insert("mode".to_string(), "user".to_string());
+
+        let mut system_labels = HashMap::new();
+        system_labels.insert("mode".to_string(), "system".to_string());
+
+        MetricPackDef {
+            name: "node_exporter_cpu".to_string(),
+            description: "test".to_string(),
+            category: "infrastructure".to_string(),
+            shared_labels: Some(shared),
+            metrics: vec![
+                MetricSpec {
+                    name: "node_cpu_seconds_total".to_string(),
+                    labels: Some(user_labels),
+                    generator: Some(GeneratorConfig::Step {
+                        start: Some(0.0),
+                        step_size: 0.25,
+                        max: None,
+                    }),
+                },
+                MetricSpec {
+                    name: "node_cpu_seconds_total".to_string(),
+                    labels: Some(system_labels),
+                    generator: Some(GeneratorConfig::Step {
+                        start: Some(0.0),
+                        step_size: 0.10,
+                        max: None,
+                    }),
+                },
+            ],
+        }
+    }
+
+    fn expand_yaml(yaml: &str, resolver: &InMemoryPackResolver) -> ExpandedFile {
+        let parsed = parse(yaml).expect("parse must succeed");
+        let normalized = normalize(parsed).expect("normalize must succeed");
+        expand(normalized, resolver).expect("expand must succeed")
+    }
+
+    // -----------------------------------------------------------------------
+    // Resolver classification & in-memory impl
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_name_reference_returns_name() {
+        assert_eq!(
+            classify_pack_reference("telegraf_snmp_interface"),
+            PackResolveOrigin::Name
+        );
+    }
+
+    #[test]
+    fn classify_file_path_reference_returns_file_path() {
+        assert_eq!(
+            classify_pack_reference("./packs/custom.yaml"),
+            PackResolveOrigin::FilePath
+        );
+        assert_eq!(
+            classify_pack_reference("/abs/path/pack.yaml"),
+            PackResolveOrigin::FilePath
+        );
+        assert_eq!(
+            classify_pack_reference("rel/pack.yaml"),
+            PackResolveOrigin::FilePath
+        );
+    }
+
+    #[test]
+    fn in_memory_resolver_returns_registered_pack() {
+        let mut r = InMemoryPackResolver::new();
+        r.insert("telegraf_snmp_interface", telegraf_pack());
+        let def = r.resolve("telegraf_snmp_interface").expect("must resolve");
+        assert_eq!(def.name, "telegraf_snmp_interface");
+    }
+
+    #[test]
+    fn in_memory_resolver_errors_on_missing_reference() {
+        let r = InMemoryPackResolver::new();
+        let err = r.resolve("nope").expect_err("must error");
+        assert_eq!(err.origin, PackResolveOrigin::Name);
+        assert!(err.message.contains("nope"));
+    }
+
+    #[test]
+    fn in_memory_resolver_classifies_file_paths() {
+        let r = InMemoryPackResolver::new();
+        let err = r.resolve("./no-such.yaml").expect_err("must error");
+        assert_eq!(err.origin, PackResolveOrigin::FilePath);
+    }
+
+    // -----------------------------------------------------------------------
+    // Happy path: pack expansion produces one entry per metric
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn expand_produces_one_entry_per_pack_metric() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+scenarios:
+  - id: primary
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        assert_eq!(expanded.entries.len(), 2);
+        assert_eq!(expanded.entries[0].name, "ifOperStatus");
+        assert_eq!(expanded.entries[1].name, "ifHCInOctets");
+    }
+
+    #[test]
+    fn expanded_signal_type_is_metrics() {
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        for e in &expanded.entries {
+            assert_eq!(e.signal_type, "metrics");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Sub-signal IDs: user-provided and auto-generated
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn sub_signal_ids_use_entry_id_when_set() {
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - id: primary
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        assert_eq!(
+            expanded.entries[0].id.as_deref(),
+            Some("primary.ifOperStatus")
+        );
+        assert_eq!(
+            expanded.entries[1].id.as_deref(),
+            Some("primary.ifHCInOctets")
+        );
+    }
+
+    #[test]
+    fn anonymous_pack_entry_gets_auto_generated_id() {
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        // Auto-ID is `{pack_def_name}_{entry_index}` = `telegraf_snmp_interface_0`.
+        assert_eq!(
+            expanded.entries[0].id.as_deref(),
+            Some("telegraf_snmp_interface_0.ifOperStatus")
+        );
+        assert_eq!(
+            expanded.entries[1].id.as_deref(),
+            Some("telegraf_snmp_interface_0.ifHCInOctets")
+        );
+    }
+
+    #[test]
+    fn two_anonymous_pack_entries_disambiguate_by_index() {
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        let ids: Vec<_> = expanded
+            .entries
+            .iter()
+            .filter_map(|e| e.id.as_deref())
+            .collect();
+        assert!(ids.contains(&"telegraf_snmp_interface_0.ifOperStatus"));
+        assert!(ids.contains(&"telegraf_snmp_interface_1.ifOperStatus"));
+        // All IDs must be unique.
+        let mut sorted = ids.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), ids.len(), "ids must be unique");
+    }
+
+    // -----------------------------------------------------------------------
+    // Label precedence chain
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn label_precedence_chain_applied_in_order() {
+        // defaults -> shared -> metric -> entry -> override
+        // We test that each layer overrides its predecessor on 'region'.
+        let mut shared = HashMap::new();
+        shared.insert("region".to_string(), "shared-region".to_string());
+        shared.insert("job".to_string(), "snmp".to_string());
+
+        let mut metric_labels = HashMap::new();
+        metric_labels.insert("region".to_string(), "metric-region".to_string());
+
+        let pack = MetricPackDef {
+            name: "p".to_string(),
+            description: "t".to_string(),
+            category: "c".to_string(),
+            shared_labels: Some(shared),
+            metrics: vec![MetricSpec {
+                name: "m".to_string(),
+                labels: Some(metric_labels),
+                generator: Some(GeneratorConfig::Constant { value: 0.0 }),
+            }],
+        };
+
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("p", pack);
+
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  labels:
+    region: defaults-region
+    env: prod
+scenarios:
+  - id: e
+    signal_type: metrics
+    pack: p
+    labels:
+      region: entry-region
+      device: rtr-01
+    overrides:
+      m:
+        labels:
+          region: override-region
+"#;
+        let expanded = expand_yaml(yaml, &resolver);
+        let labels = expanded.entries[0].labels.as_ref().unwrap();
+
+        // Highest precedence wins.
+        assert_eq!(labels.get("region").unwrap(), "override-region");
+        // Lower layers contribute when no higher layer overrides.
+        assert_eq!(labels.get("env").unwrap(), "prod");
+        assert_eq!(labels.get("job").unwrap(), "snmp");
+        assert_eq!(labels.get("device").unwrap(), "rtr-01");
+    }
+
+    #[test]
+    fn defaults_labels_flow_into_pack_metric_labels() {
+        // Spec §2.2: defaults.labels at precedence level 2 must reach the
+        // final map for pack-expanded signals.
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  labels:
+    env: prod
+scenarios:
+  - id: p
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        let labels = expanded.entries[0].labels.as_ref().unwrap();
+        assert_eq!(labels.get("env").unwrap(), "prod");
+    }
+
+    #[test]
+    fn pack_shared_labels_override_defaults_labels() {
+        let mut shared = HashMap::new();
+        shared.insert("job".to_string(), "snmp".to_string());
+        let pack = MetricPackDef {
+            name: "p".to_string(),
+            description: "t".to_string(),
+            category: "c".to_string(),
+            shared_labels: Some(shared),
+            metrics: vec![MetricSpec {
+                name: "m".to_string(),
+                labels: None,
+                generator: Some(GeneratorConfig::Constant { value: 0.0 }),
+            }],
+        };
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("p", pack);
+
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  labels:
+    job: web
+scenarios:
+  - signal_type: metrics
+    pack: p
+"#;
+        let expanded = expand_yaml(yaml, &resolver);
+        let labels = expanded.entries[0].labels.as_ref().unwrap();
+        assert_eq!(labels.get("job").unwrap(), "snmp");
+    }
+
+    #[test]
+    fn inline_entry_labels_pass_through_unchanged() {
+        // Inline entries must NOT re-apply defaults_labels; PR 3 already
+        // merged them. Verify that exactly the merged set from normalize
+        // shows up here — not doubled, not missing a defaults key.
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  labels:
+    env: prod
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    generator: { type: constant, value: 1 }
+    labels:
+      instance: web-01
+"#;
+        let resolver = InMemoryPackResolver::new();
+        let expanded = expand_yaml(yaml, &resolver);
+        let labels = expanded.entries[0].labels.as_ref().unwrap();
+        assert_eq!(labels.get("env").unwrap(), "prod");
+        assert_eq!(labels.get("instance").unwrap(), "web-01");
+        assert_eq!(labels.len(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Generator precedence: override > spec > constant(0)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn override_generator_replaces_pack_generator() {
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - id: e
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+    overrides:
+      ifOperStatus:
+        generator:
+          type: flap
+          up_duration: 60s
+          down_duration: 30s
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        // ifOperStatus got the flap override
+        assert!(matches!(
+            expanded.entries[0].generator.as_ref().unwrap(),
+            GeneratorConfig::Flap { .. }
+        ));
+        // ifHCInOctets kept its pack default (step)
+        assert!(matches!(
+            expanded.entries[1].generator.as_ref().unwrap(),
+            GeneratorConfig::Step { .. }
+        ));
+    }
+
+    #[test]
+    fn missing_generator_falls_back_to_constant_zero() {
+        let pack = MetricPackDef {
+            name: "p".to_string(),
+            description: "t".to_string(),
+            category: "c".to_string(),
+            shared_labels: None,
+            metrics: vec![MetricSpec {
+                name: "x".to_string(),
+                labels: None,
+                generator: None,
+            }],
+        };
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("p", pack);
+
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - signal_type: metrics
+    pack: p
+"#;
+        let expanded = expand_yaml(yaml, &resolver);
+        match expanded.entries[0].generator.as_ref().unwrap() {
+            GeneratorConfig::Constant { value } => assert_eq!(*value, 0.0),
+            other => panic!("expected constant(0), got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // After-clause propagation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn entry_level_after_propagates_to_every_metric() {
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - id: tail
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+    after:
+      ref: head
+      op: ">"
+      value: 5
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        for e in &expanded.entries {
+            let after = e.after.as_ref().expect("after must be propagated");
+            assert_eq!(after.ref_id, "head");
+            assert!(matches!(after.op, AfterOp::GreaterThan));
+        }
+    }
+
+    #[test]
+    fn override_after_replaces_entry_after_for_that_metric() {
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - id: tail
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+    after:
+      ref: head
+      op: ">"
+      value: 5
+    overrides:
+      ifOperStatus:
+        after:
+          ref: other
+          op: "<"
+          value: 1
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        let oper = expanded
+            .entries
+            .iter()
+            .find(|e| e.name == "ifOperStatus")
+            .unwrap();
+        assert_eq!(oper.after.as_ref().unwrap().ref_id, "other");
+        let in_octets = expanded
+            .entries
+            .iter()
+            .find(|e| e.name == "ifHCInOctets")
+            .unwrap();
+        assert_eq!(in_octets.after.as_ref().unwrap().ref_id, "head");
+    }
+
+    // -----------------------------------------------------------------------
+    // Field propagation per spec §4.3 step 7
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn schedule_delivery_fields_propagate_to_every_metric() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  duration: 2m
+scenarios:
+  - id: p
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+    phase_offset: 5s
+    clock_group: uplink
+    jitter: 0.2
+    jitter_seed: 42
+    gaps:
+      every: 2m
+      for: 20s
+    bursts:
+      every: 5m
+      for: 30s
+      multiplier: 10
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        for e in &expanded.entries {
+            assert_eq!(e.rate, 1.0);
+            assert_eq!(e.duration.as_deref(), Some("2m"));
+            assert_eq!(e.phase_offset.as_deref(), Some("5s"));
+            assert_eq!(e.clock_group.as_deref(), Some("uplink"));
+            assert_eq!(e.jitter, Some(0.2));
+            assert_eq!(e.jitter_seed, Some(42));
+            assert!(e.gaps.is_some());
+            assert!(e.bursts.is_some());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // No pack references survive
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn expanded_entries_have_no_pack_field() {
+        // The ExpandedEntry type has no `pack` field by design. This test
+        // documents that contract via the public surface: once expansion
+        // runs, the output shape cannot carry unresolved pack references.
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        // Compile-time guarantee: no access to `pack` or `overrides` on
+        // ExpandedEntry is possible. At runtime we just make sure entries
+        // look like concrete signals.
+        assert!(expanded.entries.iter().all(|e| e.generator.is_some()));
+    }
+
+    // -----------------------------------------------------------------------
+    // Error cases
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn unknown_override_key_is_an_error() {
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+    overrides:
+      not_a_metric:
+        generator:
+          type: constant
+          value: 0
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let parsed = parse(yaml).expect("parse");
+        let normalized = normalize(parsed).expect("normalize");
+        let err = expand(normalized, &resolver).expect_err("must fail");
+        match err {
+            ExpandError::UnknownOverrideKey {
+                key,
+                pack_name,
+                available,
+            } => {
+                assert_eq!(key, "not_a_metric");
+                assert_eq!(pack_name, "telegraf_snmp_interface");
+                assert!(available.contains("ifOperStatus"));
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unresolvable_pack_is_an_error() {
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - signal_type: metrics
+    pack: nonexistent
+"#;
+        let resolver = InMemoryPackResolver::new();
+        let parsed = parse(yaml).expect("parse");
+        let normalized = normalize(parsed).expect("normalize");
+        let err = expand(normalized, &resolver).expect_err("must fail");
+        match err {
+            ExpandError::ResolveFailed { reference, message } => {
+                assert_eq!(reference, "nonexistent");
+                assert!(message.contains("nonexistent"));
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_pack_is_an_error() {
+        let pack = MetricPackDef {
+            name: "empty".to_string(),
+            description: "t".to_string(),
+            category: "c".to_string(),
+            shared_labels: None,
+            metrics: vec![],
+        };
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("empty", pack);
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - signal_type: metrics
+    pack: empty
+"#;
+        let parsed = parse(yaml).expect("parse");
+        let normalized = normalize(parsed).expect("normalize");
+        let err = expand(normalized, &resolver).expect_err("must fail");
+        assert!(matches!(err, ExpandError::EmptyPack { pack_name } if pack_name == "empty"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Inline entries pass through
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn inline_entries_pass_through_untouched() {
+        let yaml = r#"
+version: 2
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    rate: 2
+    duration: 60s
+    generator: { type: constant, value: 1 }
+    labels: { instance: web-01 }
+"#;
+        let resolver = InMemoryPackResolver::new();
+        let expanded = expand_yaml(yaml, &resolver);
+        assert_eq!(expanded.entries.len(), 1);
+        let e = &expanded.entries[0];
+        assert_eq!(e.id.as_deref(), Some("cpu"));
+        assert_eq!(e.name, "cpu_usage");
+        assert_eq!(e.rate, 2.0);
+        assert_eq!(e.duration.as_deref(), Some("60s"));
+        assert_eq!(
+            e.labels.as_ref().unwrap().get("instance").unwrap(),
+            "web-01"
+        );
+    }
+
+    #[test]
+    fn mixed_inline_and_pack_entries_interleave_correctly() {
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    generator: { type: constant, value: 1 }
+  - id: net
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("telegraf_snmp_interface", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        // 1 inline + 2 pack metrics = 3 total
+        assert_eq!(expanded.entries.len(), 3);
+        assert_eq!(expanded.entries[0].id.as_deref(), Some("cpu"));
+        assert_eq!(expanded.entries[1].id.as_deref(), Some("net.ifOperStatus"));
+        assert_eq!(expanded.entries[2].id.as_deref(), Some("net.ifHCInOctets"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Multiple metric instances with same name (node_exporter_cpu case)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repeated_metric_names_produce_one_entry_per_spec_instance() {
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    pack: node_exporter_cpu
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("node_exporter_cpu", node_cpu_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        assert_eq!(expanded.entries.len(), 2);
+        assert_eq!(expanded.entries[0].name, "node_cpu_seconds_total");
+        assert_eq!(expanded.entries[1].name, "node_cpu_seconds_total");
+        // Distinct label `mode` differentiates them.
+        assert_eq!(
+            expanded.entries[0]
+                .labels
+                .as_ref()
+                .unwrap()
+                .get("mode")
+                .unwrap(),
+            "user"
+        );
+        assert_eq!(
+            expanded.entries[1]
+                .labels
+                .as_ref()
+                .unwrap()
+                .get("mode")
+                .unwrap(),
+            "system"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Pack by file path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pack_by_file_path_is_resolved_through_trait() {
+        let yaml = r#"
+version: 2
+defaults: { rate: 1 }
+scenarios:
+  - signal_type: metrics
+    pack: ./packs/telegraf-snmp-interface.yaml
+"#;
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("./packs/telegraf-snmp-interface.yaml", telegraf_pack());
+        let expanded = expand_yaml(yaml, &resolver);
+        assert_eq!(expanded.entries.len(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Contract: Send + Sync on types crossing threads
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn expanded_file_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ExpandedFile>();
+        assert_send_sync::<ExpandedEntry>();
+        assert_send_sync::<ExpandError>();
+    }
+}

--- a/sonda-core/src/compiler/mod.rs
+++ b/sonda-core/src/compiler/mod.rs
@@ -13,12 +13,16 @@
 //!
 //! - [`parse`] — YAML deserialization, schema validation, and version detection.
 //! - [`normalize`] — `defaults:` resolution and entry-level normalization.
+//! - [`expand`] — pack expansion inside `scenarios:` (Phase 3).
 
 #[cfg(feature = "config")]
 pub mod parse;
 
 #[cfg(feature = "config")]
 pub mod normalize;
+
+#[cfg(feature = "config")]
+pub mod expand;
 
 use std::collections::BTreeMap;
 

--- a/sonda-core/src/packs/mod.rs
+++ b/sonda-core/src/packs/mod.rs
@@ -163,9 +163,11 @@ pub struct MetricOverride {
     /// Optional causal dependency (`after:`) attached specifically to this
     /// expanded metric.
     ///
-    /// Only used by the v2 compiler: when present, it replaces any
-    /// entry-level `after` on the parent pack entry for this particular
-    /// expanded signal. v1 pack expansion ignores this field.
+    /// Per spec §2.4, a per-metric `after:` on a pack override sets a
+    /// causal dependency for that specific expanded signal, overriding
+    /// any entry-level `after` on the parent pack entry. The v2 compiler
+    /// propagates this onto the resulting signal in Phase 3; v1 pack
+    /// expansion ignores the field.
     #[cfg_attr(feature = "config", serde(default))]
     pub after: Option<AfterClause>,
 }

--- a/sonda-core/src/packs/mod.rs
+++ b/sonda-core/src/packs/mod.rs
@@ -18,6 +18,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
+use crate::compiler::AfterClause;
 use crate::config::{BaseScheduleConfig, ScenarioConfig, ScenarioEntry};
 use crate::encoder::EncoderConfig;
 use crate::generator::GeneratorConfig;
@@ -138,10 +139,15 @@ pub struct PackScenarioConfig {
     pub overrides: Option<HashMap<String, MetricOverride>>,
 }
 
-/// Per-metric override within a [`PackScenarioConfig`].
+/// Per-metric override within a [`PackScenarioConfig`] or a v2 pack-backed
+/// scenario entry.
 ///
-/// Allows the user to customize the generator or add extra labels for a
-/// specific metric without modifying the pack definition.
+/// Allows the user to customize the generator, add extra labels, or attach a
+/// causal dependency (`after:`) for a specific metric without modifying the
+/// pack definition. The v1 expansion path ([`expand_pack`]) consumes only
+/// `generator` and `labels`; the v2 compiler additionally propagates `after`
+/// onto the expanded signal (see
+/// [`crate::compiler::expand`]).
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "config", derive(serde::Serialize, serde::Deserialize))]
 pub struct MetricOverride {
@@ -154,6 +160,14 @@ pub struct MetricOverride {
     /// the v2 AST label types.
     #[cfg_attr(feature = "config", serde(default))]
     pub labels: Option<BTreeMap<String, String>>,
+    /// Optional causal dependency (`after:`) attached specifically to this
+    /// expanded metric.
+    ///
+    /// Only used by the v2 compiler: when present, it replaces any
+    /// entry-level `after` on the parent pack entry for this particular
+    /// expanded signal. v1 pack expansion ignores this field.
+    #[cfg_attr(feature = "config", serde(default))]
+    pub after: Option<AfterClause>,
 }
 
 #[cfg(feature = "config")]
@@ -435,6 +449,7 @@ mod tests {
             MetricOverride {
                 generator: Some(GeneratorConfig::Constant { value: 42.0 }),
                 labels: None,
+                after: None,
             },
         );
 
@@ -619,6 +634,7 @@ mod tests {
             MetricOverride {
                 generator: None,
                 labels: None,
+                after: None,
             },
         );
 
@@ -667,6 +683,7 @@ mod tests {
             MetricOverride {
                 generator: None,
                 labels: Some(override_labels),
+                after: None,
             },
         );
 

--- a/sonda-core/tests/fixtures/v2-examples/expected/valid-defaults-pack-entry.json
+++ b/sonda-core/tests/fixtures/v2-examples/expected/valid-defaults-pack-entry.json
@@ -39,7 +39,8 @@
             "type": "constant",
             "value": 0.0
           },
-          "labels": null
+          "labels": null,
+          "after": null
         }
       },
       "distribution": null,

--- a/sonda-core/tests/fixtures/v2-examples/expected/valid-expand-anonymous-pack.json
+++ b/sonda-core/tests/fixtures/v2-examples/expected/valid-expand-anonymous-pack.json
@@ -1,0 +1,214 @@
+{
+  "version": 2,
+  "entries": [
+    {
+      "id": "telegraf_snmp_interface_0.ifOperStatus",
+      "signal_type": "metrics",
+      "name": "ifOperStatus",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "constant",
+        "value": 1.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-auto",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_0.ifHCInOctets",
+      "signal_type": "metrics",
+      "name": "ifHCInOctets",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "step",
+        "start": 0.0,
+        "step_size": 125000.0,
+        "max": null
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-auto",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_0.ifHCOutOctets",
+      "signal_type": "metrics",
+      "name": "ifHCOutOctets",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "step",
+        "start": 0.0,
+        "step_size": 62500.0,
+        "max": null
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-auto",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_0.ifInErrors",
+      "signal_type": "metrics",
+      "name": "ifInErrors",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "constant",
+        "value": 0.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-auto",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_0.ifOutErrors",
+      "signal_type": "metrics",
+      "name": "ifOutErrors",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "constant",
+        "value": 0.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-auto",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    }
+  ]
+}

--- a/sonda-core/tests/fixtures/v2-examples/expected/valid-expand-multiple-packs.json
+++ b/sonda-core/tests/fixtures/v2-examples/expected/valid-expand-multiple-packs.json
@@ -1,0 +1,423 @@
+{
+  "version": 2,
+  "entries": [
+    {
+      "id": "telegraf_snmp_interface_0.ifOperStatus",
+      "signal_type": "metrics",
+      "name": "ifOperStatus",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "constant",
+        "value": 1.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-01",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_0.ifHCInOctets",
+      "signal_type": "metrics",
+      "name": "ifHCInOctets",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "step",
+        "start": 0.0,
+        "step_size": 125000.0,
+        "max": null
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-01",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_0.ifHCOutOctets",
+      "signal_type": "metrics",
+      "name": "ifHCOutOctets",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "step",
+        "start": 0.0,
+        "step_size": 62500.0,
+        "max": null
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-01",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_0.ifInErrors",
+      "signal_type": "metrics",
+      "name": "ifInErrors",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "constant",
+        "value": 0.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-01",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_0.ifOutErrors",
+      "signal_type": "metrics",
+      "name": "ifOutErrors",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "constant",
+        "value": 0.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-01",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_1.ifOperStatus",
+      "signal_type": "metrics",
+      "name": "ifOperStatus",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "constant",
+        "value": 1.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-02",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_1.ifHCInOctets",
+      "signal_type": "metrics",
+      "name": "ifHCInOctets",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "step",
+        "start": 0.0,
+        "step_size": 125000.0,
+        "max": null
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-02",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_1.ifHCOutOctets",
+      "signal_type": "metrics",
+      "name": "ifHCOutOctets",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "step",
+        "start": 0.0,
+        "step_size": 62500.0,
+        "max": null
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-02",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_1.ifInErrors",
+      "signal_type": "metrics",
+      "name": "ifInErrors",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "constant",
+        "value": 0.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-02",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "telegraf_snmp_interface_1.ifOutErrors",
+      "signal_type": "metrics",
+      "name": "ifOutErrors",
+      "rate": 1.0,
+      "duration": null,
+      "generator": {
+        "type": "constant",
+        "value": 0.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-02",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    }
+  ]
+}

--- a/sonda-core/tests/fixtures/v2-examples/expected/valid-expand-pack-file-path.json
+++ b/sonda-core/tests/fixtures/v2-examples/expected/valid-expand-pack-file-path.json
@@ -1,0 +1,214 @@
+{
+  "version": 2,
+  "entries": [
+    {
+      "id": "uplink.ifOperStatus",
+      "signal_type": "metrics",
+      "name": "ifOperStatus",
+      "rate": 1.0,
+      "duration": "30s",
+      "generator": {
+        "type": "constant",
+        "value": 1.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-01",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "uplink.ifHCInOctets",
+      "signal_type": "metrics",
+      "name": "ifHCInOctets",
+      "rate": 1.0,
+      "duration": "30s",
+      "generator": {
+        "type": "step",
+        "start": 0.0,
+        "step_size": 125000.0,
+        "max": null
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-01",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "uplink.ifHCOutOctets",
+      "signal_type": "metrics",
+      "name": "ifHCOutOctets",
+      "rate": 1.0,
+      "duration": "30s",
+      "generator": {
+        "type": "step",
+        "start": 0.0,
+        "step_size": 62500.0,
+        "max": null
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-01",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "uplink.ifInErrors",
+      "signal_type": "metrics",
+      "name": "ifInErrors",
+      "rate": 1.0,
+      "duration": "30s",
+      "generator": {
+        "type": "constant",
+        "value": 0.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-01",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "uplink.ifOutErrors",
+      "signal_type": "metrics",
+      "name": "ifOutErrors",
+      "rate": 1.0,
+      "duration": "30s",
+      "generator": {
+        "type": "constant",
+        "value": 0.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-01",
+        "ifAlias": "",
+        "ifIndex": "",
+        "ifName": "",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    }
+  ]
+}

--- a/sonda-core/tests/fixtures/v2-examples/expected/valid-expand-pack-with-overrides.json
+++ b/sonda-core/tests/fixtures/v2-examples/expected/valid-expand-pack-with-overrides.json
@@ -1,0 +1,223 @@
+{
+  "version": 2,
+  "entries": [
+    {
+      "id": "primary_uplink.ifOperStatus",
+      "signal_type": "metrics",
+      "name": "ifOperStatus",
+      "rate": 1.0,
+      "duration": "2m",
+      "generator": {
+        "type": "flap",
+        "up_duration": "60s",
+        "down_duration": "30s",
+        "up_value": null,
+        "down_value": null
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-edge-01",
+        "env": "prod",
+        "ifAlias": "",
+        "ifIndex": "1",
+        "ifName": "Gi0/0/0",
+        "job": "snmp",
+        "probe": "synthetic"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "primary_uplink.ifHCInOctets",
+      "signal_type": "metrics",
+      "name": "ifHCInOctets",
+      "rate": 1.0,
+      "duration": "2m",
+      "generator": {
+        "type": "step",
+        "start": 0.0,
+        "step_size": 125000.0,
+        "max": null
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-edge-01",
+        "env": "prod",
+        "ifAlias": "",
+        "ifIndex": "1",
+        "ifName": "Gi0/0/0",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "primary_uplink.ifHCOutOctets",
+      "signal_type": "metrics",
+      "name": "ifHCOutOctets",
+      "rate": 1.0,
+      "duration": "2m",
+      "generator": {
+        "type": "step",
+        "start": 0.0,
+        "step_size": 62500.0,
+        "max": null
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-edge-01",
+        "env": "prod",
+        "ifAlias": "",
+        "ifIndex": "1",
+        "ifName": "Gi0/0/0",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "primary_uplink.ifInErrors",
+      "signal_type": "metrics",
+      "name": "ifInErrors",
+      "rate": 1.0,
+      "duration": "2m",
+      "generator": {
+        "type": "constant",
+        "value": 0.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-edge-01",
+        "env": "prod",
+        "ifAlias": "",
+        "ifIndex": "1",
+        "ifName": "Gi0/0/0",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    },
+    {
+      "id": "primary_uplink.ifOutErrors",
+      "signal_type": "metrics",
+      "name": "ifOutErrors",
+      "rate": 1.0,
+      "duration": "2m",
+      "generator": {
+        "type": "constant",
+        "value": 0.0
+      },
+      "log_generator": null,
+      "labels": {
+        "device": "rtr-edge-01",
+        "env": "prod",
+        "ifAlias": "",
+        "ifIndex": "1",
+        "ifName": "Gi0/0/0",
+        "job": "snmp"
+      },
+      "dynamic_labels": null,
+      "encoder": {
+        "type": "prometheus_text",
+        "precision": null
+      },
+      "sink": {
+        "type": "stdout"
+      },
+      "jitter": null,
+      "jitter_seed": null,
+      "gaps": null,
+      "bursts": null,
+      "cardinality_spikes": null,
+      "phase_offset": null,
+      "clock_group": null,
+      "after": null,
+      "distribution": null,
+      "buckets": null,
+      "quantiles": null,
+      "observations_per_tick": null,
+      "mean_shift_per_sec": null,
+      "seed": null
+    }
+  ]
+}

--- a/sonda-core/tests/fixtures/v2-examples/invalid-expand-unknown-override.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-expand-unknown-override.yaml
@@ -1,0 +1,15 @@
+# Overrides key does not match any metric in the pack definition. Phase 3
+# expansion rejects this with ExpandError::UnknownOverrideKey identifying
+# the offending key, the pack name, and the list of valid metric names.
+version: 2
+defaults:
+  rate: 1
+scenarios:
+  - id: primary
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+    overrides:
+      not_a_real_metric:
+        generator:
+          type: constant
+          value: 0

--- a/sonda-core/tests/fixtures/v2-examples/valid-expand-anonymous-pack.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-expand-anonymous-pack.yaml
@@ -1,0 +1,12 @@
+# Pack entry without an `id` field. Phase 3 expansion synthesizes a
+# deterministic id of the form `{pack_def_name}_{entry_index}` so the
+# expanded metrics remain addressable through sub-signal ids
+# (e.g. `telegraf_snmp_interface_0.ifOperStatus`).
+version: 2
+defaults:
+  rate: 1
+scenarios:
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+    labels:
+      device: rtr-auto

--- a/sonda-core/tests/fixtures/v2-examples/valid-expand-multiple-packs.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-expand-multiple-packs.yaml
@@ -1,0 +1,16 @@
+# Two pack entries in the same file, both referencing the same pack
+# definition. The auto-ID scheme disambiguates them by zero-based entry
+# index, producing `{pack_name}_0.{metric}` and `{pack_name}_1.{metric}`
+# sub-signal IDs. No entry-level `id` is set on either.
+version: 2
+defaults:
+  rate: 1
+scenarios:
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+    labels:
+      device: rtr-01
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+    labels:
+      device: rtr-02

--- a/sonda-core/tests/fixtures/v2-examples/valid-expand-pack-file-path.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-expand-pack-file-path.yaml
@@ -1,0 +1,13 @@
+# Pack reference as a file path (contains '/' per spec §2.4, so the
+# resolver interprets it as a filesystem path rather than a catalog name).
+# The tests use an InMemoryPackResolver keyed on this exact string.
+version: 2
+defaults:
+  rate: 1
+  duration: 30s
+scenarios:
+  - id: uplink
+    signal_type: metrics
+    pack: ./packs/telegraf-snmp-interface.yaml
+    labels:
+      device: rtr-01

--- a/sonda-core/tests/fixtures/v2-examples/valid-expand-pack-with-overrides.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-expand-pack-with-overrides.yaml
@@ -1,0 +1,26 @@
+# Pack entry inside scenarios: with generator and label overrides, plus
+# file-level defaults.labels that must flow into every expanded metric per
+# the §2.2 precedence chain. Used as the canonical pack-expansion snapshot
+# target (Phase 3 compilation).
+version: 2
+defaults:
+  rate: 1
+  duration: 2m
+  labels:
+    env: prod
+scenarios:
+  - id: primary_uplink
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+    labels:
+      device: rtr-edge-01
+      ifName: Gi0/0/0
+      ifIndex: "1"
+    overrides:
+      ifOperStatus:
+        generator:
+          type: flap
+          up_duration: 60s
+          down_duration: 30s
+        labels:
+          probe: synthetic

--- a/sonda-core/tests/fixtures/v2-parity/node-exporter-cpu.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/node-exporter-cpu.yaml
@@ -1,0 +1,12 @@
+# Parity fixture: v2 scenario using the node_exporter_cpu pack (8 per-mode
+# metrics). No overrides — tests the straight expansion path.
+version: 2
+defaults:
+  rate: 1
+  duration: 30s
+scenarios:
+  - id: host_cpu
+    signal_type: metrics
+    pack: node_exporter_cpu
+    labels:
+      instance: web-01:9100

--- a/sonda-core/tests/fixtures/v2-parity/node-exporter-memory.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/node-exporter-memory.yaml
@@ -1,0 +1,17 @@
+# Parity fixture: v2 scenario using the node_exporter_memory pack (5
+# memory gauge metrics). Has a per-metric label override to exercise the
+# label-merge parity path.
+version: 2
+defaults:
+  rate: 1
+  duration: 30s
+scenarios:
+  - id: host_memory
+    signal_type: metrics
+    pack: node_exporter_memory
+    labels:
+      instance: web-01:9100
+    overrides:
+      node_memory_MemFree_bytes:
+        labels:
+          owner: platform

--- a/sonda-core/tests/fixtures/v2-parity/telegraf-snmp-interface.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/telegraf-snmp-interface.yaml
@@ -1,0 +1,22 @@
+# Parity fixture: v2 scenario that uses the telegraf_snmp_interface pack.
+# Expanded through the v2 compiler it must produce the same concrete set
+# of signals as the v1 `expand_pack` path given equivalent user-provided
+# config.
+version: 2
+defaults:
+  rate: 1
+  duration: 60s
+scenarios:
+  - id: primary_uplink
+    signal_type: metrics
+    pack: telegraf_snmp_interface
+    labels:
+      device: rtr-edge-01
+      ifName: GigabitEthernet0/0/0
+      ifIndex: "1"
+    overrides:
+      ifOperStatus:
+        generator:
+          type: flap
+          up_duration: 60s
+          down_duration: 30s

--- a/sonda-core/tests/v2_expand_fixtures.rs
+++ b/sonda-core/tests/v2_expand_fixtures.rs
@@ -1,0 +1,235 @@
+#![cfg(feature = "config")]
+//! Integration tests for Phase 3 pack expansion on YAML fixtures.
+//!
+//! Mirrors the pattern established by `v2_fixture_examples.rs`: every
+//! fixture under `tests/fixtures/v2-examples/` starting with
+//! `valid-expand-` is parsed, normalized, and expanded, with the output
+//! compared against a golden JSON snapshot in
+//! `tests/fixtures/v2-examples/expected/`. Invalid fixtures assert the
+//! expected [`ExpandError`] variant.
+//!
+//! Set `UPDATE_SNAPSHOTS=1` to regenerate golden files after a schema
+//! change.
+
+use std::path::{Path, PathBuf};
+
+use sonda_core::compiler::expand::{expand, ExpandError, ExpandedFile, InMemoryPackResolver};
+use sonda_core::compiler::normalize::normalize;
+use sonda_core::compiler::parse::parse;
+use sonda_core::packs::MetricPackDef;
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Read a scenario fixture relative to the crate root.
+fn fixture(name: &str) -> String {
+    let path = format!(
+        "{}/tests/fixtures/v2-examples/{name}",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read fixture {path}: {e}"))
+}
+
+/// Load a pack YAML from the repo-root `packs/` directory.
+fn load_repo_pack(file_name: &str) -> MetricPackDef {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate has a parent dir")
+        .to_path_buf();
+    let path = root.join("packs").join(file_name);
+    let yaml = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read pack {}: {}", path.display(), e));
+    serde_yaml_ng::from_str::<MetricPackDef>(&yaml)
+        .unwrap_or_else(|e| panic!("cannot parse pack {}: {}", path.display(), e))
+}
+
+/// Build a resolver preloaded with the three built-in packs, keyed by both
+/// their canonical pack name (catalog lookup) and the typical file-path
+/// reference used in test fixtures (starts with `.`, contains `/`).
+fn builtin_pack_resolver() -> InMemoryPackResolver {
+    let mut r = InMemoryPackResolver::new();
+    for (file, pack_name) in [
+        ("telegraf-snmp-interface.yaml", "telegraf_snmp_interface"),
+        ("node-exporter-cpu.yaml", "node_exporter_cpu"),
+        ("node-exporter-memory.yaml", "node_exporter_memory"),
+    ] {
+        let pack = load_repo_pack(file);
+        r.insert(pack_name, pack.clone());
+        r.insert(format!("./packs/{file}"), pack);
+    }
+    r
+}
+
+/// Serialize an [`ExpandedFile`] as pretty JSON for golden comparison.
+fn snapshot_expanded(file: &ExpandedFile) -> String {
+    let mut s =
+        serde_json::to_string_pretty(file).expect("serializing an ExpandedFile must not fail");
+    s.push('\n');
+    s
+}
+
+fn assert_snapshot(actual: &str, golden_name: &str) {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/v2-examples/expected")
+        .join(golden_name);
+
+    if std::env::var("UPDATE_SNAPSHOTS").as_deref() == Ok("1") {
+        let dir = path
+            .parent()
+            .unwrap_or_else(|| panic!("golden path {} has no parent", path.display()));
+        std::fs::create_dir_all(dir)
+            .unwrap_or_else(|e| panic!("cannot create {}: {e}", dir.display()));
+        std::fs::write(&path, actual)
+            .unwrap_or_else(|e| panic!("cannot write golden {}: {e}", path.display()));
+        return;
+    }
+
+    let expected = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "cannot read golden {} (run with UPDATE_SNAPSHOTS=1 to create it): {}",
+            path.display(),
+            e
+        )
+    });
+    assert_eq!(
+        actual,
+        expected,
+        "snapshot mismatch for {}\nRun with UPDATE_SNAPSHOTS=1 to update.",
+        path.display()
+    );
+}
+
+fn compile(yaml: &str, resolver: &InMemoryPackResolver) -> ExpandedFile {
+    let parsed = parse(yaml).expect("fixture must parse");
+    let normalized = normalize(parsed).expect("fixture must normalize");
+    expand(normalized, resolver).expect("fixture must expand")
+}
+
+// =====================================================================
+// Valid fixtures — golden snapshots
+// =====================================================================
+
+#[test]
+fn valid_expand_pack_with_overrides() {
+    let yaml = fixture("valid-expand-pack-with-overrides.yaml");
+    let resolver = builtin_pack_resolver();
+    let expanded = compile(&yaml, &resolver);
+
+    // Spot-check the expansion before snapshot comparison.
+    assert_eq!(expanded.entries.len(), 5, "5 metrics in telegraf snmp pack");
+    assert_eq!(expanded.entries[0].name, "ifOperStatus");
+    assert_eq!(
+        expanded.entries[0].id.as_deref(),
+        Some("primary_uplink.ifOperStatus")
+    );
+
+    // Override labels and defaults.labels compose correctly.
+    let labels = expanded.entries[0].labels.as_ref().unwrap();
+    assert_eq!(labels.get("env").unwrap(), "prod");
+    assert_eq!(labels.get("device").unwrap(), "rtr-edge-01");
+    assert_eq!(labels.get("probe").unwrap(), "synthetic");
+
+    let snap = snapshot_expanded(&expanded);
+    assert_snapshot(&snap, "valid-expand-pack-with-overrides.json");
+}
+
+#[test]
+fn valid_expand_pack_file_path() {
+    let yaml = fixture("valid-expand-pack-file-path.yaml");
+    let resolver = builtin_pack_resolver();
+    let expanded = compile(&yaml, &resolver);
+
+    assert_eq!(expanded.entries.len(), 5);
+    assert_eq!(expanded.entries[0].name, "ifOperStatus");
+    assert_eq!(
+        expanded.entries[0].id.as_deref(),
+        Some("uplink.ifOperStatus")
+    );
+
+    let snap = snapshot_expanded(&expanded);
+    assert_snapshot(&snap, "valid-expand-pack-file-path.json");
+}
+
+#[test]
+fn valid_expand_multiple_packs() {
+    let yaml = fixture("valid-expand-multiple-packs.yaml");
+    let resolver = builtin_pack_resolver();
+    let expanded = compile(&yaml, &resolver);
+
+    // Two packs x 5 metrics each = 10 entries.
+    assert_eq!(expanded.entries.len(), 10);
+    // Auto-IDs discriminate the two anonymous pack entries by position.
+    assert_eq!(
+        expanded.entries[0].id.as_deref(),
+        Some("telegraf_snmp_interface_0.ifOperStatus")
+    );
+    assert_eq!(
+        expanded.entries[5].id.as_deref(),
+        Some("telegraf_snmp_interface_1.ifOperStatus")
+    );
+    // Each carries its own device label.
+    assert_eq!(
+        expanded.entries[0]
+            .labels
+            .as_ref()
+            .unwrap()
+            .get("device")
+            .unwrap(),
+        "rtr-01"
+    );
+    assert_eq!(
+        expanded.entries[5]
+            .labels
+            .as_ref()
+            .unwrap()
+            .get("device")
+            .unwrap(),
+        "rtr-02"
+    );
+
+    let snap = snapshot_expanded(&expanded);
+    assert_snapshot(&snap, "valid-expand-multiple-packs.json");
+}
+
+#[test]
+fn valid_expand_anonymous_pack() {
+    let yaml = fixture("valid-expand-anonymous-pack.yaml");
+    let resolver = builtin_pack_resolver();
+    let expanded = compile(&yaml, &resolver);
+
+    assert_eq!(expanded.entries.len(), 5);
+    assert_eq!(
+        expanded.entries[0].id.as_deref(),
+        Some("telegraf_snmp_interface_0.ifOperStatus")
+    );
+
+    let snap = snapshot_expanded(&expanded);
+    assert_snapshot(&snap, "valid-expand-anonymous-pack.json");
+}
+
+// =====================================================================
+// Invalid fixtures — error cases
+// =====================================================================
+
+#[test]
+fn invalid_expand_unknown_override_key_rejected() {
+    let yaml = fixture("invalid-expand-unknown-override.yaml");
+    let parsed = parse(&yaml).expect("parse");
+    let normalized = normalize(parsed).expect("normalize");
+    let resolver = builtin_pack_resolver();
+    let err = expand(normalized, &resolver).expect_err("expand must fail");
+    match err {
+        ExpandError::UnknownOverrideKey {
+            key,
+            pack_name,
+            available,
+        } => {
+            assert_eq!(key, "not_a_real_metric");
+            assert_eq!(pack_name, "telegraf_snmp_interface");
+            assert!(available.contains("ifOperStatus"));
+            assert!(available.contains("ifHCInOctets"));
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+}

--- a/sonda-core/tests/v2_pack_parity.rs
+++ b/sonda-core/tests/v2_pack_parity.rs
@@ -1,0 +1,297 @@
+#![cfg(feature = "config")]
+//! Pack expansion parity bridge (validation matrix rows 17.1–17.3).
+//!
+//! For each built-in pack the tests:
+//!
+//! 1. Parse, normalize, and expand a v2 YAML fixture that references the
+//!    pack inside `scenarios:`.
+//! 2. Build an equivalent `PackScenarioConfig` in code and run it through
+//!    the existing v1 [`sonda_core::packs::expand_pack`] function.
+//! 3. Assert that the two outputs describe the same concrete set of
+//!    signals — same metric names, same generators, same composed label
+//!    maps, same rate, duration, encoder, and sink.
+//!
+//! Runtime parity (identical stdout output) is PR 6 work; this file is
+//! compile-parity only.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+
+use sonda_core::compiler::expand::{expand, ExpandedEntry, ExpandedFile, InMemoryPackResolver};
+use sonda_core::compiler::normalize::normalize;
+use sonda_core::compiler::parse::parse;
+use sonda_core::config::ScenarioEntry;
+use sonda_core::encoder::EncoderConfig;
+use sonda_core::generator::GeneratorConfig;
+use sonda_core::packs::{expand_pack, MetricOverride, MetricPackDef, PackScenarioConfig};
+use sonda_core::sink::SinkConfig;
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate has parent")
+        .to_path_buf()
+}
+
+fn load_pack(file_name: &str) -> MetricPackDef {
+    let path = repo_root().join("packs").join(file_name);
+    let yaml = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {}", path.display(), e));
+    serde_yaml_ng::from_str::<MetricPackDef>(&yaml)
+        .unwrap_or_else(|e| panic!("cannot parse {}: {}", path.display(), e))
+}
+
+fn parity_fixture(name: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/v2-parity")
+        .join(name);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {}", path.display(), e))
+}
+
+/// Run the v2 pipeline (parse → normalize → expand) on a fixture YAML.
+fn v2_compile(yaml: &str, resolver: &InMemoryPackResolver) -> ExpandedFile {
+    let parsed = parse(yaml).expect("parse");
+    let normalized = normalize(parsed).expect("normalize");
+    expand(normalized, resolver).expect("expand")
+}
+
+/// Normalize a label source into a sorted BTreeMap for comparison.
+///
+/// The v1 path produces `HashMap<String, String>`, v2 produces
+/// `BTreeMap<String, String>`. The equality test converts both to
+/// `BTreeMap` so iteration order cannot cause false negatives.
+fn into_btree_labels(hm: Option<&HashMap<String, String>>) -> BTreeMap<String, String> {
+    hm.cloned().unwrap_or_default().into_iter().collect()
+}
+
+/// Extract a sorted (metric-name, labels, generator, rate, duration,
+/// encoder, sink) tuple from a v2 expanded entry.
+type ComparableSignal = (
+    String,
+    BTreeMap<String, String>,
+    GeneratorConfig,
+    f64,
+    Option<String>,
+    EncoderConfig,
+    SinkConfig,
+);
+
+fn v2_signal(entry: &ExpandedEntry) -> ComparableSignal {
+    (
+        entry.name.clone(),
+        entry.labels.clone().unwrap_or_default(),
+        entry
+            .generator
+            .clone()
+            .expect("pack-expanded entries always have a generator"),
+        entry.rate,
+        entry.duration.clone(),
+        entry.encoder.clone(),
+        entry.sink.clone(),
+    )
+}
+
+fn v1_signal(entry: &ScenarioEntry) -> ComparableSignal {
+    let ScenarioEntry::Metrics(c) = entry else {
+        panic!("expected Metrics entry");
+    };
+    (
+        c.base.name.clone(),
+        into_btree_labels(c.base.labels.as_ref()),
+        c.generator.clone(),
+        c.base.rate,
+        c.base.duration.clone(),
+        c.encoder.clone(),
+        c.base.sink.clone(),
+    )
+}
+
+/// Compare two concrete-signal sets built from the v1 and v2 expansion
+/// paths. The comparison is order-insensitive: it treats each list as a
+/// multiset of `ComparableSignal` tuples so test failures don't hinge on
+/// iteration order of pack metrics.
+///
+/// For `GeneratorConfig` and `EncoderConfig` (neither implements `Eq`),
+/// equality is checked via JSON round-trip serialization — both types
+/// are `Serialize` under the `config` feature.
+fn assert_same_signal_set(label: &str, v1: &[ScenarioEntry], v2: &[ExpandedEntry]) {
+    assert_eq!(
+        v1.len(),
+        v2.len(),
+        "{label}: v1 produced {} entries, v2 produced {}",
+        v1.len(),
+        v2.len()
+    );
+
+    // Multiset comparison: sort the JSON keys for each side and compare.
+    // BTreeSet would deduplicate, which would mask duplicates like the
+    // node_cpu_seconds_total pack where the same metric name appears
+    // multiple times differentiated by labels.
+    let v1_signals: Vec<ComparableSignal> = v1.iter().map(v1_signal).collect();
+    let v2_signals: Vec<ComparableSignal> = v2.iter().map(v2_signal).collect();
+    let mut v1_sorted: Vec<String> = v1_signals.iter().map(signal_key).collect();
+    let mut v2_sorted: Vec<String> = v2_signals.iter().map(signal_key).collect();
+    v1_sorted.sort();
+    v2_sorted.sort();
+    assert_eq!(
+        v1_sorted, v2_sorted,
+        "{label}: v1 and v2 signal sets differ\nv1: {v1_sorted:#?}\nv2: {v2_sorted:#?}"
+    );
+}
+
+/// Produce a deterministic comparison key for one signal.
+fn signal_key(s: &ComparableSignal) -> String {
+    // JSON-serialize the tuple with stable field ordering.
+    #[derive(serde::Serialize)]
+    struct Key<'a> {
+        name: &'a str,
+        labels: &'a BTreeMap<String, String>,
+        generator: &'a GeneratorConfig,
+        rate: f64,
+        duration: &'a Option<String>,
+        encoder: &'a EncoderConfig,
+        sink: &'a SinkConfig,
+    }
+    let key = Key {
+        name: &s.0,
+        labels: &s.1,
+        generator: &s.2,
+        rate: s.3,
+        duration: &s.4,
+        encoder: &s.5,
+        sink: &s.6,
+    };
+    serde_json::to_string(&key).expect("serialization must succeed")
+}
+
+fn resolver_with(name: &str, pack: MetricPackDef) -> InMemoryPackResolver {
+    let mut r = InMemoryPackResolver::new();
+    r.insert(name, pack);
+    r
+}
+
+// =============================================================================
+// 17.1 — telegraf_snmp_interface parity
+// =============================================================================
+
+#[test]
+fn parity_telegraf_snmp_interface() {
+    let pack = load_pack("telegraf-snmp-interface.yaml");
+    let resolver = resolver_with("telegraf_snmp_interface", pack.clone());
+    let yaml = parity_fixture("telegraf-snmp-interface.yaml");
+
+    // v2 pipeline.
+    let v2_expanded = v2_compile(&yaml, &resolver);
+
+    // Equivalent v1 config.
+    let mut user_labels = HashMap::new();
+    user_labels.insert("device".to_string(), "rtr-edge-01".to_string());
+    user_labels.insert("ifName".to_string(), "GigabitEthernet0/0/0".to_string());
+    user_labels.insert("ifIndex".to_string(), "1".to_string());
+
+    let mut overrides = HashMap::new();
+    overrides.insert(
+        "ifOperStatus".to_string(),
+        MetricOverride {
+            generator: Some(GeneratorConfig::Flap {
+                up_duration: Some("60s".to_string()),
+                down_duration: Some("30s".to_string()),
+                up_value: None,
+                down_value: None,
+            }),
+            labels: None,
+            after: None,
+        },
+    );
+
+    let v1_config = PackScenarioConfig {
+        pack: "telegraf_snmp_interface".to_string(),
+        rate: 1.0,
+        duration: Some("60s".to_string()),
+        labels: Some(user_labels),
+        sink: SinkConfig::Stdout,
+        encoder: EncoderConfig::PrometheusText { precision: None },
+        overrides: Some(overrides),
+    };
+
+    let v1_entries = expand_pack(&pack, &v1_config).expect("v1 expansion must succeed");
+
+    assert_same_signal_set("telegraf_snmp_interface", &v1_entries, &v2_expanded.entries);
+}
+
+// =============================================================================
+// 17.2 — node_exporter_cpu parity
+// =============================================================================
+
+#[test]
+fn parity_node_exporter_cpu() {
+    let pack = load_pack("node-exporter-cpu.yaml");
+    let resolver = resolver_with("node_exporter_cpu", pack.clone());
+    let yaml = parity_fixture("node-exporter-cpu.yaml");
+
+    let v2_expanded = v2_compile(&yaml, &resolver);
+
+    let mut user_labels = HashMap::new();
+    user_labels.insert("instance".to_string(), "web-01:9100".to_string());
+
+    let v1_config = PackScenarioConfig {
+        pack: "node_exporter_cpu".to_string(),
+        rate: 1.0,
+        duration: Some("30s".to_string()),
+        labels: Some(user_labels),
+        sink: SinkConfig::Stdout,
+        encoder: EncoderConfig::PrometheusText { precision: None },
+        overrides: None,
+    };
+
+    let v1_entries = expand_pack(&pack, &v1_config).expect("v1 expansion must succeed");
+
+    assert_same_signal_set("node_exporter_cpu", &v1_entries, &v2_expanded.entries);
+}
+
+// =============================================================================
+// 17.3 — node_exporter_memory parity
+// =============================================================================
+
+#[test]
+fn parity_node_exporter_memory() {
+    let pack = load_pack("node-exporter-memory.yaml");
+    let resolver = resolver_with("node_exporter_memory", pack.clone());
+    let yaml = parity_fixture("node-exporter-memory.yaml");
+
+    let v2_expanded = v2_compile(&yaml, &resolver);
+
+    let mut user_labels = HashMap::new();
+    user_labels.insert("instance".to_string(), "web-01:9100".to_string());
+
+    let mut override_labels = BTreeMap::new();
+    override_labels.insert("owner".to_string(), "platform".to_string());
+    let mut overrides = HashMap::new();
+    overrides.insert(
+        "node_memory_MemFree_bytes".to_string(),
+        MetricOverride {
+            generator: None,
+            labels: Some(override_labels),
+            after: None,
+        },
+    );
+
+    let v1_config = PackScenarioConfig {
+        pack: "node_exporter_memory".to_string(),
+        rate: 1.0,
+        duration: Some("30s".to_string()),
+        labels: Some(user_labels),
+        sink: SinkConfig::Stdout,
+        encoder: EncoderConfig::PrometheusText { precision: None },
+        overrides: Some(overrides),
+    };
+
+    let v1_entries = expand_pack(&pack, &v1_config).expect("v1 expansion must succeed");
+
+    assert_same_signal_set("node_exporter_memory", &v1_entries, &v2_expanded.entries);
+}

--- a/sonda-core/tests/v2_pack_parity.rs
+++ b/sonda-core/tests/v2_pack_parity.rs
@@ -119,6 +119,19 @@ fn v1_signal(entry: &ScenarioEntry) -> ComparableSignal {
 /// For `GeneratorConfig` and `EncoderConfig` (neither implements `Eq`),
 /// equality is checked via JSON round-trip serialization — both types
 /// are `Serialize` under the `config` feature.
+///
+/// # Why ids are not in the comparison
+///
+/// [`ComparableSignal`] deliberately omits `id`: v1's [`ScenarioEntry`]
+/// does not carry a stable per-entry id (the v1 catalog uses the pack
+/// scenario name as the single launchable unit), while v2 synthesizes
+/// sub-signal ids of the form `"{effective_entry_id}.{metric_name}"` with
+/// an optional `"#{spec_index}"` suffix for packs that ship duplicate
+/// metric names. Comparing ids across the two paths would fail by
+/// definition.
+///
+/// Id uniqueness on the v2 side is a distinct invariant and is asserted
+/// separately via [`assert_v2_ids_are_unique`] in each parity test.
 fn assert_same_signal_set(label: &str, v1: &[ScenarioEntry], v2: &[ExpandedEntry]) {
     assert_eq!(
         v1.len(),
@@ -141,6 +154,32 @@ fn assert_same_signal_set(label: &str, v1: &[ScenarioEntry], v2: &[ExpandedEntry
     assert_eq!(
         v1_sorted, v2_sorted,
         "{label}: v1 and v2 signal sets differ\nv1: {v1_sorted:#?}\nv2: {v2_sorted:#?}"
+    );
+}
+
+/// Assert that every [`ExpandedEntry`] produced by the v2 pipeline carries
+/// a distinct, non-empty `id`.
+///
+/// Complements [`assert_same_signal_set`]: parity covers signal *shape*,
+/// this covers signal *identity*. Regression anchor for the
+/// `node_exporter_cpu` pack, which ships eight `MetricSpec` entries all
+/// named `node_cpu_seconds_total` — each must expand into a unique
+/// sub-signal id.
+fn assert_v2_ids_are_unique(label: &str, v2: &[ExpandedEntry]) {
+    let ids: Vec<&str> = v2
+        .iter()
+        .map(|e| {
+            e.id.as_deref()
+                .unwrap_or_else(|| panic!("{label}: pack-expanded entry missing id: {e:?}"))
+        })
+        .collect();
+    let mut unique = ids.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(
+        unique.len(),
+        ids.len(),
+        "{label}: sub-signal ids must be unique; saw {ids:?}"
     );
 }
 
@@ -222,6 +261,7 @@ fn parity_telegraf_snmp_interface() {
     let v1_entries = expand_pack(&pack, &v1_config).expect("v1 expansion must succeed");
 
     assert_same_signal_set("telegraf_snmp_interface", &v1_entries, &v2_expanded.entries);
+    assert_v2_ids_are_unique("telegraf_snmp_interface", &v2_expanded.entries);
 }
 
 // =============================================================================
@@ -252,6 +292,7 @@ fn parity_node_exporter_cpu() {
     let v1_entries = expand_pack(&pack, &v1_config).expect("v1 expansion must succeed");
 
     assert_same_signal_set("node_exporter_cpu", &v1_entries, &v2_expanded.entries);
+    assert_v2_ids_are_unique("node_exporter_cpu", &v2_expanded.entries);
 }
 
 // =============================================================================
@@ -294,4 +335,5 @@ fn parity_node_exporter_memory() {
     let v1_entries = expand_pack(&pack, &v1_config).expect("v1 expansion must succeed");
 
     assert_same_signal_set("node_exporter_memory", &v1_entries, &v2_expanded.entries);
+    assert_v2_ids_are_unique("node_exporter_memory", &v2_expanded.entries);
 }


### PR DESCRIPTION
## Summary

Implements **Phase 3 of the v2 compiler**: takes a `NormalizedFile` (PR 3 output) and expands every pack-backed entry into concrete per-metric signals. After this pass, no pack references survive — the representation is a flat list of concrete signals, ready for PR 5's `after` compiler.

- New module `sonda-core/src/compiler/expand.rs` with `ExpandedFile` / `ExpandedEntry` types, `PackResolver` trait, `InMemoryPackResolver`, and `ExpandError`
- Full 5-level label precedence chain per spec §2.2 (levels 2 `defaults.labels` → 4 pack `shared_labels` → 5 per-metric labels → 6 entry labels → 7 override labels)
- Auto-ID scheme for anonymous pack entries and disambiguation for packs with duplicate metric names (handles `node_exporter_cpu`'s 8-mode pattern)

## What landed

### New types and module
- `ExpandedFile` / `ExpandedEntry` — post-expansion representation with no `pack`/`overrides` fields (compile-time guarantee no pack refs survive)
- `PackResolver` trait — abstraction over pack YAML lookup; CLI will adapt `PackCatalog` in PR 7
- `classify_pack_reference()` + `PackResolveOrigin` — spec §2.4 rule (contains \`/\` or starts with \`.\` → file path)
- `ExpandError` with four variants: `ResolveFailed`, `UnknownOverrideKey`, `EmptyPack`, `DuplicateEntryId`

### Design decisions (approved before implementation)
1. **New expanded type** (not mutating `NormalizedEntry`) — makes post-expansion state unrepresentable as \"still has unresolved pack refs\"
2. **`PackResolver` trait in `sonda-core::compiler`** — keeps filesystem discovery in the CLI crate
3. **Auto-ID scheme**: \`{pack_name}_{entry_index}\` for anonymous entries; sub-signals are \`{effective_entry_id}.{metric_name}\`, disambiguated to \`{effective_entry_id}.{metric_name}#{spec_index}\` when a pack has multiple metric specs sharing a name
4. **\`after\` propagation**: override-level \`after\` replaces entry-level for that metric; otherwise entry-level \`after\` copies to every expanded signal

### Minimal cross-cutting change
- \`sonda_core::packs::MetricOverride\` gained an \`after: Option<AfterClause>\` field (spec §2.4 requires it). Additive, \`#[serde(default)]\`, v1 \`expand_pack\` ignores it.

## Validation matrix rows now Pass

- **9.1–9.8, 9.12** — pack features (name lookup, file-path, overrides, unknown-key error, label merge order, custom defs)
- **11.6** — pack inside \`scenarios:\` list
- **11.8** — auto-generated pack IDs (including duplicate-name disambiguation)
- **11.12, 11.13** — \`after\` carry-through on override and entry propagation (resolution lands in PR 5)
- **17.1, 17.2, 17.3** — compile parity for all three built-in packs (\`telegraf-snmp-interface\`, \`node-exporter-cpu\`, \`node-exporter-memory\`). Runtime parity stays PR 6.

Count: **27 of 162** rows now Pass (up from 11 at PR 3 merge).

## Test plan

- [x] 28 new unit tests in `expand.rs` — label precedence per slot, auto-ID, override propagation, duplicate-metric-name disambiguation, both ID-collision orderings, error diagnostic content
- [x] 5 fixture integration tests (`v2_expand_fixtures.rs`) with 4 golden JSON snapshots — pack with overrides, file-path pack, multiple packs, anonymous pack, unknown override key
- [x] 3 parity bridge tests (`v2_pack_parity.rs`) — compile parity against v1 \`expand_pack\` for all three built-in packs, plus ID uniqueness assertion
- [x] \`cargo build --workspace\` green
- [x] \`cargo test --workspace\` green (2,626 tests, +41 from PR 3 merge)
- [x] \`cargo clippy --workspace --all-features -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test -p sonda-core --no-default-features\` green (feature gating correct)

## Scope discipline

- Compile-time only — no runtime hot-path changes
- \`src/schedule/\`, \`src/generator/\`, \`src/encoder/\`, \`src/sink/\` untouched
- \`sonda\` CLI crate untouched (CLI adapter comes in PR 7)
- \`NormalizedFile\` / \`NormalizedEntry\` (PR 3 output contract) unchanged
- No \`v2\` prefix/suffix on any symbol in \`sonda-core::compiler\`

## Review gate

- \`@reviewer\` — APPROVED FOR MERGE (two BLOCKERs caught in first pass: sub-signal ID collision on \`node_exporter_cpu\` duplicate-name case, and auto-ID vs user-ID uniqueness check. Both fixed in \`bd0c04d\`.)
- \`@doc\` — APPROVED (5 CRs in first pass: stale prep-note references, matrix count mismatch, missing spec anchor, missing worked example, PR-number refs in durable source. All resolved in \`bd0c04d\`.)
- \`@uat\` — PASS (all quality gates green, determinism confirmed across two runs, behavioral hand-walk of label precedence, auto-ID, error UX verified)

## Handoff to PR 5

\`docs/refactor/v2-progress.md\` carries the PR 5 Preparation Notes covering:
- How to build the reference index from \`ExpandedEntry.id\` (including disambiguation scheme)
- Generator types that support \`after\` crossing-time math
- Clock-group auto-assignment strategy
- Cycle detection approach
- Override-to-duplicate-metric-name diagnostic expectation

## Commits

- \`1d07041\` feat(core): pack expansion implementation
- \`bd0c04d\` fix(core): disambiguate pack sub-signal IDs and guard against ID collisions