### PR TITLE
feat: ${VAR} env-var interpolation in v2 YAML loader (closes #223)

### DIFF
--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -119,6 +119,67 @@ steady-state   scenario  infrastructure   metrics   yes        Normal oscillatin
 ...
 ```
 
+## Environment variable interpolation
+
+Sonda substitutes `${VAR}` and `${VAR:-default}` references against the process
+environment before parsing the YAML. The same scenario file can therefore run
+from your host CLI with the baked-in defaults and from a containerized
+`sonda-server` (or a Kubernetes pod) where the environment overrides them.
+
+```yaml title="loki-json-lines.yaml (excerpt)"
+defaults:
+  sink:
+    type: loki
+    url: "${LOKI_URL:-http://localhost:3100}"
+```
+
+```bash
+# host CLI: LOKI_URL is unset, the default is used
+sonda run --scenario examples/loki-json-lines.yaml --duration 1s --dry-run
+
+# overridden: every reference to ${LOKI_URL} resolves to this value
+LOKI_URL=http://loki:3100 sonda run --scenario examples/loki-json-lines.yaml --duration 1s --dry-run
+```
+
+### Syntax
+
+| Form | Meaning |
+|---|---|
+| `${VAR}` | Required reference. If `VAR` is unset, the compile fails with `environment variable VAR is not set (referenced at line N, column N of scenario YAML)`. |
+| `${VAR:-default}` | Optional reference. If `VAR` is unset, the literal text up to the next `}` is substituted in its place. Defaults may contain `:`, `/`, `?`, `&`, and `=`; only an unescaped `}` ends the default. |
+| `$$` | Literal `$`. The only escape supported. |
+
+Variable names match `[A-Z_][A-Z0-9_]*`. Lowercase names, names starting with a
+digit, and names containing characters outside that grammar are rejected at
+compile time so a typo does not silently swallow a YAML field.
+
+### Built-in example variables
+
+The example scenarios under `examples/` honour these variable names. The
+defaults map to the host-published Compose ports so the YAMLs run untouched
+from a host CLI; setting the variable inside `sonda-server` (the bundled
+`docker-compose-victoriametrics.yml` already does this) repoints them at
+the in-network service hostnames. See
+[Endpoints & networking](../deployment/endpoints.md) for the full
+host-vs-container resolution table.
+
+| Variable | Default (host CLI) | In-network override |
+|---|---|---|
+| `VICTORIAMETRICS_URL` | `http://localhost:8428/api/v1/import/prometheus` | `http://victoriametrics:8428/api/v1/import/prometheus` |
+| `VICTORIAMETRICS_REMOTE_WRITE_URL` | `http://localhost:8428/api/v1/write` | `http://victoriametrics:8428/api/v1/write` |
+| `VMAGENT_URL` | `http://localhost:8429/api/v1/write` | `http://vmagent:8429/api/v1/write` |
+| `PROMETHEUS_URL` | `http://localhost:9090/api/v1/write` | `http://prometheus:9090/api/v1/write` |
+| `LOKI_URL` | `http://localhost:3100` | `http://loki:3100` |
+| `KAFKA_BROKERS` | `localhost:9094` | `kafka:9092` |
+| `OTLP_GRPC_ENDPOINT` | `http://localhost:4317` | `http://otel-collector:4317` |
+
+!!! note "Unsupported syntax"
+    Substitution does **not** recurse into substituted values, nested
+    references inside defaults (`${A:-${B}}`) are not parsed, the bare
+    `$VAR` form is not recognised, and bash operators beyond `:-` (`:?`,
+    `:+`, `:=`) are not implemented. If you need any of these, file an
+    issue.
+
 ## The `defaults:` block
 
 Every field in `defaults:` applies to every entry in `scenarios:` unless the entry overrides it.

--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -121,10 +121,10 @@ steady-state   scenario  infrastructure   metrics   yes        Normal oscillatin
 
 ## Environment variable interpolation
 
-Sonda substitutes `${VAR}` and `${VAR:-default}` references against the process
-environment before parsing the YAML. The same scenario file can therefore run
-from your host CLI with the baked-in defaults and from a containerized
-`sonda-server` (or a Kubernetes pod) where the environment overrides them.
+`${VAR}` and `${VAR:-default}` references in a scenario file are substituted from
+the process environment before parsing. One file runs from your host CLI on the
+defaults and from a containerized `sonda-server` on the overrides -- no edit, no
+`sed` rewrite.
 
 ```yaml title="loki-json-lines.yaml (excerpt)"
 defaults:
@@ -134,10 +134,10 @@ defaults:
 ```
 
 ```bash
-# host CLI: LOKI_URL is unset, the default is used
+# Host CLI -- LOKI_URL unset, default wins
 sonda run --scenario examples/loki-json-lines.yaml --duration 1s --dry-run
 
-# overridden: every reference to ${LOKI_URL} resolves to this value
+# Override -- every ${LOKI_URL} resolves to this value
 LOKI_URL=http://loki:3100 sonda run --scenario examples/loki-json-lines.yaml --duration 1s --dry-run
 ```
 
@@ -145,21 +145,23 @@ LOKI_URL=http://loki:3100 sonda run --scenario examples/loki-json-lines.yaml --d
 
 | Form | Meaning |
 |---|---|
-| `${VAR}` | Required reference. If `VAR` is unset, the compile fails with `environment variable VAR is not set (referenced at line N, column N of scenario YAML)`. |
-| `${VAR:-default}` | Optional reference. If `VAR` is unset, the literal text up to the next `}` is substituted in its place. Defaults may contain `:`, `/`, `?`, `&`, and `=`; only an unescaped `}` ends the default. |
-| `$$` | Literal `$`. The only escape supported. |
+| `${VAR}` | Required. Compile fails if `VAR` is unset. |
+| `${VAR:-default}` | Optional. Default text runs to the next unescaped `}`; may contain `:`, `/`, `?`, `&`, `=`. |
+| `$$` | Literal `$`. The only escape. |
 
-Variable names match `[A-Z_][A-Z0-9_]*`. Lowercase names, names starting with a
-digit, and names containing characters outside that grammar are rejected at
-compile time so a typo does not silently swallow a YAML field.
+Variable names match `[A-Z_][A-Z0-9_]*`. Lowercase, leading digits, or other
+characters are rejected at compile time so a typo cannot silently swallow a YAML field.
+
+!!! note "Not supported"
+    No recursion into substituted values, no nested defaults (`${A:-${B}}`), no
+    bare `$VAR`, no `:?` / `:+` / `:=`.
 
 ### Built-in example variables
 
-The example scenarios under `examples/` honour these variable names. The
-defaults map to the host-published Compose ports so the YAMLs run untouched
-from a host CLI; setting the variable inside `sonda-server` (the bundled
-`docker-compose-victoriametrics.yml` already does this) repoints them at
-the in-network service hostnames. See
+Every scenario under `examples/` honours these names. Defaults map to the
+host-published Compose ports; the bundled `examples/docker-compose-victoriametrics.yml`
+exports the in-network values so POSTing an example scenario to the
+containerized `sonda-server` works untouched. See
 [Endpoints & networking](../deployment/endpoints.md) for the full
 host-vs-container resolution table.
 
