### PR TITLE
fix(server): resolve packs from SONDA_PACK_PATH + scrape endpoint returns 200, not 204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,6 +2093,7 @@ dependencies = [
  "serde_yaml_ng",
  "sonda-core",
  "subtle",
+ "tempfile",
  "tokio",
  "tower",
  "tower-http",

--- a/sonda-server/Cargo.toml
+++ b/sonda-server/Cargo.toml
@@ -44,3 +44,4 @@ http-body-util = "0.1"
 hyper = "1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls"] }
 libc = "0.2"
+tempfile = "3"

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -4,6 +4,7 @@
 //! stopped over HTTP. All scenario lifecycle logic is delegated to sonda-core.
 
 mod auth;
+mod packs;
 mod routes;
 mod state;
 
@@ -106,7 +107,8 @@ async fn main() -> anyhow::Result<()> {
         info!("API key authentication disabled — all endpoints are public");
     }
 
-    let state = AppState::with_api_key(api_key);
+    let pack_resolver = packs::load_pack_resolver(&packs::build_search_path());
+    let state = AppState::with_packs(api_key, pack_resolver);
     let app = routes::router(state.clone());
 
     let listener = tokio::net::TcpListener::bind(bind_addr)

--- a/sonda-server/src/packs.rs
+++ b/sonda-server/src/packs.rs
@@ -1,0 +1,158 @@
+//! Filesystem-based metric pack loading for `sonda-server`.
+//!
+//! Mirrors the CLI's `SONDA_PACK_PATH` semantics: colon-separated dirs, each
+//! containing `*.yaml` / `*.yml` pack definitions. Parsed eagerly at startup
+//! into an [`InMemoryPackResolver`] so every `POST /scenarios` body can
+//! resolve `pack: <name>` references without filesystem access on the hot path.
+
+use std::path::{Path, PathBuf};
+
+use sonda_core::compiler::expand::InMemoryPackResolver;
+use sonda_core::packs::MetricPackDef;
+use tracing::{info, warn};
+
+/// Build the search path from `SONDA_PACK_PATH` (colon-separated). Empty when
+/// the variable is unset.
+pub fn build_search_path() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(env_val) = std::env::var("SONDA_PACK_PATH") {
+        for segment in env_val.split(':') {
+            let trimmed = segment.trim();
+            if !trimmed.is_empty() {
+                dirs.push(PathBuf::from(trimmed));
+            }
+        }
+    }
+    dirs
+}
+
+/// Load every `*.yaml` / `*.yml` file under `search_path` and register it in a
+/// fresh [`InMemoryPackResolver`].
+///
+/// Each pack is registered under two keys:
+/// - the pack's own `name` field (e.g. `srlinux_gnmi_bgp`), and
+/// - the file stem (e.g. `srlinux-gnmi-bgp.yaml` -> `srlinux-gnmi-bgp`).
+///
+/// Non-existent dirs and unreadable files emit a warning and are skipped. Name
+/// collisions across tiers are first-match-wins.
+pub fn load_pack_resolver(search_path: &[PathBuf]) -> InMemoryPackResolver {
+    let mut resolver = InMemoryPackResolver::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut count = 0usize;
+
+    for dir in search_path {
+        if !dir.is_dir() {
+            continue;
+        }
+        let read_dir = match std::fs::read_dir(dir) {
+            Ok(rd) => rd,
+            Err(e) => {
+                warn!(dir = %dir.display(), error = %e, "cannot read pack directory");
+                continue;
+            }
+        };
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let ext = path.extension().and_then(|e| e.to_str());
+            if ext != Some("yaml") && ext != Some("yml") {
+                continue;
+            }
+            match load_one(&path) {
+                Ok((name, file_stem, pack)) => {
+                    if seen.insert(name.clone()) {
+                        resolver.insert(name, pack.clone());
+                    }
+                    if seen.insert(file_stem.clone()) {
+                        resolver.insert(file_stem, pack);
+                    }
+                    count += 1;
+                }
+                Err(e) => {
+                    warn!(path = %path.display(), error = %e, "skipping pack file");
+                }
+            }
+        }
+    }
+
+    if count > 0 {
+        info!(packs_loaded = count, "loaded pack definitions");
+    }
+    resolver
+}
+
+fn load_one(path: &Path) -> Result<(String, String, MetricPackDef), String> {
+    let yaml = std::fs::read_to_string(path).map_err(|e| format!("read failed: {e}"))?;
+    let pack: MetricPackDef =
+        serde_yaml_ng::from_str(&yaml).map_err(|e| format!("YAML parse failed: {e}"))?;
+    let file_stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+        .unwrap_or_default();
+    Ok((pack.name.clone(), file_stem, pack))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sonda_core::compiler::expand::PackResolver;
+    use tempfile::TempDir;
+
+    fn write_pack(dir: &Path, filename: &str, name: &str) {
+        let body = format!(
+            "name: {name}\ndescription: t\ncategory: test\nmetrics:\n  - name: m\n    generator: {{ type: constant, value: 1.0 }}\n"
+        );
+        std::fs::write(dir.join(filename), body).expect("write pack");
+    }
+
+    #[test]
+    fn build_search_path_empty_when_unset() {
+        // SAFETY: test-only env mutation; var is unique-to-sonda namespace.
+        unsafe {
+            std::env::remove_var("SONDA_PACK_PATH");
+        }
+        assert!(build_search_path().is_empty());
+    }
+
+    #[test]
+    fn load_resolver_registers_pack_under_name_and_file_stem() {
+        let dir = TempDir::new().expect("tmpdir");
+        write_pack(dir.path(), "srlinux-gnmi-bgp.yaml", "srlinux_gnmi_bgp");
+
+        let resolver = load_pack_resolver(&[dir.path().to_path_buf()]);
+
+        // Both keys resolve to the same pack.
+        assert!(resolver.resolve("srlinux_gnmi_bgp").is_ok());
+        assert!(resolver.resolve("srlinux-gnmi-bgp").is_ok());
+    }
+
+    #[test]
+    fn load_resolver_skips_non_yaml_and_missing_dirs() {
+        let dir = TempDir::new().expect("tmpdir");
+        std::fs::write(dir.path().join("README.md"), "ignored").expect("md");
+        write_pack(dir.path(), "real_pack.yaml", "real_pack");
+
+        let missing = dir.path().join("does-not-exist");
+        let resolver = load_pack_resolver(&[missing, dir.path().to_path_buf()]);
+
+        assert!(resolver.resolve("real_pack").is_ok());
+    }
+
+    #[test]
+    fn load_resolver_first_match_wins_across_dirs() {
+        let a = TempDir::new().expect("tmpdir-a");
+        let b = TempDir::new().expect("tmpdir-b");
+        write_pack(a.path(), "p.yaml", "shared_name");
+        write_pack(b.path(), "p.yaml", "shared_name");
+
+        let resolver =
+            load_pack_resolver(&[a.path().to_path_buf(), b.path().to_path_buf()]);
+
+        // First-match-wins: only one registration succeeds; resolution still
+        // returns a pack.
+        assert!(resolver.resolve("shared_name").is_ok());
+    }
+}

