### PR TITLE
fix(sonda-server): bind port 0 + stdout announce eliminates test port race

### DIFF
--- a/sonda-server/CLAUDE.md
+++ b/sonda-server/CLAUDE.md
@@ -45,8 +45,10 @@ src/
 
 tests/
 ├── common/
-│   └── mod.rs          ← shared test infrastructure: ServerGuard RAII, free_port(), spawn_server(),
-│                         spawn_server_with(), wait_for_server(), start_server(), start_server_with(),
+│   └── mod.rs          ← shared test infrastructure: ServerGuard RAII; spawn_server() / spawn_server_with()
+│                         spawn the binary with `--port 0` and read the stdout announce to discover
+│                         the bound port (no pre-allocated port → no port-race);
+│                         start_server() / start_server_with() wrap that in a ServerGuard;
 │                         http_client(). All test files use `mod common;` for these helpers.
 ├── auth.rs             ← E2E tests: auth via --api-key flag, SONDA_API_KEY env var, no-key backwards compat
 ├── health.rs           ← server startup, GET /health, unknown routes, SIGTERM shutdown
@@ -102,7 +104,11 @@ and all endpoints are publicly accessible (backwards compatible behaviour).
 cargo run -p sonda-server -- --port 8080 --bind 0.0.0.0
 ```
 
-Respects `RUST_LOG` env var for log level (default: `info`).
+Respects `RUST_LOG` env var for log level (default: `info`). `--port 0` lets the OS
+pick a free port. After binding, the server prints a single JSON line to stdout
+announcing the bound port (`{"sonda_server":{"port":N}}`); tracing logs continue
+to go to stderr. Test harnesses use this announce to discover the port without
+racing the kernel's port allocator.
 
 ### CLI dispatch shim
 

--- a/sonda-server/CLAUDE.md
+++ b/sonda-server/CLAUDE.md
@@ -45,11 +45,10 @@ src/
 
 tests/
 ├── common/
-│   └── mod.rs          ← shared test infrastructure: ServerGuard RAII; spawn_server() / spawn_server_with()
-│                         spawn the binary with `--port 0` and read the stdout announce to discover
-│                         the bound port (no pre-allocated port → no port-race);
-│                         start_server() / start_server_with() wrap that in a ServerGuard;
-│                         http_client(). All test files use `mod common;` for these helpers.
+│   └── mod.rs          ← shared test infrastructure: ServerGuard RAII, spawn_server(),
+│                         spawn_server_with(), start_server(), start_server_with(), http_client().
+│                         Spawn helpers use `--port 0` + read the stdout announce.
+│                         All test files use `mod common;` for these helpers.
 ├── auth.rs             ← E2E tests: auth via --api-key flag, SONDA_API_KEY env var, no-key backwards compat
 ├── health.rs           ← server startup, GET /health, unknown routes, SIGTERM shutdown
 ├── integration.rs      ← full lifecycle: POST metrics + logs → GET list → stats → DELETE → verify stopped
@@ -104,11 +103,10 @@ and all endpoints are publicly accessible (backwards compatible behaviour).
 cargo run -p sonda-server -- --port 8080 --bind 0.0.0.0
 ```
 
