### PR TITLE
docs(site): add endpoints & networking page + fix Compose stack honesty (audit P0-3 + P0-4 + P0-5)

### DIFF
--- a/docs/site/docs/configuration/sinks.md
+++ b/docs/site/docs/configuration/sinks.md
@@ -6,6 +6,13 @@ omitted, the default is `stdout`.
 Most sinks buffer data before delivering it, which affects when you see output. For a full
 explanation of how this works, see [Sink Batching](sink-batching.md).
 
+!!! tip "Choosing the right `url:`"
+    Network sinks (`http_push`, `remote_write`, `loki`, `otlp_grpc`) accept a URL that is
+    resolved inside the process running the scenario. The same YAML run from your host CLI
+    vs. POSTed to a containerized `sonda-server` reaches different hosts. See
+    [Endpoints & networking](../deployment/endpoints.md) for when to use `localhost`,
+    Compose service names, or Kubernetes Service DNS.
+
 ## stdout
 
 Writes events to standard output via a buffered writer. This is the default sink.

--- a/docs/site/docs/deployment/docker.md
+++ b/docs/site/docs/deployment/docker.md
@@ -108,7 +108,8 @@ including error responses, protected vs. public endpoints, and Prometheus scrape
 
 ## Docker Compose Stack
 
-A `docker-compose.yml` ships with a full observability stack for demos and testing.
+A `docker-compose.yml` ships with `sonda-server`, Prometheus, Alertmanager, and Grafana
+for smoke-testing scenario submission and exploring the control plane.
 
 | Service | Port | Description |
 |---------|------|-------------|
@@ -116,6 +117,21 @@ A `docker-compose.yml` ships with a full observability stack for demos and testi
 | `prometheus` | 9090 | Prometheus (scrape or remote write) |
 | `alertmanager` | 9093 | Alertmanager for alert routing |
 | `grafana` | 3000 | Grafana dashboards (password: `admin`) |
