### PR TITLE
chore: speed up tests with nextest + bound target/ size

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+incremental = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - name: Build
         run: cargo build --workspace
 
-      - name: Test
-        run: cargo test --workspace
+      - name: Test (nextest)
+        run: cargo nextest run --workspace
+
+      - name: Doctests
+        run: cargo test --workspace --doc
 
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
@@ -79,11 +87,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-server-
 
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - name: Build sonda-server
         run: cargo build -p sonda-server
 
       - name: Run sonda-server integration tests
-        run: cargo test -p sonda-server --test integration -- --nocapture
+        run: cargo nextest run -p sonda-server --test integration --no-capture
         timeout-minutes: 5
 
   docker-build:
@@ -128,8 +141,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-no-default-
 
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - name: Test without default features
-        run: cargo test -p sonda-core --no-default-features
+        run: cargo nextest run -p sonda-core --no-default-features
+
+      - name: Doctests without default features
+        run: cargo test -p sonda-core --no-default-features --doc
 
   all-features:
     name: Build, Test, Clippy (all features)
@@ -155,11 +176,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-all-features-
 
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - name: Build (all features)
         run: cargo build --workspace --all-features
 
-      - name: Test (all features)
-        run: cargo test --workspace --all-features
+      - name: Test (all features, nextest)
+        run: cargo nextest run --workspace --all-features
+
+      - name: Doctests (all features)
+        run: cargo test --workspace --all-features --doc
 
       - name: Clippy (all features)
         run: cargo clippy --workspace --all-features -- -D warnings


### PR DESCRIPTION
## Summary

- All four CI test jobs switch from `cargo test` to `cargo nextest run` (parallel test-binary execution). Doctests run as a separate step since nextest doesn't run them.
- Project-level `.cargo/config.toml` disables incremental compilation to bound `target/` size locally.

## Why

`cargo test --workspace` was taking >20 minutes on macOS workstations because `target/debug/incremental/` and `target/debug/deps/` had grown to 97+ GB / 1.2M+ files. Filesystem scans dominated wall clock (CPU usage ~2%, the rest was I/O blocked).

After `cargo clean` the same suite runs in ~71 seconds. With nextest's parallel binary execution, it drops further to ~31 seconds for unit/integration + ~25s for doctests in parallel.

The `[build] incremental = false` setting prevents the local cache bloat from recurring. CI runners are ephemeral so the change is essentially a no-op there, but the GHA `actions/cache` step persists less data per run.

## CI changes per affected job

| Job | Before | After |
|---|---|---|
| `ci` (main) | `cargo test --workspace` | `cargo nextest run --workspace` + `cargo test --workspace --doc` |
| `sonda-server` integration | `cargo test -p sonda-server --test integration -- --nocapture` | `cargo nextest run -p sonda-server --test integration --no-capture` |
| `no-default-features` | `cargo test -p sonda-core --no-default-features` | `cargo nextest run -p sonda-core --no-default-features` + `cargo test ... --doc` |
| `all-features` | `cargo test --workspace --all-features` | `cargo nextest run --workspace --all-features` + `cargo test ... --doc` |

Each job gains one `taiki-e/install-action@v2` step that fetches a precompiled nextest binary in ~5 seconds. The `clippy`, `fmt`, `audit`, `docker-build`, and `docs-commands` jobs are untouched.

## Local validation

- `cargo nextest run --workspace`: 2766 tests passed in 14.16s (Summary), 31s wall clock.
- `cargo test --workspace --doc`: 5 doctests passed.

## Test plan

- [x] Local `cargo nextest run --workspace` green
- [x] Local `cargo test --workspace --doc` green
- [ ] CI green on this PR (the PR's own CI run is the validation gate for the workflow change)