### PR TITLE
chore(examples): trim otlp-metrics duration + pin grafana/loki to 3.5.5

### DIFF
--- a/examples/docker-compose-victoriametrics.yml
+++ b/examples/docker-compose-victoriametrics.yml
@@ -182,7 +182,7 @@ services:
   # This service is only started with --profile loki.
   # ---------------------------------------------------------------------------
   loki:
-    image: grafana/loki:latest
+    image: grafana/loki:3.5.5
     profiles: [loki]
     ports:
       - "3100:3100"

--- a/examples/otlp-metrics.yaml
+++ b/examples/otlp-metrics.yaml
@@ -14,7 +14,7 @@ version: 2
 
 defaults:
   rate: 10
-  duration: 60s
+  duration: 10s
   encoder:
     type: otlp
   sink:


### PR DESCRIPTION
## Summary

Two small follow-ups from the live-infra-uat audit (PR #249), bundled.

### 1. Trim \`examples/otlp-metrics.yaml\` duration 60s → 10s

The \`otel-metrics\` row of the live-infra UAT matrix blocks on \`sonda\` exit before verifying. A 60-second scenario eats 60 seconds of CI time per run with no added value — the verify-with-backoff loop already covers the ~5s flush. **Saves ~50s per CI run forever.** Row still demonstrates the same OTLP → collector → VM end-to-end shape.

### 2. Pin \`grafana/loki:latest\` → \`grafana/loki:3.5.5\`

The new \`docker-compose\` Dependabot ecosystem (PR #249) cannot track unpinned \`:latest\` tags, so Loki was the one stack image getting no continuous compatibility validation. Pinning to a specific 3-part tag means Dependabot will now open bumps when \`grafana/loki\` ships a new version, and the live-infra-uat gate validates each.

\`3.5.5\` is current stable and matches the version that was implicitly pulled during PR #249's GHA validation runs. **No behavioural change** beyond making the version reproducible.

## Gates

- \`sonda metrics --scenario examples/otlp-metrics.yaml --dry-run\` → OK
- \`python3 scripts/validate_docs_commands.py\` → 241 commands, 0 failed
- \`task site:build\` strict → clean

## Still open (deferred to its own follow-up)

OTel collector \`health_check\` extension for cleaner readiness polling. Cascades into the harness (port 13133 expose in compose, \`BACKENDS_BY_PROFILE\` update in \`scripts/live_infra_uat.py\`, harness self-tests) — split out so this PR stays "small audit-fodder bundle" rather than expanding into the live-infra-uat script.

## Bonus context

The Dependabot batch from earlier today (10 PRs spanning cargo bumps + docker-compose bumps + GHA actions) is being merged in parallel — the live-infra-uat gate validated every backend bump including a Prometheus v2→v3 major and Grafana 11→13 major. The gate is doing exactly what it was built for.