### PR TITLE
chore(deps): clear cargo audit warnings 5 → 1 (closes #209)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,14 @@
+[advisories]
+# RUSTSEC-2026-0105 — `core2` is unmaintained (and all versions yanked).
+#
+# `core2 0.4.0` is pulled in transitively via:
+#   sonda-core (kafka feature) -> rskafka 0.6.0 -> rsasl 2.2.1 -> core2 0.4.0
+#
+# rskafka 0.6.0 is the latest published version; rsasl 2.2.1 is the latest
+# rsasl release. There is no upstream bump available to remove the dep.
+# Re-evaluate when a new rskafka release lands. Tracked in issue #209.
+#
+# The companion `yanked` warning for the same crate is intentionally left
+# visible (cargo-audit has no per-crate yanked silencing) — same root cause,
+# same justification, surfaces the same actionable signal in CI logs.
+ignore = ["RUSTSEC-2026-0105"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -463,7 +463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1018,7 +1018,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1221,7 +1221,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1439,7 +1439,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1488,9 +1488,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1499,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1653,7 +1653,7 @@ dependencies = [
  "digest",
  "hmac",
  "pbkdf2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -1673,7 +1673,7 @@ dependencies = [
  "futures",
  "integer-encoding",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsasl",
  "rustls",
  "thiserror 1.0.69",
@@ -1736,7 +1736,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1768,15 +1768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,7 +1795,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2042,12 +2033,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "sonda"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2063,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2073,7 +2064,7 @@ dependencies = [
  "rskafka",
  "rstest",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -2088,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2199,7 +2190,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2818,7 +2809,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 default = ["config"]
 config = ["dep:serde_yaml_ng"]
 http = ["dep:ureq"]
-kafka = ["dep:rskafka", "dep:tokio", "dep:chrono", "dep:rustls", "dep:rustls-pemfile", "dep:webpki-roots"]
+kafka = ["dep:rskafka", "dep:tokio", "dep:chrono", "dep:rustls", "dep:rustls-pki-types", "dep:webpki-roots"]
 remote-write = ["dep:prost", "dep:snap", "dep:ureq"]
 otlp = ["dep:tonic", "dep:prost", "dep:tokio", "dep:bytes", "dep:http"]
 
@@ -29,7 +29,7 @@ rskafka = { version = "0.6.0", default-features = false, features = ["transport-
 tokio = { version = "1", features = ["rt", "net", "time", "macros"], optional = true }
 chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"], optional = true }
-rustls-pemfile = { version = "2", optional = true }
+rustls-pki-types = { version = "1", features = ["std"], optional = true }
 webpki-roots = { version = "1", optional = true }
 prost = { version = "0.14", optional = true }
 snap = { version = "1", optional = true }

--- a/sonda-core/src/sink/kafka.rs
+++ b/sonda-core/src/sink/kafka.rs
@@ -34,6 +34,7 @@ use rskafka::{
     },
     record::Record,
 };
+use rustls_pki_types::pem::PemObject;
 use tokio::runtime::Runtime;
 
 use crate::sink::retry::RetryPolicy;
@@ -97,7 +98,7 @@ fn build_rustls_config(ca_cert: Option<&str>) -> Result<rustls::ClientConfig, So
                 ))
             })?;
 
-            let certs: Vec<_> = rustls_pemfile::certs(&mut pem_data.as_slice())
+            let certs: Vec<_> = rustls_pki_types::CertificateDer::pem_slice_iter(&pem_data)
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| {
                     SondaError::Sink(std::io::Error::new(


### PR DESCRIPTION
## Summary

Closes #209 — the 4 pre-existing `cargo audit` warnings (now 5 with a fresh `core2` advisory landed since the issue was filed) brought down to 1 documented residual.

## Changes

| Warning | Resolution |
|---|---|
| `rand 0.9.2` — RUSTSEC-2026-0097 (unsound) | `cargo update -p rand@0.9.2 --precise 0.9.3` |
| `rand 0.8.5` — RUSTSEC-2026-0097 (unsound) | `cargo update -p rand@0.8.5` (→ 0.8.6) |
| `rustls-pemfile 2.2.0` — RUSTSEC-2025-0134 (unmaintained) | Migrate sonda-core kafka sink to `rustls-pki-types::CertificateDer::pem_slice_iter`. Drop the direct dep from `sonda-core/Cargo.toml`; replace with `rustls-pki-types` (already in our tree as a rustls transitive) under the `kafka` feature. |
| `core2 0.4.0` — RUSTSEC-2026-0105 (unmaintained) | Audited ignore in `.cargo/audit.toml` with rationale — transitive via rskafka 0.6.0 → rsasl 2.2.1; both at latest published version, no upstream bump path. Re-evaluate on next rskafka release. |
| `core2 0.4.0` — yanked (companion warning) | Intentionally left visible. cargo-audit has no per-crate yanked silencing, and the warning surfaces the same actionable signal — same root cause as the documented unmaintained ignore. |

## Test plan

- [x] `cargo audit` — 5 warnings → 1 (the residual yanked side-warning)
- [x] `cargo build --workspace --all-features` ✅
- [x] `cargo clippy --workspace -- -D warnings` ✅
- [x] `cargo clippy --workspace --all-features -- -D warnings` ✅
- [x] `cargo fmt --all -- --check` ✅
- [x] `cargo test -p sonda-core --features kafka --lib sink::kafka` — 27 passed, 0 failed (including `build_tls_config_with_valid_ca_cert_succeeds` which exercises the migrated cert-loading path)
- [ ] CI

## Audit-fodder

* When a new `rskafka` release lands (currently 0.6.0 is latest), drop the `.cargo/audit.toml` ignore. The `rsasl 2.2.1` chain that pulls `core2` should clear at the same time.