### PR TITLE
fix(examples): bump otel-collector to 0.150.1 + migrate loki exporter (closes #272)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/examples/docker-compose-victoriametrics.yml
+++ b/examples/docker-compose-victoriametrics.yml
@@ -395,7 +395,7 @@ services:
   # This service is only started with --profile otel-collector.
   # ---------------------------------------------------------------------------
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.116.1
+    image: otel/opentelemetry-collector-contrib:0.150.1
     profiles: [otel-collector]
     command: ["--config=/etc/otel-collector-config.yaml"]
     ports:

--- a/examples/otel-collector/config.yaml
+++ b/examples/otel-collector/config.yaml
@@ -43,8 +43,11 @@ exporters:
     endpoint: http://victoriametrics:8428/api/v1/write
     tls:
       insecure: true
-  loki:
-    endpoint: http://loki:3100/loki/api/v1/push
+  # Loki gained native OTLP support, and the standalone `loki` exporter was
+  # removed from the contrib distribution after v0.130. Use `otlphttp` against
+  # Loki's `/otlp` endpoint instead.
+  otlp_http/loki:
+    endpoint: http://loki:3100/otlp
     retry_on_failure:
       enabled: false
     sending_queue:
@@ -62,4 +65,4 @@ service:
     logs:
       receivers: [otlp]
       processors: [batch, resource]
-      exporters: [loki, debug]
+      exporters: [otlp_http/loki, debug]


### PR DESCRIPTION
## Summary

Closes #272 (the deferred Dependabot bump). Fresh fix branch on top of current main since the original Dependabot PR was stale (predated the env-var interpolation, landing pages, and 7 other Dependabot merges).

**Root cause** — the `loki` exporter was **removed** from the OTel Collector contrib distribution after v0.130. Loki gained native OTLP support, so the standalone exporter became redundant.

The bump to v0.150.1 surfaced cleanly via our live-infra UAT readiness probe:

```
Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):
'exporters' unknown type: "loki" for id: "loki" (valid values: [opensearch otelarrow otlp_grpc otlp_http loadbalancing prometheus rabbitmq syslog ...])
```

(Validates the live-infra UAT investment — this is exactly what it was built to catch.)

## Changes

- `examples/otel-collector/config.yaml` — replace `loki:` exporter with `otlp_http/loki:` pointing at Loki's `/otlp` endpoint. Also use the canonical `otlp_http` name (the `otlphttp` alias prints a deprecation warning on v0.150).
- `examples/docker-compose-victoriametrics.yml` — bump image `0.116.1 → 0.150.1`.
- `Cargo.lock` — sync workspace versions `1.1.0 → 1.2.0` (release-please drift from PR #268 / #272-precedent).

## Verification

Local boot test on v0.150.1 with the new config:

```
healthcheck/handler.go: Health Check state change ... "status": "ready"
service/service.go: Everything is ready. Begin running and processing data.

$ curl -sf -o /dev/null -w "HTTP %{http_code}\n" http://localhost:14133/
HTTP 200
```

No warnings, no errors. The endpoint the live-infra UAT polls (`:13133/`) returns 200.

## Test plan

- [x] Local boot of `otel/opentelemetry-collector-contrib:0.150.1` with the new config — clean start, `health_check status: ready`, `Everything is ready`
- [x] `curl :13133/` returns HTTP 200 (the live-infra UAT's exact probe)
- [x] No deprecation warnings (`otlp_http` not `otlphttp`)
- [x] No user-facing docs reference the OTel `loki` exporter (sonda has its own `loki` sink which is unrelated)
- [ ] CI live-infra UAT confirms in the GHA matrix