### PR TITLE
chore(api): mark public enums non_exhaustive before crates.io publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "0.15.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "0.15.0"
+version = "1.0.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "0.15.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,9 +1815,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/sonda-core/src/compile.rs
+++ b/sonda-core/src/compile.rs
@@ -29,6 +29,7 @@ use crate::config::ScenarioEntry;
 /// matching. The `#[from]` conversions let each phase's fallible call site
 /// bubble up naturally via `?`.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum CompileError {
     /// **Phase 1** (parse): YAML parsing or schema validation failed.
     #[error("parse error: {0}")]

--- a/sonda-core/src/compiler/compile_after.rs
+++ b/sonda-core/src/compiler/compile_after.rs
@@ -148,6 +148,7 @@ use crate::sink::SinkConfig;
 /// spec §3.4 validation table so diagnostics stay aligned with the
 /// published error messages.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum CompileAfterError {
     /// An `after.ref` pointed to a signal id that does not exist in the
     /// expanded file.

--- a/sonda-core/src/compiler/expand.rs
+++ b/sonda-core/src/compiler/expand.rs
@@ -156,6 +156,7 @@ use crate::sink::SinkConfig;
 
 /// Errors produced during pack expansion.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ExpandError {
     /// The pack reference could not be resolved — either unknown name or a
     /// file path load failure. The wrapped message includes the pack

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -101,6 +101,7 @@ use crate::sink::SinkConfig;
 
 /// Errors produced during defaults resolution.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum NormalizeError {
     /// An entry has no `rate` either inline or via the `defaults:` block.
     ///

--- a/sonda-core/src/compiler/parse.rs
+++ b/sonda-core/src/compiler/parse.rs
@@ -18,6 +18,7 @@ use super::{Entry, ScenarioFile};
 
 /// Errors produced during v2 scenario parsing and validation.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ParseError {
     /// The YAML could not be deserialized into the expected structure.
     #[error("YAML parse error: {0}")]

