### PR TITLE
docs: story-led guide intros, section landing pages, generator chooser table

### DIFF
--- a/docs/site/docs/configuration/generators.md
+++ b/docs/site/docs/configuration/generators.md
@@ -3,6 +3,42 @@
 Generators produce values for each tick of a scenario. For metrics, they produce `f64` values. For
 logs, they produce structured log events. You select a generator with the `generator.type` field.
 
+## Which generator?
+
+Pick the row that matches what you are simulating. The first table covers the eight
+core metric generators. The second covers [operational aliases](#operational-aliases) --
+sugar for the same engine that lets you say `flap` instead of `sequence` with hand-aligned
+values.
+
+| Generator | Use case | Shape | Key fields |
+|-----------|----------|-------|------------|
+| [`constant`](#constant) | Up/down indicators, recording-rule baselines | Flat horizontal line | `value` |
+| [`sine`](#sine) | CPU, latency, cyclical load | Smooth oscillation around a midpoint | `amplitude`, `period_secs`, `offset` |
+| [`sawtooth`](#sawtooth) | Counter wraps, queue fill cycles | Linear ramp that snaps back at period end | `min`, `max`, `period_secs` |
+| [`uniform`](#uniform) | Jitter, random-load streams | Random values drawn each tick | `min`, `max`, `seed` |
+| [`sequence`](#sequence) | Exact `for:` durations, scripted timelines | Whatever you list, tick by tick | `values`, `repeat` |
+| [`step`](#step) | `rate()` and `increase()` testing | Monotonic counter incrementing each tick | `start`, `step_size`, optional `max` |
+| [`spike`](#spike) | Anomaly detection, threshold alerts | Baseline with periodic outlier bursts | `baseline`, `magnitude`, `interval_secs` |
+| [`csv_replay`](#csv_replay) | Bit-for-bit incident reproduction | The recorded values, in order | `file`, `columns` |
+
+For [logs](#log-generators), pick `template` for synthesized messages with field pools
+or `replay` for line-by-line CSV/log-file replay. For latency distributions, see the
+[histogram and summary generators](#histogram-and-summary-generators).
+
+| Alias | Operational meaning | Shape | Key fields |
+|-------|---------------------|-------|------------|
+| [`steady`](#steady) | Healthy "everything is fine" baseline | Sine + jitter around a center | `center`, `amplitude`, `noise` |
+| [`flap`](#flap) | Interface or health-check toggling | Binary up/down with per-state durations | `up_duration`, `down_duration` |
+| [`saturation`](#saturation) | Buffer or disk filling, then resetting | Ramp from baseline to ceiling, repeats | `baseline`, `ceiling`, `time_to_saturate` |
+| [`leak`](#leak) | Memory leak, unreleased connections | One-way ramp toward ceiling, no reset | `baseline`, `ceiling`, `time_to_ceiling` |
+| [`degradation`](#degradation) | Latency climbing, throughput dropping | One-way ramp with noise on top | `baseline`, `ceiling`, `time_to_degrade` |
+| [`spike_event`](#spike_event) | CPU spikes, request surges, error floods | Baseline with periodic bursts | `baseline`, `spike_height`, `spike_interval` |
+
+!!! tip "Aliases and core generators are interchangeable"
+    Aliases are sugar -- they desugar at parse time into the core generators above. Use the
+    alias when the operational meaning is clearer; drop to the core generator when you need a
+    parameter the alias does not expose (e.g. negative spike `magnitude` for dip testing).
+
 ## Metric generators
 
 ### constant

--- a/docs/site/docs/configuration/index.md
+++ b/docs/site/docs/configuration/index.md
@@ -10,26 +10,60 @@ your pipeline, start with the [Tutorial](../guides/tutorial.md) or jump to the
 relevant guide under [Guides](../guides/index.md). This section answers "what does
 this field do" and "what are the valid values."
 
+!!! tip "Read this first"
+    If you only open one page in this section, make it
+    [**v2 Scenario Files**](v2-scenarios.md). Every other reference here -- generators,
+    encoders, sinks -- plugs into that shape.
+
 ## Scenario file shape
 
-- [**v2 Scenario Files**](v2-scenarios.md) -- the canonical file format: `version: 2`,
-  `defaults:`, `scenarios:`, packs, and `after:` temporal chains.
-- [**Scenario Fields**](scenario-fields.md) -- per-entry field reference for everything
-  inside a `scenarios:` entry (generators, schedules, labels, encoders, sinks).
+<div class="grid cards" markdown>
+
+-   :material-file-document-outline: __[v2 Scenario Files](v2-scenarios.md)__
+
+    The canonical file format: `version: 2`, `defaults:`, `scenarios:`, packs, and
+    `after:` temporal chains.
+
+-   :material-format-list-bulleted-type: __[Scenario Fields](scenario-fields.md)__
+
+    Per-entry field reference for everything inside a `scenarios:` entry --
+    generators, schedules, labels, encoders, sinks.
+
+</div>
 
 ## Building blocks
 
-- [**Generators**](generators.md) -- value shapes: `constant`, `sine`, `sawtooth`,
-  `sequence`, `step`, `spike`, `csv_replay`, plus operational aliases (`steady`, `flap`,
-  `saturation`, `leak`, `degradation`, `spike_event`) and histogram/summary generators.
-- [**Encoders**](encoders.md) -- wire formats: Prometheus text, InfluxDB line protocol,
-  JSON lines, syslog, Prometheus remote write, OTLP.
-- [**Sinks**](sinks.md) -- destinations: stdout, file, TCP, UDP, HTTP push, remote
-  write, Kafka, Loki, OTLP/gRPC.
-- [**Sink Batching**](sink-batching.md) -- how each sink buffers, default thresholds,
-  and the `batch_size` field where it applies.
+<div class="grid cards" markdown>
+
+-   :material-sine-wave: __[Generators](generators.md)__
+
+    Value shapes: `constant`, `sine`, `sawtooth`, `sequence`, `step`, `spike`,
+    `csv_replay`, plus operational aliases and histogram/summary generators.
+
+-   :material-code-braces: __[Encoders](encoders.md)__
+
+    Wire formats: Prometheus text, InfluxDB line protocol, JSON lines, syslog,
+    Prometheus remote write, OTLP.
+
+-   :material-export-variant: __[Sinks](sinks.md)__
+
+    Destinations: stdout, file, TCP, UDP, HTTP push, remote write, Kafka, Loki,
+    OTLP/gRPC.
+
+-   :material-package-variant: __[Sink Batching](sink-batching.md)__
+
+    How each sink buffers, default thresholds, and the `batch_size` field where
+    it applies.
+
+</div>
 
 ## Command line
 
-- [**CLI Reference**](cli-reference.md) -- every subcommand, every flag, exit codes,
-  and the `SONDA_*` environment variables that override flags.
+<div class="grid cards" markdown>
+
+-   :material-console: __[CLI Reference](cli-reference.md)__
+
+    Every subcommand, every flag, exit codes, and the `SONDA_*` environment
+    variables that override flags.
+
+</div>

--- a/docs/site/docs/configuration/index.md
+++ b/docs/site/docs/configuration/index.md
@@ -1,0 +1,35 @@
+# Configuration
+
+Every knob you can turn on a Sonda scenario. The CLI flags, the YAML fields, the
+generators, encoders, and sinks -- this section is the reference you reach for when
+you know what you want to change and need to confirm the exact field name or the
+default value.
+
+If you are looking for *which* generator to pick or *how* to wire a Loki sink into
+your pipeline, start with the [Tutorial](../guides/tutorial.md) or jump to the
+relevant guide under [Guides](../guides/index.md). This section answers "what does
+this field do" and "what are the valid values."
+
+## Scenario file shape
+
+- [**v2 Scenario Files**](v2-scenarios.md) -- the canonical file format: `version: 2`,
+  `defaults:`, `scenarios:`, packs, and `after:` temporal chains.
+- [**Scenario Fields**](scenario-fields.md) -- per-entry field reference for everything
+  inside a `scenarios:` entry (generators, schedules, labels, encoders, sinks).
+
+## Building blocks
+
+- [**Generators**](generators.md) -- value shapes: `constant`, `sine`, `sawtooth`,
+  `sequence`, `step`, `spike`, `csv_replay`, plus operational aliases (`steady`, `flap`,
+  `saturation`, `leak`, `degradation`, `spike_event`) and histogram/summary generators.
+- [**Encoders**](encoders.md) -- wire formats: Prometheus text, InfluxDB line protocol,
+  JSON lines, syslog, Prometheus remote write, OTLP.
+- [**Sinks**](sinks.md) -- destinations: stdout, file, TCP, UDP, HTTP push, remote
+  write, Kafka, Loki, OTLP/gRPC.
+- [**Sink Batching**](sink-batching.md) -- how each sink buffers, default thresholds,
+  and the `batch_size` field where it applies.
+
+## Command line
+
+- [**CLI Reference**](cli-reference.md) -- every subcommand, every flag, exit codes,
+  and the `SONDA_*` environment variables that override flags.

--- a/docs/site/docs/deployment/index.md
+++ b/docs/site/docs/deployment/index.md
@@ -10,19 +10,29 @@ This section covers the runtime side: where the process lives, how it reaches yo
 backends, and how scenarios are submitted. For *what* the scenarios contain, see
 [Configuration](../configuration/index.md).
 
-## Start here
-
-- [**Endpoints & networking**](endpoints.md) -- the rules for `localhost`, Compose
-  service names, Docker Desktop's `host.docker.internal`, and Kubernetes Service DNS.
-  Read this before you change a sink URL -- the `localhost` trap catches most
-  first-time `sonda-server` users.
+!!! warning "Read this first"
+    [**Endpoints & networking**](endpoints.md) covers the rules for `localhost`,
+    Compose service names, Docker Desktop's `host.docker.internal`, and Kubernetes
+    Service DNS. The `localhost` trap catches most first-time `sonda-server`
+    users -- skim it before you change a sink URL.
 
 ## Runtimes
 
-- [**Docker**](docker.md) -- pulling the image, dispatch between `sonda` and
-  `sonda-server`, and the bundled Compose stacks for VictoriaMetrics, Loki, Kafka,
-  and Grafana.
-- [**Kubernetes**](kubernetes.md) -- the Helm chart, Deployment + Service shape,
-  health probes, ConfigMap-injected scenarios, and cluster-DNS sink URLs.
-- [**Server API**](sonda-server.md) -- the REST surface for submitting scenarios,
-  inspecting live stats, scraping metrics, and stopping runs over HTTP.
+<div class="grid cards" markdown>
+
+-   :material-docker: __[Docker](docker.md)__
+
+    Pulling the image, dispatch between `sonda` and `sonda-server`, and the
+    bundled Compose stacks for VictoriaMetrics, Loki, Kafka, and Grafana.
+
+-   :material-kubernetes: __[Kubernetes](kubernetes.md)__
+
+    The Helm chart, Deployment + Service shape, health probes, ConfigMap-injected
+    scenarios, and cluster-DNS sink URLs.
+
+-   :material-server-network: __[Server API](sonda-server.md)__
+
+    The REST surface for submitting scenarios, inspecting live stats, scraping
+    metrics, and stopping runs over HTTP.
+
+</div>

--- a/docs/site/docs/deployment/index.md
+++ b/docs/site/docs/deployment/index.md
@@ -1,0 +1,28 @@
+# Deployment
+
+Sonda runs three ways: as a one-shot CLI binary you invoke from a shell, as a
+long-lived `sonda-server` HTTP control plane, or as a containerized deployment in
+Docker or Kubernetes. The shape you pick depends on whether scenarios are
+human-driven (CLI), automation-driven (server), or part of an always-on
+synthetic-monitoring fleet (Kubernetes).
+
+This section covers the runtime side: where the process lives, how it reaches your
+backends, and how scenarios are submitted. For *what* the scenarios contain, see
+[Configuration](../configuration/index.md).
+
+## Start here
+
+- [**Endpoints & networking**](endpoints.md) -- the rules for `localhost`, Compose
+  service names, Docker Desktop's `host.docker.internal`, and Kubernetes Service DNS.
+  Read this before you change a sink URL -- the `localhost` trap catches most
+  first-time `sonda-server` users.
+
+## Runtimes
+
+- [**Docker**](docker.md) -- pulling the image, dispatch between `sonda` and
+  `sonda-server`, and the bundled Compose stacks for VictoriaMetrics, Loki, Kafka,
+  and Grafana.
+- [**Kubernetes**](kubernetes.md) -- the Helm chart, Deployment + Service shape,
+  health probes, ConfigMap-injected scenarios, and cluster-DNS sink URLs.
+- [**Server API**](sonda-server.md) -- the REST surface for submitting scenarios,
+  inspecting live stats, scraping metrics, and stopping runs over HTTP.

--- a/docs/site/docs/guides/alert-testing.md
+++ b/docs/site/docs/guides/alert-testing.md
@@ -1,11 +1,16 @@
 # Alert Testing
 
-You write alert rules, deploy them, and hope they work. Common issues slip through:
-a `for: 5m` alert that never fires because the metric only breaches for 3 minutes, a
-gap-fill rule that triggers false positives during scrape outages, or a compound alert
-where two metrics never overlap. Sonda lets you generate the exact metric shapes to
-trigger -- and resolve -- alerts on demand, so you catch these problems before they hit
-production.
+3 a.m. The pager goes off for `HighRequestLatency`. By the time you log in, latency
+is back below threshold and the alert has cleared. You spend an hour reading dashboards
+and find nothing -- the spike was real, but it lasted 90 seconds and your `for: 5m`
+clause silently swallowed it. The alert is doing exactly what you told it to. You just
+told it the wrong thing.
+
+That whole class of problem -- `for:` durations that swallow real spikes, gap-fill rules
+that fire during scrape outages, compound `A AND B` rules where the two signals never
+overlap -- only shows up in production because nothing else generates the right metric
+shape. Sonda does. You write the alert, run a scenario that crosses the threshold for
+exactly the duration you care about, and watch whether the alert fires.
 
 This page is the entry point. Five focused sub-pages cover the patterns; the table
 below maps each common alert shape to the right one.

--- a/docs/site/docs/guides/csv-import.md
+++ b/docs/site/docs/guides/csv-import.md
@@ -1,9 +1,15 @@
 # CSV Import
 
-You have a CSV file -- maybe a Grafana export from a production incident, maybe a hand-recorded
-dataset -- and you want to turn it into a portable, parameterized scenario that uses Sonda's
-generators instead of replaying raw values. `sonda import` analyzes the data, detects dominant
-patterns, and generates scenario YAML you can run, share, and customize.
+After last week's incident, you exported the CPU and memory series from Grafana to
+attach to the postmortem. The CSV sits in a Drive folder. The next time someone tries
+to reproduce the alert pattern in CI, they will not find the file -- and even if they
+do, raw replay locks them to the original timestamps and the original rate.
+
+What you actually want is the *shape* of that incident as a reusable scenario:
+"a CPU spike like the one from the May 14 outage" parameterized on rate and duration,
+checked into the repo next to the alert rules. `sonda import` does that conversion in
+one step. It scans each column, classifies the pattern (steady, spike, leak, sawtooth,
+flap, step), and emits a v2 scenario YAML wired to a generator with the right knobs.
 
 ---
 

--- a/docs/site/docs/guides/index.md
+++ b/docs/site/docs/guides/index.md
@@ -6,84 +6,55 @@ The [**Tutorial**](tutorial.md) is the guided tour through every part of Sonda.
 The rest of this section is organized by what you are testing: alert rules,
 ingest pipelines, network telemetry, real-data replay, or operational scale.
 
-## Tutorial
+!!! tip "New to Sonda?"
+    Start with the [**Tutorial**](tutorial.md) -- a seven-page walkthrough of
+    generators, encoders, sinks, log generation, scheduling, multi-scenario
+    runs, and the Server API. Everything below assumes you have already done
+    that, or you know what you are looking for.
 
-A seven-page walk through generators, encoders, sinks, log generation, scheduling,
-multi-scenario runs, and the Server API. Start here if you have just installed
-Sonda and want to see what every knob does.
+## Browse by goal
 
-- [**Tutorial overview**](tutorial.md) -- the table of contents and what each page covers.
+<div class="grid cards" markdown>
 
-## Catalog and packs
+-   :material-bookshelf: __[Catalog & packs](scenarios.md)__
 
-Pre-built scenarios you can run instantly, and the building blocks that compose them.
+    Pre-built scenarios you can run instantly, plus the building blocks that
+    compose them. Start with [Built-in Scenarios](scenarios.md), then
+    [Dynamic Labels](dynamic-labels.md), [Examples](examples.md), and
+    [Metric Packs](metric-packs.md).
 
-- [**Built-in Scenarios**](scenarios.md) -- the curated catalog. `sonda catalog list`
-  to browse, `sonda catalog run <name>` to launch.
-- [**Dynamic Labels**](dynamic-labels.md) -- per-event label values via `${...}`
-  placeholders driven by RNG, sequences, or pools.
-- [**Example Scenarios**](examples.md) -- the YAML files under `examples/` and what
-  each one demonstrates.
-- [**Metric Packs**](metric-packs.md) -- inline pack expansion inside `scenarios:`
-  for fan-out across instances, services, or paths.
+-   :material-bell-alert: __[Alert testing](alert-testing.md)__
 
-## Alert testing
+    Triggering, resolving, and validating alert rules with the right metric
+    shape. The [overview](alert-testing.md) maps each alert pattern to the
+    right generator -- thresholds, resolution, correlation, cardinality,
+    histograms, recording rules, and the full pipeline.
 
-Triggering, resolving, and validating alert rules with the right metric shape.
+-   :material-pipe: __[Pipelines & scale](pipeline-validation.md)__
 
-- [**Alert testing overview**](alert-testing.md) -- the entry point. Maps each alert
-  pattern to the right generator and sub-page.
-- [**Threshold and `for:` duration**](alert-testing-thresholds.md) -- sine, sequence,
-  and constant for crossing thresholds with predictable timing.
-- [**Resolution and recovery**](alert-testing-resolution.md) -- gap windows that
-  drop the metric so resolution fires.
-- [**Compound and correlated alerts**](alert-testing-correlation.md) -- `phase_offset`
-  and `clock_group` for `A AND B` rules.
-- [**Cardinality explosion alerts**](alert-testing-cardinality.md) -- `cardinality_spikes`
-  for series-count guardrails.
-- [**Replaying recorded incidents**](alert-testing-replay.md) -- `sequence` for short
-  patterns, `csv_replay` for production exports.
-- [**Histogram and summary alerts**](histogram-alerts.md) -- bucket-based and
-  quantile-based latency alerts.
-- [**Recording rules**](recording-rules.md) -- pushing known constants to verify
-  computed outputs.
-- [**Alerting pipeline**](alerting-pipeline.md) -- end-to-end with vmalert,
-  Alertmanager, and a webhook receiver.
-- [**CI alert validation**](ci-alert-validation.md) -- catching broken rules in CI
-  before they reach production.
+    Validating ingest changes, sizing backends, and end-to-end flow. Covers
+    [pipeline validation](pipeline-validation.md),
+    [synthetic monitoring](synthetic-monitoring.md),
+    [capacity planning](capacity-planning.md), and
+    [E2E testing](e2e-testing.md).
 
-## Pipelines and scale
+-   :material-router-network: __[Network telemetry](network-device-telemetry.md)__
 
-Validating ingest changes, capacity, and end-to-end backend behavior.
+    Modeling network devices and exercising automation responses.
+    [Device telemetry](network-device-telemetry.md) covers routers, switches,
+    and link cascades; [automation testing](network-automation-testing.md)
+    covers remediation flows that react to those alerts.
 
-- [**Pipeline validation**](pipeline-validation.md) -- smoke-testing relabel rules,
-  encoder switches, and routing changes.
-- [**Synthetic monitoring**](synthetic-monitoring.md) -- always-on `sonda-server` in
-  Kubernetes for blackbox-style probes.
-- [**Capacity planning**](capacity-planning.md) -- sizing a backend before you cut
-  over real traffic.
-- [**E2E testing**](e2e-testing.md) -- the canonical start-stack, push, query loop
-  with VictoriaMetrics, Loki, Kafka, and OTLP.
+-   :material-database-import: __[Importing real data](csv-import.md)__
 
-## Network telemetry
+    Turning recorded series into reusable scenarios.
+    [CSV import](csv-import.md) detects patterns and generates portable YAML;
+    [Grafana CSV replay](grafana-csv-replay.md) reproduces the original series
+    bit-for-bit.
 
-Modeling network devices and validating automation responses.
+-   :material-tools: __[Troubleshooting](troubleshooting.md)__
 
-- [**Network device telemetry**](network-device-telemetry.md) -- routers, switches,
-  interface counters, link failover cascades.
-- [**Network automation testing**](network-automation-testing.md) -- exercising
-  remediation flows that react to network alerts.
+    Diagnostics for connection refused, empty backends, schema mismatches, and
+    the `localhost` trap.
 
-## Importing real data
-
-Turning recorded series into reusable scenarios.
-
-- [**CSV import**](csv-import.md) -- `sonda import` for pattern detection and
-  scenario generation from CSV.
-- [**Grafana CSV replay**](grafana-csv-replay.md) -- the `csv_replay` generator for
-  bit-for-bit reproduction.
-
-## Troubleshooting
-
-- [**Troubleshooting**](troubleshooting.md) -- diagnostics for connection refused,
-  empty backends, schema mismatches, and the `localhost` trap.
+</div>

--- a/docs/site/docs/guides/index.md
+++ b/docs/site/docs/guides/index.md
@@ -1,0 +1,89 @@
+# Guides
+
+Task-shaped pages: pick the one that matches what you are trying to do.
+
+The [**Tutorial**](tutorial.md) is the guided tour through every part of Sonda.
+The rest of this section is organized by what you are testing: alert rules,
+ingest pipelines, network telemetry, real-data replay, or operational scale.
+
+## Tutorial
+
+A seven-page walk through generators, encoders, sinks, log generation, scheduling,
+multi-scenario runs, and the Server API. Start here if you have just installed
+Sonda and want to see what every knob does.
+
+- [**Tutorial overview**](tutorial.md) -- the table of contents and what each page covers.
+
+## Catalog and packs
+
+Pre-built scenarios you can run instantly, and the building blocks that compose them.
+
+- [**Built-in Scenarios**](scenarios.md) -- the curated catalog. `sonda catalog list`
+  to browse, `sonda catalog run <name>` to launch.
+- [**Dynamic Labels**](dynamic-labels.md) -- per-event label values via `${...}`
+  placeholders driven by RNG, sequences, or pools.
+- [**Example Scenarios**](examples.md) -- the YAML files under `examples/` and what
+  each one demonstrates.
+- [**Metric Packs**](metric-packs.md) -- inline pack expansion inside `scenarios:`
+  for fan-out across instances, services, or paths.
+
+## Alert testing
+
+Triggering, resolving, and validating alert rules with the right metric shape.
+
+- [**Alert testing overview**](alert-testing.md) -- the entry point. Maps each alert
+  pattern to the right generator and sub-page.
+- [**Threshold and `for:` duration**](alert-testing-thresholds.md) -- sine, sequence,
+  and constant for crossing thresholds with predictable timing.
+- [**Resolution and recovery**](alert-testing-resolution.md) -- gap windows that
+  drop the metric so resolution fires.
+- [**Compound and correlated alerts**](alert-testing-correlation.md) -- `phase_offset`
+  and `clock_group` for `A AND B` rules.
+- [**Cardinality explosion alerts**](alert-testing-cardinality.md) -- `cardinality_spikes`
+  for series-count guardrails.
+- [**Replaying recorded incidents**](alert-testing-replay.md) -- `sequence` for short
+  patterns, `csv_replay` for production exports.
+- [**Histogram and summary alerts**](histogram-alerts.md) -- bucket-based and
+  quantile-based latency alerts.
+- [**Recording rules**](recording-rules.md) -- pushing known constants to verify
+  computed outputs.
+- [**Alerting pipeline**](alerting-pipeline.md) -- end-to-end with vmalert,
+  Alertmanager, and a webhook receiver.
+- [**CI alert validation**](ci-alert-validation.md) -- catching broken rules in CI
+  before they reach production.
+
+## Pipelines and scale
+
+Validating ingest changes, capacity, and end-to-end backend behavior.
+
+- [**Pipeline validation**](pipeline-validation.md) -- smoke-testing relabel rules,
+  encoder switches, and routing changes.
+- [**Synthetic monitoring**](synthetic-monitoring.md) -- always-on `sonda-server` in
+  Kubernetes for blackbox-style probes.
+- [**Capacity planning**](capacity-planning.md) -- sizing a backend before you cut
+  over real traffic.
+- [**E2E testing**](e2e-testing.md) -- the canonical start-stack, push, query loop
+  with VictoriaMetrics, Loki, Kafka, and OTLP.
+
+## Network telemetry
+
+Modeling network devices and validating automation responses.
+
+- [**Network device telemetry**](network-device-telemetry.md) -- routers, switches,
+  interface counters, link failover cascades.
+- [**Network automation testing**](network-automation-testing.md) -- exercising
+  remediation flows that react to network alerts.
+
+## Importing real data
+
+Turning recorded series into reusable scenarios.
+
+- [**CSV import**](csv-import.md) -- `sonda import` for pattern detection and
+  scenario generation from CSV.
+- [**Grafana CSV replay**](grafana-csv-replay.md) -- the `csv_replay` generator for
+  bit-for-bit reproduction.
+
+## Troubleshooting
+
+- [**Troubleshooting**](troubleshooting.md) -- diagnostics for connection refused,
+  empty backends, schema mismatches, and the `localhost` trap.

--- a/docs/site/docs/guides/network-device-telemetry.md
+++ b/docs/site/docs/guides/network-device-telemetry.md
@@ -1,9 +1,19 @@
 # Network Device Telemetry
 
-You are building dashboards and alerts for network infrastructure -- routers, switches, firewalls --
-and you need realistic test data. SNMP polling intervals, interface counter wraps, link flaps, and
-traffic redistribution are hard to simulate in a lab. Sonda lets you model a network device with
-multiple interfaces and generate correlated metrics that behave like the real thing.
+You inherit a snmp_exporter dashboard for a 200-router fleet. The PR that introduces
+a new "Top Talkers" panel and an `InterfaceErrorBurst` alert needs to ship Monday.
+The lab has two routers and a port-channel that never flaps. The interesting cases --
+a 32-bit counter wrapping at peak traffic, a primary uplink dropping while the backup
+saturates, BGP sessions toggling between Established and Idle -- are exactly the
+shapes neither lab will produce on demand. Asking netops to break a production link
+to test your dashboard is not a strategy.
+
+Sonda models each interface as its own metric stream with the labels snmp_exporter
+emits (`device`, `ifName`, `ifAlias`, `job=snmp`), then composes them into a scenario
+that recreates the failure cascade you cannot trigger in the lab. PromQL written
+against the synthetic data is the same PromQL you ship: `rate(interface_in_octets[1m])`
+behaves the same way against a sawtooth-modeled counter as it does against a real
+SNMP poll. The dashboard you tune against this scenario is the dashboard you ship.
 
 This guide walks you through modeling a router with multiple uplinks, generating SNMP-style
 metrics, simulating a link failure cascade, and validating your PromQL queries against the

--- a/docs/site/docs/guides/pipeline-validation.md
+++ b/docs/site/docs/guides/pipeline-validation.md
@@ -1,8 +1,15 @@
 # Pipeline Validation
 
-You changed your ingest pipeline, added an encoder, or modified a routing rule. How do you know
-nothing broke? Sonda gives you a fast, repeatable way to push known data through your pipeline
-and verify it arrives correctly at the other end.
+You shipped a one-line change to a vmagent relabel rule on Friday. By Monday morning,
+half the dashboards for `service=payments` are blank. The metrics still arrive, the
+counts are normal -- but the rule rewrote `service` to lowercase and the dashboards
+filter for `Payments`. Nothing in your pipeline noticed: the data flowed, the writes
+succeeded, the only thing that broke was the contract with downstream consumers.
+
+This is the gap CI is supposed to catch. Sonda fills it by giving you a known input
+on one end of the pipeline and a check at the other end -- exit code, line count,
+backend query -- so any rewrite, drop, or schema drift surfaces as a failed step
+before it reaches the dashboards.
 
 ---
 

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -49,6 +49,9 @@ markdown_extensions:
         - docs/site/docs
       auto_append:
         - includes/abbreviations.md
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - attr_list
   - md_in_html
   - toc:

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Configuration:
+    - configuration/index.md
     - Scenario Fields: configuration/scenario-fields.md
     - v2 Scenario Files: configuration/v2-scenarios.md
     - Generators: configuration/generators.md
@@ -66,13 +67,15 @@ nav:
     - Sink Batching: configuration/sink-batching.md
     - CLI Reference: configuration/cli-reference.md
   - Deployment:
+    - deployment/index.md
     - Endpoints & networking: deployment/endpoints.md
     - Docker: deployment/docker.md
     - Kubernetes: deployment/kubernetes.md
     - Server API: deployment/sonda-server.md
   - Guides:
+    - guides/index.md
     - Tutorial:
-      - Overview: guides/tutorial.md
+      - guides/tutorial.md
       - Generators: guides/tutorial-generators.md
       - Encoders: guides/tutorial-encoders.md
       - Sinks: guides/tutorial-sinks.md


### PR DESCRIPTION
## Summary

Three engagement-polish moves for the conference talk's onramp. Bundle of medium lifts #5, #7, and section landing pages from the prior reference-site research.

### Story-led guide intros (4 pages)

Each opens with a concrete failure narrative *before* the existing abstract intro. A reader scrolling to top knows in 60 seconds why to keep reading.

- **`alert-testing.md`** — 3 a.m. page for `HighRequestLatency` clears before login (90s spike inside `for: 5m`). Frames the page as "the alert is doing exactly what you told it to. You just told it the wrong thing."
- **`pipeline-validation.md`** — Friday vmagent relabel lowercases `service=Payments` and silently blanks dashboards by Monday. Frames pipeline validation as catching contract drift, not delivery.
- **`csv-import.md`** — postmortem CSV in a Drive folder, unreproducible in CI. Frames `sonda import` as turning that artifact into a checked-in scenario.
- **`network-device-telemetry.md`** — 200-router fleet failure modes (counter wrap, link failover, BGP flap) you can't break in prod. Frames the guide as recreating cascades you can't reproduce safely.

### Section landing pages

Activates `navigation.indexes` shipped in #277 — sidebar section headers become clickable. Each landing page is a useful map (orientation paragraph + categorized index with one-liners), not filler.

- `configuration/index.md` — scopes the section as "every knob, with the exact field name or default" + 3 categories
- `deployment/index.md` — three runtimes by who drives the scenarios + start-here pointer to the localhost trap
- `guides/index.md` — 6 categories matching nav (Tutorial, Catalog, Alert testing, Pipelines, Network telemetry, Importing) with one-liner per page
- Tutorial promoted to bare-path nav entry (no new file needed; `guides/tutorial.md` already existed)

### Generator chooser table

Two 4-column tables (`Generator | Use case | Shape | Key fields`) at the top of `configuration/generators.md` — one for core generators, one for operational aliases. A chooser picks a generator without scrolling through every variant.

## Test plan

- [x] `task site:build` strict — zero warnings, zero broken anchor refs
- [x] All 4 story-leads render BEFORE the existing intro `<h2>` — UAT verified line numbers in rendered HTML
- [x] Configuration / Deployment / Guides section headers render as clickable `<a>` in left rail
- [x] Generator tables render at the top of `configuration/generators.md`, before `## Metric generators`
- [x] No regressions on neighboring pages (`endpoints.md`, `sink-batching.md`, `troubleshooting.md`)
- [x] Voice matches the recently-trimmed anchor pages — terse, no architectural narration
- [x] Live preview verification on the deploy preview after merge

## Audit-fodder (deferred)

* Tutorial-generators.md narrower table left in place — intentionally narrower for tutorial audience; consolidation could be a future pass but two tables for two audiences is fine.
* No editorial expansion of landing pages beyond the 1-2 paragraph orientation — voice calibration trumped fancier landing-page formats from the reference site.