### PR TITLE
refactor(scenario-loader): consolidate v2 compile dispatch + promote discriminant (issue #213 A1+A2)

### DIFF
--- a/sonda-core/src/config/mod.rs
+++ b/sonda-core/src/config/mod.rs
@@ -577,6 +577,30 @@ impl ScenarioEntry {
     pub fn clock_group_is_auto(&self) -> Option<bool> {
         self.base().clock_group_is_auto
     }
+
+    /// Return the human-readable signal type name for this entry.
+    ///
+    /// Matches the `signal_type:` discriminant used in v2 scenario YAML
+    /// (`"metrics"`, `"logs"`, `"histogram"`, `"summary"`). Intended for
+    /// diagnostics and user-facing mismatch messages.
+    ///
+    /// [`ScenarioEntry`] is `#[non_exhaustive]`; variants added in the
+    /// future surface here as `"unknown"` until wired in. The catch-all
+    /// arm is intra-crate-unreachable today (Rust only enforces
+    /// `#[non_exhaustive]` across crate boundaries) but is retained so
+    /// the forward-compat contract is visible at the method site.
+    #[allow(unreachable_patterns)]
+    pub fn signal_type_name(&self) -> &'static str {
+        match self {
+            ScenarioEntry::Metrics(_) => "metrics",
+            ScenarioEntry::Logs(_) => "logs",
+            ScenarioEntry::Histogram(_) => "histogram",
+            ScenarioEntry::Summary(_) => "summary",
+            // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary;
+            // future signal kinds will surface here as "unknown" until wired in.
+            _ => "unknown",
+        }
+    }
 }
 
 /// Validate the `columns` field of a `CsvReplay` generator config.
@@ -2086,6 +2110,69 @@ generator:
             }
             other => panic!("expected CsvReplay variant, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // ScenarioEntry::signal_type_name()
+    // -----------------------------------------------------------------------
+
+    /// `signal_type_name()` returns the v2 YAML discriminant string for
+    /// every currently wired [`ScenarioEntry`] variant.
+    #[test]
+    fn scenario_entry_signal_type_name_covers_all_variants() {
+        // Metrics entry.
+        let metrics_yaml = r#"
+signal_type: metrics
+name: cpu
+rate: 1
+generator:
+  type: constant
+  value: 1.0
+"#;
+        let metrics: ScenarioEntry = serde_yaml_ng::from_str(metrics_yaml).unwrap();
+        assert_eq!(metrics.signal_type_name(), "metrics");
+
+        // Logs entry.
+        let logs_yaml = r#"
+signal_type: logs
+name: app_logs
+rate: 1
+generator:
+  type: replay
+  file: /tmp/does-not-need-to-exist.log
+"#;
+        let logs: ScenarioEntry = serde_yaml_ng::from_str(logs_yaml).unwrap();
+        assert_eq!(logs.signal_type_name(), "logs");
+
+        // Histogram entry.
+        let histogram_yaml = r#"
+signal_type: histogram
+name: req_latency
+rate: 1
+observations_per_tick: 100
+buckets: [0.1, 0.5, 1.0]
+distribution:
+  type: uniform
+  min: 0.0
+  max: 1.0
+"#;
+        let histogram: ScenarioEntry = serde_yaml_ng::from_str(histogram_yaml).unwrap();
+        assert_eq!(histogram.signal_type_name(), "histogram");
+
+        // Summary entry.
+        let summary_yaml = r#"
+signal_type: summary
+name: req_latency_summary
+rate: 1
+observations_per_tick: 100
+quantiles: [0.5, 0.9, 0.99]
+distribution:
+  type: uniform
+  min: 0.0
+  max: 1.0
+"#;
+        let summary: ScenarioEntry = serde_yaml_ng::from_str(summary_yaml).unwrap();
+        assert_eq!(summary.signal_type_name(), "summary");
     }
 }
 

--- a/sonda/src/config.rs
+++ b/sonda/src/config.rs
@@ -542,20 +542,6 @@ impl LoadedSingleEntry {
     }
 }
 
