### PR TITLE
fix(examples): migrate alerting-scenario to v2 + recurse example sweep (issue #223 #3)

### DIFF
--- a/examples/alertmanager/alerting-scenario.yaml
+++ b/examples/alertmanager/alerting-scenario.yaml
@@ -11,7 +11,7 @@
 # Prerequisites:
 #   docker compose -f examples/docker-compose-victoriametrics.yml --profile alerting up -d
 #
-# Usage:
+# Usage with the CLI (host-run):
 #   sonda metrics --scenario examples/alertmanager/alerting-scenario.yaml
 #
 # Verify data arrived:
@@ -20,25 +20,28 @@
 # Check fired alerts:
 #   curl -s http://localhost:8880/api/v1/alerts | jq .
 
-name: docker_alert_cpu
-rate: 2
-duration: 300s
+version: 2
 
-generator:
-  type: sine
-  amplitude: 50.0
-  period_secs: 30
-  offset: 50.0
+defaults:
+  rate: 2
+  duration: 300s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: http_push
+    url: "http://localhost:8428/api/v1/import/prometheus"
+    content_type: "text/plain"
+  labels:
+    host: docker-alert-demo
+    region: us-east-1
+    service: payment-service
+    env: staging
 
-labels:
-  host: docker-alert-demo
-  region: us-east-1
-  service: payment-service
-  env: staging
-
-encoder:
-  type: prometheus_text
-sink:
-  type: http_push
-  url: "http://localhost:8428/api/v1/import/prometheus"
-  content_type: "text/plain"
+scenarios:
+  - signal_type: metrics
+    name: docker_alert_cpu
+    generator:
+      type: sine
+      amplitude: 50.0
+      period_secs: 30
+      offset: 50.0

--- a/sonda/tests/example_scenarios.rs
+++ b/sonda/tests/example_scenarios.rs
@@ -104,9 +104,29 @@ fn discover_sonda_example_files() -> Vec<PathBuf> {
     assert!(dir.is_dir(), "examples/ directory must exist at repo root");
 
     let mut files = Vec::new();
-    for entry in std::fs::read_dir(&dir).expect("read examples/ directory") {
+    collect_sonda_scenario_yamls(&dir, &mut files);
+    files.sort();
+    files
+}
+
+/// Recursively walk `dir` and push every `.yaml` file whose contents
+/// [`is_sonda_scenario`] accepts.
+///
+/// The walk is intentionally simple (no `walkdir` dep) since `examples/`
+/// is small and the structure is shallow. Recursion catches scenarios
+/// nested under subdirectories like `examples/alertmanager/` that the
+/// prior single-level `read_dir` glob missed.
+fn collect_sonda_scenario_yamls(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).unwrap_or_else(|e| {
+        panic!("read {}: {e}", dir.display());
+    }) {
         let entry = entry.expect("directory entry must be readable");
         let path = entry.path();
+
+        if path.is_dir() {
+            collect_sonda_scenario_yamls(&path, out);
+            continue;
+        }
 
         if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
             continue;
@@ -116,12 +136,9 @@ fn discover_sonda_example_files() -> Vec<PathBuf> {
             .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
 
         if is_sonda_scenario(&content) {
-            files.push(path);
+            out.push(path);
         }
     }
-
-    files.sort();
-    files
 }
 
 /// Load the YAML text at `relative` (a workspace-relative path).


### PR DESCRIPTION
## Summary

Addresses item **#3** of issue #223.

PR #218's v1 → v2 examples migration used a single-level directory scan, which missed subdirectory contents. One file slipped through: \`examples/alertmanager/alerting-scenario.yaml\`. Users following the alerting quick-start hit HTTP 400 from sonda-server because the v1 shape is no longer accepted anywhere.

## Changes

- **Migrate** \`examples/alertmanager/alerting-scenario.yaml\` to v2 canonical form (\`version: 2\` + \`defaults:\` + \`scenarios:\` list). Preserves the exact original semantics — metric name, rate, duration, labels, sine params, http_push sink config.
- **Make the example sweep recursive**: \`discover_sonda_example_files\` in \`sonda/tests/example_scenarios.rs\` now walks subdirectories via a new private \`collect_sonda_scenario_yamls\` helper. No \`walkdir\` dep — \`examples/\` is small and shallow. Any future miss of this class is caught by CI.

## Intentional scope boundaries

- **Sink URL stays \`localhost:8428\`**. The host-CLI vs. compose-network \`localhost\` tension is **papercut #4**, its own PR.
- **No \`batch_size\` override added**. The http_push default-batching trap is **papercut #2** — either the default changes globally or examples get the override. This file follows whichever decision lands.

## Gate verdicts

- **@reviewer-quick**: PASS (mechanical class)
- **Orchestrator gates**: \`cargo build/test/clippy/fmt/audit\` all green
- 12/12 example_scenarios tests pass, including the sweep picking up the newly-migrated file

## Test plan

- [ ] CI passes
- [ ] Spot-check: \`sonda metrics --scenario examples/alertmanager/alerting-scenario.yaml --dry-run\`