### PR TITLE
fix(ci): pin Release workflow toolchain to 1.95.0 so cross targets find core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # Match the version pinned in rust-toolchain.toml. Using `@stable` installs
+        # rust-std for the matrix target under the "stable" rustup install, but
+        # rust-toolchain.toml then activates the "1.95.0" install (a separate
+        # rustup name) which does not have the target std — surfacing as
+        # `error[E0463]: can't find crate for core`. Bumping rust-toolchain.toml
+        # requires bumping this version too.
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }}
 


### PR DESCRIPTION
## Summary

The Release workflow's `binaries` matrix has been failing on every tag push since **v1.1.0**. v1.1.0, v1.2.0, v1.2.1, and **v1.2.2** all have **zero binary artifacts** on their GitHub Release pages — only the Docker images shipped (multi-arch image build is a separate job that succeeded). v1.0.1 was the last release that produced binaries.

The matrix runs four targets:

| Target | Status | Why |
|---|---|---|
| `aarch64-unknown-linux-musl` | ✅ | Cross via `cross` |
| `aarch64-apple-darwin` | ✅ | Native on `macos-latest` (now ARM64) |
| `x86_64-apple-darwin` | ❌ | `error[E0463]: can't find crate for core` |
| `x86_64-unknown-linux-musl` | ❌ | Same error |

## Root cause

The breaking change is `5454311 chore(tooling): pin rust toolchain to 1.95.0 via rust-toolchain.toml`, landed between v1.0.1 and v1.1.0.

`dtolnay/rust-toolchain@stable` with `targets: <T>` installs `rust-std` for the target under the **"stable"** rustup install. When `cargo build` runs in the workspace, rust-toolchain.toml activates the **"1.95.0"** install — a separately-named install without the target std. Result: `can't find crate for core`. Native ARM64 targets keep working because they don't need target std (host == target).

## Fix

Pin the action to `@1.95.0` so it matches rust-toolchain.toml exactly. Both the action's target install and the activated workspace toolchain become the same rustup install.

A comment on the step calls out the version-coupling: bumping `rust-toolchain.toml` requires bumping the workflow's `dtolnay/rust-toolchain@<version>` too.

## Test plan

- [x] Local diff: 1-line action ref change + a 6-line comment
- [x] Confirmed on the failed runs that ARM64 native succeeded and x86_64 cross failed (consistent with the diagnosis)
- [ ] CI: this PR exercises only the CI/clippy/fmt path on the change to a workflow file. The actual fix verifies on the next tag push (or via manual `gh workflow run release.yml --ref v1.2.2`).

## Republishing v1.2.2 binaries after this lands

```bash
# After this PR merges:
gh workflow run release.yml --ref v1.2.2
```

That re-runs the Release workflow at the existing v1.2.2 tag, which now succeeds and uploads the four `.tar.gz` archives + `SHA256SUMS` to the GitHub Release page. (Optionally also do the same for v1.1.0, v1.2.0, v1.2.1 if those binaries are wanted retroactively.)

## Related

- Bug report: workshops/notes/sonda-bug-report-2026-04-27.md (the user's "publish failed" follow-up; crates.io publish actually succeeded — only the Release-workflow binary build was broken)
- PR #285 — sink batch_size fixes (already merged + 1.2.2 published to crates.io)
- PR #286 — server pack resolution + scrape endpoint (already merged + 1.2.2 published to crates.io)