### PR TITLE
docs(server): trim verbose comments and unwrap docs in /events

### DIFF
--- a/docs/site/docs/deployment/events.md
+++ b/docs/site/docs/deployment/events.md
@@ -1,11 +1,8 @@
 # Single-Event API
 
-`POST /events` emits **one** log or metric event synchronously. The request blocks until the
-sink ACKs delivery, then returns the latency it took. Use it when you want a single signal
-to land *now* and you want to know it landed before continuing.
+`POST /events` emits **one** log or metric event synchronously. The request blocks until the sink ACKs delivery, then returns the latency it took. Use it when you want a single signal to land *now* and you want to know it landed before continuing.
 
-The flat JSON body is the easy alternative to the v2 scenario shape — paste the encoder
-and sink inline, no `defaults:`, no `version: 2`, no scenario IDs to track.
+The flat JSON body is the easy alternative to the v2 scenario shape — paste the encoder and sink inline, no `defaults:`, no `version: 2`, no scenario IDs to track.
 
 ## When to use `/events` vs `/scenarios`
 
@@ -14,25 +11,18 @@ and sink inline, no `defaults:`, no `version: 2`, no scenario IDs to track.
 | One signal, one moment, blocks until delivered | **`POST /events`** |
 | A stream of signals at a sustained rate | [`POST /scenarios`](sonda-server.md#start-a-scenario) |
 
-Both share the same encoders, sinks, auth, and loopback-warning behavior. They differ only
-in lifecycle:
+Both share the same encoders, sinks, auth, and loopback-warning behavior. They differ only in lifecycle:
 
-- **`/events`** is synchronous. The handler encodes the event, pushes it through the sink,
-  and returns `{sent, signal_type, latency_ms}` once the destination ACKs (typically
-  5–30 ms). There is no scenario ID — the call is fire-and-confirm.
-- **`/scenarios`** is asynchronous. The server returns a scenario ID immediately and the
-  scenario runs in the background until its `duration` expires or you call
-  `DELETE /scenarios/{id}`.
+- **`/events`** is synchronous. The handler encodes the event, pushes it through the sink, and returns `{sent, signal_type, latency_ms}` once the destination ACKs (typically 5–30 ms). There is no scenario ID — the call is fire-and-confirm.
+- **`/scenarios`** is asynchronous. The server returns a scenario ID immediately and the scenario runs in the background until its `duration` expires or you call `DELETE /scenarios/{id}`.
 
 !!! tip "Two real-world drivers"
     - **Workshop CLI** — fire teaching events without learning the v2 YAML shape.
-    - **Live demos** — a single `curl` on stage produces a Loki log line that Grafana picks
-      up as a panel annotation within ~5–15 ms.
+    - **Live demos** — a single `curl` on stage produces a Loki log line that Grafana picks up as a panel annotation within ~5–15 ms.
 
 ## Request body
 
-The body is a JSON object tagged by `signal_type`. The discriminator selects which
-per-branch field is required (`log` for logs, `metric` for metrics).
+The body is a JSON object tagged by `signal_type`. The discriminator selects which per-branch field is required (`log` for logs, `metric` for metrics).
 
 === "Logs"
 
@@ -100,8 +90,7 @@ per-branch field is required (`log` for logs, `metric` for metrics).
 | `name` | string | yes | Metric name. Must match `[a-zA-Z_:][a-zA-Z0-9_:]*`. |
 | `value` | number (f64) | yes | Sample value. |
 
-The on-wire metric shape (counter, gauge, histogram lines, TimeSeries protobuf, …) is
-determined by the `encoder` you pick — there is no separate `metric_type` field.
+The on-wire metric shape (counter, gauge, histogram lines, TimeSeries protobuf, …) is determined by the `encoder` you pick — there is no separate `metric_type` field.
 
 ## Response
 
@@ -115,12 +104,9 @@ determined by the `encoder` you pick — there is no separate `metric_type` fiel
 }
 ```
 
-`latency_ms` is the wall-clock time the handler spent encoding the event and waiting for
-the sink to ACK.
+`latency_ms` is the wall-clock time the handler spent encoding the event and waiting for the sink to ACK.
 
-When pre-flight checks find advisories (e.g. a sink URL pointing at a loopback host), the
-response includes a `warnings` array. The field is **omitted entirely** when no warnings
-fire, so older clients parse responses unchanged:
+When pre-flight checks find advisories (e.g. a sink URL pointing at a loopback host), the response includes a `warnings` array. The field is **omitted entirely** when no warnings fire, so older clients parse responses unchanged:
 
 ```json title="Response with loopback warning"
 {
@@ -133,8 +119,7 @@ fire, so older clients parse responses unchanged:
 }
 ```
 
-Warnings are informational — they never block delivery. The same message is also written
-to the server log via `tracing::warn!`.
+Warnings are informational — they never block delivery. The same message is also written to the server log via `tracing::warn!`.
 
 ### Errors
 
@@ -150,10 +135,7 @@ All errors share the envelope `{"error": "<short_code>", "detail": "<message>"}`
 
 ## Authentication
 
-`/events` follows the same auth model as `/scenarios`. When the server starts with
-`--api-key <key>` (or `SONDA_API_KEY=<key>`), every request must include
-`Authorization: Bearer <key>`. When no key is configured, `/events` is publicly
-accessible — backwards compatible with existing deployments.
+`/events` follows the same auth model as `/scenarios`. When the server starts with `--api-key <key>` (or `SONDA_API_KEY=<key>`), every request must include `Authorization: Bearer <key>`. When no key is configured, `/events` is publicly accessible — backwards compatible with existing deployments.
 
 ```bash title="Authenticated request"
 curl -X POST http://localhost:8080/events \
