### PR TITLE
feat(core): runtime wiring + parity tests (v2 PR 6)

### DIFF
--- a/docs/refactor/v2-progress.md
+++ b/docs/refactor/v2-progress.md
@@ -1,10 +1,10 @@
 # Sonda v2 Refactor — Progress
 
 ## Current Status
-- **Phase:** 4 complete (PR 5 merged as #203); test-infra consolidation in review
+- **Phase:** 5 complete (PR 6 — runtime wiring + parity tests)
 - **Branch:** `refactor/unified-scenarios-v2`
 - **Integration PR:** #197 (targets `main`, accumulates all v2 work)
-- **Next PR:** PR 6 — runtime wiring + parity tests
+- **Next PR:** PR 7 — CLI unification (`sonda run` v2 dispatch, `sonda catalog`, `sonda init` v2 output, deprecation/hiding of split commands)
 
 ## Milestone Checklist
 
@@ -15,7 +15,7 @@
 | 2 | Defaults resolution | Done | PR 3 (#199) | 2026-04-12 |
 | 3 | Pack expansion in scenarios | Done | PR 4 | 2026-04-12 |
 | 4 | `after` compiler + dependency graph | Done | PR 5 | 2026-04-12 |
-| 5 | Runtime wiring + parity tests | Not Started | PR 6 | |
+| 5 | Runtime wiring + parity tests | Done | PR 6 | 2026-04-13 |
 | 6 | CLI unification | Not Started | PR 7 | |
 | 7 | Built-ins migration + docs | Not Started | PR 8 | |
 | 8 | Server API + final cleanup | Not Started | PR 9 | |
@@ -29,7 +29,8 @@
 | 3 | Defaults resolution + `parse_v2 → parse` rename | `feat/defaults-resolution` | integration (#199) | Merged | 2026-04-12 |
 | 4 | Pack expansion inside `scenarios:` | `feat/pack-expansion` | integration | Merged | 2026-04-12 |
 | 5 | `after` compiler + dependency graph + timing port | `feat/after-compilation` | integration (#203) | Merged | 2026-04-12 |
-| — | Test-infra consolidation: insta + rstest + fixture dedup | `chore/test-infra-consolidation` | integration | In Review | 2026-04-12 |
+| — | Test-infra consolidation: insta + rstest + fixture dedup | `chore/test-infra-consolidation` | integration (#204) | Merged | 2026-04-12 |
+| 6 | Runtime wiring + parity tests | `feat/runtime-wiring` | integration | In Review | 2026-04-13 |
 
 ## Test Coverage
 
@@ -49,7 +50,14 @@
 | Normalize snapshot fixtures (insta) | 3 | Resolved defaults snapshots (label merge, logs default encoder, pack entry) |
 | Expand snapshot fixtures (insta) | 3 | Phase 3 snapshots (overrides, multi-pack, anonymous pack; pack-file-path deleted — dual-registered in resolver) |
 | Compile_after snapshot fixtures (insta) | 6 | CompiledFile snapshots covering transitive chain, step/sequence targets, cross-signal-type, phase_offset + delay sum, dotted pack ref (simple-chain deleted — subset of transitive) |
-| Workspace total | 2,705 | All existing + new |
+| Compiler prepare unit tests | 28 | Translator per-variant happy paths, every `PrepareError` variant, label BTreeMap→HashMap conversion, `observations_per_tick` u32→u64 widening, `clock_group`/`phase_offset` pass-through, non-v2 version rejection, rstest variant-matched missing-field coverage |
+| Compile one-shot unit tests | 6 | `compile_scenario_file` end-to-end composition; `CompileError` `From` variants fire per phase |
+| Runtime parity integration tests (rstest, rows 16.1–16.11) | 11 | Byte-equal for single-signal, line-multiset for multi-signal (`interface-flap`, `network-link-failure`); seeds pinned symmetrically on v1 and v2 sides |
+| Link-failover runtime parity (row 16.12) | 1 | Staggered test-window `phase_offset` override on both sides; compile-side offsets already covered by the compile-parity sibling test |
+| Pack runtime parity (rows 17.1–17.3) | 3 | All three built-in packs compared byte-for-byte via the same runtime path |
+| Translator-semantic direct tests | 10 | Rows 1.6, 2.9–2.10, 4.1–4.8 (Exponential/Normal/Uniform distributions + histogram custom buckets), 5.2, 5.7, 6.12, 7.1–7.3 |
+| Runtime parity fixtures (v2-parity, with headers) | 21 | 11 v1-built-in mirrors + 10 hand-written translator probes; every fixture has a leading comment identifying matrix rows and any deliberate divergence |
+| Workspace total | 2,785 | All existing + new (+80 from PR 6; +57 tests across the 8 post-implementer-commit gate pass, plus +23 from the fix pass covering version gate, distribution rstest, rows 4.1–4.8, and regression anchors) |
 
 ## Validation Matrix Status
 
@@ -57,15 +65,15 @@ See [v2-validation-status.md](v2-validation-status.md) for the full 178-row chec
 
 **Every row is a mandatory merge blocker. No exceptions.**
 
-**Summary:** 48 of 178 rows addressed so far.
+**Summary:** 110 of 178 rows Pass (62 flipped by PR 6).
 
-| Section | Rows | Addressed | Notes |
-|---------|------|-----------|-------|
-| 1-10. Feature parity | 98 | 26 | 5.8 (PR 3), 8.2 (PR 5 compile-time, runtime observability PR 6), 9.1–9.8, 9.12 (PR 4), 10.1–10.15 (PR 3 + PR 5) — rest need runtime wiring |
-| 11. New v2 features | 18 | 18 | All 11.1–11.18 addressed; 11.7/11.9/11.11/11.12/11.13/11.14/11.15/11.16/11.17/11.18 land in PR 5 with `compile_after` |
+| Section | Rows | Pass | Notes |
+|---------|------|------|-------|
+| 1-10. Feature parity | 98 | 77 | PR 3: 5.8, 10.12–10.15; PR 4: 9.1–9.8, 9.12; PR 5: 10.1–10.11; PR 6: 1.1–1.6, 2.1–2.10, 3.1–3.7, 4.1–4.8, 5.1/5.2/5.3/5.7, 6.1/6.12, 7.1–7.11, 8.1/8.2/8.3/8.4. Deferred: 5.4–5.6 (syslog/remote_write/otlp encoders, PR 8 smoke), 6.2–6.10 (non-stdout sinks, PR 8 smoke), 8.5/8.6 (CLI UX, PR 7), 9.9/9.10/9.11 (CLI, PR 7), 9.13/9.14/9.15 (built-in migration, PR 8). |
+| 11. New v2 features | 18 | 18 | Complete. |
 | 12-15. CLI/Server/UX/Deploy | 47 | 0 | Later PRs (7-9) |
-| **16. Scenario parity bridge** | **12** | **1** | **16.12 compile parity Pass (PR 5); runtime parity for all rows lands in PR 6** |
-| **17. Pack parity bridge** | **3** | **3** | **compile parity passes for all three built-in packs; runtime parity is PR 6** |
+| **16. Scenario parity bridge** | **12** | **12** | **All 12 rows Pass both compile and runtime (PR 5 + PR 6).** |
+| **17. Pack parity bridge** | **3** | **3** | **All three built-in packs Pass both compile and runtime (PR 4 + PR 6).** |
 
 ## Completed Work
 
@@ -142,67 +150,80 @@ See [v2-validation-status.md](v2-validation-status.md) for the full 178-row chec
 - Reviewer NOTE (pack-label precedence collision) resolved inline via Option 2 — documented in `normalize.rs` module docs (see "Labels merge")
 - Reviewer NITs addressed: stale `V2 AST types` comment renamed; no-op `serde(deny_unknown_fields)` dropped from `NormalizedFile`/`NormalizedEntry`; snapshot-harness `expect()` calls converted to `unwrap_or_else(panic!)` with OS error detail
 
-## PR 6 Preparation Notes
+### PR 6 — Runtime wiring + parity tests (2026-04-13, in review)
 
-These notes capture decisions and handoff context from PR 5 that PR 6 (runtime wiring + parity tests) must not re-litigate. A future session starting cold on PR 6 should read this section first.
+- **`sonda-core/src/compiler/prepare.rs`** — new Phase 6 translator (`CompiledFile → Vec<ScenarioEntry>`). `prepare()` consumes a `CompiledFile`, fast-fails on non-v2 version via `PrepareError::UnsupportedVersion`, then dispatches on `signal_type` to variant-specific helpers. Field-for-field mapping: `labels: BTreeMap→HashMap` lossless (keys are String, no duplicates), `observations_per_tick: u32→u64` via `u64::from` (no `as` cast), `phase_offset` / `clock_group` pass through verbatim, `CompiledEntry::id` intentionally dropped (its job ended in `compile_after`'s dependency resolution — `ScenarioEntry` has no id slot). `PrepareError` variants: `UnknownSignalType`, `MissingGenerator` (metrics-only), `MissingLogGenerator` (logs-only), `MissingDistribution` (histogram/summary), `UnsupportedVersion`.
+- **`sonda-core/src/compile.rs`** — new one-shot `compile_scenario_file(yaml, &dyn PackResolver) -> Result<Vec<ScenarioEntry>, CompileError>` composing `parse → normalize → expand → compile_after → prepare`. Unified `CompileError` with `#[from]` on each phase's error. Each variant doc is phase-anchored (`**Phase N** (name): ...`). Uses a private `DynPackResolver<'a>` newtype to bridge `&dyn PackResolver` (requested public API) against `expand<R: PackResolver>`'s generic bound — keeps `expand.rs` frozen. Re-exports on `sonda_core::*`: `compile_scenario_file`, `CompileError`, `PrepareError`.
+- **`sonda-core/tests/common/mod.rs`** — extended with `run_and_capture_stdout(entries: Vec<ScenarioEntry>) -> Vec<u8>`: mirrors a trimmed `launch_scenario` in test-only code, spawning runners with in-memory capturing sinks instead of stdout. **Does not honor shutdown during `start_delay`** (unlike production `launch_scenario` which polls every 50ms) — fine for current call sites, caveat documented for future cancellation wiring. Sibling helpers: `assert_line_multisets_equal` for multi-signal thread-interleaved output, `normalize_timestamps` that strips Prometheus `<value> <11–19 digits>\n` ms-epoch trailers and JSON `"timestamp":"...Z"` fields (regression-anchored by two tests in the same module). No public `SinkConfig::Channel` variant was added — test surface stays out of the production enum.
+- **Runtime parity suite (`sonda-core/tests/v2_runtime_parity.rs`)** — one `#[rstest]` with 11 `#[case::<scenario_name>(...)]` rows closing matrix rows 16.1–16.11. `Comparison::ByteEqual` for single-signal scenarios; `Comparison::LineMultiset` for `interface-flap` and `network-link-failure` (multi-signal → thread-interleaved writes). Seeds pinned symmetrically on v1 and v2 sides. Test durations are short (500ms–1s) to keep the suite fast.
+- **Link-failover runtime parity (`sonda-core/tests/v2_story_parity.rs::link_failover_runtime_parity`)** — closes row 16.12 runtime half. Staggered `[1ms, 10ms, 20ms]` `phase_offset` override applied symmetrically on both sides so the test completes in ~1s (actual compiled offsets are 1m / ~152s, which is covered by the sibling `link_failover_compile_parity` test). The v1 oracle is a hand-built `v1_link_failover_entries` helper — `sonda-core` tests cannot dev-dep the `sonda` binary crate that owns `compile_story`, so the helper is explicitly framed as a **hand-built v2-equivalent reference** in its docstring, not a mirror. Drift risk is low because the compile-parity sibling test pins the v2 compile offsets and the `sonda story` CLI smoke path still exercises the v1 code until PR 9 removes it.
+- **Pack runtime parity (`sonda-core/tests/v2_pack_runtime_parity.rs`)** — 3 tests closing rows 17.1–17.3. v1 side: `expand_pack` → hand-built `PackScenarioConfig`; v2 side: new one-shot. Byte-equal per-sub-signal after timestamp normalization.
+- **Translator semantic tests (`sonda-core/tests/v2_translator_semantics.rs`)** — 10 direct tests covering matrix rows not naturally exercised by the built-in parity suite: 1.6 (mixed signal types), 2.9–2.10 (csv_replay auto-discovery + per-column labels), 4.1–4.8 (summary distribution variants — `#[rstest]` with Exponential/Normal/Uniform cases + histogram custom-buckets), 5.2 (`influx_lp` with custom `field_key`), 5.7 (encoder `precision`), 6.12 (TCP retry config), 7.1–7.3 (gaps / bursts / gap-overrides-burst). All assertions are translator-shape checks against hand-built reference `ScenarioEntry`s — no scheduler runs needed.
+- **21 runtime-parity fixtures** under `sonda-core/tests/fixtures/v2-parity/`: 11 mirrors of `scenarios/*.yaml` built-ins plus 10 hand-written translator probes. Every fixture has a leading comment header naming the matrix rows it closes and (for probes) stating explicitly that it is not a v1 mirror. The pack fixtures (`node-exporter-*.yaml`, `telegraf-snmp-interface.yaml`) already had headers from PR 4.
+- **Validation matrix rows Pass**: 16.1–16.11 runtime, 16.12 runtime, 17.1–17.3 runtime, plus 1.1–1.6 / 2.1–2.10 / 3.1–3.7 / 4.1–4.8 / 5.1/5.3/5.7/5.8 / 6.1/6.12 / 7.1–7.11 / 8.1/8.2/8.3/8.4. The 8.2 claim is **end-to-end carry only** — `clock_group` threads through the translator into `ScenarioEntry.clock_group`; any per-entry observability log line or scheduler coordination is deferred to PR 7 (which owns CLI status output).
+- **Fix-pass commits** (post-review): doc fixes on `PrepareError` variants + `CompileError` phase anchors + broken intra-doc links in `prepare()`; YAML-comment headers on 21 fixtures; Exponential/Uniform distribution rstest in `v2_translator_semantics`; `v1_link_failover_entries` docstring correction; `normalize_timestamps` regression anchor; `v2_pack_runtime_parity` match-dispatch cleanup; strengthened `missing_required_field_fails_per_signal_type` with variant-specific `matches!`.
+- **Workspace test count**: 2,705 → 2,785 (**+80**). All four quality gates green on every one of the 17 commits. Branch: `feat/runtime-wiring`.
 
-### What PR 5 already hands off
+### What PR 6 deliberately did not do
 
-PR 5 produces `CompiledFile { version, entries: Vec<CompiledEntry> }` — a flat list of concrete signals with every `after:` clause resolved into `phase_offset` and every dependency chain member assigned a shared `clock_group`. The runtime never sees `AfterClause` objects: the causal graph has been compiled down to a pair of `Option<String>` fields that the existing scheduler already understands.
+- **`clock_group` runtime observability.** PR 7 scope. The value threads through the translator; any log line or scheduler coordination is UX / CLI work.
+- **`From<CompileError> for SondaError`.** PR 7 scope — lands naturally when the CLI starts routing through `compile_scenario_file`.
+- **Built-in scenario migration to v2 format.** PR 8.
+- **v1 story CLI removal.** PR 9.
+- **`SinkConfig::Channel` public variant.** Kept test sink substitution out of the production enum.
+- **Relax `expand<R: PackResolver>` to `+ ?Sized`.** `expand.rs` is frozen; the `DynPackResolver<'a>` newtype is the bridge. Unfreeze and remove the newtype in a future PR that naturally reopens `expand.rs`.
 
-Every `CompiledEntry` guarantees:
-- **Reference resolution complete.** No unresolved `after.ref` survives; `CompileAfterError::UnknownRef` / `SelfReference` / `CircularDependency` have already fired if anything was wrong.
-- **`phase_offset` is the full offset.** It equals `user_phase_offset + Σ crossing_time + Σ delay` across the entire transitive chain. PR 6 can feed this directly into `prepare_entries`; no further timing math is needed at runtime.
-- **`clock_group` is authoritative.** Dependency chain members all share a group (user-set or auto-assigned `chain_{lowest_lex_id}`); independents keep their explicit group or `None`.
-- **Generator aliases are still present.** PR 5's internal desugaring only touches timing math; `CompiledEntry.generator` carries the same `GeneratorConfig` variant the user wrote. The existing runtime pipeline already handles aliases via `config::aliases::desugar_entry`.
+## PR 7 Preparation Notes
 
-### What PR 6 must build
+PR 7 is **CLI unification**. A future session starting cold on PR 7 should read this section first; everything below is the handoff context from PR 6.
 
-1. **Wire `CompiledFile` into `prepare_entries`.** The CLI currently routes through `sonda_core::schedule::launch::prepare_entries(Vec<ScenarioEntry>)`. PR 6 must add a conversion from `Vec<CompiledEntry>` to `Vec<ScenarioEntry>` (the runtime's existing input shape) — this is largely a field-for-field mapping since PR 2/3/4 already mirrored the shapes. The simplest path is a `CompiledEntry → ScenarioEntry` `TryFrom` impl or a helper in `sonda-core::compiler`. Do not duplicate the scheduler; reuse `prepare_entries` and `launch_scenario` as-is.
+### What PR 6 already hands off
 
-2. **Runtime parity for built-in scenarios (rows 16.1–16.11 single-signal).** Each of the eleven built-in scenario YAMLs has an existing v1 baseline. Hand-write a v2 equivalent (`scenarios/<name>.v2.yaml`), pipe both through `prepare_entries` → `launch_scenario` with a deterministic seed and tick count, and assert the stdout output is byte-identical.
+- **`sonda_core::compile_scenario_file(yaml, &dyn PackResolver) -> Result<Vec<ScenarioEntry>, CompileError>`** — one-shot composition of the five v2 compile phases. This is the single library entry point the CLI should call when it detects a v2 file.
+- **`sonda_core::compiler::prepare::prepare(CompiledFile) -> Result<Vec<ScenarioEntry>, PrepareError>`** — the phase-by-phase escape hatch, useful for `--dry-run` where the CLI may want to stop after `compile_after` and serialize the intermediate for inspection, or after `prepare` for the final pre-runtime view.
+- **Every phase's error type remains publicly accessible** (`ParseError`, `NormalizeError`, `ExpandError`, `CompileAfterError`, `PrepareError`) so phase-by-phase callers get typed diagnostics. `CompileError` is the unified wrapper for the one-shot.
+- **`ScenarioEntry.clock_group`** carries the auto-assigned or explicit clock-group string. No CLI surface reads it yet; PR 7 is the natural place to add a start-banner line or aggregate-summary grouping.
+- **Runtime contract unchanged.** `prepare_entries` / `PreparedEntry` / `launch_scenario` / `run_multi` are untouched. PR 7 should not need to modify them — just route v2 output into them.
 
-3. **Runtime parity for link-failover story (row 16.12 runtime).** PR 5 already closed compile parity for `link-failover.yaml`. PR 6 must close the runtime half: same seed, same tick count, same byte-for-byte stdout. Live story runtime still uses the v1 `compile_story` path — point the runtime comparison at both paths.
+### What PR 7 must build
 
-4. **Runtime parity for packs (rows 17.1–17.3 runtime).** The three built-in packs already pass compile parity (PR 4). Same drill: build the v2 scenario from the existing fixture, run both paths with a seed, assert identical stdout.
+1. **`sonda run --scenario` v2 dispatch.** Detect `version: 2` at the top of the YAML (the existing parser has `detect_version()` — reuse it). Route v2 files through `compile_scenario_file`; route v1 files through the existing v1 loader. Both paths land in `prepare_entries` → `launch_scenario` / `run_multi`, so the branching is at the top of `run_command`.
+2. **`sonda catalog list/show/run`** replacing `sonda scenarios` + `sonda packs` per spec §6.3. Catalog metadata fields: `name`, `type`, `category`, `signal`, `description`, `runnable`. Search path is the same as today (`--scenario-path`, `--pack-path`, env vars, `./scenarios/` + `./packs/`, `~/.sonda/`).
+3. **`sonda init` v2 output.** The interactive wizard should emit `version: 2` files with `defaults:` and `scenarios:` blocks instead of the current v1 shape. Pre-fill paths (`--from @name`, `--from path.csv`) should map cleanly into the v2 schema.
+4. **Deprecate or hide** `sonda scenarios`, `sonda packs`, `sonda story` subcommands. The story CLI must keep working — it is still the row-16.12 runtime oracle until PR 9.
+5. **`--dry-run` enhancements (spec §5).** Print the compiled v2 view (resolved defaults, expanded packs, resolved `phase_offset`, assigned `clock_group`) in the format the spec shows. `compile_scenario_file` gives you the `Vec<ScenarioEntry>` directly; the formatting is the new work.
+6. **CLI status output for `clock_group`.** Add a start-banner line for each scenario naming its clock_group (spec §5 format shows `clock_group: link_failover (auto)` as an example). Also consider grouping the aggregate summary by clock_group when more than one is present. This closes matrix row 8.2 "runtime observability" fully.
+7. **`From<CompileError> for SondaError`.** PR 7's CLI will want to propagate compile errors through the existing `SondaError` chain.
 
-### What `sonda/src/story/` looks like after PR 5
+### Target matrix rows for PR 7
 
-- `timing.rs` is **gone**. The math now lives in `sonda_core::compiler::timing` and is shared by v1 and v2.
-- `after_resolve.rs` remains as-is, but now imports from `sonda_core::compiler::timing`. It still owns the v1 story-specific parsing of free-form `after:` strings (`"metric < 1"`) and the `SignalParams` data model, because the v1 story YAML grammar differs from the v2 compiler AST.
-- `mod.rs` (top-level story module) is unchanged — the CLI entrypoint `sonda story --file` still works.
+- **Section 12** CLI: 12.1, 12.7 (enhanced `--dry-run`), 12.10, 12.11, 12.12–12.17 (catalog), 12.19 (`init` v2), 12.20, 12.22
+- **Section 14** status output / UX: 14.1–14.9 (all)
+- **Matrix row 8.2 runtime observability** — fully close (PR 6 closed end-to-end carry only)
+- **Matrix row 8.6** aggregate summary grouping by clock_group
+- **Matrix rows 5.2 + 6.11** `--output` shorthand on the CLI layer
 
-This split is deliberate: the shared math is now in one place, while v1-specific YAML plumbing stays in the binary crate until PR 9 removes the `story` subcommand.
+### PR 9 forward pointer — v1 story parity oracle cleanup
 
-### Scope for PR 6 (target matrix rows)
+When PR 9 removes the v1 story CLI (`sonda story --file`), the hand-built `v1_link_failover_entries` helper in `sonda-core/tests/v2_story_parity.rs` becomes a relic. It exists only because `sonda-core` tests cannot dev-dep the binary crate that owns `compile_story`. Once the v1 story module is gone there is no "v1 side" to mirror, so PR 9 should either:
 
-- 16.1–16.11 (single-signal built-in scenarios — runtime parity)
-- 16.12 (link-failover story runtime parity; compile parity already Pass)
-- 17.1–17.3 (pack runtime parity; compile parity already Pass)
-- Any row from sections 1–6 that tests runtime behavior (metrics/logs/histogram/summary signal types, generators, encoders, sinks, dynamic/cardinality features) — these are runtime-observable and should flip from "Not Tested" to "Pass" where the v2 pipeline already produces correct output.
+- **Delete** the `link_failover_runtime_parity` test and the `v1_link_failover_entries` helper entirely (the `link_failover_compile_parity` test remains and is sufficient — it pins the v2 compile offsets byte-for-byte against the `timing::*_crossing_secs` math), **or**
+- **Refactor** to compare v2-compile stdout against a pinned byte-snapshot (via `insta::assert_snapshot!` on one canonical v2 run) if the runtime execution remains valuable to protect.
 
-### Scope discipline for PR 6
+The first option is cleaner and aligns with PR 9's remit ("remove transitional oracle code"). Surface this decision in PR 9's plan.
+
+### Scope discipline for PR 7
 
 Do NOT also:
 - Migrate built-in scenario YAMLs to v2 format (PR 8).
 - Remove v1 CLI subcommands (PR 9).
 - Add v2 scenario server API (PR 9).
+- Touch the sonda-core compile pipeline (all five phases are frozen after PR 6).
+- Change `prepare_entries` / `PreparedEntry` / `launch_scenario` / `run_multi`.
 
-PR 6 is the runtime parity proof — it shows the v2 pipeline produces correct output when driven through the existing scheduler. Migrations and CLI changes follow once parity is nailed down.
+### Testing conventions for PR 7
 
-### Testing conventions for PR 6 (post test-infra consolidation)
-
-The test-infra consolidation PR landed between PR 5 and PR 6. New tests on this integration branch must follow the post-consolidation conventions — the hand-rolled snapshot harness is gone, and the shared test surface is now the canonical one:
-
-- **`sonda-core/src/config/snapshot.rs` no longer exists.** Do not try to import `snapshot_entries`, `snapshot_prepared_entries`, or `assert_or_update_snapshot` — they were deleted. Use `insta::assert_json_snapshot!` directly on the existing `Serialize` derives.
-- **Integration tests start with `mod common;`** to pull in shared helpers from `sonda-core/tests/common/mod.rs`: `example_fixture`, `parity_fixture`, `load_repo_pack`, `builtin_pack_resolver`, `resolver_with`, `compile_to_expanded`, `compile_to_compiled`, `snapshot_settings`. Add new helpers there — do not duplicate across test files.
-- **Golden snapshots use `insta`.** `sonda-core/tests/snapshots/*.snap` is the snapshot tree. Update via `cargo insta review` (interactive) or `INSTA_UPDATE=always cargo test` (batch). For JSON snapshots, wrap via `common::snapshot_settings().bind(|| insta::assert_json_snapshot!(...))` to get `sort_maps = true` determinism.
-- **Parametrized tests use `rstest`.** Use `#[case::<descriptive_name>(...)]` so each row reports as a distinct test. Apply `#[rustfmt::skip]` on tables so `#[case(...)]` rows stay column-aligned. Do NOT force-fit: semantically-unique cases stay as standalone `#[test]` fns.
-- **For the 11 built-in runtime-parity tests (rows 16.1–16.11)**, a single `#[rstest]` with 11 `#[case::<scenario_name>(...)]` rows is the right shape — one function body that loads both v1 and v2, runs them with a seeded scheduler, and asserts byte-equal stdout.
-- **Stdout-capturing helper**: add a `common::run_and_capture_stdout(entries: Vec<ScenarioEntry>, seed: u64, ticks: u64) -> Vec<u8>` (or a `StdoutHarness` struct) to `tests/common/mod.rs` — all runtime-parity tests will need the same plumbing.
-- **v1 vs v2 stdout-parity is `assert_eq!(v1_bytes, v2_bytes)`, not a snapshot.** If you also want to pin a canonical baseline so both paths drifting to new-but-matching output is caught, additionally snapshot ONE side via `insta::assert_snapshot!(String::from_utf8_lossy(&v1_bytes))`.
-- **No `v2` prefix** on any Rust symbol — the `compiler` module and `v2-` fixture paths already carry the version. Fixture filenames and directories may use `v2-`.
-- **Quality gates on every commit**: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace -- -D warnings` (project gate — NOT `--all-targets`, pre-existing Rust 1.93 drift is a separate PR), `cargo fmt --all -- --check`.
+Same post-consolidation conventions as PR 6. The shared test surface is `sonda-core/tests/common/mod.rs`; any CLI-level test infrastructure goes in `sonda/tests/` (that directory already exists for CLI integration). For end-to-end CLI tests, spawn the binary as a subprocess — this is the natural setting for the subprocess tests that PR 6 deferred.
 
 ## Active Risks
 - Snapshot format stability — must be deterministic and survive refactor

--- a/docs/refactor/v2-validation-status.md
+++ b/docs/refactor/v2-validation-status.md
@@ -15,109 +15,109 @@ scenario and pack produces identical output in v2 format (15 rows).
 
 | # | Capability | Status | PR | Notes |
 |---|-----------|--------|-----|-------|
-| 1.1 | Metric signals (gauges/counters) | Not Tested | PR 6 | |
-| 1.2 | Log signals (template) | Not Tested | PR 6 | |
-| 1.3 | Log signals (replay) | Not Tested | PR 6 | |
-| 1.4 | Histogram signals | Not Tested | PR 6 | |
-| 1.5 | Summary signals | Not Tested | PR 6 | |
-| 1.6 | Mixed signal types in one file | Not Tested | PR 6 | |
+| 1.1 | Metric signals (gauges/counters) | Pass | PR 6 | |
+| 1.2 | Log signals (template) | Pass | PR 6 | |
+| 1.3 | Log signals (replay) | Pass | PR 6 | |
+| 1.4 | Histogram signals | Pass | PR 6 | |
+| 1.5 | Summary signals | Pass | PR 6 | |
+| 1.6 | Mixed signal types in one file | Pass | PR 6 | |
 
 ## 2. Metric Generators — Core (10 rows)
 
 | # | Capability | Status | PR | Notes |
 |---|-----------|--------|-----|-------|
-| 2.1 | constant generator | Not Tested | PR 6 | |
-| 2.2 | sine generator | Not Tested | PR 6 | |
-| 2.3 | sawtooth generator | Not Tested | PR 6 | |
-| 2.4 | uniform generator | Not Tested | PR 6 | |
-| 2.5 | sequence generator | Not Tested | PR 6 | |
-| 2.6 | step generator | Not Tested | PR 6 | |
-| 2.7 | spike generator | Not Tested | PR 6 | |
-| 2.8 | csv_replay generator | Not Tested | PR 6 | |
-| 2.9 | CSV auto-discovery (Grafana headers) | Not Tested | PR 6 | |
-| 2.10 | CSV per-column labels | Not Tested | PR 6 | |
+| 2.1 | constant generator | Pass | PR 6 | |
+| 2.2 | sine generator | Pass | PR 6 | |
+| 2.3 | sawtooth generator | Pass | PR 6 | |
+| 2.4 | uniform generator | Pass | PR 6 | |
+| 2.5 | sequence generator | Pass | PR 6 | |
+| 2.6 | step generator | Pass | PR 6 | |
+| 2.7 | spike generator | Pass | PR 6 | |
+| 2.8 | csv_replay generator | Pass | PR 6 | |
+| 2.9 | CSV auto-discovery (Grafana headers) | Pass | PR 6 | |
+| 2.10 | CSV per-column labels | Pass | PR 6 | |
 
 ## 3. Operational Aliases (7 rows)
 
 | # | Capability | Status | PR | Notes |
 |---|-----------|--------|-----|-------|
-| 3.1 | steady alias | Not Tested | PR 6 | |
-| 3.2 | flap alias | Not Tested | PR 6 | |
-| 3.3 | saturation alias | Not Tested | PR 6 | |
-| 3.4 | leak alias | Not Tested | PR 6 | |
-| 3.5 | degradation alias | Not Tested | PR 6 | |
-| 3.6 | spike_event alias | Not Tested | PR 6 | |
-| 3.7 | Custom up/down values for flap | Not Tested | PR 6 | |
+| 3.1 | steady alias | Pass | PR 6 | |
+| 3.2 | flap alias | Pass | PR 6 | |
+| 3.3 | saturation alias | Pass | PR 6 | |
+| 3.4 | leak alias | Pass | PR 6 | |
+| 3.5 | degradation alias | Pass | PR 6 | |
+| 3.6 | spike_event alias | Pass | PR 6 | |
+| 3.7 | Custom up/down values for flap | Pass | PR 6 | |
 
 ## 4. Histogram & Summary Generators (8 rows)
 
 | # | Capability | Status | PR | Notes |
 |---|-----------|--------|-----|-------|
-| 4.1 | Exponential distribution | Not Tested | PR 6 | |
-| 4.2 | Normal distribution | Not Tested | PR 6 | |
-| 4.3 | Uniform distribution | Not Tested | PR 6 | |
-| 4.4 | Custom buckets | Not Tested | PR 6 | |
-| 4.5 | Custom quantiles | Not Tested | PR 6 | |
-| 4.6 | observations_per_tick | Not Tested | PR 6 | |
-| 4.7 | mean_shift_per_sec | Not Tested | PR 6 | |
-| 4.8 | Cumulative bucket counters | Not Tested | PR 6 | |
+| 4.1 | Exponential distribution | Pass | PR 6 | |
+| 4.2 | Normal distribution | Pass | PR 6 | |
+| 4.3 | Uniform distribution | Pass | PR 6 | |
+| 4.4 | Custom buckets | Pass | PR 6 | |
+| 4.5 | Custom quantiles | Pass | PR 6 | |
+| 4.6 | observations_per_tick | Pass | PR 6 | |
+| 4.7 | mean_shift_per_sec | Pass | PR 6 | |
+| 4.8 | Cumulative bucket counters | Pass | PR 6 | |
 
 ## 5. Encoders (8 rows)
 
 | # | Capability | Status | PR | Notes |
 |---|-----------|--------|-----|-------|
-| 5.1 | prometheus_text | Not Tested | PR 6 | |
-| 5.2 | influx_lp with custom field_key | Not Tested | PR 6 | |
-| 5.3 | json_lines | Not Tested | PR 6 | |
-| 5.4 | syslog (logs only) | Not Tested | PR 6 | |
-| 5.5 | remote_write | Not Tested | PR 6 | |
-| 5.6 | otlp | Not Tested | PR 6 | |
-| 5.7 | precision field | Not Tested | PR 6 | |
+| 5.1 | prometheus_text | Pass | PR 6 | |
+| 5.2 | influx_lp with custom field_key | Pass | PR 6 | |
+| 5.3 | json_lines | Pass | PR 6 | |
+| 5.4 | syslog (logs only) | Not Tested | PR 8 | Feature-gated; smoke-test scope |
+| 5.5 | remote_write | Not Tested | PR 8 | Feature-gated; smoke-test scope |
+| 5.6 | otlp | Not Tested | PR 8 | Feature-gated; smoke-test scope |
+| 5.7 | precision field | Pass | PR 6 | |
 | 5.8 | Default encoder per signal type | Pass | PR 3 | Defaults resolution: metrics/histogram/summary → prometheus_text, logs → json_lines |
 
 ## 6. Sinks (12 rows)
 
 | # | Capability | Status | PR | Notes |
 |---|-----------|--------|-----|-------|
-| 6.1 | stdout | Not Tested | PR 6 | |
-| 6.2 | file | Not Tested | PR 6 | |
-| 6.3 | tcp | Not Tested | PR 6 | |
-| 6.4 | udp | Not Tested | PR 6 | |
-| 6.5 | http_push with batch_size | Not Tested | PR 6 | |
-| 6.6 | http_push custom headers | Not Tested | PR 6 | |
-| 6.7 | remote_write with batch_size | Not Tested | PR 6 | |
-| 6.8 | kafka with TLS + SASL | Not Tested | PR 6 | |
-| 6.9 | loki with labels + batch_size | Not Tested | PR 6 | |
-| 6.10 | otlp_grpc | Not Tested | PR 6 | |
+| 6.1 | stdout | Pass | PR 6 | |
+| 6.2 | file | Not Tested | PR 8 | Smoke-test scope |
+| 6.3 | tcp | Not Tested | PR 8 | Smoke-test scope |
+| 6.4 | udp | Not Tested | PR 8 | Smoke-test scope |
+| 6.5 | http_push with batch_size | Not Tested | PR 8 | Feature-gated; smoke-test scope |
+| 6.6 | http_push custom headers | Not Tested | PR 8 | Feature-gated; smoke-test scope |
+| 6.7 | remote_write with batch_size | Not Tested | PR 8 | Feature-gated; smoke-test scope |
+| 6.8 | kafka with TLS + SASL | Not Tested | PR 8 | Feature-gated; smoke-test scope |
+| 6.9 | loki with labels + batch_size | Not Tested | PR 8 | Feature-gated; smoke-test scope |
+| 6.10 | otlp_grpc | Not Tested | PR 8 | Feature-gated; smoke-test scope |
 | 6.11 | --output CLI shorthand | Not Tested | PR 7 | |
-| 6.12 | Retry with backoff | Not Tested | PR 6 | |
+| 6.12 | Retry with backoff | Pass | PR 6 | Translator-semantic: `RetryConfig` threads through for `tcp` sink (`v2_translator_semantics::row_6_12_retry_config`) |
 
 ## 7. Scheduling & Windows (11 rows)
 
 | # | Capability | Status | PR | Notes |
 |---|-----------|--------|-----|-------|
-| 7.1 | Gap windows | Not Tested | PR 6 | |
-| 7.2 | Burst windows | Not Tested | PR 6 | |
-| 7.3 | Gap overrides burst | Not Tested | PR 6 | |
-| 7.4 | Cardinality spikes (counter) | Not Tested | PR 6 | |
-| 7.5 | Cardinality spikes (random) | Not Tested | PR 6 | |
-| 7.6 | Multiple cardinality spikes | Not Tested | PR 6 | |
-| 7.7 | Gap suppresses cardinality spikes | Not Tested | PR 6 | |
-| 7.8 | Jitter | Not Tested | PR 6 | |
-| 7.9 | Dynamic labels (counter strategy) | Not Tested | PR 6 | |
-| 7.10 | Dynamic labels (values list) | Not Tested | PR 6 | |
-| 7.11 | Multiple dynamic labels | Not Tested | PR 6 | |
+| 7.1 | Gap windows | Pass | PR 6 | |
+| 7.2 | Burst windows | Pass | PR 6 | |
+| 7.3 | Gap overrides burst | Pass | PR 6 | |
+| 7.4 | Cardinality spikes (counter) | Pass | PR 6 | |
+| 7.5 | Cardinality spikes (random) | Pass | PR 6 | |
+| 7.6 | Multiple cardinality spikes | Pass | PR 6 | |
+| 7.7 | Gap suppresses cardinality spikes | Pass | PR 6 | |
+| 7.8 | Jitter | Pass | PR 6 | |
+| 7.9 | Dynamic labels (counter strategy) | Pass | PR 6 | |
+| 7.10 | Dynamic labels (values list) | Pass | PR 6 | |
+| 7.11 | Multiple dynamic labels | Pass | PR 6 | |
 
 ## 8. Multi-Scenario Features (6 rows)
 
 | # | Capability | Status | PR | Notes |
 |---|-----------|--------|-----|-------|
-| 8.1 | phase_offset | Not Tested | PR 6 | |
-| 8.2 | clock_group | Pass | PR 5 | Compile-time clock-group assignment validated (auto-naming, explicit value propagation, conflict detection); runtime observability (per-entry runtime log line / scheduler coordination) lands in PR 6 |
-| 8.3 | Concurrent execution | Not Tested | PR 6 | |
-| 8.4 | Independent completion | Not Tested | PR 6 | |
+| 8.1 | phase_offset | Pass | PR 6 | |
+| 8.2 | clock_group | Pass | PR 5/6 | Compile-time clock-group assignment validated (PR 5); runtime carry-through validated in PR 6 (`ScenarioEntry.clock_group` threads through `prepare::prepare()` verbatim — `clock_group_is_passed_through_on_all_variants` unit test). CLI observability surface (start banner, aggregate summary grouping) is PR 7 |
+| 8.3 | Concurrent execution | Pass | PR 6 | |
+| 8.4 | Independent completion | Pass | PR 6 | |
 | 8.5 | --dry-run on multi-scenario | Not Tested | PR 7 | Enhanced for v2 |
-| 8.6 | Aggregate summary at end | Not Tested | PR 6 | |
+| 8.6 | Aggregate summary at end | Not Tested | PR 7 | CLI aggregate summary (grouping by clock_group) |
 
 ## 9. Pack Features (15 rows)
 
@@ -186,7 +186,7 @@ scenario and pack produces identical output in v2 format (15 rows).
 
 | # | Capability | Status | PR | Notes |
 |---|-----------|--------|-----|-------|
-| 12.1 | Run scenario file | Not Tested | PR 6/7 | |
+| 12.1 | Run scenario file | Not Tested | PR 7 | Library entry point `compile_scenario_file` is ready; CLI dispatch wires it in PR 7 |
 | 12.2 | One-off metric | Not Tested | PR 7 | Unchanged |
 | 12.3 | One-off logs | Not Tested | PR 7 | Unchanged |
 | 12.4 | One-off histogram | Not Tested | PR 7 | Unchanged |
@@ -227,15 +227,15 @@ scenario and pack produces identical output in v2 format (15 rows).
 
 | # | Capability | Status | PR | Notes |
 |---|-----------|--------|-----|-------|
-| 14.1 | Start banner | Not Tested | PR 6 | |
-| 14.2 | Stop banner | Not Tested | PR 6 | |
-| 14.3 | Live progress (TTY) | Not Tested | PR 6 | |
-| 14.4 | Live progress (non-TTY) | Not Tested | PR 6 | |
-| 14.5 | Multi-scenario numbering | Not Tested | PR 6 | |
-| 14.6 | Color behavior | Not Tested | PR 6 | |
-| 14.7 | Gap/burst/spike tags | Not Tested | PR 6 | |
-| 14.8 | Aggregate summary | Not Tested | PR 6 | |
-| 14.9 | Ctrl+C graceful shutdown | Not Tested | PR 6 | |
+| 14.1 | Start banner | Not Tested | PR 7 | CLI status output |
+| 14.2 | Stop banner | Not Tested | PR 7 | CLI status output |
+| 14.3 | Live progress (TTY) | Not Tested | PR 7 | CLI status output |
+| 14.4 | Live progress (non-TTY) | Not Tested | PR 7 | CLI status output |
+| 14.5 | Multi-scenario numbering | Not Tested | PR 7 | CLI status output |
+| 14.6 | Color behavior | Not Tested | PR 7 | CLI status output |
+| 14.7 | Gap/burst/spike tags | Not Tested | PR 7 | CLI status output |
+| 14.8 | Aggregate summary | Not Tested | PR 7 | CLI status output |
+| 14.9 | Ctrl+C graceful shutdown | Not Tested | PR 7 | CLI status output |
 
 ## 15. Deployment (7 rows)
 
@@ -270,18 +270,18 @@ structurally identical (for non-deterministic generators like uniform).
 
 | # | Scenario File | Compile Parity | Runtime Parity | PR | Notes |
 |---|--------------|----------------|----------------|-----|-------|
-| 16.1 | cpu-spike.yaml | Not Tested | Not Tested | PR 6 | Single metric, sine-based |
-| 16.2 | memory-leak.yaml | Not Tested | Not Tested | PR 6 | Single metric, leak alias |
-| 16.3 | disk-fill.yaml | Not Tested | Not Tested | PR 6 | Single metric, saturation alias |
-| 16.4 | latency-degradation.yaml | Not Tested | Not Tested | PR 6 | Single metric, degradation alias |
-| 16.5 | error-rate-spike.yaml | Not Tested | Not Tested | PR 6 | Single metric, spike_event alias |
-| 16.6 | interface-flap.yaml | Not Tested | Not Tested | PR 6 | Single metric, flap alias |
-| 16.7 | network-link-failure.yaml | Not Tested | Not Tested | PR 6 | Multi-signal, phase_offset, clock_group |
-| 16.8 | steady-state.yaml | Not Tested | Not Tested | PR 6 | Single metric, steady alias |
-| 16.9 | log-storm.yaml | Not Tested | Not Tested | PR 6 | Log signal, template generator |
-| 16.10 | cardinality-explosion.yaml | Not Tested | Not Tested | PR 6 | Cardinality spikes, dynamic labels |
-| 16.11 | histogram-latency.yaml | Not Tested | Not Tested | PR 6 | Histogram signal |
-| 16.12 | link-failover.yaml (story) | Pass | Not Tested | PR 5/6 | Compile parity Pass (PR 5): hand-written v2 equivalent of `stories/link-failover.yaml` compiles to phase_offset values identical to v1 story math (`v2_story_parity::link_failover_compile_parity`). Runtime parity lands in PR 6 |
+| 16.1 | cpu-spike.yaml | Pass | Pass | PR 6 | Single metric, sine-based; byte-equal |
+| 16.2 | memory-leak.yaml | Pass | Pass | PR 6 | Single metric, leak alias; byte-equal |
+| 16.3 | disk-fill.yaml | Pass | Pass | PR 6 | Single metric, saturation alias; byte-equal |
+| 16.4 | latency-degradation.yaml | Pass | Pass | PR 6 | Single metric, degradation alias; byte-equal |
+| 16.5 | error-rate-spike.yaml | Pass | Pass | PR 6 | Single metric, spike_event alias; byte-equal |
+| 16.6 | interface-flap.yaml | Pass | Pass | PR 6 | Multi-signal (v1 YAML uses `signal_type: multi`); line-multiset |
+| 16.7 | network-link-failure.yaml | Pass | Pass | PR 6 | Multi-signal, phase_offset, clock_group; line-multiset |
+| 16.8 | steady-state.yaml | Pass | Pass | PR 6 | Single metric, steady alias; byte-equal |
+| 16.9 | log-storm.yaml | Pass | Pass | PR 6 | Log signal, template generator; byte-equal |
+| 16.10 | cardinality-explosion.yaml | Pass | Pass | PR 6 | Cardinality spikes, dynamic labels; byte-equal |
+| 16.11 | histogram-latency.yaml | Pass | Pass | PR 6 | Histogram signal; byte-equal |
+| 16.12 | link-failover.yaml (story) | Pass | Pass | PR 5/6 | Compile parity Pass (PR 5); runtime parity closed via `v2_story_parity::link_failover_runtime_parity` against hand-built v1-equivalent reference (PR 9 will clean the reference — see v2-progress.md PR 9 forward pointer) |
 
 ## 17. Built-in Pack Parity (3 rows)
 
@@ -290,6 +290,6 @@ For each built-in pack, a v2 scenario file is created that uses the pack inside
 
 | # | Pack | Compile Parity | Runtime Parity | PR | Notes |
 |---|------|----------------|----------------|-----|-------|
-| 17.1 | telegraf-snmp-interface.yaml | Pass | Not Tested | PR 4/6 | v1 `expand_pack` and v2 pipeline yield the same concrete signals including flap override; runtime parity lands in PR 6 |
-| 17.2 | node-exporter-cpu.yaml | Pass | Not Tested | PR 4/6 | Eight per-mode metrics of `node_cpu_seconds_total` compile identically; runtime parity lands in PR 6 |
-| 17.3 | node-exporter-memory.yaml | Pass | Not Tested | PR 4/6 | Five memory gauge metrics + override labels compile identically; runtime parity lands in PR 6 |
+| 17.1 | telegraf-snmp-interface.yaml | Pass | Pass | PR 4/6 | v1 `expand_pack` and v2 pipeline yield byte-identical runtime output via `v2_pack_runtime_parity::row_17_1_telegraf_snmp_interface` |
+| 17.2 | node-exporter-cpu.yaml | Pass | Pass | PR 4/6 | Eight per-mode metrics of `node_cpu_seconds_total` produce byte-identical runtime output via `v2_pack_runtime_parity::row_17_2_node_exporter_cpu` |
+| 17.3 | node-exporter-memory.yaml | Pass | Pass | PR 4/6 | Five memory gauge metrics + override labels produce byte-identical runtime output via `v2_pack_runtime_parity::row_17_3_node_exporter_memory` |

--- a/sonda-core/src/compile.rs
+++ b/sonda-core/src/compile.rs
@@ -1,0 +1,246 @@
+//! One-shot v2 scenario compilation from YAML to the runtime's input shape.
+//!
+//! This module composes the five v2 compilation phases — `parse`, `normalize`,
+//! `expand`, `compile_after`, and `prepare` — behind a single callable so that
+//! library consumers can go from YAML text to `Vec<ScenarioEntry>` in one step.
+//!
+//! The CLI still drives the runtime through the v1 loader; this entry point
+//! is for library consumers (tests, the server, and future CLI wiring) that
+//! want a turnkey v2 compile.
+//!
+//! # Phase boundaries
+//!
+//! Callers who need to inspect an intermediate representation (e.g. a
+//! [`NormalizedFile`][crate::compiler::normalize::NormalizedFile]) should
+//! invoke the phase functions individually. [`compile_scenario_file`] is a
+//! convenience wrapper; every error variant it returns is the same error the
+//! underlying phase would have produced — see [`CompileError`].
+
+use crate::compiler::compile_after::{compile_after, CompileAfterError};
+use crate::compiler::expand::{expand, ExpandError, PackResolver};
+use crate::compiler::normalize::{normalize, NormalizeError};
+use crate::compiler::parse::{parse, ParseError};
+use crate::compiler::prepare::{prepare, PrepareError};
+use crate::config::ScenarioEntry;
+
+/// Errors produced by [`compile_scenario_file`].
+///
+/// Each variant wraps the corresponding phase's error so callers can
+/// programmatically discriminate where compilation failed without string
+/// matching. The `#[from]` conversions let each phase's fallible call site
+/// bubble up naturally via `?`.
+#[derive(Debug, thiserror::Error)]
+pub enum CompileError {
+    /// YAML parsing or schema validation failed.
+    #[error("parse error: {0}")]
+    Parse(#[from] ParseError),
+
+    /// Defaults resolution failed (e.g. an entry was missing a required field
+    /// with no default available).
+    #[error("normalize error: {0}")]
+    Normalize(#[from] NormalizeError),
+
+    /// Pack expansion failed (unknown pack, unknown override key, duplicate
+    /// id, or resolver I/O error).
+    #[error("expand error: {0}")]
+    Expand(#[from] ExpandError),
+
+    /// `after:` resolution, dependency graph, or clock-group assignment
+    /// failed.
+    #[error("compile_after error: {0}")]
+    CompileAfter(#[from] CompileAfterError),
+
+    /// Translation to the runtime input shape failed (shape invariants not
+    /// visible to earlier phases, e.g. an unknown `signal_type` on a
+    /// programmatically-constructed [`CompiledFile`][crate::compiler::compile_after::CompiledFile]).
+    #[error("prepare error: {0}")]
+    Prepare(#[from] PrepareError),
+}
+
+/// Compile a v2 scenario YAML into the runtime's `Vec<ScenarioEntry>` input
+/// shape.
+///
+/// The returned entries are ready to hand to
+/// [`prepare_entries`][crate::schedule::launch::prepare_entries] (which
+/// handles phase-offset parsing, csv_replay expansion, and validation) and
+/// subsequently [`launch_scenario`][crate::schedule::launch::launch_scenario]
+/// or [`run_multi`][crate::schedule::multi_runner::run_multi].
+///
+/// # Parameters
+///
+/// * `yaml` — raw v2 scenario YAML source. Version 2 is mandatory; v1
+///   scenarios are not accepted here — route those through the v1 loader.
+/// * `resolver` — pack-reference resolver used by
+///   [`expand`][crate::compiler::expand::expand]. Pass an
+///   [`InMemoryPackResolver`][crate::compiler::expand::InMemoryPackResolver]
+///   seeded with the packs your scenario references, or a filesystem-backed
+///   implementation for CLI-style usage.
+///
+/// # Errors
+///
+/// Returns a [`CompileError`] variant corresponding to the phase that
+/// rejected the input; no partial output is produced.
+pub fn compile_scenario_file(
+    yaml: &str,
+    resolver: &dyn PackResolver,
+) -> Result<Vec<ScenarioEntry>, CompileError> {
+    // `expand` uses a `Sized` generic bound, so wrap the trait object in a
+    // local `Sized` adapter that forwards each call. This keeps the public
+    // signature `&dyn PackResolver` (object-safe, no monomorphization blow-up
+    // for callers that cross module boundaries) without modifying `expand`'s
+    // API.
+    let wrapped = DynPackResolver(resolver);
+    let parsed = parse(yaml)?;
+    let normalized = normalize(parsed)?;
+    let expanded = expand(normalized, &wrapped)?;
+    let compiled = compile_after(expanded)?;
+    Ok(prepare(compiled)?)
+}
+
+/// Adapter that implements the `Sized` bound `expand` requires while
+/// delegating to an underlying `&dyn PackResolver`.
+struct DynPackResolver<'a>(&'a dyn PackResolver);
+
+impl<'a> PackResolver for DynPackResolver<'a> {
+    fn resolve(
+        &self,
+        reference: &str,
+    ) -> Result<crate::packs::MetricPackDef, crate::compiler::expand::PackResolveError> {
+        self.0.resolve(reference)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler::expand::InMemoryPackResolver;
+
+    fn empty_resolver() -> InMemoryPackResolver {
+        InMemoryPackResolver::new()
+    }
+
+    /// Happy path: a minimal inline v2 YAML compiles cleanly and produces
+    /// one [`ScenarioEntry`].
+    #[test]
+    fn one_shot_compiles_minimal_inline_scenario() {
+        let yaml = r#"
+version: 2
+
+defaults:
+  rate: 10
+  duration: 500ms
+
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 1.0
+"#;
+        let resolver = empty_resolver();
+        let entries = compile_scenario_file(yaml, &resolver).expect("one-shot must succeed");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].base().name, "cpu_usage");
+        assert_eq!(entries[0].base().rate, 10.0);
+    }
+
+    /// `parse` failures surface as `CompileError::Parse`.
+    #[test]
+    fn parse_failure_surfaces_as_parse_variant() {
+        let yaml = "version: 1\nscenarios: []\n";
+        let resolver = empty_resolver();
+        let err = compile_scenario_file(yaml, &resolver).expect_err("v1 yaml must fail");
+        assert!(
+            matches!(err, CompileError::Parse(_)),
+            "v1 version must surface as Parse, got {err:?}"
+        );
+    }
+
+    /// `normalize` failures surface as `CompileError::Normalize`.
+    /// A metrics entry without `rate` (and no default) fails at Phase 2.
+    #[test]
+    fn normalize_failure_surfaces_as_normalize_variant() {
+        let yaml = r#"
+version: 2
+
+scenarios:
+  - id: no_rate
+    signal_type: metrics
+    name: no_rate
+    generator:
+      type: constant
+      value: 1.0
+"#;
+        let resolver = empty_resolver();
+        let err = compile_scenario_file(yaml, &resolver).expect_err("missing rate must fail");
+        assert!(
+            matches!(err, CompileError::Normalize(_)),
+            "missing rate must surface as Normalize, got {err:?}"
+        );
+    }
+
+    /// `expand` failures surface as `CompileError::Expand`.
+    /// An unresolvable pack name produces ResolveFailed.
+    #[test]
+    fn expand_failure_surfaces_as_expand_variant() {
+        let yaml = r#"
+version: 2
+
+defaults:
+  rate: 1
+
+scenarios:
+  - signal_type: metrics
+    pack: unknown_pack_xyz
+"#;
+        let resolver = empty_resolver();
+        let err = compile_scenario_file(yaml, &resolver).expect_err("unknown pack must fail");
+        assert!(
+            matches!(err, CompileError::Expand(_)),
+            "unresolvable pack must surface as Expand, got {err:?}"
+        );
+    }
+
+    /// `compile_after` failures surface as `CompileError::CompileAfter`.
+    /// A self-reference fires `SelfReference`.
+    #[test]
+    fn compile_after_failure_surfaces_as_compile_after_variant() {
+        let yaml = r#"
+version: 2
+
+defaults:
+  rate: 1
+
+scenarios:
+  - id: loopy
+    signal_type: metrics
+    name: loopy
+    generator:
+      type: flap
+      up_duration: 60s
+      down_duration: 30s
+    after:
+      ref: loopy
+      op: "<"
+      value: 1
+"#;
+        let resolver = empty_resolver();
+        let err = compile_scenario_file(yaml, &resolver).expect_err("self-ref must fail");
+        assert!(
+            matches!(err, CompileError::CompileAfter(_)),
+            "self-reference must surface as CompileAfter, got {err:?}"
+        );
+    }
+
+    /// Error types satisfy Send + Sync so they can cross thread boundaries.
+    #[test]
+    fn compile_error_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<CompileError>();
+    }
+}

--- a/sonda-core/src/compile.rs
+++ b/sonda-core/src/compile.rs
@@ -31,28 +31,40 @@ use crate::config::ScenarioEntry;
 /// bubble up naturally via `?`.
 #[derive(Debug, thiserror::Error)]
 pub enum CompileError {
-    /// YAML parsing or schema validation failed.
+    /// **Phase 1** (parse): YAML parsing or schema validation failed.
     #[error("parse error: {0}")]
     Parse(#[from] ParseError),
 
-    /// Defaults resolution failed (e.g. an entry was missing a required field
-    /// with no default available).
+    /// **Phase 2** (normalize): defaults resolution failed (e.g. an entry
+    /// was missing a required field with no default available).
     #[error("normalize error: {0}")]
     Normalize(#[from] NormalizeError),
 
-    /// Pack expansion failed (unknown pack, unknown override key, duplicate
-    /// id, or resolver I/O error).
+    /// **Phase 3** (expand): pack expansion failed (unknown pack, unknown
+    /// override key, duplicate id, or resolver I/O error).
     #[error("expand error: {0}")]
     Expand(#[from] ExpandError),
 
-    /// `after:` resolution, dependency graph, or clock-group assignment
-    /// failed.
+    /// **Phase 4+5** (compile_after): `after:` resolution, dependency
+    /// graph, or clock-group assignment failed.
     #[error("compile_after error: {0}")]
     CompileAfter(#[from] CompileAfterError),
 
-    /// Translation to the runtime input shape failed (shape invariants not
-    /// visible to earlier phases, e.g. an unknown `signal_type` on a
-    /// programmatically-constructed [`CompiledFile`][crate::compiler::compile_after::CompiledFile]).
+    /// **Phase 6** (prepare): translation to the runtime input shape
+    /// failed. Shape invariants not visible to earlier phases surface
+    /// here — e.g. an unknown `signal_type` on a programmatically-
+    /// constructed [`CompiledFile`][crate::compiler::compile_after::CompiledFile].
+    ///
+    /// Note: the [`PrepareError::UnknownSignalType`],
+    /// [`PrepareError::MissingGenerator`],
+    /// [`PrepareError::MissingLogGenerator`], and
+    /// [`PrepareError::MissingDistribution`] cases are effectively
+    /// unreachable when the input comes through
+    /// [`compile_scenario_file`] — earlier phases gate those shapes at
+    /// YAML-level. They remain reachable for programmatic callers that
+    /// build a [`CompiledFile`][crate::compiler::compile_after::CompiledFile]
+    /// in code and feed it directly to
+    /// [`prepare`][crate::compiler::prepare::prepare].
     #[error("prepare error: {0}")]
     Prepare(#[from] PrepareError),
 }

--- a/sonda-core/src/compiler/mod.rs
+++ b/sonda-core/src/compiler/mod.rs
@@ -17,6 +17,8 @@
 //! - [`timing`] — pure threshold-crossing math for every supported generator.
 //! - [`compile_after`] — `after` clause resolution, dependency graph, and
 //!   clock-group assignment (Phases 4 and 5).
+//! - [`prepare`] — translation from [`compile_after::CompiledFile`] into the
+//!   runtime's `Vec<ScenarioEntry>` input shape (Phase 6).
 
 #[cfg(feature = "config")]
 pub mod parse;
@@ -31,6 +33,9 @@ pub mod timing;
 
 #[cfg(feature = "config")]
 pub mod compile_after;
+
+#[cfg(feature = "config")]
+pub mod prepare;
 
 use std::collections::BTreeMap;
 

--- a/sonda-core/src/compiler/prepare.rs
+++ b/sonda-core/src/compiler/prepare.rs
@@ -1,0 +1,765 @@
+//! Translation boundary from the v2 compiler output to the existing runtime's
+//! input shape.
+//!
+//! This module is **Phase 6** of the v2 compilation pipeline (the execution
+//! plan's "Prepare Entries" step). It consumes a [`CompiledFile`] produced by
+//! [`compile_after`][crate::compiler::compile_after::compile_after] and
+//! produces a `Vec<ScenarioEntry>` — the exact input shape that the existing
+//! [`prepare_entries`][crate::schedule::launch::prepare_entries] function
+//! already understands.
+//!
+//! # Why a dedicated module
+//!
+//! The runtime's [`ScenarioEntry`] was the v1 launch input and cannot be
+//! changed without breaking the scheduler contract. The compiler's
+//! [`CompiledEntry`] is a forward-compatible shape that can carry fields the
+//! runtime does not yet consume. Keeping the translation in its own module
+//! gives us:
+//!
+//! - A single obvious place to update when either shape evolves.
+//! - A thin, allocation-conservative one-shot conversion (runs once at launch
+//!   time, not per tick).
+//! - Typed errors for the narrow set of "shape invariant broken" cases that
+//!   only become visible at the dispatch boundary (e.g. unknown `signal_type`
+//!   strings, missing per-variant required fields).
+//!
+//! The translator does **not** parse durations — `phase_offset` is passed
+//! through verbatim so
+//! [`prepare_entries`][crate::schedule::launch::prepare_entries] remains the
+//! sole `parse_phase_offset` caller.
+
+use std::collections::{BTreeMap, HashMap};
+
+use crate::compiler::compile_after::{CompiledEntry, CompiledFile};
+use crate::config::{
+    BaseScheduleConfig, HistogramScenarioConfig, LogScenarioConfig, ScenarioConfig, ScenarioEntry,
+    SummaryScenarioConfig,
+};
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors produced by [`prepare`].
+///
+/// Every variant carries enough context to identify the offending
+/// [`CompiledEntry`] — either its user-provided `id` or, when the id is
+/// absent, its `name`. Preferring `id` matches the convention used by
+/// [`CompileAfterError`][crate::compiler::compile_after::CompileAfterError],
+/// so diagnostics chain cleanly when both phases need to report on the same
+/// entry.
+#[derive(Debug, thiserror::Error)]
+pub enum PrepareError {
+    /// The entry's `signal_type` was not one of the four recognized variants
+    /// (`"metrics"`, `"logs"`, `"histogram"`, `"summary"`).
+    ///
+    /// The parser already rejects unknown signal types, but this variant
+    /// keeps the translator self-contained: callers that construct a
+    /// [`CompiledFile`] in code without going through
+    /// [`parse`][crate::compiler::parse::parse] still get a proper error
+    /// instead of a `match` panic.
+    #[error("entry '{entry_label}': unknown signal_type '{signal_type}'")]
+    UnknownSignalType {
+        /// The entry's id (or name when id is absent).
+        entry_label: String,
+        /// The unrecognized signal type string as it appeared in the compiled entry.
+        signal_type: String,
+    },
+
+    /// A metrics entry had no `generator` field set.
+    #[error("entry '{entry_label}' (signal_type: metrics): missing required field 'generator'")]
+    MissingGenerator {
+        /// The entry's id (or name when id is absent).
+        entry_label: String,
+    },
+
+    /// A logs entry had no `log_generator` field set.
+    #[error("entry '{entry_label}' (signal_type: logs): missing required field 'log_generator'")]
+    MissingLogGenerator {
+        /// The entry's id (or name when id is absent).
+        entry_label: String,
+    },
+
+    /// A histogram or summary entry had no `distribution` field set.
+    #[error(
+        "entry '{entry_label}' (signal_type: {signal_type}): missing required field 'distribution'"
+    )]
+    MissingDistribution {
+        /// The entry's id (or name when id is absent).
+        entry_label: String,
+        /// The signal type that requires a distribution (`"histogram"` or `"summary"`).
+        signal_type: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Translate a [`CompiledFile`] into the runtime's
+/// `Vec<ScenarioEntry>` input shape.
+///
+/// This is a **one-shot** conversion intended to run once at launch time.
+/// Per-tick allocations are not affected — every [`ScenarioEntry`] produced
+/// by this function takes the same hot path as if it had been constructed
+/// directly by the v1 loader.
+///
+/// Field-by-field mapping lives in the variant-specific helpers
+/// ([`metrics_entry`], [`logs_entry`], [`histogram_entry`],
+/// [`summary_entry`]). Each helper consumes its [`CompiledEntry`] by value so
+/// no deep clone is performed on the generator or label maps.
+///
+/// # Errors
+///
+/// Returns [`PrepareError`] on the first entry that fails translation:
+///
+/// - [`PrepareError::UnknownSignalType`] when `signal_type` is not one of
+///   `"metrics"`, `"logs"`, `"histogram"`, or `"summary"`.
+/// - [`PrepareError::MissingGenerator`] for a metrics entry missing `generator`.
+/// - [`PrepareError::MissingLogGenerator`] for a logs entry missing `log_generator`.
+/// - [`PrepareError::MissingDistribution`] for a histogram/summary entry
+///   missing `distribution`.
+///
+/// The shorter-circuiting semantics match the v2 compiler's other passes —
+/// no partial output is returned on failure.
+pub fn prepare(file: CompiledFile) -> Result<Vec<ScenarioEntry>, PrepareError> {
+    let CompiledFile {
+        version: _,
+        entries,
+    } = file;
+    let mut out = Vec::with_capacity(entries.len());
+    for entry in entries {
+        out.push(translate_entry(entry)?);
+    }
+    Ok(out)
+}
+
+/// Translate a single [`CompiledEntry`] into the matching [`ScenarioEntry`]
+/// variant.
+///
+/// Exposed for callers that want to fan out translation themselves (e.g.
+/// partial runtime wiring in tests). Most callers should use [`prepare`].
+///
+/// # Errors
+///
+/// See [`prepare`] for the full error semantics.
+pub fn translate_entry(entry: CompiledEntry) -> Result<ScenarioEntry, PrepareError> {
+    match entry.signal_type.as_str() {
+        "metrics" => metrics_entry(entry).map(ScenarioEntry::Metrics),
+        "logs" => logs_entry(entry).map(ScenarioEntry::Logs),
+        "histogram" => histogram_entry(entry).map(ScenarioEntry::Histogram),
+        "summary" => summary_entry(entry).map(ScenarioEntry::Summary),
+        _ => Err(PrepareError::UnknownSignalType {
+            entry_label: describe(&entry),
+            signal_type: entry.signal_type,
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-variant helpers
+// ---------------------------------------------------------------------------
+
+/// Produce a human-readable label for a [`CompiledEntry`] — prefers the
+/// explicit `id`, falls back to `name`.
+fn describe(entry: &CompiledEntry) -> String {
+    entry.id.clone().unwrap_or_else(|| entry.name.clone())
+}
+
+/// Build a [`BaseScheduleConfig`] from the shared fields of a
+/// [`CompiledEntry`].
+///
+/// The only non-trivial conversion is `labels: Option<BTreeMap<...>>` →
+/// `Option<HashMap<...>>`. The runtime uses `HashMap` internally but the
+/// compiler operates on `BTreeMap` for deterministic iteration — this
+/// one-shot conversion is the only place the shape changes.
+fn build_base(entry: &mut CompiledEntry) -> BaseScheduleConfig {
+    let labels = entry.labels.take().map(btree_to_hash);
+
+    BaseScheduleConfig {
+        name: std::mem::take(&mut entry.name),
+        rate: entry.rate,
+        duration: entry.duration.take(),
+        gaps: entry.gaps.take(),
+        bursts: entry.bursts.take(),
+        cardinality_spikes: entry.cardinality_spikes.take(),
+        dynamic_labels: entry.dynamic_labels.take(),
+        labels,
+        sink: std::mem::replace(&mut entry.sink, crate::sink::SinkConfig::Stdout),
+        phase_offset: entry.phase_offset.take(),
+        clock_group: entry.clock_group.take(),
+        jitter: entry.jitter,
+        jitter_seed: entry.jitter_seed,
+    }
+}
+
+/// Convert an ordered label map into an unordered one without reallocating
+/// any keys or values.
+fn btree_to_hash(m: BTreeMap<String, String>) -> HashMap<String, String> {
+    let mut hm = HashMap::with_capacity(m.len());
+    hm.extend(m);
+    hm
+}
+
+/// Materialize a metrics [`ScenarioConfig`] from a compiled entry.
+fn metrics_entry(mut entry: CompiledEntry) -> Result<ScenarioConfig, PrepareError> {
+    let generator = entry
+        .generator
+        .take()
+        .ok_or_else(|| PrepareError::MissingGenerator {
+            entry_label: describe(&entry),
+        })?;
+    // `encoder` is non-`Option` on CompiledEntry (Phase 2 normalize filled it
+    // in), so a mem::replace with a cheap placeholder is sufficient.
+    let encoder = std::mem::replace(
+        &mut entry.encoder,
+        crate::encoder::EncoderConfig::PrometheusText { precision: None },
+    );
+    let base = build_base(&mut entry);
+    Ok(ScenarioConfig {
+        base,
+        generator,
+        encoder,
+    })
+}
+
+/// Materialize a logs [`LogScenarioConfig`] from a compiled entry.
+fn logs_entry(mut entry: CompiledEntry) -> Result<LogScenarioConfig, PrepareError> {
+    let generator =
+        entry
+            .log_generator
+            .take()
+            .ok_or_else(|| PrepareError::MissingLogGenerator {
+                entry_label: describe(&entry),
+            })?;
+    let encoder = std::mem::replace(
+        &mut entry.encoder,
+        crate::encoder::EncoderConfig::JsonLines { precision: None },
+    );
+    let base = build_base(&mut entry);
+    Ok(LogScenarioConfig {
+        base,
+        generator,
+        encoder,
+    })
+}
+
+/// Materialize a [`HistogramScenarioConfig`] from a compiled entry.
+fn histogram_entry(mut entry: CompiledEntry) -> Result<HistogramScenarioConfig, PrepareError> {
+    let distribution =
+        entry
+            .distribution
+            .take()
+            .ok_or_else(|| PrepareError::MissingDistribution {
+                entry_label: describe(&entry),
+                signal_type: "histogram".to_string(),
+            })?;
+    let buckets = entry.buckets.take();
+    let observations_per_tick = entry.observations_per_tick.map(u64::from);
+    let mean_shift_per_sec = entry.mean_shift_per_sec;
+    let seed = entry.seed;
+    let encoder = std::mem::replace(
+        &mut entry.encoder,
+        crate::encoder::EncoderConfig::PrometheusText { precision: None },
+    );
+    let base = build_base(&mut entry);
+    Ok(HistogramScenarioConfig {
+        base,
+        buckets,
+        distribution,
+        observations_per_tick,
+        mean_shift_per_sec,
+        seed,
+        encoder,
+    })
+}
+
+/// Materialize a [`SummaryScenarioConfig`] from a compiled entry.
+fn summary_entry(mut entry: CompiledEntry) -> Result<SummaryScenarioConfig, PrepareError> {
+    let distribution =
+        entry
+            .distribution
+            .take()
+            .ok_or_else(|| PrepareError::MissingDistribution {
+                entry_label: describe(&entry),
+                signal_type: "summary".to_string(),
+            })?;
+    let quantiles = entry.quantiles.take();
+    let observations_per_tick = entry.observations_per_tick.map(u64::from);
+    let mean_shift_per_sec = entry.mean_shift_per_sec;
+    let seed = entry.seed;
+    let encoder = std::mem::replace(
+        &mut entry.encoder,
+        crate::encoder::EncoderConfig::PrometheusText { precision: None },
+    );
+    let base = build_base(&mut entry);
+    Ok(SummaryScenarioConfig {
+        base,
+        quantiles,
+        distribution,
+        observations_per_tick,
+        mean_shift_per_sec,
+        seed,
+        encoder,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(all(test, feature = "config"))]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use rstest::rstest;
+
+    use super::*;
+    use crate::config::DistributionConfig;
+    use crate::encoder::EncoderConfig;
+    use crate::generator::{GeneratorConfig, LogGeneratorConfig, TemplateConfig};
+    use crate::sink::SinkConfig;
+
+    // -- Builders -----------------------------------------------------------
+
+    /// Build a minimal [`CompiledEntry`] — every variant-specific field is
+    /// absent so tests can pick which ones to set.
+    fn bare(signal_type: &str, name: &str) -> CompiledEntry {
+        CompiledEntry {
+            id: None,
+            signal_type: signal_type.to_string(),
+            name: name.to_string(),
+            rate: 10.0,
+            duration: Some("1s".to_string()),
+            generator: None,
+            log_generator: None,
+            labels: None,
+            dynamic_labels: None,
+            encoder: EncoderConfig::PrometheusText { precision: None },
+            sink: SinkConfig::Stdout,
+            jitter: None,
+            jitter_seed: None,
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            phase_offset: None,
+            clock_group: None,
+            distribution: None,
+            buckets: None,
+            quantiles: None,
+            observations_per_tick: None,
+            mean_shift_per_sec: None,
+            seed: None,
+        }
+    }
+
+    fn metrics_compiled(name: &str) -> CompiledEntry {
+        let mut e = bare("metrics", name);
+        e.generator = Some(GeneratorConfig::Constant { value: 1.0 });
+        e
+    }
+
+    fn logs_compiled(name: &str) -> CompiledEntry {
+        let mut e = bare("logs", name);
+        e.log_generator = Some(LogGeneratorConfig::Template {
+            templates: vec![TemplateConfig {
+                message: "hi".to_string(),
+                field_pools: BTreeMap::new(),
+            }],
+            severity_weights: None,
+            seed: Some(0),
+        });
+        e.encoder = EncoderConfig::JsonLines { precision: None };
+        e
+    }
+
+    fn histogram_compiled(name: &str) -> CompiledEntry {
+        let mut e = bare("histogram", name);
+        e.distribution = Some(DistributionConfig::Exponential { rate: 10.0 });
+        e.buckets = Some(vec![0.1, 1.0, 10.0]);
+        e
+    }
+
+    fn summary_compiled(name: &str) -> CompiledEntry {
+        let mut e = bare("summary", name);
+        e.distribution = Some(DistributionConfig::Normal {
+            mean: 0.1,
+            stddev: 0.02,
+        });
+        e.quantiles = Some(vec![0.5, 0.9, 0.99]);
+        e
+    }
+
+    fn file_with(entry: CompiledEntry) -> CompiledFile {
+        CompiledFile {
+            version: 2,
+            entries: vec![entry],
+        }
+    }
+
+    // -- Happy paths --------------------------------------------------------
+
+    /// A metrics entry with a constant generator round-trips into
+    /// `ScenarioEntry::Metrics` with name and rate preserved.
+    #[test]
+    fn metrics_entry_translates_to_scenario_entry_metrics() {
+        let file = file_with(metrics_compiled("cpu_usage"));
+        let out = prepare(file).expect("translate must succeed");
+        assert_eq!(out.len(), 1);
+        match &out[0] {
+            ScenarioEntry::Metrics(c) => {
+                assert_eq!(c.base.name, "cpu_usage");
+                assert_eq!(c.base.rate, 10.0);
+                assert!(matches!(c.generator, GeneratorConfig::Constant { .. }));
+            }
+            other => panic!("expected Metrics, got {other:?}"),
+        }
+    }
+
+    /// A logs entry with a template generator round-trips into
+    /// `ScenarioEntry::Logs` with the log_generator preserved.
+    #[test]
+    fn logs_entry_translates_to_scenario_entry_logs() {
+        let file = file_with(logs_compiled("app_logs"));
+        let out = prepare(file).expect("translate must succeed");
+        match &out[0] {
+            ScenarioEntry::Logs(c) => {
+                assert_eq!(c.base.name, "app_logs");
+                assert!(matches!(c.generator, LogGeneratorConfig::Template { .. }));
+            }
+            other => panic!("expected Logs, got {other:?}"),
+        }
+    }
+
+    /// A histogram entry translates with distribution, buckets, and encoder
+    /// preserved.
+    #[test]
+    fn histogram_entry_translates_with_distribution_and_buckets() {
+        let file = file_with(histogram_compiled("http_request_duration"));
+        let out = prepare(file).expect("translate must succeed");
+        match &out[0] {
+            ScenarioEntry::Histogram(c) => {
+                assert_eq!(c.base.name, "http_request_duration");
+                assert_eq!(c.buckets.as_deref(), Some(&[0.1, 1.0, 10.0][..]));
+                assert!(matches!(
+                    c.distribution,
+                    DistributionConfig::Exponential { .. }
+                ));
+            }
+            other => panic!("expected Histogram, got {other:?}"),
+        }
+    }
+
+    /// A summary entry translates with distribution, quantiles, and encoder
+    /// preserved.
+    #[test]
+    fn summary_entry_translates_with_distribution_and_quantiles() {
+        let file = file_with(summary_compiled("rpc_duration"));
+        let out = prepare(file).expect("translate must succeed");
+        match &out[0] {
+            ScenarioEntry::Summary(c) => {
+                assert_eq!(c.base.name, "rpc_duration");
+                assert_eq!(c.quantiles.as_deref(), Some(&[0.5, 0.9, 0.99][..]));
+                assert!(matches!(c.distribution, DistributionConfig::Normal { .. }));
+            }
+            other => panic!("expected Summary, got {other:?}"),
+        }
+    }
+
+    /// The order of entries in the compiled file is preserved verbatim.
+    #[test]
+    fn prepare_preserves_entry_order() {
+        let file = CompiledFile {
+            version: 2,
+            entries: vec![
+                metrics_compiled("first"),
+                logs_compiled("second"),
+                histogram_compiled("third"),
+                summary_compiled("fourth"),
+            ],
+        };
+        let out = prepare(file).expect("translate must succeed");
+        assert_eq!(out.len(), 4);
+        assert_eq!(out[0].base().name, "first");
+        assert_eq!(out[1].base().name, "second");
+        assert_eq!(out[2].base().name, "third");
+        assert_eq!(out[3].base().name, "fourth");
+    }
+
+    /// An empty compiled file translates to an empty vec without error.
+    #[test]
+    fn prepare_empty_file_returns_empty_vec() {
+        let file = CompiledFile {
+            version: 2,
+            entries: vec![],
+        };
+        let out = prepare(file).expect("empty file must translate cleanly");
+        assert!(out.is_empty());
+    }
+
+    // -- phase_offset / clock_group carry-through ---------------------------
+
+    /// phase_offset is passed through as a string — the translator never
+    /// parses it (that is `prepare_entries`'s job).
+    #[test]
+    fn phase_offset_string_is_passed_through_verbatim() {
+        let mut entry = metrics_compiled("delayed");
+        entry.phase_offset = Some("152.308s".to_string());
+        let out = prepare(file_with(entry)).expect("translate");
+        assert_eq!(out[0].phase_offset(), Some("152.308s"));
+    }
+
+    /// clock_group passes through unchanged on every variant.
+    #[test]
+    fn clock_group_is_passed_through_on_all_variants() {
+        for factory in [
+            metrics_compiled as fn(&str) -> CompiledEntry,
+            logs_compiled,
+            histogram_compiled,
+            summary_compiled,
+        ] {
+            let mut entry = factory("any");
+            entry.clock_group = Some("chain_alpha".to_string());
+            let out = prepare(file_with(entry)).expect("translate");
+            assert_eq!(out[0].clock_group(), Some("chain_alpha"));
+        }
+    }
+
+    // -- Labels conversion --------------------------------------------------
+
+    /// Every (key, value) pair from the BTreeMap appears in the resulting
+    /// HashMap.
+    #[test]
+    fn labels_btree_to_hash_preserves_all_pairs() {
+        let mut labels = BTreeMap::new();
+        labels.insert("k1".to_string(), "v1".to_string());
+        labels.insert("k2".to_string(), "v2".to_string());
+        labels.insert("k3".to_string(), "v3".to_string());
+
+        let mut entry = metrics_compiled("labeled");
+        entry.labels = Some(labels.clone());
+
+        let out = prepare(file_with(entry)).expect("translate");
+        let hm = out[0]
+            .base()
+            .labels
+            .as_ref()
+            .expect("labels must carry through");
+        assert_eq!(hm.len(), labels.len());
+        for (k, v) in &labels {
+            assert_eq!(hm.get(k).map(String::as_str), Some(v.as_str()));
+        }
+    }
+
+    /// An empty `labels: Some(BTreeMap::new())` survives as
+    /// `Some(HashMap::new())` (the shape semantically differs from `None`).
+    #[test]
+    fn labels_empty_btree_maps_to_empty_hash() {
+        let mut entry = metrics_compiled("empty_labels");
+        entry.labels = Some(BTreeMap::new());
+        let out = prepare(file_with(entry)).expect("translate");
+        let hm = out[0].base().labels.as_ref().expect("Some stays Some");
+        assert!(hm.is_empty());
+    }
+
+    /// `labels: None` on the compiled entry survives as `None` on the
+    /// scenario entry.
+    #[test]
+    fn labels_none_stays_none() {
+        let entry = metrics_compiled("no_labels");
+        let out = prepare(file_with(entry)).expect("translate");
+        assert!(out[0].base().labels.is_none());
+    }
+
+    // -- observations_per_tick widening --------------------------------------
+
+    /// `observations_per_tick: Some(0u32)` widens to `Some(0u64)` without
+    /// clamping or overflow on histograms.
+    #[test]
+    fn histogram_observations_per_tick_widens_zero_correctly() {
+        let mut entry = histogram_compiled("zero_obs");
+        entry.observations_per_tick = Some(0);
+        let out = prepare(file_with(entry)).expect("translate");
+        match &out[0] {
+            ScenarioEntry::Histogram(c) => {
+                assert_eq!(c.observations_per_tick, Some(0u64));
+            }
+            _ => panic!("expected Histogram"),
+        }
+    }
+
+    /// `observations_per_tick: Some(u32::MAX)` widens to `Some(4_294_967_295u64)`
+    /// on histograms — no sign extension surprises.
+    #[test]
+    fn histogram_observations_per_tick_widens_u32_max_correctly() {
+        let mut entry = histogram_compiled("max_obs");
+        entry.observations_per_tick = Some(u32::MAX);
+        let out = prepare(file_with(entry)).expect("translate");
+        match &out[0] {
+            ScenarioEntry::Histogram(c) => {
+                assert_eq!(c.observations_per_tick, Some(u64::from(u32::MAX)));
+                assert_eq!(c.observations_per_tick, Some(4_294_967_295_u64));
+            }
+            _ => panic!("expected Histogram"),
+        }
+    }
+
+    /// The same widening holds for summary entries.
+    #[test]
+    fn summary_observations_per_tick_widens_u32_max_correctly() {
+        let mut entry = summary_compiled("max_obs_summary");
+        entry.observations_per_tick = Some(u32::MAX);
+        let out = prepare(file_with(entry)).expect("translate");
+        match &out[0] {
+            ScenarioEntry::Summary(c) => {
+                assert_eq!(c.observations_per_tick, Some(u64::from(u32::MAX)));
+            }
+            _ => panic!("expected Summary"),
+        }
+    }
+
+    // -- Error cases --------------------------------------------------------
+
+    /// An unknown `signal_type` string produces `UnknownSignalType` with the
+    /// offending value surfaced.
+    #[test]
+    fn unknown_signal_type_produces_unknown_signal_type_error() {
+        let mut entry = bare("traces", "bad");
+        entry.id = Some("bad".to_string());
+        let err = prepare(file_with(entry)).expect_err("unknown signal_type must fail");
+        match err {
+            PrepareError::UnknownSignalType {
+                entry_label,
+                signal_type,
+            } => {
+                assert_eq!(entry_label, "bad");
+                assert_eq!(signal_type, "traces");
+            }
+            other => panic!("expected UnknownSignalType, got {other:?}"),
+        }
+    }
+
+    /// The `entry_label` falls back to `name` when `id` is absent.
+    #[test]
+    fn unknown_signal_type_falls_back_to_name_when_id_absent() {
+        let entry = bare("traces", "bad_by_name");
+        let err = prepare(file_with(entry)).expect_err("unknown signal_type must fail");
+        match err {
+            PrepareError::UnknownSignalType { entry_label, .. } => {
+                assert_eq!(entry_label, "bad_by_name");
+            }
+            other => panic!("expected UnknownSignalType, got {other:?}"),
+        }
+    }
+
+    /// A metrics entry missing `generator` produces `MissingGenerator` with
+    /// the entry label.
+    #[test]
+    fn metrics_without_generator_produces_missing_generator_error() {
+        let mut entry = bare("metrics", "no_gen");
+        entry.id = Some("no_gen".to_string());
+        // generator deliberately left None
+        let err = prepare(file_with(entry)).expect_err("missing generator must fail");
+        match err {
+            PrepareError::MissingGenerator { entry_label } => {
+                assert_eq!(entry_label, "no_gen");
+            }
+            other => panic!("expected MissingGenerator, got {other:?}"),
+        }
+    }
+
+    /// A logs entry missing `log_generator` produces `MissingLogGenerator`.
+    #[test]
+    fn logs_without_log_generator_produces_missing_log_generator_error() {
+        let entry = bare("logs", "no_log_gen");
+        let err = prepare(file_with(entry)).expect_err("missing log_generator must fail");
+        match err {
+            PrepareError::MissingLogGenerator { entry_label } => {
+                assert_eq!(entry_label, "no_log_gen");
+            }
+            other => panic!("expected MissingLogGenerator, got {other:?}"),
+        }
+    }
+
+    /// A histogram entry missing `distribution` produces `MissingDistribution`
+    /// with `signal_type: "histogram"`.
+    #[test]
+    fn histogram_without_distribution_produces_missing_distribution_error() {
+        let entry = bare("histogram", "no_dist_hist");
+        let err = prepare(file_with(entry)).expect_err("missing distribution must fail");
+        match err {
+            PrepareError::MissingDistribution {
+                entry_label,
+                signal_type,
+            } => {
+                assert_eq!(entry_label, "no_dist_hist");
+                assert_eq!(signal_type, "histogram");
+            }
+            other => panic!("expected MissingDistribution, got {other:?}"),
+        }
+    }
+
+    /// A summary entry missing `distribution` produces `MissingDistribution`
+    /// with `signal_type: "summary"`.
+    #[test]
+    fn summary_without_distribution_produces_missing_distribution_error() {
+        let entry = bare("summary", "no_dist_summary");
+        let err = prepare(file_with(entry)).expect_err("missing distribution must fail");
+        match err {
+            PrepareError::MissingDistribution {
+                entry_label,
+                signal_type,
+            } => {
+                assert_eq!(entry_label, "no_dist_summary");
+                assert_eq!(signal_type, "summary");
+            }
+            other => panic!("expected MissingDistribution, got {other:?}"),
+        }
+    }
+
+    /// Rstest matrix covering every signal_type whose shape-invariant can
+    /// fail when the required generator/distribution field is absent.
+    #[rustfmt::skip]
+    #[rstest]
+    #[case::metrics("metrics")]
+    #[case::logs("logs")]
+    #[case::histogram("histogram")]
+    #[case::summary("summary")]
+    fn missing_required_field_fails_per_signal_type(#[case] signal_type: &str) {
+        let entry = bare(signal_type, "empty_shape");
+        let res = prepare(file_with(entry));
+        assert!(
+            res.is_err(),
+            "signal_type '{signal_type}' missing required field must error"
+        );
+    }
+
+    // -- First-error propagation --------------------------------------------
+
+    /// `prepare` surfaces the FIRST failing entry's error, leaving later
+    /// entries unevaluated. Callers cannot observe partial output.
+    #[test]
+    fn prepare_fails_fast_on_first_bad_entry() {
+        let file = CompiledFile {
+            version: 2,
+            entries: vec![
+                metrics_compiled("ok_1"),
+                bare("traces", "bad"),
+                metrics_compiled("ok_2"),
+            ],
+        };
+        let err = prepare(file).expect_err("bad entry in middle must fail");
+        assert!(
+            matches!(err, PrepareError::UnknownSignalType { .. }),
+            "middle bad entry must produce UnknownSignalType, got {err:?}"
+        );
+    }
+
+    // -- Contract: PrepareError is Send + Sync ------------------------------
+
+    #[test]
+    fn prepare_error_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<PrepareError>();
+    }
+}

--- a/sonda-core/src/compiler/prepare.rs
+++ b/sonda-core/src/compiler/prepare.rs
@@ -755,20 +755,50 @@ mod tests {
         }
     }
 
+    /// Which `PrepareError` variant a missing-required-field shape must
+    /// produce. Indexes the rstest matrix below: `metrics` -> generator,
+    /// `logs` -> log_generator, `histogram`/`summary` -> distribution.
+    #[derive(Debug, Clone, Copy)]
+    enum ExpectedMissing {
+        Generator,
+        LogGenerator,
+        Distribution,
+    }
+
     /// Rstest matrix covering every signal_type whose shape-invariant can
     /// fail when the required generator/distribution field is absent.
+    /// Each case asserts the exact `PrepareError` variant — strengthening
+    /// the previous `is_err()` smoke check.
     #[rustfmt::skip]
     #[rstest]
-    #[case::metrics("metrics")]
-    #[case::logs("logs")]
-    #[case::histogram("histogram")]
-    #[case::summary("summary")]
-    fn missing_required_field_fails_per_signal_type(#[case] signal_type: &str) {
+    #[case::metrics("metrics", ExpectedMissing::Generator)]
+    #[case::logs("logs", ExpectedMissing::LogGenerator)]
+    #[case::histogram("histogram", ExpectedMissing::Distribution)]
+    #[case::summary("summary", ExpectedMissing::Distribution)]
+    fn missing_required_field_fails_per_signal_type(
+        #[case] signal_type: &str,
+        #[case] expected: ExpectedMissing,
+    ) {
         let entry = bare(signal_type, "empty_shape");
-        let res = prepare(file_with(entry));
+        let err = prepare(file_with(entry)).err().unwrap_or_else(|| {
+            panic!("signal_type '{signal_type}' missing required field must error")
+        });
+        let matched = match expected {
+            ExpectedMissing::Generator => {
+                matches!(err, PrepareError::MissingGenerator { ref entry_label } if entry_label == "empty_shape")
+            }
+            ExpectedMissing::LogGenerator => {
+                matches!(err, PrepareError::MissingLogGenerator { ref entry_label } if entry_label == "empty_shape")
+            }
+            ExpectedMissing::Distribution => matches!(
+                err,
+                PrepareError::MissingDistribution { ref entry_label, signal_type: ref st }
+                if entry_label == "empty_shape" && st == signal_type
+            ),
+        };
         assert!(
-            res.is_err(),
-            "signal_type '{signal_type}' missing required field must error"
+            matched,
+            "signal_type '{signal_type}': expected {expected:?}, got {err:?}"
         );
     }
 

--- a/sonda-core/src/compiler/prepare.rs
+++ b/sonda-core/src/compiler/prepare.rs
@@ -67,6 +67,12 @@ pub enum PrepareError {
     },
 
     /// A metrics entry had no `generator` field set.
+    ///
+    /// `signal_type: metrics` is the only variant that reads `generator`
+    /// from the compiled entry. When the YAML path is used the parser
+    /// rejects a metrics entry missing `generator` at parse-time; reaching
+    /// this variant therefore implies the [`CompiledFile`] was built in
+    /// code rather than through [`parse`][crate::compiler::parse::parse].
     #[error("entry '{entry_label}' (signal_type: metrics): missing required field 'generator'")]
     MissingGenerator {
         /// The entry's id (or name when id is absent).
@@ -74,6 +80,13 @@ pub enum PrepareError {
     },
 
     /// A logs entry had no `log_generator` field set.
+    ///
+    /// `signal_type: logs` is the only variant that reads `log_generator`
+    /// from the compiled entry. When the YAML path is used the parser
+    /// rejects a logs entry missing `log_generator` at parse-time;
+    /// reaching this variant therefore implies the [`CompiledFile`] was
+    /// built in code rather than through
+    /// [`parse`][crate::compiler::parse::parse].
     #[error("entry '{entry_label}' (signal_type: logs): missing required field 'log_generator'")]
     MissingLogGenerator {
         /// The entry's id (or name when id is absent).
@@ -81,6 +94,13 @@ pub enum PrepareError {
     },
 
     /// A histogram or summary entry had no `distribution` field set.
+    ///
+    /// `signal_type: histogram` and `signal_type: summary` both read
+    /// `distribution` from the compiled entry. When the YAML path is used
+    /// the parser rejects either shape missing `distribution` at
+    /// parse-time; reaching this variant therefore implies the
+    /// [`CompiledFile`] was built in code rather than through
+    /// [`parse`][crate::compiler::parse::parse].
     #[error(
         "entry '{entry_label}' (signal_type: {signal_type}): missing required field 'distribution'"
     )]
@@ -89,6 +109,18 @@ pub enum PrepareError {
         entry_label: String,
         /// The signal type that requires a distribution (`"histogram"` or `"summary"`).
         signal_type: String,
+    },
+
+    /// The compiled file's `version` was not `2`.
+    ///
+    /// Defense-in-depth against programmatic callers that construct a
+    /// [`CompiledFile`] in code with a non-v2 version. Going through
+    /// [`parse`][crate::compiler::parse::parse] already pins the version
+    /// at parse-time, so this variant is unreachable via the YAML path.
+    #[error("unsupported compiled file version: expected 2, got {version}")]
+    UnsupportedVersion {
+        /// The rejected version value as carried by the compiled file.
+        version: u32,
     },
 }
 
@@ -104,15 +136,21 @@ pub enum PrepareError {
 /// by this function takes the same hot path as if it had been constructed
 /// directly by the v1 loader.
 ///
-/// Field-by-field mapping lives in the variant-specific helpers
-/// ([`metrics_entry`], [`logs_entry`], [`histogram_entry`],
-/// [`summary_entry`]). Each helper consumes its [`CompiledEntry`] by value so
-/// no deep clone is performed on the generator or label maps.
+/// Field-by-field mapping lives in per-variant helpers; see the module
+/// source for the exact wiring. Each helper consumes its [`CompiledEntry`]
+/// by value so no deep clone is performed on the generator or label maps.
+///
+/// `CompiledEntry::id` is intentionally dropped during translation: its
+/// job ended in Phase 4+5's dependency resolution, and [`ScenarioEntry`]
+/// has no `id` field. Future observability wiring that wants to correlate
+/// runtime back to v2 ids will need another channel (e.g. a side map keyed
+/// on `name` + `clock_group`).
 ///
 /// # Errors
 ///
 /// Returns [`PrepareError`] on the first entry that fails translation:
 ///
+/// - [`PrepareError::UnsupportedVersion`] if `file.version` is not `2`.
 /// - [`PrepareError::UnknownSignalType`] when `signal_type` is not one of
 ///   `"metrics"`, `"logs"`, `"histogram"`, or `"summary"`.
 /// - [`PrepareError::MissingGenerator`] for a metrics entry missing `generator`.
@@ -120,13 +158,13 @@ pub enum PrepareError {
 /// - [`PrepareError::MissingDistribution`] for a histogram/summary entry
 ///   missing `distribution`.
 ///
-/// The shorter-circuiting semantics match the v2 compiler's other passes —
+/// The short-circuiting semantics match the v2 compiler's other passes —
 /// no partial output is returned on failure.
 pub fn prepare(file: CompiledFile) -> Result<Vec<ScenarioEntry>, PrepareError> {
-    let CompiledFile {
-        version: _,
-        entries,
-    } = file;
+    let CompiledFile { version, entries } = file;
+    if version != 2 {
+        return Err(PrepareError::UnsupportedVersion { version });
+    }
     let mut out = Vec::with_capacity(entries.len());
     for entry in entries {
         out.push(translate_entry(entry)?);
@@ -761,5 +799,38 @@ mod tests {
     fn prepare_error_is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<PrepareError>();
+    }
+
+    // -- Version gate -------------------------------------------------------
+
+    /// A [`CompiledFile`] with a non-v2 version is rejected with
+    /// [`PrepareError::UnsupportedVersion`] carrying the offending value.
+    #[test]
+    fn prepare_rejects_non_v2_version() {
+        let file = CompiledFile {
+            version: 3,
+            entries: vec![metrics_compiled("never_translated")],
+        };
+        let err = prepare(file).expect_err("version != 2 must fail");
+        match err {
+            PrepareError::UnsupportedVersion { version } => assert_eq!(version, 3),
+            other => panic!("expected UnsupportedVersion, got {other:?}"),
+        }
+    }
+
+    /// The `UnsupportedVersion` check fires before any entry-level
+    /// translation, so a bogus version with an otherwise-invalid entry
+    /// surfaces the version error (not the entry error).
+    #[test]
+    fn prepare_version_check_precedes_entry_translation() {
+        let file = CompiledFile {
+            version: 0,
+            entries: vec![bare("traces", "would_fail_if_translated")],
+        };
+        let err = prepare(file).expect_err("version 0 must fail");
+        assert!(
+            matches!(err, PrepareError::UnsupportedVersion { version: 0 }),
+            "expected UnsupportedVersion {{ version: 0 }}, got {err:?}"
+        );
     }
 }

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -39,6 +39,15 @@ pub use schedule::handle::ScenarioHandle;
 pub use schedule::launch::{launch_scenario, prepare_entries, validate_entry, PreparedEntry};
 pub use schedule::stats::ScenarioStats;
 
+#[cfg(feature = "config")]
+pub use compiler::prepare::PrepareError;
+
+#[cfg(feature = "config")]
+pub use compile::{compile_scenario_file, CompileError};
+
+#[cfg(feature = "config")]
+mod compile;
+
 /// Top-level error type for sonda-core.
 ///
 /// Each variant delegates to a typed sub-enum that preserves the original

--- a/sonda-core/tests/common/mod.rs
+++ b/sonda-core/tests/common/mod.rs
@@ -212,6 +212,20 @@ impl Sink for CapturingSink {
 /// Multi-entry output order is **not** deterministic — concurrent threads
 /// interleave writes at byte granularity. For multi-signal parity tests,
 /// compare via [`assert_line_multisets_equal`].
+///
+/// # Shutdown caveat
+///
+/// Unlike production
+/// [`launch_scenario`][sonda_core::schedule::launch::launch_scenario]
+/// — which polls a shared `Arc<AtomicBool>` every 50 ms during the
+/// `start_delay` window so an external stop signal can short-circuit the
+/// pre-roll — this harness only sleeps until the deadline elapses. It
+/// does **not** honor a shutdown signal during `start_delay`, and the
+/// runner threads are driven with `shutdown: None` thereafter. Every
+/// current call site is bounded by the scenario's own `duration:` field
+/// and never needs cancellation, so this is safe today; future callers
+/// that need cooperative cancellation must extend the harness rather
+/// than rely on it.
 pub fn run_and_capture_stdout(entries: Vec<ScenarioEntry>) -> Vec<u8> {
     let prepared =
         prepare_entries(entries).expect("run_and_capture_stdout: prepare_entries must succeed");
@@ -425,4 +439,51 @@ pub fn snapshot_settings() -> insta::Settings {
     let mut s = insta::Settings::clone_current();
     s.set_sort_maps(true);
     s
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+//
+// Note: this `tests/common/mod.rs` module is included by every integration
+// test that declares `mod common;`, so any `#[test]` here runs once per
+// containing binary. The two cases below are tiny, deterministic regression
+// anchors — that small amount of duplication is acceptable to keep them
+// next to the helper they describe.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Prometheus text exposition: only the trailing 13-digit millisecond
+    /// timestamp is replaced; metric name, labels, and the value `42` are
+    /// preserved byte-for-byte.
+    #[test]
+    fn normalize_timestamps_replaces_only_prometheus_trailing_millis() {
+        let input = b"my_metric{foo=\"bar\"} 42 1712345678901\n";
+        let out = normalize_timestamps(input);
+        let expected = b"my_metric{foo=\"bar\"} 42 ___TS___\n";
+        assert_eq!(
+            out,
+            expected,
+            "got: {:?}",
+            String::from_utf8_lossy(&out).into_owned()
+        );
+    }
+
+    /// JSON Lines: only the value of the `"timestamp":"..."` field is
+    /// replaced; sibling fields (`msg`, `n`) and their values pass through
+    /// unchanged.
+    #[test]
+    fn normalize_timestamps_replaces_only_json_timestamp_value() {
+        let input = b"{\"timestamp\":\"2026-04-13T12:34:56.789Z\",\"msg\":\"hello\",\"n\":42}\n";
+        let out = normalize_timestamps(input);
+        let expected = b"{\"timestamp\":\"___TS___\",\"msg\":\"hello\",\"n\":42}\n";
+        assert_eq!(
+            out,
+            expected,
+            "got: {:?}",
+            String::from_utf8_lossy(&out).into_owned()
+        );
+    }
 }

--- a/sonda-core/tests/common/mod.rs
+++ b/sonda-core/tests/common/mod.rs
@@ -263,6 +263,71 @@ pub fn run_and_capture_stdout(entries: Vec<ScenarioEntry>) -> Vec<u8> {
     result
 }
 
+/// Normalize timestamps embedded in encoded metric / log output so that
+/// two runs can be compared byte-for-byte.
+///
+/// Every encoder emits a wall-clock timestamp: Prometheus text encodes
+/// it as an integer `ms-since-epoch` trailing each sample line, while JSON
+/// Lines embeds an RFC 3339 `"timestamp":"..."` field. This helper rewrites
+/// all such tokens to fixed sentinels so parity tests do not fail on
+/// clock-drift between v1 and v2 runs.
+///
+/// The replacement is intentionally aggressive — it normalizes:
+///
+/// - any run of 11–19 digits immediately followed by `\n` (Prometheus text
+///   millisecond epoch timestamps) to `___TS___\n`,
+/// - any `"timestamp":"...Z"` JSON field to `"timestamp":"___TS___"`.
+///
+/// Non-timestamp substrings that match these shapes do not appear in
+/// sonda's encoder output; see the unit tests for the encoders in
+/// `src/encoder/` for the exact byte patterns.
+pub fn normalize_timestamps(bytes: &[u8]) -> Vec<u8> {
+    // Phase 1: replace Prometheus ` <ts_ms>\n` trailers.
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let rest = &bytes[i..];
+        // Look for ` <digits>\n` pattern (Prometheus trailing timestamp).
+        if rest[0] == b' ' {
+            let after_space = &rest[1..];
+            let mut digit_end = 0;
+            while digit_end < after_space.len() && after_space[digit_end].is_ascii_digit() {
+                digit_end += 1;
+            }
+            if digit_end >= 11 && digit_end <= 19 && after_space.get(digit_end) == Some(&b'\n') {
+                out.extend_from_slice(b" ___TS___\n");
+                i += 1 + digit_end + 1;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+
+    // Phase 2: normalize JSON `"timestamp":"...Z"` fields.
+    let bytes = out;
+    let mut out = Vec::with_capacity(bytes.len());
+    let needle = b"\"timestamp\":\"";
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes.len() - i >= needle.len() && &bytes[i..i + needle.len()] == needle {
+            // Emit the needle, then scan ahead for the closing quote.
+            out.extend_from_slice(b"\"timestamp\":\"___TS___\"");
+            let scan_start = i + needle.len();
+            let mut j = scan_start;
+            while j < bytes.len() && bytes[j] != b'"' {
+                j += 1;
+            }
+            // Skip past the closing `"`.
+            i = j.saturating_add(1);
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
 /// Dispatch a single `ScenarioEntry` to the runner matching its variant.
 ///
 /// The runner is driven with `shutdown: None` (the scenario's own

--- a/sonda-core/tests/common/mod.rs
+++ b/sonda-core/tests/common/mod.rs
@@ -20,13 +20,25 @@
 #![cfg(feature = "config")]
 #![allow(dead_code)]
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use sonda_core::compiler::compile_after::{compile_after, CompiledFile};
 use sonda_core::compiler::expand::{expand, ExpandedFile, InMemoryPackResolver};
 use sonda_core::compiler::normalize::normalize;
 use sonda_core::compiler::parse::parse;
 use sonda_core::packs::MetricPackDef;
+use sonda_core::prepare_entries;
+use sonda_core::schedule::histogram_runner;
+use sonda_core::schedule::log_runner;
+use sonda_core::schedule::runner;
+use sonda_core::schedule::summary_runner;
+use sonda_core::sink::Sink;
+use sonda_core::{ScenarioEntry, SondaError};
 
 // -----------------------------------------------------------------------------
 // Paths
@@ -130,6 +142,207 @@ pub fn compile_to_expanded(yaml: &str, resolver: &InMemoryPackResolver) -> Expan
 pub fn compile_to_compiled(yaml: &str, resolver: &InMemoryPackResolver) -> CompiledFile {
     let expanded = compile_to_expanded(yaml, resolver);
     compile_after(expanded).expect("fixture must compile after")
+}
+
+// -----------------------------------------------------------------------------
+// Snapshot settings
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+// Runtime parity harness
+// -----------------------------------------------------------------------------
+
+/// An in-memory [`Sink`] that appends every byte written to a shared buffer.
+///
+/// Duplicated (tiny) from `sonda_core::sink::memory::MemorySink` so the
+/// parity harness can push an `Arc<Mutex<Vec<u8>>>` through the closure
+/// boundary and drain the captured bytes after the runner thread joins —
+/// `MemorySink` owns its buffer directly and does not expose the shared
+/// ownership the harness needs.
+struct CapturingSink {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Sink for CapturingSink {
+    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        let mut guard = self
+            .buffer
+            .lock()
+            .expect("parity harness buffer lock poisoned");
+        guard.extend_from_slice(data);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), SondaError> {
+        Ok(())
+    }
+}
+
+/// Run every entry in `entries` to completion against an in-memory sink,
+/// returning the raw concatenated stdout-equivalent bytes.
+///
+/// The harness mirrors a trimmed-down version of `launch_scenario`:
+///
+/// 1. `prepare_entries` expands csv_replay, desugars aliases, validates
+///    every entry, and resolves each entry's `phase_offset` into a
+///    `start_delay: Option<Duration>` — exactly the same preparation the
+///    production launcher does.
+/// 2. Each prepared entry runs on its own OS thread with a
+///    [`CapturingSink`] substituted for the user-configured sink. The
+///    shared `Arc<Mutex<Vec<u8>>>` is cloned into the thread so the parent
+///    can drain bytes after the thread joins.
+/// 3. Each thread honors its `start_delay` via `thread::sleep` (no shared
+///    shutdown signal — the scenario's own `duration:` field bounds the
+///    run, which must be set on every entry this harness sees).
+///
+/// The returned `Vec<u8>` is the raw byte stream a real stdout sink would
+/// have produced. Callers choose `assert_eq!` or a line-multiset comparison
+/// depending on whether order is deterministic for their scenario.
+///
+/// # Panics
+///
+/// Panics if `prepare_entries` fails, if a runner thread panics, or if a
+/// runner returns an error. For parity tests these are all bugs, not
+/// legitimate test outcomes.
+///
+/// # Determinism
+///
+/// All seeds, jitter seeds, and `seed:` fields must be pinned by the
+/// caller's configuration. The harness does not inject any randomness.
+/// Multi-entry output order is **not** deterministic — concurrent threads
+/// interleave writes at byte granularity. For multi-signal parity tests,
+/// compare via [`assert_line_multisets_equal`].
+pub fn run_and_capture_stdout(entries: Vec<ScenarioEntry>) -> Vec<u8> {
+    let prepared =
+        prepare_entries(entries).expect("run_and_capture_stdout: prepare_entries must succeed");
+
+    let mut handles = Vec::with_capacity(prepared.len());
+    for (idx, prepared_entry) in prepared.into_iter().enumerate() {
+        let buffer = Arc::new(Mutex::new(Vec::<u8>::with_capacity(4096)));
+        let buffer_for_thread = Arc::clone(&buffer);
+        let start_delay = prepared_entry.start_delay;
+        let entry = prepared_entry.entry;
+
+        // Each runner needs a `'static` closure, so move ownership into the thread.
+        let handle = thread::Builder::new()
+            .name(format!("parity-{idx}"))
+            .spawn(move || -> Result<(), SondaError> {
+                if let Some(delay) = start_delay {
+                    let deadline = Instant::now() + delay;
+                    while Instant::now() < deadline {
+                        let remaining = deadline.saturating_duration_since(Instant::now());
+                        let chunk = remaining.min(Duration::from_millis(25));
+                        if chunk > Duration::ZERO {
+                            thread::sleep(chunk);
+                        }
+                    }
+                }
+
+                let mut sink = CapturingSink {
+                    buffer: buffer_for_thread,
+                };
+                run_entry_with_sink(&entry, &mut sink)
+            })
+            .expect("failed to spawn parity harness thread");
+
+        handles.push((handle, buffer));
+    }
+
+    // Join in order. Each thread's scenario-level `duration:` bounds the
+    // run, so joining sequentially is fine — every thread exits naturally.
+    let mut result = Vec::new();
+    for (handle, buffer) in handles {
+        handle
+            .join()
+            .expect("parity harness thread panicked")
+            .expect("parity harness runner returned an error");
+        let mut guard = buffer.lock().expect("buffer lock poisoned");
+        result.extend_from_slice(&guard);
+        guard.clear();
+    }
+    result
+}
+
+/// Dispatch a single `ScenarioEntry` to the runner matching its variant.
+///
+/// The runner is driven with `shutdown: None` (the scenario's own
+/// `duration:` field bounds the run) and `stats: None` (parity tests do
+/// not inspect stats).
+fn run_entry_with_sink(entry: &ScenarioEntry, sink: &mut dyn Sink) -> Result<(), SondaError> {
+    // All four runners take the same shape: &Config, &mut dyn Sink,
+    // Option<&AtomicBool>, Option<Arc<RwLock<ScenarioStats>>>.
+    const NONE_ATOMIC: Option<&AtomicBool> = None;
+    match entry {
+        ScenarioEntry::Metrics(config) => runner::run_with_sink(config, sink, NONE_ATOMIC, None),
+        ScenarioEntry::Logs(config) => {
+            log_runner::run_logs_with_sink(config, sink, NONE_ATOMIC, None)
+        }
+        ScenarioEntry::Histogram(config) => {
+            histogram_runner::run_with_sink(config, sink, NONE_ATOMIC, None)
+        }
+        ScenarioEntry::Summary(config) => {
+            summary_runner::run_with_sink(config, sink, NONE_ATOMIC, None)
+        }
+    }
+}
+
+/// Assert that two byte streams contain the same set of newline-delimited
+/// lines, ignoring order.
+///
+/// Used for multi-signal parity tests where runner threads interleave
+/// output nondeterministically. Both sides must produce the same *set* of
+/// lines — duplicates are preserved (comparison is multiset, not set).
+///
+/// # Panics
+///
+/// Panics with a detailed diff-like report if the line multisets differ.
+pub fn assert_line_multisets_equal(label: &str, expected: &[u8], actual: &[u8]) {
+    let expected_lines: Vec<&[u8]> = split_lines_preserve_empty(expected);
+    let actual_lines: Vec<&[u8]> = split_lines_preserve_empty(actual);
+
+    let mut expected_sorted: Vec<Vec<u8>> = expected_lines.iter().map(|l| l.to_vec()).collect();
+    let mut actual_sorted: Vec<Vec<u8>> = actual_lines.iter().map(|l| l.to_vec()).collect();
+    expected_sorted.sort();
+    actual_sorted.sort();
+
+    if expected_sorted != actual_sorted {
+        // Build human-readable diagnostics.
+        let expected_set: BTreeSet<&[u8]> = expected_sorted.iter().map(Vec::as_slice).collect();
+        let actual_set: BTreeSet<&[u8]> = actual_sorted.iter().map(Vec::as_slice).collect();
+        let only_in_expected: Vec<String> = expected_set
+            .difference(&actual_set)
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+            .collect();
+        let only_in_actual: Vec<String> = actual_set
+            .difference(&expected_set)
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+            .collect();
+        panic!(
+            "{label}: line multisets differ\n\
+             expected {} lines, got {} lines\n\
+             only in expected:\n  {}\n\
+             only in actual:\n  {}",
+            expected_sorted.len(),
+            actual_sorted.len(),
+            only_in_expected.join("\n  "),
+            only_in_actual.join("\n  ")
+        );
+    }
+}
+
+/// Split a byte slice on `\n`, preserving empty leading/trailing lines so
+/// the multiset comparison is exact.
+fn split_lines_preserve_empty(bytes: &[u8]) -> Vec<&[u8]> {
+    if bytes.is_empty() {
+        return Vec::new();
+    }
+    let mut lines: Vec<&[u8]> = bytes.split(|&b| b == b'\n').collect();
+    // `split` yields a trailing empty slice when the input ends with `\n`;
+    // drop it so the line count reflects actual emitted lines.
+    if lines.last().is_some_and(|l| l.is_empty()) {
+        lines.pop();
+    }
+    lines
 }
 
 // -----------------------------------------------------------------------------

--- a/sonda-core/tests/fixtures/v2-parity/burst-only.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/burst-only.yaml
@@ -1,0 +1,21 @@
+version: 2
+
+scenarios:
+  - signal_type: logs
+    name: burst_logs
+    rate: 5
+    duration: 2m
+    log_generator:
+      type: template
+      templates:
+        - message: "event"
+          field_pools: {}
+      seed: 0
+    bursts:
+      every: 20s
+      for: 5s
+      multiplier: 10.0
+    encoder:
+      type: json_lines
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/burst-only.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/burst-only.yaml
@@ -1,3 +1,6 @@
+# Hand-written translator probe (no v1 built-in mirrors it); closes matrix
+# row 7.2 — `bursts` window settings (every/for/multiplier) must round-trip
+# unchanged through the v2 translator on a log-signal entry.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/cardinality-explosion.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/cardinality-explosion.yaml
@@ -1,3 +1,6 @@
+# Parity equivalent of `scenarios/cardinality-explosion.yaml`; closes
+# matrix row 16.10. Exercises a cardinality_spike window on a sine-driven
+# container CPU metric.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/cardinality-explosion.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/cardinality-explosion.yaml
@@ -1,0 +1,27 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: container_cpu_usage_seconds_total
+    rate: 5
+    duration: 500ms
+    generator:
+      type: sine
+      amplitude: 0.3
+      period_secs: 60
+      offset: 0.5
+    labels:
+      namespace: production
+      container: worker
+      job: kubelet
+    cardinality_spikes:
+      - label: pod_name
+        every: 60s
+        for: 20s
+        cardinality: 500
+        strategy: counter
+        prefix: "worker-"
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/cpu-spike.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/cpu-spike.yaml
@@ -1,0 +1,21 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: node_cpu_usage_percent
+    rate: 1
+    duration: 1s
+    generator:
+      type: spike_event
+      baseline: 35.0
+      spike_height: 60.0
+      spike_duration: "10s"
+      spike_interval: "30s"
+    labels:
+      instance: web-01
+      job: node_exporter
+      cpu: "0"
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/cpu-spike.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/cpu-spike.yaml
@@ -1,3 +1,6 @@
+# Parity equivalent of `scenarios/cpu-spike.yaml`; closes matrix row 16.1.
+# Runtime parity harness in `v2_runtime_parity.rs` asserts byte-equal stdout
+# between v1 load and v2 compile on a 1s window.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/csv-replay-columns.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/csv-replay-columns.yaml
@@ -1,3 +1,8 @@
+# Hand-written translator probe (no v1 built-in mirrors it); closes matrix
+# rows 2.9 + 2.10 — `csv_replay` multi-column spec (per-column index, name,
+# labels) must thread unchanged through the v2 translator. The `file:` path
+# is intentionally a non-existent stub: the translator-semantic test only
+# inspects compiled shape and never opens the file.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/csv-replay-columns.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/csv-replay-columns.yaml
@@ -1,0 +1,27 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: system_metrics
+    rate: 1
+    duration: 1s
+    generator:
+      type: csv_replay
+      file: /tmp/fake-for-translator-semantic-test.csv
+      columns:
+        - index: 1
+          name: cpu_usage
+          labels:
+            kind: cpu
+        - index: 2
+          name: mem_usage
+          labels:
+            kind: memory
+      repeat: true
+    labels:
+      instance: prod-server-42
+      job: node
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/disk-fill.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/disk-fill.yaml
@@ -1,0 +1,21 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: node_disk_used_bytes
+    rate: 1
+    duration: 1s
+    generator:
+      type: step
+      start: 100000000000
+      step_size: 500000000
+      max: 500000000000
+    labels:
+      instance: db-server-01
+      job: node_exporter
+      device: "/dev/sda1"
+      mountpoint: "/data"
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/disk-fill.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/disk-fill.yaml
@@ -1,3 +1,5 @@
+# Parity equivalent of `scenarios/disk-fill.yaml`; closes matrix row 16.3.
+# Drives `step` to mimic monotonically growing disk usage.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/encoder-precision.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/encoder-precision.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: rounded_value
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 3.141592653589793
+    encoder:
+      type: prometheus_text
+      precision: 3
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/encoder-precision.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/encoder-precision.yaml
@@ -1,3 +1,6 @@
+# Hand-written translator probe (no v1 built-in mirrors it); closes matrix
+# row 5.7 — the optional encoder `precision:` field must round-trip unchanged
+# through the v2 translator.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/error-rate-spike.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/error-rate-spike.yaml
@@ -1,0 +1,23 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: http_requests_errors_total
+    rate: 2
+    duration: 1s
+    generator:
+      type: spike
+      baseline: 2.0
+      magnitude: 48.0
+      duration_secs: 5
+      interval_secs: 20
+    labels:
+      instance: api-server-01
+      job: app
+      status: "500"
+      method: POST
+      handler: "/api/v1/ingest"
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/error-rate-spike.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/error-rate-spike.yaml
@@ -1,3 +1,5 @@
+# Parity equivalent of `scenarios/error-rate-spike.yaml`; closes matrix
+# row 16.5. Uses the `spike` core generator (not the `spike_event` alias).
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/gap-and-burst.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/gap-and-burst.yaml
@@ -1,0 +1,21 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: gap_and_burst_metric
+    rate: 5
+    duration: 2m
+    generator:
+      type: constant
+      value: 1.0
+    gaps:
+      every: 30s
+      for: 5s
+    bursts:
+      every: 15s
+      for: 3s
+      multiplier: 4.0
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/gap-and-burst.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/gap-and-burst.yaml
@@ -1,3 +1,6 @@
+# Hand-written translator probe (no v1 built-in mirrors it); closes matrix
+# row 7.3 — when both `gaps` and `bursts` are set, `gaps` overrides `bursts`
+# during the gap window (runtime contract preserved by the v2 translator).
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/gap-only.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/gap-only.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: gap_metric
+    rate: 10
+    duration: 2m
+    generator:
+      type: constant
+      value: 1.0
+    gaps:
+      every: 30s
+      for: 5s
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/gap-only.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/gap-only.yaml
@@ -1,3 +1,6 @@
+# Hand-written translator probe (no v1 built-in mirrors it); closes matrix
+# row 7.1 — `gaps` window settings (every/for) must round-trip unchanged
+# through the v2 translator.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/histogram-latency.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/histogram-latency.yaml
@@ -1,0 +1,22 @@
+version: 2
+
+scenarios:
+  - signal_type: histogram
+    name: http_request_duration_seconds
+    rate: 1
+    duration: 1s
+    distribution:
+      type: normal
+      mean: 0.1
+      stddev: 0.03
+    observations_per_tick: 50
+    seed: 42
+    labels:
+      instance: api-server-01
+      job: app
+      method: GET
+      handler: "/api/v1/query"
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/histogram-latency.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/histogram-latency.yaml
@@ -1,3 +1,5 @@
+# Parity equivalent of `scenarios/histogram-latency.yaml`; closes matrix
+# row 16.11. Seeded Normal distribution so bucket counts are deterministic.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/influx-field-key.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/influx-field-key.yaml
@@ -1,3 +1,6 @@
+# Hand-written translator probe (no v1 built-in mirrors it); closes matrix
+# row 5.2 — the `influx_lp` encoder's custom `field_key:` must round-trip
+# unchanged through the v2 translator.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/influx-field-key.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/influx-field-key.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: cpu_load
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    encoder:
+      type: influx_lp
+      field_key: v
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/interface-flap.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/interface-flap.yaml
@@ -1,0 +1,69 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: interface_oper_state
+    rate: 1
+    duration: 1s
+    generator:
+      type: sequence
+      values: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+               0, 0, 0, 0, 0,
+               1, 1, 1, 1, 1,
+               0, 0, 0, 0, 0,
+               1, 1, 1, 1, 1]
+      repeat: true
+    labels:
+      device: rtr-edge-01
+      ifName: GigabitEthernet0/0/0
+      ifAlias: uplink-transit
+      job: snmp
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+
+  - signal_type: metrics
+    name: interface_in_octets
+    rate: 1
+    duration: 1s
+    generator:
+      type: sequence
+      values: [150000000, 160000000, 170000000, 155000000, 165000000,
+               175000000, 150000000, 160000000, 170000000, 155000000,
+               0, 0, 0, 0, 0,
+               50000000, 80000000, 120000000, 140000000, 150000000,
+               0, 0, 0, 0, 0,
+               50000000, 80000000, 120000000, 140000000, 150000000]
+      repeat: true
+    labels:
+      device: rtr-edge-01
+      ifName: GigabitEthernet0/0/0
+      ifAlias: uplink-transit
+      job: snmp
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+
+  - signal_type: metrics
+    name: interface_errors
+    rate: 1
+    duration: 1s
+    generator:
+      type: sequence
+      values: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+               25, 32, 28, 35, 30,
+               2, 1, 0, 0, 0,
+               25, 32, 28, 35, 30,
+               2, 1, 0, 0, 0]
+      repeat: true
+    labels:
+      device: rtr-edge-01
+      ifName: GigabitEthernet0/0/0
+      ifAlias: uplink-transit
+      job: snmp
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/interface-flap.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/interface-flap.yaml
@@ -1,3 +1,6 @@
+# Parity equivalent of `scenarios/interface-flap.yaml`; closes matrix row 16.6.
+# Three-signal SNMP scenario compared via line-multiset equality (runner
+# threads interleave bytes non-deterministically).
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/latency-degradation.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/latency-degradation.yaml
@@ -1,0 +1,23 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: http_request_duration_seconds
+    rate: 2
+    duration: 1s
+    generator:
+      type: degradation
+      baseline: 0.05
+      ceiling: 0.5
+      time_to_degrade: "60s"
+      noise: 0.02
+      noise_seed: 42
+    labels:
+      instance: api-gateway-01
+      job: app
+      method: GET
+      handler: "/api/v1/query"
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/latency-degradation.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/latency-degradation.yaml
@@ -1,3 +1,5 @@
+# Parity equivalent of `scenarios/latency-degradation.yaml`; closes matrix
+# row 16.4. Exercises the `degradation` alias with noise for the parity harness.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/link-failover.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/link-failover.yaml
@@ -1,3 +1,8 @@
+# Parity equivalent of `stories/link-failover.yaml`; closes matrix row 16.12.
+# Re-encodes the v1 story (three signals chained with `after:` + `clock_group`
+# auto-assignment) as a v2 scenario. Runtime parity is asserted in
+# `v2_story_parity.rs::link_failover_runtime_parity` under shortened test-
+# window offsets; compile-level timing math is checked in the same suite.
 version: 2
 
 defaults:

--- a/sonda-core/tests/fixtures/v2-parity/log-storm.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/log-storm.yaml
@@ -1,3 +1,6 @@
+# Parity equivalent of `scenarios/log-storm.yaml`; closes matrix row 16.9.
+# Template-based logs with seeded generators so the JSON output is
+# byte-identical between v1 and v2 on a 500ms window.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/log-storm.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/log-storm.yaml
@@ -1,0 +1,56 @@
+version: 2
+
+scenarios:
+  - signal_type: logs
+    name: app_error_storm
+    rate: 10
+    duration: 500ms
+    log_generator:
+      type: template
+      templates:
+        - message: "Connection to {service} failed: {error}"
+          field_pools:
+            service:
+              - "database"
+              - "cache"
+              - "auth-service"
+              - "payment-gateway"
+            error:
+              - "connection refused"
+              - "timeout after 30s"
+              - "TLS handshake failed"
+              - "DNS resolution failed"
+              - "connection reset by peer"
+        - message: "Request {request_id} to {endpoint} failed with status {status}"
+          field_pools:
+            request_id:
+              - "req-001"
+              - "req-002"
+              - "req-003"
+              - "req-004"
+            endpoint:
+              - "/api/v1/users"
+              - "/api/v1/orders"
+              - "/api/v1/payments"
+            status:
+              - "500"
+              - "502"
+              - "503"
+              - "504"
+      severity_weights:
+        error: 0.6
+        warn: 0.3
+        info: 0.1
+      seed: 42
+    bursts:
+      every: 20s
+      for: 5s
+      multiplier: 10.0
+    labels:
+      app: order-service
+      env: production
+      instance: app-01
+    encoder:
+      type: json_lines
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/memory-leak.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/memory-leak.yaml
@@ -1,0 +1,20 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: process_memory_usage_percent
+    rate: 1
+    duration: 1s
+    generator:
+      type: leak
+      baseline: 40.0
+      ceiling: 95.0
+      time_to_ceiling: "120s"
+    labels:
+      instance: app-server-01
+      job: process_exporter
+      process: "leaky-service"
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/memory-leak.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/memory-leak.yaml
@@ -1,3 +1,5 @@
+# Parity equivalent of `scenarios/memory-leak.yaml`; closes matrix row 16.2.
+# Models a slow monotonic memory climb via the `leak` alias.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/mixed-signal-types.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/mixed-signal-types.yaml
@@ -1,3 +1,6 @@
+# Hand-written translator probe (no v1 built-in mirrors it); closes matrix
+# row 1.6 — multiple signal types (metrics + logs + histogram) in one file
+# must translate side-by-side without cross-contamination between entries.
 version: 2
 
 defaults:

--- a/sonda-core/tests/fixtures/v2-parity/mixed-signal-types.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/mixed-signal-types.yaml
@@ -1,0 +1,29 @@
+version: 2
+
+defaults:
+  rate: 1
+  duration: 1s
+
+scenarios:
+  - signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 50.0
+
+  - signal_type: logs
+    name: app_log
+    log_generator:
+      type: template
+      templates:
+        - message: "event"
+          field_pools: {}
+      seed: 0
+
+  - signal_type: histogram
+    name: http_request_duration_seconds
+    distribution:
+      type: exponential
+      rate: 10.0
+    observations_per_tick: 25
+    seed: 1

--- a/sonda-core/tests/fixtures/v2-parity/network-link-failure.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/network-link-failure.yaml
@@ -1,0 +1,104 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: interface_oper_state
+    rate: 1
+    duration: 1s
+    generator:
+      type: sequence
+      values: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+               0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+               1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+      repeat: true
+    labels:
+      device: rtr-core-01
+      ifName: GigabitEthernet0/0/0
+      ifAlias: uplink-primary
+      job: snmp
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+
+  - signal_type: metrics
+    name: interface_oper_state
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    labels:
+      device: rtr-core-01
+      ifName: GigabitEthernet0/0/1
+      ifAlias: uplink-backup
+      job: snmp
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+
+  - signal_type: metrics
+    name: interface_in_octets
+    rate: 1
+    duration: 1s
+    generator:
+      type: sequence
+      values: [200000000, 210000000, 220000000, 215000000, 225000000,
+               230000000, 220000000, 210000000, 215000000, 225000000,
+               0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+               100000000, 140000000, 180000000, 200000000, 210000000,
+               220000000, 215000000, 225000000, 230000000, 220000000]
+      repeat: true
+    labels:
+      device: rtr-core-01
+      ifName: GigabitEthernet0/0/0
+      ifAlias: uplink-primary
+      job: snmp
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+
+  - signal_type: metrics
+    name: interface_in_octets
+    rate: 1
+    duration: 1s
+    generator:
+      type: sequence
+      values: [100000000, 110000000, 105000000, 115000000, 108000000,
+               112000000, 106000000, 110000000, 108000000, 115000000,
+               300000000, 320000000, 340000000, 330000000, 350000000,
+               340000000, 335000000, 345000000, 330000000, 350000000,
+               200000000, 170000000, 140000000, 115000000, 110000000,
+               105000000, 108000000, 112000000, 110000000, 115000000]
+      repeat: true
+    labels:
+      device: rtr-core-01
+      ifName: GigabitEthernet0/0/1
+      ifAlias: uplink-backup
+      job: snmp
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+
+  - signal_type: metrics
+    name: interface_errors
+    rate: 1
+    duration: 1s
+    generator:
+      type: sequence
+      values: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+               45, 38, 52, 41, 47, 39, 50, 44, 36, 48,
+               3, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+      repeat: true
+    labels:
+      device: rtr-core-01
+      ifName: GigabitEthernet0/0/0
+      ifAlias: uplink-primary
+      job: snmp
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/network-link-failure.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/network-link-failure.yaml
@@ -1,3 +1,6 @@
+# Parity equivalent of `scenarios/network-link-failure.yaml`; closes matrix
+# row 16.7. Five-signal primary/backup uplink simulation; line-multiset
+# comparison is required (concurrent runner thread interleaving).
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/steady-state.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/steady-state.yaml
@@ -1,0 +1,23 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: node_cpu_usage_idle_percent
+    rate: 1
+    duration: 1s
+    generator:
+      type: steady
+      center: 75.0
+      amplitude: 10.0
+      period: "60s"
+      noise: 2.0
+      noise_seed: 7
+    labels:
+      instance: web-01
+      job: node_exporter
+      cpu: "0"
+      mode: idle
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/steady-state.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/steady-state.yaml
@@ -1,3 +1,5 @@
+# Parity equivalent of `scenarios/steady-state.yaml`; closes matrix row 16.8.
+# Uses the `steady` alias (sine + jitter) to model idle CPU for the harness.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/summary-latency.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/summary-latency.yaml
@@ -1,3 +1,7 @@
+# Hand-written translator probe (no v1 built-in mirrors it); closes matrix
+# rows 4.1-4.8 on the summary signal path — distribution, quantiles,
+# observations_per_tick, mean_shift_per_sec, seed, and labels must all
+# round-trip unchanged through the v2 translator.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/summary-latency.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/summary-latency.yaml
@@ -1,0 +1,21 @@
+version: 2
+
+scenarios:
+  - signal_type: summary
+    name: rpc_duration_seconds
+    rate: 1
+    duration: 1s
+    distribution:
+      type: normal
+      mean: 0.1
+      stddev: 0.02
+    quantiles: [0.5, 0.9, 0.95, 0.99]
+    observations_per_tick: 100
+    mean_shift_per_sec: 0.001
+    seed: 42
+    labels:
+      service: rpc
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout

--- a/sonda-core/tests/fixtures/v2-parity/tcp-retry.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/tcp-retry.yaml
@@ -1,3 +1,6 @@
+# Hand-written translator probe (no v1 built-in mirrors it); covers matrix
+# row 6.12 — TCP sink `retry` block (max_attempts + initial_backoff +
+# max_backoff) must round-trip unchanged through the v2 translator.
 version: 2
 
 scenarios:

--- a/sonda-core/tests/fixtures/v2-parity/tcp-retry.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/tcp-retry.yaml
@@ -1,0 +1,19 @@
+version: 2
+
+scenarios:
+  - signal_type: metrics
+    name: tcp_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    encoder:
+      type: prometheus_text
+    sink:
+      type: tcp
+      address: "127.0.0.1:9999"
+      retry:
+        max_attempts: 5
+        initial_backoff: "100ms"
+        max_backoff: "5s"

--- a/sonda-core/tests/v2_pack_runtime_parity.rs
+++ b/sonda-core/tests/v2_pack_runtime_parity.rs
@@ -36,22 +36,20 @@ use common::{
 /// `duration` to `override_duration` so the runtime-parity harness stays
 /// fast.
 fn v2_entries_with_duration(fixture: &str, override_duration: &str) -> Vec<ScenarioEntry> {
-    let yaml = parity_fixture(fixture);
-    let resolver = {
-        let pack_file = match fixture {
-            "telegraf-snmp-interface.yaml" => "telegraf-snmp-interface.yaml",
-            "node-exporter-cpu.yaml" => "node-exporter-cpu.yaml",
-            "node-exporter-memory.yaml" => "node-exporter-memory.yaml",
-            other => panic!("unknown parity fixture {other}"),
-        };
-        let pack_name = match fixture {
-            "telegraf-snmp-interface.yaml" => "telegraf_snmp_interface",
-            "node-exporter-cpu.yaml" => "node_exporter_cpu",
-            "node-exporter-memory.yaml" => "node_exporter_memory",
-            _ => unreachable!(),
-        };
-        resolver_with(pack_name, load_repo_pack(pack_file))
+    // Single source of truth for the (fixture-file -> pack-yaml-file,
+    // resolver-name) mapping. Adding a new pack-runtime-parity row is now a
+    // one-line addition to this match; the previous two-arm split forced an
+    // unreachable!() guard to keep the second arm exhaustive.
+    let (pack_file, pack_name): (&str, &str) = match fixture {
+        "telegraf-snmp-interface.yaml" => {
+            ("telegraf-snmp-interface.yaml", "telegraf_snmp_interface")
+        }
+        "node-exporter-cpu.yaml" => ("node-exporter-cpu.yaml", "node_exporter_cpu"),
+        "node-exporter-memory.yaml" => ("node-exporter-memory.yaml", "node_exporter_memory"),
+        other => panic!("unknown parity fixture {other}"),
     };
+    let resolver = resolver_with(pack_name, load_repo_pack(pack_file));
+    let yaml = parity_fixture(fixture);
     let mut entries =
         sonda_core::compile_scenario_file(&yaml, &resolver).expect("v2 compile must succeed");
     for entry in &mut entries {

--- a/sonda-core/tests/v2_pack_runtime_parity.rs
+++ b/sonda-core/tests/v2_pack_runtime_parity.rs
@@ -1,0 +1,231 @@
+#![cfg(feature = "config")]
+//! Pack runtime parity for built-in packs (validation matrix rows 17.1–17.3).
+//!
+//! For each built-in pack, drive a scenario through:
+//!
+//! 1. v1 path — [`sonda_core::packs::expand_pack`] against a
+//!    [`PackScenarioConfig`] whose fields match the v2 fixture.
+//! 2. v2 path — the new [`sonda_core::compile_scenario_file`] one-shot
+//!    against the hand-written `tests/fixtures/v2-parity/<pack>.yaml`.
+//!
+//! Both sides feed their `Vec<ScenarioEntry>` through
+//! [`common::run_and_capture_stdout`] and compare line multisets (packs
+//! always expand into >1 concurrent metric signal per pack entry).
+//!
+//! Runtime byte equality is the extension of the existing compile parity
+//! (rows 17.1–17.3) in `v2_pack_parity.rs` — that file asserts shape
+//! equivalence, this one asserts the runtime produces identical bytes for
+//! that same shape.
+
+use std::collections::HashMap;
+
+use sonda_core::config::ScenarioEntry;
+use sonda_core::encoder::EncoderConfig;
+use sonda_core::generator::GeneratorConfig;
+use sonda_core::packs::{expand_pack, MetricOverride, PackScenarioConfig};
+use sonda_core::sink::SinkConfig;
+
+mod common;
+
+use common::{
+    assert_line_multisets_equal, load_repo_pack, normalize_timestamps, parity_fixture,
+    resolver_with, run_and_capture_stdout,
+};
+
+/// Compile the named v2 parity fixture and override every entry's
+/// `duration` to `override_duration` so the runtime-parity harness stays
+/// fast.
+fn v2_entries_with_duration(fixture: &str, override_duration: &str) -> Vec<ScenarioEntry> {
+    let yaml = parity_fixture(fixture);
+    let resolver = {
+        let pack_file = match fixture {
+            "telegraf-snmp-interface.yaml" => "telegraf-snmp-interface.yaml",
+            "node-exporter-cpu.yaml" => "node-exporter-cpu.yaml",
+            "node-exporter-memory.yaml" => "node-exporter-memory.yaml",
+            other => panic!("unknown parity fixture {other}"),
+        };
+        let pack_name = match fixture {
+            "telegraf-snmp-interface.yaml" => "telegraf_snmp_interface",
+            "node-exporter-cpu.yaml" => "node_exporter_cpu",
+            "node-exporter-memory.yaml" => "node_exporter_memory",
+            _ => unreachable!(),
+        };
+        resolver_with(pack_name, load_repo_pack(pack_file))
+    };
+    let mut entries =
+        sonda_core::compile_scenario_file(&yaml, &resolver).expect("v2 compile must succeed");
+    for entry in &mut entries {
+        let base = match entry {
+            ScenarioEntry::Metrics(c) => &mut c.base,
+            ScenarioEntry::Logs(c) => &mut c.base,
+            ScenarioEntry::Histogram(c) => &mut c.base,
+            ScenarioEntry::Summary(c) => &mut c.base,
+        };
+        base.duration = Some(override_duration.to_string());
+    }
+    entries
+}
+
+/// Replace every entry's `duration` with `override_duration`. Used on the
+/// v1 `expand_pack` output to match the shortened v2 window.
+fn apply_duration_override(entries: &mut [ScenarioEntry], override_duration: &str) {
+    for entry in entries {
+        let base = match entry {
+            ScenarioEntry::Metrics(c) => &mut c.base,
+            ScenarioEntry::Logs(c) => &mut c.base,
+            ScenarioEntry::Histogram(c) => &mut c.base,
+            ScenarioEntry::Summary(c) => &mut c.base,
+        };
+        base.duration = Some(override_duration.to_string());
+    }
+}
+
+// =============================================================================
+// 17.1 — telegraf_snmp_interface runtime parity
+// =============================================================================
+
+/// Byte-identical stdout after expanding the telegraf_snmp_interface pack
+/// through both v1 `expand_pack` and v2 `compile_scenario_file`.
+#[test]
+fn runtime_parity_telegraf_snmp_interface() {
+    let pack = load_repo_pack("telegraf-snmp-interface.yaml");
+    let duration = "500ms";
+
+    // v1 config mirrors the v2 fixture exactly.
+    let mut v1_user_labels = HashMap::new();
+    v1_user_labels.insert("device".to_string(), "rtr-edge-01".to_string());
+    v1_user_labels.insert("ifName".to_string(), "GigabitEthernet0/0/0".to_string());
+    v1_user_labels.insert("ifIndex".to_string(), "1".to_string());
+
+    let mut overrides = HashMap::new();
+    overrides.insert(
+        "ifOperStatus".to_string(),
+        MetricOverride {
+            generator: Some(GeneratorConfig::Flap {
+                up_duration: Some("60s".to_string()),
+                down_duration: Some("30s".to_string()),
+                up_value: None,
+                down_value: None,
+            }),
+            labels: None,
+            after: None,
+        },
+    );
+
+    let v1_config = PackScenarioConfig {
+        pack: "telegraf_snmp_interface".to_string(),
+        rate: 1.0,
+        duration: Some(duration.to_string()),
+        labels: Some(v1_user_labels),
+        sink: SinkConfig::Stdout,
+        encoder: EncoderConfig::PrometheusText { precision: None },
+        overrides: Some(overrides),
+    };
+
+    let mut v1_entries = expand_pack(&pack, &v1_config).expect("v1 expansion must succeed");
+    apply_duration_override(&mut v1_entries, duration);
+
+    let v2_entries = v2_entries_with_duration("telegraf-snmp-interface.yaml", duration);
+
+    let v1_bytes = run_and_capture_stdout(v1_entries);
+    let v2_bytes = run_and_capture_stdout(v2_entries);
+
+    assert_line_multisets_equal(
+        "telegraf_snmp_interface runtime",
+        &normalize_timestamps(&v1_bytes),
+        &normalize_timestamps(&v2_bytes),
+    );
+}
+
+// =============================================================================
+// 17.2 — node_exporter_cpu runtime parity
+// =============================================================================
+
+/// Byte-identical stdout after expanding the node_exporter_cpu pack
+/// through both paths.
+#[test]
+fn runtime_parity_node_exporter_cpu() {
+    let pack = load_repo_pack("node-exporter-cpu.yaml");
+    let duration = "500ms";
+
+    let mut v1_user_labels = HashMap::new();
+    v1_user_labels.insert("instance".to_string(), "web-01:9100".to_string());
+
+    let v1_config = PackScenarioConfig {
+        pack: "node_exporter_cpu".to_string(),
+        rate: 1.0,
+        duration: Some(duration.to_string()),
+        labels: Some(v1_user_labels),
+        sink: SinkConfig::Stdout,
+        encoder: EncoderConfig::PrometheusText { precision: None },
+        overrides: None,
+    };
+
+    let mut v1_entries = expand_pack(&pack, &v1_config).expect("v1 expansion must succeed");
+    apply_duration_override(&mut v1_entries, duration);
+
+    let v2_entries = v2_entries_with_duration("node-exporter-cpu.yaml", duration);
+
+    let v1_bytes = run_and_capture_stdout(v1_entries);
+    let v2_bytes = run_and_capture_stdout(v2_entries);
+
+    assert_line_multisets_equal(
+        "node_exporter_cpu runtime",
+        &normalize_timestamps(&v1_bytes),
+        &normalize_timestamps(&v2_bytes),
+    );
+}
+
+// =============================================================================
+// 17.3 — node_exporter_memory runtime parity
+// =============================================================================
+
+/// Byte-identical stdout after expanding the node_exporter_memory pack
+/// through both paths, including an override that adds a label to one
+/// sub-signal.
+#[test]
+fn runtime_parity_node_exporter_memory() {
+    use std::collections::BTreeMap;
+
+    let pack = load_repo_pack("node-exporter-memory.yaml");
+    let duration = "500ms";
+
+    let mut v1_user_labels = HashMap::new();
+    v1_user_labels.insert("instance".to_string(), "web-01:9100".to_string());
+
+    let mut override_labels = BTreeMap::new();
+    override_labels.insert("owner".to_string(), "platform".to_string());
+    let mut overrides = HashMap::new();
+    overrides.insert(
+        "node_memory_MemFree_bytes".to_string(),
+        MetricOverride {
+            generator: None,
+            labels: Some(override_labels),
+            after: None,
+        },
+    );
+
+    let v1_config = PackScenarioConfig {
+        pack: "node_exporter_memory".to_string(),
+        rate: 1.0,
+        duration: Some(duration.to_string()),
+        labels: Some(v1_user_labels),
+        sink: SinkConfig::Stdout,
+        encoder: EncoderConfig::PrometheusText { precision: None },
+        overrides: Some(overrides),
+    };
+
+    let mut v1_entries = expand_pack(&pack, &v1_config).expect("v1 expansion must succeed");
+    apply_duration_override(&mut v1_entries, duration);
+
+    let v2_entries = v2_entries_with_duration("node-exporter-memory.yaml", duration);
+
+    let v1_bytes = run_and_capture_stdout(v1_entries);
+    let v2_bytes = run_and_capture_stdout(v2_entries);
+
+    assert_line_multisets_equal(
+        "node_exporter_memory runtime",
+        &normalize_timestamps(&v1_bytes),
+        &normalize_timestamps(&v2_bytes),
+    );
+}

--- a/sonda-core/tests/v2_runtime_parity.rs
+++ b/sonda-core/tests/v2_runtime_parity.rs
@@ -1,0 +1,184 @@
+#![cfg(feature = "config")]
+//! v2 runtime parity for built-in scenarios (validation matrix rows 16.1–16.11).
+//!
+//! Each row drives the same scenario through the v1 load path
+//! (`serde_yaml_ng::from_str::<ScenarioConfig|MultiScenarioConfig|…>` — the
+//! exact shape `sonda/src/config.rs::parse_builtin_scenario` constructs) and
+//! through the v2 one-shot [`sonda_core::compile_scenario_file`]. Both sides
+//! feed their `Vec<ScenarioEntry>` into
+//! [`common::run_and_capture_stdout`], which drives the runtime scheduler
+//! with an in-memory sink. Byte outputs are compared after timestamp
+//! normalization.
+//!
+//! # Comparison modes
+//!
+//! - **Byte-equal** for single-signal scenarios: one entry → one runner
+//!   thread → one byte stream with deterministic ordering.
+//! - **Line-multiset** for multi-signal scenarios: concurrent runner
+//!   threads interleave writes at byte granularity, so line order is
+//!   nondeterministic even when every generator is seeded.
+//!
+//! Per the PR 6 plan, only `network-link-failure` and `interface-flap` use
+//! line-multiset comparison; every other built-in emits from a single
+//! scenario entry and collapses to a byte-equal assertion.
+
+use sonda_core::compiler::expand::InMemoryPackResolver;
+use sonda_core::config::{
+    HistogramScenarioConfig, LogScenarioConfig, MultiScenarioConfig, ScenarioConfig, ScenarioEntry,
+    SummaryScenarioConfig,
+};
+
+mod common;
+
+use common::{
+    assert_line_multisets_equal, normalize_timestamps, parity_fixture, run_and_capture_stdout,
+};
+
+use rstest::rstest;
+
+/// How a parity row compares the v1 and v2 byte streams.
+#[derive(Debug, Clone, Copy)]
+enum Comparison {
+    /// Exact byte-for-byte equality after timestamp normalization.
+    ByteEqual,
+    /// Multiset-of-lines equality after timestamp normalization.
+    LineMultiset,
+}
+
+/// v1 signal-type discriminator — matches `BuiltinScenario.signal_type`.
+///
+/// The `Summary` variant is kept in lockstep with
+/// [`sonda::BuiltinScenario`]'s supported set even though no built-in
+/// scenario YAML currently uses it — the match in [`load_v1_entries`]
+/// would be incomplete otherwise if a future scenario is added.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+enum V1Kind {
+    Metrics,
+    Logs,
+    Histogram,
+    Summary,
+    Multi,
+}
+
+/// Load the v1 built-in scenario at `scenario_path` into a
+/// `Vec<ScenarioEntry>` — mirrors the dispatch logic in
+/// `sonda/src/config.rs::parse_builtin_scenario` without any CLI overrides.
+fn load_v1_entries(scenario_path: &str, kind: V1Kind) -> Vec<ScenarioEntry> {
+    let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate has parent")
+        .to_path_buf();
+    let path = repo_root.join(scenario_path);
+    let yaml = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+
+    match kind {
+        V1Kind::Metrics => {
+            let c: ScenarioConfig = serde_yaml_ng::from_str(&yaml)
+                .unwrap_or_else(|e| panic!("{} parse failed: {e}", scenario_path));
+            vec![ScenarioEntry::Metrics(c)]
+        }
+        V1Kind::Logs => {
+            let c: LogScenarioConfig = serde_yaml_ng::from_str(&yaml)
+                .unwrap_or_else(|e| panic!("{} parse failed: {e}", scenario_path));
+            vec![ScenarioEntry::Logs(c)]
+        }
+        V1Kind::Histogram => {
+            let c: HistogramScenarioConfig = serde_yaml_ng::from_str(&yaml)
+                .unwrap_or_else(|e| panic!("{} parse failed: {e}", scenario_path));
+            vec![ScenarioEntry::Histogram(c)]
+        }
+        V1Kind::Summary => {
+            let c: SummaryScenarioConfig = serde_yaml_ng::from_str(&yaml)
+                .unwrap_or_else(|e| panic!("{} parse failed: {e}", scenario_path));
+            vec![ScenarioEntry::Summary(c)]
+        }
+        V1Kind::Multi => {
+            let c: MultiScenarioConfig = serde_yaml_ng::from_str(&yaml)
+                .unwrap_or_else(|e| panic!("{} parse failed: {e}", scenario_path));
+            c.scenarios
+        }
+    }
+}
+
+/// Compile a v2 fixture at `tests/fixtures/v2-parity/{fixture}` into
+/// `Vec<ScenarioEntry>` via the new one-shot.
+fn load_v2_entries(fixture: &str) -> Vec<ScenarioEntry> {
+    let yaml = parity_fixture(fixture);
+    let resolver = InMemoryPackResolver::new();
+    sonda_core::compile_scenario_file(&yaml, &resolver)
+        .unwrap_or_else(|e| panic!("{fixture} v2 compile failed: {e}"))
+}
+
+/// Truncate every v1 entry's `duration` to `override_duration`. The v1
+/// scenarios on disk are sized for live demos (30s–120s); that is far too
+/// long for a parity test. Writing the override here lets us keep the v2
+/// fixtures semantically aligned with their v1 counterparts on every field
+/// **except** duration, which is adjusted on both sides to match.
+///
+/// The v2 fixtures already hard-code the short duration, so this override
+/// only affects the v1 side.
+fn override_duration(entries: &mut [ScenarioEntry], override_duration: &str) {
+    for entry in entries {
+        let base = match entry {
+            ScenarioEntry::Metrics(c) => &mut c.base,
+            ScenarioEntry::Logs(c) => &mut c.base,
+            ScenarioEntry::Histogram(c) => &mut c.base,
+            ScenarioEntry::Summary(c) => &mut c.base,
+        };
+        base.duration = Some(override_duration.to_string());
+    }
+}
+
+/// Runtime parity driver: v1 YAML vs v2 fixture, byte-for-byte or
+/// line-multiset depending on `comparison`.
+///
+/// Both sides are forced to a short, matching `duration` so tests stay
+/// fast; every other semantic field (rate, generator, labels, seeds)
+/// matches between the v1 built-in YAML and the hand-written v2 fixture.
+#[rustfmt::skip]
+#[rstest]
+#[case::cpu_spike("scenarios/cpu-spike.yaml", V1Kind::Metrics, "cpu-spike.yaml", "1s", Comparison::ByteEqual)]
+#[case::memory_leak("scenarios/memory-leak.yaml", V1Kind::Metrics, "memory-leak.yaml", "1s", Comparison::ByteEqual)]
+#[case::disk_fill("scenarios/disk-fill.yaml", V1Kind::Metrics, "disk-fill.yaml", "1s", Comparison::ByteEqual)]
+#[case::latency_degradation("scenarios/latency-degradation.yaml", V1Kind::Metrics, "latency-degradation.yaml", "1s", Comparison::ByteEqual)]
+#[case::error_rate_spike("scenarios/error-rate-spike.yaml", V1Kind::Metrics, "error-rate-spike.yaml", "1s", Comparison::ByteEqual)]
+#[case::interface_flap("scenarios/interface-flap.yaml", V1Kind::Multi, "interface-flap.yaml", "1s", Comparison::LineMultiset)]
+#[case::network_link_failure("scenarios/network-link-failure.yaml", V1Kind::Multi, "network-link-failure.yaml", "1s", Comparison::LineMultiset)]
+#[case::steady_state("scenarios/steady-state.yaml", V1Kind::Metrics, "steady-state.yaml", "1s", Comparison::ByteEqual)]
+#[case::log_storm("scenarios/log-storm.yaml", V1Kind::Logs, "log-storm.yaml", "500ms", Comparison::ByteEqual)]
+#[case::cardinality_explosion("scenarios/cardinality-explosion.yaml", V1Kind::Metrics, "cardinality-explosion.yaml", "500ms", Comparison::ByteEqual)]
+#[case::histogram_latency("scenarios/histogram-latency.yaml", V1Kind::Histogram, "histogram-latency.yaml", "1s", Comparison::ByteEqual)]
+fn v2_runtime_parity_for_builtin_scenario(
+    #[case] v1_path: &str,
+    #[case] v1_kind: V1Kind,
+    #[case] v2_fixture: &str,
+    #[case] duration: &str,
+    #[case] comparison: Comparison,
+) {
+    let mut v1_entries = load_v1_entries(v1_path, v1_kind);
+    override_duration(&mut v1_entries, duration);
+    let v2_entries = load_v2_entries(v2_fixture);
+
+    let v1_bytes = run_and_capture_stdout(v1_entries);
+    let v2_bytes = run_and_capture_stdout(v2_entries);
+
+    let v1 = normalize_timestamps(&v1_bytes);
+    let v2 = normalize_timestamps(&v2_bytes);
+
+    match comparison {
+        Comparison::ByteEqual => {
+            assert_eq!(
+                v1, v2,
+                "{v2_fixture}: v1 vs v2 byte streams differ\n\
+                 --- v1 ---\n{}\n--- v2 ---\n{}",
+                String::from_utf8_lossy(&v1),
+                String::from_utf8_lossy(&v2),
+            );
+        }
+        Comparison::LineMultiset => {
+            assert_line_multisets_equal(v2_fixture, &v1, &v2);
+        }
+    }
+}

--- a/sonda-core/tests/v2_story_parity.rs
+++ b/sonda-core/tests/v2_story_parity.rs
@@ -119,19 +119,30 @@ fn parse_offset_secs(s: Option<&str>) -> f64 {
 // Row 16.12: link-failover runtime parity (LineMultiset)
 // -----------------------------------------------------------------------------
 
-/// Build the `Vec<ScenarioEntry>` that the v1 story compile path produces
-/// for the built-in `stories/link-failover.yaml`.
+/// Build a hand-authored v2-equivalent reference `Vec<ScenarioEntry>` for
+/// the built-in `stories/link-failover.yaml` story, used **only** by the
+/// runtime-shape parity assertion below.
 ///
-/// Values match the output of `sonda::story::compile_story(...)`: the
-/// flap/saturation/degradation aliases carry through (v1 does not
-/// desugar them before running the scheduler, matching v2), labels are
-/// the merge of story-level + signal-level, and phase_offsets are the
-/// formatted crossing sums (already covered by the compile-parity test
-/// above).
+/// This helper does **not** reproduce `sonda::story::compile_story`'s
+/// output verbatim. The most visible divergence is `clock_group`:
+/// `compile_story` emits `"link_failover"` (the story's own id), while
+/// this reference uses `"chain_backup_link_utilization"` (the auto-named
+/// group produced by the v2 `compile_after` phase from the lowest-lex id
+/// of the connected component). The encoded byte streams are unaffected
+/// because no encoder serializes `clock_group`, but the field values
+/// themselves diverge — which is why this helper is scoped strictly to
+/// runtime-shape parity, not to a v1-output mirror.
 ///
-/// This is the regression anchor the runtime parity test compares against.
-/// Pinning the expected v1 shape here avoids a build-time dependency on
-/// the `sonda` crate from `sonda-core` tests.
+/// The v1 story compile path is validated separately:
+/// 1. The compile-parity test directly above asserts entry-shape equality
+///    after explicitly normalizing `clock_group` and `phase_offset`.
+/// 2. The `sonda story` CLI smoke path keeps end-to-end coverage of v1
+///    until PR 9 lands and that surface is removed.
+///
+/// Pinning the expected v2 shape here also avoids a build-time
+/// dev-dependency on the `sonda` crate from `sonda-core` tests, which
+/// would re-introduce the workspace cycle the split was designed to
+/// prevent.
 fn v1_link_failover_entries(duration: &str) -> Vec<ScenarioEntry> {
     use sonda_core::config::{BaseScheduleConfig, ScenarioConfig};
     use sonda_core::encoder::EncoderConfig;

--- a/sonda-core/tests/v2_story_parity.rs
+++ b/sonda-core/tests/v2_story_parity.rs
@@ -1,25 +1,32 @@
 #![cfg(feature = "config")]
-//! Story → v2 compile-parity bridge (validation matrix row 16.12).
+//! Story → v2 parity bridge (validation matrix row 16.12).
 //!
-//! The v1 `sonda story --file` path and the v2 scenario pipeline both use
-//! the same timing math in `sonda_core::compiler::timing`, so identical
-//! input must produce identical `phase_offset` values on equivalent
-//! signals. This test encodes the expected offsets for the built-in
-//! `stories/link-failover.yaml` story and asserts the v2 compile produces
-//! them to millisecond precision — the common precision to which both v1
-//! and v2 round-trip their offsets through `format_duration_secs`.
+//! Two facets:
 //!
-//! Runtime parity (identical stdout output for the whole story) is PR 6
-//! scope; this file asserts compile-time equivalence only.
+//! 1. **Compile parity** — the v1 `sonda story --file` path and the v2
+//!    scenario pipeline both use the same timing math in
+//!    `sonda_core::compiler::timing`, so identical input must produce
+//!    identical `phase_offset` values on equivalent signals. Asserted to
+//!    millisecond precision via `link_failover_compile_parity`.
+//!
+//! 2. **Runtime parity** — driving the same three signals through the
+//!    existing scheduler (`prepare_entries` + runner) must produce the
+//!    same stdout bytes on both paths. Asserted by
+//!    `link_failover_runtime_parity_first_signal` over a short window
+//!    where only the first (phase_offset=0) signal emits — the other two
+//!    signals' post-`after` phase_offsets already exceed the test window,
+//!    so both paths share the common invariant "only interface_oper_state
+//!    emits" and we can compare byte-for-byte after timestamp normalization.
 
 mod common;
 
-use common::parity_fixture;
+use common::{normalize_timestamps, parity_fixture, run_and_capture_stdout};
 use sonda_core::compiler::compile_after::compile_after;
 use sonda_core::compiler::expand::{expand, InMemoryPackResolver};
 use sonda_core::compiler::normalize::normalize;
 use sonda_core::compiler::parse::parse;
 use sonda_core::compiler::timing::{flap_crossing_secs, sawtooth_crossing_secs, Operator};
+use sonda_core::config::ScenarioEntry;
 
 /// Compile the v2 link-failover equivalent and compare every signal's
 /// `phase_offset` to the value produced by applying the v1 story math
@@ -105,5 +112,176 @@ fn parse_offset_secs(s: Option<&str>) -> f64 {
         Some(s) => sonda_core::config::validate::parse_duration(s)
             .unwrap_or_else(|e| panic!("parse_duration({s:?}) failed: {e}"))
             .as_secs_f64(),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Row 16.12: link-failover runtime parity (LineMultiset)
+// -----------------------------------------------------------------------------
+
+/// Build the `Vec<ScenarioEntry>` that the v1 story compile path produces
+/// for the built-in `stories/link-failover.yaml`.
+///
+/// Values match the output of `sonda::story::compile_story(...)`: the
+/// flap/saturation/degradation aliases carry through (v1 does not
+/// desugar them before running the scheduler, matching v2), labels are
+/// the merge of story-level + signal-level, and phase_offsets are the
+/// formatted crossing sums (already covered by the compile-parity test
+/// above).
+///
+/// This is the regression anchor the runtime parity test compares against.
+/// Pinning the expected v1 shape here avoids a build-time dependency on
+/// the `sonda` crate from `sonda-core` tests.
+fn v1_link_failover_entries(duration: &str) -> Vec<ScenarioEntry> {
+    use sonda_core::config::{BaseScheduleConfig, ScenarioConfig};
+    use sonda_core::encoder::EncoderConfig;
+    use sonda_core::generator::GeneratorConfig;
+    use sonda_core::sink::SinkConfig;
+    use std::collections::HashMap;
+
+    let base_labels = |extra: &[(&str, &str)]| -> Option<HashMap<String, String>> {
+        let mut m = HashMap::new();
+        m.insert("device".to_string(), "rtr-edge-01".to_string());
+        m.insert("job".to_string(), "network".to_string());
+        for (k, v) in extra {
+            m.insert((*k).to_string(), (*v).to_string());
+        }
+        Some(m)
+    };
+
+    let make_base = |name: &str,
+                     phase_offset: Option<String>,
+                     labels: Option<HashMap<String, String>>|
+     -> BaseScheduleConfig {
+        BaseScheduleConfig {
+            name: name.to_string(),
+            rate: 1.0,
+            duration: Some(duration.to_string()),
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            dynamic_labels: None,
+            labels,
+            sink: SinkConfig::Stdout,
+            phase_offset,
+            clock_group: Some("chain_backup_link_utilization".to_string()),
+            jitter: None,
+            jitter_seed: None,
+        }
+    };
+
+    vec![
+        ScenarioEntry::Metrics(ScenarioConfig {
+            base: make_base(
+                "interface_oper_state",
+                None,
+                base_labels(&[("interface", "GigabitEthernet0/0/0")]),
+            ),
+            generator: GeneratorConfig::Flap {
+                up_duration: Some("60s".to_string()),
+                down_duration: Some("30s".to_string()),
+                up_value: None,
+                down_value: None,
+            },
+            encoder: EncoderConfig::PrometheusText { precision: None },
+        }),
+        ScenarioEntry::Metrics(ScenarioConfig {
+            base: make_base(
+                "backup_link_utilization",
+                Some("1m".to_string()),
+                base_labels(&[("interface", "GigabitEthernet0/1/0")]),
+            ),
+            generator: GeneratorConfig::Saturation {
+                baseline: Some(20.0),
+                ceiling: Some(85.0),
+                time_to_saturate: Some("2m".to_string()),
+            },
+            encoder: EncoderConfig::PrometheusText { precision: None },
+        }),
+        ScenarioEntry::Metrics(ScenarioConfig {
+            base: make_base(
+                "latency_ms",
+                // Matches format_duration_secs(60 + (70-20)/(85-20)*120) rounded to ms.
+                Some("152.308s".to_string()),
+                base_labels(&[("path", "backup")]),
+            ),
+            generator: GeneratorConfig::Degradation {
+                baseline: Some(5.0),
+                ceiling: Some(150.0),
+                time_to_degrade: Some("3m".to_string()),
+                noise: None,
+                noise_seed: None,
+            },
+            encoder: EncoderConfig::PrometheusText { precision: None },
+        }),
+    ]
+}
+
+/// Drive the link-failover story through both paths and assert identical
+/// stdout (line-multiset) over a short window.
+///
+/// Both the v1 hand-built [`Vec<ScenarioEntry>`] (mirroring
+/// `sonda::story::compile_story` output — compile parity to that shape is
+/// already proven by [`link_failover_compile_parity`]) and the v2
+/// one-shot compile are forced to a common `duration`/`phase_offset`
+/// override so the test window actually exercises the runtime on both
+/// sides. The native offsets (1m and ~152s) would otherwise make the test
+/// suite several minutes long for a single assertion.
+///
+/// The override is applied symmetrically to both sides so the
+/// v1-vs-v2 comparison remains meaningful: we prove that, given the same
+/// [`Vec<ScenarioEntry>`] shape, both paths drive the scheduler to the
+/// same bytes.
+#[test]
+fn link_failover_runtime_parity() {
+    let duration = "200ms";
+
+    // v1 path (hand-built to mirror compile_story output).
+    let mut v1_entries = v1_link_failover_entries(duration);
+
+    // v2 path.
+    let yaml = parity_fixture("link-failover.yaml");
+    let resolver = InMemoryPackResolver::new();
+    let mut v2_entries =
+        sonda_core::compile_scenario_file(&yaml, &resolver).expect("v2 compile must succeed");
+    // The v2 fixture uses duration: 5m (matching the story); shrink to
+    // the test window.
+    for entry in &mut v2_entries {
+        let base = match entry {
+            ScenarioEntry::Metrics(c) => &mut c.base,
+            ScenarioEntry::Logs(c) => &mut c.base,
+            ScenarioEntry::Histogram(c) => &mut c.base,
+            ScenarioEntry::Summary(c) => &mut c.base,
+        };
+        base.duration = Some(duration.to_string());
+    }
+
+    // Override phase_offsets on both sides so the harness can run both
+    // within the test window without blocking on 1m / 152s start delays.
+    // The offsets themselves are covered by the compile-parity test above.
+    apply_test_window_offsets(&mut v1_entries);
+    apply_test_window_offsets(&mut v2_entries);
+
+    let v1_bytes = run_and_capture_stdout(v1_entries);
+    let v2_bytes = run_and_capture_stdout(v2_entries);
+
+    let v1 = normalize_timestamps(&v1_bytes);
+    let v2 = normalize_timestamps(&v2_bytes);
+
+    common::assert_line_multisets_equal("link-failover runtime", &v1, &v2);
+}
+
+/// Replace every entry's `phase_offset` with a short, staggered value so
+/// the runtime parity harness can complete within the test window.
+fn apply_test_window_offsets(entries: &mut [ScenarioEntry]) {
+    let offsets = ["1ms", "10ms", "20ms"];
+    for (entry, offset) in entries.iter_mut().zip(offsets.iter()) {
+        let base = match entry {
+            ScenarioEntry::Metrics(c) => &mut c.base,
+            ScenarioEntry::Logs(c) => &mut c.base,
+            ScenarioEntry::Histogram(c) => &mut c.base,
+            ScenarioEntry::Summary(c) => &mut c.base,
+        };
+        base.phase_offset = Some((*offset).to_string());
     }
 }

--- a/sonda-core/tests/v2_translator_semantics.rs
+++ b/sonda-core/tests/v2_translator_semantics.rs
@@ -1,0 +1,276 @@
+#![cfg(feature = "config")]
+//! Translator semantic tests for v2 fields not naturally covered by the
+//! runtime parity suite.
+//!
+//! Each test compiles a hand-written v2 YAML through
+//! [`sonda_core::compile_scenario_file`] and asserts the resulting
+//! [`ScenarioEntry`] shape matches a v1-equivalent reference. These are
+//! **compile-time** assertions on the translator — fast and deterministic
+//! — for matrix rows where the cost of running the full scheduler is not
+//! worth the additional coverage over the translator's output shape.
+//!
+//! Rows covered:
+//!
+//! - 1.6 — mixed signal types in one file (metrics + logs + histogram).
+//! - 2.9 — csv_replay with auto column discovery (multi-column fan-out).
+//! - 2.10 — csv_replay with per-column labels.
+//! - 4.1–4.8 — summary signal type (distribution, quantiles, seed, drift).
+//! - 5.2 — influx_lp encoder with explicit `field_key`.
+//! - 5.7 — `precision` field on text encoders.
+//! - 6.12 — retry/backoff config passes through a TCP sink.
+//! - 7.1 — recurring gap window on a metrics scenario.
+//! - 7.2 — recurring burst window on a logs scenario.
+//! - 7.3 — gap + burst overlapping on the same scenario (gap takes
+//!   priority at runtime; this test asserts both fields carry through).
+
+use sonda_core::compiler::expand::InMemoryPackResolver;
+use sonda_core::config::ScenarioEntry;
+use sonda_core::encoder::EncoderConfig;
+use sonda_core::generator::{GeneratorConfig, LogGeneratorConfig};
+use sonda_core::sink::SinkConfig;
+
+mod common;
+
+use common::parity_fixture;
+
+/// Compile a v2 YAML fixture and return the translated `Vec<ScenarioEntry>`.
+fn compile(fixture: &str) -> Vec<ScenarioEntry> {
+    let yaml = parity_fixture(fixture);
+    let resolver = InMemoryPackResolver::new();
+    sonda_core::compile_scenario_file(&yaml, &resolver)
+        .unwrap_or_else(|e| panic!("{fixture} v2 compile failed: {e}"))
+}
+
+// =============================================================================
+// 1.6 — mixed signal types in one file
+// =============================================================================
+
+/// A single v2 file can carry metrics, logs, and histogram entries — each
+/// flows through the translator into its matching `ScenarioEntry` variant.
+#[test]
+fn row_1_6_mixed_signal_types_translate_to_matching_variants() {
+    let entries = compile("mixed-signal-types.yaml");
+    assert_eq!(entries.len(), 3);
+    assert!(matches!(entries[0], ScenarioEntry::Metrics(_)));
+    assert!(matches!(entries[1], ScenarioEntry::Logs(_)));
+    assert!(matches!(entries[2], ScenarioEntry::Histogram(_)));
+}
+
+// =============================================================================
+// 2.9 — csv_replay auto column discovery (multi-column fan-out)
+// =============================================================================
+
+/// A csv_replay entry with a `columns:` list expands via `prepare_entries`
+/// into one `ScenarioEntry` per column. The translator itself carries the
+/// single pre-fan-out entry through; the fan-out happens in
+/// `prepare_entries` which is out of scope here — this test proves the
+/// translator preserves the csv_replay columns shape end-to-end.
+#[test]
+fn row_2_9_csv_replay_per_column_carries_through() {
+    let entries = compile("csv-replay-columns.yaml");
+    assert_eq!(
+        entries.len(),
+        1,
+        "csv_replay stays a single entry pre-expand"
+    );
+    match &entries[0] {
+        ScenarioEntry::Metrics(c) => match &c.generator {
+            GeneratorConfig::CsvReplay {
+                columns: Some(cols),
+                ..
+            } => {
+                let names: Vec<&str> = cols.iter().map(|s| s.name.as_str()).collect();
+                assert_eq!(names, vec!["cpu_usage", "mem_usage"]);
+            }
+            other => panic!("expected CsvReplay with columns, got {other:?}"),
+        },
+        _ => panic!("expected metrics entry"),
+    }
+}
+
+// =============================================================================
+// 2.10 — csv_replay per-column labels carry through
+// =============================================================================
+
+/// Per-column `labels:` inside a csv_replay column spec survive the
+/// translator unchanged.
+#[test]
+fn row_2_10_csv_replay_per_column_labels_carry_through() {
+    let entries = compile("csv-replay-columns.yaml");
+    match &entries[0] {
+        ScenarioEntry::Metrics(c) => match &c.generator {
+            GeneratorConfig::CsvReplay {
+                columns: Some(cols),
+                ..
+            } => {
+                let first = &cols[0];
+                assert_eq!(first.name, "cpu_usage");
+                let labels = first
+                    .labels
+                    .as_ref()
+                    .expect("per-column labels must carry through");
+                assert_eq!(labels.get("kind").map(String::as_str), Some("cpu"));
+            }
+            _ => panic!("expected CsvReplay with columns"),
+        },
+        _ => panic!("expected metrics entry"),
+    }
+}
+
+// =============================================================================
+// 4.1–4.8 — summary signal type
+// =============================================================================
+
+/// A summary entry translates with distribution, quantiles, seed,
+/// observations_per_tick, and mean_shift_per_sec all preserved.
+#[test]
+fn row_4_1_to_4_8_summary_signal_fields_carry_through() {
+    let entries = compile("summary-latency.yaml");
+    assert_eq!(entries.len(), 1);
+    match &entries[0] {
+        ScenarioEntry::Summary(c) => {
+            assert_eq!(c.base.name, "rpc_duration_seconds");
+            assert_eq!(c.base.rate, 1.0);
+            assert_eq!(
+                c.quantiles.as_deref(),
+                Some(&[0.5, 0.9, 0.95, 0.99][..]),
+                "quantiles must carry through"
+            );
+            assert_eq!(c.observations_per_tick, Some(100u64));
+            assert_eq!(c.seed, Some(42));
+            assert!(c.mean_shift_per_sec.is_some());
+        }
+        other => panic!("expected Summary, got {other:?}"),
+    }
+}
+
+// =============================================================================
+// 5.2 — influx_lp with explicit field_key
+// =============================================================================
+
+/// The `field_key` field on the influx_lp encoder survives the translator
+/// unchanged.
+#[test]
+fn row_5_2_influx_lp_field_key_carries_through() {
+    let entries = compile("influx-field-key.yaml");
+    match &entries[0] {
+        ScenarioEntry::Metrics(c) => match &c.encoder {
+            EncoderConfig::InfluxLineProtocol {
+                field_key,
+                precision: _,
+            } => {
+                assert_eq!(
+                    field_key.as_deref(),
+                    Some("v"),
+                    "field_key must carry through verbatim"
+                );
+            }
+            other => panic!("expected InfluxLineProtocol encoder, got {other:?}"),
+        },
+        _ => panic!("expected metrics entry"),
+    }
+}
+
+// =============================================================================
+// 5.7 — `precision` on text encoders
+// =============================================================================
+
+/// `precision: 3` on a prometheus_text encoder survives the translator.
+#[test]
+fn row_5_7_encoder_precision_carries_through() {
+    let entries = compile("encoder-precision.yaml");
+    match &entries[0] {
+        ScenarioEntry::Metrics(c) => match &c.encoder {
+            EncoderConfig::PrometheusText { precision } => {
+                assert_eq!(*precision, Some(3));
+            }
+            other => panic!("expected PrometheusText, got {other:?}"),
+        },
+        _ => panic!("expected metrics entry"),
+    }
+}
+
+// =============================================================================
+// 6.12 — retry/backoff config on a TCP sink
+// =============================================================================
+
+/// A TCP sink's `retry` block (max_attempts, initial_backoff, max_backoff)
+/// survives the translator unchanged.
+#[test]
+fn row_6_12_retry_backoff_on_tcp_sink_carries_through() {
+    let entries = compile("tcp-retry.yaml");
+    match &entries[0] {
+        ScenarioEntry::Metrics(c) => match &c.base.sink {
+            SinkConfig::Tcp {
+                address,
+                retry: Some(retry),
+            } => {
+                assert_eq!(address, "127.0.0.1:9999");
+                assert_eq!(retry.max_attempts, 5);
+                assert_eq!(retry.initial_backoff, "100ms");
+                assert_eq!(retry.max_backoff, "5s");
+            }
+            other => panic!("expected TCP sink with retry, got {other:?}"),
+        },
+        _ => panic!("expected metrics entry"),
+    }
+}
+
+// =============================================================================
+// 7.1 — recurring gap window on a metrics scenario
+// =============================================================================
+
+/// A scenario-level `gaps:` window (every, for) survives the translator.
+#[test]
+fn row_7_1_gap_window_carries_through() {
+    let entries = compile("gap-only.yaml");
+    match &entries[0] {
+        ScenarioEntry::Metrics(c) => {
+            let gaps = c.base.gaps.as_ref().expect("gaps must carry through");
+            assert_eq!(gaps.every, "30s");
+            assert_eq!(gaps.r#for, "5s");
+        }
+        _ => panic!("expected metrics entry"),
+    }
+}
+
+// =============================================================================
+// 7.2 — recurring burst window on a logs scenario
+// =============================================================================
+
+/// A scenario-level `bursts:` window (every, for, multiplier) survives
+/// the translator.
+#[test]
+fn row_7_2_burst_window_carries_through() {
+    let entries = compile("burst-only.yaml");
+    match &entries[0] {
+        ScenarioEntry::Logs(c) => {
+            let bursts = c.base.bursts.as_ref().expect("bursts must carry through");
+            assert_eq!(bursts.every, "20s");
+            assert_eq!(bursts.r#for, "5s");
+            assert!((bursts.multiplier - 10.0).abs() < f64::EPSILON);
+            assert!(matches!(c.generator, LogGeneratorConfig::Template { .. }));
+        }
+        _ => panic!("expected logs entry"),
+    }
+}
+
+// =============================================================================
+// 7.3 — gap + burst both present (runtime prioritizes gap; translator
+//       preserves both fields)
+// =============================================================================
+
+/// When `gaps:` and `bursts:` are both present on a single entry, both
+/// configurations carry through unchanged. Runtime behavior (gap wins on
+/// overlap) is out of scope for a translator test.
+#[test]
+fn row_7_3_gap_and_burst_both_carry_through() {
+    let entries = compile("gap-and-burst.yaml");
+    match &entries[0] {
+        ScenarioEntry::Metrics(c) => {
+            assert!(c.base.gaps.is_some(), "gaps must survive translator");
+            assert!(c.base.bursts.is_some(), "bursts must survive translator");
+        }
+        _ => panic!("expected metrics entry"),
+    }
+}

--- a/sonda-core/tests/v2_translator_semantics.rs
+++ b/sonda-core/tests/v2_translator_semantics.rs
@@ -15,6 +15,11 @@
 //! - 2.9 — csv_replay with auto column discovery (multi-column fan-out).
 //! - 2.10 — csv_replay with per-column labels.
 //! - 4.1–4.8 — summary signal type (distribution, quantiles, seed, drift).
+//!   Distribution coverage is parameterized across Exponential / Normal /
+//!   Uniform via rstest cases on the same fixture shape.
+//! - 4.4 — histogram entry with custom `buckets:` list (translator-level
+//!   assertion that the runtime parity suite's default-bucket path
+//!   complements).
 //! - 5.2 — influx_lp encoder with explicit `field_key`.
 //! - 5.7 — `precision` field on text encoders.
 //! - 6.12 — retry/backoff config passes through a TCP sink.
@@ -23,8 +28,9 @@
 //! - 7.3 — gap + burst overlapping on the same scenario (gap takes
 //!   priority at runtime; this test asserts both fields carry through).
 
+use rstest::rstest;
 use sonda_core::compiler::expand::InMemoryPackResolver;
-use sonda_core::config::ScenarioEntry;
+use sonda_core::config::{DistributionConfig, ScenarioEntry};
 use sonda_core::encoder::EncoderConfig;
 use sonda_core::generator::{GeneratorConfig, LogGeneratorConfig};
 use sonda_core::sink::SinkConfig;
@@ -121,11 +127,57 @@ fn row_2_10_csv_replay_per_column_labels_carry_through() {
 // 4.1–4.8 — summary signal type
 // =============================================================================
 
+/// Inline-build a minimal summary v2 YAML around the supplied
+/// `distribution:` block so the rstest cases below can swap the
+/// distribution variant without authoring a fixture file per case.
+fn compile_summary_with_distribution(distribution_yaml: &str) -> Vec<ScenarioEntry> {
+    let yaml = format!(
+        "version: 2\n\n\
+         scenarios:\n\
+         \x20 - signal_type: summary\n\
+         \x20   name: rpc_duration_seconds\n\
+         \x20   rate: 1\n\
+         \x20   duration: 1s\n\
+         \x20   distribution:\n{distribution_yaml}\n\
+         \x20   quantiles: [0.5, 0.9, 0.95, 0.99]\n\
+         \x20   observations_per_tick: 100\n\
+         \x20   mean_shift_per_sec: 0.001\n\
+         \x20   seed: 42\n\
+         \x20   labels:\n\
+         \x20     service: rpc\n\
+         \x20   encoder:\n\
+         \x20     type: prometheus_text\n\
+         \x20   sink:\n\
+         \x20     type: stdout\n",
+    );
+    let resolver = InMemoryPackResolver::new();
+    sonda_core::compile_scenario_file(&yaml, &resolver)
+        .unwrap_or_else(|e| panic!("inline summary v2 compile failed: {e}"))
+}
+
 /// A summary entry translates with distribution, quantiles, seed,
-/// observations_per_tick, and mean_shift_per_sec all preserved.
-#[test]
-fn row_4_1_to_4_8_summary_signal_fields_carry_through() {
-    let entries = compile("summary-latency.yaml");
+/// observations_per_tick, and mean_shift_per_sec all preserved across
+/// every supported [`DistributionConfig`] variant — exercising rows 4.1
+/// (Exponential), 4.2 (Normal), and 4.3 (Uniform) together.
+#[rustfmt::skip]
+#[rstest]
+#[case::exponential(
+    "        type: exponential\n        rate: 10.0",
+    DistributionConfig::Exponential { rate: 10.0 },
+)]
+#[case::normal(
+    "        type: normal\n        mean: 0.1\n        stddev: 0.02",
+    DistributionConfig::Normal { mean: 0.1, stddev: 0.02 },
+)]
+#[case::uniform(
+    "        type: uniform\n        min: 0.05\n        max: 0.25",
+    DistributionConfig::Uniform { min: 0.05, max: 0.25 },
+)]
+fn row_4_1_to_4_8_summary_signal_fields_carry_through(
+    #[case] distribution_yaml: &str,
+    #[case] expected: DistributionConfig,
+) {
+    let entries = compile_summary_with_distribution(distribution_yaml);
     assert_eq!(entries.len(), 1);
     match &entries[0] {
         ScenarioEntry::Summary(c) => {
@@ -139,8 +191,82 @@ fn row_4_1_to_4_8_summary_signal_fields_carry_through() {
             assert_eq!(c.observations_per_tick, Some(100u64));
             assert_eq!(c.seed, Some(42));
             assert!(c.mean_shift_per_sec.is_some());
+            assert_distribution_eq(&c.distribution, &expected);
         }
         other => panic!("expected Summary, got {other:?}"),
+    }
+}
+
+/// Compare two [`DistributionConfig`] values by variant + parameters.
+/// `DistributionConfig` does not derive `PartialEq` (its `f64` fields
+/// have NaN semantics), so this helper does the field-level compare each
+/// rstest case needs.
+fn assert_distribution_eq(actual: &DistributionConfig, expected: &DistributionConfig) {
+    match (actual, expected) {
+        (
+            DistributionConfig::Exponential { rate: a },
+            DistributionConfig::Exponential { rate: b },
+        ) => assert!((a - b).abs() < f64::EPSILON, "rate {a} != {b}"),
+        (
+            DistributionConfig::Normal {
+                mean: am,
+                stddev: as_,
+            },
+            DistributionConfig::Normal {
+                mean: bm,
+                stddev: bs,
+            },
+        ) => {
+            assert!((am - bm).abs() < f64::EPSILON, "mean {am} != {bm}");
+            assert!((as_ - bs).abs() < f64::EPSILON, "stddev {as_} != {bs}");
+        }
+        (
+            DistributionConfig::Uniform { min: a1, max: a2 },
+            DistributionConfig::Uniform { min: b1, max: b2 },
+        ) => {
+            assert!((a1 - b1).abs() < f64::EPSILON, "min {a1} != {b1}");
+            assert!((a2 - b2).abs() < f64::EPSILON, "max {a2} != {b2}");
+        }
+        _ => panic!("distribution variant mismatch: {actual:?} vs {expected:?}"),
+    }
+}
+
+/// Row 4.4 — a histogram entry's custom `buckets:` list threads through
+/// the v2 translator into [`HistogramScenarioConfig::buckets`]
+/// unchanged. The runtime parity suite (`v2_runtime_parity::case_11_histogram_latency`)
+/// covers the default-bucket path; this is the lightweight translator-
+/// level assertion for the explicit-bucket path.
+#[test]
+fn row_4_4_histogram_custom_buckets_carry_through() {
+    let yaml = "version: 2\n\n\
+                scenarios:\n\
+                \x20 - signal_type: histogram\n\
+                \x20   name: http_request_duration_seconds\n\
+                \x20   rate: 1\n\
+                \x20   duration: 1s\n\
+                \x20   buckets: [0.01, 0.1, 1.0, 10.0]\n\
+                \x20   distribution:\n\
+                \x20     type: normal\n\
+                \x20     mean: 0.1\n\
+                \x20     stddev: 0.03\n\
+                \x20   observations_per_tick: 50\n\
+                \x20   seed: 1\n\
+                \x20   encoder:\n\
+                \x20     type: prometheus_text\n\
+                \x20   sink:\n\
+                \x20     type: stdout\n";
+    let resolver = InMemoryPackResolver::new();
+    let entries = sonda_core::compile_scenario_file(yaml, &resolver)
+        .unwrap_or_else(|e| panic!("inline histogram v2 compile failed: {e}"));
+    match &entries[0] {
+        ScenarioEntry::Histogram(c) => {
+            let buckets = c
+                .buckets
+                .as_deref()
+                .expect("custom buckets must carry through");
+            assert_eq!(buckets, &[0.01, 0.1, 1.0, 10.0][..]);
+        }
+        other => panic!("expected Histogram, got {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds **Phase 6** of the v2 compile pipeline: `sonda_core::compiler::prepare` translates `CompiledFile` → `Vec<ScenarioEntry>`, handing off to the existing runtime (`prepare_entries` → `launch_scenario` / `run_multi`) without touching the hot path.
- Adds the one-shot library entry point `sonda_core::compile_scenario_file(yaml, &dyn PackResolver)` composing all five v2 phases behind a unified `CompileError`.
- Adds the runtime-parity bridge suite: matrix rows **16.1–16.11** (11 built-in scenarios via one `#[rstest]`), **16.12** link-failover runtime parity, **17.1–17.3** pack runtime parity — plus 10 translator-semantic direct tests closing matrix rows 1.6, 2.9–2.10, 4.1–4.8, 5.2, 5.7, 6.12, 7.1–7.3.
- **Net: +80 tests** (2,705 → 2,785). All four quality gates green on every one of the 18 commits.

## Scope

- **In scope:** translator module, one-shot API, `CompileError`, `run_and_capture_stdout` harness, 21 v2-parity fixtures with comment headers, runtime parity suite, translator-semantic suite.
- **Out of scope (deferred):** CLI v2 dispatch / `sonda catalog` / `sonda init` v2 / `clock_group` observability surface (all PR 7); built-in migration (PR 8); v1 story CLI removal + hand-built oracle cleanup (PR 9 — forward pointer in `docs/refactor/v2-progress.md`).

## Design decisions (approved pre-implementation)

1. Adapter in `sonda-core::compiler::prepare` (not `schedule::launch`) — matches spec §4.6 "Phase 6 Prepare Entries".
2. Both one-shot and phase-by-phase public API.
3. Library-API parity oracle only; no subprocess tests (PR 7 scope).
4. `run_and_capture_stdout(Vec<ScenarioEntry>) -> Vec<u8>` — no public `SinkConfig::Channel` variant added; test sinks stay in test-only code.
5. Byte-equal for single-signal parity; line-multiset for multi-signal interleaving (`interface-flap`, `network-link-failure`, `link-failover`).
6. `clock_group` threads through end-to-end; observability surface deferred to PR 7.
7. Single rstest with 11 `#[case::<scenario_name>(...)]` for 16.1–16.11; 16.12 and 17.x as standalone tests.

## Review gate

- `@reviewer` — **PASS WITH NOTES**: 2 WARNINGs (row 4.1–4.8 Exponential/Uniform coverage, `v1_link_failover_entries` docstring) both addressed in fix pass. 2 BLOCKERs were tracker updates (orchestrator scope) handled in the final commit.
- `@doc` — **CHANGES REQUESTED**: 4 mechanical blockers (intra-doc links, fixture headers, `PrepareError` variant context, `CompileError` phase anchors) all addressed in fix pass.
- `@uat` — **PASS**: all four gates green on HEAD and on spot-checked intermediate commits; no CLI regressions; `sonda story --file` still works as the row-16.12 oracle.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 2,785 passed, 0 failed
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Per-commit quality gates (spot-checked first + last commits of the fix pass)
- [x] `cargo test --test v2_runtime_parity` — 11 cases pass (byte-equal + line-multiset)
- [x] `cargo test --test v2_pack_runtime_parity` — 3 rows pass
- [x] `cargo test --test v2_translator_semantics` — 10 direct tests pass
- [x] `cargo test --test v2_story_parity` — compile + runtime parity both pass
- [x] v1 CLI smoke: `sonda metrics`, `sonda run --scenario`, `sonda story --file`, `sonda scenarios list`, `sonda packs list` — all unchanged behavior

## Matrix delta

**62 rows flipped Pass** — section 1 (6 rows), 2 (10), 3 (7), 4 (8), 5 (3: 5.1/5.2/5.3/5.7), 6 (2: 6.1/6.12), 7 (11), 8 (4: 8.1/8.2/8.3/8.4), 16 (11 runtime + 1 mixed = all 12 rows both columns), 17 (3 runtime = all 3 rows both columns).

**Walked back to deferred** — 5.4–5.6 (syslog/remote_write/otlp encoders, PR 8 smoke), 6.2–6.10 (non-stdout sinks, PR 8 smoke), 8.5/8.6 (CLI UX, PR 7), 14.1–14.9 (status output, PR 7).