-/// Human-readable label for the signal type carried by a
-/// [`sonda_core::ScenarioEntry`]. Used in mismatch diagnostics.
-fn scenario_entry_signal_label(entry: &sonda_core::ScenarioEntry) -> &'static str {
-    match entry {
-        sonda_core::ScenarioEntry::Metrics(_) => "metrics",
-        sonda_core::ScenarioEntry::Logs(_) => "logs",
-        sonda_core::ScenarioEntry::Histogram(_) => "histogram",
-        sonda_core::ScenarioEntry::Summary(_) => "summary",
-        // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary;
-        // future signal kinds will surface here as "unknown" until wired in.
-        _ => "unknown",
-    }
-}
-
 /// Load exactly one scenario entry from a file for a single-signal
 /// subcommand (`metrics`, `logs`, `histogram`, `summary`).
 ///
@@ -594,8 +580,6 @@ fn load_single_entry_from_scenario_file(
     kind: SignalKind,
     subcommand: &str,
 ) -> Result<LoadedSingleEntry> {
-    use crate::scenario_loader::FilesystemPackResolver;
-
     let yaml = resolve_scenario_source(path, scenario_catalog)?;
     let version = sonda_core::compiler::parse::detect_version(&yaml);
 
@@ -609,8 +593,7 @@ fn load_single_entry_from_scenario_file(
         );
     }
 
