### PR TITLE
fix(cli): infer signal_type from first entry for v2 scenarios (v2 PR 8a.2a)

### DIFF
--- a/sonda/src/scenarios.rs
+++ b/sonda/src/scenarios.rs
@@ -222,6 +222,12 @@ fn read_scenario_metadata(path: &Path) -> Result<BuiltinScenario, String> {
         category: Option<String>,
         signal_type: Option<String>,
         description: Option<String>,
+        scenarios: Option<Vec<EntrySignalProbe>>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct EntrySignalProbe {
+        signal_type: Option<String>,
     }
 
     let probe: Probe =
@@ -240,7 +246,17 @@ fn read_scenario_metadata(path: &Path) -> Result<BuiltinScenario, String> {
         .category
         .unwrap_or_else(|| "uncategorized".to_string());
 
-    let signal_type = probe.signal_type.unwrap_or_else(|| "metrics".to_string());
+    // Fallback order for signal_type: root wins (v1 preserved) → first entry's
+    // signal_type (v2 migrations) → `"metrics"` default.
+    let signal_type = probe
+        .signal_type
+        .or_else(|| {
+            probe
+                .scenarios
+                .and_then(|entries| entries.into_iter().next())
+                .and_then(|entry| entry.signal_type)
+        })
+        .unwrap_or_else(|| "metrics".to_string());
 
     let description = probe.description.unwrap_or_default();
 
@@ -589,6 +605,146 @@ sink:
         assert_eq!(entry.category, "uncategorized");
         assert_eq!(entry.signal_type, "metrics");
         assert!(entry.description.is_empty());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ---- signal_type fallback via first scenario entry (v2) -------------------
+
+    #[test]
+    fn v2_scenario_first_entry_signal_type_logs_wins_when_root_absent() {
+        let dir = temp_scenario_dir("v2-entry-logs");
+        write_scenario(
+            &dir,
+            "log-storm.yaml",
+            r#"version: 2
+scenario_name: log-storm
+category: application
+description: "v2 log storm"
+scenarios:
+  - name: bursty_logs
+    signal_type: logs
+"#,
+        );
+        let catalog = ScenarioCatalog::discover(&[dir.clone()]);
+        assert_eq!(catalog.list().len(), 1);
+        assert_eq!(catalog.list()[0].signal_type, "logs");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn v2_scenario_first_entry_signal_type_histogram_wins_when_root_absent() {
+        let dir = temp_scenario_dir("v2-entry-histogram");
+        write_scenario(
+            &dir,
+            "histogram-latency.yaml",
+            r#"version: 2
+scenario_name: histogram-latency
+category: application
+description: "v2 histogram latency"
+scenarios:
+  - name: latency_buckets
+    signal_type: histogram
+"#,
+        );
+        let catalog = ScenarioCatalog::discover(&[dir.clone()]);
+        assert_eq!(catalog.list().len(), 1);
+        assert_eq!(catalog.list()[0].signal_type, "histogram");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn v2_scenario_root_signal_type_wins_over_first_entry() {
+        let dir = temp_scenario_dir("v2-root-wins");
+        write_scenario(
+            &dir,
+            "mixed.yaml",
+            r#"version: 2
+scenario_name: mixed
+category: infrastructure
+signal_type: metrics
+description: "root metrics overrides entry logs"
+scenarios:
+  - name: some_logs
+    signal_type: logs
+"#,
+        );
+        let catalog = ScenarioCatalog::discover(&[dir.clone()]);
+        assert_eq!(catalog.list().len(), 1);
+        assert_eq!(catalog.list()[0].signal_type, "metrics");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn v1_scenario_root_signal_type_logs_preserved_without_entries() {
+        let dir = temp_scenario_dir("v1-root-logs");
+        write_scenario(
+            &dir,
+            "legacy-logs.yaml",
+            r#"scenario_name: legacy-logs
+category: application
+signal_type: logs
+description: "v1 log scenario"
+
+name: test_log
+rate: 1
+generator:
+  type: constant
+  value: 1.0
+encoder:
+  type: json
+sink:
+  type: stdout
+"#,
+        );
+        let catalog = ScenarioCatalog::discover(&[dir.clone()]);
+        assert_eq!(catalog.list().len(), 1);
+        assert_eq!(catalog.list()[0].signal_type, "logs");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn v1_scenario_without_any_signal_type_defaults_to_metrics() {
+        let dir = temp_scenario_dir("v1-no-signal");
+        write_scenario(
+            &dir,
+            "untyped.yaml",
+            r#"scenario_name: untyped
+category: uncategorized
+description: "no signal_type anywhere"
+
+name: test_metric
+rate: 1
+generator:
+  type: constant
+  value: 1.0
+encoder:
+  type: prometheus_text
+sink:
+  type: stdout
+"#,
+        );
+        let catalog = ScenarioCatalog::discover(&[dir.clone()]);
+        assert_eq!(catalog.list().len(), 1);
+        assert_eq!(catalog.list()[0].signal_type, "metrics");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn v2_scenario_empty_scenarios_list_defaults_to_metrics() {
+        let dir = temp_scenario_dir("v2-empty-scenarios");
+        write_scenario(
+            &dir,
+            "empty.yaml",
+            r#"version: 2
+scenario_name: empty
+category: infrastructure
+description: "v2 with empty scenarios list"
+scenarios: []
+"#,
+        );
+        let catalog = ScenarioCatalog::discover(&[dir.clone()]);
+        assert_eq!(catalog.list().len(), 1);
+        assert_eq!(catalog.list()[0].signal_type, "metrics");
         let _ = fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## Summary

- `read_scenario_metadata` in `sonda/src/scenarios.rs` now falls back through **root `signal_type` → first entry's `signal_type` → `"metrics"` default** when probing scenario YAMLs.
- Before: the probe defaulted to `"metrics"` whenever root-level `signal_type` was absent — accidentally correct for the migrated `steady-state.yaml` (metrics) and for v1 files (which always carry root `signal_type`), but wrong for any future v2 migration of a non-metrics scenario.
- Probe layer fix only — no AST change in sonda-core, no `scenario_loader.rs` changes, no public API surface touched.

## Unblocks

PR 8a sub-slice 2b (batch migration of the remaining 10 built-in scenarios: `cardinality-explosion`, `cpu-spike`, `disk-fill`, `error-rate-spike`, `histogram-latency`, `interface-flap`, `latency-degradation`, `log-storm`, `memory-leak`, `network-link-failure`). With 2a in place, 2b stays mechanical — pure YAML + parity-row removal.

## Plan B dogfood

Second run of the tiered-reviewer pipeline. Internal-fix class → Sonnet `@reviewer-quick` only, PASS with no escalation. Total pipeline: 49 agent tool calls (35 implementer + 14 reviewer), skipped UAT and doc per class routing.

## Test plan

- [ ] CI: `cargo build --workspace`
- [ ] CI: `cargo test --workspace`
- [ ] CI: `cargo test -p sonda-core --no-default-features`
- [ ] CI: `cargo clippy --workspace -- -D warnings`
- [ ] CI: `cargo fmt --all -- --check`
- [ ] CI: `cargo audit` (exit 0; 4 pre-existing warnings tracked in #209)
- [ ] New coverage — 6 unit tests in `scenarios.rs` exercise: v2 entry-level signal_type (logs, histogram), root-over-entry precedence, v1 preservation, v1 default behavior, v2 empty-scenarios edge case.
- [ ] Regression: `sonda scenarios list --category infrastructure` still lists `steady-state` with signal `metrics` and populated description.

## Out of scope

- `sonda/src/scenario_loader.rs::load_flat_single_scenario` has a parallel `"metrics"` default. Pre-existing v1-path latent issue, unrelated to migration. Leave for a separate chore if it materially matters.
- Any scenario YAML migrations — that's sub-slice 2b.