--- a/sonda-core/src/compiler/prepare.rs
+++ b/sonda-core/src/compiler/prepare.rs
@@ -49,6 +49,7 @@ use crate::config::{
 /// so diagnostics chain cleanly when both phases need to report on the same
 /// entry.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum PrepareError {
     /// The entry's `signal_type` was not one of the four recognized variants
     /// (`"metrics"`, `"logs"`, `"histogram"`, `"summary"`).

--- a/sonda-core/src/config/mod.rs
+++ b/sonda-core/src/config/mod.rs
@@ -364,6 +364,7 @@ impl std::ops::DerefMut for ScenarioConfig {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "config", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "config", serde(tag = "type"))]
+#[non_exhaustive]
 pub enum DistributionConfig {
     /// Exponential distribution with rate parameter lambda.
     ///
@@ -527,6 +528,7 @@ impl std::ops::DerefMut for SummaryScenarioConfig {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "config", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "config", serde(tag = "signal_type"))]
+#[non_exhaustive]
 pub enum ScenarioEntry {
     /// A metrics scenario entry.
     #[cfg_attr(feature = "config", serde(rename = "metrics"))]

--- a/sonda-core/src/encoder/mod.rs
+++ b/sonda-core/src/encoder/mod.rs
@@ -52,6 +52,7 @@ pub trait Encoder: Send + Sync {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "config", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "config", serde(tag = "type"))]
+#[non_exhaustive]
 pub enum EncoderConfig {
     /// Prometheus text exposition format (version 0.0.4).
     ///

--- a/sonda-core/src/generator/mod.rs
+++ b/sonda-core/src/generator/mod.rs
@@ -126,6 +126,7 @@ pub struct CsvColumnSpec {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "config", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "config", serde(tag = "type"))]
+#[non_exhaustive]
 pub enum GeneratorConfig {
     /// A generator that always returns the same value.
     #[cfg_attr(feature = "config", serde(rename = "constant"))]

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -3,6 +3,20 @@
 //! This crate owns all domain logic: telemetry models, value generators,
 //! schedulers, encoders, and sinks. The CLI and HTTP server are thin layers
 //! that call into this library.
+//!
+//! # Stability
+//!
+//! Public enums and structs on the library surface — including [`SondaError`]
+//! and its sub-enums ([`ConfigError`], [`GeneratorError`], [`EncoderError`],
+//! [`RuntimeError`]), the config enums ([`GeneratorConfig`](generator::GeneratorConfig),
+//! [`EncoderConfig`](encoder::EncoderConfig), [`SinkConfig`](sink::SinkConfig),
+//! [`DistributionConfig`], [`ScenarioEntry`]), the compile-phase error enums
+//! under [`compiler`], and [`ScenarioStats`] — are marked
+//! `#[non_exhaustive]`. Downstream consumers that `match` on these types must
+//! include a wildcard `_ =>` arm, and [`ScenarioStats`] must be constructed
+//! via `Default::default()` plus field updates rather than a struct literal.
+//! This lets sonda-core add new variants and fields in a minor release
+//! without a semver-major bump.
 
 pub mod compiler;
 pub mod config;
@@ -60,6 +74,7 @@ mod compile;
 /// variant at the call site. This prevents generator or config I/O errors
 /// from being misclassified as sink errors.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum SondaError {
     /// An error in scenario configuration (invalid values, missing fields).
     #[error("configuration error: {0}")]
@@ -97,6 +112,7 @@ pub enum SondaError {
 /// durations, and similar problems that the user can fix by editing their
 /// YAML scenario file or adjusting programmatic config construction.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ConfigError {
     /// A configuration field has an invalid value.
     ///
@@ -121,6 +137,7 @@ impl ConfigError {
 /// contents), `ParseFailed` (unparseable numeric columns), or
 /// `UnsupportedFormat` as generator capabilities grow.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum GeneratorError {
     /// Failed to read a generator input file (CSV replay, log replay).
     ///
@@ -155,6 +172,7 @@ impl GeneratorError {
 /// Preserves original error sources where possible so callers can inspect
 /// the underlying failure without string parsing.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum EncoderError {
     /// JSON serialization failed.
     ///
@@ -189,6 +207,7 @@ pub enum EncoderError {
 /// These represent environmental failures (OS thread limits, thread panics)
 /// that cannot be resolved by changing configuration.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum RuntimeError {
     /// The OS refused to spawn a new thread.
     ///

--- a/sonda-core/src/schedule/stats.rs
+++ b/sonda-core/src/schedule/stats.rs
@@ -23,6 +23,7 @@ pub const MAX_RECENT_METRICS: usize = 100;
 /// scrape-based integration (e.g., Prometheus pulling from
 /// `GET /scenarios/{id}/metrics`). It is bounded by [`MAX_RECENT_METRICS`].
 #[derive(Debug, Clone, Default, Serialize)]
+#[non_exhaustive]
 pub struct ScenarioStats {
     /// Total number of events emitted since the scenario started.
     pub total_events: u64,

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -94,6 +94,7 @@ impl std::fmt::Debug for KafkaSaslConfig {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "config", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "config", serde(tag = "type"))]
+#[non_exhaustive]
 pub enum SinkConfig {
     /// Write encoded events to stdout, buffered via [`BufWriter`](std::io::BufWriter).
     #[cfg_attr(feature = "config", serde(rename = "stdout"))]

--- a/sonda-core/tests/common/mod.rs
+++ b/sonda-core/tests/common/mod.rs
@@ -361,6 +361,12 @@ fn run_entry_with_sink(entry: &ScenarioEntry, sink: &mut dyn Sink) -> Result<(),
         ScenarioEntry::Summary(config) => {
             summary_runner::run_with_sink(config, sink, NONE_ATOMIC, None)
         }
+        // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary
+        // (integration tests are a separate crate), so a wildcard arm is
+        // required. A future signal variant has no runner wired in here yet.
+        _ => Err(SondaError::Config(sonda_core::ConfigError::InvalidValue(
+            "test harness encountered an unknown ScenarioEntry variant".to_string(),
+        ))),
     }
 }
 

--- a/sonda-core/tests/fixture_examples.rs
+++ b/sonda-core/tests/fixture_examples.rs
@@ -296,5 +296,9 @@ fn invalid_missing_rate_rejected() {
             assert_eq!(index, 0);
             assert_eq!(label, "cpu");
         }
+        // `NormalizeError` is `#[non_exhaustive]` across the crate boundary
+        // (integration tests are a separate crate); any other variant is an
+        // unexpected regression for this fixture.
+        other => panic!("expected MissingRate, got {other:?}"),
     }
 }

--- a/sonda-core/tests/pack_parity.rs
+++ b/sonda-core/tests/pack_parity.rs
@@ -49,11 +49,17 @@ fn metric_names(entries: &[ExpandedEntry]) -> BTreeSet<&str> {
 /// once per variant here.
 fn shorten_duration(entries: &mut [ScenarioEntry], duration: &str) {
     for entry in entries {
+        // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary
+        // (integration tests are a separate crate), so the wildcard arm is
+        // required. Unknown future variants are skipped here rather than
+        // panicking — they will fail the parity assertions downstream if
+        // truly unsupported.
         let base = match entry {
             ScenarioEntry::Metrics(c) => &mut c.base,
             ScenarioEntry::Logs(c) => &mut c.base,
             ScenarioEntry::Histogram(c) => &mut c.base,
             ScenarioEntry::Summary(c) => &mut c.base,
+            _ => continue,
         };
         base.duration = Some(duration.to_string());
     }

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -1312,15 +1312,16 @@ scenarios:
     /// StatsResponse correctly converts from ScenarioStats.
     #[test]
     fn stats_response_from_scenario_stats_converts_all_fields() {
-        let stats = ScenarioStats {
-            total_events: 42,
-            bytes_emitted: 1024,
-            current_rate: 10.5,
-            errors: 3,
-            in_gap: true,
-            in_burst: false,
-            ..Default::default()
-        };
+        // `ScenarioStats` is `#[non_exhaustive]` across the crate boundary,
+        // so struct-literal construction is forbidden here. Start from
+        // `Default::default()` and set the fields the test cares about.
+        let mut stats = ScenarioStats::default();
+        stats.total_events = 42;
+        stats.bytes_emitted = 1024;
+        stats.current_rate = 10.5;
+        stats.errors = 3;
+        stats.in_gap = true;
+        stats.in_burst = false;
         let resp: StatsResponse = stats.into();
         assert_eq!(resp.total_events, 42);
         assert_eq!(resp.bytes_emitted, 1024);
@@ -2401,15 +2402,13 @@ scenarios:
     /// GET /scenarios/{id}/stats returns a JSON body with all expected fields.
     #[tokio::test]
     async fn stats_endpoint_returns_all_expected_fields() {
-        let stats = ScenarioStats {
-            total_events: 500,
-            bytes_emitted: 32000,
-            current_rate: 99.5,
-            errors: 2,
-            in_gap: false,
-            in_burst: true,
-            ..Default::default()
-        };
+        let mut stats = ScenarioStats::default();
+        stats.total_events = 500;
+        stats.bytes_emitted = 32000;
+        stats.current_rate = 99.5;
+        stats.errors = 2;
+        stats.in_gap = false;
+        stats.in_burst = true;
         let h = make_handle_with_stats("id-stats-all", "all_fields", 100.0, stats, true);
         let app = router_with_handles(vec![h]);
 
@@ -2522,15 +2521,13 @@ scenarios:
     /// When in_gap is set to true in the stats, the endpoint reflects it.
     #[tokio::test]
     async fn stats_endpoint_in_gap_true_when_stats_indicate_gap() {
-        let stats = ScenarioStats {
-            total_events: 10,
-            bytes_emitted: 640,
-            current_rate: 0.0,
-            errors: 0,
-            in_gap: true,
-            in_burst: false,
-            ..Default::default()
-        };
+        let mut stats = ScenarioStats::default();
+        stats.total_events = 10;
+        stats.bytes_emitted = 640;
+        stats.current_rate = 0.0;
+        stats.errors = 0;
+        stats.in_gap = true;
+        stats.in_burst = false;
         let h = make_handle_with_stats("id-stats-gap", "gap_test", 50.0, stats, true);
         let app = router_with_handles(vec![h]);
 
@@ -2555,15 +2552,13 @@ scenarios:
     /// When a scenario has stopped, GET /scenarios/{id}/stats returns state "stopped".
     #[tokio::test]
     async fn stats_endpoint_returns_stopped_state_for_finished_scenario() {
-        let stats = ScenarioStats {
-            total_events: 1000,
-            bytes_emitted: 64000,
-            current_rate: 0.0,
-            errors: 5,
-            in_gap: false,
-            in_burst: false,
-            ..Default::default()
-        };
+        let mut stats = ScenarioStats::default();
+        stats.total_events = 1000;
+        stats.bytes_emitted = 64000;
+        stats.current_rate = 0.0;
+        stats.errors = 5;
+        stats.in_gap = false;
+        stats.in_burst = false;
         let h = make_handle_with_stats("id-stats-stopped", "stopped_test", 200.0, stats, false);
         let app = router_with_handles(vec![h]);
 
@@ -2641,15 +2636,13 @@ scenarios:
     /// The target_rate field reflects the configured rate on the handle, not measured rate.
     #[tokio::test]
     async fn stats_endpoint_target_rate_reflects_configured_rate() {
-        let stats = ScenarioStats {
-            total_events: 0,
-            bytes_emitted: 0,
-            current_rate: 45.0,
-            errors: 0,
-            in_gap: false,
-            in_burst: false,
-            ..Default::default()
-        };
+        let mut stats = ScenarioStats::default();
+        stats.total_events = 0;
+        stats.bytes_emitted = 0;
+        stats.current_rate = 45.0;
+        stats.errors = 0;
+        stats.in_gap = false;
+        stats.in_burst = false;
         // target_rate = 500.0, but current_rate = 45.0 (different).
         let h = make_handle_with_stats("id-stats-rate", "rate_test", 500.0, stats, true);
         let app = router_with_handles(vec![h]);

--- a/sonda/src/config.rs
+++ b/sonda/src/config.rs
@@ -550,6 +550,9 @@ fn scenario_entry_signal_label(entry: &sonda_core::ScenarioEntry) -> &'static st
         sonda_core::ScenarioEntry::Logs(_) => "logs",
         sonda_core::ScenarioEntry::Histogram(_) => "histogram",
         sonda_core::ScenarioEntry::Summary(_) => "summary",
+        // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary;
+        // future signal kinds will surface here as "unknown" until wired in.
+        _ => "unknown",
     }
 }
 
@@ -931,6 +934,15 @@ fn apply_retry_to_sink(sink: &mut SinkConfig, retry: RetryConfig) -> Result<()> 
                  that was not compiled in"
             );
         }
+        // `SinkConfig` is `#[non_exhaustive]` across the crate boundary;
+        // a future variant reaches this arm until retry semantics are wired in.
+        _ => {
+            bail!(
+                "--retry-* flags cannot be applied to sink variant {:?}: \
+                 this sink type is not yet supported",
+                sink
+            );
+        }
     }
     Ok(())
 }
@@ -962,6 +974,9 @@ fn sink_type_name(sink: &SinkConfig) -> &'static str {
         SinkConfig::KafkaDisabled { .. } => "kafka",
         #[cfg(not(feature = "otlp"))]
         SinkConfig::OtlpGrpcDisabled { .. } => "otlp_grpc",
+        // `SinkConfig` is `#[non_exhaustive]` across the crate boundary;
+        // future variants surface as "unknown" until wired in here.
+        _ => "unknown",
     }
 }
 
@@ -1606,6 +1621,9 @@ pub fn apply_run_overrides(
             sonda_core::ScenarioEntry::Logs(ref mut c) => &mut c.base,
             sonda_core::ScenarioEntry::Histogram(ref mut c) => &mut c.base,
             sonda_core::ScenarioEntry::Summary(ref mut c) => &mut c.base,
+            // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary;
+            // a future signal variant reaches this arm until wired in here.
+            _ => bail!("cannot apply `run` overrides to unknown scenario variant"),
         };
 
         if let Some(ref dur) = args.duration {
@@ -1630,6 +1648,8 @@ pub fn apply_run_overrides(
                 sonda_core::ScenarioEntry::Logs(ref mut c) => c.encoder = enc.clone(),
                 sonda_core::ScenarioEntry::Histogram(ref mut c) => c.encoder = enc.clone(),
                 sonda_core::ScenarioEntry::Summary(ref mut c) => c.encoder = enc.clone(),
+                // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary.
+                _ => bail!("cannot apply encoder override to unknown scenario variant"),
             }
         }
     }
