### PR TITLE
fix(sinks): lower default batch_size for remote_write/loki/otlp_grpc 100 → 5

### DIFF
--- a/docs/site/docs/configuration/sink-batching.md
+++ b/docs/site/docs/configuration/sink-batching.md
@@ -23,9 +23,9 @@ Sonda has two kinds of batching depending on the sink type:
 | `udp` | None (immediate) | -- | -- | -- |
 | `http_push` | Application-level | 4 KiB | Yes | bytes |
 | `kafka` | Application-level | 64 KiB | No | bytes |
-| `loki` | Application-level | 100 entries | Yes | entries |
-| `remote_write` | Application-level | 100 entries | Yes | entries |
-| `otlp_grpc` | Application-level | 100 entries | Yes | entries |
+| `loki` | Application-level | 5 entries | Yes | entries |
+| `remote_write` | Application-level | 5 entries | Yes | entries |
+| `otlp_grpc` | Application-level | 5 entries | Yes | entries |
 
 ### OS-level buffering (stdout, file, tcp)
 
@@ -75,40 +75,40 @@ Four sinks let you tune the batch threshold via the `batch_size` field in the si
 
 === "remote_write"
 
-    `batch_size` is in **TimeSeries entries**. Default: `100`.
+    `batch_size` is in **TimeSeries entries**. Default: `5`.
 
-    ```yaml title="Smaller remote write batches"
+    ```yaml title="Larger remote write batches for high-rate scenarios"
     encoder:
       type: remote_write
     sink:
       type: remote_write
       url: "http://localhost:8428/api/v1/write"
-      batch_size: 10  # flush every 10 time series
+      batch_size: 100  # fewer requests at thousands of events/s
     ```
 
 === "loki"
 
-    `batch_size` is in **log entries**. Default: `100`.
+    `batch_size` is in **log entries**. Default: `5`.
 
-    ```yaml title="Smaller Loki batches"
+    ```yaml title="Larger Loki batches for high-rate scenarios"
     sink:
       type: loki
       url: "http://localhost:3100"
-      batch_size: 20  # flush every 20 log lines
+      batch_size: 100  # fewer requests at thousands of events/s
     ```
 
 === "otlp_grpc"
 
-    `batch_size` is in **data points / log records**. Default: `100`.
+    `batch_size` is in **data points / log records**. Default: `5`.
 
-    ```yaml title="Smaller OTLP batches"
+    ```yaml title="Larger OTLP batches for high-rate scenarios"
     encoder:
       type: otlp
     sink:
       type: otlp_grpc
       endpoint: "http://localhost:4317"
       signal_type: metrics
-      batch_size: 10  # flush every 10 data points
+      batch_size: 100  # fewer requests at thousands of events/s
     ```
 
 ??? tip "Choosing a batch size"

--- a/docs/site/docs/configuration/sinks.md
+++ b/docs/site/docs/configuration/sinks.md
@@ -146,7 +146,7 @@ HTTP POSTs with the correct protocol headers.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `url` | string | yes | -- | Remote write endpoint URL. |
-| `batch_size` | integer | no | `100` | Flush threshold in number of TimeSeries entries. |
+| `batch_size` | integer | no | `5` | Flush threshold in number of TimeSeries entries. Raise for high-rate scenarios. |
 
 ```yaml title="Remote write sink"
 encoder:
@@ -154,7 +154,7 @@ encoder:
 sink:
   type: remote_write
   url: "http://localhost:8428/api/v1/write"
-  batch_size: 100
+  batch_size: 5
 ```
 
 **CLI equivalent** -- use `--encoder remote_write --sink remote_write --endpoint`:
@@ -368,7 +368,7 @@ labels are used as Loki stream labels in the push API envelope.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `url` | string | yes | -- | Base URL of the Loki instance. |
-| `batch_size` | integer | no | `100` | Flush threshold in number of log entries. |
+| `batch_size` | integer | no | `5` | Flush threshold in number of log entries. Raise for high-rate scenarios. |
 
 ```yaml title="Loki sink with top-level labels"
 version: 2