--- a/sonda-server/src/packs.rs
+++ b/sonda-server/src/packs.rs
@@ -148,8 +148,7 @@ mod tests {
         write_pack(a.path(), "p.yaml", "shared_name");
         write_pack(b.path(), "p.yaml", "shared_name");
 
-        let resolver =
-            load_pack_resolver(&[a.path().to_path_buf(), b.path().to_path_buf()]);
+        let resolver = load_pack_resolver(&[a.path().to_path_buf(), b.path().to_path_buf()]);
 
         // First-match-wins: only one registration succeeds; resolution still
         // returns a pack.

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -276,15 +276,33 @@ enum ParsedBody {
 /// subset of YAML, so the transcoded text parses byte-for-byte identically
 /// to the equivalent hand-written YAML.
 ///
-/// The server has no filesystem pack catalog; pack references in posted
-/// scenarios are resolved against an empty [`InMemoryPackResolver`] and will
-/// surface as a compile error. Real pack delivery over HTTP is deferred to a
-/// future endpoint.
+/// Pack references (`pack: <name>`) are resolved against the server's startup
+/// pack catalog (loaded from `SONDA_PACK_PATH`). Bodies referencing a pack
+/// that is not in the catalog surface as a compile error with the missing
+/// pack name and the searched paths.
 ///
 /// Returns a descriptive error string on failure. The handler maps all
 /// failures to `400 Bad Request` because the server contract is "POST v2
 /// YAML/JSON"; anything else is ill-formed by contract.
-fn parse_body(body: &[u8], headers: &HeaderMap) -> Result<ParsedBody, String> {
+/// Walk the error source chain and join Display strings with `: `, so a 400
+/// response carries the failing pack name / search path detail instead of a
+/// bare `expand error`.
+fn format_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut out = err.to_string();
+    let mut cause: Option<&(dyn std::error::Error + 'static)> = err.source();
+    while let Some(c) = cause {
+        out.push_str(": ");
+        out.push_str(&c.to_string());
+        cause = c.source();
+    }
+    out
+}
+
+fn parse_body(
+    body: &[u8],
+    headers: &HeaderMap,
+    pack_resolver: &InMemoryPackResolver,
+) -> Result<ParsedBody, String> {
     let text = yaml_body_text(body, headers)?;
 
     let version = detect_version(&text);
@@ -292,9 +310,12 @@ fn parse_body(body: &[u8], headers: &HeaderMap) -> Result<ParsedBody, String> {
         return Err(format!("body is not a v2 scenario. {V1_REJECTION_HINT}"));
     }
 
-    let resolver = InMemoryPackResolver::new();
-    let entries = compile_scenario_file(&text, &resolver)
-        .map_err(|e| format!("v2 scenario body failed to compile: {e}"))?;
+    let entries = compile_scenario_file(&text, pack_resolver).map_err(|e| {
+        format!(
+            "v2 scenario body failed to compile: {}",
+            format_error_chain(&e)
+        )
+    })?;
 
     if entries.is_empty() {
         return Err("v2 scenario body produced zero entries".to_string());
@@ -515,7 +536,7 @@ pub async fn post_scenario(
     body: axum::body::Bytes,
 ) -> Result<Response, Response> {
     // 1. Parse the body, detecting single vs multi-scenario.
-    let parsed = parse_body(&body, &headers).map_err(|msg| {
+    let parsed = parse_body(&body, &headers, &state.pack_resolver).map_err(|msg| {
         warn!(error = %msg, "POST /scenarios: invalid request body");
         bad_request(msg)
     })?;
@@ -885,10 +906,11 @@ const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8"
 ///
 /// * `limit` — maximum number of events to return (default 100, max 1000).
 ///
-/// # Error responses
+/// # Responses
 ///
+/// * `200 OK` — Prometheus text exposition (possibly empty when no events
+///   are buffered between scrapes).
 /// * `404 Not Found` — scenario ID not found.
-/// * `204 No Content` — scenario exists but no metric events are buffered.
 pub async fn get_scenario_metrics(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -909,12 +931,13 @@ pub async fn get_scenario_metrics(
     // Drain recent metric events from the handle's stats buffer.
     let events = handle.recent_metrics();
 
-    if events.is_empty() {
-        return Ok(StatusCode::NO_CONTENT.into_response());
-    }
-
-    // Apply the limit: take at most `limit` events from the end (most recent).
-    let events_to_encode = if events.len() > limit {
+    // Empty buffer renders as `200 OK` with an empty Prometheus exposition,
+    // matching the contract Prometheus / vmagent / Telegraf scrapers expect.
+    // Returning 204 here breaks scrapers that use `curl --fail` or treat
+    // anything but 200 as an exposition error.
+    let events_to_encode: &[_] = if events.is_empty() {
+        &[]
+    } else if events.len() > limit {
         &events[events.len() - limit..]
     } else {
         &events
@@ -1977,8 +2000,12 @@ scenarios:
     fn parse_body_accepts_v2_metrics_yaml() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/x-yaml".parse().unwrap());
-        let parsed = parse_body(VALID_METRICS_YAML.as_bytes(), &headers)
-            .expect("v2 metrics body must parse");
+        let parsed = parse_body(
+            VALID_METRICS_YAML.as_bytes(),
+            &headers,
+            &InMemoryPackResolver::new(),
+        )
+        .expect("v2 metrics body must parse");
         match parsed {
             ParsedBody::Single(entry) => match *entry {
                 ScenarioEntry::Metrics(c) => assert_eq!(c.name, "test_metric"),
@@ -1993,8 +2020,12 @@ scenarios:
     fn parse_body_accepts_v2_logs_yaml() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/x-yaml".parse().unwrap());
-        let parsed =
-            parse_body(VALID_LOGS_YAML.as_bytes(), &headers).expect("v2 logs body must parse");
+        let parsed = parse_body(
+            VALID_LOGS_YAML.as_bytes(),
+            &headers,
+            &InMemoryPackResolver::new(),
+        )
+        .expect("v2 logs body must parse");
         match parsed {
             ParsedBody::Single(entry) => match *entry {
                 ScenarioEntry::Logs(c) => assert_eq!(c.name, "test_logs"),
@@ -2016,8 +2047,8 @@ generator:
   type: constant
   value: 1.0
 ";
-        let err =
-            parse_body(v1_yaml.as_bytes(), &headers).expect_err("v1 flat YAML must be rejected");
+        let err = parse_body(v1_yaml.as_bytes(), &headers, &InMemoryPackResolver::new())
+            .expect_err("v1 flat YAML must be rejected");
         assert!(
             err.contains("v2"),
             "rejection must mention v2 requirement, got: {err}"
@@ -2042,7 +2073,7 @@ scenarios:
       type: constant
       value: 1.0
 ";
-        let err = parse_body(v1_multi.as_bytes(), &headers)
+        let err = parse_body(v1_multi.as_bytes(), &headers, &InMemoryPackResolver::new())
             .expect_err("v1 multi-scenario YAML must be rejected");
         assert!(
             err.contains("v2"),
@@ -2055,7 +2086,8 @@ scenarios:
     fn parse_body_rejects_garbage_yaml() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/x-yaml".parse().unwrap());
-        let err = parse_body(b"not valid: [}{", &headers).expect_err("garbage must fail");
+        let err = parse_body(b"not valid: [}{", &headers, &InMemoryPackResolver::new())
+            .expect_err("garbage must fail");
         assert!(!err.is_empty(), "error message must not be empty");
     }
 
@@ -2081,8 +2113,12 @@ scenarios:
                 }
             ]
         });
-        let parsed =
-            parse_body(json.to_string().as_bytes(), &headers).expect("v2 JSON body must parse");
+        let parsed = parse_body(
+            json.to_string().as_bytes(),
+            &headers,
+            &InMemoryPackResolver::new(),
+        )
+        .expect("v2 JSON body must parse");
         assert!(matches!(parsed, ParsedBody::Single(_)));
     }
 
@@ -2091,7 +2127,8 @@ scenarios:
     fn parse_body_rejects_invalid_json() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/json".parse().unwrap());
-        let err = parse_body(b"not json", &headers).expect_err("invalid JSON must fail");
+        let err = parse_body(b"not json", &headers, &InMemoryPackResolver::new())
+            .expect_err("invalid JSON must fail");
         assert!(!err.is_empty(), "error message must not be empty");
     }
 
@@ -3072,19 +3109,22 @@ scenarios:
         );
     }
 
-    // ---- Metrics scrape: 204 when no metrics buffered -----------------------
+    // ---- Metrics scrape: empty buffer returns 200 with empty body -----------
 
-    /// GET /scenarios/{id}/metrics returns 204 No Content when the buffer is empty.
+    /// Empty buffer must render as `200 OK` with an empty Prometheus exposition
+    /// (the contract Prometheus / vmagent / Telegraf scrapers expect). 204
+    /// breaks scrapers that use `curl --fail`.
     #[tokio::test]
-    async fn metrics_endpoint_empty_buffer_returns_204() {
+    async fn metrics_endpoint_empty_buffer_returns_200_empty_body() {
         let h = make_handle_with_metrics("id-metrics-empty", "empty_metrics", vec![]);
         let app = router_with_handles(vec![h]);
 
         let resp = get_metrics_req(app, "id-metrics-empty").await;
-        assert_eq!(
-            resp.status(),
-            StatusCode::NO_CONTENT,
-            "empty metrics buffer must return 204 No Content"
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            body.is_empty(),
+            "empty buffer must render as empty Prometheus exposition, got: {body:?}"
         );
     }
 
@@ -3188,38 +3228,24 @@ scenarios:
         );
     }
 
-    /// limit=0 returns 204 No Content (zero events requested).
+    /// `limit=0` drains the buffer but encodes zero events; returns 200 with empty body.
     #[tokio::test]
-    async fn metrics_endpoint_limit_zero_returns_no_content_after_drain() {
+    async fn metrics_endpoint_limit_zero_returns_200_empty_body() {
         let events = vec![make_metric_event("up", 1.0)];
         let h = make_handle_with_metrics("id-metrics-lim0", "lim0_test", events);
         let app = router_with_handles(vec![h]);
 
-        // limit=0 means take 0 events from the drained buffer. But drain
-        // still happens. The implementation drains first, then limits. With
-        // limit=0, events_to_encode is empty, so we should get the encoded
-        // output of zero events. Since the events are drained and the
-        // limited slice is empty, the encode loop produces nothing.
-        // However, the check for events.is_empty() happens BEFORE the limit
-        // is applied, so if the buffer had events the status is 200.
-        // Let's verify what actually happens.
         let resp = get_metrics_with_limit(app, "id-metrics-lim0", 0).await;
-        // The implementation drains 1 event, events is not empty, then takes
-        // the last 0 from the end: &events[1..] which is an empty slice.
-        // The encoder loop runs 0 times, buf is empty. It returns 200 with
-        // empty body (not 204, because the is_empty check passed before limit).
-        assert_eq!(
-            resp.status(),
-            StatusCode::OK,
-            "limit=0 with non-empty buffer drains events but encodes zero, returns 200 with empty body"
-        );
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     // ---- Metrics scrape: drain clears buffer --------------------------------
 
-    /// After scraping, a second request returns 204 because the buffer was drained.
+    /// After scraping, a second request returns 200 with an empty body because
+    /// the buffer was drained. Prometheus contract: 200 with empty exposition,
+    /// not 204.
     #[tokio::test]
-    async fn metrics_endpoint_drain_clears_buffer_second_request_returns_204() {
+    async fn metrics_endpoint_drain_clears_buffer_second_request_returns_200_empty() {
         let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
         let h = make_handle_with_metrics("id-metrics-drain", "drain_test", events);
         let state = AppState::new();
@@ -3228,30 +3254,19 @@ scenarios:
             map.insert(h.id.clone(), h);
         }
 
-        // First request: should return 200 with Prometheus text.
         let app1 = router(state.clone());
         let resp1 = get_metrics_req(app1, "id-metrics-drain").await;
-        assert_eq!(
-            resp1.status(),
-            StatusCode::OK,
-            "first scrape must return 200 with metrics"
-        );
-        let body1 = body_string(resp1).await;
-        assert!(
-            !body1.is_empty(),
-            "first scrape must return non-empty Prometheus text"
-        );
+        assert_eq!(resp1.status(), StatusCode::OK);
+        assert!(!body_string(resp1).await.is_empty());
 
-        // Second request: buffer is now drained, should return 204.
         let app2 = router(state.clone());
         let resp2 = get_metrics_req(app2, "id-metrics-drain").await;
-        assert_eq!(
-            resp2.status(),
-            StatusCode::NO_CONTENT,
-            "second scrape must return 204 No Content because buffer was drained"
+        assert_eq!(resp2.status(), StatusCode::OK);
+        assert!(
+            body_string(resp2).await.is_empty(),
+            "drained buffer must render as empty Prometheus exposition"
         );
 
-        // Clean up.
         cleanup_scenarios(&state);
     }
 
@@ -4087,8 +4102,12 @@ scenarios:
     fn parse_body_returns_multi_for_v2_scenarios_array() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/x-yaml".parse().unwrap());
-        let parsed = parse_body(VALID_MULTI_YAML.as_bytes(), &headers)
-            .expect("v2 multi YAML body must parse");
+        let parsed = parse_body(
+            VALID_MULTI_YAML.as_bytes(),
+            &headers,
+            &InMemoryPackResolver::new(),
+        )
+        .expect("v2 multi YAML body must parse");
         match parsed {
             ParsedBody::Multi(entries) => {
                 assert_eq!(entries.len(), 2, "multi YAML must produce 2 entries");

--- a/sonda-server/src/state.rs
+++ b/sonda-server/src/state.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
+use sonda_core::compiler::expand::InMemoryPackResolver;
 use sonda_core::ScenarioHandle;
 
 /// Shared application state for the HTTP server.
@@ -19,31 +20,41 @@ pub struct AppState {
     /// Map from scenario ID to its lifecycle handle.
     pub scenarios: Arc<RwLock<HashMap<String, ScenarioHandle>>>,
     /// Optional API key for bearer-token authentication on protected routes.
-    ///
-    /// When `None`, all routes are publicly accessible (backwards compatible).
-    /// When `Some`, requests to `/scenarios/*` must include a valid
-    /// `Authorization: Bearer <key>` header.
     pub api_key: Option<Arc<String>>,
+    /// Pack catalog populated at startup from `SONDA_PACK_PATH`. Used to
+    /// resolve `pack:` references in `POST /scenarios` bodies.
+    pub pack_resolver: Arc<InMemoryPackResolver>,
 }
 
 impl AppState {
-    /// Create a new, empty application state with no authentication.
+    /// Create a new, empty application state with no authentication and an
+    /// empty pack resolver.
     pub fn new() -> Self {
         Self {
             scenarios: Arc::new(RwLock::new(HashMap::new())),
             api_key: None,
+            pack_resolver: Arc::new(InMemoryPackResolver::new()),
         }
     }
 
-    /// Create a new, empty application state with an optional API key.
-    ///
-    /// When `api_key` is `Some`, all `/scenarios/*` endpoints require a
-    /// matching `Authorization: Bearer <key>` header. When `None`, auth is
-    /// disabled and the server behaves identically to [`AppState::new`].
+    /// Create a new, empty application state with an optional API key and an
+    /// empty pack resolver.
+    #[allow(dead_code, reason = "kept for tests; main uses with_packs")]
     pub fn with_api_key(api_key: Option<String>) -> Self {
         Self {
             scenarios: Arc::new(RwLock::new(HashMap::new())),
             api_key: api_key.map(Arc::new),
+            pack_resolver: Arc::new(InMemoryPackResolver::new()),
+        }
+    }
+
+    /// Create a new state with both an optional API key and a pre-populated
+    /// pack resolver.
+    pub fn with_packs(api_key: Option<String>, pack_resolver: InMemoryPackResolver) -> Self {
+        Self {
+            scenarios: Arc::new(RwLock::new(HashMap::new())),
+            api_key: api_key.map(Arc::new),
+            pack_resolver: Arc::new(pack_resolver),
         }
     }
 }


### PR DESCRIPTION
## Summary

CRITICAL workshop-unblocking bundle. Discovered during AutoCon5 workshop validation (`~/projects/workshops/notes/sonda-bug-report-2026-04-27.md`, Issues 2 + 3 + the bonus QoL find). PR #285 fixes Issue 1 (sink batch sizes) on the same workshop bug report.

## Issue 2 — server pack resolution

**Bug**: `POST /scenarios` rejected every body that referenced `pack: <name>` with `400 Bad Request: expand error`. The handler constructed an empty `InMemoryPackResolver::new()` per request and never consulted `SONDA_PACK_PATH`. The docstring marked this "deferred to a future endpoint" — but in practice the server had no path to deliver packs, leaving a hole between what the CLI accepts and what the server accepts for the same v2 YAML.

**Fix**:
- New `sonda-server::packs::load_pack_resolver` reads `SONDA_PACK_PATH` (colon-separated dirs) at startup, parses every `*.yaml` / `*.yml` as `MetricPackDef`, registers each pack under both its `name` field AND the file stem so `pack: srlinux_gnmi_bgp` and `pack: srlinux-gnmi-bgp` both resolve.
- `AppState` gains `pack_resolver: Arc<InMemoryPackResolver>` plus a new `with_packs(api_key, resolver)` constructor.
- `parse_body` accepts the resolver as a parameter; `post_scenario` threads `state.pack_resolver` through.

**Live verified**: workshop's exact shape (rate=1, `pack: srlinux_gnmi_bgp`, labels device + peer_address) — server logs `loaded pack definitions packs_loaded=1`, `POST /scenarios` returns `201` with both expanded scenarios running.

## Issue 3 — scrape endpoint Prometheus contract

**Bug**: `GET /scenarios/{id}/metrics` returned `204 No Content` when the internal buffer was empty. Violates the Prometheus exposition contract (scrapers expect 200 + possibly empty body) and collides with `curl --fail` in scrape scripts (silently exits non-zero on 204). The workshop's `scrape-sonda-metrics.sh` uses `curl -sf` and reported zero metrics across the board even when scenarios were healthy.

**Fix**: Empty buffer now renders as `200 OK` with empty body (Prometheus content-type header preserved). Three existing test assertions updated to match.

**Live verified**: `curl -sf` against an empty buffer now exits 0 (was non-zero).

## QoL — error chain in 400 response

**Bug**: The 400 response read `v2 scenario body failed to compile: expand error` — no failing pack name, no search paths, no actionable detail. Cause: `format!("...: {e}")` against `CompileError` which (after PR #283's `#[error(...)]` cleanup) renders just the variant tag, with the inner cause living in the source chain that `Display` doesn't walk.

**Fix**: New `format_error_chain(err)` helper walks `std::error::Error::source()` and joins Display strings with `: `.

**Live verified**: posting a non-existent pack now returns
```
v2 scenario body failed to compile: expand error: pack 'nonexistent_pack' could not be resolved: pack reference 'nonexistent_pack' not found in resolver
```

## Test plan

- [x] `cargo build --workspace` ✅
- [x] `cargo test -p sonda-server --all-features` — 210 tests pass (171 bin + 7 + 5 + 1 + 26 integration). Includes 4 new `packs::tests` cases (search-path empty when env unset, name+stem registration, non-yaml/missing-dir tolerance, first-match-wins) and 3 updated metrics-endpoint assertions for the 200/empty-body contract.
- [x] `cargo clippy --workspace -- -D warnings` ✅ (CI gate)
- [x] `cargo clippy --workspace --all-features -- -D warnings` ✅ (CI gate)
- [x] `cargo fmt --all -- --check` ✅
- [x] **Live repro of all three fixes** — server with `SONDA_PACK_PATH=/tmp/packs`, posted pack-using YAML → 201; empty-buffer scrape → 200 with `curl -sf` exit 0; bad pack name → full chain in detail field
- [ ] CI

## Workshop deployment path

After this + #285 merge and 1.2.2 publishes:
- Workshop YAMLs: **no edits needed** — `pack:` refs resolve, scenarios without explicit `batch_size` flush within seconds, scrape script works with or without `curl --fail`.
- Workshop compose: keep `SONDA_PACK_PATH: "/packs:/sonda/packs"` exactly as-is, swap the image tag from 1.2.1 → 1.2.2.

## Related

- PR #285 — Issue 1 (sink default batch_size)
- Bug report — `~/projects/workshops/notes/sonda-bug-report-2026-04-27.md`