### PR TITLE
docs: glossary tooltips, scroll-aware TOC, one tabbed snippet

### DIFF
--- a/docs/site/docs/guides/troubleshooting.md
+++ b/docs/site/docs/guides/troubleshooting.md
@@ -14,13 +14,17 @@ Before diving into specific issues, run these quick checks.
 
 Use `--dry-run` to parse and validate a scenario without emitting any events:
 
-```bash
-sonda --dry-run metrics --name cpu --rate 10 --duration 30s
-```
+=== "Inline CLI flags"
 
-```bash
-sonda --dry-run run --scenario my-scenario.yaml
-```
+    ```bash
+    sonda --dry-run metrics --name cpu --rate 10 --duration 30s
+    ```
+
+=== "Scenario file"
+
+    ```bash
+    sonda --dry-run run --scenario my-scenario.yaml
+    ```
 
 If the config is valid, Sonda prints the resolved settings and exits with code `0`. If there's
 an error, it prints the problem to stderr and exits with code `1`.

--- a/docs/site/docs/includes/abbreviations.md
+++ b/docs/site/docs/includes/abbreviations.md
@@ -1,0 +1,25 @@
+*[OTLP]: OpenTelemetry Protocol -- the wire format used by OpenTelemetry collectors and SDKs to ship traces, metrics, and logs.
+*[OTel]: Short for OpenTelemetry, the CNCF observability framework for traces, metrics, and logs.
+*[TSDB]: Time-series database -- storage engine optimised for timestamp-indexed numeric samples (e.g., Prometheus, VictoriaMetrics).
+*[remote-write]: Prometheus protocol for pushing samples from a producer to a TSDB over HTTP, using protobuf + Snappy compression.
+*[exposition format]: Prometheus text format for metrics scraped from an HTTP endpoint (`# HELP`, `# TYPE`, `name{label="v"} value`).
+*[cardinality]: Number of unique label-value combinations for a metric. High cardinality blows up TSDB memory and index size.
+*[scrape]: Prometheus pull model -- the server periodically GETs an exposition endpoint to ingest metrics.
+*[line protocol]: InfluxDB text format: `measurement,tag=v field=v timestamp`. Used by Telegraf and InfluxDB ingest.
+*[PromQL]: Prometheus Query Language -- the query syntax for selecting and aggregating time-series data.
+*[LogQL]: Loki's query language -- combines label selectors with log line filters and metric extractors.
+*[Loki]: Grafana's log aggregation system. Stores logs indexed by labels rather than full-text.
+*[VictoriaMetrics]: High-performance Prometheus-compatible TSDB with native remote-write and import endpoints.
+*[Alertmanager]: Prometheus component that handles alert routing, deduplication, grouping, and silencing.
+*[recording rule]: Prometheus rule that pre-computes a query and stores the result as a new time series.
+*[SLO]: Service Level Objective -- a target reliability level (e.g., 99.9% availability over 30 days).
+*[SLI]: Service Level Indicator -- the measured value (latency, error rate) used to evaluate an SLO.
+*[scenario]: Sonda's unit of work -- a YAML file describing what to generate, how, and where to send it.
+*[generator]: Sonda component that produces synthetic events (metrics, logs) according to a pattern.
+*[encoder]: Sonda component that serialises events into a wire format (Prometheus text, OTLP, JSON lines).
+*[sink]: Sonda component that delivers encoded bytes to a destination (stdout, HTTP push, Kafka, OTLP gRPC).
+*[metric pack]: Curated bundle of generators that simulate a known system (Linux node, NGINX, network device).
+*[Telegraf]: InfluxData's plugin-driven agent for collecting and shipping telemetry.
+*[Containerlab]: Tool for spinning up multi-vendor network topologies as containers, used in the netobs lab.
+*[SASL]: Simple Authentication and Security Layer -- pluggable auth framework used by Kafka brokers.
+*[mTLS]: Mutual TLS -- both client and server present certificates to authenticate each other.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -4,6 +4,9 @@ site_url: https://davidban77.github.io/sonda/
 repo_url: https://github.com/davidban77/sonda
 repo_name: davidban77/sonda
 
+not_in_nav: |
+  /includes/
+
 theme:
   name: material
   palette:
@@ -24,12 +27,15 @@ theme:
   features:
     - navigation.sections
     - navigation.expand
+    - navigation.indexes
     - navigation.top
     - search.highlight
     - content.code.copy
     - content.tabs.link
+    - toc.follow
 
 markdown_extensions:
+  - abbr
   - admonition
   - pymdownx.details
   - pymdownx.superfences
@@ -38,7 +44,11 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.tabbed:
       alternate_style: true
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      base_path:
+        - docs/site/docs
+      auto_append:
+        - includes/abbreviations.md
   - attr_list
   - md_in_html
   - toc:


### PR DESCRIPTION
## Summary

Adopts three patterns from a senior look at a sibling network-automation docs site (per the proposal user reviewed). Quick wins #1, #2, #4 from that proposal — #3 (v1↔v2 comparison) explicitly dropped because the conference audience hasn't used v1.

* **Glossary tooltips** — `markdown.extensions.abbr` + auto-appended `docs/includes/abbreviations.md` snippet (25 sonda-specific terms: `OTLP`, `TSDB`, `remote-write`, `cardinality`, `Loki`, `VictoriaMetrics`, `exposition format`, `PromQL`, …). Hovering renders the definition. Common terms (`JSON`, `HTTP`, `YAML`, `stdout`) intentionally excluded to avoid hover-haze.
* **Scroll-aware right-rail TOC** — `toc.follow` + `navigation.indexes` added to `theme.features`. `toc.integrate` evaluated and backed out — would have doubled the already-expanded left-rail tree.
* **One tabbed code-block** — converted "Validate your configuration" in `troubleshooting.md` from two sequential bash blocks into a `pymdownx.tabbed` group (`Inline CLI flags` / `Scenario file`). The extension was already enabled site-wide via `endpoints.md`; this is a surgical demo on a real diagnostic block.

## Test plan

- [x] `task site:build` strict — zero warnings, 1.07s clean build
- [x] `<abbr>` tags render with correct `title=` definitions on `getting-started`, `troubleshooting`, `cardinality` pages (UAT confirmed)
- [x] Tab strip renders on troubleshooting "Validate your configuration" — `class="tabbed-set"` confirmed in HTML
- [x] No false-positive abbreviations on common prose words across `endpoints.md`, `sink-batching.md`, `tutorial/index.md`
- [x] `JSON` / `HTTP` / `YAML` / `stdout` confirmed NOT abbreviated (zero matches in rendered HTML)
- [x] `includes/abbreviations.md` suppressed from left-rail nav via `not_in_nav: "/includes/"`
- [x] Section landing pages remain non-clickable today — `navigation.indexes` is registered but inert until `index.md` files are added (deferred audit-fodder)
- [ ] Live preview verification on the deploy preview after merge

## Audit-fodder (out of scope, deferred)

* Section index pages missing for the four top-level sidebar groups + 6 guide sub-groups (10 total). Adding them would make the sidebar section headers clickable. Post-conference.
* Snippet-only files conventionally live under `docs/_includes/` (underscore-prefixed); could rename later for cleaner semantics.