### PR TITLE
feat(sonda-server): warn on POST when a sink URL targets loopback (audit FU-2)

### DIFF
--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -52,6 +52,26 @@ Post a [v2 scenario](../configuration/v2-scenarios.md) YAML or JSON body to
       `http://vmsingle:8428` for same-namespace, or
       `http://vmsingle.monitoring.svc.cluster.local:8428` for cross-namespace.
 
+    When a POSTed scenario targets `localhost`, `127.0.0.1`, or `[::1]`, the server
+    still returns **201 Created** -- the trap is likely a mistake but sometimes
+    legitimate, so the scenario launches regardless. A `warnings: [...]` field on
+    the response identifies the offending sink and points here. The same message is
+    emitted via `tracing::warn!` so operators can catch it in server logs:
+
+    ```json title="Response (201 with loopback warning)"
+    {
+      "id": "a1b2c3d4-...",
+      "name": "up",
+      "status": "running",
+      "warnings": [
+        "scenario entry 'up' sink `http_push` targets `http://localhost:8428/api/v1/write` — this host resolves to the sonda-server container's own loopback, not your host. Use a Docker Compose service name (e.g. `victoriametrics:8428`) or a Kubernetes Service DNS name instead. See docs/deployment/endpoints.md."
+      ]
+    }
+    ```
+
+    The `warnings` field is omitted entirely when no issues were detected, so existing
+    clients that do not know about the field continue to parse the response unchanged.
+
     See [Endpoints & networking](endpoints.md) for the full reference and a `sed`
     one-liner that rewrites `localhost` URLs before posting.
 

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -335,38 +335,16 @@ fn yaml_body_text(body: &[u8], headers: &HeaderMap) -> Result<String, String> {
 /// deployment networking reference without grepping docs.
 const LOOPBACK_HINT_DOC: &str = "See docs/deployment/endpoints.md.";
 
-/// Hostnames that, in a containerized `sonda-server`, resolve to the
-/// server's own network namespace rather than the operator's host.
-///
-/// Matched case-insensitively against the host component of a sink URL or
-/// `host:port` address. IPv4 addresses in the wider `127.0.0.0/8` range are
-/// not matched — the brief explicitly scopes this to `127.0.0.1` only.
 const LOOPBACK_HOSTS: &[&str] = &["localhost", "127.0.0.1", "::1"];
 
-/// Return `true` when `host` names a loopback interface.
-///
-/// The comparison is case-insensitive (`Localhost` and `LOCALHOST` also
-/// match) because DNS hostnames are case-insensitive and users do write
-/// YAML in either case.
 fn is_loopback_host(host: &str) -> bool {
     LOOPBACK_HOSTS
         .iter()
         .any(|candidate| host.eq_ignore_ascii_case(candidate))
 }
 
-/// Extract the host portion from an HTTP/gRPC URL or a bare `host:port`
-/// address.
-///
-/// Implemented as a small hand-rolled parser so we don't take a
-/// dependency on the `url` crate for a single-purpose check. Supports:
-///
-/// - Full URLs with a scheme (`http://...`, `https://...`, `grpc://...`).
-/// - Bare authority strings (`host:port`, `host`).
-/// - IPv6 literals wrapped in brackets (`[::1]:8428`, `http://[::1]/path`).
-///
-/// Returns `None` when the input is empty or otherwise unparseable. The
-/// caller treats that as "nothing to warn about" — the sink's own
-/// constructor will surface the real parse error at launch time.
+/// Extract the host from a URL or `host:port` authority. Returns `None` for
+/// unparseable input — sink construction will surface the real error.
 fn extract_host(input: &str) -> Option<&str> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
@@ -413,12 +391,6 @@ fn extract_host(input: &str) -> Option<&str> {
     }
 }
 
-/// Format a single "sink targets loopback" warning message.
-///
-/// The message is intentionally long-form and actionable: it names the
-/// scenario entry, the sink type tag, the offending URL/host, and the
-/// docs page operators should consult. sonda-server log output is
-/// operator-facing, so the extra bytes are justified.
 fn format_loopback_warning(entry_name: &str, sink_tag: &str, offender: &str) -> String {
     format!(
         "scenario entry '{entry_name}' sink `{sink_tag}` targets `{offender}` — this host \
@@ -428,19 +400,6 @@ fn format_loopback_warning(entry_name: &str, sink_tag: &str, offender: &str) -> 
     )
 }
 
