### PR TITLE
docs(guides): trim pipeline-validation E2E section + capacity-planning intro (audit P2-4)

### DIFF
--- a/docs/site/docs/guides/capacity-planning.md
+++ b/docs/site/docs/guides/capacity-planning.md
@@ -42,37 +42,19 @@ The first question in capacity planning: how many data points per second can you
 ingest before it falls behind? Sonda's `rate` field controls events per second per scenario,
 and multi-scenario files let you run several streams in parallel.
 
-### Quick CLI test
+### Smoke-check before scaling up
 
-Start simple. Push 1,000 metrics per second to stdout and verify Sonda keeps up:
+Before you push thousands of events per second at a backend, confirm Sonda generates at the
+target rate on your hardware. A 5-second stdout run is enough:
 
 ```bash
-sonda -q metrics --name throughput_test --rate 1000 --duration 5s \
-  --value-mode sine --amplitude 50 --period-secs 60 --offset 100 \
-  --label job=capacity_test --label env=load-test | wc -l
+sonda -q metrics --name throughput_test --rate 1000 --duration 5s | wc -l
 # ~5000 lines
 ```
 
-If the line count roughly matches `rate * duration`, Sonda is keeping up on the generation side.
-Now push that load into a real backend.
-
-### Single-stream push to VictoriaMetrics
-
-Push a single metric stream directly to VictoriaMetrics with CLI flags -- no YAML needed:
-
-```bash
-sonda -q metrics --name throughput_test --rate 1000 --duration 30s \
-  --value-mode sine --amplitude 50 --period-secs 60 --offset 100 \
-  --label job=capacity_test --label env=load-test \
-  --sink http_push --endpoint http://localhost:8428/api/v1/import/prometheus \
-  --content-type "text/plain"
-```
-
-Verify the data arrived:
-
-```bash
-curl -s "http://localhost:8428/api/v1/query?query=throughput_test" | jq '.data.result | length'
-```
+If the line count roughly matches `rate * duration`, generation is keeping up. See
+[Pipeline Validation](pipeline-validation.md) for the full smoke-test pattern with exit-code
+checks and CI snippets. The rest of this section assumes the smoke check passed.
 
 ### Multi-stream throughput test
 

--- a/docs/site/docs/guides/pipeline-validation.md
+++ b/docs/site/docs/guides/pipeline-validation.md
@@ -154,40 +154,16 @@ CI catches regressions automatically. For deeper validation against real backend
 
 ## E2E Testing With Docker Compose
 
-For full end-to-end validation, spin up Sonda alongside a backend and verify data arrives.
+The smoke and CI checks above confirm Sonda emitted the expected number of lines and exited
+cleanly. They don't prove the data arrived in the shape your backend expects -- only the
+backend can answer that.
 
-The project includes a ready-to-use e2e test suite in `tests/e2e/`. See [E2E Testing](e2e-testing.md)
-for the full suite with Prometheus, VictoriaMetrics, Kafka, and Loki.
+For full end-to-end validation against a real Prometheus, VictoriaMetrics, Kafka, or Loki
+instance -- with backend queries that assert arrival, schema, and labels -- see
+[E2E Testing](e2e-testing.md). That guide is the canonical worked example for backend-side
+assertions.
 
-For a quick single-scenario check against VictoriaMetrics -- no YAML file needed:
-
-```bash
-# Start the stack
-docker compose -f examples/docker-compose-victoriametrics.yml up -d
-
-# Push data (CLI only, no scenario file)
-sonda metrics --name e2e_pipeline_check --rate 1 --duration 10s --value 99 \
-  --label test=pipeline --label env=ci \
-  --sink http_push --endpoint http://localhost:8428/api/v1/import/prometheus \
-  --content-type "text/plain"
-
-# Wait for ingestion, then verify
-sleep 5
-curl -s "http://localhost:8428/api/v1/query?query=e2e_pipeline_check" \
-  | jq '.data.result | length'
-# Expected: 1 (at least one series)
-
-# Tear down
-docker compose -f examples/docker-compose-victoriametrics.yml down -v
-```
-
-The same scenario also exists as a YAML file at `examples/e2e-scenario.yaml` if you prefer:
-
-```bash
-sonda metrics --scenario examples/e2e-scenario.yaml
-```
-
-Single-scenario checks validate one signal type. For full pipeline coverage, test metrics and logs together.
+Backend assertions cover one signal at a time. For full pipeline coverage, test metrics and logs together.
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses **P2-4** of the v1.0.1 docs audit tracker.

