### PR TITLE
fix(ci): use semver-stripped Docker tag in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,15 @@ jobs:
       - name: Generate SHA256SUMS
         run: sha256sum sonda-*.tar.gz > SHA256SUMS
 
+      # docker/metadata-action emits tags without the `v` prefix via
+      # `type=semver,pattern={{version}}`, so the Docker registry has
+      # `ghcr.io/davidban77/sonda:1.0.0`, not `:v1.0.0`. Strip the prefix
+      # for the docs/install snippet so users can copy-paste the correct
+      # pull command.
+      - name: Compute Docker tag (strip leading v)
+        id: docker_tag
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
@@ -123,7 +132,7 @@ jobs:
 
             **Docker:**
             ```
-            docker pull ghcr.io/davidban77/sonda:${{ github.ref_name }}
+            docker pull ghcr.io/davidban77/sonda:${{ steps.docker_tag.outputs.value }}
             ```
 
             See the [README](https://github.com/davidban77/sonda#installation) for all installation methods.


### PR DESCRIPTION
## Summary

Fixes a copy-paste trap in the GitHub Release body: users landing on a release page get a `docker pull ghcr.io/davidban77/sonda:v1.0.0` snippet, but the actual pushed tags are `1.0.0`, `1.0`, `1`, `latest` (no `v` prefix).

### Root cause

`docker/metadata-action` in the Docker-push job uses:
```yaml
type=semver,pattern={{version}}
```
which strips the `v` prefix per SemVer convention. The release-notes body in the `release` job used `${{ github.ref_name }}` which **includes** the `v` prefix, so the two don't match.

### Fix

Adds a one-step version-stripping helper before the release-body creation:
```yaml
- name: Compute Docker tag (strip leading v)
  id: docker_tag
  run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
```
And references `${{ steps.docker_tag.outputs.value }}` in the Docker pull snippet instead of `${{ github.ref_name }}`.

## User impact

- Future releases have a working `docker pull` copy-paste on the release page.
- v1.0.0's release body was manually patched out-of-band (`gh release edit v1.0.0`).

## Test plan

- [ ] CI: release workflow is tag-triggered — changes won't exercise until the next tag push. Sanity-verify the YAML parses (no quote/escaping issue).
- [ ] Next release (whenever cut): visit release page, confirm `docker pull ...:<stripped-version>` snippet.

## Related

- v1.0.0 Docker image: `ghcr.io/davidban77/sonda:1.0.0` (user confirmed working).
- Release notes manually fixed via `gh release edit v1.0.0`.