### PR TITLE
docs(cli): add sonda-server section + fix sonda-server.md cross-ref (audit P1-1)

### DIFF
--- a/docs/site/docs/configuration/cli-reference.md
+++ b/docs/site/docs/configuration/cli-reference.md
@@ -1606,6 +1606,90 @@ directory on the [scenario search path](../guides/scenarios.md#scenario-search-p
 read `signal_type` from the first entry. See
 [v2 catalog metadata](v2-scenarios.md#catalog-metadata) for the field reference.
 
+## sonda-server
+
+`sonda-server` is the HTTP control-plane binary. It exposes the same scenario surface as
+`sonda run` over a REST API so you can drive Sonda from CI pipelines, test harnesses, or
+dashboards without shell access. This section covers the binary's CLI surface only -- see
+[Server API](../deployment/sonda-server.md) for the full endpoint reference.
+
+```bash
+sonda-server [OPTIONS]
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--port <PORT>` | integer | `8080` | Port to listen on. |
+| `--bind <BIND>` | string | `0.0.0.0` | Address to bind to. Use `127.0.0.1` to restrict the server to localhost. |
+| `--api-key <API_KEY>` | string | none | API key for bearer-token authentication on `/scenarios/*` endpoints. When set, all requests to `/scenarios/*` must include an `Authorization: Bearer <key>` header. The `/health` endpoint stays public. Also readable from `SONDA_API_KEY`. |
+| `--help` | -- | -- | Print help information (`-h` for a short summary). |
+
+### Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `SONDA_API_KEY` | Bearer token for `/scenarios/*` authentication. Equivalent to `--api-key`; the CLI flag wins if both are set. An empty value disables auth and logs a warning. |
+| `RUST_LOG` | Log level filter consumed by `tracing-subscriber`. Defaults to `info`. Common values: `debug`, `sonda_server=debug,info`, `warn`. |
+
+### Examples
+
+Start with defaults (port 8080, bind to all interfaces, no auth):
+
+```bash
+sonda-server
+```
+
+Listen on a custom port and restrict to localhost:
+
+```bash
+sonda-server --port 9090 --bind 127.0.0.1
+```
+
+Enable API key authentication from the environment:
+
+```bash
+export SONDA_API_KEY=$(openssl rand -hex 32)
+sonda-server --port 8080
+```
+
+Raise log verbosity for troubleshooting:
+
+```bash
+RUST_LOG=debug sonda-server --port 8080
+```
+
+### Graceful shutdown
+
+Press Ctrl+C to stop the server. Sonda signals every running scenario to stop, waits up to
+5 seconds for each scenario thread to join so sinks can flush, then exits. Threads that
+miss the 5-second window are logged at `warn` level and abandoned -- the process still
+exits cleanly.
+
+### Authentication
+
+Authentication is opt-in. When neither `--api-key` nor `SONDA_API_KEY` is set, every
+endpoint is publicly accessible (the startup log reads
+`API key authentication disabled -- all endpoints are public`).
+
+When a key is configured, `/scenarios/*` requires the `Authorization: Bearer <key>` header.
+The token is compared in constant time using [`subtle::ConstantTimeEq`] to avoid timing
+side-channels. Requests fall into three buckets:
+
+| Request | Response |
+|---------|----------|
+| Correct bearer token | Request proceeds to the handler |
+| Missing or malformed `Authorization` header | `401 Unauthorized` with `detail: "missing or malformed Authorization header"` |
+| Wrong token | `401 Unauthorized` with `detail: "invalid API key"` |
+
+`GET /health` is always public so load balancers and Kubernetes liveness probes work
+without credentials. See the deployment guide's
+[Authentication section](../deployment/sonda-server.md#authentication) for curl examples,
+Prometheus scrape configuration, and Kubernetes Secret wiring.
+
+[`subtle::ConstantTimeEq`]: https://docs.rs/subtle/latest/subtle/trait.ConstantTimeEq.html
+
 ## Precedence rules
 
 Configuration values are resolved in this order (highest priority wins):

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -13,7 +13,7 @@ cargo run -p sonda-server
 cargo run -p sonda-server -- --port 9090 --bind 127.0.0.1
 ```
 
-See [CLI Reference](../configuration/cli-reference.md) for all `sonda-server` flags.
+See [CLI Reference: sonda-server](../configuration/cli-reference.md#sonda-server) for all `sonda-server` flags.
 Control log verbosity with the `RUST_LOG` environment variable (default: `info`):
 
 ```bash


### PR DESCRIPTION
## Summary

Addresses **P1-1** of the v1.0.1 docs audit tracker — the warmup item in the P1 batch.

\`deployment/sonda-server.md:16\` previously read:

> See [CLI Reference](../configuration/cli-reference.md) for all \`sonda-server\` flags.

…but \`cli-reference.md\` was 100% the \`sonda\` CLI. Pure textual broken promise.

## Changes

### \`cli-reference.md\` — new \`## sonda-server\` H2 section (+84 lines)

Slots between \`## sonda init\` and \`## Precedence rules\`. Covers:

- **Flags table**: \`--port\` (default \`8080\`), \`--bind\` (default \`0.0.0.0\`), \`--api-key\`, \`--help\`.
- **Environment variables**: \`SONDA_API_KEY\`, \`RUST_LOG\` (default \`info\`).
- **Examples**: 4 runnable startup commands (defaults / custom port + localhost-bind / API key from env / debug logging).
- **Graceful shutdown**: Ctrl+C → all running scenarios stop → 5s thread-join window → exit cleanly.
- **Authentication**: opt-in bearer-token check via \`subtle::ConstantTimeEq\`, 401 response shapes for missing/wrong tokens, cross-link to \`deployment/sonda-server.md\` for the curl recipes.

### \`deployment/sonda-server.md\` — anchored cross-ref (+1 / -1)

Line 16 now reads \`[CLI Reference: sonda-server](../configuration/cli-reference.md#sonda-server)\` so users land directly at the new section.

## Surprise finding (filed as audit FU-4)

\`sonda-server\` has **no \`--version\` / \`-V\`** flag — \`sonda-server -V\` errors out. The clap derive in \`sonda-server/src/main.rs:23\` is missing \`version = ...\`. The \`sonda\` binary has it. The new docs section deliberately omits \`--version\` to match the binary's actual surface; the gap is filed as **FU-4** (one-line code fix, deferred).

## Gate verdicts

- **@doc** wrote the new section.
- **@reviewer-quick**: PASS — flag defaults, anchor naming, 401 response strings, and 5-second timeout all verified against live binary + source.
- **Render check** (orchestrator): \`task site:build\` strict mode clean; \`<h2 id="sonda-server">\` present in rendered HTML; cross-ref from sonda-server.md resolves to \`../../configuration/cli-reference/#sonda-server\`.

## Audit tracker

On merge, check off **P1-1** in \`~/.claude/projects/-Users-netpanda-projects-sonda/audits/2026-04-22-v1.0.1-docs-audit.md\`. Remaining P1: P1-2 (16 missing examples), P1-3 (\`scenario-file.md\` collapse), P1-4 (Guides nav regroup, bundle with P1-3).

## Test plan

- [ ] CI mkdocs strict build passes
- [ ] Live site renders \`/configuration/cli-reference/#sonda-server\` correctly after gh-pages deploy
- [ ] Click the cross-link from \`/deployment/sonda-server/\` and confirm landing