### PR TITLE
fix(sonda-server): wire clap version flag + document in CLI reference (audit FU-4)

### DIFF
--- a/docs/site/docs/configuration/cli-reference.md
+++ b/docs/site/docs/configuration/cli-reference.md
@@ -1625,6 +1625,7 @@ sonda-server [OPTIONS]
 | `--bind <BIND>` | string | `0.0.0.0` | Address to bind to. Use `127.0.0.1` to restrict the server to localhost. |
 | `--api-key <API_KEY>` | string | none | API key for bearer-token authentication on `/scenarios/*` endpoints. When set, all requests to `/scenarios/*` must include an `Authorization: Bearer <key>` header. The `/health` endpoint stays public. Also readable from `SONDA_API_KEY`. |
 | `--help` | -- | -- | Print help information (`-h` for a short summary). |
+| `--version` | -- | -- | Print the binary version and exit (`-V` for the short form). |
 
 ### Environment variables
 

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -21,7 +21,7 @@ use crate::state::AppState;
 /// Uses a manual `Debug` implementation to redact `api_key`, preventing
 /// accidental exposure of the secret in log output.
 #[derive(Parser)]
-#[command(name = "sonda-server", about = "HTTP control plane for Sonda")]
+#[command(name = "sonda-server", version, about = "HTTP control plane for Sonda")]
 struct Args {
     /// Port to listen on.
     #[arg(long, default_value_t = 8080)]


### PR DESCRIPTION
## Summary

Addresses **FU-4** of the v1.0.1 docs audit tracker. Surfaced while writing the P1-1 sonda-server CLI reference section (PR #239) — \`sonda-server -V\` errored out because the clap derive in \`sonda-server/src/main.rs\` lacked the \`version\` attribute. The \`sonda\` binary already has it.

## Change

One word in Rust + one row in docs:

\`\`\`diff
- #[command(name = "sonda-server", about = "HTTP control plane for Sonda")]
+ #[command(name = "sonda-server", version, about = "HTTP control plane for Sonda")]
\`\`\`

Plus a new \`--version\` row in the \`## sonda-server\` flags table in \`cli-reference.md\` to match the binary's now-actual surface.

## Verification

- \`cargo run -p sonda-server -- --version\` → \`sonda-server 1.0.1\` (matches the version pulled from \`sonda-server/Cargo.toml\` per clap's standard derive behavior)
- \`cargo run -p sonda-server -- -V\` → \`sonda-server 1.0.1\`
- \`cargo run -p sonda-server -- --help\` shows \`-V, --version  Print version\`

## Gate verdicts

- Orchestrator-only inline gates (1-line Rust + 1-row docs is too small to warrant agent spawn — matches the pattern from PR #240's lockfile bump and PR #242's docstring trim).
- \`cargo build --workspace --all-features\`: exit 0
- \`cargo test --workspace\`: exit 0
- \`cargo clippy --workspace --all-features -- -D warnings\`: exit 0
- \`cargo fmt --all -- --check\`: exit 0
- \`task site:build\`: strict, exit 0
- Docs-drift catcher (PR #242): would still pass — no new \`sonda-server\` invocations in docs.

## Audit tracker

On merge, check off **FU-4**. Remaining: **FU-5** (e2e-testing.md test-fixture-or-rewrite decision via \`@doc\`), **FU-3** (env-var YAML interpolation, deferred feature), and the P2 items (consolidate overlapping guides, tutorial split, asciinema).