@@ -1671,6 +1691,9 @@ fn apply_builtin_overrides(
         sonda_core::ScenarioEntry::Logs(ref mut c) => &mut c.base,
         sonda_core::ScenarioEntry::Histogram(ref mut c) => &mut c.base,
         sonda_core::ScenarioEntry::Summary(ref mut c) => &mut c.base,
+        // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary;
+        // a future signal variant reaches this arm until wired in here.
+        _ => bail!("cannot apply `scenarios run` overrides to unknown scenario variant"),
     };
 
     if let Some(ref dur) = args.duration {
@@ -1693,6 +1716,8 @@ fn apply_builtin_overrides(
             sonda_core::ScenarioEntry::Logs(ref mut c) => c.encoder = encoder,
             sonda_core::ScenarioEntry::Histogram(ref mut c) => c.encoder = encoder,
             sonda_core::ScenarioEntry::Summary(ref mut c) => c.encoder = encoder,
+            // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary.
+            _ => bail!("cannot apply encoder override to unknown scenario variant"),
         }
     }
 

--- a/sonda/src/dry_run.rs
+++ b/sonda/src/dry_run.rs
@@ -122,6 +122,9 @@ fn write_entry_text<W: Write>(
         ScenarioEntry::Logs(c) => write_logs_fields(out, c)?,
         ScenarioEntry::Histogram(c) => write_histogram_fields(out, c)?,
         ScenarioEntry::Summary(c) => write_summary_fields(out, c)?,
+        // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary;
+        // emit a marker line so future variants render rather than panic.
+        _ => write_field(out, "signal:", "unknown")?,
     }
     Ok(())
 }
