### PR TITLE
docs(site): announce v1.0.1 crates.io release + fix k8s servicemonitor anchor (audit P0-1 + P0-2)

### DIFF
--- a/docs/site/docs/configuration/cli-reference.md
+++ b/docs/site/docs/configuration/cli-reference.md
@@ -41,7 +41,7 @@ sonda --version
 ```
 
 ```text title="Output"
-sonda 0.11.0
+sonda 1.0.1
 ```
 
 ## Status output
@@ -412,7 +412,7 @@ sonda --verbose metrics --name up --rate 1 --duration 2s
 ```
 
 ```text title="Output (stderr)"
-sonda 0.11.0 (http) — synthetic telemetry generator
+sonda 1.0.1 (http) — synthetic telemetry generator
 [config] up
 
   name:          up

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -291,7 +291,7 @@ with:
 helm install sonda ./helm/sonda --set serviceMonitor.enabled=true
 ```
 
-See the [ServiceMonitor](#servicemonitor-1) values reference for all options
+See the [ServiceMonitor](#servicemonitor) values reference for all options
 (`interval`, `scrapeTimeout`, `path`, `additionalLabels`).
 
 Alternatively, apply a custom ServiceMonitor manually for full control:

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -3,6 +3,14 @@
 This guide walks you through installing Sonda and generating your first metrics and logs.
 By the end, you will have synthetic telemetry streaming to stdout.
 
+!!! info "What's new in 1.0.1"
+    Sonda 1.0.1 is the first release on [crates.io](https://crates.io), so
+    `cargo install sonda` is a brand-new install path — use the **Cargo** tab below if you
+    have the Rust toolchain handy. The library crates are also published:
+    [`sonda-core`](https://crates.io/crates/sonda-core),
+    [`sonda`](https://crates.io/crates/sonda),
+    [`sonda-server`](https://crates.io/crates/sonda-server).
+
 ## Installation
 
 === "Install script (Linux/macOS)"
@@ -16,7 +24,7 @@ By the end, you will have synthetic telemetry streaming to stdout.
     To pin a specific version:
 
     ```bash
-    curl -fsSL https://raw.githubusercontent.com/davidban77/sonda/main/install.sh | SONDA_VERSION=v0.11.0 sh
+    curl -fsSL https://raw.githubusercontent.com/davidban77/sonda/main/install.sh | SONDA_VERSION=v1.0.1 sh
     ```
 
 === "Cargo"
@@ -62,7 +70,7 @@ sonda --version
 ```
 
 ```text title="Output"
-sonda 0.11.0
+sonda 1.0.1
 ```
 
 ## Your first metric

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -4,6 +4,18 @@ Sonda is a synthetic telemetry generator that produces realistic metrics and log
 observability pipelines. It models the failure patterns that actually break real systems: gaps,
 micro-bursts, cardinality spikes, and shaped value sequences.
 
+!!! tip "New in 1.0.1 — Sonda is on crates.io"
+    Sonda 1.0.1 is the first release published to [crates.io](https://crates.io). You can now
+    pull the binary with `cargo install sonda`, or depend on the library crates directly from
+    any Rust project:
+
+    - [`sonda-core`](https://crates.io/crates/sonda-core) — generators, encoders, sinks, and the v2 scenario compiler.
+    - [`sonda`](https://crates.io/crates/sonda) — the CLI binary.
+    - [`sonda-server`](https://crates.io/crates/sonda-server) — the HTTP control-plane binary.
+
+    The [v2 scenario format](configuration/v2-scenarios.md) is the canonical shape for every
+    scenario file in 1.0.1 — v1 has been fully retired.
+
 ## What you can do with Sonda
 
 - **Validate alert rules** -- generate exact metric shapes (sine waves, sequences, CSV replays) to


### PR DESCRIPTION
## Summary

Addresses **P0-1** and **P0-2** of the v1.0.1 docs audit tracker (the first two items, shipping together as a quick-win "PR A").

### P0-1 — Stale \`0.11.0\` / \`v0.11.0\` references + crates.io announcement

Sonda **shipped v1.0.1 to crates.io yesterday (2026-04-22)** — the first crates.io release ever. Docs still referenced \`v0.11.0\` in four places, silently pinning new users to a pre-1.0 release on their very first copy-paste.

- Replace four references with \`1.0.1\`. Matches live \`sonda --version\` output character-for-character.
- Add a \`!!! tip\` admonition to \`index.md\` — **"New in 1.0.1 — Sonda is on crates.io"** — links to all three newly-published crates (\`sonda-core\`, \`sonda\`, \`sonda-server\`).
- Add a \`!!! info\` admonition to \`getting-started.md\` — **"What's new in 1.0.1"** — highlights the Cargo install tab as a brand-new path.

### P0-2 — Broken k8s anchor

\`[ServiceMonitor](#servicemonitor-1)\` at \`kubernetes.md:294\` was circular-linking to itself. MkDocs disambiguates duplicate headings (\`### ServiceMonitor\` appears at lines 150 and 284) with a \`-1\` suffix. The link intent was the values-reference heading at line 150 → drop the suffix → correctly resolves to \`#servicemonitor\`.

The previously-suppressed "missing anchor" warning is now gone from \`task site:build --strict\`.

## Gate verdicts

- **@doc** wrote. Voice approved by author.
- **@reviewer-quick**: PASS.
- **@uat**: PASS — strict build clean, both callouts render as Material admonitions, k8s anchor navigates to the values reference, all three crates verified published at 1.0.1 via the crates.io REST API.

## Test plan

- [ ] CI passes (mkdocs strict build in the docs workflow)
- [ ] Merged view on gh-pages shows the callouts on Home and Getting Started
- [ ] Click the kubernetes ServiceMonitor cross-link after deploy; confirm it lands at the values table

## Audit tracker

On merge, check off P0-1 and P0-2 in \`~/.claude/projects/-Users-netpanda-projects-sonda/audits/2026-04-22-v1.0.1-docs-audit.md\`. Next PR up is **PR B** (P0-3 + P0-4 + P0-5 — new "Endpoints and networking" page + honest \`docker.md\` Compose Stack rewrite + localhost-trap paragraphs).