@@ -172,13 +174,6 @@ host-vs-container resolution table.
 | `LOKI_URL` | `http://localhost:3100` | `http://loki:3100` |
 | `KAFKA_BROKERS` | `localhost:9094` | `kafka:9092` |
 | `OTLP_GRPC_ENDPOINT` | `http://localhost:4317` | `http://otel-collector:4317` |
-
-!!! note "Unsupported syntax"
-    Substitution does **not** recurse into substituted values, nested
-    references inside defaults (`${A:-${B}}`) are not parsed, the bare
-    `$VAR` form is not recognised, and bash operators beyond `:-` (`:?`,
-    `:+`, `:=`) are not implemented. If you need any of these, file an
-    issue.
 
 ## The `defaults:` block
 

--- a/docs/site/docs/deployment/docker.md
+++ b/docs/site/docs/deployment/docker.md
@@ -171,11 +171,11 @@ Prometheus at [http://localhost:9090](http://localhost:9090) -- they just will n
 sonda data from the stdout scenarios above. Use the VictoriaMetrics Stack for that.
 
 !!! info "Swapping `stdout` for `http_push` in this stack"
-    You can rewrite either scenario on the fly to push to Prometheus's remote-write
-    receiver instead. See
-    [Rewriting URLs before POSTing](endpoints.md#rewriting-urls-before-posting) --
-    the Prometheus service name inside this Compose network is `prometheus`, and its
-    remote-write path is `/api/v1/write`.
+    Rewrite either scenario on the fly to push to Prometheus's remote-write receiver
+    (`http://prometheus:9090/api/v1/write`). See
+    [Endpoints & networking](endpoints.md#one-file-both-paths-var-default) -- use
+    `${VAR:-default}` so one file works from both host CLI and inside the container,
+    or `sed` the URL just before POSTing.
 
 Two scenario files are provided for this stack:
 
@@ -212,11 +212,11 @@ curl "http://localhost:8428/api/v1/series?match[]={__name__=~'sonda.*'}"
 docker compose -f examples/docker-compose-victoriametrics.yml down -v
 ```
 
-The scenario uses `url: http://victoriametrics:8428/...` -- the VictoriaMetrics service
-name, not `localhost` -- because the sink runs inside the `sonda-server` container and
-resolves DNS through the Compose network. If you adapt a host-CLI example that points at
-`localhost:8428`, rewrite the URL before POSTing. See
-[Endpoints & networking](endpoints.md) for the full explanation and a one-liner swap.
+The scenario URL uses `${VICTORIAMETRICS_URL:-http://localhost:8428/...}`: the compose
+file exports `VICTORIAMETRICS_URL` on the `sonda-server` container so the scenario
+resolves the in-network service name when POSTed, and falls back to host loopback when
+run from your host CLI. See
+[Endpoints & networking](endpoints.md#one-file-both-paths-var-default) for the pattern.
 
 You can also push from the host CLI using a pipe to VictoriaMetrics.
 See [Sinks](../configuration/sinks.md) for all available sink types (`http_push`, `remote_write`, `loki`, etc.).

--- a/docs/site/docs/deployment/endpoints.md
+++ b/docs/site/docs/deployment/endpoints.md
@@ -41,15 +41,14 @@ port), but the scenario it carries runs one level deeper, inside the server cont
 
 !!! warning "The `localhost` trap"
     A scenario with `url: http://localhost:8428` works from the host CLI and silently
-    fails when POSTed to a containerized `sonda-server`. From inside the container,
-    `localhost` is the container, not your host or the Compose network. The server
-    accepts the POST, the scenario starts, the sink tries to connect -- and the
-    connection is refused or times out with no data in your backend.
+    fails when POSTed to a containerized `sonda-server` -- inside the container,
+    `localhost` is the container, not your host. The POST returns 201, the sink times
+    out, no data lands.
 
-    When you adapt a host-CLI example to run inside `sonda-server`, rewrite the URL to
-    match the server's network. For Compose, that means using the service name
-    (`http://victoriametrics:8428`). For Kubernetes, use the in-cluster Service DNS
-    (`http://vmsingle.monitoring.svc.cluster.local:8428`).
+    Two fixes: write the URL with [`${VAR:-default}`](#one-file-both-paths-var-default)
+    so one file works from both paths, or hardcode the in-network address (Compose
+    service name like `http://victoriametrics:8428`, or the Kubernetes Service DNS
+    `http://vmsingle.monitoring.svc.cluster.local:8428`).
 
 ## Endpoint resolution reference
 
@@ -70,15 +69,28 @@ Pick the row that matches where `sonda` runs and where your backend lives.
     Either add `--add-host=host.docker.internal:host-gateway` to the `sonda-server`
     container or use the host's LAN IP.
 
+## One file, both paths: `${VAR:-default}`
+
+The first-class fix is `${VAR:-default}` interpolation in the YAML itself. The same
+file then runs from your host CLI on the defaults and from a containerized
+`sonda-server` on the overrides -- no edit, no `sed`, no second copy.
+
+```yaml title="A sink URL that works from both paths"
+sink:
+  type: http_push
+  url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
+```
+
+The bundled `examples/docker-compose-victoriametrics.yml` exports the in-network
+overrides on the `sonda-server` container, so every scenario under `examples/`
+already works untouched in both places. See the
+[full reference](../configuration/v2-scenarios.md#environment-variable-interpolation)
+for syntax and the seven built-in variable names every example honours.
+
 ## Rewriting URLs before POSTing
 
-The first-class fix is environment-variable interpolation -- see
-[URL interpolation with `${VAR:-default}`](#url-interpolation-with-var-default) below.
-The bundled examples already use `${VAR:-default}` syntax so the same file works from
-both invocation paths without edits.
-
-If you have a YAML file that hardcodes `http://localhost:<port>` and you cannot or do not
-want to add interpolation, rewrite the URL in flight when POSTing:
+If a YAML file hardcodes `http://localhost:<port>` and you would rather not add
+interpolation, rewrite the URL in flight:
 
 ```bash title="Swap localhost for Compose service names"
 sed 's|http://localhost:8428|http://victoriametrics:8428|g; \
@@ -90,7 +102,7 @@ sed 's|http://localhost:8428|http://victoriametrics:8428|g; \
       http://localhost:8080/scenarios
 ```
 
-The three swaps cover the Compose backends Sonda ships with:
+The swaps cover the Compose backends Sonda ships with:
 
 | Backend | Host CLI URL (published port) | Compose URL (service name) |
 |---|---|---|
@@ -98,13 +110,10 @@ The three swaps cover the Compose backends Sonda ships with:
 | Loki | `http://localhost:3100` | `http://loki:3100` |
 | Kafka | `localhost:9094` (external listener) | `kafka:9092` (internal listener) |
 
-The service names come from `examples/docker-compose-victoriametrics.yml`. If you
-customize the compose file, match the `sed` substitutions to your service names.
+Service names come from `examples/docker-compose-victoriametrics.yml`. Match the
+`sed` substitutions to your service names if you customize the compose file.
 
-!!! tip "Verify the swap first"
-    Pipe the rewritten YAML to `less` or `diff` before posting, so you can eyeball that
-    every URL has been updated:
-
+!!! tip "Diff before you POST"
     ```bash
     sed 's|http://localhost:8428|http://victoriametrics:8428|g' \
       examples/http-push-retry.yaml | diff examples/http-push-retry.yaml -
@@ -164,30 +173,6 @@ customize the compose file, match the `sed` substitutions to your service names.
       type: http_push
       url: "http://vmsingle.monitoring.svc.cluster.local:8428/api/v1/import/prometheus"
     ```
-
-## URL interpolation with `${VAR:-default}`
-
-The example scenarios in `examples/` use environment variable interpolation so the same
-file works from both invocation paths. A sink URL like
-
-```yaml
-sink:
-  type: http_push
-  url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
-```
-
-resolves to the host-loopback default when no environment variable is set, and to the
-in-network service hostname when `sonda-server` exports `VICTORIAMETRICS_URL=http://victoriametrics:8428/api/v1/import/prometheus`
-in its container environment. The bundled `examples/docker-compose-victoriametrics.yml`
-already wires up the right values for the Compose-network case, so POSTing an example
-scenario to the containerized server "just works" out of the box.
-
-See the full [Environment variable interpolation reference](../configuration/v2-scenarios.md#environment-variable-interpolation)
-for the syntax, the variable name grammar, and the table of built-in variables every
-example file honours.
-
-When you cannot or do not want to set environment variables, the rewrite-before-POST
-workflow above still works.
 
 ## See also
 

--- a/docs/site/docs/deployment/endpoints.md
+++ b/docs/site/docs/deployment/endpoints.md
@@ -72,9 +72,13 @@ Pick the row that matches where `sonda` runs and where your backend lives.
 
 ## Rewriting URLs before POSTing
 
-Sonda's example YAMLs in `examples/` use `http://localhost:<port>` so they work out of
-the box for host-CLI users running against a published Compose port. When you want to
-POST the same file into a containerized `sonda-server`, rewrite the URL in flight:
+The first-class fix is environment-variable interpolation -- see
+[URL interpolation with `${VAR:-default}`](#url-interpolation-with-var-default) below.
+The bundled examples already use `${VAR:-default}` syntax so the same file works from
+both invocation paths without edits.
+
+If you have a YAML file that hardcodes `http://localhost:<port>` and you cannot or do not
+want to add interpolation, rewrite the URL in flight when POSTing:
 
 ```bash title="Swap localhost for Compose service names"
 sed 's|http://localhost:8428|http://victoriametrics:8428|g; \
@@ -161,13 +165,29 @@ customize the compose file, match the `sed` substitutions to your service names.
       url: "http://vmsingle.monitoring.svc.cluster.local:8428/api/v1/import/prometheus"
     ```
 
-## URL interpolation (future)
+## URL interpolation with `${VAR:-default}`
 
-Making the same YAML work from both invocation paths today requires either two files or
-a `sed` swap. Environment variable interpolation in YAML
-(`url: ${VM_URL:-http://localhost:8428}`) is under consideration as a proper fix. The
-audit follow-up is tracked in the repository; for now the rewrite-before-POST workflow
-is the supported path.
+The example scenarios in `examples/` use environment variable interpolation so the same
+file works from both invocation paths. A sink URL like
+
+```yaml
+sink:
+  type: http_push
+  url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
+```
+
+resolves to the host-loopback default when no environment variable is set, and to the
+in-network service hostname when `sonda-server` exports `VICTORIAMETRICS_URL=http://victoriametrics:8428/api/v1/import/prometheus`
+in its container environment. The bundled `examples/docker-compose-victoriametrics.yml`
+already wires up the right values for the Compose-network case, so POSTing an example
+scenario to the containerized server "just works" out of the box.
+
+See the full [Environment variable interpolation reference](../configuration/v2-scenarios.md#environment-variable-interpolation)
+for the syntax, the variable name grammar, and the table of built-in variables every
+example file honours.
+
+When you cannot or do not want to set environment variables, the rewrite-before-POST
+workflow above still works.
 
 ## See also
 

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -72,8 +72,9 @@ Post a [v2 scenario](../configuration/v2-scenarios.md) YAML or JSON body to
     The `warnings` field is omitted entirely when no issues were detected, so existing
     clients that do not know about the field continue to parse the response unchanged.
 
-    See [Endpoints & networking](endpoints.md) for the full reference and a `sed`
-    one-liner that rewrites `localhost` URLs before posting.
+    See [Endpoints & networking](endpoints.md) for the full reference,
+    [`${VAR:-default}` interpolation](../configuration/v2-scenarios.md#environment-variable-interpolation)
+    so one file works from both paths, and a `sed` one-liner for the rewrite-before-POST fallback.
 
 ### Single-scenario body
 

--- a/docs/site/docs/guides/e2e-testing.md
+++ b/docs/site/docs/guides/e2e-testing.md
@@ -135,17 +135,16 @@ A few sinks intentionally fall outside that pattern:
 ## The localhost trap
 
 The matrix above runs `sonda` on your host, so `url: http://localhost:8428` reaches the
-Compose-published port. If you POST the same scenario to a containerized
-`sonda-server`, the URL resolves inside the server container — `localhost` is the
-container, not your host, and the push silently fails.
+Compose-published port. POST the same scenario to a containerized `sonda-server` and the
+URL resolves inside the server container — `localhost` is the container, and the push
+silently fails.
 
-Rewrite the URL to match the server's network before POSTing:
+Two ways to make one scenario file work from both paths:
 
-- **Compose**: `http://victoriametrics:8428`, `http://loki:3100`, `kafka:9092`.
-- **Kubernetes**: `http://<svc>.<ns>.svc.cluster.local:<port>`.
-
-See [Endpoints & networking](../deployment/endpoints.md) for the full resolution table
-and an in-flight `sed` rewrite recipe.
+- Use `${VAR:-default}` in the URL — the bundled examples already do this. See
+  [Environment variable interpolation](../configuration/v2-scenarios.md#environment-variable-interpolation).
+- Rewrite the URL with `sed` before POSTing — see
+  [Endpoints & networking](../deployment/endpoints.md#rewriting-urls-before-posting).
 
 ---
 

--- a/docs/site/docs/guides/troubleshooting.md
+++ b/docs/site/docs/guides/troubleshooting.md
@@ -72,7 +72,7 @@ Sonda runs without errors but you don't see data in your backend.
 | No data in Prometheus | Prometheus needs remote write receiver enabled | Start Prometheus with `--web.enable-remote-write-receiver` |
 | Encoder/sink mismatch | Using `prometheus_text` encoder with `remote_write` sink (or vice versa) | Match encoder to sink: `remote_write` encoder with `remote_write` sink, `otlp` encoder with `otlp_grpc` sink |
 | HTTP 400 Bad Request | Wrong `content_type` for the endpoint | Use `text/plain` for VictoriaMetrics import endpoint |
-| POST to `sonda-server` succeeds but no data in backend | Sink `url: http://localhost:<port>` resolves inside the server container | Use the reachable address: Compose service name (`http://victoriametrics:8428`) or Kubernetes Service DNS. See [Endpoints & networking](../deployment/endpoints.md) |
+| POST to `sonda-server` succeeds but no data in backend | Sink `url: http://localhost:<port>` resolves inside the server container | Use the in-network address (Compose service name `http://victoriametrics:8428`, or Kubernetes Service DNS), or write the URL with [`${VAR:-default}`](../configuration/v2-scenarios.md#environment-variable-interpolation) so one file works from both paths. See [Endpoints & networking](../deployment/endpoints.md) |
 
 ### Batching delays
 

--- a/docs/site/docs/guides/tutorial-server.md
+++ b/docs/site/docs/guides/tutorial-server.md
@@ -74,6 +74,11 @@ curl -X POST \
 See [Multi-scenario body](../deployment/sonda-server.md#multi-scenario-body) for batch
 error handling, `phase_offset`, and `after:` chains.
 
+!!! tip "One file, host CLI and container"
+    A sink URL like `${VICTORIAMETRICS_URL:-http://localhost:8428/...}` runs from your
+    host CLI on the default and from a containerized `sonda-server` on the override. See
+    [Environment variable interpolation](../configuration/v2-scenarios.md#environment-variable-interpolation).
+
 ## Monitor a running scenario
 
 ```bash title="List all scenarios"

--- a/examples/alertmanager/alerting-scenario.yaml
+++ b/examples/alertmanager/alerting-scenario.yaml
@@ -29,7 +29,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain"
   labels:
     host: docker-alert-demo

--- a/examples/capacity-burst-test.yaml
+++ b/examples/capacity-burst-test.yaml
@@ -21,7 +21,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain"
 
 scenarios:

--- a/examples/capacity-cardinality-stress.yaml
+++ b/examples/capacity-cardinality-stress.yaml
@@ -24,7 +24,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain"
 
 scenarios:

--- a/examples/capacity-throughput-test.yaml
+++ b/examples/capacity-throughput-test.yaml
@@ -22,7 +22,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain"
   labels:
     job: capacity_test

--- a/examples/cardinality-alert-test.yaml
+++ b/examples/cardinality-alert-test.yaml
@@ -22,7 +22,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain"
 
 scenarios:

--- a/examples/ci-alert-validation.yaml
+++ b/examples/ci-alert-validation.yaml
@@ -19,7 +19,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain"
 
 scenarios:

--- a/examples/docker-compose-victoriametrics.yml
+++ b/examples/docker-compose-victoriametrics.yml
@@ -51,6 +51,19 @@ services:
       - "8080:8080"
     volumes:
       - ./:/scenarios:ro
+    # Environment variables consumed by ${VAR:-default} interpolation in
+    # the example scenario YAMLs. When a scenario is POSTed to this server
+    # the substitution resolves to the in-network service name; running the
+    # same YAML from the host CLI falls back to the localhost defaults
+    # baked into the YAML.
+    environment:
+      VICTORIAMETRICS_URL: "http://victoriametrics:8428/api/v1/import/prometheus"
+      VICTORIAMETRICS_REMOTE_WRITE_URL: "http://victoriametrics:8428/api/v1/write"
+      VMAGENT_URL: "http://vmagent:8429/api/v1/write"
+      PROMETHEUS_URL: "http://prometheus:9090/api/v1/write"
+      LOKI_URL: "http://loki:3100"
+      KAFKA_BROKERS: "kafka:9092"
+      OTLP_GRPC_ENDPOINT: "http://otel-collector:4317"
     depends_on:
       victoriametrics:
         condition: service_healthy

--- a/examples/e2e-scenario.yaml
+++ b/examples/e2e-scenario.yaml
@@ -21,7 +21,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain"
 
 scenarios:

--- a/examples/http-push-retry.yaml
+++ b/examples/http-push-retry.yaml
@@ -20,7 +20,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain"
     batch_size: 32768
     retry:

--- a/examples/http-push-sink.yaml
+++ b/examples/http-push-sink.yaml
@@ -18,7 +18,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain; version=0.0.4"
     batch_size: 65536
 

--- a/examples/kafka-json-logs.yaml
+++ b/examples/kafka-json-logs.yaml
@@ -7,7 +7,7 @@ defaults:
     type: json_lines
   sink:
     type: kafka
-    brokers: "localhost:9094"
+    brokers: "${KAFKA_BROKERS:-localhost:9094}"
     topic: sonda-logs
 
 scenarios:

--- a/examples/kafka-sink.yaml
+++ b/examples/kafka-sink.yaml
@@ -21,7 +21,7 @@ defaults:
     type: prometheus_text
   sink:
     type: kafka
-    brokers: "localhost:9094"
+    brokers: "${KAFKA_BROKERS:-localhost:9094}"
     topic: sonda-metrics
 
 scenarios:

--- a/examples/loki-json-lines.yaml
+++ b/examples/loki-json-lines.yaml
@@ -7,7 +7,7 @@ defaults:
     type: json_lines
   sink:
     type: loki
-    url: http://localhost:3100
+    url: "${LOKI_URL:-http://localhost:3100}"
     batch_size: 50
   labels:
     job: sonda

--- a/examples/otlp-logs.yaml
+++ b/examples/otlp-logs.yaml
@@ -19,7 +19,7 @@ defaults:
     type: otlp
   sink:
     type: otlp_grpc
-    endpoint: "http://localhost:4317"
+    endpoint: "${OTLP_GRPC_ENDPOINT:-http://localhost:4317}"
     signal_type: logs
     batch_size: 50
 

--- a/examples/otlp-metrics.yaml
+++ b/examples/otlp-metrics.yaml
@@ -19,7 +19,7 @@ defaults:
     type: otlp
   sink:
     type: otlp_grpc
-    endpoint: "http://localhost:4317"
+    endpoint: "${OTLP_GRPC_ENDPOINT:-http://localhost:4317}"
     signal_type: metrics
     batch_size: 100
 

--- a/examples/prometheus-http-push.yaml
+++ b/examples/prometheus-http-push.yaml
@@ -24,7 +24,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain; version=0.0.4"
     batch_size: 65536
 

--- a/examples/rate-rule-input.yaml
+++ b/examples/rate-rule-input.yaml
@@ -23,7 +23,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain"
 
 scenarios:

--- a/examples/recording-rule-test.yaml
+++ b/examples/recording-rule-test.yaml
@@ -23,7 +23,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain"
 
 scenarios:

--- a/examples/remote-write-prometheus.yaml
+++ b/examples/remote-write-prometheus.yaml
@@ -23,7 +23,7 @@ defaults:
     type: remote_write
   sink:
     type: remote_write
-    url: "http://localhost:9090/api/v1/write"
+    url: "${PROMETHEUS_URL:-http://localhost:9090/api/v1/write}"
     batch_size: 100
 
 scenarios:

--- a/examples/remote-write-vm.yaml
+++ b/examples/remote-write-vm.yaml
@@ -27,7 +27,7 @@ defaults:
     type: remote_write
   sink:
     type: remote_write
-    url: "http://localhost:8428/api/v1/write"
+    url: "${VICTORIAMETRICS_REMOTE_WRITE_URL:-http://localhost:8428/api/v1/write}"
     batch_size: 100
 
 scenarios:

--- a/examples/remote-write-vmagent.yaml
+++ b/examples/remote-write-vmagent.yaml
@@ -24,7 +24,7 @@ defaults:
     type: remote_write
   sink:
     type: remote_write
-    url: "http://localhost:8429/api/v1/write"
+    url: "${VMAGENT_URL:-http://localhost:8429/api/v1/write}"
     batch_size: 100
 
 scenarios:

--- a/examples/victoriametrics-metrics.yaml
+++ b/examples/victoriametrics-metrics.yaml
@@ -35,7 +35,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://victoriametrics:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain"
     batch_size: 65536
 

--- a/examples/vm-push-scenario.yaml
+++ b/examples/vm-push-scenario.yaml
@@ -18,7 +18,7 @@ defaults:
     type: prometheus_text
   sink:
     type: http_push
-    url: "http://localhost:8428/api/v1/import/prometheus"
+    url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
     content_type: "text/plain"
 
 scenarios:

--- a/sonda-core/src/compile.rs
+++ b/sonda-core/src/compile.rs
@@ -1,8 +1,11 @@
 //! One-shot v2 scenario compilation from YAML to the runtime's input shape.
 //!
-//! This module composes the five v2 compilation phases — `parse`, `normalize`,
-//! `expand`, `compile_after`, and `prepare` — behind a single callable so that
-//! library consumers can go from YAML text to `Vec<ScenarioEntry>` in one step.
+//! This module composes the v2 compilation phases — `env_interpolate`,
+//! `parse`, `normalize`, `expand`, `compile_after`, and `prepare` — behind a
+//! single callable so that library consumers can go from YAML text to
+//! `Vec<ScenarioEntry>` in one step. `env_interpolate` runs first so every
+//! caller (CLI file load, HTTP body POST, programmatic) gets the same
+//! `${VAR}` / `${VAR:-default}` substitution semantics.
 //!
 //! Every caller (CLI, server, tests) goes through this entry point — the
 //! runtime accepts `Vec<ScenarioEntry>` directly and there is no v1 fallback.
@@ -16,6 +19,7 @@
 //! underlying phase would have produced — see [`CompileError`].
 
 use crate::compiler::compile_after::{compile_after, CompileAfterError};
+use crate::compiler::env_interpolate::{interpolate, InterpolateError};
 use crate::compiler::expand::{expand, ExpandError, PackResolver};
 use crate::compiler::normalize::{normalize, NormalizeError};
 use crate::compiler::parse::{parse, ParseError};
@@ -31,23 +35,29 @@ use crate::config::ScenarioEntry;
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum CompileError {
+    /// **Phase 0** (env_interpolate): `${VAR}` substitution against the
+    /// process environment failed (unset required variable, malformed
+    /// reference, or invalid variable name).
+    #[error("env interpolation error")]
+    EnvInterpolate(#[from] InterpolateError),
+
     /// **Phase 1** (parse): YAML parsing or schema validation failed.
-    #[error("parse error: {0}")]
+    #[error("parse error")]
     Parse(#[from] ParseError),
 
     /// **Phase 2** (normalize): defaults resolution failed (e.g. an entry
     /// was missing a required field with no default available).
-    #[error("normalize error: {0}")]
+    #[error("normalize error")]
     Normalize(#[from] NormalizeError),
 
     /// **Phase 3** (expand): pack expansion failed (unknown pack, unknown
     /// override key, duplicate id, or resolver I/O error).
-    #[error("expand error: {0}")]
+    #[error("expand error")]
     Expand(#[from] ExpandError),
 
     /// **Phase 4+5** (compile_after): `after:` resolution, dependency
     /// graph, or clock-group assignment failed.
-    #[error("compile_after error: {0}")]
+    #[error("compile_after error")]
     CompileAfter(#[from] CompileAfterError),
 
     /// **Phase 6** (prepare): translation to the runtime input shape
@@ -65,7 +75,7 @@ pub enum CompileError {
     /// build a [`CompiledFile`][crate::compiler::compile_after::CompiledFile]
     /// in code and feed it directly to
     /// [`prepare`][crate::compiler::prepare::prepare].
-    #[error("prepare error: {0}")]
+    #[error("prepare error")]
     Prepare(#[from] PrepareError),
 }
 
@@ -104,7 +114,8 @@ pub fn compile_scenario_file(
     // for callers that cross module boundaries) without modifying `expand`'s
     // API.
     let wrapped = DynPackResolver(resolver);
-    let parsed = parse(yaml)?;
+    let interpolated = interpolate(yaml)?;
+    let parsed = parse(&interpolated)?;
     let normalized = normalize(parsed)?;
     let expanded = expand(normalized, &wrapped)?;
     let compiled = compile_after(expanded)?;

--- a/sonda-core/src/compiler/env_interpolate.rs
+++ b/sonda-core/src/compiler/env_interpolate.rs
@@ -1,0 +1,443 @@
+//! Pre-parse env-var interpolation over raw scenario YAML.
+//!
+//! Syntax:
+//! - `${VAR}` — required; errors if unset.
+//! - `${VAR:-default}` — optional; default is the literal text up to the next `}`.
+//! - `$$` — literal `$` (the only escape).
+//!
+//! Variable names must match `[A-Z_][A-Z0-9_]*`.
+
+use std::env;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InterpolateError {
+    #[error(
+        "environment variable {name} is not set (referenced at line {line}, column {column} of scenario YAML)"
+    )]
+    UnsetVariable {
+        name: String,
+        line: usize,
+        column: usize,
+    },
+
+    #[error(
+        "unterminated `${{...}}` reference (started at line {line}, column {column} of scenario YAML)"
+    )]
+    Unterminated { line: usize, column: usize },
+
+    #[error(
+        "invalid environment variable name {name:?} (at line {line}, column {column} of scenario YAML): names must match [A-Z_][A-Z0-9_]*"
+    )]
+    InvalidName {
+        name: String,
+        line: usize,
+        column: usize,
+    },
+}
+
+/// Expand `${VAR}` / `${VAR:-default}` references against the process environment.
+pub fn interpolate(input: &str) -> Result<String, InterpolateError> {
+    interpolate_with(input, |name| env::var(name).ok())
+}
+
+/// Variant of [`interpolate`] with a caller-supplied lookup. Test seam.
+pub fn interpolate_with<F>(input: &str, mut lookup: F) -> Result<String, InterpolateError>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let bytes = input.as_bytes();
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    let mut line = 1usize;
+    let mut column = 1usize;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        if b == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'$' {
+            out.push('$');
+            i += 2;
+            column += 2;
+            continue;
+        }
+
+        if b == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
+            let ref_line = line;
+            let ref_column = column;
+            let close = match bytes[i + 2..].iter().position(|&c| c == b'}') {
+                Some(off) => i + 2 + off,
+                None => {
+                    return Err(InterpolateError::Unterminated {
+                        line: ref_line,
+                        column: ref_column,
+                    });
+                }
+            };
+            let body = &input[i + 2..close];
+            let (name, default) = match body.find(":-") {
+                Some(sep) => (&body[..sep], Some(&body[sep + 2..])),
+                None => (body, None),
+            };
+            validate_name(name, ref_line, ref_column)?;
+            match lookup(name) {
+                Some(value) => out.push_str(&value),
+                None => match default {
+                    Some(d) => out.push_str(d),
+                    None => {
+                        return Err(InterpolateError::UnsetVariable {
+                            name: name.to_string(),
+                            line: ref_line,
+                            column: ref_column,
+                        });
+                    }
+                },
+            }
+            advance_position(&bytes[i..=close], &mut line, &mut column);
+            i = close + 1;
+            continue;
+        }
+
+        // Step over the source char (1-4 bytes for UTF-8) without splitting.
+        let char_len = utf8_char_len(b);
+        let end = (i + char_len).min(bytes.len());
+        out.push_str(&input[i..end]);
+        if b == b'\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+        i = end;
+    }
+
+    Ok(out)
+}
+
+#[inline]
+fn utf8_char_len(lead: u8) -> usize {
+    match lead {
+        0x00..=0x7f => 1,
+        0xc0..=0xdf => 2,
+        0xe0..=0xef => 3,
+        0xf0..=0xf7 => 4,
+        _ => 1,
+    }
+}
+
+fn advance_position(consumed: &[u8], line: &mut usize, column: &mut usize) {
+    for &c in consumed {
+        if c == b'\n' {
+            *line += 1;
+            *column = 1;
+        } else {
+            *column += 1;
+        }
+    }
+}
+
+fn validate_name(name: &str, line: usize, column: usize) -> Result<(), InterpolateError> {
+    let mut chars = name.chars();
+    let first = match chars.next() {
+        Some(c) => c,
+        None => {
+            return Err(InterpolateError::InvalidName {
+                name: name.to_string(),
+                line,
+                column,
+            });
+        }
+    };
+    if !(first.is_ascii_uppercase() || first == '_') {
+        return Err(InterpolateError::InvalidName {
+            name: name.to_string(),
+            line,
+            column,
+        });
+    }
+    for c in chars {
+        if !(c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_') {
+            return Err(InterpolateError::InvalidName {
+                name: name.to_string(),
+                line,
+                column,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn lookup_from(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    fn interp(input: &str, pairs: &[(&str, &str)]) -> Result<String, InterpolateError> {
+        let map = lookup_from(pairs);
+        interpolate_with(input, |name| map.get(name).cloned())
+    }
+
+    #[test]
+    fn empty_input_returns_empty_output() {
+        let out = interp("", &[]).unwrap();
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn input_without_references_is_unchanged() {
+        let yaml = "version: 2\nscenarios: []\n";
+        let out = interp(yaml, &[]).unwrap();
+        assert_eq!(out, yaml);
+    }
+
+    #[test]
+    fn required_var_set_is_substituted() {
+        let out = interp("url: ${HOST}", &[("HOST", "example.com")]).unwrap();
+        assert_eq!(out, "url: example.com");
+    }
+
+    #[test]
+    fn required_var_unset_returns_error_with_position() {
+        let err = interp("a: b\nurl: ${HOST}", &[]).unwrap_err();
+        assert_eq!(
+            err,
+            InterpolateError::UnsetVariable {
+                name: "HOST".into(),
+                line: 2,
+                column: 6,
+            }
+        );
+    }
+
+    #[test]
+    fn optional_var_set_uses_value_not_default() {
+        let out = interp(
+            "url: ${HOST:-fallback.com}",
+            &[("HOST", "real.example.com")],
+        )
+        .unwrap();
+        assert_eq!(out, "url: real.example.com");
+    }
+
+    #[test]
+    fn optional_var_unset_uses_default() {
+        let out = interp("url: ${HOST:-fallback.com}", &[]).unwrap();
+        assert_eq!(out, "url: fallback.com");
+    }
+
+    #[test]
+    fn empty_default_is_allowed() {
+        let out = interp("prefix${VAR:-}suffix", &[]).unwrap();
+        assert_eq!(out, "prefixsuffix");
+    }
+
+    #[test]
+    fn default_may_contain_colons_slashes_and_query_strings() {
+        let out = interp(
+            "url: ${URL:-http://localhost:8428/api/v1/import?foo=bar&baz=qux}",
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "url: http://localhost:8428/api/v1/import?foo=bar&baz=qux"
+        );
+    }
+
+    #[test]
+    fn multiple_vars_in_one_string_all_substituted() {
+        let out = interp(
+            "${SCHEME}://${HOST}:${PORT}/path",
+            &[
+                ("SCHEME", "https"),
+                ("HOST", "api.example.com"),
+                ("PORT", "443"),
+            ],
+        )
+        .unwrap();
+        assert_eq!(out, "https://api.example.com:443/path");
+    }
+
+    #[test]
+    fn dollar_dollar_escape_produces_literal_dollar() {
+        let out = interp("price: $$5.00", &[]).unwrap();
+        assert_eq!(out, "price: $5.00");
+    }
+
+    #[test]
+    fn dollar_dollar_does_not_consume_following_brace() {
+        let out = interp("$${VAR}", &[("VAR", "ignored")]).unwrap();
+        assert_eq!(out, "${VAR}");
+    }
+
+    #[test]
+    fn lone_dollar_at_eof_passes_through() {
+        let out = interp("trailing $", &[]).unwrap();
+        assert_eq!(out, "trailing $");
+    }
+
+    #[test]
+    fn dollar_followed_by_non_special_char_passes_through() {
+        let out = interp("price: $5", &[]).unwrap();
+        assert_eq!(out, "price: $5");
+    }
+
+    #[test]
+    fn malformed_unterminated_reference_returns_error() {
+        let err = interp("url: ${HOST", &[]).unwrap_err();
+        assert_eq!(err, InterpolateError::Unterminated { line: 1, column: 6 });
+    }
+
+    #[test]
+    fn malformed_empty_name_returns_error() {
+        let err = interp("url: ${}", &[]).unwrap_err();
+        assert_eq!(
+            err,
+            InterpolateError::InvalidName {
+                name: "".into(),
+                line: 1,
+                column: 6,
+            }
+        );
+    }
+
+    #[test]
+    fn lowercase_name_returns_invalid_name_error() {
+        let err = interp("url: ${host}", &[]).unwrap_err();
+        assert_eq!(
+            err,
+            InterpolateError::InvalidName {
+                name: "host".into(),
+                line: 1,
+                column: 6,
+            }
+        );
+    }
+
+    #[test]
+    fn name_with_invalid_chars_returns_error() {
+        let err = interp("url: ${HOST-NAME}", &[]).unwrap_err();
+        assert_eq!(
+            err,
+            InterpolateError::InvalidName {
+                name: "HOST-NAME".into(),
+                line: 1,
+                column: 6,
+            }
+        );
+    }
+
+    #[test]
+    fn name_starting_with_digit_returns_error() {
+        let err = interp("url: ${1HOST}", &[]).unwrap_err();
+        assert_eq!(
+            err,
+            InterpolateError::InvalidName {
+                name: "1HOST".into(),
+                line: 1,
+                column: 6,
+            }
+        );
+    }
+
+    #[test]
+    fn name_starting_with_underscore_is_valid() {
+        let out = interp("v: ${_PRIVATE}", &[("_PRIVATE", "ok")]).unwrap();
+        assert_eq!(out, "v: ok");
+    }
+
+    #[test]
+    fn name_with_digits_after_first_char_is_valid() {
+        let out = interp("v: ${HOST1}", &[("HOST1", "h1")]).unwrap();
+        assert_eq!(out, "v: h1");
+    }
+
+    #[test]
+    fn multi_line_input_reports_correct_line_for_unset_var() {
+        let yaml = "version: 2\ndefaults:\n  sink:\n    url: ${MISSING}\n";
+        let err = interp(yaml, &[]).unwrap_err();
+        match err {
+            InterpolateError::UnsetVariable { name, line, column } => {
+                assert_eq!(name, "MISSING");
+                assert_eq!(line, 4);
+                assert_eq!(column, 10);
+            }
+            other => panic!("expected UnsetVariable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn substitution_is_single_pass_not_recursive() {
+        let out = interp(
+            "a: ${OUTER}",
+            &[("OUTER", "${INNER}"), ("INNER", "should-not-appear")],
+        )
+        .unwrap();
+        assert_eq!(out, "a: ${INNER}");
+    }
+
+    #[test]
+    fn position_tracks_source_columns_past_a_substitution() {
+        let err = interp("${A}${B}", &[("A", "value-of-a")]).unwrap_err();
+        match err {
+            InterpolateError::UnsetVariable { name, line, column } => {
+                assert_eq!(name, "B");
+                assert_eq!(line, 1);
+                assert_eq!(column, 5);
+            }
+            other => panic!("expected UnsetVariable for B, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn long_default_with_special_chars() {
+        let out = interp(
+            "${KAFKA:-broker-1.example.com:9094,broker-2.example.com:9094}",
+            &[],
+        )
+        .unwrap();
+        assert_eq!(out, "broker-1.example.com:9094,broker-2.example.com:9094");
+    }
+
+    #[test]
+    fn nested_dollar_brace_inside_default_terminates_at_first_close() {
+        // `${A:-${B}` — default scans to the first `}`, yielding `${B`.
+        let out = interp("${A:-${B}", &[]).unwrap();
+        assert_eq!(out, "${B");
+    }
+
+    #[test]
+    fn non_ascii_input_passes_through_unchanged() {
+        let yaml = "name: caf\u{00e9}-\u{1f600}-\u{4e2d}\nurl: ${HOST}";
+        let out = interp(yaml, &[("HOST", "x")]).unwrap();
+        assert_eq!(out, "name: caf\u{00e9}-\u{1f600}-\u{4e2d}\nurl: x");
+    }
+
+    #[test]
+    fn error_type_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<InterpolateError>();
+    }
+
+    #[test]
+    fn interpolate_uses_process_env() {
+        let var = "SONDA_INTERPOLATE_TEST_VAR_2026";
+        // SAFETY: unique-to-this-test var name; mutates process-global state.
+        unsafe {
+            env::set_var(var, "from-env");
+        }
+        let out = interpolate(&format!("v: ${{{var}}}")).unwrap();
+        assert_eq!(out, "v: from-env");
+        // SAFETY: see above.
+        unsafe {
+            env::remove_var(var);
+        }
+    }
+}

--- a/sonda-core/src/compiler/mod.rs
+++ b/sonda-core/src/compiler/mod.rs
@@ -11,6 +11,8 @@
 //!
 //! # Submodules
 //!
+//! - [`env_interpolate`] — Phase 0: pre-parse `${VAR}` / `${VAR:-default}`
+//!   substitution against the process environment.
 //! - [`parse`] — YAML deserialization, schema validation, and version detection.
 //! - [`normalize`] — `defaults:` resolution and entry-level normalization.
 //! - [`expand`] — pack expansion inside `scenarios:` (Phase 3).
@@ -19,6 +21,9 @@
 //!   clock-group assignment (Phases 4 and 5).
 //! - [`prepare`] — translation from [`compile_after::CompiledFile`] into the
 //!   runtime's `Vec<ScenarioEntry>` input shape (Phase 6).
+
+#[cfg(feature = "config")]
+pub mod env_interpolate;
 
 #[cfg(feature = "config")]
 pub mod parse;

--- a/sonda-core/tests/env_interpolation.rs
+++ b/sonda-core/tests/env_interpolation.rs
@@ -1,0 +1,192 @@
+#![cfg(feature = "config")]
+//! End-to-end env-var interpolation through `compile_scenario_file`.
+
+mod common;
+
+use sonda_core::compile_scenario_file;
+use sonda_core::compiler::expand::InMemoryPackResolver;
+#[cfg(feature = "http")]
+use sonda_core::sink::SinkConfig;
+use sonda_core::{CompileError, ScenarioEntry};
+use std::env;
+
+const TEST_VAR: &str = "SONDA_E2E_INTERPOLATION_URL_2026";
+
+fn unique_var(suffix: &str) -> String {
+    format!("{TEST_VAR}_{suffix}")
+}
+
+fn yaml_with_var(var_name: &str) -> String {
+    format!(
+        r#"
+version: 2
+
+defaults:
+  rate: 1
+  duration: 1s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 1.0
+    labels:
+      url_label: "${{{var_name}:-http://localhost:8428/api/v1/import/prometheus}}"
+"#
+    )
+}
+
+#[test]
+fn unset_var_resolves_to_default_in_compiled_scenario() {
+    let var = unique_var("DEFAULT_PATH");
+    // SAFETY: unique-to-this-test var name; mutates process-global state.
+    unsafe {
+        env::remove_var(&var);
+    }
+    let yaml = yaml_with_var(&var);
+    let resolver = InMemoryPackResolver::new();
+    let entries =
+        compile_scenario_file(&yaml, &resolver).expect("compile must succeed when default is used");
+    let url_label = label_value(&entries, "url_label");
+    assert_eq!(
+        url_label, "http://localhost:8428/api/v1/import/prometheus",
+        "unset var should fall back to the literal default"
+    );
+}
+
+#[test]
+fn set_var_overrides_default_in_compiled_scenario() {
+    let var = unique_var("OVERRIDE_PATH");
+    let override_value = "http://victoriametrics.svc.cluster.local:8428/api/v1/import/prometheus";
+    // SAFETY: unique-to-this-test var name; mutates process-global state.
+    unsafe {
+        env::set_var(&var, override_value);
+    }
+    let yaml = yaml_with_var(&var);
+    let resolver = InMemoryPackResolver::new();
+    let result = compile_scenario_file(&yaml, &resolver);
+    // SAFETY: see comment above.
+    unsafe {
+        env::remove_var(&var);
+    }
+    let entries = result.expect("compile must succeed when var is set");
+    let url_label = label_value(&entries, "url_label");
+    assert_eq!(
+        url_label, override_value,
+        "set var should override the default"
+    );
+}
+
+#[test]
+fn required_var_unset_surfaces_as_compile_error() {
+    let var = unique_var("REQUIRED_UNSET");
+    // SAFETY: see comment above.
+    unsafe {
+        env::remove_var(&var);
+    }
+    // Use a required reference (no default) for this test.
+    let yaml = format!(
+        r#"
+version: 2
+
+defaults:
+  rate: 1
+  duration: 1s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 1.0
+    labels:
+      url_label: "${{{var}}}"
+"#
+    );
+    let resolver = InMemoryPackResolver::new();
+    let err = compile_scenario_file(&yaml, &resolver)
+        .expect_err("required-but-unset var must fail to compile");
+    let inner = match &err {
+        CompileError::EnvInterpolate(inner) => inner,
+        other => panic!("expected CompileError::EnvInterpolate, got {other:?}"),
+    };
+    let msg = inner.to_string();
+    assert!(
+        msg.contains(&var) && msg.contains("not set"),
+        "error message must name the missing variable, got: {msg}"
+    );
+}
+
+#[cfg(feature = "http")]
+#[test]
+fn env_var_substitution_reaches_http_push_sink_url() {
+    let var = unique_var("HTTP_PUSH_URL");
+    let override_value = "http://victoriametrics:8428/api/v1/import/prometheus";
+    // SAFETY: see comment above.
+    unsafe {
+        env::set_var(&var, override_value);
+    }
+    let yaml = format!(
+        r#"
+version: 2
+
+defaults:
+  rate: 1
+  duration: 1s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: http_push
+    url: "${{{var}:-http://localhost:8428/api/v1/import/prometheus}}"
+
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 1.0
+"#
+    );
+    let resolver = InMemoryPackResolver::new();
+    let result = compile_scenario_file(&yaml, &resolver);
+    // SAFETY: see comment above.
+    unsafe {
+        env::remove_var(&var);
+    }
+    let entries = result.expect("compile must succeed");
+    let entry = entries.first().expect("at least one entry");
+    match &entry.base().sink {
+        SinkConfig::HttpPush { url, .. } => {
+            assert_eq!(
+                url, override_value,
+                "sink URL must be the env-overridden value"
+            );
+        }
+        other => panic!("expected HttpPush sink, got {other:?}"),
+    }
+}
+
+fn label_value(entries: &[ScenarioEntry], key: &str) -> String {
+    let entry = entries.first().expect("at least one compiled entry");
+    let labels = entry
+        .base()
+        .labels
+        .as_ref()
+        .expect("entry must carry labels");
+    labels
+        .get(key)
+        .cloned()
+        .unwrap_or_else(|| panic!("label {key:?} not found on compiled entry"))
+}


### PR DESCRIPTION
## Summary

Closes [#223](https://github.com/davidban77/sonda/issues/223) — the last open papercut (#4). Same scenario YAML now works from host CLI (defaults take effect) **and** from sonda-server-in-compose (env vars from compose `environment:` block override).

* **New Phase 0 of the v2 compile pipeline** — `${VAR}` (required, errors if unset) and `${VAR:-default}` (optional) substitution over the raw YAML text *before* parse. Hand-rolled scanner — **no new crate dep**. `$$` is the only escape; variable names match `[A-Z_][A-Z0-9_]*`.
* **Wired at `compile_scenario_file`** — single entry point covers CLI file loads, HTTP body POSTs, and programmatic callers.
* **23 example YAMLs migrated** to `${VAR:-http://localhost:port/...}`. The bundled `examples/docker-compose-victoriametrics.yml` exports 7 canonical vars on the `sonda-server` service so demos POST examples as-shipped.
* **Bonus latent fix** — every `CompileError` phase variant used `#[error("foo error: {0}")]` + `#[from]`, which double-prints the inner message under anyhow's chain display. Switched all 6 to `#[error("foo error")]` so anyhow's source-chain walk produces a clean single-line error.

## The conference demo path

```sh
# Host CLI — default localhost:3100 wins
sonda run --scenario examples/loki-json-lines.yaml --duration 30s

# sonda-server in compose — LOKI_URL=http://loki:3100 wins, no YAML edit
docker compose -f examples/docker-compose-victoriametrics.yml --profile loki up -d
curl -X POST -H "Content-Type: text/yaml" --data-binary @examples/loki-json-lines.yaml \
  http://localhost:8080/scenarios
```

## Test plan

- [x] `cargo build --workspace` ✅
- [x] `cargo clippy --workspace -- -D warnings` ✅
- [x] `cargo clippy --workspace --all-features -- -D warnings` ✅
- [x] `cargo fmt --all -- --check` ✅
- [x] **28 unit tests** in `env_interpolate.rs` (substitution, escape, errors with line/column, multi-line, non-ASCII, single-pass-not-recursive, real `std::env::var` round-trip)
- [x] **4 integration tests** in `tests/env_interpolation.rs` — `unset_var_resolves_to_default_in_compiled_scenario`, `set_var_overrides_default_in_compiled_scenario`, `required_var_unset_surfaces_as_compile_error`, `env_var_substitution_reaches_http_push_sink_url` (verifies `SinkConfig::HttpPush::url` ends up with the resolved value)
- [x] **Full sonda-core test sweep** — 1610 lib + 154 integration tests pass under `--features http`
- [x] **UAT live test** — POSTed `examples/vm-push-scenario.yaml` to sonda-server-in-compose AS-IS; data landed in VictoriaMetrics (121 sine-wave points) without any YAML edit. Loki path verified the same way (601 log entries).
- [x] **Required-but-unset error UX** — single clean line: `error: failed to compile v2 scenario file <path>: env interpolation error: environment variable REQUIRED_BACKEND_URL is not set (referenced at line 8, column 11 of scenario YAML)`
- [x] `task site:build` — strict, zero warnings
- [ ] CI

## Audit-fodder (out of scope for this PR)

* Other compose files (`docker-compose-loki.yml`, `docker-compose-kafka.yml` if they exist) should also ship pre-wired `environment:` blocks for parity. None present today.
* Helm chart env-var threading — chart still hardcodes URLs. Defer to separate PR.
* Nested vars (`${A:-${B}}`), bare `$VAR` (no braces), bash operators beyond `:-` — designed out, document/file as enhancement issues if anyone asks.