-    let resolver = FilesystemPackResolver::new(pack_catalog);
-    let mut entries = sonda_core::compile_scenario_file(&yaml, &resolver)
+    let mut entries = crate::scenario_loader::compile_v2_yaml(&yaml, pack_catalog)
         .with_context(|| format!("failed to compile v2 scenario file {}", path.display()))?;
 
     if entries.len() != 1 {
@@ -640,7 +623,7 @@ fn load_single_entry_from_scenario_file(
             Ok(LoadedSingleEntry::Summary(cfg))
         }
         (_, entry) => {
-            let actual = scenario_entry_signal_label(&entry);
+            let actual = entry.signal_type_name();
             bail!(
                 "v2 scenario file {} contains a {} entry; \
                  `sonda {} --scenario` expects a {} entry. \
@@ -1568,16 +1551,14 @@ pub fn parse_builtin_scenario(
         );
     }
 
-    use crate::scenario_loader::FilesystemPackResolver;
-
-    let resolver = FilesystemPackResolver::new(pack_catalog);
-    let mut entries = sonda_core::compile_scenario_file(&yaml, &resolver).with_context(|| {
-        format!(
-            "failed to compile v2 scenario {:?} from {}",
-            scenario.name,
-            scenario.source_path.display()
-        )
-    })?;
+    let mut entries =
+        crate::scenario_loader::compile_v2_yaml(&yaml, pack_catalog).with_context(|| {
+            format!(
+                "failed to compile v2 scenario {:?} from {}",
+                scenario.name,
+                scenario.source_path.display()
+            )
+        })?;
 
     // Apply overrides to each entry.
     for entry in &mut entries {

--- a/sonda/src/scenario_loader.rs
+++ b/sonda/src/scenario_loader.rs
@@ -23,10 +23,39 @@ use sonda_core::compiler::expand::{
 };
 use sonda_core::compiler::parse::detect_version;
 use sonda_core::packs::MetricPackDef;
-use sonda_core::{compile_scenario_file, ScenarioEntry};
+use sonda_core::{compile_scenario_file, CompileError, ScenarioEntry};
 
 use crate::packs::PackCatalog;
 use crate::scenarios::ScenarioCatalog;
+
+/// Compile a v2 scenario YAML string into [`ScenarioEntry`] values using
+/// the CLI's filesystem-backed pack resolver.
+///
+/// This is the shared resolver+compile step used by every CLI entry
+/// point that loads a v2 scenario file
+/// ([`load_scenario_entries`], the single-entry subcommand loader in
+/// `sonda::config`, and the catalog dispatcher
+/// [`parse_builtin_scenario`](crate::config::parse_builtin_scenario)).
+///
+/// Callers are expected to have already performed the `version: 2`
+/// check — this helper does not reject v1 YAML shapes. It also does not
+/// wrap the returned [`CompileError`] in `anyhow::Context`; each caller
+/// attaches its own path-specific context so diagnostics stay accurate
+/// to the source that was loaded.
+///
+/// # Errors
+///
+/// Returns the raw [`CompileError`] produced by
+/// [`sonda_core::compile_scenario_file`] so callers can pattern-match
+/// on typed compilation failures or wrap the error with caller-specific
+/// context via [`anyhow::Context`].
+pub fn compile_v2_yaml(
+    yaml: &str,
+    pack_catalog: &PackCatalog,
+) -> Result<Vec<ScenarioEntry>, CompileError> {
+    let resolver = FilesystemPackResolver::new(pack_catalog);
+    compile_scenario_file(yaml, &resolver)
+}
 
 /// The result of loading a scenario file: the prepared runtime entries
 /// plus the detected schema version.
@@ -71,8 +100,7 @@ pub fn load_scenario_entries(
 
     match version {
         Some(2) => {
-            let resolver = FilesystemPackResolver::new(pack_catalog);
-            let entries = compile_scenario_file(&yaml, &resolver).with_context(|| {
+            let entries = compile_v2_yaml(&yaml, pack_catalog).with_context(|| {
                 format!(
                     "failed to compile v2 scenario file {}",
                     scenario_ref.display()


### PR DESCRIPTION
## Summary

Addresses items **A1** and **A2** of issue #213.

### A1 — Dispatch consolidation

Three call sites duplicated the same \`FilesystemPackResolver::new(...)\` + \`compile_scenario_file(...)\` pair:

- \`sonda/src/scenario_loader.rs::load_scenario_entries\`
- \`sonda/src/config.rs::load_single_entry_from_scenario_file\`
- \`sonda/src/config.rs::parse_builtin_scenario\`

Factor a small \`compile_v2_yaml(yaml, pack_catalog) -> Result<Vec<ScenarioEntry>, CompileError>\` helper in \`sonda::scenario_loader\`. The helper owns the resolver+compile step and returns the raw typed \`CompileError\` — each caller attaches its own path-specific \`anyhow::Context\` and keeps its exact prior v2 rejection message (the catalog variant's \"cataloged scenario ...\" wording must stay, so the version check does NOT move into the helper).

### A2 — Discriminant helper

Move the local \`scenario_entry_signal_label\` (CLI-side wrapper) to \`sonda_core::ScenarioEntry::signal_type_name()\` as a public method on the enum it discriminates. Keeps the \`_ => \"unknown\"\` catch-all for the \`#[non_exhaustive]\` forward-compat contract. Added a unit test covering the four currently wired variants (metrics / logs / histogram / summary).

## Scope

- \`sonda-core/src/config/mod.rs\` — new \`ScenarioEntry::signal_type_name()\` + unit test.
- \`sonda/src/scenario_loader.rs\` — new \`compile_v2_yaml\` helper; \`load_scenario_entries\` re-routed.
- \`sonda/src/config.rs\` — deleted \`scenario_entry_signal_label\`; two dispatch sites re-routed; mismatch arm uses \`entry.signal_type_name()\`.

**Intentionally out of scope**: \`LoadedSingleEntry\` + its \`unreachable!\` arms — those require a wider restructure that would change the return-type surface of \`load_single_entry_from_scenario_file\`.

## Gate verdicts

- **@reviewer-quick**: PASS (internal-fix class)
- **Orchestrator gates**: \`cargo build/test/clippy/fmt/audit\` green on default features AND \`--all-features\`.

## Test plan

- [ ] CI passes (including \`all-features\` job)
- [ ] Spot-check: \`sonda run --scenario @cpu-spike --dry-run\`, \`sonda metrics --scenario @steady-state --dry-run\` — error messages on v1 files remain unchanged