### PR TITLE
chore(tooling): pin rust toolchain to 1.95.0 (issue #213 D1)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Adds \`rust-toolchain.toml\` at repo root pinning the Rust toolchain to \`1.95.0\` with \`rustfmt\` + \`clippy\` components.

Addresses item **D1** of issue #213.

## Why

- **Before**: CI used \`dtolnay/rust-toolchain@stable\` (floating latest) while local dev used whatever each contributor had installed. That drift hid \`clippy::unnecessary_sort_by\` (new/stricter in Rust 1.95.0) from local gates during PR #212, surfacing only in CI — forcing two tiny follow-up PRs.
- **After**: both environments honor \`rust-toolchain.toml\`. \`dtolnay/rust-toolchain\` auto-detects the file, so no workflow edits are needed.

## Bump cadence

Manual lift of the pin when a new stable lands and the workspace lints clean against it. No automation for now.

## Gate verdicts

- **@reviewer-quick**: PASS (mechanical class, zero production code)
- **Orchestrator gates**: \`cargo build/test/clippy/fmt/audit\` all green on 1.95.0.

## Test plan

- [ ] CI passes (proves CI also resolves 1.95.0 via \`rust-toolchain.toml\`)
- [ ] Fresh clone + \`cargo build\` auto-installs 1.95.0 on a machine without it cached