### PR TITLE
chore(release-please): remove release-as pin after v1.0.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "release-as": "1.0.1",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "extra-files": [


### PR DESCRIPTION
## Summary

The \`release-as: 1.0.1\` field was added in PR #227 as a temporary override to force release-please to cut v1.0.1 instead of a false-positive v2.0.0. v1.0.1 is now released (tag pushed, binaries + Docker building), so remove the pin to restore normal conventional-commit version detection for the next release.

## Test plan

- [ ] Merge this PR
- [ ] Next conventional-commit merge should regenerate a release-please PR at v1.0.2 / v1.1.0 (depending on commit types), not v1.0.1