### PR TITLE
test(parse): lock flat-shorthand metadata=None invariant (issue #213 B1)

### DIFF
--- a/sonda-core/src/compiler/parse.rs
+++ b/sonda-core/src/compiler/parse.rs
@@ -572,6 +572,43 @@ labels:
         assert_eq!(labels.get("device").map(String::as_str), Some("rtr-01"));
     }
 
+    /// Locks the invariant that the flat shorthand shape never produces
+    /// top-level `scenario_name`, `category`, or `description` on the
+    /// resulting [`ScenarioFile`]. Those fields are only reachable via the
+    /// canonical `scenarios:` form (see `metadata_unknown_field_is_rejected_
+    /// by_deny_unknown_fields` and friends for the canonical-side tests).
+    #[test]
+    fn flat_shorthand_never_carries_top_level_metadata() {
+        let yaml = r#"
+version: 2
+name: cpu_usage
+signal_type: metrics
+rate: 1
+generator:
+  type: sine
+  amplitude: 50
+  period_secs: 60
+  offset: 50
+"#;
+
+        let file = parse(yaml).expect("must parse flat shorthand");
+        assert!(
+            file.scenario_name.is_none(),
+            "flat shorthand must not carry scenario_name; got {:?}",
+            file.scenario_name
+        );
+        assert!(
+            file.category.is_none(),
+            "flat shorthand must not carry category; got {:?}",
+            file.category
+        );
+        assert!(
+            file.description.is_none(),
+            "flat shorthand must not carry description; got {:?}",
+            file.description
+        );
+    }
+
     #[test]
     fn entry_with_after_clause() {
         let yaml = r#"


### PR DESCRIPTION
## Summary

Adds a regression test for item **B1** of issue #213.

\`FlatFile::into_scenario_file\` hardcodes \`scenario_name\` / \`category\` / \`description\` to \`None\` — the flat-shorthand shape is the terse single-signal authoring form and never carries canonical-form metadata. No explicit test locked this invariant, so a refactor could accidentally start carrying those fields forward without failing any gate.

## Change

One new test in \`sonda-core/src/compiler/parse.rs\`'s existing \`#[cfg(test)] mod tests\` block: parses a valid flat-shorthand YAML and asserts all three metadata fields are \`None\` on the returned \`ScenarioFile\`.

## Gate verdicts

- **@reviewer-quick**: PASS (mechanical class)
- **Orchestrator gates**: \`cargo build/test/clippy/fmt/audit\` all green

## Test plan

- [ ] CI passes

## After this merges

Issue #213 is fully resolved — all items addressed or auto-closed:

- ✅ **A1** dispatch consolidation (PR #233)
- ✅ **A2** discriminant helper (PR #233)
- ✅ **B1** this PR
- ✅ **B2** flaky test fix (PR #232)
- ✅ **C1** auto-closed (v1 \`load_flat_single_scenario\` removed by PR 9)
- ✅ **D1** rust-toolchain.toml (PR #231)

Can close #213 on merge.