-/// Inspect every sink in `entries` and return one warning per loopback match.
-///
-/// The function short-circuits for sink variants that do not carry a
-/// network address (`Stdout`, `File`, `Channel`, `Memory`, and the
-/// `*Disabled` placeholders used when a feature flag is off). For
-/// address-carrying variants it splits the brokers / endpoint / url string
-/// via [`extract_host`] and tests each discovered host with
-/// [`is_loopback_host`].
-///
-/// Feature-gated sink variants are only matched when their corresponding
-/// Cargo feature is enabled; the wildcard arm absorbs both unknown
-/// (`#[non_exhaustive]`) future variants and the placeholder
-/// `*Disabled` cases.
 fn sink_loopback_warnings(entries: &[ScenarioEntry]) -> Vec<String> {
     let mut warnings = Vec::new();
     for entry in entries {
@@ -451,11 +410,6 @@ fn sink_loopback_warnings(entries: &[ScenarioEntry]) -> Vec<String> {
     warnings
 }
 
-/// Push one warning per loopback host found in `sink` into `out`.
-///
-/// Split out from [`sink_loopback_warnings`] so the per-variant match
-/// lives in one place and is easy to extend when a new address-carrying
-/// sink lands.
 fn collect_warnings_for_sink(sink: &SinkConfig, entry_name: &str, out: &mut Vec<String>) {
     match sink {
         #[cfg(feature = "http")]
@@ -492,9 +446,7 @@ fn collect_warnings_for_sink(sink: &SinkConfig, entry_name: &str, out: &mut Vec<
         }
         #[cfg(feature = "kafka")]
         SinkConfig::Kafka { brokers, .. } => {
-            // Kafka brokers is a comma-separated list; warn once per
-            // loopback broker so operators can see exactly which one is
-            // wrong in a mixed list.
+            // brokers is comma-separated; warn per loopback entry, not per sink.
             for broker in brokers.split(',') {
                 let broker = broker.trim();
                 if broker.is_empty() {
@@ -521,17 +473,12 @@ fn collect_warnings_for_sink(sink: &SinkConfig, entry_name: &str, out: &mut Vec<
                 }
             }
         }
-        // Stdout / File carry no network address. `#[non_exhaustive]`
-        // plus feature-gated `*Disabled` placeholders land in this arm.
+        // Stdout/File/Channel/Memory carry no address; `*Disabled` placeholders
+        // and future `#[non_exhaustive]` variants also land here.
         _ => {}
     }
 }
 
-/// Emit a `tracing::warn!` event for every warning in `warnings`.
-///
-/// Kept separate from [`sink_loopback_warnings`] so the pure pre-flight
-/// check stays test-friendly (no tracing subscriber required) and the
-/// logging happens exactly once per POST request in the handler.
 fn log_scenario_warnings(warnings: &[String]) {
     for message in warnings {
         warn!(message = %message, "POST /scenarios: sink pre-flight warning");

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -37,6 +37,7 @@ use uuid::Uuid;
 use sonda_core::compile_scenario_file;
 use sonda_core::config::ScenarioEntry;
 use sonda_core::schedule::launch::{launch_scenario, prepare_entries};
+use sonda_core::sink::SinkConfig;
 
 use crate::state::AppState;
 
@@ -51,6 +52,17 @@ pub struct CreatedScenario {
     pub name: String,
     /// Always `"running"` for a freshly launched scenario.
     pub status: &'static str,
+    /// Non-fatal warnings raised while validating the posted body.
+    ///
+    /// Populated, for example, when a sink URL points at `localhost` — which
+    /// resolves to the `sonda-server` container's own loopback rather than
+    /// the operator's host. The scenario still launches; the warnings exist
+    /// so operators can spot the misconfiguration without grepping logs.
+    ///
+    /// Omitted from the JSON response when no warnings were raised so
+    /// clients that predate this field continue to parse cleanly.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub warnings: Vec<String>,
 }
 
 /// Response body for a successfully created multi-scenario batch.
@@ -62,6 +74,16 @@ pub struct CreatedScenario {
 pub struct CreatedScenariosResponse {
     /// One entry per launched scenario, in the same order as the input.
     pub scenarios: Vec<CreatedScenario>,
+    /// Non-fatal warnings raised while validating the posted body.
+    ///
+    /// Collected across every entry in the batch — one string per flagged
+    /// sink. See [`CreatedScenario::warnings`] for the per-entry shape;
+    /// the batch response aggregates them at the top level so clients do
+    /// not need to walk the `scenarios` array to surface operator hints.
+    ///
+    /// Omitted from the JSON response when no warnings were raised.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub warnings: Vec<String>,
 }
 
 /// Summary of a single scenario in the list response.
@@ -307,6 +329,215 @@ fn yaml_body_text(body: &[u8], headers: &HeaderMap) -> Result<String, String> {
     }
 }
 
+// ---- Sink loopback pre-flight ----------------------------------------------
+
+/// Pointer appended to every loopback warning so operators can find the
+/// deployment networking reference without grepping docs.
+const LOOPBACK_HINT_DOC: &str = "See docs/deployment/endpoints.md.";
+
+/// Hostnames that, in a containerized `sonda-server`, resolve to the
+/// server's own network namespace rather than the operator's host.
+///
+/// Matched case-insensitively against the host component of a sink URL or
+/// `host:port` address. IPv4 addresses in the wider `127.0.0.0/8` range are
+/// not matched — the brief explicitly scopes this to `127.0.0.1` only.
+const LOOPBACK_HOSTS: &[&str] = &["localhost", "127.0.0.1", "::1"];
+
+/// Return `true` when `host` names a loopback interface.
+///
+/// The comparison is case-insensitive (`Localhost` and `LOCALHOST` also
+/// match) because DNS hostnames are case-insensitive and users do write
+/// YAML in either case.
+fn is_loopback_host(host: &str) -> bool {
+    LOOPBACK_HOSTS
+        .iter()
+        .any(|candidate| host.eq_ignore_ascii_case(candidate))
+}
+
+/// Extract the host portion from an HTTP/gRPC URL or a bare `host:port`
+/// address.
+///
+/// Implemented as a small hand-rolled parser so we don't take a
+/// dependency on the `url` crate for a single-purpose check. Supports:
+///
+/// - Full URLs with a scheme (`http://...`, `https://...`, `grpc://...`).
+/// - Bare authority strings (`host:port`, `host`).
+/// - IPv6 literals wrapped in brackets (`[::1]:8428`, `http://[::1]/path`).
+///
+/// Returns `None` when the input is empty or otherwise unparseable. The
+/// caller treats that as "nothing to warn about" — the sink's own
+/// constructor will surface the real parse error at launch time.
+fn extract_host(input: &str) -> Option<&str> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Strip a URL scheme (`http://`, `https://`, `grpc://`, ...) if present.
+    let after_scheme = match trimmed.find("://") {
+        Some(idx) => &trimmed[idx + 3..],
+        None => trimmed,
+    };
+
+    // Drop any path / query / fragment tail so we only parse the authority.
+    let authority_end = after_scheme
+        .find(['/', '?', '#'])
+        .unwrap_or(after_scheme.len());
+    let authority = &after_scheme[..authority_end];
+
+    // Strip userinfo (`user:pass@host`) if present.
+    let authority = match authority.rfind('@') {
+        Some(idx) => &authority[idx + 1..],
+        None => authority,
+    };
+
+    if authority.is_empty() {
+        return None;
+    }
+
+    // IPv6 literal: `[::1]` optionally followed by `:port`.
+    if let Some(rest) = authority.strip_prefix('[') {
+        return rest.find(']').map(|end| &rest[..end]);
+    }
+
+    // IPv4 / hostname: split on the last `:` to drop the port, if any.
+    let host = match authority.rfind(':') {
+        Some(idx) => &authority[..idx],
+        None => authority,
+    };
+
+    if host.is_empty() {
+        None
+    } else {
+        Some(host)
+    }
+}
+
+/// Format a single "sink targets loopback" warning message.
+///
+/// The message is intentionally long-form and actionable: it names the
+/// scenario entry, the sink type tag, the offending URL/host, and the
+/// docs page operators should consult. sonda-server log output is
+/// operator-facing, so the extra bytes are justified.
+fn format_loopback_warning(entry_name: &str, sink_tag: &str, offender: &str) -> String {
+    format!(
+        "scenario entry '{entry_name}' sink `{sink_tag}` targets `{offender}` — this host \
+         resolves to the sonda-server container's own loopback, not your host. Use a Docker \
+         Compose service name (e.g. `victoriametrics:8428`) or a Kubernetes Service DNS name \
+         instead. {LOOPBACK_HINT_DOC}"
+    )
+}
+
+/// Inspect every sink in `entries` and return one warning per loopback match.
+///
+/// The function short-circuits for sink variants that do not carry a
+/// network address (`Stdout`, `File`, `Channel`, `Memory`, and the
+/// `*Disabled` placeholders used when a feature flag is off). For
+/// address-carrying variants it splits the brokers / endpoint / url string
+/// via [`extract_host`] and tests each discovered host with
+/// [`is_loopback_host`].
+///
+/// Feature-gated sink variants are only matched when their corresponding
+/// Cargo feature is enabled; the wildcard arm absorbs both unknown
+/// (`#[non_exhaustive]`) future variants and the placeholder
+/// `*Disabled` cases.
+fn sink_loopback_warnings(entries: &[ScenarioEntry]) -> Vec<String> {
+    let mut warnings = Vec::new();
+    for entry in entries {
+        let base = entry.base();
+        let name = base.name.as_str();
+        collect_warnings_for_sink(&base.sink, name, &mut warnings);
+    }
+    warnings
+}
+
+/// Push one warning per loopback host found in `sink` into `out`.
+///
+/// Split out from [`sink_loopback_warnings`] so the per-variant match
+/// lives in one place and is easy to extend when a new address-carrying
+/// sink lands.
+fn collect_warnings_for_sink(sink: &SinkConfig, entry_name: &str, out: &mut Vec<String>) {
+    match sink {
+        #[cfg(feature = "http")]
+        SinkConfig::HttpPush { url, .. } => {
+            if let Some(host) = extract_host(url) {
+                if is_loopback_host(host) {
+                    out.push(format_loopback_warning(entry_name, "http_push", url));
+                }
+            }
+        }
+        #[cfg(feature = "http")]
+        SinkConfig::Loki { url, .. } => {
+            if let Some(host) = extract_host(url) {
+                if is_loopback_host(host) {
+                    out.push(format_loopback_warning(entry_name, "loki", url));
+                }
+            }
+        }
+        #[cfg(feature = "remote-write")]
+        SinkConfig::RemoteWrite { url, .. } => {
+            if let Some(host) = extract_host(url) {
+                if is_loopback_host(host) {
+                    out.push(format_loopback_warning(entry_name, "remote_write", url));
+                }
+            }
+        }
+        #[cfg(feature = "otlp")]
+        SinkConfig::OtlpGrpc { endpoint, .. } => {
+            if let Some(host) = extract_host(endpoint) {
+                if is_loopback_host(host) {
+                    out.push(format_loopback_warning(entry_name, "otlp_grpc", endpoint));
+                }
+            }
+        }
+        #[cfg(feature = "kafka")]
+        SinkConfig::Kafka { brokers, .. } => {
+            // Kafka brokers is a comma-separated list; warn once per
+            // loopback broker so operators can see exactly which one is
+            // wrong in a mixed list.
+            for broker in brokers.split(',') {
+                let broker = broker.trim();
+                if broker.is_empty() {
+                    continue;
+                }
+                if let Some(host) = extract_host(broker) {
+                    if is_loopback_host(host) {
+                        out.push(format_loopback_warning(entry_name, "kafka", broker));
+                    }
+                }
+            }
+        }
+        SinkConfig::Tcp { address, .. } => {
+            if let Some(host) = extract_host(address) {
+                if is_loopback_host(host) {
+                    out.push(format_loopback_warning(entry_name, "tcp", address));
+                }
+            }
+        }
+        SinkConfig::Udp { address } => {
+            if let Some(host) = extract_host(address) {
+                if is_loopback_host(host) {
+                    out.push(format_loopback_warning(entry_name, "udp", address));
+                }
+            }
+        }
+        // Stdout / File carry no network address. `#[non_exhaustive]`
+        // plus feature-gated `*Disabled` placeholders land in this arm.
+        _ => {}
+    }
+}
+
+/// Emit a `tracing::warn!` event for every warning in `warnings`.
+///
+/// Kept separate from [`sink_loopback_warnings`] so the pure pre-flight
+/// check stays test-friendly (no tracing subscriber required) and the
+/// logging happens exactly once per POST request in the handler.
+fn log_scenario_warnings(warnings: &[String]) {
+    for message in warnings {
+        warn!(message = %message, "POST /scenarios: sink pre-flight warning");
+    }
+}
+
 // ---- Handlers ---------------------------------------------------------------
 
 /// `POST /scenarios` — start scenarios from a v2 YAML or JSON body.
@@ -342,9 +573,20 @@ pub async fn post_scenario(
         bad_request(msg)
     })?;
 
+    // 2. Pre-flight sink check: warn (do not reject) when a sink URL points
+    //    at loopback, which in a containerized server resolves to the
+    //    server's own network namespace rather than the operator's host.
+    //    The warnings are logged and returned in the response — operators
+    //    can ignore them if the loopback target is intentional.
+    let warnings = match &parsed {
+        ParsedBody::Single(entry) => sink_loopback_warnings(std::slice::from_ref(entry.as_ref())),
+        ParsedBody::Multi(entries) => sink_loopback_warnings(entries),
+    };
+    log_scenario_warnings(&warnings);
+
     match parsed {
-        ParsedBody::Single(entry) => post_single_scenario(state, *entry).await,
-        ParsedBody::Multi(entries) => post_multi_scenario(state, entries).await,
+        ParsedBody::Single(entry) => post_single_scenario(state, *entry, warnings).await,
+        ParsedBody::Multi(entries) => post_multi_scenario(state, entries, warnings).await,
     }
 }
 
@@ -354,7 +596,11 @@ pub async fn post_scenario(
 /// pipeline as the multi-scenario path. This ensures identical behavior
 /// regardless of whether a scenario is posted alone or inside a `scenarios:`
 /// array.
-async fn post_single_scenario(state: AppState, entry: ScenarioEntry) -> Result<Response, Response> {
+async fn post_single_scenario(
+    state: AppState,
+    entry: ScenarioEntry,
+    warnings: Vec<String>,
+) -> Result<Response, Response> {
     // Use the shared pipeline for expansion, validation, and phase offset.
     let mut prepared = prepare_entries(vec![entry]).map_err(|e| {
         warn!(error = %e, "POST /scenarios: validation failed");
@@ -392,6 +638,7 @@ async fn post_single_scenario(state: AppState, entry: ScenarioEntry) -> Result<R
             id: id.clone(),
             name,
             status: "running",
+            warnings: Vec::new(),
         });
         handles_to_store.push((id, handle));
     }
@@ -409,14 +656,20 @@ async fn post_single_scenario(state: AppState, entry: ScenarioEntry) -> Result<R
     }
     drop(scenarios);
 
-    // Respond based on whether expansion produced a single or multiple entries.
+    // Respond based on whether expansion produced a single or multiple
+    // entries. Warnings (if any) attach at the top level in both shapes so
+    // clients see them without walking the `scenarios` array.
     if created.len() == 1 {
-        let single = created.into_iter().next().expect("len checked above");
+        let mut single = created.into_iter().next().expect("len checked above");
+        single.warnings = warnings;
         Ok((StatusCode::CREATED, Json(single)).into_response())
     } else {
         Ok((
             StatusCode::CREATED,
-            Json(CreatedScenariosResponse { scenarios: created }),
+            Json(CreatedScenariosResponse {
+                scenarios: created,
+                warnings,
+            }),
         )
             .into_response())
     }
@@ -430,6 +683,7 @@ async fn post_single_scenario(state: AppState, entry: ScenarioEntry) -> Result<R
 async fn post_multi_scenario(
     state: AppState,
     entries: Vec<ScenarioEntry>,
+    warnings: Vec<String>,
 ) -> Result<Response, Response> {
     // Reject empty batches.
     if entries.is_empty() {
@@ -474,6 +728,7 @@ async fn post_multi_scenario(
             id: id.clone(),
             name,
             status: "running",
+            warnings: Vec::new(),
         });
         handles_to_store.push((id, handle));
     }
@@ -493,8 +748,13 @@ async fn post_multi_scenario(
     }
     drop(scenarios);
 
-    // Respond with 201 Created.
-    let response_body = CreatedScenariosResponse { scenarios: created };
+    // Respond with 201 Created. Warnings attach at the top level of the
+    // batch response; the per-entry `warnings` field stays empty to keep
+    // the shape predictable for clients.
+    let response_body = CreatedScenariosResponse {
+        scenarios: created,
+        warnings,
+    };
     Ok((StatusCode::CREATED, Json(response_body)).into_response())
 }
 
@@ -1931,11 +2191,31 @@ scenarios:
             id: "abc-123".to_string(),
             name: "my_scenario".to_string(),
             status: "running",
+            warnings: Vec::new(),
         };
         let json = serde_json::to_value(&cs).expect("must serialize");
         assert_eq!(json["id"], "abc-123");
         assert_eq!(json["name"], "my_scenario");
         assert_eq!(json["status"], "running");
+        assert!(
+            json.get("warnings").is_none(),
+            "empty warnings vec must be omitted from JSON"
+        );
+    }
+
+    /// Populated warnings serialize as a JSON string array on the response.
+    #[test]
+    fn created_scenario_serializes_warnings_when_present() {
+        let cs = CreatedScenario {
+            id: "abc-123".to_string(),
+            name: "my_scenario".to_string(),
+            status: "running",
+            warnings: vec!["loopback warning".to_string()],
+        };
+        let json = serde_json::to_value(&cs).expect("must serialize");
+        let arr = json["warnings"].as_array().expect("warnings must be array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0], "loopback warning");
     }
 
     // ========================================================================
@@ -3881,19 +4161,44 @@ scenarios:
                     id: "id-1".to_string(),
                     name: "s1".to_string(),
                     status: "running",
+                    warnings: Vec::new(),
                 },
                 CreatedScenario {
                     id: "id-2".to_string(),
                     name: "s2".to_string(),
                     status: "running",
+                    warnings: Vec::new(),
                 },
             ],