+
+!!! warning "Scenarios POSTed here write to container stdout"
+    The two scenario files referenced below (`docker-metrics.yaml`,
+    `docker-alerts.yaml`) use `sink: stdout`. When you POST them into `sonda-server`,
+    the generated events land on the server container's stdout -- visible via
+    `docker logs sonda-server` -- and nothing reaches Prometheus or Grafana in this
+    stack.
+
+    This stack is useful for verifying `sonda-server` accepts and runs your scenario
+    body. **To see data flowing into Prometheus and Grafana, use the
+    [VictoriaMetrics Stack](#victoriametrics-stack) below**, which ships scenarios
+    that push to an HTTP backend reachable from inside the container.
+
+    The [Endpoints & networking](endpoints.md) page explains why a sink URL resolves
+    differently depending on where `sonda` runs.
 
 Start, use, and tear down:
 
@@ -126,7 +142,7 @@ docker compose up -d
 # Verify the server
 curl http://localhost:8080/health
 
-# Post a metrics scenario
+# Post a metrics scenario (events go to sonda-server container stdout)
 curl -X POST -H "Content-Type: text/yaml" \
   --data-binary @examples/docker-metrics.yaml \
   http://localhost:8080/scenarios
@@ -136,6 +152,9 @@ curl -X POST -H "Content-Type: text/yaml" \
   --data-binary @examples/docker-alerts.yaml \
   http://localhost:8080/scenarios
 
+# Inspect the generated events
+docker logs -f sonda-server
+
 # List running scenarios
 curl http://localhost:8080/scenarios
 
@@ -143,8 +162,16 @@ curl http://localhost:8080/scenarios
 docker compose down
 ```
 
-Open Grafana at [http://localhost:3000](http://localhost:3000) and Prometheus at
-[http://localhost:9090](http://localhost:9090) to explore your data.
+Grafana is still provisioned at [http://localhost:3000](http://localhost:3000) and
+Prometheus at [http://localhost:9090](http://localhost:9090) -- they just will not show
+sonda data from the stdout scenarios above. Use the VictoriaMetrics Stack for that.
+
+!!! info "Swapping `stdout` for `http_push` in this stack"
+    You can rewrite either scenario on the fly to push to Prometheus's remote-write
+    receiver instead. See
+    [Rewriting URLs before POSTing](endpoints.md#rewriting-urls-before-posting) --
+    the Prometheus service name inside this Compose network is `prometheus`, and its
+    remote-write path is `/api/v1/write`.
 
 Two scenario files are provided for this stack:
 
@@ -180,6 +207,12 @@ curl "http://localhost:8428/api/v1/series?match[]={__name__=~'sonda.*'}"
 # Tear down
 docker compose -f examples/docker-compose-victoriametrics.yml down -v
 ```
+
+The scenario uses `url: http://victoriametrics:8428/...` -- the VictoriaMetrics service
+name, not `localhost` -- because the sink runs inside the `sonda-server` container and
+resolves DNS through the Compose network. If you adapt a host-CLI example that points at
+`localhost:8428`, rewrite the URL before POSTing. See
+[Endpoints & networking](endpoints.md) for the full explanation and a one-liner swap.
 
 You can also push from the host CLI using a pipe to VictoriaMetrics.
 See [Sinks](../configuration/sinks.md) for all available sink types (`http_push`, `remote_write`, `loki`, etc.).

--- a/docs/site/docs/deployment/endpoints.md
+++ b/docs/site/docs/deployment/endpoints.md
@@ -1,0 +1,178 @@
+# Endpoints & networking
+
+Sonda scenarios resolve sink URLs in the process that runs them, not in the process that
+submits them. Running the same YAML from your host CLI and POSTing it to a containerized
+`sonda-server` can reach very different backends -- or reach nothing at all.
+
+This page explains how to pick the right `url:` for every realistic combination of where
+`sonda` runs and where your backend lives.
+
+## Two invocation paths
+
+Every sink URL is resolved inside the process that is about to write to it. Sonda has two
+invocation paths, and they resolve `localhost` very differently.
+
+=== "Host CLI"
+
+    You run `sonda metrics --scenario file.yaml` on your laptop or a bare host. The
+    scenario runs **in the shell process on your host**. `http://localhost:8428` resolves
+    to your host's loopback, which reaches whatever is listening on port 8428 there --
+    typically a Compose-published port or a native install.
+
+    ```bash
+    sonda metrics --scenario examples/victoriametrics-metrics.yaml
+    ```
+
+=== "`sonda-server` in a container"
+
+    You POST a scenario body to `sonda-server` running inside a container. The scenario
+    is compiled and runs **inside that container's network namespace**.
+    `http://localhost:8428` resolves to the container's own loopback -- nothing is there,
+    the request fails.
+
+    ```bash
+    curl -X POST -H "Content-Type: text/yaml" \
+      --data-binary @file.yaml \
+      http://localhost:8080/scenarios
+    ```
+
+The host-side `curl` talks to the host's loopback (hitting the published `8080:8080`
+port), but the scenario it carries runs one level deeper, inside the server container.
+
+!!! warning "The `localhost` trap"
+    A scenario with `url: http://localhost:8428` works from the host CLI and silently
+    fails when POSTed to a containerized `sonda-server`. From inside the container,
+    `localhost` is the container, not your host or the Compose network. The server
+    accepts the POST, the scenario starts, the sink tries to connect -- and the
+    connection is refused or times out with no data in your backend.
+
+    When you adapt a host-CLI example to run inside `sonda-server`, rewrite the URL to
+    match the server's network. For Compose, that means using the service name
+    (`http://victoriametrics:8428`). For Kubernetes, use the in-cluster Service DNS
+    (`http://vmsingle.monitoring.svc.cluster.local:8428`).
+
+## Endpoint resolution reference
+
+Pick the row that matches where `sonda` runs and where your backend lives.
+
+| Process runs here | Backend runs here | Correct `url:` | Why |
+|---|---|---|---|
+| Host CLI | Backend on host (native install) | `http://localhost:<port>` | Host loopback reaches the native listener. |
+| Host CLI | Backend in Compose (port-published) | `http://localhost:<published-port>` | The Compose-published port is exposed on the host. |
+| `sonda-server` in Compose | Backend in same Compose network | `http://<service-name>:<port>` | Compose provides a DNS entry per service. `victoriametrics`, `loki`, `kafka`. |
+| `sonda-server` in Compose | Backend on host (Docker Desktop) | `http://host.docker.internal:<port>` | Docker Desktop publishes a virtual DNS name that routes back to the host. |
+| `sonda-server` in Kubernetes (same namespace) | Service in same namespace | `http://<svc>:<port>` | Kubernetes DNS resolves short names within a namespace. |
+| `sonda-server` in Kubernetes (cross-namespace) | Service in another namespace | `http://<svc>.<ns>.svc.cluster.local:<port>` | FQDN is required for cross-namespace resolution. |
+| `sonda-server` anywhere | External backend (SaaS, cloud) | `https://<public-dns>:<port>` | Fully qualified external DNS plus TLS. |
+
+!!! note
+    On Linux without Docker Desktop, `host.docker.internal` does not resolve by default.
+    Either add `--add-host=host.docker.internal:host-gateway` to the `sonda-server`
+    container or use the host's LAN IP.
+
+## Rewriting URLs before POSTing
+
+Sonda's example YAMLs in `examples/` use `http://localhost:<port>` so they work out of
+the box for host-CLI users running against a published Compose port. When you want to
+POST the same file into a containerized `sonda-server`, rewrite the URL in flight:
+
+```bash title="Swap localhost for Compose service names"
+sed 's|http://localhost:8428|http://victoriametrics:8428|g; \
+     s|http://localhost:3100|http://loki:3100|g; \
+     s|http://localhost:9094|http://kafka:9092|g' \
+  examples/http-push-retry.yaml \
+  | curl -X POST -H "Content-Type: text/yaml" \
+      --data-binary @- \
+      http://localhost:8080/scenarios
+```
+
+The three swaps cover the Compose backends Sonda ships with:
+
+| Backend | Host CLI URL (published port) | Compose URL (service name) |
+|---|---|---|
+| VictoriaMetrics | `http://localhost:8428` | `http://victoriametrics:8428` |
+| Loki | `http://localhost:3100` | `http://loki:3100` |
+| Kafka | `localhost:9094` (external listener) | `kafka:9092` (internal listener) |
+
+The service names come from `examples/docker-compose-victoriametrics.yml`. If you
+customize the compose file, match the `sed` substitutions to your service names.
+
+!!! tip "Verify the swap first"
+    Pipe the rewritten YAML to `less` or `diff` before posting, so you can eyeball that
+    every URL has been updated:
+
+    ```bash
+    sed 's|http://localhost:8428|http://victoriametrics:8428|g' \
+      examples/http-push-retry.yaml | diff examples/http-push-retry.yaml -
+    ```
+
+## Examples
+
+=== "Host CLI to Compose VictoriaMetrics"
+
+    `sonda` runs on your host. The Compose stack publishes VictoriaMetrics on
+    `localhost:8428`. The scenario's `url:` uses host loopback.
+
+    ```yaml
+    sink:
+      type: http_push
+      url: "http://localhost:8428/api/v1/import/prometheus"
+      content_type: "text/plain"
+    ```
+
+    ```bash
+    sonda metrics --scenario examples/vm-push-scenario.yaml
+    ```
+
+=== "sonda-server (Compose) to VictoriaMetrics (Compose)"
+
+    Both services run in the same Compose network. The sink URL uses the VictoriaMetrics
+    service name -- **not** `localhost`.
+
+    ```yaml
+    sink:
+      type: http_push
+      url: "http://victoriametrics:8428/api/v1/import/prometheus"
+      content_type: "text/plain"
+    ```
+
+    ```bash
+    curl -X POST -H "Content-Type: text/yaml" \
+      --data-binary @examples/victoriametrics-metrics.yaml \
+      http://localhost:8080/scenarios
+    ```
+
+=== "sonda-server (Kubernetes) to VictoriaMetrics (Kubernetes)"
+
+    Both workloads run in the same namespace. Use the Kubernetes Service short name.
+
+    ```yaml
+    sink:
+      type: http_push
+      url: "http://vmsingle:8428/api/v1/import/prometheus"
+      content_type: "text/plain"
+    ```
+
+    For a Service in a different namespace, use the fully qualified name:
+
+    ```yaml
+    sink:
+      type: http_push
+      url: "http://vmsingle.monitoring.svc.cluster.local:8428/api/v1/import/prometheus"
+    ```
+
+## URL interpolation (future)
+
+Making the same YAML work from both invocation paths today requires either two files or
+a `sed` swap. Environment variable interpolation in YAML
+(`url: ${VM_URL:-http://localhost:8428}`) is under consideration as a proper fix. The
+audit follow-up is tracked in the repository; for now the rewrite-before-POST workflow
+is the supported path.
+
+## See also
+
+- [Docker](docker.md) -- Compose stacks and host-side `docker run` examples.
+- [Server API](sonda-server.md) -- POSTing scenarios to `sonda-server`.
+- [Kubernetes](kubernetes.md) -- Helm chart, Service DNS, cross-namespace access.
+- [Sinks](../configuration/sinks.md) -- all sink types and their `url:` fields.
+- [Troubleshooting](../guides/troubleshooting.md) -- diagnostics for connection-refused and empty-backend symptoms.

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -41,6 +41,20 @@ Post a [v2 scenario](../configuration/v2-scenarios.md) YAML or JSON body to
     rejected with `400 Bad Request` and a migration hint. See
     [Migrating v1 bodies](#migrating-v1-bodies) below.
 
+!!! warning "Sink URLs resolve inside the server's network"
+    POSTed scenarios compile and run inside the `sonda-server` process. A sink with
+    `url: http://localhost:<port>` reaches the server container's loopback, not your
+    host. Use the address the server can actually see:
+
+    - In Docker Compose, use the service name -- `http://victoriametrics:8428`,
+      `http://loki:3100`, `kafka:9092`.
+    - In Kubernetes, use the in-cluster Service DNS --
+      `http://vmsingle:8428` for same-namespace, or
+      `http://vmsingle.monitoring.svc.cluster.local:8428` for cross-namespace.
+
+    See [Endpoints & networking](endpoints.md) for the full reference and a `sed`
+    one-liner that rewrites `localhost` URLs before posting.
+
 ### Single-scenario body
 
 === "YAML"

--- a/docs/site/docs/guides/troubleshooting.md
+++ b/docs/site/docs/guides/troubleshooting.md
@@ -72,6 +72,7 @@ Sonda runs without errors but you don't see data in your backend.
 | No data in Prometheus | Prometheus needs remote write receiver enabled | Start Prometheus with `--web.enable-remote-write-receiver` |
 | Encoder/sink mismatch | Using `prometheus_text` encoder with `remote_write` sink (or vice versa) | Match encoder to sink: `remote_write` encoder with `remote_write` sink, `otlp` encoder with `otlp_grpc` sink |
 | HTTP 400 Bad Request | Wrong `content_type` for the endpoint | Use `text/plain` for VictoriaMetrics import endpoint |
+| POST to `sonda-server` succeeds but no data in backend | Sink `url: http://localhost:<port>` resolves inside the server container | Use the reachable address: Compose service name (`http://victoriametrics:8428`) or Kubernetes Service DNS. See [Endpoints & networking](../deployment/endpoints.md) |
 
 ### Batching delays
 

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
     - Sink Batching: configuration/sink-batching.md
     - CLI Reference: configuration/cli-reference.md
   - Deployment:
+    - Endpoints & networking: deployment/endpoints.md
     - Docker: deployment/docker.md
     - Kubernetes: deployment/kubernetes.md
     - Server API: deployment/sonda-server.md


### PR DESCRIPTION
## Summary

Addresses **P0-3, P0-4, and P0-5** of the v1.0.1 docs audit tracker — the meaty "PR B" of the conference-prep ramp-up.

### P0-3 — New \`deployment/endpoints.md\` (178 lines)

The canonical answer to **"what goes in my sink \`url:\` field?"** across every realistic invocation path × backend location. Today that answer is **nowhere in the docs**, and 23 of the 64 example YAMLs ship with \`localhost\` URLs that silently break inside \`sonda-server\`.

Ships with:

- **Two invocation paths** (tabbed) — host CLI vs. \`sonda-server\`-in-container.
- \`!!! warning "The localhost trap"\` — names the footgun with the concrete VM example.
- **7-row resolution table** — host native, host ↔ Compose (published port), sonda-server-in-Compose (same net), sonda-server-in-Compose-to-host (Docker Desktop), sonda-server-in-k8s (same-ns / cross-ns), external backends.
- **Tested \`sed\` one-liner** for rewriting \`localhost\` → service-name before POSTing.
- **Tabbed examples** covering host-CLI→VM, server(Compose)→VM, server(k8s)→VM (same-ns + cross-ns FQDN).
- Brief future-work note pointing at env-var interpolation as the real long-term fix (audit FU-3).
- **Nav**: first entry under Deployment, ahead of Docker/Kubernetes/Server API — establishes the mental model first.

### P0-4 — Honest rewrite of \`docker.md\` "Docker Compose Stack"

**The previous lie**: section ended with "Open Grafana at \`http://localhost:3000\` and explore your data." Both scenarios it directed users to POST (\`docker-metrics.yaml\`, \`docker-alerts.yaml\`) use \`sink: stdout\`. Data goes to container stdout, Prometheus never scrapes sonda-server (no target in \`docker/prometheus.yml\`), Grafana stays empty. Users saw the stack "work" but couldn't find their data.

**The rewrite**: acknowledge \`sink: stdout\` means events go to \`docker logs sonda-server\`. Point readers to the VictoriaMetrics Stack section for the actual data-flow-to-dashboards path. Add a new \`!!! info\` showing how to rewrite the scenarios to use \`http_push\` + Prometheus remote-write instead (via the new \`endpoints.md\` \`sed\` recipe).

### P0-5 — Localhost-trap \`!!! warning\` admonitions

Two warnings placed at the point of risk:

- **\`docker.md\`** Compose Stack — "Scenarios POSTed here write to container stdout" (frames the stack honestly + routes to \`endpoints.md\` for the "why").
- **\`sonda-server.md\`** near the first POST example — "Sink URLs resolve inside the server's network" (covers both Compose service-names and k8s Service-DNS, including the cross-namespace FQDN).

### Cross-links

- \`configuration/sinks.md\` — tip block near the \`url:\` field discussion.
- \`guides/troubleshooting.md\` — new row under "data not appearing at the destination."
- Existing VictoriaMetrics Stack section in \`docker.md\` — one-paragraph cross-link explaining why the scenario uses \`victoriametrics:8428\` instead of \`localhost\`.

## Gate verdicts

- **@doc** wrote. Voice approved by author.
- **@reviewer-quick**: **FAIL** → fixed inline (pre-commit FQDN inconsistency: k8s warning example used \`vm\` instead of \`vmsingle\` — made consistent across the page and \`sonda-server.md\`).
- **@uat** (original, ~7.5h agent run): PASS. Blocker: agent was waiting on tool approvals while author slept → timing-sensitive claims weren't rigorously validated.
- **@uat tight-timing re-run** (orchestrator, 5 min real time): **PASS**. Surfaced a sharper finding worth noting below.

## Tight-timing re-run finding

Posting a scenario with \`url: http://localhost:8428\` to sonda-server in the Compose VM stack:

- Scenario runs 20s at 10 events/s with \`batch_size: 256\` (many flush attempts).
- \`docker logs examples-sonda-server-1\` shows **zero sink errors** — just "scenario launched."
- \`GET /scenarios\` reports the scenario cleanly \`"stopped"\` with no error indication.
- VM queried at T+25s: \`result: []\`.

The silent-fail is **more silent than the docs imply**: the server doesn't surface sink-flush failures to its INFO log, and the scenarios-list API doesn't indicate the sink dropped everything. This is pre-existing sonda-server behavior, not a regression, but it strengthens the case for audit follow-up **FU-2** ("sonda-server should warn at runtime when a sink URL is unreachable").

The canonical path (\`url: http://victoriametrics:8428\`) works: data lands in VM after the scenario stops.

## Intentional scope boundaries

- **No example YAML edits**. The 23 files that use \`localhost\` stay as-is; \`endpoints.md\` teaches the \`sed\` swap. Baking compose service names into a parallel example set is a bigger scope for later.
- **No \`docker/prometheus.yml\` edit**. The "Prometheus doesn't scrape sonda-server" question is audit FU-1, a code/config change, not a docs fix.
- **No env-var interpolation**. Separate feature (audit FU-3).

## Gate artifacts

- \`task site:build\` clean (strict mode): exit 0, zero warnings on the PR's files.
- All internal links resolve in rendered HTML.
- Nav renders \`Endpoints & networking\` first under Deployment.
- Cross-link reachability verified end-to-end.

## Test plan (for post-merge sanity)

- [ ] CI docs workflow passes (mkdocs strict build)
- [ ] gh-pages deploy renders the new \`/deployment/endpoints/\` page at the public URL
- [ ] Quick eyeball of the Deployment sidebar on the live site

## Audit tracker

On merge, check off P0-3, P0-4, and P0-5 in the tracker at \`~/.claude/projects/-Users-netpanda-projects-sonda/audits/2026-04-22-v1.0.1-docs-audit.md\`. **All P0 items shipped.** Remaining: P1 (sonda-server flags docs, missing examples catalog, scenario-file.md merge, Guides nav regroup) — fix before conference if time allows. P2 (tutorial split, CI docs-drift catcher, asciinema) — post-conference.