-Respects `RUST_LOG` env var for log level (default: `info`). `--port 0` lets the OS
-pick a free port. After binding, the server prints a single JSON line to stdout
-announcing the bound port (`{"sonda_server":{"port":N}}`); tracing logs continue
-to go to stderr. Test harnesses use this announce to discover the port without
-racing the kernel's port allocator.
+Respects `RUST_LOG` env var for log level (default: `info`).
+
+`--port 0` lets the OS assign a port. The server then prints
+`{"sonda_server":{"port":N}}` to stdout; tracing logs go to stderr.
 
 ### CLI dispatch shim
 

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -75,8 +75,7 @@ impl std::fmt::Debug for Args {
 async fn main() -> anyhow::Result<()> {
     maybe_dispatch_to_sonda_cli();
 
-    // Initialise structured logging. Respects RUST_LOG env var. Writes to
-    // stderr so stdout is reserved for the bound-port announce contract.
+    // Tracing on stderr — stdout is reserved for the bound-port announce.
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -114,9 +113,6 @@ async fn main() -> anyhow::Result<()> {
         .await
         .with_context(|| format!("failed to bind to {bind_addr}"))?;
 
-    // Announce the actual bound port on stdout so parents (test harnesses,
-    // tooling) get a typed, parseable signal once the OS has assigned a port
-    // (necessary when `--port 0` is used) and the listener is ready to accept.
     let bound_addr = listener
         .local_addr()
         .context("failed to read local address from bound listener")?;
@@ -175,11 +171,7 @@ fn maybe_dispatch_to_sonda_cli() {
     exit(127);
 }
 
-/// Write the bound-port announce line to stdout and flush.
-///
-/// Contract: a single JSON line `{"sonda_server":{"port":N}}\n` is the first
-/// (and only) thing written to stdout. The namespaced envelope leaves room for
-/// future fields without colliding with anything else a tool might print.
+/// Write `{"sonda_server":{"port":N}}\n` to stdout and flush.
 fn announce_bound_port(port: u16) -> anyhow::Result<()> {
     let line = serde_json::json!({ "sonda_server": { "port": port } });
     let stdout = std::io::stdout();
@@ -197,15 +189,13 @@ async fn shutdown_signal(state: AppState) {
 
     info!("shutdown signal received — stopping all running scenarios");
 
-    // Stop every running scenario so their threads exit cleanly.
     if let Ok(scenarios) = state.scenarios.read() {
         for handle in scenarios.values() {
             handle.stop();
         }
     }
 
-    // Join scenario threads with a timeout so sinks can flush before exit.
-    // Requires a write lock because join() consumes the inner JoinHandle.
+    // Write lock: join() consumes the inner JoinHandle.
     if let Ok(mut scenarios) = state.scenarios.write() {
         for (id, handle) in scenarios.iter_mut() {
             match handle.join(Some(Duration::from_secs(5))) {

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -8,6 +8,7 @@ mod routes;
 mod state;
 
 use std::env;
+use std::io::Write;
 use std::net::SocketAddr;
 use std::os::unix::process::CommandExt;
 use std::process::{exit, Command};
@@ -74,12 +75,14 @@ impl std::fmt::Debug for Args {
 async fn main() -> anyhow::Result<()> {
     maybe_dispatch_to_sonda_cli();
 
-    // Initialise structured logging. Respects RUST_LOG env var.
+    // Initialise structured logging. Respects RUST_LOG env var. Writes to
+    // stderr so stdout is reserved for the bound-port announce contract.
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
+        .with_writer(std::io::stderr)
         .init();
 
     let args = Args::parse();
@@ -111,7 +114,15 @@ async fn main() -> anyhow::Result<()> {
         .await
         .with_context(|| format!("failed to bind to {bind_addr}"))?;
 
-    info!(addr = %bind_addr, "sonda-server listening");
+    // Announce the actual bound port on stdout so parents (test harnesses,
+    // tooling) get a typed, parseable signal once the OS has assigned a port
+    // (necessary when `--port 0` is used) and the listener is ready to accept.
+    let bound_addr = listener
+        .local_addr()
+        .context("failed to read local address from bound listener")?;
+    announce_bound_port(bound_addr.port())?;
+
+    info!(addr = %bound_addr, "sonda-server listening");
 
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(state))
@@ -162,6 +173,20 @@ fn maybe_dispatch_to_sonda_cli() {
         sibling.display()
     );
     exit(127);
+}
+
+/// Write the bound-port announce line to stdout and flush.
+///
+/// Contract: a single JSON line `{"sonda_server":{"port":N}}\n` is the first
+/// (and only) thing written to stdout. The namespaced envelope leaves room for
+/// future fields without colliding with anything else a tool might print.
+fn announce_bound_port(port: u16) -> anyhow::Result<()> {
+    let line = serde_json::json!({ "sonda_server": { "port": port } });
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    writeln!(handle, "{line}").context("failed to write stdout announce")?;
+    handle.flush().context("failed to flush stdout announce")?;
+    Ok(())
 }
 
 /// Wait for Ctrl+C, then stop all running scenarios and signal shutdown.

--- a/sonda-server/tests/common/mod.rs
+++ b/sonda-server/tests/common/mod.rs
@@ -1,16 +1,21 @@
 //! Shared test infrastructure for sonda-server integration tests.
 //!
-//! Provides an RAII `ServerGuard` that kills the child process on drop,
-//! a portable `free_port()` helper, and convenience functions for spawning
-//! and waiting on the sonda-server binary.
+//! Spawns the sonda-server binary with `--port 0` so the OS picks a free port
+//! and the server announces it on stdout. The harness reads the announce —
+//! eliminating the bind/spawn race that pre-allocating a port introduces.
+//! See `sonda-server/src/main.rs::announce_bound_port` for the contract.
 
 // Each test file compiles its own copy of this module, so not every file
 // uses every helper. Suppress the per-file dead_code warnings.
 #![allow(dead_code)]
 
-use std::net::TcpListener;
-use std::process::{Child, Command, Stdio};
+use std::io::{BufRead, BufReader};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::mpsc;
 use std::time::Duration;
+
+/// How long to wait for the server to print its bound-port announce.
+const ANNOUNCE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// RAII guard that kills the child process on drop, ensuring cleanup even on
 /// test failure or panic.
@@ -25,80 +30,56 @@ impl Drop for ServerGuard {
     }
 }
 
-/// Find a free port by binding to port 0 and returning the OS-assigned port.
-pub fn free_port() -> u16 {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("must bind to a free port");
-    listener.local_addr().unwrap().port()
-}
-
-/// Spawn the sonda-server binary on the given port with optional extra CLI
-/// args and environment variables.
+/// Spawn the sonda-server binary with `--port 0`, read the announced port from
+/// stdout, and return both the port and the child handle.
 ///
 /// The `SONDA_API_KEY` environment variable is always removed from the
-/// inherited environment so that tests running under a shell with the
-/// variable set do not accidentally enable authentication.
-pub fn spawn_server_with(port: u16, extra_args: &[&str], extra_env: &[(&str, &str)]) -> Child {
+/// inherited environment so that tests running under a shell with the variable
+/// set do not accidentally enable authentication.
+///
+/// Stdout is piped (and consumed by the announce reader); stderr is piped so
+/// callers can collect tracing output for diagnostics on failure.
+pub fn spawn_server_with(extra_args: &[&str], extra_env: &[(&str, &str)]) -> (u16, Child) {
     let binary = env!("CARGO_BIN_EXE_sonda-server");
 
     let mut cmd = Command::new(binary);
-    cmd.args(["--port", &port.to_string(), "--bind", "127.0.0.1"])
+    cmd.args(["--port", "0", "--bind", "127.0.0.1"])
         .args(extra_args)
         .env("RUST_LOG", "warn")
         .env_remove("SONDA_API_KEY")
-        .stdout(Stdio::null())
+        .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
     for (key, value) in extra_env {
         cmd.env(key, value);
     }
 
-    cmd.spawn().expect("failed to spawn sonda-server binary")
+    let mut child = cmd.spawn().expect("failed to spawn sonda-server binary");
+    let stdout = child
+        .stdout
+        .take()
+        .expect("child stdout must be piped (Stdio::piped above)");
+
+    let port = read_announced_port(stdout)
+        .unwrap_or_else(|err| panic!("sonda-server announce failed: {err}"));
+
+    (port, child)
 }
 
-/// Spawn the sonda-server binary on the given port with default settings
-/// (no extra args, no extra env).
-pub fn spawn_server(port: u16) -> Child {
-    spawn_server_with(port, &[], &[])
+/// Spawn the sonda-server binary with default settings.
+pub fn spawn_server() -> (u16, Child) {
+    spawn_server_with(&[], &[])
 }
 
-/// Wait until the server responds to `GET /health` or the timeout elapses.
-///
-/// Returns `true` if the server became ready within the timeout, `false`
-/// otherwise.
-pub fn wait_for_server(port: u16, timeout: Duration) -> bool {
-    let deadline = std::time::Instant::now() + timeout;
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(1))
-        .build()
-        .expect("must build reqwest client");
-    while std::time::Instant::now() < deadline {
-        if client
-            .get(format!("http://127.0.0.1:{port}/health"))
-            .send()
-            .is_ok()
-        {
-            return true;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-    false
-}
-
-/// Start the server on a random port with default settings, wrapped in a
-/// `ServerGuard` for automatic cleanup.
+/// Start the server with default settings, wrapped in a `ServerGuard`.
 pub fn start_server() -> (u16, ServerGuard) {
     start_server_with(&[], &[])
 }
 
-/// Start the server on a random port with extra CLI args and env vars,
-/// wrapped in a `ServerGuard` for automatic cleanup.
+/// Start the server with extra CLI args and env vars, wrapped in a
+/// `ServerGuard` for automatic cleanup.
 pub fn start_server_with(extra_args: &[&str], extra_env: &[(&str, &str)]) -> (u16, ServerGuard) {
-    let port = free_port();
-    let child = spawn_server_with(port, extra_args, extra_env);
-    assert!(
-        wait_for_server(port, Duration::from_secs(10)),
-        "sonda-server must start accepting connections within 10 seconds on port {port}"
-    );
+    let (port, child) = spawn_server_with(extra_args, extra_env);
     (port, ServerGuard { child })
 }
 
@@ -108,4 +89,38 @@ pub fn http_client() -> reqwest::blocking::Client {
         .timeout(Duration::from_secs(10))
         .build()
         .expect("must build HTTP client")
+}
+
+/// Read the first line of the child's stdout and parse it as the server's
+/// bound-port announce: `{"sonda_server":{"port":N}}`.
+///
+/// Uses a worker thread + mpsc so the read is bounded by `ANNOUNCE_TIMEOUT` —
+/// otherwise a server that never printed would hang the test indefinitely.
+fn read_announced_port(stdout: ChildStdout) -> Result<u16, String> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        let result = match reader.read_line(&mut line) {
+            Ok(0) => Err("child stdout closed before announce".to_string()),
+            Ok(_) => Ok(line),
+            Err(e) => Err(format!("failed to read child stdout: {e}")),
+        };
+        let _ = tx.send(result);
+    });
+
+    let line = rx
+        .recv_timeout(ANNOUNCE_TIMEOUT)
+        .map_err(|_| format!("no announce within {ANNOUNCE_TIMEOUT:?}"))??;
+
+    let value: serde_json::Value = serde_json::from_str(line.trim())
+        .map_err(|e| format!("announce was not valid JSON ({e}): {line:?}"))?;
+
+    let port = value
+        .get("sonda_server")
+        .and_then(|inner| inner.get("port"))
+        .and_then(|p| p.as_u64())
+        .ok_or_else(|| format!("announce missing sonda_server.port: {line:?}"))?;
+
+    u16::try_from(port).map_err(|_| format!("announced port out of range: {port}"))
 }

--- a/sonda-server/tests/common/mod.rs
+++ b/sonda-server/tests/common/mod.rs
@@ -1,12 +1,7 @@
-//! Shared test infrastructure for sonda-server integration tests.
-//!
-//! Spawns the sonda-server binary with `--port 0` so the OS picks a free port
-//! and the server announces it on stdout. The harness reads the announce —
-//! eliminating the bind/spawn race that pre-allocating a port introduces.
-//! See `sonda-server/src/main.rs::announce_bound_port` for the contract.
+//! Shared test infrastructure: spawns sonda-server with `--port 0` and reads
+//! the bound port from the stdout announce.
 
-// Each test file compiles its own copy of this module, so not every file
-// uses every helper. Suppress the per-file dead_code warnings.
+// Each test file compiles its own copy; not every file uses every helper.
 #![allow(dead_code)]
 
 use std::io::{BufRead, BufReader};
@@ -14,11 +9,9 @@ use std::process::{Child, ChildStdout, Command, Stdio};
 use std::sync::mpsc;
 use std::time::Duration;
 
-/// How long to wait for the server to print its bound-port announce.
 const ANNOUNCE_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// RAII guard that kills the child process on drop, ensuring cleanup even on
-/// test failure or panic.
+/// RAII guard: kills the child on drop.
 pub struct ServerGuard {
     child: Child,
 }
@@ -30,15 +23,8 @@ impl Drop for ServerGuard {
     }
 }
 
-/// Spawn the sonda-server binary with `--port 0`, read the announced port from
-/// stdout, and return both the port and the child handle.
-///
-/// The `SONDA_API_KEY` environment variable is always removed from the
-/// inherited environment so that tests running under a shell with the variable
-/// set do not accidentally enable authentication.
-///
-/// Stdout is piped (and consumed by the announce reader); stderr is piped so
-/// callers can collect tracing output for diagnostics on failure.
+/// Spawn `sonda-server --port 0`, read the announced port, return `(port, child)`.
+/// Strips `SONDA_API_KEY` from the inherited env so a shell-set key doesn't leak in.
 pub fn spawn_server_with(extra_args: &[&str], extra_env: &[(&str, &str)]) -> (u16, Child) {
     let binary = env!("CARGO_BIN_EXE_sonda-server");
 
@@ -66,24 +52,20 @@ pub fn spawn_server_with(extra_args: &[&str], extra_env: &[(&str, &str)]) -> (u1
     (port, child)
 }
 
-/// Spawn the sonda-server binary with default settings.
 pub fn spawn_server() -> (u16, Child) {
     spawn_server_with(&[], &[])
 }
 
-/// Start the server with default settings, wrapped in a `ServerGuard`.
 pub fn start_server() -> (u16, ServerGuard) {
     start_server_with(&[], &[])
 }
 
-/// Start the server with extra CLI args and env vars, wrapped in a
-/// `ServerGuard` for automatic cleanup.
+/// `spawn_server_with` wrapped in a `ServerGuard`.
 pub fn start_server_with(extra_args: &[&str], extra_env: &[(&str, &str)]) -> (u16, ServerGuard) {
     let (port, child) = spawn_server_with(extra_args, extra_env);
     (port, ServerGuard { child })
 }
 
-/// Build a `reqwest::blocking::Client` with a 10-second timeout.
 pub fn http_client() -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(10))
@@ -91,11 +73,8 @@ pub fn http_client() -> reqwest::blocking::Client {
         .expect("must build HTTP client")
 }
 
-/// Read the first line of the child's stdout and parse it as the server's
-/// bound-port announce: `{"sonda_server":{"port":N}}`.
-///
-/// Uses a worker thread + mpsc so the read is bounded by `ANNOUNCE_TIMEOUT` —
-/// otherwise a server that never printed would hang the test indefinitely.
+/// Parse the first stdout line as `{"sonda_server":{"port":N}}`. Worker thread +
+/// mpsc bound the read to `ANNOUNCE_TIMEOUT` so a silent server can't hang the test.
 fn read_announced_port(stdout: ChildStdout) -> Result<u16, String> {
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {

--- a/sonda-server/tests/health.rs
+++ b/sonda-server/tests/health.rs
@@ -88,8 +88,7 @@ fn unknown_route_returns_404() {
 /// (exit code 0 or signal-terminated without panic).
 #[test]
 fn server_shuts_down_cleanly_on_sigterm() {
-    // Drive the child directly so we can SIGTERM it and inspect the exit
-    // status — the RAII guard would kill on drop instead.
+    // Direct child handle: the RAII guard would kill on drop before SIGTERM.
     let (_port, mut child) = common::spawn_server();
 
     // Send SIGTERM (the Unix equivalent of Ctrl+C for graceful shutdown).

--- a/sonda-server/tests/health.rs
+++ b/sonda-server/tests/health.rs
@@ -5,8 +5,6 @@
 
 mod common;
 
-use std::time::Duration;
-
 // ---- Test: Server starts and binds to port ----------------------------------
 
 /// The server binary must start and bind to the specified port within 10 seconds.
@@ -90,12 +88,9 @@ fn unknown_route_returns_404() {
 /// (exit code 0 or signal-terminated without panic).
 #[test]
 fn server_shuts_down_cleanly_on_sigterm() {
-    let port = common::free_port();
-    let mut child = common::spawn_server(port);
-    assert!(
-        common::wait_for_server(port, Duration::from_secs(10)),
-        "sonda-server must start within 10 seconds on port {port}"
-    );
+    // Drive the child directly so we can SIGTERM it and inspect the exit
+    // status — the RAII guard would kill on drop instead.
+    let (_port, mut child) = common::spawn_server();
 
     // Send SIGTERM (the Unix equivalent of Ctrl+C for graceful shutdown).
     unsafe {


### PR DESCRIPTION
## Summary

Closes #264.

The integration test harness used to pre-bind a free port via \`TcpListener::bind("127.0.0.1:0")\`, read \`.local_addr()\`, then drop the listener and pass the port number to the spawned server. **Between the drop and the server's bind, another parallel test could (and intermittently did) grab the same port** — the test client then connected to a *different* server (e.g. a no-auth one) and the assertion flipped 401 → 200.

Most recent failure: https://github.com/davidban77/sonda/actions/runs/24935418165/job/73020038090

## Fix

Server-side bind-and-announce. Eliminates the race entirely because no port number reaches the test client until the server has already bound it.

### Always-on stdout contract

After \`TcpListener::bind\` returns Ok, the server writes one JSON line to stdout and flushes:

\`\`\`
{"sonda_server":{"port":N}}
\`\`\`

This fires for both \`--port 0\` (OS-assigned) and explicit ports — gives test harnesses + tooling a stable single line to parse. \`--port\` defaults stay at \`8080\`; behavior unchanged for normal users.

### Test harness

\`free_port()\` removed (no callers remain). \`spawn_server_with\` now spawns with \`--port 0\`, pipes stdout, and reads the announce via a worker-thread + mpsc + \`recv_timeout(10s)\` so a hung or non-announcing server fails fast with a descriptive error instead of hanging forever. \`wait_for_server\` removed too: the announce arrives only after bind succeeds, and the kernel queues SYNs between announce and accept so any immediate client connect just waits.

\`(u16, ServerGuard)\` API unchanged — existing test call sites don't move.

## Behavior change worth flagging

\`tracing_subscriber::fmt()\` defaults to **stdout**, not stderr. The fix explicitly redirects via \`.with_writer(std::io::stderr)\` so the stdout announce stays clean. Backward compatible for the common case (\`> server.log 2>&1\`); only changes behavior for users splitting streams (rare; they'd actually benefit from the cleaner split). The cli-reference docs make no claims about the stdout/stderr contract today, so practically a no-op for users.

## Files changed (4 files, +109 / -68)

- \`sonda-server/src/main.rs\` — accept \`--port 0\`, announce after bind, redirect tracing to stderr
- \`sonda-server/tests/common/mod.rs\` — remove \`free_port\` + \`wait_for_server\`, add \`read_announced_port\`
- \`sonda-server/tests/health.rs\` — refactor \`server_shuts_down_cleanly_on_sigterm\` to new \`spawn_server() -> (u16, Child)\` shape
- \`sonda-server/CLAUDE.md\` — document the announce contract under Startup + harness changes under tests/common

## Verification

- **Burst test** (orchestrator): \`cargo test -p sonda-server --test auth -- --test-threads=8\` × 5 iterations → 7 tests, 0 failed, every iteration. **No flake reproduced**.
- \`cargo build/test/clippy/fmt --workspace --all-features\` all green.
- Manual smoke: \`sonda-server --port 0 --bind 127.0.0.1\` → stdout \`{"sonda_server":{"port":61463}}\`, stderr is the existing INFO logs only. \`sonda-server --port 8080\` → stdout \`{"sonda_server":{"port":8080}}\` (announce fires for explicit ports too).

## Gate verdicts

- **@rust-implementer** wrote with full scope.
- **@reviewer-quick**: PASS.
- Orchestrator burst test confirms the flake is gone.

No new crate dependencies (\`serde_json\` already a non-dev dep; \`std::sync::mpsc\` is stdlib).