@@ -168,13 +150,11 @@ curl -X POST http://localhost:8080/events \
   }'
 ```
 
-See [Authentication](sonda-server.md#authentication) on the Server API page for the full
-configuration reference.
+See [Authentication](sonda-server.md#authentication) on the Server API page for the full configuration reference.
 
 ## Demo: Grafana annotation from one curl
 
-Fire a single log line and watch it appear as a Grafana panel annotation within seconds.
-This works on the **default `sonda-server` binary** — no feature flags required.
+Fire a single log line and watch it appear as a Grafana panel annotation within seconds. This works on the **default `sonda-server` binary** — no feature flags required.
 
 ```bash title="Step 1 — fire the event"
 curl -s -X POST http://127.0.0.1:8080/events \
@@ -195,15 +175,11 @@ curl -s 'http://localhost:3100/loki/api/v1/query_range' \
   --data-urlencode 'limit=1'
 ```
 
-End-to-end latency observed against a real Loki instance: **5–15 ms** from `curl` to ACK.
-Wire a Grafana annotation query against `{event="deploy_start"}` and the panel renders an
-overlay automatically.
+End-to-end latency observed against a real Loki instance: **5–15 ms** from `curl` to ACK. Wire a Grafana annotation query against `{event="deploy_start"}` and the panel renders an overlay automatically.
 
 ## Build-time feature flags
 
-The default `sonda-server` binary supports `loki`, `stdout`, `file`, `tcp`, `udp`,
-`http_push`, `json_lines`, `prometheus_text`, and `syslog`. The Loki annotation demo above
-works out of the box.
+The default `sonda-server` binary supports `loki`, `stdout`, `file`, `tcp`, `udp`, `http_push`, `json_lines`, `prometheus_text`, and `syslog`. The Loki annotation demo above works out of the box.
 
 A few sinks and encoders are gated behind cargo features to keep the default binary small:
 
@@ -213,21 +189,14 @@ A few sinks and encoders are gated behind cargo features to keep the default bin
 | `otlp` encoder, `otlp_grpc` sink | `cargo build --release -p sonda-server -F otlp` |
 | `kafka` sink | `cargo build --release -p sonda-server -F kafka` |
 
-If a request references a type that isn't compiled in, the server returns **422** with a
-clear hint, e.g. `encoder type 'remote_write' requires the 'remote-write' feature: cargo
-build -F remote-write`.
+If a request references a type that isn't compiled in, the server returns **422** with a clear hint, e.g. `encoder type 'remote_write' requires the 'remote-write' feature: cargo build -F remote-write`.
 
 ## Sink URL gotchas
 
-When the server runs in a container, a `sink.url` of `http://localhost:<port>` resolves to
-the **server's own loopback**, not your host. The request still succeeds, but the
-`warnings` array calls out the misconfiguration. In Docker Compose use the service name
-(`http://loki:3100`); in Kubernetes use the in-cluster Service DNS. See
-[Endpoints & networking](endpoints.md) for the full reference.
+When the server runs in a container, a `sink.url` of `http://localhost:<port>` resolves to the **server's own loopback**, not your host. The request still succeeds, but the `warnings` array calls out the misconfiguration. In Docker Compose use the service name (`http://loki:3100`); in Kubernetes use the in-cluster Service DNS. See [Endpoints & networking](endpoints.md) for the full reference.
 
 ## Not in this version
 