+            warnings: Vec::new(),
         };
         let json = serde_json::to_value(&resp).expect("must serialize");
         let arr = json["scenarios"].as_array().unwrap();
         assert_eq!(arr.len(), 2);
         assert_eq!(arr[0]["id"], "id-1");
         assert_eq!(arr[1]["name"], "s2");
+        assert!(
+            json.get("warnings").is_none(),
+            "empty top-level warnings vec must be omitted from JSON"
+        );
+    }
+
+    /// Batch response emits a top-level `warnings` array when populated.
+    #[test]
+    fn created_scenarios_response_serializes_warnings_when_present() {
+        let resp = CreatedScenariosResponse {
+            scenarios: vec![CreatedScenario {
+                id: "id-1".to_string(),
+                name: "s1".to_string(),
+                status: "running",
+                warnings: Vec::new(),
+            }],
+            warnings: vec!["loopback warning".to_string()],
+        };
+        let json = serde_json::to_value(&resp).expect("must serialize");
+        let arr = json["warnings"].as_array().expect("warnings must be array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0], "loopback warning");
     }
 
     // ========================================================================
@@ -3950,5 +4255,222 @@ scenarios:
             StatusCode::UNPROCESSABLE_ENTITY,
             "POST single scenario with rate=0 must return 422"
         );
