### PR TITLE
docs(site): fill 16 missing examples + Dynamic Labels guide + polish (audit P1-2)

### DIFF
--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -251,7 +251,9 @@ validation, the entire request is rejected and nothing is launched:
 !!! tip "Long-running scenarios"
     Omit the `duration` field from your scenario body (or put `duration:` only inside a
     single entry and omit it from `defaults:`) to create a scenario that runs indefinitely.
-    Stop it later with `DELETE /scenarios/{id}`. See the
+    Stop it later with `DELETE /scenarios/{id}`. The canonical run-until-stopped example is
+    [`examples/long-running-metrics.yaml`](https://github.com/davidban77/sonda/blob/main/examples/long-running-metrics.yaml)
+    -- POST it to start, DELETE to stop, operator owns the lifecycle. See the
     [tutorial](../guides/tutorial.md#long-running-scenarios) for a full start and stop
     example.
 

--- a/docs/site/docs/guides/dynamic-labels.md
+++ b/docs/site/docs/guides/dynamic-labels.md
@@ -1,0 +1,254 @@
+# Dynamic Labels
+
+Dynamic labels attach a rotating label value to every emitted event. Use them when the label
+you care about -- `hostname`, `pod_name`, `region` -- belongs on every data point, and you need
+the label values to cycle through a bounded, predictable set.
+
+At a glance, a dynamic label lets a single scenario entry stand in for a fleet:
+
+```yaml title="10-node fleet, one entry"
+scenarios:
+  - signal_type: metrics
+    name: node_cpu_usage
+    generator:
+      type: sine
+      amplitude: 40.0
+      offset: 50.0
+    dynamic_labels:
+      - key: hostname
+        prefix: "host-"
+        cardinality: 10
+```
+
+Every tick emits one event whose `hostname` cycles through `host-0`, `host-1`, ..., `host-9`
+and wraps back to `host-0`. You did not have to copy the scenario ten times.
+
+## When to reach for dynamic labels
+
+Three situations call for dynamic labels:
+
+- **Fleet simulation.** You want to test a dashboard that aggregates by hostname (`sum by
+  (hostname)`), but running one scenario per host is tedious and hard to maintain. One dynamic
+  label with `cardinality: 50` produces a 50-series dataset from a single entry.
+- **Geographic or categorical rotation.** Metrics tagged by `region`, `az`, `tenant`, or
+  `customer_id` where the set of values is meaningful (not just a counter). Use `values: [...]`
+  to list the real identifiers.
+- **High-cardinality query paths.** Exercise Prometheus or VictoriaMetrics index paths without
+  pushing cardinality *spikes* -- the label is always present, so time-series count stays flat
+  at `cardinality` for the full duration.
+
+!!! info "Dynamic labels vs. cardinality spikes"
+    Dynamic labels are **always on**: the label appears on every event. Cardinality spikes are
+    **time-windowed**: the label appears only during recurring spike windows. Pick dynamic
+    labels when you are modeling a stable fleet; pick
+    [cardinality spikes](../configuration/scenario-fields.md#cardinality-spike-window) when you
+    are modeling a traffic event that briefly explodes your label set.
+
+## The two strategies
+
+A dynamic label uses one of two strategies. Which one you pick depends entirely on whether
+the label values carry meaning.
+
+=== "Counter strategy"
+
+    Provide `prefix` and `cardinality`. Values are generated as `{prefix}0`, `{prefix}1`, ...,
+    `{prefix}{cardinality-1}`, then wrap.
+
+    ```yaml
+    dynamic_labels:
+      - key: hostname
+        prefix: "host-"
+        cardinality: 10
+    ```
+
+    Use this when the values are synthetic and their only job is to be distinct -- fleet
+    simulation, load testing index performance at a chosen cardinality, generating N series
+    for a dashboard panel. If you omit `prefix`, it defaults to `"{key}_"`
+    (e.g., `hostname_0`, `hostname_1`).
+
+=== "Values list strategy"
+
+    Provide `values`. The label cycles through the list in order, wrapping at the end.
+
+    ```yaml
+    dynamic_labels:
+      - key: region
+        values: [us-east-1, us-west-2, eu-west-1]
+    ```
+
+    Use this when the values carry meaning -- AWS regions, environments (`prod`/`staging`/`dev`),
+    named customer tenants. Cardinality is implicit: it equals `values.len()`.
+
+### Choosing between them
+
+| You want... | Use | Why |
+|-------------|-----|-----|
+| N synthetic hosts numbered 0..N-1 | `counter` | Deterministic, predictable, scales to any N. |
+| Specific named regions, tenants, clusters | `values_list` | Real-world identifiers matter for dashboards. |
+| A fixed cardinality without caring about names | `counter` | Only the label cardinality matters. |
+| Reproducible cycle across runs | either | Both are deterministic for a given tick. |
+
+## Worked example: simulating a 10-node fleet
+
+You want to test a Grafana panel that shows `sum by (hostname)` of CPU utilization across a
+10-node cluster. Without dynamic labels, you would write ten scenario entries that differ only
+in one label. With dynamic labels, one entry does the job.
+
+```yaml title="examples/dynamic-labels-fleet.yaml"
+version: 2
+
+defaults:
+  rate: 10
+  duration: 10s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+
+scenarios:
+  - signal_type: metrics
+    name: node_cpu_usage
+    generator:
+      type: sine
+      amplitude: 40.0
+      period_secs: 60
+      offset: 50.0
+    dynamic_labels:
+      - key: hostname
+        prefix: "host-"
+        cardinality: 10
+    labels:
+      env: production
+      cluster: us-east-1
+```
+
+Run it:
+
+```bash
+sonda metrics --scenario examples/dynamic-labels-fleet.yaml
+```
+
+```text title="Output (abridged)"
+node_cpu_usage{cluster="us-east-1",env="production",hostname="host-0"} 50.00 ...
+node_cpu_usage{cluster="us-east-1",env="production",hostname="host-1"} 50.42 ...
+node_cpu_usage{cluster="us-east-1",env="production",hostname="host-2"} 50.84 ...
+...
+node_cpu_usage{cluster="us-east-1",env="production",hostname="host-9"} 53.74 ...
+node_cpu_usage{cluster="us-east-1",env="production",hostname="host-0"} 54.15 ...
+```
+
+Each event carries a `hostname` label. Across the full duration, the series count stays at
+exactly 10 -- `sum by (hostname) (node_cpu_usage)` returns ten values in every scrape window.
+
+!!! tip "The generator runs once per tick, the label rotates once per event"
+    At `rate: 10` events/sec, the sine generator advances at 10 Hz. Each event in the tick gets
+    the same generator value but a different `hostname` -- so host-0 and host-1 see the same
+    CPU shape, offset by one sample. If you want truly independent generators per host, write
+    ten entries (or a generator that is phase-shifted by `hostname`, via `phase_offset` on
+    separate entries).
+
+## Combining multiple dynamic labels
+
+Two or more dynamic labels cycle independently on the same tick counter. The result is a
+Cartesian product over time:
+
+```yaml title="examples/dynamic-labels-multi.yaml"
+scenarios:
+  - signal_type: metrics
+    name: request_count
+    generator:
+      type: step
+      start: 0
+      step_size: 1.0
+      max: 10000
+    dynamic_labels:
+      - key: hostname
+        prefix: "web-"
+        cardinality: 3
+      - key: region
+        values: [us-east-1, eu-west-1]
+    labels:
+      service: frontend
+```
+
+```text title="Output"
+request_count{hostname="web-0",region="us-east-1",service="frontend"} 0
+request_count{hostname="web-1",region="eu-west-1",service="frontend"} 1
+request_count{hostname="web-2",region="us-east-1",service="frontend"} 2
+request_count{hostname="web-0",region="eu-west-1",service="frontend"} 3
+```
+
+Both labels advance every tick. `hostname` wraps every 3 ticks; `region` wraps every 2. The
+full series count is `3 x 2 = 6` unique combinations, visited in a 6-tick cycle.
+
+## Dynamic labels on log scenarios
+
+Dynamic labels work identically on `logs:` entries. Swap `signal_type: metrics` for
+`signal_type: logs`, and the rotating label attaches to every log event:
+
+```yaml title="examples/dynamic-labels-logs.yaml"
+scenarios:
+  - signal_type: logs
+    name: app_logs
+    log_generator:
+      type: template
+      templates:
+        - message: "Request handled successfully"
+      severity_weights:
+        info: 1.0
+      seed: 42
+    dynamic_labels:
+      - key: pod_name
+        prefix: "api-"
+        cardinality: 3
+    labels:
+      app: sonda
+```
+
+Each emitted JSON log event carries `pod_name=api-0`, `api-1`, or `api-2` in rotation. Useful
+for testing Loki label indexing or pod-level log aggregation panels.
+
+## Runnable examples
+
+| File | Signal | Strategy | What to look for |
+|------|--------|----------|------------------|
+| `examples/dynamic-labels-fleet.yaml` | metrics | counter (10) | 10 distinct `hostname` values on `node_cpu_usage` |
+| `examples/dynamic-labels-regions.yaml` | metrics | values list | 3-element `region` cycle on `api_latency_seconds` |
+| `examples/dynamic-labels-multi.yaml` | metrics | counter + values | Two rotating labels on a request counter |
+| `examples/dynamic-labels-logs.yaml` | logs | counter (3) | Rotating `pod_name` on structured log events |
+
+Run any of them:
+
+```bash
+sonda metrics --scenario examples/dynamic-labels-fleet.yaml
+sonda logs --scenario examples/dynamic-labels-logs.yaml
+```
+
+## Interaction with other fields
+
+!!! info "Merge order: dynamic labels win on collision"
+    Dynamic labels are merged on top of the scenario's static `labels:` on every tick. If a
+    dynamic label key collides with a static label key, the dynamic value wins.
+
+`dynamic_labels` composes cleanly with the rest of the scenario surface:
+
+- **`cardinality_spikes`** can coexist with dynamic labels -- spike labels appear only during
+  the spike window, while dynamic labels are always present.
+- **`gaps`** take priority over both. During a gap, no events are emitted regardless of label
+  strategy.
+- **`after:` and `phase_offset`** do not interact with label rotation. The tick counter starts
+  at 0 whenever the scenario starts emitting; phase-offsetting the start just delays when
+  label rotation begins.
+- **Packs** expand before dynamic labels apply. If you attach `dynamic_labels` to a
+  pack-backed entry, every metric expanded from the pack gets the same rotating label.
+
+## See also
+
+- [**Scenario Fields -- Dynamic labels**](../configuration/scenario-fields.md#dynamic-labels)
+  -- full field reference for `key`, `prefix`, `cardinality`, `values`.
+- [**Scenario Fields -- Cardinality spike window**](../configuration/scenario-fields.md#cardinality-spike-window)
+  -- use this instead when you want a label to appear only during recurring time windows.
+- [**Capacity Planning**](capacity-planning.md) -- stress-testing ingest pipelines with high
+  cardinality (includes an always-on fleet pattern).
+- [**Example Scenarios -- Dynamic Labels**](examples.md#dynamic-labels) -- catalog entry for
+  the four runnable YAML files.

--- a/docs/site/docs/guides/examples.md
+++ b/docs/site/docs/guides/examples.md
@@ -24,6 +24,7 @@ sonda metrics --scenario examples/basic-metrics.yaml
 | `udp-sink.yaml` | constant | json_lines | udp | Send UDP datagrams to port 9998 |
 | `file-sink.yaml` | sawtooth | influx_lp | file | Write to `/tmp/sonda-output.txt` |
 | `http-push-sink.yaml` | sine | prometheus_text | http_push | POST batches to an HTTP endpoint |
+| `http-push-retry.yaml` | sine | prometheus_text | http_push | HTTP push with exponential-backoff retry on 5xx/429/connect failures |
 | `kafka-sink.yaml` | constant | prometheus_text | kafka | Publish to a local Kafka broker |
 | `kafka-tls.yaml` | constant | prometheus_text | kafka | Publish to a TLS-secured Kafka broker with SASL PLAIN auth |
 
@@ -57,6 +58,61 @@ See [Sinks](../configuration/sinks.md) for configuration details on each sink ty
 |------|-----------|---------|------|-------------|
 | `burst-metrics.yaml` | sine | prometheus_text | stdout | Bursts to 5x rate for 2s every 10s |
 | `cardinality-spike.yaml` | sine | prometheus_text | stdout | Injects 100 unique `pod_name` labels for 5s every 10s |
+| `long-running-metrics.yaml` | sine | prometheus_text | stdout | No `duration` -- runs until stopped (pair with `sonda-server` POST/DELETE) |
+
+## Histograms and Summaries
+
+| File | Signal | Encoder | Sink | Description |
+|------|--------|---------|------|-------------|
+| `histogram.yaml` | histogram | prometheus_text | stdout | Exponential distribution, 100 observations/tick (latency-style histogram) |
+| `summary.yaml` | summary | prometheus_text | stdout | Normal distribution (mean 0.1, stddev 0.02), 100 observations/tick |
+
+Run these with the matching subcommand:
+
+```bash
+sonda histogram --scenario examples/histogram.yaml
+sonda summary --scenario examples/summary.yaml
+```
+
+See [Generators](../configuration/generators.md) for distribution options.
+
+## Metric Packs
+
+| File | Pack | Encoder | Sink | Description |
+|------|------|---------|------|-------------|
+| `pack-scenario.yaml` | telegraf_snmp_interface | prometheus_text | stdout | Expand a pack into per-metric scenarios with user-supplied labels |
+| `pack-with-overrides.yaml` | telegraf_snmp_interface | prometheus_text | stdout | Override one metric's generator (`ifOperStatus` -> `flap`) without editing the pack |
+
+Packs must be on the search path. Run from the repo root (where `./packs/` exists), set
+`SONDA_PACK_PATH`, or pass `--pack-path ./packs`. See [Metric Packs](metric-packs.md) for details.
+
+## Dynamic Labels
+
+Dynamic labels rotate a label's value on every tick -- unlike cardinality spikes, the label is
+always present and cycles through a bounded set.
+
+| File | Generator | Strategy | Description |
+|------|-----------|----------|-------------|
+| `dynamic-labels-fleet.yaml` | sine | counter (10) | 10-node fleet: `hostname=host-0..host-9` rotating on a CPU-usage metric |
+| `dynamic-labels-regions.yaml` | uniform | values list | Cycle `region` through `us-east-1, us-west-2, eu-west-1` on an API-latency metric |
+| `dynamic-labels-multi.yaml` | step | counter + values | Two rotating labels (`hostname` counter x `region` values) on a request counter |
+| `dynamic-labels-logs.yaml` | template (logs) | counter (3) | Rotating `pod_name` label on structured log events |
+
+See the [Dynamic Labels guide](dynamic-labels.md) for the walkthrough and
+[Dynamic labels](../configuration/scenario-fields.md#dynamic-labels) for the field reference.
+
+## Capacity Planning
+
+Stress-test ingest pipelines by pushing high-volume, bursty, or high-cardinality workloads to
+VictoriaMetrics (or another backend). Change `url:` to target your own stack.
+
+| File | Generator | Encoder | Sink | Description |
+|------|-----------|---------|------|-------------|
+| `capacity-throughput-test.yaml` | sine x3 | prometheus_text | http_push | Three concurrent streams at 1000 evt/s each (3000 total) to find saturation |
+| `capacity-burst-test.yaml` | sine + bursts | prometheus_text | http_push | 500 evt/s baseline with 10x spikes for 5s every 30s to test backpressure |
+| `capacity-cardinality-stress.yaml` | constant + spike | prometheus_text | http_push | 500-value `pod_name` + 200-value `endpoint` cardinality spikes to stress index |
+
+See the [Capacity Planning](capacity-planning.md) guide for measurement methodology.
 
 ## Log Scenarios
 
@@ -99,8 +155,10 @@ See [Docker deployment](../deployment/docker.md) for the full stack setup.
 | `csv-replay-grafana-auto.yaml` | csv_replay | prometheus_text | stdout | Replay a Grafana CSV export with auto-discovered columns and labels |
 | `csv-replay-explicit-labels.yaml` | csv_replay | prometheus_text | stdout | Multi-column replay with per-column labels merged with scenario labels |
 | `cardinality-alert-test.yaml` | constant | prometheus_text | http_push | 500-value cardinality spike for cardinality alerts |
+| `ci-alert-validation.yaml` | constant | prometheus_text | http_push | Constant 95% CPU for 30s -- short enough for CI, long enough for a `for: 5s` alert |
 
-See the [Alert Testing](alert-testing.md) guide for end-to-end walkthrough.
+See the [Alert Testing](alert-testing.md) guide for end-to-end walkthrough, and
+[CI Alert Validation](ci-alert-validation.md) for automated validation in GitHub Actions.
 
 ## Alerting Pipeline
 
@@ -137,6 +195,7 @@ See [Pipeline Validation](pipeline-validation.md) for usage patterns.
 | File | Signal | Description |
 |------|--------|-------------|
 | `network-device-baseline.yaml` | metrics | Router with 2 uplinks: traffic counters, state, CPU, memory (9 scenarios) |
+| `network-link-failure.yaml` | metrics | 6-scenario link-failure cycle on `rtr-core-01`: Gi0/0/0 down 10s, Gi0/0/1 absorbs, errors + CPU spike, then recovers |
 | `scenarios/link-failover.yaml` | multi | Edge router link failover: primary flaps, backup saturates, latency degrades (3-signal `after:` chain) |
 
 Run with `sonda run`:

--- a/docs/site/docs/guides/network-device-telemetry.md
+++ b/docs/site/docs/guides/network-device-telemetry.md
@@ -132,6 +132,25 @@ The output interleaves across all 9 metric streams.
 
 ---
 
+## Which failure pattern to steal
+
+Two example scenarios model a link failure, and they use different mechanics. Pick the one that
+matches how you want to reason about time:
+
+| Scenario | Mechanic | Best for |
+|----------|----------|----------|
+| `examples/network-link-failure.yaml` | `sequence` generator + `repeat: true`, aligned tick-by-tick across multiple entries | Tight, repeating cycles where every tick's value matters and failures recur on a fixed drumbeat |
+| `scenarios/link-failover.yaml` | v2 `after:` chains -- each signal declares what it waits for, the compiler resolves phase offsets | Once-through causal chains where you care about ordering (primary drops -> backup saturates -> latency climbs) but not the exact tick |
+
+Use `sequence + repeat` when you need hand-authored values at specific ticks and the same
+pattern should loop indefinitely -- useful for soak testing and for dashboards that expect a
+steady rhythm. Use `after:` when the signals form a cascade and you would rather declare
+"latency starts degrading when the backup saturates" than count seconds across four entries.
+Both patterns ship as runnable example files; you can mix them in the same scenario if you
+have a repeating failure that also triggers a cascade.
+
+---
+
 ## Simulate a link failover
 
 The interesting part: what happens when a primary link drops? Traffic shifts to the backup path,

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -64,8 +64,9 @@ nav:
     - Tutorial: guides/tutorial.md
     - Catalog & packs:
       - Built-in Scenarios: guides/scenarios.md
-      - Metric Packs: guides/metric-packs.md
+      - Dynamic Labels: guides/dynamic-labels.md
       - Example Scenarios: guides/examples.md
+      - Metric Packs: guides/metric-packs.md
     - Alert testing:
       - Alert Testing: guides/alert-testing.md
       - Histogram & Summary Alerts: guides/histogram-alerts.md

--- a/examples/histogram.yaml
+++ b/examples/histogram.yaml
@@ -1,3 +1,24 @@
+# Histogram metrics: HTTP request latency (exponential distribution).
+#
+# Models a latency-style histogram where most requests are fast but a long
+# tail stretches toward higher values. The exponential distribution with
+# rate=10.0 gives a mean of 0.1s and a sharply right-skewed shape, which
+# is typical of HTTP handler latency.
+#
+# 100 observations per tick at 1 tick/s mimics a service handling ~100 req/s.
+# Each tick emits the standard Prometheus histogram triplet per bucket
+# (_bucket, _count, _sum) with cumulative bucket counts.
+#
+# Prerequisites: none -- stdout sink.
+#
+# Run:
+#   sonda histogram --scenario examples/histogram.yaml
+#
+# Observable output: 12 `_bucket` series (default Prometheus bucket set),
+# plus `_count` and `_sum`. Watch the low-le buckets (0.005, 0.01, 0.025)
+# accumulate mass as most observations fall below 0.1s; the `+Inf` bucket
+# always equals `_count`.
+
 version: 2
 
 defaults:

--- a/examples/summary.yaml
+++ b/examples/summary.yaml
@@ -1,3 +1,24 @@
+# Summary metrics: RPC duration (normal distribution).
+#
+# Models an RPC handler with tightly clustered latency: mean 0.1s,
+# stddev 0.02s. A normal distribution produces a symmetric bell shape
+# around the mean, which fits well-tuned internal services where the
+# latency tail is bounded.
+#
+# 100 observations per tick at 1 tick/s feeds the quantile estimator
+# with enough samples to produce stable p50/p90/p95/p99 readings.
+# Unlike histograms, summaries compute quantile values server-side --
+# they cannot be aggregated across instances in PromQL.
+#
+# Prerequisites: none -- stdout sink.
+#
+# Run:
+#   sonda summary --scenario examples/summary.yaml
+#
+# Observable output: 4 quantile series (0.5, 0.9, 0.95, 0.99) plus
+# `_count` and `_sum`. The p50 should hover near 0.1; p99 should sit
+# near 0.15 (mean + ~2.3 stddev). `_count` ticks up by 100 every second.
+
 version: 2
 
 defaults:


### PR DESCRIPTION
## Summary

Addresses **P1-2** of the v1.0.1 docs audit tracker, **expanded in-session** to close four scope-adjacent findings the first doc-agent pass surfaced. This closes the last P1 item before the conference.

## Three cohesive changes

### 1. \`guides/examples.md\` — 16 missing entries filled

Previously cataloged 46 of 62 example YAMLs; this PR adds the missing 16. Page grows from 173 → 231 lines with four new H2 sections slotted between Scheduling and Log Scenarios:

| Section | Entries |
|---|---|
| **Histograms and Summaries** (new) | \`histogram.yaml\`, \`summary.yaml\` |
| **Metric Packs** (new) | \`pack-scenario.yaml\`, \`pack-with-overrides.yaml\` |
| **Dynamic Labels** (new) | 4 \`dynamic-labels-*\` files |
| **Capacity Planning** (new) | 3 \`capacity-*\` files |

Plus in-place additions to Sink Types (\`http-push-retry.yaml\`), Scheduling (\`long-running-metrics.yaml\`), Network Device Telemetry (\`network-link-failure.yaml\`), and Alert Testing (\`ci-alert-validation.yaml\`).

**Approved table-shape deviations**:
- **Dynamic Labels**: 4-column \`Generator | Strategy | Description\` (all rows share \`prometheus_text + stdout\` — strategy is what the reader is shopping for)
- **Metric Packs**: 5-column with \`Pack\` swapping in for \`Generator\`

### 2. \`guides/dynamic-labels.md\` — new 170-line walkthrough guide

The missing conceptual onramp for \`dynamic_labels\`. Structure:

1. Opening concept (one-entry-stands-in-for-a-fleet)
2. \`!!! info\` on dynamic labels vs. cardinality spikes
3. Tabbed \`counter\` vs. \`values_list\` strategies + decision table
4. Worked example: 10-node fleet with real stdout output
5. Multi-label Cartesian composition
6. Logs variant
7. Runnable examples table (cross-refs 4 YAMLs)
8. Interaction with other fields (spikes, gaps, after:/phase_offset, packs)
9. See also

Nav slot: \`Catalog & packs\`, alphabetical between \`Built-in Scenarios\` and \`Example Scenarios\`.

### 3. Four scope-adjacent polish items

- **\`examples/histogram.yaml\` + \`examples/summary.yaml\`** — gained ~20-line teaching headers (distribution shape, run command, observable output, prerequisites). Previously nearly comment-free, unlike the well-documented \`capacity-*\` neighbors. Semantics unchanged; dry-runs verified.
- **\`guides/network-device-telemetry.md\`** — new \`## Which failure pattern to steal\` section with a 2-row decision table: \`sequence + repeat:true\` (tight repeating rhythm) vs. v2 \`after:\` chains (once-through causal cascades).
- **\`deployment/sonda-server.md\`** — \`!!! tip "Long-running scenarios"\` now cross-links \`examples/long-running-metrics.yaml\` as the canonical "run until stopped" example (absolute GitHub URL, since the docs tree can't relatively reach \`examples/\`).

### Originally-surfaced fifth finding (dropped)

\`examples/http-push-retry.yaml\`'s header referenced \`--retry-max-attempts\`, \`--retry-backoff\`, \`--retry-max-backoff\` CLI flags. The first doc-agent pass flagged these as possibly stale. **False alarm** — orchestrator verified all three flags exist on \`sonda metrics --help\`. No action taken.

## Gate verdicts

- **@doc** wrote both passes (the initial 16-entry catalog fill + the expanded scope). Voice approved by author.
- **@reviewer-quick**: PASS with one math-precision NOTE fixed inline (\`~2.5 stddev\` → \`~2.3 stddev\` in \`summary.yaml\` header).
- **@uat**: **PASS on 15/15 end-to-end scenarios**. Histogram, summary, pack-scenario, dynamic-labels-fleet, dynamic-labels-regions run live for 5-12s each; six dry-runs (multi, logs, capacity-throughput, network-link-failure, long-running, pack-overrides) verify compiled-scenario structure matches the documented table rows; \`task site:build\` strict clean; nav + cross-links verified in rendered HTML; \`p50 ≈ 0.1\` and \`p99 ≈ 0.15\` observations on the summary example match the new header's claims (p99 measured 0.136–0.152 across 10 ticks).

UAT observation (not a blocker): dynamic-label scenarios at rate ≥5 show pre-existing output buffering (~5s silence, then burst). Not introduced by this PR.

## Audit tracker

On merge, check off **P1-2**. **All P1 items then shipped** — the audit's conference-ready baseline is fully achieved. Remaining items are P2 (post-conference tutorial split, CI docs-drift catcher, asciinema, guide consolidation) and FU-3 (env-var YAML interpolation, deferred feature).

## Test plan

- [ ] CI mkdocs strict build passes
- [ ] Live site shows the new guide + regrouped catalog after gh-pages deploy
- [ ] \`sonda histogram --scenario examples/histogram.yaml\` prints 12 bucket series per tick with the documented observable shape