-- **Burst path** — there is no `count` or `duration` field. For sustained emission, use
-  [`POST /scenarios`](sonda-server.md#start-a-scenario).
+- **Burst path** — there is no `count` or `duration` field. For sustained emission, use [`POST /scenarios`](sonda-server.md#start-a-scenario).
 - **Trace and flow signal types** — only `logs` and `metrics` are supported.
 - **CLI subcommand** — there is no `sonda emit` yet. The endpoint is the only entry point.

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -37,9 +37,7 @@ Post a [v2 scenario](../configuration/v2-scenarios.md) YAML or JSON body to
 `application/json` content types.
 
 !!! tip "Need just one event?"
-    `POST /scenarios` is for sustained emission over time. To fire a single log or
-    metric synchronously and block until the sink ACKs, use the
-    [Single-Event API (`POST /events`)](events.md) instead.
+    `POST /scenarios` is for sustained emission over time. To fire a single log or metric synchronously and block until the sink ACKs, use the [Single-Event API (`POST /events`)](events.md) instead.
 
 !!! warning "v2 scenarios only"
     The server only accepts v2 bodies (`version: 2` at the top level). Legacy v1 bodies are
@@ -350,10 +348,7 @@ shape conversions.
 
 ## Authentication
 
-You can protect scenario endpoints with API key authentication. When enabled, all
-`/scenarios/*` requests and `POST /events` must include a bearer token. The `/health`
-endpoint is always public, so health probes and load balancer checks work without
-credentials.
+You can protect scenario endpoints with API key authentication. When enabled, all `/scenarios/*` requests and `POST /events` must include a bearer token. The `/health` endpoint is always public, so health probes and load balancer checks work without credentials.
 
 ### Enabling authentication
 

--- a/sonda-core/src/emit.rs
+++ b/sonda-core/src/emit.rs
@@ -1,7 +1,4 @@
 //! Synchronous single-event emission.
-//!
-//! Build a one-shot encoder + sink, encode one event, write, flush, drop.
-//! I/O-agnostic — no latency measurement, no tracing.
 
 use std::collections::HashMap;
 
@@ -11,16 +8,7 @@ use crate::model::metric::MetricEvent;
 use crate::sink::{create_sink, SinkConfig};
 use crate::SondaError;
 
-/// Encode a single [`LogEvent`] and deliver it through a one-shot sink.
-///
-/// `labels` is forwarded to [`create_sink`]; use `None` when unused.
-///
-/// # Errors
-///
-/// Returns the underlying [`SondaError`] from any of the four steps:
-/// encoder construction, sink construction, encoding, or sink
-/// write/flush. Sink-side I/O failures surface as [`SondaError::Sink`];
-/// invalid encoder/sink configs surface as [`SondaError::Config`].
+/// Encode a [`LogEvent`] and deliver it through a one-shot sink.
 pub fn emit_log(
     event: &LogEvent,
     encoder: &EncoderConfig,
@@ -35,16 +23,7 @@ pub fn emit_log(
     sink.flush()
 }
 
-/// Encode a single [`MetricEvent`] and deliver it through a one-shot sink.
-///
-/// `labels` is forwarded to [`create_sink`]; use `None` when unused.
-///
-/// # Errors
-///
-/// Returns the underlying [`SondaError`] from any of the four steps:
-/// encoder construction, sink construction, encoding, or sink
-/// write/flush. Sink-side I/O failures surface as [`SondaError::Sink`];
-/// invalid encoder/sink configs surface as [`SondaError::Config`].
+/// Encode a [`MetricEvent`] and deliver it through a one-shot sink.
 pub fn emit_metric(
     event: &MetricEvent,
     encoder: &EncoderConfig,
@@ -68,8 +47,6 @@ mod tests {
     use crate::model::metric::Labels;
     use crate::sink::retry::RetryConfig;
 
-    /// Per-test temp file path. Tagged with PID + thread id so parallel
-    /// test runs (and reruns) do not collide on the same path.
     fn temp_path(tag: &str) -> std::path::PathBuf {
         let mut p = std::env::temp_dir();
         p.push(format!(
@@ -81,14 +58,6 @@ mod tests {
         p
     }
 
-    /// `emit_log` writes the encoded line through the constructed sink.
-    ///
-    /// The brief specifies `MemorySink` for this assertion, but the
-    /// helpers take `&SinkConfig` and there is no public `Memory` variant
-    /// in [`SinkConfig`]. The file sink is the closest stand-in that
-    /// exercises the full helper end to end (encoder construction, sink
-    /// construction, encode, write, flush) without reaching into private
-    /// internals.
     #[test]
     fn emit_log_writes_encoded_line_to_sink() {
         let path = temp_path("emit_log_writes");
@@ -128,7 +97,6 @@ mod tests {
         );
     }
 
-    /// `emit_metric` writes the encoded line through the constructed sink.
     #[test]
     fn emit_metric_writes_encoded_line_to_sink() {
         let path = temp_path("emit_metric_writes");
@@ -164,9 +132,6 @@ mod tests {
         );
     }
 
-    /// `emit_log` propagates `SondaError::Config` when the sink config is
-    /// invalid (here: a TCP sink with `max_attempts = 0`, which the retry
-    /// validator rejects).
     #[test]
     fn emit_log_propagates_config_error_for_invalid_sink_config() {
         let event = LogEvent::new(
@@ -199,8 +164,6 @@ mod tests {
         );
     }
 
-    /// `emit_metric` propagates `SondaError::Config` when the sink config
-    /// is invalid (here: a TCP sink with `max_attempts = 0`).
     #[test]
     fn emit_metric_propagates_config_error_for_invalid_sink_config() {
         let event =

--- a/sonda-server/src/routes/events.rs
+++ b/sonda-server/src/routes/events.rs
@@ -1,6 +1,4 @@
-//! POST /events — synchronous single-event emission. Dispatches on
-//! `signal_type`, builds the event, delegates to `sonda_core::emit`,
-//! returns once the sink ACKs.
+//! POST /events — synchronous single-event emission.
 
 use std::collections::HashMap;
 use std::time::Instant;
@@ -21,125 +19,56 @@ use tracing::info;
 use crate::routes::sink_warnings::{collect_warnings_for_sink, log_warnings};
 use crate::state::AppState;
 
-// ---- Wire types -------------------------------------------------------------
-
-/// Payload describing a single log event in a `POST /events` request.
 #[derive(Debug, Deserialize)]
 pub struct LogPayload {
-    /// Severity of the log entry: `trace` / `debug` / `info` / `warn`
-    /// / `error` / `fatal` (case-sensitive lowercase).
     pub severity: Severity,
-    /// Human-readable log message.
     pub message: String,
-    /// Optional event-level structured fields.
     #[serde(default)]
     pub fields: HashMap<String, String>,
 }
 
-/// Payload describing a single metric event in a `POST /events` request.
-///
-/// Unknown fields on the metric payload are ignored; future metric-type
-/// semantics will use a dedicated field.
 #[derive(Debug, Deserialize)]
 pub struct MetricPayload {
-    /// Metric name (must match `[a-zA-Z_:][a-zA-Z0-9_:]*`).
     pub name: String,
-    /// Numeric sample value.
     pub value: f64,
 }
 
-/// Tagged-union request body for `POST /events`.
-///
-/// The `signal_type` discriminator selects the per-branch payload field
-/// (`log` for logs, `metric` for metrics). Matches the
-/// `signal_type` convention used by [`sonda_core::config::ScenarioEntry`].
 #[derive(Debug, Deserialize)]
 #[serde(tag = "signal_type")]
 pub enum EventRequest {
-    /// A single log event.
     #[serde(rename = "logs")]
     Logs {
-        /// Optional static labels attached to the event.
         #[serde(default)]
         labels: HashMap<String, String>,
-        /// The log payload.
         log: LogPayload,
-        /// Encoder configuration used to format this event.
         encoder: EncoderConfig,
-        /// Sink configuration used to deliver this event.
         sink: SinkConfig,
     },
-    /// A single metric event.
     #[serde(rename = "metrics")]
     Metrics {
-        /// Optional static labels attached to the event.
         #[serde(default)]
         labels: HashMap<String, String>,
-        /// The metric payload.
         metric: MetricPayload,
-        /// Encoder configuration used to format this event.
         encoder: EncoderConfig,
-        /// Sink configuration used to deliver this event.
         sink: SinkConfig,
     },
 }
 
-/// `POST /events` success response body.
 #[derive(Debug, Serialize)]
 pub struct EventAck {
-    /// Always `true` on a 200 response.
     pub sent: bool,
-    /// Echo of the request's `signal_type` (`"logs"` or `"metrics"`).
     pub signal_type: &'static str,
-    /// Wall-clock latency of the encode + sink push, in milliseconds.
     pub latency_ms: u128,
-    /// Operator-facing pre-flight warnings (e.g. loopback sink URL).
-    /// Omitted when empty so older clients parse cleanly.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub warnings: Vec<String>,
 }
 
-// ---- Handler ----------------------------------------------------------------
-
-/// `POST /events` — encode and deliver one event, blocking on sink ack.
-///
-/// Accepts a JSON body tagged by `signal_type` (`"logs"` or
-/// `"metrics"`). The handler:
-///
-/// 1. Deserializes the body. Malformed JSON or an unknown
-///    `signal_type` returns 400.
-/// 2. Builds a [`LogEvent`] or [`MetricEvent`] from the payload.
-///    Field-level validation failures (e.g. invalid metric name)
-///    return 422.
-/// 3. Computes loopback warnings against the supplied sink.
-/// 4. Spawns a blocking task that calls
-///    [`emit_log`](sonda_core::emit::emit_log) or
-///    [`emit_metric`](sonda_core::emit::emit_metric).
-/// 5. Maps the result variant to a status code and returns the JSON
-///    response.
-///
-/// # Error responses
-///
-/// - `400` — malformed body, unknown `signal_type`, or per-branch
-///   field missing / wrong shape.
-/// - `422` — encoder/sink config failed validation
-///   ([`SondaError::Config`]).
-/// - `502` — sink push or flush failed
-///   ([`SondaError::Sink`]).
-/// - `500` — encoder error ([`SondaError::Encoder`]), runtime error
-///   ([`SondaError::Runtime`]), generator error
-///   ([`SondaError::Generator`]) — none expected on this path — or a
-///   `JoinError` from the blocking task.
 pub async fn post_events(State(_state): State<AppState>, body: axum::body::Bytes) -> Response {
-    // 1. Deserialize. serde_json's tag handling produces helpful
-    //    messages for unknown tags and missing per-branch fields.
     let req: EventRequest = match serde_json::from_slice::<EventRequest>(&body) {
         Ok(r) => r,
         Err(e) => return bad_request(format!("invalid event body: {e}")),
     };
 
-    // 2. Pre-flight loopback warnings — never gate on these, only
-    //    surface them in the response and the log.
     let mut warnings: Vec<String> = Vec::new();
     let warning_label = match &req {
         EventRequest::Logs { .. } => "events.logs",
@@ -152,7 +81,6 @@ pub async fn post_events(State(_state): State<AppState>, body: axum::body::Bytes
     }
     log_warnings("POST /events", &warnings);
 
-    // 3. Build the event + run blocking emit.
     let started = Instant::now();
     let (signal_type, sink_type, emit_result) = match req {
         EventRequest::Logs {
@@ -227,9 +155,6 @@ pub async fn post_events(State(_state): State<AppState>, body: axum::body::Bytes
     }
 }
 
-// ---- Helpers ----------------------------------------------------------------
-
-/// Build a [`LogEvent`] from the wire payload + request labels.
 fn build_log_event(
     log: LogPayload,
     labels: &HashMap<String, String>,
@@ -239,7 +164,6 @@ fn build_log_event(
     Ok(LogEvent::new(log.severity, log.message, labels, fields))
 }
 
-/// Build a [`MetricEvent`] from the wire payload + request labels.
 fn build_metric_event(
     metric: MetricPayload,
     labels: &HashMap<String, String>,
@@ -248,9 +172,6 @@ fn build_metric_event(
     MetricEvent::new(metric.name, metric.value, labels)
 }
 
-/// Convert the wire-side `HashMap<String, String>` of labels into the
-/// validated [`Labels`] type, surfacing key validation failures as
-/// [`SondaError::Config`].
 fn labels_from_map(map: &HashMap<String, String>) -> Result<Labels, SondaError> {
     if map.is_empty() {
         return Ok(Labels::default());
@@ -259,8 +180,6 @@ fn labels_from_map(map: &HashMap<String, String>) -> Result<Labels, SondaError> 
     Labels::from_pairs(&pairs)
 }
 
-/// Run a synchronous closure on a blocking task, mapping `JoinError`
-/// (panic in the blocking task) to [`SondaError::Runtime`].
 async fn run_blocking<F>(f: F) -> Result<(), SondaError>
 where
     F: FnOnce() -> Result<(), SondaError> + Send + 'static,
@@ -273,7 +192,6 @@ where
     }
 }
 
-/// Map a [`SondaError`] to the matching HTTP error response.
 fn error_response(err: SondaError) -> Response {
     match err {
         SondaError::Config(e) => unprocessable(format!("{e}")),
@@ -281,12 +199,10 @@ fn error_response(err: SondaError) -> Response {
         SondaError::Encoder(e) => internal_error(format!("encoder error: {e}")),
         SondaError::Generator(e) => internal_error(format!("generator error: {e}")),
         SondaError::Runtime(e) => internal_error(format!("runtime error: {e}")),
-        // SondaError is #[non_exhaustive]; future variants land here.
         _ => internal_error("unexpected error variant"),
     }
 }
 
-/// Stable sink-type tag used in trace logs.
 fn sink_kind(sink: &SinkConfig) -> &'static str {
     match sink {
         SinkConfig::Stdout => "stdout",
@@ -303,7 +219,6 @@ fn sink_kind(sink: &SinkConfig) -> &'static str {
         SinkConfig::Kafka { .. } => "kafka",
         #[cfg(feature = "otlp")]
         SinkConfig::OtlpGrpc { .. } => "otlp_grpc",
-        // Disabled placeholders + future #[non_exhaustive] variants.
         _ => "other",
     }
 }
@@ -332,7 +247,6 @@ fn internal_error(detail: impl std::fmt::Display) -> Response {
 mod tests {
     use super::*;
 
-    /// `EventRequest` deserializes the logs branch from JSON.
     #[test]
     fn deserializes_logs_branch() {
         let payload = serde_json::json!({
@@ -352,7 +266,6 @@ mod tests {
         }
     }
 
-    /// `EventRequest` deserializes the metrics branch from JSON.
     #[test]
     fn deserializes_metrics_branch() {
         let payload = serde_json::json!({
@@ -372,7 +285,6 @@ mod tests {
         }
     }
 
-    /// Unknown `signal_type` produces a serde error mentioning the bad tag.
     #[test]
     fn unknown_signal_type_fails_to_deserialize() {
         let payload = serde_json::json!({
@@ -389,7 +301,6 @@ mod tests {
         );
     }
 
-    /// A logs body missing `message` fails deserialization.
     #[test]
     fn missing_log_message_fails_to_deserialize() {
         let payload = serde_json::json!({
@@ -406,7 +317,6 @@ mod tests {
         );
     }
 
-    /// `error_response` maps `SondaError::Config` to 422.
     #[test]
     fn error_response_maps_config_to_422() {
         let err = SondaError::Config(sonda_core::ConfigError::InvalidValue("bad".to_string()));
@@ -414,7 +324,6 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
-    /// `error_response` maps `SondaError::Sink` to 502.
     #[test]
     fn error_response_maps_sink_to_502() {
         let err = SondaError::Sink(std::io::Error::new(
@@ -425,7 +334,6 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
     }
 
-    /// `error_response` maps `SondaError::Runtime` to 500.
     #[test]
     fn error_response_maps_runtime_to_500() {
         let err = SondaError::Runtime(sonda_core::RuntimeError::ThreadPanicked);
@@ -433,7 +341,6 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
-    /// `sink_kind` returns the expected stable tag.
     #[test]
     fn sink_kind_tags_match_yaml_type_names() {
         assert_eq!(sink_kind(&SinkConfig::Stdout), "stdout");
@@ -452,7 +359,6 @@ mod tests {
         );
     }
 
-    /// Empty labels deserialize to `Labels::default()`.
     #[test]
     fn labels_from_empty_map_returns_default() {
         let map: HashMap<String, String> = HashMap::new();
@@ -460,7 +366,6 @@ mod tests {
         assert!(labels.is_empty());
     }
 
-    /// Invalid label keys surface as `SondaError::Config`.
     #[test]
     fn labels_from_map_rejects_invalid_keys() {
         let mut map = HashMap::new();

--- a/sonda-server/src/routes/sink_warnings.rs
+++ b/sonda-server/src/routes/sink_warnings.rs
@@ -1,55 +1,36 @@
-//! Sink loopback pre-flight warnings shared by `POST /scenarios` and
-//! `POST /events`.
-//!
-//! When a sink URL points at `localhost`, `127.0.0.1`, or `::1`, the
-//! request still launches — these warnings exist so operators can spot
-//! the misconfiguration in containerized deployments where loopback
-//! resolves to the server's own network namespace, not the operator's
-//! host.
-//!
-//! All helpers here are `pub(crate)` and have no side effects beyond
-//! formatting strings (the logging helper writes to `tracing::warn`).
+//! Sink loopback pre-flight warnings shared by `POST /scenarios` and `POST /events`.
 
 use sonda_core::config::ScenarioEntry;
 use sonda_core::sink::SinkConfig;
 use tracing::warn;
 
-/// Pointer appended to every loopback warning so operators can find the
-/// deployment networking reference without grepping docs.
 pub(crate) const LOOPBACK_HINT_DOC: &str = "See docs/deployment/endpoints.md.";
 
-/// Hosts treated as loopback by [`is_loopback_host`].
 pub(crate) const LOOPBACK_HOSTS: &[&str] = &["localhost", "127.0.0.1", "::1"];
 
-/// Returns `true` when `host` is one of the canonical loopback names
-/// (case-insensitive).
 pub(crate) fn is_loopback_host(host: &str) -> bool {
     LOOPBACK_HOSTS
         .iter()
         .any(|candidate| host.eq_ignore_ascii_case(candidate))
 }
 
-/// Extract the host from a URL or `host:port` authority. Returns `None`
-/// for unparseable input — sink construction will surface the real error.
+/// Pulls the host out of a URL or bare `host:port` authority.
 pub(crate) fn extract_host(input: &str) -> Option<&str> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
         return None;
     }
 
-    // Strip a URL scheme (`http://`, `https://`, `grpc://`, ...) if present.
     let after_scheme = match trimmed.find("://") {
         Some(idx) => &trimmed[idx + 3..],
         None => trimmed,
     };
 
-    // Drop any path / query / fragment tail so we only parse the authority.
     let authority_end = after_scheme
         .find(['/', '?', '#'])
         .unwrap_or(after_scheme.len());
     let authority = &after_scheme[..authority_end];
 
-    // Strip userinfo (`user:pass@host`) if present.
     let authority = match authority.rfind('@') {
         Some(idx) => &authority[idx + 1..],
         None => authority,
@@ -59,12 +40,10 @@ pub(crate) fn extract_host(input: &str) -> Option<&str> {
         return None;
     }
 
-    // IPv6 literal: `[::1]` optionally followed by `:port`.
     if let Some(rest) = authority.strip_prefix('[') {
         return rest.find(']').map(|end| &rest[..end]);
     }
 
-    // IPv4 / hostname: split on the last `:` to drop the port, if any.
     let host = match authority.rfind(':') {
         Some(idx) => &authority[..idx],
         None => authority,
@@ -77,7 +56,6 @@ pub(crate) fn extract_host(input: &str) -> Option<&str> {
     }
 }
 
-/// Format the operator-facing warning string for a single offending sink.
 pub(crate) fn format_loopback_warning(entry_name: &str, sink_tag: &str, offender: &str) -> String {
     format!(
         "scenario entry '{entry_name}' sink `{sink_tag}` targets `{offender}` — this host \
@@ -87,9 +65,6 @@ pub(crate) fn format_loopback_warning(entry_name: &str, sink_tag: &str, offender
     )
 }
 
-/// Inspect every entry's sink and return one warning string per loopback
-/// target. Stdout/File/Channel/Memory sinks (and `*Disabled` placeholders)
-/// produce no warnings.
 pub(crate) fn sink_loopback_warnings(entries: &[ScenarioEntry]) -> Vec<String> {
     let mut warnings = Vec::new();
     for entry in entries {
@@ -100,11 +75,6 @@ pub(crate) fn sink_loopback_warnings(entries: &[ScenarioEntry]) -> Vec<String> {
     warnings
 }
 
-/// Inspect a single sink config and append any loopback warnings it
-/// generates to `out`.
-///
-/// Used directly by `POST /events`, which has a single sink rather than
-/// a list of entries.
 pub(crate) fn collect_warnings_for_sink(
     sink: &SinkConfig,
     entry_name: &str,
@@ -145,7 +115,6 @@ pub(crate) fn collect_warnings_for_sink(
         }
         #[cfg(feature = "kafka")]
         SinkConfig::Kafka { brokers, .. } => {
-            // brokers is comma-separated; warn per loopback entry, not per sink.
             for broker in brokers.split(',') {
                 let broker = broker.trim();
                 if broker.is_empty() {
@@ -172,14 +141,10 @@ pub(crate) fn collect_warnings_for_sink(
                 }
             }
         }
-        // Stdout/File/Channel/Memory carry no address; `*Disabled` placeholders
-        // and future `#[non_exhaustive]` variants also land here.
         _ => {}
     }
 }
 
-/// Emit one `tracing::warn` per warning string, tagged with the route
-/// label so operators can grep logs by endpoint.
 pub(crate) fn log_warnings(route: &str, warnings: &[String]) {
     for message in warnings {
         warn!(message = %message, route = %route, "{}: sink pre-flight warning", route);
@@ -191,8 +156,6 @@ mod tests {
     use super::*;
     use sonda_core::compile_scenario_file;
     use sonda_core::compiler::expand::InMemoryPackResolver;
-
-    // ---- is_loopback_host ----------------------------------------------------
 
     #[test]
     fn is_loopback_host_matches_canonical_hosts() {
@@ -213,12 +176,8 @@ mod tests {
         assert!(!is_loopback_host("loki"));
         assert!(!is_loopback_host("10.0.0.1"));
         assert!(!is_loopback_host("192.168.1.10"));
-        // 127/8 non-exact addresses are deliberately NOT matched per the
-        // canonical-only policy.
         assert!(!is_loopback_host("127.0.0.2"));
     }
-
-    // ---- extract_host --------------------------------------------------------
 
     #[test]
     fn extract_host_parses_http_url() {
@@ -270,11 +229,6 @@ mod tests {
         assert_eq!(extract_host("   "), None);
     }
 
-    // ---- sink_loopback_warnings (entry-list path used by /scenarios) --------
-
-    /// Build a minimal v2 YAML body with the given sink block injected into
-    /// `defaults` and compile it to a single `ScenarioEntry`. Used by the
-    /// loopback pre-flight tests so we exercise the real compiler path.
     fn compile_single_entry_with_sink(sink_yaml: &str) -> ScenarioEntry {
         let yaml = format!(
             "version: 2\n\
@@ -410,8 +364,6 @@ mod tests {
         assert!(warnings[0].contains("otlp_grpc"));
         assert!(warnings[0].contains("http://localhost:4317"));
     }
-
-    // ---- collect_warnings_for_sink (single-sink path used by /events) -------
 
     #[test]
     fn collect_warnings_for_sink_flags_tcp_localhost() {

--- a/sonda-server/tests/events.rs
+++ b/sonda-server/tests/events.rs
@@ -1,7 +1,4 @@
 //! End-to-end tests for `POST /events`.
-//!
-//! These tests spawn the real `sonda-server` binary, post a single
-//! event over HTTP, and verify the response shape and side effects.
 
 mod common;
 
@@ -11,11 +8,6 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-// ---------------------------------------------------------------------------
-// Mock Loki server helpers — same pattern as sonda-core's loki.rs tests.
-// ---------------------------------------------------------------------------
-
-/// Bind a TCP listener on an OS-chosen port and return `(listener, base_url)`.
 fn mock_loki_listener() -> (TcpListener, String) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
     let port = listener.local_addr().expect("local addr").port();
@@ -23,8 +15,6 @@ fn mock_loki_listener() -> (TcpListener, String) {
     (listener, url)
 }
 
-/// Accept one HTTP request from the listener and reply with the given status.
-/// Returns the request body bytes the server sent us.
 fn accept_one_and_respond(listener: TcpListener, status: u16) -> Vec<u8> {
     let (mut stream, _) = listener.accept().expect("accept connection");
     let body = read_http_body(&mut stream);
@@ -55,9 +45,6 @@ fn read_http_body(stream: &mut TcpStream) -> Vec<u8> {
     body
 }
 
-/// Spawn a thread that runs `accept_one_and_respond` on the supplied
-/// listener so the test thread can fire its HTTP request without
-/// deadlocking. Returns a receiver for the captured request body.
 fn spawn_loki_responder(listener: TcpListener, status: u16) -> mpsc::Receiver<Vec<u8>> {
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
@@ -67,19 +54,11 @@ fn spawn_loki_responder(listener: TcpListener, status: u16) -> mpsc::Receiver<Ve
     rx
 }
 
-// ---------------------------------------------------------------------------
-// Test 1 — happy path, logs.
-// ---------------------------------------------------------------------------
-
-/// POST /events with a logs payload returns 200 and reports
-/// `signal_type: "logs"` plus a `latency_ms` integer.
 #[test]
 fn post_events_logs_happy_path_returns_200() {
     let (port, _guard) = common::start_server();
     let client = common::http_client();
 
-    // Use a temp file as the sink so the test verifies end-to-end delivery
-    // without standing up a network listener.
     let mut path = std::env::temp_dir();
     path.push(format!("sonda-events-logs-{}.log", std::process::id()));
     let _ = std::fs::remove_file(&path);
@@ -112,7 +91,6 @@ fn post_events_logs_happy_path_returns_200() {
         "latency_ms must be present and numeric, got: {json}"
     );
 
-    // Side effect: the file received the encoded line.
     let contents = std::fs::read_to_string(&path).expect("read sink file");
     let _ = std::fs::remove_file(&path);
     assert!(
@@ -121,12 +99,6 @@ fn post_events_logs_happy_path_returns_200() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Test 2 — happy path, metrics.
-// ---------------------------------------------------------------------------
-
-/// POST /events with a metrics payload returns 200 and reports
-/// `signal_type: "metrics"`.
 #[test]
 fn post_events_metrics_happy_path_returns_200() {
     let (port, _guard) = common::start_server();
@@ -168,11 +140,6 @@ fn post_events_metrics_happy_path_returns_200() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Test 3 — malformed JSON body.
-// ---------------------------------------------------------------------------
-
-/// A garbled JSON body returns 400.
 #[test]
 fn post_events_malformed_json_returns_400() {
     let (port, _guard) = common::start_server();
@@ -190,11 +157,6 @@ fn post_events_malformed_json_returns_400() {
     assert_eq!(json["error"], "bad_request");
 }
 
-// ---------------------------------------------------------------------------
-// Test 4 — unknown signal_type tag.
-// ---------------------------------------------------------------------------
-
-/// `signal_type: "traces"` is not yet supported and returns 400.
 #[test]
 fn post_events_unknown_signal_type_returns_400() {
     let (port, _guard) = common::start_server();
@@ -223,11 +185,6 @@ fn post_events_unknown_signal_type_returns_400() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Test 5 — missing per-branch field.
-// ---------------------------------------------------------------------------
-
-/// A logs body missing `log.message` returns 400.
 #[test]
 fn post_events_missing_required_log_field_returns_400() {
     let (port, _guard) = common::start_server();
@@ -235,7 +192,7 @@ fn post_events_missing_required_log_field_returns_400() {
 
     let body = serde_json::json!({
         "signal_type": "logs",
-        "log": {"severity": "info"},  // message missing
+        "log": {"severity": "info"},
         "encoder": {"type": "json_lines"},
         "sink": {"type": "stdout"},
     });
@@ -256,12 +213,6 @@ fn post_events_missing_required_log_field_returns_400() {
         .unwrap_or(false));
 }
 
-// ---------------------------------------------------------------------------
-// Test 6 — invalid sink config → 422.
-// ---------------------------------------------------------------------------
-
-/// A sink config with `retry.max_attempts = 0` fails sink construction
-/// with `SondaError::Config`, which the handler maps to 422.
 #[test]
 fn post_events_invalid_sink_config_returns_422() {
     let (port, _guard) = common::start_server();
@@ -294,12 +245,6 @@ fn post_events_invalid_sink_config_returns_422() {
     assert_eq!(json["error"], "unprocessable_entity");
 }
 
-// ---------------------------------------------------------------------------
-// Test 7 — sink push 5xx → 502.
-// ---------------------------------------------------------------------------
-
-/// HTTP client with an extended timeout so the loopback / 5xx tests do
-/// not race the server's blocking sink on slow CI machines.
 fn long_timeout_http_client() -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(30))
@@ -307,8 +252,6 @@ fn long_timeout_http_client() -> reqwest::blocking::Client {
         .expect("build long-timeout HTTP client")
 }
 
-/// A real Loki-shaped sink whose target returns 502 surfaces as 502
-/// from `POST /events`.
 #[test]
 fn post_events_sink_push_5xx_returns_502() {
     let (port, _guard) = common::start_server();
@@ -345,11 +288,6 @@ fn post_events_sink_push_5xx_returns_502() {
     assert_eq!(json["error"], "bad_gateway");
 }
 
-// ---------------------------------------------------------------------------
-// Test 8 — auth required, no Bearer → 401.
-// ---------------------------------------------------------------------------
-
-/// When `--api-key` is set, POST /events without a Bearer header returns 401.
 #[test]
 fn post_events_without_auth_returns_401() {
     let (port, _guard) = common::start_server_with(&["--api-key", "test-secret"], &[]);
@@ -374,12 +312,6 @@ fn post_events_without_auth_returns_401() {
     assert_eq!(json["error"], "unauthorized");
 }
 
-// ---------------------------------------------------------------------------
-// Test 9 — loopback warning surfaced on success.
-// ---------------------------------------------------------------------------
-
-/// A loopback Loki URL produces a warning string in the success response
-/// without changing the 200 status.
 #[test]
 fn post_events_loopback_sink_attaches_warning() {
     let (port, _guard) = common::start_server();


### PR DESCRIPTION
## Summary
Follow-up cleanup to #289. No behavior change — pure style/comment trim + markdown reflow.

- Trim architectural-narration doc comments, `# Errors` / `# Examples` blocks, tautological field and variant docs, and section-banner inline comments from `sonda-core/src/emit.rs`, `sonda-server/src/routes/events.rs`, `sonda-server/src/routes/sink_warnings.rs`, and `sonda-server/tests/events.rs`.
- Unwrap hard-wrapped paragraphs in `docs/site/docs/deployment/events.md` (added in #289) and the `/events` paragraphs of `docs/site/docs/deployment/sonda-server.md`. Lists, tables, code fences, and admonition headers untouched.
- Net: 6 files changed, +27 / -311.

Comment-line counts before → after on the four touched `.rs` files:
- `sonda-core/src/emit.rs`: 24 → 3
- `sonda-server/src/routes/events.rs`: 55 → 1
- `sonda-server/src/routes/sink_warnings.rs`: 29 → 2
- `sonda-server/tests/events.rs`: 56 → 1

## Test plan
- [x] No source logic touched — comments and markdown reflow only
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [ ] `cargo test --workspace` (running locally; results posted in PR before merge)