+    }
+
+    // ========================================================================
+    // Sink loopback pre-flight (FU-2)
+    // ========================================================================
+
+    #[test]
+    fn is_loopback_host_matches_canonical_hosts() {
+        assert!(is_loopback_host("localhost"));
+        assert!(is_loopback_host("127.0.0.1"));
+        assert!(is_loopback_host("::1"));
+    }
+
+    #[test]
+    fn is_loopback_host_is_case_insensitive() {
+        assert!(is_loopback_host("LOCALHOST"));
+        assert!(is_loopback_host("LocalHost"));
+    }
+
+    #[test]
+    fn is_loopback_host_rejects_real_hostnames() {
+        assert!(!is_loopback_host("victoriametrics"));
+        assert!(!is_loopback_host("loki"));
+        assert!(!is_loopback_host("10.0.0.1"));
+        assert!(!is_loopback_host("192.168.1.10"));
+        // 127/8 non-exact addresses are deliberately NOT matched per the
+        // brief — only exact 127.0.0.1 counts.
+        assert!(!is_loopback_host("127.0.0.2"));
+    }
+
+    #[test]
+    fn extract_host_parses_http_url() {
+        assert_eq!(
+            extract_host("http://localhost:8428/api/v1/write"),
+            Some("localhost")
+        );
+        assert_eq!(
+            extract_host("https://victoriametrics:8428/write"),
+            Some("victoriametrics")
+        );
+    }
+
+    #[test]
+    fn extract_host_parses_url_without_port() {
+        assert_eq!(extract_host("http://localhost/push"), Some("localhost"));
+    }
+
+    #[test]
+    fn extract_host_parses_bare_authority() {
+        assert_eq!(extract_host("localhost:9094"), Some("localhost"));
+        assert_eq!(
+            extract_host("broker.example.com:9092"),
+            Some("broker.example.com")
+        );
+    }
+
+    #[test]
+    fn extract_host_parses_ipv6_literal() {
+        assert_eq!(extract_host("http://[::1]:8428/write"), Some("::1"));
+        assert_eq!(extract_host("[::1]:9000"), Some("::1"));
+        assert_eq!(
+            extract_host("http://[2001:db8::1]/push"),
+            Some("2001:db8::1")
+        );
+    }
+
+    #[test]
+    fn extract_host_handles_userinfo() {
+        assert_eq!(
+            extract_host("http://user:pass@localhost:8428/write"),
+            Some("localhost")
+        );
+    }
+
+    #[test]
+    fn extract_host_rejects_empty_input() {
+        assert_eq!(extract_host(""), None);
+        assert_eq!(extract_host("   "), None);
+    }
+
+    /// Build a minimal v2 YAML body with the given sink block injected into
+    /// `defaults` and compile it to a single `ScenarioEntry`. Used by the
+    /// loopback pre-flight tests so we exercise the real compiler path.
+    fn compile_single_entry_with_sink(sink_yaml: &str) -> ScenarioEntry {
+        let yaml = format!(
+            "version: 2\n\
+             defaults:\n\
+             \x20\x20rate: 10\n\
+             \x20\x20duration: 500ms\n\
+             \x20\x20encoder:\n\
+             \x20\x20\x20\x20type: prometheus_text\n\
+             {sink_yaml}\n\
+             scenarios:\n\
+             \x20\x20- id: loopback_test\n\
+             \x20\x20\x20\x20signal_type: metrics\n\
+             \x20\x20\x20\x20name: loopback_test\n\
+             \x20\x20\x20\x20generator:\n\
+             \x20\x20\x20\x20\x20\x20type: constant\n\
+             \x20\x20\x20\x20\x20\x20value: 1.0\n"
+        );
+        let resolver = InMemoryPackResolver::new();
+        let mut entries = compile_scenario_file(&yaml, &resolver).expect("compile must succeed");
+        assert_eq!(entries.len(), 1, "test fixture must compile to one entry");
+        entries.pop().unwrap()
+    }
+
+    #[test]
+    fn sink_loopback_warnings_flags_tcp_localhost() {
+        let entry = compile_single_entry_with_sink(
+            "\x20\x20sink:\n\x20\x20\x20\x20type: tcp\n\x20\x20\x20\x20address: localhost:9000",
+        );
+        let warnings = sink_loopback_warnings(std::slice::from_ref(&entry));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("loopback_test"));
+        assert!(warnings[0].contains("tcp"));
+        assert!(warnings[0].contains("localhost:9000"));
+        assert!(warnings[0].contains("deployment/endpoints"));
+    }
+
+    #[test]
+    fn sink_loopback_warnings_flags_udp_127_0_0_1() {
+        let entry = compile_single_entry_with_sink(
+            "\x20\x20sink:\n\x20\x20\x20\x20type: udp\n\x20\x20\x20\x20address: 127.0.0.1:9000",
+        );
+        let warnings = sink_loopback_warnings(std::slice::from_ref(&entry));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("udp"));
+        assert!(warnings[0].contains("127.0.0.1:9000"));
+    }
+
+    #[test]
+    fn sink_loopback_warnings_skips_stdout() {
+        let entry = compile_single_entry_with_sink("\x20\x20sink:\n\x20\x20\x20\x20type: stdout");
+        let warnings = sink_loopback_warnings(std::slice::from_ref(&entry));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn sink_loopback_warnings_skips_real_tcp_host() {
+        let entry = compile_single_entry_with_sink(
+            "\x20\x20sink:\n\x20\x20\x20\x20type: tcp\n\x20\x20\x20\x20address: syslog.example.com:514",
+        );
+        let warnings = sink_loopback_warnings(std::slice::from_ref(&entry));
+        assert!(warnings.is_empty());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn sink_loopback_warnings_flags_http_push_localhost() {
+        let entry = compile_single_entry_with_sink(
+            "\x20\x20sink:\n\x20\x20\x20\x20type: http_push\n\x20\x20\x20\x20url: http://localhost:8428/api/v1/write",
+        );
+        let warnings = sink_loopback_warnings(std::slice::from_ref(&entry));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("http_push"));
+        assert!(warnings[0].contains("http://localhost:8428/api/v1/write"));
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn sink_loopback_warnings_flags_http_push_ipv6_loopback() {
+        let entry = compile_single_entry_with_sink(
+            "\x20\x20sink:\n\x20\x20\x20\x20type: http_push\n\x20\x20\x20\x20url: http://[::1]:8428/api/v1/write",
+        );
+        let warnings = sink_loopback_warnings(std::slice::from_ref(&entry));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("[::1]"));
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn sink_loopback_warnings_skips_http_push_service_name() {
+        let entry = compile_single_entry_with_sink(
+            "\x20\x20sink:\n\x20\x20\x20\x20type: http_push\n\x20\x20\x20\x20url: http://victoriametrics:8428/api/v1/write",
+        );
+        let warnings = sink_loopback_warnings(std::slice::from_ref(&entry));
+        assert!(warnings.is_empty());
+    }
+
+    #[cfg(feature = "remote-write")]
+    #[test]
+    fn sink_loopback_warnings_flags_remote_write_localhost() {
+        let entry = compile_single_entry_with_sink(
+            "\x20\x20sink:\n\x20\x20\x20\x20type: remote_write\n\x20\x20\x20\x20url: http://localhost:8428/api/v1/write",
+        );
+        let warnings = sink_loopback_warnings(std::slice::from_ref(&entry));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("remote_write"));
+    }
+
+    #[cfg(feature = "kafka")]
+    #[test]
+    fn sink_loopback_warnings_flags_one_localhost_broker_in_mixed_list() {
+        let entry = compile_single_entry_with_sink(
+            "\x20\x20sink:\n\x20\x20\x20\x20type: kafka\n\
+             \x20\x20\x20\x20brokers: \"localhost:9094,real-broker:9092\"\n\
+             \x20\x20\x20\x20topic: logs",
+        );
+        let warnings = sink_loopback_warnings(std::slice::from_ref(&entry));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("kafka"));
+        assert!(warnings[0].contains("localhost:9094"));
+        assert!(!warnings[0].contains("real-broker"));
+    }
+
+    #[cfg(feature = "otlp")]
+    #[test]
+    fn sink_loopback_warnings_flags_otlp_grpc_localhost() {
+        let entry = compile_single_entry_with_sink(
+            "\x20\x20sink:\n\x20\x20\x20\x20type: otlp_grpc\n\
+             \x20\x20\x20\x20endpoint: http://localhost:4317\n\
+             \x20\x20\x20\x20signal_type: metrics",
+        );
+        let warnings = sink_loopback_warnings(std::slice::from_ref(&entry));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("otlp_grpc"));
+        assert!(warnings[0].contains("http://localhost:4317"));
     }
 }