The audit flagged three guides as overlapping (\`pipeline-validation\`, \`capacity-planning\`, \`ci-alert-validation\`), but the \`@doc\` agent's investigation pass found **<15% real overlap** — the three serve distinct audiences:

| Page | Audience |
|---|---|
| \`pipeline-validation.md\` | Engineer who just changed an encoder/sink/route, wants smoke-check |
| \`capacity-planning.md\` | SRE sizing infra / capacity-modeling |
| \`ci-alert-validation.md\` | CI engineer wiring alert-rule validation into GitHub Actions |

The real defect was 1-2 sections in each that drifted from the page's core thesis. **Option D** (section-level reshuffling) fixes the drift surgically. \`ci-alert-validation.md\` needs no change.

## Two surgical edits

### \`pipeline-validation.md\`: trim "E2E Testing With Docker Compose" section (254 → 230 lines)

Replace the full Docker-compose start/push/verify/teardown block with a 7-line handoff to \`e2e-testing.md\` (the canonical home for backend-query-assertion patterns post-PR #244). The handoff names the value-add contrast: pipeline-validation does line-count smoke checks; e2e-testing queries the backend to assert arrival shape. Section header preserved so the page narrative flow (smoke → multi-format → CI → e2e → multi-scenario) stays intact.

### \`capacity-planning.md\`: trim weak intro subsections (601 → 583 lines)

The "Quick CLI test" + "Single-stream push to VictoriaMetrics" subsections taught Sonda basics, not capacity methodology. Trim to a single 6-line "Smoke-check before scaling up" paragraph that runs one quick CLI command and points to \`pipeline-validation.md\` for the full smoke-test pattern. "Multi-stream throughput test" promoted to lead the section so capacity content starts immediately. **Everything from "Find cardinality limits" onward is untouched** — that's the page's load-bearing content. The \`#performance-baselines\` anchor (deep-linked from \`troubleshooting.md:159\`) is preserved.

### \`ci-alert-validation.md\`: untouched

Per the audit, the page is well-scoped. No structural changes.

## Why not a merge

The audit considered Options A/B/C/D. Why D wins:

- **Not A (status quo)**: would leave two real defects (pipeline-validation duplicating e2e-testing's content, capacity-planning's weak intro) unfixed.
- **Not B (merge two of three)**: no defensible merge pair — pipeline+ci-alert assert different things; capacity+anything has wildly different page lengths and audiences.
- **Not C (single-page consolidation)**: 1,300-line Frankenstein, three audiences forced through each other's content, kills targeted nav placement.

## Scope-adjacent finds (deferred)

Two findings from the audit pass tracked in the audit doc as new follow-ups:

- **FU-6** — Trim "push-to-VM via curl + jq" micro-pattern duplication on \`alert-testing.md\` (Pushing to a Backend tab) and \`troubleshooting.md\` (connection-diagnostics examples). Same-shape trim as the above; ~30 lines net delta. PR-able as its own small follow-up.
- **FU-7** — \`alert-testing.md\` is 549 lines / 11 H2 sections — better candidate for a tutorial-style split than for cross-page consolidation. Same shape as P2-1 (the tutorial split) — investigation → IA → 4-6 new pages → nav restructure → cross-link updates.

## Gate verdicts

- **@doc** ran the investigation pass + wrote the implementation pass. Voice approved by author.
- **@reviewer-quick**: PASS.
- \`task site:build\` strict mode: clean.
- \`python3 scripts/validate_docs_commands.py\` (fully strict, no \`--skip-file\`): **250 commands checked, 0 failed**.
- Critical anchors preserved: \`pipeline-validation.md#ci-integration\`, \`capacity-planning.md#performance-baselines\`.

## Test plan

- [ ] CI \`docs-commands\` job (fully strict) passes
- [ ] Live site renders the trimmed pages after gh-pages deploy
- [ ] Both deep-linked anchors still resolve (\`pipeline-validation.md#ci-integration\`, \`capacity-planning.md#performance-baselines\`)

## Audit tracker

On merge, check off **P2-4**. Remaining: **P2-1** (tutorial split — biggest scope), **P2-3** (asciinema recordings), plus the two new follow-ups **FU-6** and **FU-7**. **FU-3** (env-var YAML interpolation) explicitly deferred.