### PR TITLE
docs(alert-testing): split monolithic page into 6 progressive sub-pages (audit FU-7)

### DIFF
--- a/docs/site/docs/guides/alert-testing-cardinality.md
+++ b/docs/site/docs/guides/alert-testing-cardinality.md
@@ -1,0 +1,57 @@
+# Cardinality explosion alerts
+
+Many monitoring stacks page when series cardinality crosses a guardrail
+(`count(up) > 10000`, `prometheus_tsdb_symbol_table_size_bytes > N`, etc.). The rule
+fires the first time a deploy ships a label with too many distinct values -- and the
+only way to know it works is to push a controlled explosion through it. Sonda's
+[cardinality spikes](../configuration/scenario-fields.md) generate a bounded burst of
+unique label values on a recurring schedule, so you can verify the alert fires during
+the spike and resolves after.
+
+```bash
+sonda metrics --scenario examples/cardinality-alert-test.yaml
+```
+
+```yaml title="examples/cardinality-alert-test.yaml (key fields)"
+cardinality_spikes:
+  - label: pod_name
+    every: 30s
+    for: 10s
+    cardinality: 500
+    strategy: counter
+    prefix: "pod-"
+```
+
+During the 10-second spike window, each tick injects a `pod_name` label drawn from a
+pool of up to 500 unique values (`pod-0` through `pod-499`). The actual per-spike
+series count is `min(cardinality, ticks_in_window)` — at `rate: 10, for: 10s` that's
+100 ticks per spike, so each spike grows the visible series count by up to 100 new
+`pod-N` values until the 500-value pool fills across recurrences. Outside the spike
+window the label is absent and only one series is emitted. This on/off pattern
+exercises both the firing and resolution paths of the cardinality rule.
+
+!!! info "Docker stack required"
+    The bundled example pushes to VictoriaMetrics via `http_push`. Start the backend
+    first:
+    `docker compose -f examples/docker-compose-victoriametrics.yml up -d`
+
+## Tuning the spike
+
+Three knobs shape the explosion:
+
+| Field | Effect |
+|-------|--------|
+| `cardinality` | Number of unique label values per spike. Set this just above your alert threshold. |
+| `for` | How long the spike lasts. Set this longer than your rule's `for:` clause. |
+| `every` | How often the spike recurs. Useful for proving the rule re-fires after a quiet window. |
+
+For a rule like `ALERT HighCardinality IF count(...) > 400 FOR 5m`, set
+`cardinality: 500` and `for: 360s` and watch the alert pend, fire, then clear after the
+spike ends.
+
+## Next
+
+Synthetic spikes are great for testing the alert path. To replay an actual production
+incident -- with the values that paged you last week -- use the replay generators next.
+
+[Continue to **Replaying recorded incidents** -->](alert-testing-replay.md)

