### PR TITLE
docs(e2e): close 3 of 4 matrix gaps + trim curl/jq dup + repoint 2 examples (issue #245 + audit FU-6)

### DIFF
--- a/docs/site/docs/guides/alert-testing.md
+++ b/docs/site/docs/guides/alert-testing.md
@@ -277,70 +277,16 @@ With local testing covered, let's push metrics to a real backend.
 
 ## Pushing to a Backend
 
-The fastest path to end-to-end alert testing: push metrics into a TSDB and verify alerts fire.
+Once you can shape the alert pattern locally, push it into a real TSDB and verify the alert
+fires there. The push-and-query loop -- start the backend, run the scenario, `curl` the query
+API -- is the same one [E2E Testing](e2e-testing.md) walks through, with the full coverage
+matrix of encoder and sink combinations.
 
-=== "HTTP Push"
-
-    POST metrics directly to VictoriaMetrics using the Prometheus text import API.
-    No scenario file needed:
-
-    ```bash
-    sonda metrics --name cpu_usage --rate 1 --duration 180s --value 95 \
-      --label instance=server-01 --label job=node \
-      --sink http_push --endpoint http://localhost:8428/api/v1/import/prometheus \
-      --content-type "text/plain"
-    ```
-
-    Or use a scenario file for generators that require YAML (sequence, csv_replay):
-
-    ```bash
-    sonda metrics --scenario examples/vm-push-scenario.yaml
-    ```
-
-=== "Remote Write"
-
-    Use the Prometheus remote write protocol for native compatibility with any
-    remote-write receiver. No scenario file needed:
-
-    ```bash
-    sonda metrics --name cpu_usage --rate 1 --duration 180s --value 95 \
-      --label instance=server-01 --label job=node \
-      --encoder remote_write \
-      --sink remote_write --endpoint http://localhost:8428/api/v1/write
-    ```
-
-    Or use a scenario file:
-
-    ```bash
-    sonda metrics --scenario examples/remote-write-vm.yaml
-    ```
-
-!!! warning "Remote write requires a feature flag when building from source"
-    Pre-built binaries and Docker images include remote-write support. When building from
-    source, add `--features remote-write`: `cargo build --features remote-write -p sonda`.
-
-| Target | URL |
-|--------|-----|
-| VictoriaMetrics | `http://localhost:8428/api/v1/write` |
-| vmagent | `http://localhost:8429/api/v1/write` |
-| Prometheus | `http://localhost:9090/api/v1/write` |
-| Thanos Receive | `http://localhost:19291/api/v1/receive` |
-| Cortex/Mimir | `http://localhost:9009/api/v1/push` |
-
-### Verify data arrived
-
-```bash
-# Check that the series exists
-curl "http://localhost:8428/api/v1/series?match[]={__name__='cpu_usage'}"
-
-# Query the latest value
-curl "http://localhost:8428/api/v1/query?query=cpu_usage"
-```
-
-!!! info "Docker Compose stack required"
-    These push scenarios require a running backend. Start the included stack with:
-    `docker compose -f examples/docker-compose-victoriametrics.yml up -d`.
-    See [Docker Deployment](../deployment/docker.md) for details.
+For alerting specifically, the two scenarios you'll reach for first are
+`examples/vm-push-scenario.yaml` (Prometheus text via `http_push`) and
+`examples/remote-write-vm.yaml` (`remote_write` to VictoriaMetrics, vmagent, or upstream
+Prometheus). Both land in the stack from
+`examples/docker-compose-victoriametrics.yml`.
 
 You can also use the pull model instead of pushing.
 

--- a/docs/site/docs/guides/e2e-testing.md
+++ b/docs/site/docs/guides/e2e-testing.md
@@ -92,24 +92,43 @@ profile from `examples/docker-compose-victoriametrics.yml` first.
 | Metrics | `prometheus_text` | `http_push` (VictoriaMetrics) | `examples/e2e-scenario.yaml` | `curl -s 'http://localhost:8428/api/v1/query?query=e2e_pipeline_check' \| jq '.data.result \| length'` |
 | Metrics | `prometheus_text` | `http_push` (VictoriaMetrics, sine) | `examples/vm-push-scenario.yaml` | `curl -s 'http://localhost:8428/api/v1/query?query=cpu_usage' \| jq '.data.result \| length'` |
 | Metrics | `remote_write` | `remote_write` (VictoriaMetrics) | `examples/remote-write-vm.yaml` | `curl -s 'http://localhost:8428/api/v1/query?query=cpu_usage_rw' \| jq '.data.result \| length'` |
+| Metrics | `remote_write` | `remote_write` (vmagent → VM) | `examples/remote-write-vmagent.yaml` | `curl -s 'http://localhost:8428/api/v1/query?query=cpu_usage_vmagent' \| jq '.data.result \| length'` |
+| Metrics | `remote_write` | `remote_write` (Prometheus) | `examples/remote-write-prometheus.yaml` | `curl -s 'http://localhost:9090/api/v1/query?query=cpu_usage_prom' \| jq '.data.result \| length'` |
+| Metrics | `otlp` | `otlp_grpc` (OTel Collector → VM) | `examples/otlp-metrics.yaml` | `curl -s 'http://localhost:8428/api/v1/query?query=cpu_usage' \| jq '.data.result \| length'` |
+| Logs | `otlp` | `otlp_grpc` (OTel Collector → Loki) | `examples/otlp-logs.yaml` | `curl -sG 'http://localhost:3100/loki/api/v1/query_range' --data-urlencode 'query={service_name="sonda"}' \| jq '.data.result \| length'` |
 | Metrics | `prometheus_text` | `kafka` | `examples/kafka-sink.yaml` | `docker exec <kafka> /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic sonda-metrics --from-beginning --timeout-ms 5000` |
 | Logs | `json_lines` | `loki` | `examples/loki-json-lines.yaml` | `curl -sG 'http://localhost:3100/loki/api/v1/query_range' --data-urlencode 'query={job="sonda"}' \| jq '.data.result \| length'` |
 | Logs | `json_lines` | `kafka` | `examples/kafka-json-logs.yaml` | `docker exec <kafka> /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic sonda-logs --from-beginning --timeout-ms 5000` |
 | Metrics | `influx_lp` | `file` | `examples/influx-file.yaml` | `wc -l < /tmp/sonda-influx-output.txt` |
 
 !!! info "Compose profiles"
-    Loki and Kafka are behind profiles to keep the base stack lean. Bring them up with
-    `--profile loki` or `--profile kafka` (or both):
+    Loki, Kafka, Prometheus, and the OTel Collector are behind profiles to keep the base
+    stack lean. Bring up only what each row needs. The vmagent row uses the default stack —
+    no extra profile.
     ```bash
     docker compose -f examples/docker-compose-victoriametrics.yml \
-      --profile loki --profile kafka up -d
+      --profile loki --profile kafka --profile prometheus --profile otel-collector up -d
     ```
+    The OTLP-logs row needs both `--profile otel-collector` and `--profile loki` so the
+    collector has somewhere to forward log records.
 
 !!! tip "Feature-gated sinks"
     `remote_write`, `kafka`, and `otlp_grpc` are compile-time features. Pre-built binaries
     and the Docker image include them; if you `cargo build` from source, add
     `--features remote-write,kafka,otlp` (or the subset you need). See
     [Sinks](../configuration/sinks.md) for the full feature flag list.
+
+### Intentionally out of scope
+
+The matrix covers sinks that talk to a queryable backend over HTTP, gRPC, or a broker.
+A few sinks intentionally fall outside that pattern:
+
+- **`tcp`, `udp`, `json-tcp`** — raw socket sinks. The fixtures (`examples/tcp-sink.yaml`,
+  `examples/udp-sink.yaml`, `examples/json-tcp.yaml`) push to whatever process is listening
+  on the configured port; verification is "did `nc -l 5000` print anything?", not a
+  backend query. Use them when you're integrating with a custom collector or socket-based
+  ingest path.
+- **`stdout`** — pipes to the terminal. Already covered by [Pipeline Validation](pipeline-validation.md).
 
 ---
 

--- a/docs/site/docs/guides/troubleshooting.md
+++ b/docs/site/docs/guides/troubleshooting.md
@@ -125,14 +125,6 @@ Data arrives in chunks or only appears when the scenario ends.
 | HTTP 400 from backend | Wrong endpoint URL for the backend | Each backend has a specific path. See the [compatible endpoints table](../configuration/sinks.md#remote_write) |
 | HTTP 403 or 401 | Backend requires authentication headers | Add auth headers via `http_push` with custom `headers` instead |
 
-??? tip "Common remote write URLs"
-    | Backend | URL |
-    |---------|-----|
-    | VictoriaMetrics | `http://host:8428/api/v1/write` |
-    | Prometheus | `http://host:9090/api/v1/write` |
-    | Cortex / Mimir | `http://host:9009/api/v1/push` |
-    | Thanos Receive | `http://host:19291/api/v1/receive` |
-
 ### OTLP gRPC
 
 | Symptom | Likely cause | Fix |

--- a/examples/docker-compose-victoriametrics.yml
+++ b/examples/docker-compose-victoriametrics.yml
@@ -27,6 +27,9 @@
 #   docker compose -f examples/docker-compose-victoriametrics.yml --profile loki up -d
 #   docker compose -f examples/docker-compose-victoriametrics.yml --profile kafka up -d
 #   docker compose -f examples/docker-compose-victoriametrics.yml --profile loki --profile kafka up -d
+#   docker compose -f examples/docker-compose-victoriametrics.yml --profile prometheus up -d
+#   docker compose -f examples/docker-compose-victoriametrics.yml --profile otel-collector up -d
+#   docker compose -f examples/docker-compose-victoriametrics.yml --profile otel-collector --profile loki up -d
 #
 # Tear down:
 #
@@ -331,6 +334,65 @@ services:
     environment:
       - HTTP_PORT=8080
       - LOG_WITHOUT_NEWLINE=true
+
+  # ---------------------------------------------------------------------------
+  # prometheus: upstream Prometheus with the remote-write receiver enabled.
+  #
+  # Started with --web.enable-remote-write-receiver so Sonda's remote_write
+  # sink can POST to http://localhost:9090/api/v1/write. Use this profile when
+  # you specifically need to verify against real Prometheus instead of (or
+  # alongside) VictoriaMetrics.
+  #
+  # Query at http://localhost:9090/api/v1/query.
+  #
+  # This service is only started with --profile prometheus.
+  # ---------------------------------------------------------------------------
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    profiles: [prometheus]
+    ports:
+      - "9090:9090"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.enable-remote-write-receiver"
+      - "--web.listen-address=:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:9090/-/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  # ---------------------------------------------------------------------------
+  # otel-collector: OpenTelemetry Collector (contrib distribution).
+  #
+  # Receives OTLP/gRPC on :4317 and OTLP/HTTP on :4318. Forwards metrics to
+  # VictoriaMetrics via the Prometheus remote-write exporter, so the standard
+  # VM query path (http://localhost:8428/api/v1/query) verifies arrival.
+  #
+  # Logs go to Loki via the loki exporter when the loki profile is also up;
+  # the debug exporter mirrors them to collector stdout for inspection with:
+  #
+  #   docker compose -f examples/docker-compose-victoriametrics.yml \
+  #     --profile otel-collector logs -f otel-collector
+  #
+  # This service is only started with --profile otel-collector.
+  # ---------------------------------------------------------------------------
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.116.1
+    profiles: [otel-collector]
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    volumes:
+      - ./otel-collector/config.yaml:/etc/otel-collector-config.yaml:ro
+    depends_on:
+      victoriametrics:
+        condition: service_healthy
 
 volumes:
   vm-data:

--- a/examples/http-push-sink.yaml
+++ b/examples/http-push-sink.yaml
@@ -1,3 +1,14 @@
+# Demonstrates the http_push sink with the prometheus_text encoder, targeting
+# the VictoriaMetrics import API. Bring up the stack with:
+#
+#   docker compose -f examples/docker-compose-victoriametrics.yml up -d
+#
+# Then run:
+#
+#   sonda metrics --scenario examples/http-push-sink.yaml
+#
+# Verify with: curl 'http://localhost:8428/api/v1/query?query=cpu_usage'
+
 version: 2
 
 defaults:
@@ -7,7 +18,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:9090/api/v1/push"
+    url: "http://localhost:8428/api/v1/import/prometheus"
     content_type: "text/plain; version=0.0.4"
     batch_size: 65536
 

--- a/examples/otel-collector/config.yaml
+++ b/examples/otel-collector/config.yaml
@@ -1,0 +1,57 @@
+# OpenTelemetry Collector config used by the otel-collector compose profile.
+#
+# Receives OTLP/gRPC on :4317 and OTLP/HTTP on :4318. Forwards metrics to
+# VictoriaMetrics over the Prometheus remote-write protocol so the same
+# `curl ... | jq ...` query path the rest of the matrix uses still works.
+# Forwards logs to Loki when the `loki` profile is also enabled, and always
+# to the `debug` exporter (collector stdout). The Loki exporter is configured
+# without retries or queueing so failed exports are dropped silently when Loki
+# is not running — `docker logs otel-collector` still shows incoming events
+# via the debug exporter.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 1s
+    send_batch_size: 100
+  # Inject `service.name=sonda` so the Loki exporter promotes it to the
+  # `service_name` label. Without this the exporter falls back to
+  # `unknown_service` because Sonda's OTLP encoder doesn't set this
+  # resource attribute itself.
+  resource:
+    attributes:
+      - key: service.name
+        value: sonda
+        action: upsert
+
+exporters:
+  prometheusremotewrite:
+    endpoint: http://victoriametrics:8428/api/v1/write
+    tls:
+      insecure: true
+  loki:
+    endpoint: http://loki:3100/loki/api/v1/push
+    retry_on_failure:
+      enabled: false
+    sending_queue:
+      enabled: false
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [prometheusremotewrite]
+    logs:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [loki, debug]

--- a/examples/prometheus-http-push.yaml
+++ b/examples/prometheus-http-push.yaml
@@ -1,18 +1,19 @@
-# Prometheus text encoder → HTTP push sink
+# Prometheus text encoder → HTTP push sink (against VictoriaMetrics).
 #
-# POSTs Prometheus text exposition format in batches to a remote HTTP endpoint.
-# Compatible with VictoriaMetrics, vmagent, and the Prometheus HTTP API.
+# POSTs Prometheus text exposition format in batches to VictoriaMetrics's
+# import endpoint. Bring up the stack with:
 #
-# Start a local receiver before running (netcat for quick testing):
+#   docker compose -f examples/docker-compose-victoriametrics.yml up -d
 #
-#   nc -l 9090 &
+# Then run:
+#
 #   sonda metrics --scenario examples/prometheus-http-push.yaml
 #
-# For VictoriaMetrics:
-#   change url to: http://localhost:8428/api/v1/import/prometheus
+# Verify with: curl 'http://localhost:8428/api/v1/query?query=node_cpu_seconds_total'
 #
-# For Prometheus (with remote write receiver enabled):
-#   change url to: http://localhost:9090/api/v1/write
+# To target real Prometheus instead, see examples/remote-write-prometheus.yaml
+# (Prometheus's remote_write receiver expects protobuf+snappy, not text — different
+# encoder + sink combo, not just a URL change).
 
 version: 2
 
@@ -23,7 +24,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:9090/api/v1/import/prometheus"
+    url: "http://localhost:8428/api/v1/import/prometheus"
     content_type: "text/plain; version=0.0.4"
     batch_size: 65536
 

--- a/examples/prometheus/prometheus.yml
+++ b/examples/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+# Prometheus config used by the prometheus compose profile.
+#
+# The container is started with --web.enable-remote-write-receiver so it
+# accepts data POSTed by Sonda's remote_write sink. No scrape jobs needed —
+# the verify path queries Prometheus directly via /api/v1/query.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs: []

--- a/examples/remote-write-prometheus.yaml
+++ b/examples/remote-write-prometheus.yaml
@@ -1,0 +1,37 @@
+# Push metrics via Prometheus remote write protocol to upstream Prometheus.
+#
+# Prerequisites:
+#   docker compose -f examples/docker-compose-victoriametrics.yml \
+#     --profile prometheus up -d
+#
+# Usage:
+#   sonda metrics --scenario examples/remote-write-prometheus.yaml
+#
+# Verify data arrived (Prometheus query API):
+#   curl -s "http://localhost:9090/api/v1/query?query=cpu_usage_prom" \
+#     | jq '.data.result | length'
+#
+# Pre-built binaries and Docker images include remote-write support.
+# When building from source: cargo build --features remote-write -p sonda
+
+version: 2
+
+defaults:
+  rate: 1
+  duration: 30s
+  encoder:
+    type: remote_write
+  sink:
+    type: remote_write
+    url: "http://localhost:9090/api/v1/write"
+    batch_size: 100
+
+scenarios:
+  - signal_type: metrics
+    name: cpu_usage_prom
+    generator:
+      type: constant
+      value: 77.0
+    labels:
+      instance: server-01
+      job: sonda

--- a/examples/remote-write-vmagent.yaml
+++ b/examples/remote-write-vmagent.yaml
@@ -1,0 +1,38 @@
+# Push metrics via Prometheus remote write protocol to vmagent.
+#
+# vmagent ships in the default compose stack and forwards everything it
+# receives to VictoriaMetrics. Targeting vmagent first lets you exercise the
+# relay path (rewriting, queueing, retries) end-to-end before data lands in
+# the TSDB.
+#
+# Prerequisites:
+#   docker compose -f examples/docker-compose-victoriametrics.yml up -d
+#
+# Usage:
+#   sonda metrics --scenario examples/remote-write-vmagent.yaml
+#
+# Verify data arrived (query VictoriaMetrics, where vmagent forwards to):
+#   curl -s "http://localhost:8428/api/v1/query?query=cpu_usage_vmagent" \
+#     | jq '.data.result | length'
+
+version: 2
+
+defaults:
+  rate: 1
+  duration: 30s
+  encoder:
+    type: remote_write
+  sink:
+    type: remote_write
+    url: "http://localhost:8429/api/v1/write"
+    batch_size: 100
+
+scenarios:
+  - signal_type: metrics
+    name: cpu_usage_vmagent
+    generator:
+      type: constant
+      value: 88.0
+    labels:
+      instance: server-01
+      job: sonda


### PR DESCRIPTION
## Summary

Bundles two related follow-ups + 2 audit-fodder fixes per user request:

- **Issue #245** — fill the e2e matrix coverage gaps (or document them as wontfix-by-design)
- **Audit FU-6** — trim "push-to-VM via curl + jq" duplication on \`alert-testing.md\` + \`troubleshooting.md\` (PR #244 + #246 cleared the other two pages; this closes the cycle)
- **Bonus audit-fodder** — repoint two misleading example YAMLs (\`http-push-sink.yaml\`, \`prometheus-http-push.yaml\`) at URLs that actually work

Closes #245.

## Issue #245 outcome — 3 of 4 gaps filled with new infra

\`guides/e2e-testing.md\` matrix grew **7 → 11 rows** + a compact "Intentionally out of scope" wontfix block.

| Gap | Outcome |
|---|---|
| OTLP × metrics → otlp_grpc | New \`otel-collector\` profile (\`otel/opentelemetry-collector-contrib:0.116.1\`) with \`prometheusremotewrite\` exporter to VM. Reuses existing \`examples/otlp-metrics.yaml\`. |
| OTLP × logs → otlp_grpc | Same \`otel-collector\` profile, \`loki\` exporter (requires \`--profile otel-collector --profile loki\` together). Reuses existing \`examples/otlp-logs.yaml\`. |
| Prometheus remote-write receiver | New \`prometheus\` profile (\`prom/prometheus:v2.55.1\` + \`--web.enable-remote-write-receiver\`) + new \`examples/remote-write-prometheus.yaml\`. |
| vmagent target | New \`examples/remote-write-vmagent.yaml\`. No new infra (vmagent already in default stack). |
| TCP/UDP/json-tcp raw sockets | Wontfix-by-design — documented below the matrix in an "Intentionally out of scope" block. |

**Compose profiles are gated** so default \`docker compose up\` doesn't pull the new images.

**OTel Collector config notes** (both surfaced + fixed during gates):
- Loki exporter has retries + queueing disabled → silently drops failures when Loki isn't running (e.g., OTLP-metrics row uses \`--profile otel-collector\` alone). Otherwise the collector logs would be noisy with connection errors.
- Resource processor injects \`service.name=sonda\` so the Loki exporter promotes it to the \`service_name\` label. Without it, OTel falls back to \`unknown_service\`. UAT caught this on the live-infra run.

## FU-6 outcome

| Page | Net delta | What changed |
|---|---|---|
| \`alert-testing.md\` | **-62** | "Pushing to a Backend" tab section trimmed to a 12-line handoff to \`e2e-testing.md\`. Quick Reference table at page bottom still surfaces VM scenarios for discoverability. |
| \`troubleshooting.md\` | **-8** | Removed only the duplicated "Common remote write URLs" table. Diagnostic-flavored snippets (\`curl\` connectivity tests, OTLP \`4317\` vs \`4318\`, Loki + Kafka diagnostics, \`nc -zv\`) all preserved per "lean toward leaving it" guidance. |

Catcher count: 245 → 241 (the trim removed 4 \`sonda metrics\` invocations).

## Bonus audit-fodder

Two existing examples that targeted URLs that don't actually exist on real Prometheus or VM:

- \`examples/http-push-sink.yaml\`: was \`http://localhost:9090/api/v1/push\` → repointed at VM's \`/api/v1/import/prometheus\`. Added a small header comment with run instructions.
- \`examples/prometheus-http-push.yaml\`: was \`http://localhost:9090/api/v1/import/prometheus\` (a path that doesn't exist on real Prometheus) → repointed at VM. Header comment dropped the misleading "For Prometheus" guidance and points at \`remote-write-prometheus.yaml\` for the actual Prometheus path (which needs \`remote_write\` encoder + sink, not \`http_push + prometheus_text\`).

## Gate verdicts

- **@doc** owned items 1+2 with full autonomy. Orchestrator did the audit-fodder URL fixes inline.
- **@reviewer-quick**: caught 1 BLOCKER (\`Cargo.lock\` leak from orchestrator's dry-run cargo invocations — restored) + 1 WARNING (OTel logs-to-Loki noise on metrics-only profile — fixed by disabling exporter retries/queueing) + 1 NOTE (matrix-cell-only references aren't catcher-validated — accepted, matches existing pattern).
- **@uat (live infra)**: caught 1 BLOCKER (Row 4 \`service_name=unknown_service\` — fixed by adding resource processor that injects \`service.name=sonda\`). All 4 new matrix rows re-verified **end-to-end against live containers**:
  - Row 1 (vmagent): 31 events relayed, query returns 1 series ✓
  - Row 2 (Prometheus): 31 events accepted via remote-write, query returns 1 series ✓
  - Row 3 (OTel → VM via prometheusremotewrite): query returns 1 series ✓
  - Row 4 (OTel → Loki): query \`{service_name="sonda"}\` returns 1 series with 100 values ✓
  - Both repointed YAMLs: data lands in VM end-to-end ✓
- Strict mkdocs build: clean.
- Catcher fully strict: **241 commands, 0 failed**.

## Test plan

- [ ] CI \`docs-commands\` job (fully strict) passes
- [ ] Live site renders the expanded matrix after gh-pages deploy
- [ ] Spot-check matrix Row 3 / Row 4 against a fresh \`docker compose --profile otel-collector --profile loki up -d\`

## Audit tracker

On merge:
- Close **issue #245**
- Check off **FU-6** in the audit tracker

Remaining: **FU-7** (alert-testing.md 549-line split — same shape as P2-1), **FU-3** (env-var YAML interpolation — feature work), **P2-3** (asciinema — deliberately deferred for now).