### PR TITLE
chore(release-please): pin next release to 1.0.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
+      "release-as": "1.0.1",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "extra-files": [


### PR DESCRIPTION
## Summary

Release-please auto-detected v2.0.0 from a false positive: the phrase \`BREAKING CHANGE:\` appears in commit [62027fc](https://github.com/davidban77/sonda/commit/62027fc)'s body as prose (describing v1.0.0's past footers), not as a real footer.

Nothing since v1.0.0 breaks any consumer — sonda is not yet on crates.io, so there's no downstream for \`#[non_exhaustive]\` (PR #225) to break. Pin the next release to **v1.0.1** via the \`release-as\` field.

## After v1.0.1 ships

Remove the \`release-as: 1.0.1\` line in a follow-up PR so release-please resumes its normal conventional-commit version detection for future releases.

## Test plan

- [ ] Merge this PR
- [ ] Wait for release-please to regenerate its PR as **v1.0.1** (not v2.0.0)
- [ ] Manually expand that PR body with integrator note (PR #220 pattern)
- [ ] Merge v1.0.1 release PR → triggers tag push + release artifact build
- [ ] Trigger \`publish.yml\` with \`dry_run: false\` to publish to crates.io