@@ -357,6 +360,9 @@ fn generator_display(gen: &sonda_core::generator::GeneratorConfig) -> String {
             let amp_v = amplitude.unwrap_or(10.0);
             format!("steady (center: {center_v}, amplitude: {amp_v})")
         }
+        // `GeneratorConfig` is `#[non_exhaustive]` across the crate boundary;
+        // fall back to the Debug form so a future variant still renders.
+        other => format!("unknown ({other:?})"),
     }
 }
 
@@ -385,6 +391,9 @@ fn encoder_display(enc: &sonda_core::encoder::EncoderConfig) -> String {
         EncoderConfig::Otlp => "otlp".to_string(),
         #[cfg(not(feature = "otlp"))]
         EncoderConfig::OtlpDisabled {} => "otlp (disabled)".to_string(),
+        // `EncoderConfig` is `#[non_exhaustive]` across the crate boundary;
+        // fall back to the Debug form so a future variant still renders.
+        other => format!("unknown ({other:?})"),
     }
 }
 
@@ -510,6 +519,26 @@ fn to_scenario_dto(index: usize, entry: &ScenarioEntry) -> ScenarioDto<'_> {
             clock_group: c.clock_group.as_deref(),
             clock_group_is_auto: c.clock_group_is_auto,
         },
+        // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary;
+        // borrow schedule-level fields via `base()` so a future variant still
+        // round-trips through the JSON DTO with a marker signal label.
+        other => {
+            let base = other.base();
+            ScenarioDto {
+                index,
+                name: base.name.as_str(),
+                signal: "unknown",
+                rate: base.rate,
+                duration: base.duration.as_deref(),
+                generator: format!("unknown ({other:?})"),
+                encoder: String::from("unknown"),
+                sink: sink_display(&base.sink),
+                labels: labels_btree(&base.labels),
+                phase_offset: base.phase_offset.as_deref(),
+                clock_group: base.clock_group.as_deref(),
+                clock_group_is_auto: base.clock_group_is_auto,
+            }
+        }
     }
 }
 