--- a/sonda-server/tests/scenarios.rs
+++ b/sonda-server/tests/scenarios.rs
@@ -741,6 +741,341 @@ sink:
     );
 }
 
+// ---- FU-2: loopback sink pre-flight warnings ---------------------------------
+
+/// POST a scenario whose sink points at `localhost` — the server still
+/// returns 201 (warnings are informational, not errors) but the response
+/// body carries a `warnings` array explaining the container-loopback trap.
+#[test]
+fn post_tcp_localhost_sink_returns_warning() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let yaml = "\
+version: 2
+defaults:
+  rate: 10
+  duration: 500ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: tcp
+    address: localhost:9000
+scenarios:
+  - id: loopback_tcp
+    signal_type: metrics
+    name: loopback_tcp
+    generator:
+      type: constant
+      value: 1.0
+";
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(yaml)
+        .send()
+        .expect("POST must succeed at HTTP level");
+
+    assert_eq!(
+        resp.status().as_u16(),
+        201,
+        "loopback sink must still return 201 — warning, not rejection"
+    );
+
+    let body: serde_json::Value = resp.json().expect("response must be valid JSON");
+    let warnings = body["warnings"]
+        .as_array()
+        .expect("response must carry a warnings array");
+    assert_eq!(
+        warnings.len(),
+        1,
+        "single loopback sink must produce one warning"
+    );
+    let msg = warnings[0].as_str().unwrap();
+    assert!(
+        msg.contains("loopback_tcp"),
+        "warning must name the entry: {msg}"
+    );
+    assert!(
+        msg.contains("tcp"),
+        "warning must mention the sink type: {msg}"
+    );
+    assert!(
+        msg.contains("localhost:9000"),
+        "warning must echo the offending address: {msg}"
+    );
+    assert!(
+        msg.contains("deployment/endpoints"),
+        "warning must point at the docs: {msg}"
+    );
+}
+
+/// POST a scenario whose sink points at a real service name — no warnings
+/// in the response.
+#[test]
+fn post_tcp_real_hostname_sink_has_no_warnings() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let yaml = "\
+version: 2
+defaults:
+  rate: 10
+  duration: 500ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: tcp
+    address: syslog.example.com:514
+scenarios:
+  - id: real_host_tcp
+    signal_type: metrics
+    name: real_host_tcp
+    generator:
+      type: constant
+      value: 1.0
+";
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(yaml)
+        .send()
+        .expect("POST must succeed");
+
+    assert_eq!(resp.status().as_u16(), 201);
+
+    let body: serde_json::Value = resp.json().expect("response must be valid JSON");
+    // Empty warnings vec is skipped via skip_serializing_if — the key must be absent.
+    assert!(
+        body.get("warnings").is_none(),
+        "clean sink must not emit a warnings field"
+    );
+}
+
+/// POST a `stdout` sink — no warnings (sink carries no address).
+#[test]
+fn post_stdout_sink_has_no_warnings() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(VALID_METRICS_YAML)
+        .send()
+        .expect("POST must succeed");
+
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: serde_json::Value = resp.json().expect("response must be valid JSON");
+    assert!(
+        body.get("warnings").is_none(),
+        "stdout sink must not emit a warnings field"
+    );
+}
+
+/// POST a UDP sink pointed at `localhost:9000` — produces a warning.
+#[test]
+fn post_udp_localhost_sink_returns_warning() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let yaml = "\
+version: 2
+defaults:
+  rate: 10
+  duration: 500ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: udp
+    address: localhost:9000
+scenarios:
+  - id: loopback_udp
+    signal_type: metrics
+    name: loopback_udp
+    generator:
+      type: constant
+      value: 1.0
+";
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(yaml)
+        .send()
+        .expect("POST must succeed");
+
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: serde_json::Value = resp.json().expect("response must be valid JSON");
+    let warnings = body["warnings"]
+        .as_array()
+        .expect("warnings array required");
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].as_str().unwrap().contains("udp"));
+}
+
+/// POST a multi-scenario batch with one localhost sink and one service-name
+/// sink — batch response carries exactly one warning at the top level.
+#[test]
+fn post_multi_scenario_mixed_sinks_returns_one_warning() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let yaml = "\
+version: 2
+defaults:
+  rate: 10
+  duration: 500ms
+  encoder:
+    type: prometheus_text
+scenarios:
+  - id: multi_loopback
+    signal_type: metrics
+    name: multi_loopback
+    sink:
+      type: tcp
+      address: localhost:9000
+    generator:
+      type: constant
+      value: 1.0
+  - id: multi_clean
+    signal_type: metrics
+    name: multi_clean
+    sink:
+      type: tcp
+      address: collector.internal:9000
+    generator:
+      type: constant
+      value: 2.0
+";
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(yaml)
+        .send()
+        .expect("POST must succeed");
+
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: serde_json::Value = resp.json().expect("response must be valid JSON");
+    // Multi-scenario shape: top-level `warnings` next to `scenarios`.
+    let warnings = body["warnings"]
+        .as_array()
+        .expect("multi-scenario warnings must live at the top level");
+    assert_eq!(
+        warnings.len(),
+        1,
+        "mixed batch must surface exactly one warning"
+    );
+    assert!(warnings[0].as_str().unwrap().contains("multi_loopback"));
+}
+
+/// POST a multi-scenario batch with two clean sinks — response has no
+/// `warnings` field at all.
+#[test]
+fn post_multi_scenario_both_clean_has_no_warnings() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(VALID_MULTI_YAML)
+        .send()
+        .expect("POST must succeed");
+
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: serde_json::Value = resp.json().expect("response must be valid JSON");
+    assert!(
+        body.get("warnings").is_none(),
+        "all-clean batch must not emit a warnings field"
+    );
+}
+
+/// POST a scenario pointing at `127.0.0.1` — produces a warning.
+#[test]
+fn post_tcp_127_0_0_1_sink_returns_warning() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let yaml = "\
+version: 2
+defaults:
+  rate: 10
+  duration: 500ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: tcp
+    address: 127.0.0.1:9000
+scenarios:
+  - id: loopback_v4
+    signal_type: metrics
+    name: loopback_v4
+    generator:
+      type: constant
+      value: 1.0
+";
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(yaml)
+        .send()
+        .expect("POST must succeed");
+
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: serde_json::Value = resp.json().expect("response must be valid JSON");
+    let warnings = body["warnings"]
+        .as_array()
+        .expect("warnings array required");
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].as_str().unwrap().contains("127.0.0.1"));
+}
+
+/// POST a scenario pointing at `[::1]` (IPv6 loopback) — produces a warning.
+#[test]
+fn post_tcp_ipv6_loopback_sink_returns_warning() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let yaml = "\
+version: 2
+defaults:
+  rate: 10
+  duration: 500ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: tcp
+    address: \"[::1]:9000\"
+scenarios:
+  - id: loopback_v6
+    signal_type: metrics
+    name: loopback_v6
+    generator:
+      type: constant
+      value: 1.0
+";
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(yaml)
+        .send()
+        .expect("POST must succeed");
+
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: serde_json::Value = resp.json().expect("response must be valid JSON");
+    let warnings = body["warnings"]
+        .as_array()
+        .expect("warnings array required");
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].as_str().unwrap().contains("::1"));
+}
+
 /// POST a v1 multi-scenario YAML (top-level `scenarios:` without
 /// `version: 2`) — also rejected with 400 + migration hint. Companion to
 /// the flat-v1 case above.