@@ -414,7 +414,7 @@ an `ExportMetricsServiceRequest` or `ExportLogsServiceRequest` and sends via gRP
 |-----------|------|----------|---------|-------------|
 | `endpoint` | string | yes | -- | gRPC endpoint URL of the OTEL Collector (e.g. `"http://localhost:4317"`). |
 | `signal_type` | string | yes | -- | `"metrics"` or `"logs"` -- must match the scenario signal type. |
-| `batch_size` | integer | no | `100` | Flush threshold in number of data points or log records. |
+| `batch_size` | integer | no | `5` | Flush threshold in number of data points or log records. Raise for high-rate scenarios. |
 
 ```yaml title="OTLP gRPC sink (metrics)"
 encoder:
@@ -423,7 +423,7 @@ sink:
   type: otlp_grpc
   endpoint: "http://localhost:4317"
   signal_type: metrics
-  batch_size: 100
+  batch_size: 5
 ```
 
 ```yaml title="OTLP gRPC sink (logs)"

--- a/sonda-core/src/sink/loki.rs
+++ b/sonda-core/src/sink/loki.rs
@@ -22,6 +22,9 @@ use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
 use crate::SondaError;
 
+/// Default batch size in entries — sized so low-rate scenarios flush within seconds.
+pub const DEFAULT_BATCH_SIZE: usize = 5;
+
 /// Delivers encoded log lines to Grafana Loki via its HTTP push API.
 ///
 /// Log lines are accumulated in a batch. When the batch reaches `batch_size` entries,
@@ -908,28 +911,31 @@ batch_size: 50
     }
 
     #[test]
-    fn create_sink_loki_uses_default_batch_size_of_100_when_none() {
-        // We can't inspect the internal batch_size directly, but we can verify
-        // construction succeeds (batch_size=100 is valid) and write 99 lines
-        // without triggering a flush (no server running → would fail if it tried).
+    fn default_batch_size_is_5() {
+        assert_eq!(DEFAULT_BATCH_SIZE, 5);
+    }
+
+    #[test]
+    fn create_sink_loki_with_no_batch_size_uses_default() {
+        // Construction succeeds with `batch_size: None`; writing fewer entries
+        // than DEFAULT_BATCH_SIZE must not trigger a flush attempt against the
+        // non-existent server.
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
-        drop(listener); // No server — any HTTP call would fail.
+        drop(listener);
 
         let url = format!("http://127.0.0.1:{port}");
         let config = SinkConfig::Loki {
             url,
-            batch_size: None, // should default to 100
+            batch_size: None,
             retry: None,
         };
         let mut sink = create_sink(&config, None).expect("factory ok");
 
-        // Write 99 lines — must not trigger a flush (no server running).
-        for i in 0..99u32 {
+        for i in 0..(DEFAULT_BATCH_SIZE - 1) as u32 {
             sink.write(format!("line {i}\n").as_bytes())
                 .expect("write must succeed below batch_size");
         }
-        // If we reach here without an error, batch_size defaults to ≥ 100.
     }
 
     #[test]

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -412,7 +412,7 @@ pub fn create_sink(
             batch_size,
             retry: retry_cfg,
         } => {
-            let bs = batch_size.unwrap_or(100);
+            let bs = batch_size.unwrap_or(loki::DEFAULT_BATCH_SIZE);
             let loki_labels = labels.cloned().unwrap_or_default();
             let rp = retry_cfg
                 .as_ref()

--- a/sonda-core/src/sink/otlp_grpc.rs
+++ b/sonda-core/src/sink/otlp_grpc.rs
@@ -36,8 +36,8 @@ use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
 use crate::SondaError;
 
-/// Default batch size in data point / log record entries (not bytes).
-pub const DEFAULT_BATCH_SIZE: usize = 100;
+/// Default batch size in data point / log record entries — sized so low-rate scenarios flush within seconds.
+pub const DEFAULT_BATCH_SIZE: usize = 5;
 
 /// The gRPC service path for the OTLP metrics export RPC.
 const METRICS_EXPORT_PATH: &str = "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export";
@@ -487,8 +487,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn default_batch_size_is_100() {
-        assert_eq!(DEFAULT_BATCH_SIZE, 100);
+    fn default_batch_size_is_5() {
+        assert_eq!(DEFAULT_BATCH_SIZE, 5);
     }
 
     // -----------------------------------------------------------------------

--- a/sonda-core/src/sink/remote_write.rs
+++ b/sonda-core/src/sink/remote_write.rs
@@ -23,8 +23,8 @@ use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
 use crate::{EncoderError, SondaError};
 
-/// Default batch size in TimeSeries entries (not bytes).
-pub const DEFAULT_BATCH_SIZE: usize = 100;
+/// Default batch size in TimeSeries entries — sized so low-rate scenarios flush within seconds.
+pub const DEFAULT_BATCH_SIZE: usize = 5;
 
 /// Delivers metric events to a Prometheus remote write endpoint.
 ///


### PR DESCRIPTION
## Summary

Mirrors the `http_push` fix from PR #267 (64 KiB → 4 KiB) for the three remaining application-level batched sinks. **CRITICAL workshop-unblocking fix** — discovered during AutoCon5 workshop validation (workshops/notes/sonda-bug-report-2026-04-27.md, "Issue 1").

## The bug

`remote_write` / `loki` / `otlp_grpc` shipped with `DEFAULT_BATCH_SIZE = 100 entries`. The sink only POSTs when `batch.len() >= batch_size`, so:

- `rate: 0.1/s` → 1000 seconds (16.7 min) before first flush
- `rate: 1.0/s` → 100 seconds before first flush
- pack-expanded scenarios are worse — each pack metric becomes its own entry with its own sink instance and its own independent 100-entry buffer

The `[progress]` counter shows events that arrived at `sink.write()` (bytes encoded into the sink's buffer), **not** events flushed over the wire. So users see healthy event counts climbing while their backend stays empty.

## Root cause

```
sink.write(buf)?           // appends to internal Vec<TimeSeries>
if batch.len() >= 100 {    // <-- threshold rarely hit at low rates
    self.send_batch()?;
}
```

`flush()` only fires on `duration` end or scenario shutdown — never during steady-state long-running ops.

## The fix

Lower `DEFAULT_BATCH_SIZE` from 100 → 5 across all three sinks. Matches the `http_push` fix's UX bar: low-rate demo / CI scenarios see data within seconds. High-rate users (≥1000 events/s) override explicitly via the existing `batch_size` field.

## Live verification

Same scenario shape (rate=1/s, no batch_size override, 30s run, real Prometheus):

| | Pre-fix | Post-fix |
|---|---|---|
| Events into encoder | 30 | 5+ batched per flush |
| Events in Prometheus | **0** | **5 series visible at t+5s** |

## Test plan

- [x] `cargo build --workspace --all-features` ✅
- [x] `cargo test --workspace` — 1717+ tests pass (renamed `default_batch_size_is_100` → `default_batch_size_is_5` for both `loki` + `otlp_grpc`; rewrote `create_sink_loki_uses_default_batch_size_of_100_when_none` to use the new constant and write `(DEFAULT_BATCH_SIZE - 1)` lines)
- [x] `cargo clippy --workspace --all-features -- -D warnings` ✅
- [x] `cargo fmt --all -- --check` ✅
- [x] **Live repro**: 30s `cargo run -p sonda --release -- run --scenario` against real Prometheus v3.11.2 with remote_write enabled — metric `post_fix_metric` appears with value 99 at t+5s
- [x] Docs updated: `configuration/sinks.md` + `configuration/sink-batching.md` reflect the new `5` default
- [ ] CI

## Workshop band-aid that this PR replaces

For users on shipped 1.2.1, the workaround is to explicitly set `batch_size: 1` in `defaults.sink`. With this PR merged + 1.2.2 published, the workaround is no longer needed.

## Related

- PR #267 — same fix for `http_push` (64 KiB → 4 KiB)
- Issue #266 — complementary `flush_interval` time-based flush, tracked separately
- The workshops/AutoCon5 bug report has a longer trail: `~/projects/workshops/notes/sonda-bug-report-2026-04-27.md` (Issue 1)