--- a/sonda/src/progress.rs
+++ b/sonda/src/progress.rs
@@ -562,38 +562,33 @@ mod tests {
 
     #[test]
     fn window_tag_plain_gap_active() {
-        let stats = ScenarioStats {
-            in_gap: true,
-            ..Default::default()
-        };
+        // `ScenarioStats` is `#[non_exhaustive]` across the crate boundary,
+        // so struct-literal construction is forbidden here. Start from
+        // `Default::default()` and set the fields the test cares about.
+        let mut stats = ScenarioStats::default();
+        stats.in_gap = true;
         assert_eq!(format_window_tag_plain(&stats), " [gap]");
     }
 
     #[test]
     fn window_tag_plain_burst_active() {
-        let stats = ScenarioStats {
-            in_burst: true,
-            ..Default::default()
-        };
+        let mut stats = ScenarioStats::default();
+        stats.in_burst = true;
         assert_eq!(format_window_tag_plain(&stats), " [burst]");
     }
 
     #[test]
     fn window_tag_plain_spike_active() {
-        let stats = ScenarioStats {
-            in_cardinality_spike: true,
-            ..Default::default()
-        };
+        let mut stats = ScenarioStats::default();
+        stats.in_cardinality_spike = true;
         assert_eq!(format_window_tag_plain(&stats), " [spike]");
     }
 
     #[test]
     fn window_tag_plain_multiple_windows_active() {
-        let stats = ScenarioStats {
-            in_burst: true,
-            in_cardinality_spike: true,
-            ..Default::default()
-        };
+        let mut stats = ScenarioStats::default();
+        stats.in_burst = true;
+        stats.in_cardinality_spike = true;
         assert_eq!(format_window_tag_plain(&stats), " [burst] [spike]");
     }
 
@@ -617,12 +612,10 @@ mod tests {
 
     #[test]
     fn non_tty_line_contains_scenario_name() {
-        let stats = ScenarioStats {
-            total_events: 42,
-            bytes_emitted: 1024,
-            current_rate: 10.0,
-            ..Default::default()
-        };
+        let mut stats = ScenarioStats::default();
+        stats.total_events = 42;
+        stats.bytes_emitted = 1024;
+        stats.current_rate = 10.0;
         let line = format_non_tty_line("cpu_usage", &stats, 10.0, Duration::from_secs(5));
         assert!(
             line.contains("cpu_usage"),
@@ -637,10 +630,8 @@ mod tests {
 
     #[test]
     fn non_tty_line_shows_window_state() {
-        let stats = ScenarioStats {
-            in_burst: true,
-            ..Default::default()
-        };
+        let mut stats = ScenarioStats::default();
+        stats.in_burst = true;
         let line = format_non_tty_line("test", &stats, 10.0, Duration::from_secs(1));
         assert!(
             line.contains("[burst]"),

--- a/sonda/src/sink_format.rs
+++ b/sonda/src/sink_format.rs
@@ -63,6 +63,9 @@ pub fn sink_display(sink: &SinkConfig) -> String {
         SinkConfig::OtlpGrpc { endpoint, .. } => format!("otlp_grpc ({endpoint})"),
         #[cfg(not(feature = "otlp"))]
         SinkConfig::OtlpGrpcDisabled {} => "otlp_grpc (disabled)".to_string(),
+        // `SinkConfig` is `#[non_exhaustive]` across the crate boundary;
+        // fall back to the Debug form so a future variant still renders.
+        other => format!("unknown ({other:?})"),
     }
 }
 

--- a/sonda/src/status.rs
+++ b/sonda/src/status.rs
@@ -72,6 +72,20 @@ pub fn print_start(entry: &ScenarioEntry, verbosity: Verbosity, position: Option
             sink_display(&c.sink),
             c.duration.as_deref(),
         ),
+        // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary;
+        // fall back to `base()` fields so a future variant still prints a
+        // start banner with an "unknown" signal-type marker.
+        other => {
+            let base = other.base();
+            (
+                base.name.as_str(),
+                "unknown",
+                base.rate,
+                String::from("unknown"),
+                sink_display(&base.sink),
+                base.duration.as_deref(),
+            )
+        }
     };
     let clock_group = entry.clock_group();
     let clock_group_is_auto = entry.clock_group_is_auto();
@@ -207,6 +221,15 @@ pub fn print_config(entry: &ScenarioEntry, index: usize, total: usize) {
         ScenarioEntry::Logs(c) => print_logs_config(c, index, total),
         ScenarioEntry::Histogram(c) => print_histogram_config(c, index, total),
         ScenarioEntry::Summary(c) => print_summary_config(c, index, total),
+        // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary;
+        // render a header + marker line so a future variant is observable
+        // in `--verbose` / `--dry-run` output instead of silently skipped.
+        other => {
+            print_config_header(other.base().name.as_str(), index, total);
+            eprintln!();
+            print_config_field("signal:", "unknown");
+            eprintln!();
+        }
     }
 }
 
@@ -815,6 +838,9 @@ fn generator_display(gen: &GeneratorConfig) -> String {
             let i = spike_interval.as_deref().unwrap_or("30s");
             format!("spike_event (baseline: {base}, height: {h}, duration: {d}, interval: {i})")
         }
+        // `GeneratorConfig` is `#[non_exhaustive]` across the crate boundary;
+        // fall back to the Debug form so a future variant still renders.
+        other => format!("unknown ({other:?})"),
     }
 }
 
@@ -860,6 +886,9 @@ fn encoder_display(encoder: &EncoderConfig) -> String {
         EncoderConfig::RemoteWriteDisabled { .. } => ("remote_write (feature disabled)", None),
         #[cfg(not(feature = "otlp"))]
         EncoderConfig::OtlpDisabled { .. } => ("otlp (feature disabled)", None),
+        // `EncoderConfig` is `#[non_exhaustive]` across the crate boundary;
+        // fall back to a generic marker so a future variant still renders.
+        _ => ("unknown", None),
     };
     match precision {
         Some(p) => format!("{name} (precision: {p})"),
@@ -1450,12 +1479,13 @@ mod tests {
 
     #[test]
     fn print_stop_with_errors_does_not_panic() {
-        let stats = ScenarioStats {
-            total_events: 100,
-            bytes_emitted: 4096,
-            errors: 3,
-            ..Default::default()
-        };
+        // `ScenarioStats` is `#[non_exhaustive]` across the crate boundary,
+        // so struct-literal construction is forbidden here. Start from
+        // `Default::default()` and set the fields the test cares about.
+        let mut stats = ScenarioStats::default();
+        stats.total_events = 100;
+        stats.bytes_emitted = 4096;
+        stats.errors = 3;
         // When errors > 0, the stop icon should be yellow and error count red.
         // We just verify it does not panic.
         print_stop(
@@ -1481,10 +1511,8 @@ mod tests {
 
     #[test]
     fn print_stop_with_large_byte_count_does_not_panic() {
-        let stats = ScenarioStats {
-            bytes_emitted: 2_000_000_000,
-            ..Default::default()
-        };
+        let mut stats = ScenarioStats::default();
+        stats.bytes_emitted = 2_000_000_000;
         print_stop(
             "big_bytes",
             Duration::from_secs(60),


### PR DESCRIPTION
## Summary

- Adds `#[non_exhaustive]` to 17 public types in `sonda-core` before the first crates.io publish (v1.0.1).
- Lets us add variants/fields post-1.0.0 without cutting a major — future-proofing the public API surface.
- Sonda is **not yet on crates.io**, so there are no downstream breakages today; this is a preventive patch before the first publish.

## Types marked `#[non_exhaustive]`

**Error enums (5):** `SondaError`, `ConfigError`, `GeneratorError`, `EncoderError`, `RuntimeError`
**Compile-phase error enums (5):** `ParseError`, `NormalizeError`, `ExpandError`, `CompileAfterError`, `PrepareError`
**Top-level compile error (1):** `CompileError`
**Config enums (3):** `GeneratorConfig`, `EncoderConfig`, `SinkConfig`
**Other config (2):** `DistributionConfig`, `ScenarioEntry`
**Struct (1):** `ScenarioStats`

## In-crate churn

Since `#[non_exhaustive]` is crate-boundary-scoped, `sonda`, `sonda-server`, and `sonda-core/tests` all needed either:

- Wildcard `_ =>` arms on match sites (19 arms), using sensible fallbacks (`format!("unknown ({other:?})")` for strings, `bail!(...)` / `Err(ConfigError::invalid(...))` for Results, `panic!(...)` for tests, `.base()` accessor for DTO fallbacks).
- `ScenarioStats::default()` rewrites (13 sites) at struct-literal construction points.

## Docs

- Adds a `# Stability` section to `sonda-core`'s crate-level docs explaining the `#[non_exhaustive]` contract for library integrators.
- No `docs/site/**` changes — the doc agent confirmed `mkdocs --strict` is clean and this is a library-API concern, not a user-facing behavior change.
- **Changelog**: follows PR #220's pattern — do NOT edit `CHANGELOG.md` in-PR. After merge, release-please will cut a v1.0.1 PR; manually expand its body with the breaking-change-for-integrators note.

## Gate verdicts

- **Opus @reviewer**: PASS — verified all 17 attributes, 19 wildcard arms, 13 struct rewrites, and explicit confirmation that deferred items (OTLP types, AST structs, `AfterOp`, `Severity`, `SpikeStrategy`, `DynamicLabelStrategy`) were correctly NOT annotated.
- **@uat**: PASS on 7 smoke scenarios (v1 YAML rejection, catalog list, multi-signal causal chain, dry-run output).
- **@doc**: crate-level stability section added; site clean.
- **Orchestrator gates**: `cargo build/test/clippy --workspace --all-features` + `cargo fmt --all -- --check` + `cargo audit` all green.

## Test plan

- [ ] `cargo build --workspace --all-features`
- [ ] `cargo test --workspace --all-features`
- [ ] `cargo clippy --workspace --all-features -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] CI passes (including the new `all-features` job added in PR #224)