### PR DESCRIPTION
## Summary

Addresses **FU-2** of the v1.0.1 docs audit tracker. PR #237 documented the localhost-resolution trap textually; this PR catches it proactively at POST time.

## The trap

When a v2 scenario is POSTed with \`url: http://localhost:8428/...\`, that URL resolves to the **sonda-server container's** loopback at runtime — not the host or the Docker Compose network. The scenario starts cleanly, the sink fails to connect on every flush, and operators only discover the trap by querying the backend and finding nothing. PR #237's docs explained the gotcha; this PR makes the server itself surface it.

## Behavior

When sonda-server receives \`POST /scenarios\` with a sink URL whose host is \`localhost\` / \`127.0.0.1\` / \`::1\`:

1. **Scenario still launches** — warning is advisory, not 4xx. Sometimes loopback is intentional.
2. \`tracing::warn!\` fires once per offending sink with the entry name, sink tag, offending URL, and a docs pointer.
3. The 201 response gains a \`warnings: [...]\` field listing the same messages so HTTP clients can surface them.

When clean: \`warnings\` is omitted entirely (\`#[serde(skip_serializing_if = "Vec::is_empty")]\`) — backward-compatible for clients ignoring the field.

### Sample warning text (lands in both log and response)

> scenario entry 'docker_alert_cpu' sink \`http_push\` targets \`http://localhost:8428/api/v1/import/prometheus\` — this host resolves to the sonda-server container's own loopback, not your host. Use a Docker Compose service name (e.g. \`victoriametrics:8428\`) or a Kubernetes Service DNS name instead. See docs/deployment/endpoints.md.

### Sample response (warnings present)

\`\`\`json
{ "id": "...", "name": "docker_alert_cpu", "status": "running", "warnings": ["..."] }
\`\`\`

## Coverage

URL-bearing sink variants checked:

- \`http_push\`, \`loki\`, \`remote_write\` (\`url\` field)
- \`otlp_grpc\` (\`endpoint\` field)
- \`kafka\` (\`brokers\` — comma-separated, each broker checked individually so mixed lists give per-broker warnings)
- \`tcp\`, \`udp\` (\`address\` field)

Skipped: \`stdout\`, \`file\`, \`channel\`, \`memory\`, all \`*Disabled\` placeholders, future non-exhaustive variants.

Loopback hosts: \`localhost\`, \`127.0.0.1\`, \`::1\`. IPv6 brackets handled. Kafka mixed lists give per-broker warnings.

## Implementation notes

- All logic lives in \`sonda-server/src/routes/scenarios.rs\` — no \`sonda-core\` changes, no new deps.
- \`extract_host\` is hand-rolled (~50 LOC) — no \`url\` crate added. Handles scheme prefix, IPv6 brackets, userinfo, bare \`host:port\`.
- Feature-gated to compile cleanly under any feature combination.
- Warnings computed once per POST (not per-event); zero runtime hot-path cost.

## Tests

- **17 inline unit tests** for the helpers (\`is_loopback_host\`, \`extract_host\`, \`format_loopback_warning\`, \`sink_loopback_warnings\`, \`collect_warnings_for_sink\`, response-DTO serialization).
- **8 integration tests** in \`sonda-server/tests/scenarios.rs\`: TCP localhost, UDP localhost, TCP 127.0.0.1, TCP \`[::1]\`, stdout (negative), real hostname (negative), multi-scenario mixed, multi-scenario both-clean.

## Gate verdicts

- **@rust-implementer** wrote.
- **@reviewer-quick**: PASS.
- **@uat**: PASS (8 scenarios end-to-end against running release binary, ~6 min real-time, both response shape and WARN log line verified).
- **Orchestrator gates**: \`cargo build/test/clippy/fmt/audit\` all green on \`--all-features\`.

## Docs

Extended the existing "Sink URLs resolve inside the server's network" admonition in \`deployment/sonda-server.md\` with a paragraph describing the new \`warnings\` field, a sample 201 response, and the omission-when-empty guarantee.

## Audit tracker

On merge, check off **FU-2** in \`~/.claude/projects/-Users-netpanda-projects-sonda/audits/2026-04-22-v1.0.1-docs-audit.md\`. Remaining: FU-3 (env-var YAML interpolation) and the P1 docs items.

## Test plan

- [ ] CI passes (default + \`--all-features\` jobs)
- [ ] Spot-check on a real sonda-server deployment: POST a scenario with localhost URL, verify warning lands in the response body