### PR TITLE
docs(scenarios): clarify v2 cascade duration semantics

### DIFF
--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -347,7 +347,16 @@ Validation: OK (3 scenarios)
 
 The `phase_offset` lines show the concrete delays Sonda computed from the threshold-crossing
 math. The `(auto)` suffix on `clock_group` indicates Sonda assigned the group automatically
-because of the `after:` relationship. The scenario also ships in the built-in catalog:
+because of the `after:` relationship.
+
+!!! info "Duration is per-entry, not per-cascade"
+    Each entry's `duration:` runs from that entry's own resolved start time (`phase_offset`), not from cascade registration. The cascade's total wall-clock is therefore `max(phase_offset + duration)` across all entries, which can exceed `defaults.duration`.
+
+    For the `link-failover` example above, `defaults.duration` is `5m` and the largest `phase_offset` is `152.308s` (on `latency_ms`), so the chain finishes at roughly `152.308s + 5m ≈ 7m32s` of wall-clock — not 5m.
+
+    The CLI `--duration` flag (and the body-level `duration` field on `POST /scenarios`) shorten **every entry's `duration` individually**; they do not cap the cascade's total wall-clock. Running the same chain with `--duration 2m` produces `152.308s + 2m ≈ 4m32s`, because every entry now runs for 2m from its own start.
+
+The scenario also ships in the built-in catalog:
 
 ```bash
 sonda catalog run link-failover

--- a/scenarios/link-failover.yaml
+++ b/scenarios/link-failover.yaml
@@ -16,6 +16,12 @@
 #   sonda run --scenario scenarios/link-failover.yaml
 #   sonda run --scenario scenarios/link-failover.yaml --dry-run
 #   sonda run --scenario scenarios/link-failover.yaml --duration 2m
+#
+# Each entry's `duration:` runs from its own resolved start (`phase_offset`),
+# so a cascade's total wall-clock can exceed `defaults.duration`. With the
+# values below the chain finishes around `152s + 5m ≈ 7m32s`; `--duration 2m`
+# shortens every phase individually (so the cascade ends near `152s + 2m`),
+# it does not cap the total wall-clock.
 
 version: 2
 

--- a/sonda-core/src/compiler/mod.rs
+++ b/sonda-core/src/compiler/mod.rs
@@ -120,7 +120,9 @@ pub struct Defaults {
     /// Default event rate in events per second.
     #[cfg_attr(feature = "config", serde(default))]
     pub rate: Option<f64>,
-    /// Default total run duration (e.g. `"30s"`, `"5m"`).
+    /// Default total run duration (e.g. `"30s"`, `"5m"`). Applied per entry —
+    /// each entry runs for this long from its own resolved start, so a cascade's
+    /// total wall-clock is `max(phase_offset + duration)`, not `duration`.
     #[cfg_attr(feature = "config", serde(default))]
     pub duration: Option<String>,
     /// Default encoder configuration.


### PR DESCRIPTION
## Summary

- Document that each entry's `duration:` runs from its own resolved `phase_offset`, so a cascade's total wall-clock is `max(phase_offset + duration)` — not `defaults.duration`.
- Add an `!!! info` admonition to `docs/site/docs/configuration/v2-scenarios.md` showing the on-page math: `link-failover` finishes at `152.308s + 5m ≈ 7m32s`, and `--duration 2m` shortens every entry individually rather than capping the cascade.
- Mirror the rule in the `scenarios/link-failover.yaml` header and on the `Defaults.duration` field doc comment in `sonda-core/src/compiler/mod.rs`.

### Why

Real-consumer feedback from the AutoCon5 workshop CLI: building a cascade body in memory, POSTing to `/scenarios`, and expecting the chain to finish in `defaults.duration` led to "why is Phase 3 still running an hour later?". Behavior is correct and intentional; the docs just didn't warn about it.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (1615 passed)
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo audit` (1 pre-existing yanked-dep warning, unrelated)
- [x] `mkdocs build --strict` from `docs/site/`
- [x] `sonda run --scenario scenarios/link-failover.yaml --dry-run` confirms `phase_offset: 1m`, `phase_offset: 152.308s`, `duration: 5m` — the exact numbers cited in the new admonition
- [x] `@uat` PASS on rendered admonition (title, paragraph separation, inline code, bold), YAML still parses, doc-comment style clean