### PR TITLE
fix: repair --all-features gate failures + add CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,3 +130,36 @@ jobs:
 
       - name: Test without default features
         run: cargo test -p sonda-core --no-default-features
+
+  all-features:
+    name: Build, Test, Clippy (all features)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-all-features-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-all-features-
+
+      - name: Build (all features)
+        run: cargo build --workspace --all-features
+
+      - name: Test (all features)
+        run: cargo test --workspace --all-features
+
+      - name: Clippy (all features)
+        run: cargo clippy --workspace --all-features -- -D warnings

--- a/sonda-core/src/encoder/remote_write.rs
+++ b/sonda-core/src/encoder/remote_write.rs
@@ -609,6 +609,7 @@ mod tests {
         let log_event = LogEvent::new(
             crate::model::log::Severity::Info,
             "test message".to_string(),
+            crate::model::metric::Labels::default(),
             BTreeMap::new(),
         );
         let mut buf = Vec::new();

--- a/sonda/src/dry_run.rs
+++ b/sonda/src/dry_run.rs
@@ -382,7 +382,7 @@ fn encoder_display(enc: &sonda_core::encoder::EncoderConfig) -> String {
         #[cfg(not(feature = "remote-write"))]
         EncoderConfig::RemoteWriteDisabled {} => "remote_write (disabled)".to_string(),
         #[cfg(feature = "otlp")]
-        EncoderConfig::Otlp { .. } => "otlp".to_string(),
+        EncoderConfig::Otlp => "otlp".to_string(),
         #[cfg(not(feature = "otlp"))]
         EncoderConfig::OtlpDisabled {} => "otlp (disabled)".to_string(),
     }


### PR DESCRIPTION
## Summary

Fixes two bugs that escaped the default-features CI gate and surfaced during the v1.0.0 pre-publish audit when running `--all-features`:

| # | Location | Issue | Fix |
|---|---|---|---|
| 1 | `sonda-core/src/encoder/remote_write.rs:609` | Test calls `LogEvent::new` with 3 args, signature requires 4 (missing `Labels` arg) | Add `Labels::default()` as 3rd arg |
| 2 | `sonda/src/dry_run.rs:385` | `EncoderConfig::Otlp { .. }` flagged by clippy 1.95+ (`unneeded_struct_pattern`); `Otlp` is a unit variant | Remove `{ .. }` braces |

Plus adds an `all-features` CI job so this class of bug can't escape again.

## Why the default-features gate missed this

- `sonda-core`'s default feature set is only `["config"]`.
- `remote-write` is an opt-in feature; its test file never compiles unless the feature is enabled.
- Similarly `otlp` guards the failing clippy arm under `#[cfg(feature = "otlp")]`.
- Running `cargo test --workspace` exercises only the default set — neither issue surfaces.

## What changed

- `sonda-core/src/encoder/remote_write.rs` — one-line addition: `crate::model::metric::Labels::default(),` inserted as the third argument to `LogEvent::new`.
- `sonda/src/dry_run.rs` — remove `{ .. }` from the `EncoderConfig::Otlp` match arm.
- `.github/workflows/ci.yml` — new `all-features` job running build + test + clippy under `--all-features`. Separate cache key (`cargo-all-features-*`) so runs don't contend with the default-features job.

## Pre-publish audit context

v1.0.0 was tagged (`ad23601`), GitHub Release cut with binaries, Docker images pushed to ghcr.io. Crates.io publish was put on hold when an Opus staff-engineer reviewer flagged these two BLOCKERs during the ship-readiness audit. Catching them here means the first crates.io publish lands clean at v1.0.1 instead of shipping v1.0.0 with latent bugs that would need a v1.0.1 hotfix within a day.

## Test plan

- [ ] CI default features (existing gates): build / test / clippy / fmt / audit.
- [ ] **New**: CI `--all-features` job: build / test / clippy.
- [ ] CI `--no-default-features`: unchanged, still green.
- [ ] Manual verification (passed locally on Rust 1.95.0):
  - `cargo test --workspace --all-features` → exit 0
  - `cargo clippy --workspace --all-features -- -D warnings` → exit 0
  - `cargo fmt --all -- --check` → exit 0

## Follow-up

After this merges:
1. `#[non_exhaustive]` pass on public enums (separate PR; the other item from the ship-readiness audit).
2. Release-please auto-cuts v1.0.1.
3. First crates.io publish happens at v1.0.1.

## Reviewer reference

Ship-readiness audit identified these as two hard BLOCKERs that would fail the `cargo test --workspace --all-features` gate required for shipping.