--- a/docs/site/docs/guides/alert-testing-correlation.md
+++ b/docs/site/docs/guides/alert-testing-correlation.md
@@ -1,0 +1,77 @@
+# Compound and correlated alerts
+
+Production alerts often depend on more than one metric. Compound rules like
+`cpu_usage > 90 AND memory_usage_percent > 85` only fire when both conditions are
+true at the same moment -- which means your test data needs an overlapping window
+across two scenarios. Sonda gives you `phase_offset` and `clock_group` to build that
+overlap deterministically.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `phase_offset` | `"0s"` | Delay before this scenario starts emitting |
+| `clock_group` | (none) | Groups scenarios under a shared timing reference |
+
+```bash
+sonda run --scenario examples/multi-metric-correlation.yaml
+```
+
+```yaml title="examples/multi-metric-correlation.yaml (excerpt)"
+version: 2
+
+defaults:
+  rate: 1
+  duration: 120s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+
+scenarios:
+  - signal_type: metrics
+    name: cpu_usage
+    clock_group: alert-test
+    generator:
+      type: sequence
+      values: [20, 20, 20, 95, 95, 95, 95, 95, 20, 20]
+      repeat: true
+
+  - signal_type: metrics
+    name: memory_usage_percent
+    phase_offset: "3s"
+    clock_group: alert-test
+    generator:
+      type: sequence
+      values: [40, 40, 40, 88, 88, 88, 88, 88, 40, 40]
+      repeat: true
+```
+
+## Reading the timeline
+
+```text
+Wall time  cpu_usage (offset=0s)   memory_usage (offset=3s)
+--------   ---------------------   ------------------------
+t=0s       starts: 20             sleeping
+t=3s       95 (above threshold)   starts: 40
+t=6s       95                     88 (above threshold)
+t=8s       20 (drops)             88
+```
+
+The overlap window -- where **both** metrics are above threshold -- runs from t=6s to
+t=8s (2 seconds per cycle). For a `for: 5m` compound rule, extend the above-threshold
+sequences or switch to constant generators with a longer overall duration.
+
+!!! info "clock_group ties scenarios to a shared timeline"
+    Without `clock_group`, every scenario starts at its own wall-clock time and the
+    overlap drifts. With `clock_group: alert-test`, all members share a reference clock
+    and `phase_offset` is measured against that reference. See
+    [Scenario Fields -- Temporal fields](../configuration/scenario-fields.md#temporal-fields)
+    for the full ordering semantics.
+
+See [Example Scenarios](examples.md) for the full `multi-metric-correlation.yaml` file.
+
+## Next
+
+Threshold and compound rules cover scalar values. The next pattern is different in
+kind -- alerts that fire when the **count of series** changes, not the values inside them.
+
+[Continue to **Cardinality explosion alerts** -->](alert-testing-cardinality.md)

--- a/docs/site/docs/guides/alert-testing-replay.md
+++ b/docs/site/docs/guides/alert-testing-replay.md
@@ -1,0 +1,82 @@
+# Replaying recorded incidents
+
+Synthetic shapes prove the alert path works in the abstract. Replay proves it would
+have caught the real incident. Two generators handle the replay case: `sequence` for
+short hand-crafted patterns, and `csv_replay` for long recordings exported from your
+TSDB.
+
+| Generator | Best for | Storage |
+|-----------|----------|---------|
+| `sequence` | ≤ 20 values, hand-tuned | Inline in the YAML |
+| `csv_replay` | Real incidents, long recordings | External CSV file |
+
+## Hand-crafted patterns with sequence
+
+The [sequence generator](../configuration/generators.md#sequence) steps through an
+explicit list of values, perfect for short, deterministic threshold patterns:
+
+```bash
+sonda metrics --scenario examples/sequence-alert-test.yaml
+```
+
+```yaml title="examples/sequence-alert-test.yaml (key fields)"
+generator:
+  type: sequence
+  values: [10, 10, 10, 10, 10, 95, 95, 95, 95, 95, 10, 10, 10, 10, 10, 10]
+  repeat: true
+```
+
+With `repeat: true`, the pattern loops continuously. With `repeat: false`, the generator
+holds the last value after the sequence ends -- useful for "the metric pegged at 100
+and never recovered" scenarios.
+
+## Production replay with csv_replay
+
+For replaying real production data, the [csv_replay generator](../configuration/generators.md#csv_replay)
+reads values from a CSV file. If you have a Grafana dashboard showing the incident, see
+the [Grafana CSV Replay](grafana-csv-replay.md) guide for the full export-and-replay
+workflow.
+
+```bash
+sonda metrics --scenario examples/csv-replay-metrics.yaml
+```
+
+```yaml title="examples/csv-replay-metrics.yaml (key fields)"
+generator:
+  type: csv_replay
+  file: examples/sample-cpu-values.csv
+  columns:
+    - index: 1
+      name: cpu_replay
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `file` | (required) | Path to the CSV file |
+| `columns` | -- | Explicit column specs. When absent, columns are auto-discovered from the header. See [Generators](../configuration/generators.md#csv_replay). |
+| `repeat` | `true` | Cycle back to the first value after reaching the end |
+
+!!! tip "When to use csv_replay vs sequence"
+    Use `csv_replay` over `sequence` when you have more than ~20 values. It keeps the
+    YAML clean and makes it easy to update the data by replacing the CSV file -- the
+    scenario stays identical.
+
+??? info "Exporting values from VictoriaMetrics"
+    ```bash
+    curl -s "http://your-vm:8428/api/v1/query_range?\
+    query=cpu_usage{instance='prod-01'}&\
+    start=$(date -d '1 hour ago' +%s)&\
+    end=$(date +%s)&\
+    step=10s" \
+      | jq -r '["timestamp","cpu_percent"], (.data.result[0].values[] | [.[0], .[1]]) | @csv' \
+      > incident-values.csv
+    ```
+
+## Where to go from here
+
+Replay closes the loop on the local-testing side. To take any of these patterns to a
+real backend and prove the alert fires end-to-end, head back to the
+[Alert Testing landing page](alert-testing.md#push-to-a-real-backend) for the
+backend handoff, or jump straight to the
+[Alerting Pipeline](alerting-pipeline.md) walkthrough that wires vmalert and
+Alertmanager into the loop.

--- a/docs/site/docs/guides/alert-testing-resolution.md
+++ b/docs/site/docs/guides/alert-testing-resolution.md
@@ -1,0 +1,62 @@
+# Resolution and recovery
+
+A rule that fires but never clears is a paging incident waiting to happen. When a metric
+goes silent during a gap, Prometheus treats it as stale and resolves the alert -- the
+same path a real scrape failure or restart takes. Use [gap windows](../configuration/scenario-fields.md)
+to control when metrics disappear, so you can confirm both the firing and the resolution
+side of the rule.
+
+```text
+Time:  0s          40s         60s         100s        120s
+       |-----------|xxxxxxxxxxx|-----------|xxxxxxxxxxx|
+       emit events   gap (20s)  emit events   gap (20s)
+```
+
+Gaps occupy the **tail** of each cycle. With `every: 60s` and `for: 20s`, the gap runs
+from second 40 to second 60 of each cycle.
+
+```bash
+sonda metrics --scenario examples/gap-alert-test.yaml
+```
+
+```yaml title="examples/gap-alert-test.yaml"
+version: 2
+
+defaults:
+  rate: 1
+  duration: 300s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+
+scenarios:
+  - signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 95.0
+    gaps:
+      every: 60s
+      for: 20s
+    labels:
+      instance: server-01
+      job: node
+```
+
+The value stays at 95 (above threshold) but goes silent for 20 seconds every 60-second
+cycle. The alert enters pending state during the 40-second emit window but may not reach
+the `for:` duration before the gap resets it -- which is exactly the flapping pattern
+you want to validate against.
+
+!!! tip "Combine gaps with any generator"
+    Gaps work with any generator. A sine wave with periodic gaps creates a realistic
+    "flapping service" pattern -- useful for testing that your alert hysteresis or
+    `keep_firing_for` clause actually suppresses the noise.
+
+## Next
+
+Single-metric resolution is straightforward. Compound rules that depend on two or more
+metrics need careful timing -- that is the next pattern.
+
+[Continue to **Compound and correlated alerts** -->](alert-testing-correlation.md)

--- a/docs/site/docs/guides/alert-testing-thresholds.md
+++ b/docs/site/docs/guides/alert-testing-thresholds.md
@@ -1,0 +1,153 @@
+# Threshold and `for:` duration alerts
+
+The two most common alert shapes are also the two easiest to get wrong: a `> threshold`
+rule that never fires because the metric only breaches for 30 seconds, and a `for: 5m`
+clause that fires three minutes early because the test data was lumpier than expected.
+Sonda gives you three generators that cover both cases deterministically.
+
+| Pattern | Generator | When to reach for it |
+|---------|-----------|----------------------|
+| Crosses threshold predictably | `sine` | Verifying that the rule fires at all |
+| Stays above threshold for an exact duration | `sequence` | Validating short `for:` clauses (≤ 30s) |
+| Holds above threshold indefinitely | `constant` | Validating long `for:` clauses (minutes) |
+
+## Threshold crossings with sine
+
+The sine generator produces a smooth wave that crosses your threshold predictably.
+With `amplitude=50` and `offset=50` it oscillates between 0 and 100, crossing 90 for
+about 12 seconds per 60-second cycle -- enough to trigger a bare `> 90` rule on every
+period.
+
+```bash
+sonda metrics --scenario examples/sine-threshold-test.yaml
+```
+
+```yaml title="examples/sine-threshold-test.yaml"
+version: 2
+
+defaults:
+  rate: 1
+  duration: 180s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+
+scenarios:
+  - signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: sine
+      amplitude: 50.0
+      period_secs: 60
+      offset: 50.0
+    labels:
+      instance: server-01
+      job: node
+```
+
+The metric crosses 90 around tick 9, stays above until tick 21, then drops -- giving you
+roughly 12 seconds above threshold per cycle.
+
+??? info "Sine wave math"
+    The formula is: `value = offset + amplitude * sin(2 * pi * tick / period_ticks)`
+
+    With `amplitude=50` and `offset=50`, the threshold at 90 is crossed when `sin(x) > 0.8`:
+
+    - `sin(x) = 0.8` at `x = arcsin(0.8) = 0.927 radians`
+    - The sine exceeds 0.8 from `x = 0.927` to `x = pi - 0.927 = 2.214`
+    - That's `1.287 / 6.283 = 20.5%` of each cycle
+    - With a 60-second period: **~12.3 seconds above 90 per cycle**
+
+    | Tick (sec) | sin(2*pi*t/60) | Value | Above 90? |
+    |------------|----------------|-------|-----------|
+    | 0  | 0.000  | 50.0  | No  |
+    | 5  | 0.500  | 75.0  | No  |
+    | 10 | 0.866  | 93.3  | Yes |
+    | 15 | 1.000  | 100.0 | Yes |
+    | 20 | 0.866  | 93.3  | Yes |
+    | 25 | 0.500  | 75.0  | No  |
+
+Sine works for unbounded threshold rules. For a `for:` clause you need the breach to
+last an exact, predictable number of seconds.
+
+## Exact `for:` durations with sequence
+
+Prometheus alerts with a `for:` clause require the condition to be true for a
+**continuous** duration before firing. The [sequence generator](../configuration/generators.md#sequence)
+steps through an explicit list of values, one per tick, so you control the breach
+window down to the second:
+
+```bash
+sonda metrics --scenario examples/for-duration-test.yaml
+```
+
+```yaml title="examples/for-duration-test.yaml"
+version: 2
+
+defaults:
+  rate: 1
+  duration: 80s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+
+scenarios:
+  - signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: sequence
+      values: [10, 10, 10, 10, 10, 95, 95, 95, 95, 95, 10, 10, 10, 10, 10, 10]
+      repeat: true
+    labels:
+      instance: server-01
+      job: node
+```
+
+At `rate: 1`, ticks 5-9 are above 90 -- exactly 5 seconds continuous breach -- then
+the pattern repeats. To match a `for: 30s` alert, extend the run of `95`s to 30 entries.
+
+!!! tip "When sequence stops being practical"
+    Typing 300 values to satisfy a `for: 5m` alert is no fun. Past about 30 values,
+    switch to the constant generator below and let the runtime duration do the work.
+
+## Constant generator shortcut
+
+For sustained-breach tests longer than ~30 seconds, the
+[constant generator](../configuration/generators.md#constant) is more practical:
+
+```bash
+sonda metrics --scenario examples/constant-threshold-test.yaml
+```
+
+```yaml title="examples/constant-threshold-test.yaml"
+version: 2
+
+defaults:
+  rate: 1
+  duration: 360s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+
+scenarios:
+  - signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 95.0
+    labels:
+      instance: server-01
+      job: node
+```
+
+Run this for 6 minutes to test a `for: 5m` alert. The value stays at 95 for the entire
+duration -- the alert should fire after 5 minutes of continuous breach.
+
+## Next
+
+You can trigger an alert. Now make sure it resolves cleanly when the breach ends.
+
+[Continue to **Resolution and recovery** -->](alert-testing-resolution.md)

--- a/docs/site/docs/guides/alert-testing.md
+++ b/docs/site/docs/guides/alert-testing.md
@@ -1,303 +1,89 @@
 # Alert Testing
 
-You write alert rules, deploy them, and hope they work. But common issues slip through:
-a `for: 5m` alert that never fires because the metric only breaches for 3 minutes, a gap-fill
-rule that triggers false positives during scrape outages, or a compound alert where two metrics
-never overlap. Sonda lets you generate the exact metric shapes to trigger (and resolve) alerts
-on demand, so you can catch these problems before they hit production.
+You write alert rules, deploy them, and hope they work. Common issues slip through:
+a `for: 5m` alert that never fires because the metric only breaches for 3 minutes, a
+gap-fill rule that triggers false positives during scrape outages, or a compound alert
+where two metrics never overlap. Sonda lets you generate the exact metric shapes to
+trigger -- and resolve -- alerts on demand, so you catch these problems before they hit
+production.
 
----
+This page is the entry point. Five focused sub-pages cover the patterns; the table
+below maps each common alert shape to the right one.
 
-## Threshold Alerts
+## Pick your pattern
 
-The most basic alert test: verify that a `HighCPU` rule fires when `cpu_usage > 90`.
+| You want to test... | Go to | Generator |
+|---------------------|-------|-----------|
+| A simple `> threshold` rule | [Threshold and `for:` duration](alert-testing-thresholds.md) | `sine` |
+| A short `for:` clause (≤ 30s) | [Threshold and `for:` duration](alert-testing-thresholds.md) | `sequence` |
+| A long `for:` clause (minutes) | [Threshold and `for:` duration](alert-testing-thresholds.md) | `constant` |
+| Resolution / flapping behavior | [Resolution and recovery](alert-testing-resolution.md) | any + `gaps` |
+| Compound `A AND B` rules | [Compound and correlated alerts](alert-testing-correlation.md) | multi-scenario |
+| Cardinality guardrails | [Cardinality explosion alerts](alert-testing-cardinality.md) | any + `cardinality_spikes` |
+| Replaying a known incident | [Replaying recorded incidents](alert-testing-replay.md) | `sequence` or `csv_replay` |
 
-The sine generator produces a smooth wave that crosses your threshold predictably.
-With `amplitude=50` and `offset=50`, it oscillates between 0 and 100, crossing 90 for
-about 12 seconds per 60-second cycle.
+The pages are written as a tour and link forward to one another, but each one stands
+on its own -- jump straight to the one that matches the rule you are testing.
 
-```bash
-sonda metrics --scenario examples/sine-threshold-test.yaml
-```
+## The tour
 
-```yaml title="examples/sine-threshold-test.yaml"
-version: 2
+1. [**Threshold and `for:` duration**](alert-testing-thresholds.md) -- sine for
+   predictable crossings, sequence for exact breach windows, constant for sustained
+   load.
+2. [**Resolution and recovery**](alert-testing-resolution.md) -- gap windows that drop
+   the metric so you can confirm the alert clears.
+3. [**Compound and correlated alerts**](alert-testing-correlation.md) -- `phase_offset`
+   and `clock_group` to overlap two scenarios for `A AND B` rules.
+4. [**Cardinality explosion alerts**](alert-testing-cardinality.md) --
+   `cardinality_spikes` for testing series-count guardrails.
+5. [**Replaying recorded incidents**](alert-testing-replay.md) -- `sequence` for short
+   patterns, `csv_replay` for production exports.
 
-defaults:
-  rate: 1
-  duration: 180s
-  encoder:
-    type: prometheus_text
-  sink:
-    type: stdout
+## Push to a real backend
 
-scenarios:
-  - signal_type: metrics
-    name: cpu_usage
-    generator:
-      type: sine
-      amplitude: 50.0
-      period_secs: 60
-      offset: 50.0
-    labels:
-      instance: server-01
-      job: node
-```
+Once you can shape the alert pattern locally, push it into a real TSDB and verify the
+alert fires there. The push-and-query loop -- start the backend, run the scenario,
+`curl` the query API -- is the same one [E2E Testing](e2e-testing.md) walks through,
+with the full coverage matrix of encoder and sink combinations.
 
-The metric crosses 90 around tick 9, stays above until tick 21, then drops -- giving you
-roughly 12 seconds above threshold per cycle.
-
-??? info "Sine wave math"
-    The formula is: `value = offset + amplitude * sin(2 * pi * tick / period_ticks)`
-
-    With `amplitude=50` and `offset=50`, the threshold at 90 is crossed when `sin(x) > 0.8`:
-
-    - `sin(x) = 0.8` at `x = arcsin(0.8) = 0.927 radians`
-    - The sine exceeds 0.8 from `x = 0.927` to `x = pi - 0.927 = 2.214`
-    - That's `1.287 / 6.283 = 20.5%` of each cycle
-    - With a 60-second period: **~12.3 seconds above 90 per cycle**
-
-    | Tick (sec) | sin(2*pi*t/60) | Value | Above 90? |
-    |------------|----------------|-------|-----------|
-    | 0  | 0.000  | 50.0  | No  |
-    | 5  | 0.500  | 75.0  | No  |
-    | 10 | 0.866  | 93.3  | Yes |
-    | 15 | 1.000  | 100.0 | Yes |
-    | 20 | 0.866  | 93.3  | Yes |
-    | 25 | 0.500  | 75.0  | No  |
-
-Smooth waves are great for threshold crossings, but Prometheus `for:` clauses need precise timing control.
-
----
-
-## Testing `for:` Duration Behavior
-
-Prometheus alerts with a `for:` clause require the condition to be true for a **continuous**
-duration before firing. You need exact control over how long the metric stays above threshold.
-
-### Sequence generator
-
-The [sequence generator](../configuration/generators.md#sequence) steps through an explicit
-list of values, one per tick. Each value lasts exactly `1/rate` seconds:
-
-```bash
-sonda metrics --scenario examples/for-duration-test.yaml
-```
-
-```yaml title="examples/for-duration-test.yaml"
-version: 2
-
-defaults:
-  rate: 1
-  duration: 80s
-  encoder:
-    type: prometheus_text
-  sink:
-    type: stdout
-
-scenarios:
-  - signal_type: metrics
-    name: cpu_usage
-    generator:
-      type: sequence
-      values: [10, 10, 10, 10, 10, 95, 95, 95, 95, 95, 10, 10, 10, 10, 10, 10]
-      repeat: true
-    labels:
-      instance: server-01
-      job: node
-```
-
-At `rate: 1`, ticks 5-9 are above 90 (5 seconds continuous), then the pattern repeats.
-Adjust the number of above-threshold values to match your `for:` duration.
-
-!!! tip "Matching your `for:` duration"
-    For a `for: 5m` alert, you need 300 consecutive above-threshold values at `rate: 1`.
-    Rather than typing 300 values, use the constant generator instead (next section).
-
-### Constant generator shortcut
-
-For simple sustained-threshold tests, the [constant generator](../configuration/generators.md#constant) is more practical:
-
-```bash
-sonda metrics --scenario examples/constant-threshold-test.yaml
-```
-
-```yaml title="examples/constant-threshold-test.yaml"
-version: 2
-
-defaults:
-  rate: 1
-  duration: 360s
-  encoder:
-    type: prometheus_text
-  sink:
-    type: stdout
-
-scenarios:
-  - signal_type: metrics
-    name: cpu_usage
-    generator:
-      type: constant
-      value: 95.0
-    labels:
-      instance: server-01
-      job: node
-```
-
-Run this for 6 minutes to test a `for: 5m` alert. The value stays at 95 for the entire
-duration -- the alert should fire after 5 minutes of continuous breach.
-
-Now that you can trigger alerts, what about testing when they resolve?
-
----
-
-## Testing Alert Resolution
-
-When a metric goes silent during a gap, Prometheus treats it as stale and the alert resolves.
-Use [gap windows](../configuration/scenario-fields.md) to control when metrics disappear.
-
-```
-Time:  0s          40s         60s         100s        120s
-       |-----------|xxxxxxxxxxx|-----------|xxxxxxxxxxx|
-       emit events   gap (20s)  emit events   gap (20s)
-```
-
-Gaps occupy the **tail** of each cycle. With `every: 60s` and `for: 20s`, the gap runs from
-second 40 to second 60 of each cycle.
-
-```bash
-sonda metrics --scenario examples/gap-alert-test.yaml
-```
-
-```yaml title="examples/gap-alert-test.yaml"
-version: 2
-
-defaults:
-  rate: 1
-  duration: 300s
-  encoder:
-    type: prometheus_text
-  sink:
-    type: stdout
-
-scenarios:
-  - signal_type: metrics
-    name: cpu_usage
-    generator:
-      type: constant
-      value: 95.0
-    gaps:
-      every: 60s
-      for: 20s
-    labels:
-      instance: server-01
-      job: node
-```
-
-The value stays at 95 (above threshold) but goes silent for 20 seconds every 60-second cycle.
-The alert enters pending state during the 40-second emit window but may not reach the `for:`
-duration before the gap resets it.
-
-!!! tip "Combine with generators"
-    Gaps work with any generator. A sine wave with periodic gaps creates a realistic
-    "flapping service" pattern for alert testing.
-
-With single-metric alerts covered, let's move on to compound alerts that depend on multiple metrics.
-
----
-
-## Multi-Metric Correlation
-
-Production alerts often depend on more than one metric. Compound rules like
-`cpu_usage > 90 AND memory_usage_percent > 85` require both conditions to be true
-simultaneously. Sonda supports this with `phase_offset` and `clock_group` in
-multi-scenario YAML files.
-
-| Field | Default | Description |
-|-------|---------|-------------|
-| `phase_offset` | `"0s"` | Delay before this scenario starts emitting |
-| `clock_group` | (none) | Groups scenarios under a shared timing reference |
-
-```bash
-sonda run --scenario examples/multi-metric-correlation.yaml
-```
-
-```yaml title="examples/multi-metric-correlation.yaml (excerpt)"
-version: 2
-
-defaults:
-  rate: 1
-  duration: 120s
-  encoder:
-    type: prometheus_text
-  sink:
-    type: stdout
-
-scenarios:
-  - signal_type: metrics
-    name: cpu_usage
-    clock_group: alert-test
-    generator:
-      type: sequence
-      values: [20, 20, 20, 95, 95, 95, 95, 95, 20, 20]
-      repeat: true
-    # ...
-
-  - signal_type: metrics
-    name: memory_usage_percent
-    phase_offset: "3s"
-    clock_group: alert-test
-    generator:
-      type: sequence
-      values: [40, 40, 40, 88, 88, 88, 88, 88, 40, 40]
-      repeat: true
-    # ...
-```
-
-### Understanding the timing
-
-```
-Wall time  cpu_usage (offset=0s)   memory_usage (offset=3s)
---------   ---------------------   ------------------------
-t=0s       starts: 20             sleeping
-t=3s       95 (above threshold)   starts: 40
-t=6s       95                     88 (above threshold)
-t=8s       20 (drops)             88
-```
-
-The overlap window -- where **both** metrics are above threshold -- runs from t=6s to t=8s
-(2 seconds per cycle). For a `for: 5m` alert, extend the above-threshold sequences or use
-constant generators with a longer duration.
-
-See [Example Scenarios](examples.md) for the full `multi-metric-correlation.yaml` file.
-
-With local testing covered, let's push metrics to a real backend.
-
----
-
-## Pushing to a Backend
-
-Once you can shape the alert pattern locally, push it into a real TSDB and verify the alert
-fires there. The push-and-query loop -- start the backend, run the scenario, `curl` the query
-API -- is the same one [E2E Testing](e2e-testing.md) walks through, with the full coverage
-matrix of encoder and sink combinations.
-
-For alerting specifically, the two scenarios you'll reach for first are
+For alerting specifically, the two scenarios you will reach for first are
 `examples/vm-push-scenario.yaml` (Prometheus text via `http_push`) and
-`examples/remote-write-vm.yaml` (`remote_write` to VictoriaMetrics, vmagent, or upstream
-Prometheus). Both land in the stack from
-`examples/docker-compose-victoriametrics.yml`.
+`examples/remote-write-vm.yaml` (`remote_write` to VictoriaMetrics, vmagent, or
+upstream Prometheus). Both land in the stack from
+`examples/docker-compose-victoriametrics.yml`:
 
-You can also use the pull model instead of pushing.
+```bash
+# Start the stack
+docker compose -f examples/docker-compose-victoriametrics.yml up -d
 
----
+# Push test data
+sonda metrics --scenario examples/vm-push-scenario.yaml
 
-## Scrape-Based Integration
+# Verify the metric exists (wait ~15s for ingestion)
+curl "http://localhost:8428/api/v1/query?query=cpu_usage"
+
+# Tear down
+docker compose -f examples/docker-compose-victoriametrics.yml down -v
+```
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| sonda-server | 8080 | REST API for scenario management |
+| VictoriaMetrics | 8428 | Time series database |
+| vmagent | 8429 | Metrics relay agent |
+| Grafana | 3000 | Dashboards (auto-provisioned) |
+
+See [Docker Deployment](../deployment/docker.md) for the full stack configuration.
+
+!!! tip "Close the loop with Alertmanager"
+    This stack verifies that data arrives in VictoriaMetrics, but does not prove alerts
+    fire. To add vmalert, Alertmanager, and a webhook receiver to the stack, see the
+    [Alerting Pipeline](alerting-pipeline.md) guide.
+
+## Scrape model instead of push
 
 If you prefer the Prometheus pull model, sonda-server exposes a scrape endpoint for each
-running scenario.
-
-Start sonda-server and submit a scenario:
+running scenario. Start the server and submit a scenario:
 
 ```bash
 cargo run -p sonda-server -- --port 8080
@@ -319,156 +105,15 @@ scrape_configs:
     metrics_path: /scenarios/<scenario-id>/metrics
 ```
 
-!!! tip "Scrape path"
-    Replace `<scenario-id>` with the UUID returned from `POST /scenarios`. Each running
-    scenario exposes its own metrics endpoint.
-
 See [Server API](../deployment/sonda-server.md) for the full API reference.
 
-Beyond simple threshold alerts, Sonda can also test cardinality explosions and replay real incidents.
+## Quick reference
 
----
-
-## Cardinality Explosion Alerts
-
-Many monitoring stacks alert when series cardinality crosses a threshold (e.g.,
-`count(up) > 10000`). Sonda's [cardinality spikes](../configuration/scenario-fields.md)
-generate a controlled burst of unique label values to verify your cardinality-limiting
-rules fire correctly.
-
-```bash
-sonda metrics --scenario examples/cardinality-alert-test.yaml
-```
-
-```yaml title="examples/cardinality-alert-test.yaml (key fields)"
-cardinality_spikes:
-  - label: pod_name
-    every: 30s
-    for: 10s
-    cardinality: 500
-    strategy: counter
-    prefix: "pod-"
-```
-
-During the 10-second spike window, each tick injects a `pod_name` label with one of 500 unique
-values (`pod-0` through `pod-499`), producing 500 distinct series. Outside the window the label
-is absent and only one series is emitted. This on/off pattern lets you verify that alerts fire
-during the spike and resolve after it ends.
-
-!!! info "Docker stack required"
-    This example pushes to VictoriaMetrics via `http_push`. Start the backend first:
-    `docker compose -f examples/docker-compose-victoriametrics.yml up -d`
-
-For testing with recorded production data instead of synthetic patterns, use the replay generators.
-
----
-
-## Replay Generators
-
-### Sequence generator
-
-The [sequence generator](../configuration/generators.md#sequence) steps through an explicit
-list of values, perfect for hand-crafted threshold patterns:
-
-```bash
-sonda metrics --scenario examples/sequence-alert-test.yaml
-```
-
-```yaml title="examples/sequence-alert-test.yaml (key fields)"
-generator:
-  type: sequence
-  values: [10, 10, 10, 10, 10, 95, 95, 95, 95, 95, 10, 10, 10, 10, 10, 10]
-  repeat: true
-```
-
-With `repeat: true`, the pattern loops continuously. With `repeat: false`, the generator
-holds the last value after the sequence ends.
-
-### CSV replay generator
-
-For replaying real production data, the [csv_replay generator](../configuration/generators.md#csv_replay) reads values from a CSV file. If you have a Grafana dashboard showing the incident, see the [Grafana CSV Replay](grafana-csv-replay.md) guide for the full export-and-replay workflow.
-
-```bash
-sonda metrics --scenario examples/csv-replay-metrics.yaml
-```
-
-```yaml title="examples/csv-replay-metrics.yaml (key fields)"
-generator:
-  type: csv_replay
-  file: examples/sample-cpu-values.csv
-  columns:
-    - index: 1
-      name: cpu_replay
-```
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `file` | (required) | Path to the CSV file |
-| `columns` | -- | Explicit column specs. When absent, columns are auto-discovered from the header. See [Generators](../configuration/generators.md#csv_replay). |
-| `repeat` | `true` | Cycle back to the first value after reaching the end |
-
-!!! tip "When to use csv_replay vs sequence"
-    Use `csv_replay` over `sequence` when you have more than ~20 values. It keeps the YAML
-    clean and makes it easy to update the data by replacing the CSV file.
-
-??? info "Exporting values from VictoriaMetrics"
-    ```bash
-    curl -s "http://your-vm:8428/api/v1/query_range?\
-    query=cpu_usage{instance='prod-01'}&\
-    start=$(date -d '1 hour ago' +%s)&\
-    end=$(date +%s)&\
-    step=10s" \
-      | jq -r '["timestamp","cpu_percent"], (.data.result[0].values[] | [.[0], .[1]]) | @csv' \
-      > incident-values.csv
-    ```
-
----
-
-## Full Docker Compose Example
-
-For a complete end-to-end setup with VictoriaMetrics, Grafana, and sonda-server, use the
-included Docker Compose stack.
-
-```bash
-# Start the stack
-docker compose -f examples/docker-compose-victoriametrics.yml up -d
-
-# Push test data
-sonda metrics --scenario examples/vm-push-scenario.yaml
-
-# Verify the metric exists (wait ~15s for ingestion)
-curl "http://localhost:8428/api/v1/query?query=cpu_usage"
-
-# Open Grafana at http://localhost:3000
-# Navigate to Dashboards > Sonda > Sonda Overview
-
-# Tear down
-docker compose -f examples/docker-compose-victoriametrics.yml down -v
-```
-
-| Service | Port | Purpose |
-|---------|------|---------|
-| sonda-server | 8080 | REST API for scenario management |
-| VictoriaMetrics | 8428 | Time series database |
-| vmagent | 8429 | Metrics relay agent |
-| Grafana | 3000 | Dashboards (auto-provisioned) |
-
-See [Docker Deployment](../deployment/docker.md) for the full stack configuration.
-
-!!! tip "Close the loop with Alertmanager"
-    This stack verifies that data arrives in VictoriaMetrics, but doesn't prove alerts fire.
-    To add vmalert, Alertmanager, and a webhook receiver to the stack, see the
-    [Alerting Pipeline](alerting-pipeline.md) guide.
-
----
-
-## Quick Reference
-
-| Scenario | Generator | Example File |
-|----------|-----------|------------|
+| Pattern | Generator | Example file |
+|---------|-----------|--------------|
 | Threshold crossing | `sine` | `sine-threshold-test.yaml` |
 | Sustained breach | `constant` | `constant-threshold-test.yaml` |
-| Alert resolution via gap | `constant` + gaps | `gap-alert-test.yaml` |
+| Alert resolution via gap | `constant` + `gaps` | `gap-alert-test.yaml` |
 | Precise `for:` duration | `sequence` | `for-duration-test.yaml` |
 | Compound alert | multi-scenario | `multi-metric-correlation.yaml` |
 | Cardinality explosion | any + `cardinality_spikes` | `cardinality-alert-test.yaml` |
@@ -478,15 +123,13 @@ See [Docker Deployment](../deployment/docker.md) for the full stack configuratio
 | Push to VictoriaMetrics | any | `vm-push-scenario.yaml` |
 | Remote write | any | `remote-write-vm.yaml` |
 
----
+## Next steps
 
-## Next Steps
+**Verifying alerts fire end-to-end?** See [Alerting Pipeline](alerting-pipeline.md) to
+run vmalert, Alertmanager, and a webhook receiver with Docker Compose.
 
-**Verifying alerts fire end-to-end?** See [Alerting Pipeline](alerting-pipeline.md) to run
-vmalert, Alertmanager, and a webhook receiver with Docker Compose.
-
-**Validating alert rules in CI?** See [CI Alert Validation](ci-alert-validation.md) to catch
-broken rules before they reach production.
+**Validating alert rules in CI?** See [CI Alert Validation](ci-alert-validation.md) to
+catch broken rules before they reach production.
 
 **Validating a pipeline change?** See [Pipeline Validation](pipeline-validation.md).
 

--- a/docs/site/docs/guides/ci-alert-validation.md
+++ b/docs/site/docs/guides/ci-alert-validation.md
@@ -230,7 +230,7 @@ scenarios:
 ```
 
 The constant generator is ideal here -- you need the value to stay above threshold for long
-enough to satisfy the `for:` clause. See [Alert Testing](alert-testing.md#constant-generator-shortcut)
+enough to satisfy the `for:` clause. See [Threshold and `for:` duration](alert-testing-thresholds.md#constant-generator-shortcut)
 for more on choosing the right generator.
 
 ### Wait for evaluation

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -76,7 +76,12 @@ nav:
       - Example Scenarios: guides/examples.md
       - Metric Packs: guides/metric-packs.md
     - Alert testing:
-      - Alert Testing: guides/alert-testing.md
+      - Overview: guides/alert-testing.md
+      - "Threshold & for: duration": guides/alert-testing-thresholds.md
+      - Resolution & recovery: guides/alert-testing-resolution.md
+      - Compound & correlated alerts: guides/alert-testing-correlation.md
+      - Cardinality explosion: guides/alert-testing-cardinality.md
+      - Replaying incidents: guides/alert-testing-replay.md
       - Histogram & Summary Alerts: guides/histogram-alerts.md
       - Recording Rules: guides/recording-rules.md
       - Alerting Pipeline: guides/alerting-pipeline.md


### PR DESCRIPTION
## Summary

Addresses **FU-7** of the v1.0.1 docs audit tracker — the second IA split of the audit (P2-1 was the first; PR #247). The 495-line \`guides/alert-testing.md\` is split into a thin landing page + 5 single-pattern progressive sub-pages so each page concentrates on one alert shape.

\`alert-testing.md\` is sonda's bread-and-butter use-case page — alert validation is the most common reason to reach for sonda. A 495-line monolith with 11 H2 sections was hard to scan; a reader who only wants "how do I trigger a \`for: 5m\` alert" had to wade through threshold + duration + resolution + correlation + pushing-to-backend before they found their pattern.

Per user direction, the doc agent owned this end-to-end: IA decisions, page count, naming, ordering, nav placement, cross-link strategy.

## Final IA — 6 pages

| Page | Lines | Purpose |
|---|---|---|
| \`alert-testing.md\` | 138 | Landing — pattern-picker table, 5-stop tour, push-to-backend handoff, quick reference, next steps |
| \`alert-testing-thresholds.md\` | 153 | Threshold crossings (sine) + \`for:\` duration testing (sequence + constant) — combined since most readers think of them together |
| \`alert-testing-resolution.md\` | 62 | Gap-driven resolution + flapping behavior |
| \`alert-testing-correlation.md\` | 77 | Compound \`A AND B\` rules with \`phase_offset\` + \`clock_group\` |
| \`alert-testing-cardinality.md\` | 55 | Cardinality-spike alerts + tuning table |
| \`alert-testing-replay.md\` | 82 | sequence (≤20 values) vs csv_replay (production exports) |

Net 495 → ~570 lines across 6 pages — the marginal expansion buys per-page intros, "Next" tour-arrow footers, the landing's pattern-picker table, and consistent voice with PR #247's tutorial-* family.

## Nav

\`Alert testing\` themed sub-group expanded; existing 4 alert-testing-adjacent entries (Histogram & Summary Alerts, Recording Rules, Alerting Pipeline, CI Alert Validation) preserved at the bottom.

\`\`\`yaml
- Alert testing:
  - Overview: guides/alert-testing.md
  - "Threshold & for: duration": guides/alert-testing-thresholds.md
  - Resolution & recovery: guides/alert-testing-resolution.md
  - Compound & correlated alerts: guides/alert-testing-correlation.md
  - Cardinality explosion: guides/alert-testing-cardinality.md
  - Replaying incidents: guides/alert-testing-replay.md
  - Histogram & Summary Alerts: guides/histogram-alerts.md
  - Recording Rules: guides/recording-rules.md
  - Alerting Pipeline: guides/alerting-pipeline.md
  - CI Alert Validation: guides/ci-alert-validation.md
\`\`\`

(YAML quoting on \`"Threshold & for: duration"\` because the colon would be parsed as a mapping key.)

## Inbound cross-link audit

17 references across 14 files. The landing-page approach (matching P2-1) means **16 of 17 inbound refs stayed valid without edits**. Only \`ci-alert-validation.md:233\` needed redirecting because its anchor (\`#constant-generator-shortcut\`) physically moved off the landing into \`alert-testing-thresholds.md\` (anchor preserved verbatim).

## Catcher count: unchanged

241 → 241 (no \`sonda\` commands added or removed, only redistributed across 6 pages instead of 1).

## Gate verdicts

- **@doc** owned the IA + writing with full autonomy.
- **@reviewer-quick**: PASS.
- **@uat**: caught one **non-blocker pedagogy gap** in \`alert-testing-cardinality.md\` (prose claimed "500 distinct series during a spike" but actual config \`rate: 10, for: 10s\` produces \`min(cardinality, ticks_in_window) = 100\` per spike — \`cardinality: 500\` is the pool cap, not the per-spike count). **Fixed inline** by reframing the math so the visible behavior matches the example config.
- **Strict gates re-verified after fix**: \`task site:build\` clean, \`python3 scripts/validate_docs_commands.py\` reports **241 commands checked, 0 failed**.

The UAT caught a subtle pedagogy issue the static review couldn't — same value the P2-1 UAT delivered when it found the \`/healthz\` BLOCKER. Same playbook continues to pay off.

## Test plan

- [ ] CI \`docs-commands\` (fully strict) job passes
- [ ] Live site renders the new \`Alert testing\` sub-group correctly after gh-pages deploy
- [ ] \`ci-alert-validation.md → alert-testing-thresholds.md#constant-generator-shortcut\` deep-link still resolves

## Audit tracker

On merge, check off **FU-7**. **All P0/P1 + most P2 + FU-{2,4,5,6,7} now shipped.** Conference docs ramp-up is structurally complete.

Remaining (genuinely deferred):
- **P2-3** (asciinema/screenshots) — needs human-in-the-loop artifacts; user re-evaluates pre-conference based on whether they naturally generate recordings during talk prep.
- **FU-3** (env-var YAML interpolation) — real Rust feature work, separate session.
- **Issue #245** is closed.

A handful of small audit-fodder items surfaced during the recent PRs (trim \`otlp-metrics.yaml\` duration, pin \`grafana/loki:latest\`, add OTel \`health_check\` extension, expand the live-infra UAT to cover the 7 older matrix rows) are tracked in the audit doc.