### PR TITLE
ci(live-infra): wire OTel collector health_check extension end-to-end

### DIFF
--- a/examples/docker-compose-victoriametrics.yml
+++ b/examples/docker-compose-victoriametrics.yml
@@ -388,11 +388,18 @@ services:
     ports:
       - "4317:4317"
       - "4318:4318"
+      - "13133:13133"
     volumes:
       - ./otel-collector/config.yaml:/etc/otel-collector-config.yaml:ro
     depends_on:
       victoriametrics:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:13133/"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
 
 volumes:
   vm-data:

--- a/examples/otel-collector/config.yaml
+++ b/examples/otel-collector/config.yaml
@@ -9,6 +9,13 @@
 # is not running — `docker logs otel-collector` still shows incoming events
 # via the debug exporter.
 
+extensions:
+  # Surfaces `:13133/` HTTP 200 once the collector is ready. Polled by the
+  # live-infra UAT harness in lieu of the verify-with-backoff loop absorbing
+  # collector warmup.
+  health_check:
+    endpoint: 0.0.0.0:13133
+
 receivers:
   otlp:
     protocols:
@@ -46,6 +53,7 @@ exporters:
     verbosity: basic
 
 service:
+  extensions: [health_check]
   pipelines:
     metrics:
       receivers: [otlp]

--- a/scripts/live_infra_uat.py
+++ b/scripts/live_infra_uat.py
@@ -156,9 +156,7 @@ BACKENDS_BY_PROFILE: dict[str, tuple[Backend, ...]] = {
         Backend(name="loki", health_url="http://localhost:3100/ready"),
     ),
     "otel-collector": (
-        # Collector exposes no health endpoint by default; we rely on the
-        # downstream backends being ready and a short post-up grace via the
-        # verify-with-backoff loop.
+        Backend(name="otel-collector", health_url="http://localhost:13133/"),
     ),
 }
 


### PR DESCRIPTION
## Summary

Last small audit-fodder follow-up from PR #249 (live-infra UAT harness) + PR #262 (audit-fodder bundle). Replaces the verify-with-backoff loop's de-facto role of absorbing OTel collector warmup with a proper readiness probe.

## Three coordinated changes

1. **\`examples/otel-collector/config.yaml\`** — add the \`health_check\` extension on \`:13133\` and register it under \`service.extensions\`.
2. **\`examples/docker-compose-victoriametrics.yml\`** — expose the new \`:13133\` port on the otel-collector service + add a healthcheck block that polls the same endpoint via wget.
3. **\`scripts/live_infra_uat.py\`** — populate the previously-empty \`BACKENDS_BY_PROFILE["otel-collector"]\` slot with a \`Backend\` pointing at \`http://localhost:13133/\`. The harness now polls the collector for readiness before running otel-* matrix rows instead of relying on verify-with-backoff to absorb warmup.

## Verified locally

\`\`\`
==> compose up (profiles: loki,otel-collector,prometheus)
==> waiting for victoriametrics (http://localhost:8428/health)
==> waiting for vmagent (http://localhost:8429/health)
==> waiting for loki (http://localhost:3100/ready)
==> waiting for otel-collector (http://localhost:13133/)    ← new
==> waiting for prometheus (http://localhost:9090/-/ready)
==> running [vmagent]      [vmagent] PASS (34.3s)
==> running [prometheus]   [prometheus] PASS (30.1s)
==> running [otel-metrics] [otel-metrics] PASS (30.4s)      ← was 60.0s pre-#262
==> running [otel-logs]    [otel-logs] PASS (30.2s)
4 rows checked, 0 failed
\`\`\`

\`--self-test\`: 33/33 still passing.

## What this closes

This is the last small audit-fodder thread from the live-infra UAT work. The full chain:
- PR #249 — harness + workflow + Dependabot extension
- PR #262 — trim otlp-metrics duration (60 → 10s) + pin grafana/loki :latest → :3.5.5
- This PR — OTel collector health_check end-to-end

## Remaining (genuinely deferred)

- **P2-3** — asciinema/screenshots (needs human-in-the-loop artifacts; user re-evaluates pre-conference)
- **FU-3** — env-var YAML interpolation (real Rust feature, separate session)
- **7-older-matrix-rows expansion** of the harness (KafkaVerifier + FileVerifier strategies; deferred to its own follow-up)

## Test plan

- [ ] CI \`Live Infra UAT (e2e matrix)\` job passes — same 4 rows now poll the collector readiness explicitly
- [ ] \`task site:build\` strict still clean (no docs touched)