### PR TITLE
feat(surface): user-facing surface for while: gating (PR 3 of #295)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,8 @@ checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
+ "pest",
+ "pest_derive",
  "regex",
  "serde",
  "similar",
@@ -1418,6 +1420,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project"
@@ -2149,7 +2194,9 @@ dependencies = [
  "clap",
  "ctrlc",
  "dialoguer",
+ "insta",
  "owo-colors",
+ "rstest",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -2195,6 +2242,7 @@ dependencies = [
  "insta",
  "libc",
  "reqwest",
+ "rstest",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -2628,6 +2676,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-bidi"

--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -416,6 +416,163 @@ sonda catalog run link-failover
     `flap`, `saturation`, `leak`, `degradation`, `spike_event`. Using `steady` as the target is
     rejected -- sine crossings are ambiguous.
 
+For continuous gating that pauses and resumes a downstream as the upstream's value oscillates above and below a threshold, see [Continuous coupling with `while:`](#continuous-coupling-with-while).
+
+## Continuous coupling with `while:`
+
+`after:` is a one-shot trigger -- it fires once and the dependent scenario runs to completion. `while:` is the continuous-coupling counterpart: the gated scenario emits only while the upstream's latest value satisfies the predicate, pauses when the predicate fails, and resumes when the predicate becomes true again. Use `while:` when an event stream should track an upstream signal's lifecycle, not just its first crossing.
+
+```yaml title="scenarios/link-traffic.yaml"
+version: 2
+
+defaults:
+  rate: 1
+  duration: 5m
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+
+scenarios:
+  - id: primary_link
+    signal_type: metrics
+    name: interface_oper_state
+    generator:
+      type: flap
+      up_duration: 60s
+      down_duration: 30s
+
+  - id: backup_traffic
+    signal_type: metrics
+    name: backup_link_throughput
+    generator:
+      type: constant
+      value: 50.0
+    while:
+      ref: primary_link
+      op: "<"
+      value: 1
+```
+
+`backup_traffic` emits only while `primary_link` reports a value below `1` -- in other words, while the primary link is down. When the primary flaps back up, the gate closes and `backup_traffic` pauses; when the primary drops again, the gate reopens and emission resumes. The schedule is debounced via the optional `delay:` clause shown below.
+
+### Lifecycle states
+
+A scenario carrying a `while:` clause walks through four lifecycle states. The runtime exposes the live state on `GET /scenarios/{id}/stats` so monitors can react to gate transitions without polling the upstream signal.
+
+```
+            +-----------+
+            |  pending  |
+            +-----+-----+
+                  | upstream's first eligible tick
+                  v
+       +------+--------+   close transition
+       |              |    +------------+
+       |   running    |--->|   paused   |
+       |              |<---|            |
+       +------+-------+    +------------+
+              |  open transition
+              | duration elapsed / shutdown
+              v
+        +-----+-----+
+        |  finished |
+        +-----------+
+```
+
+`pending` covers the wait for the upstream's first eligible tick. The downstream enters `running` when the gate first opens, oscillates between `running` and `paused` for the rest of the run, and ends in `finished` when its `duration:` elapses or shutdown is signaled. A scenario with both `after:` and `while:` whose `after:` fires while the gate is closed enters `paused` directly -- `pending` need not always precede `running`.
+
+### Debouncing transitions with `delay:`
+
+Pair `while:` with `delay:` to debounce noisy upstream signals.
+
+```yaml
+  - id: backup_traffic
+    signal_type: metrics
+    name: backup_link_throughput
+    generator:
+      type: constant
+      value: 50.0
+    while:
+      ref: primary_link
+      op: "<"
+      value: 1
+    delay:
+      open: 250ms
+      close: 1s
+```
+
+`open` is the duration the upstream value must satisfy the predicate before the gate transitions from closed to open; `close` is the duration the value must violate the predicate before the gate transitions back to closed. Either field defaults to `0s` when omitted. `delay:` requires `while:` -- standalone `delay:` is rejected at compile time.
+
+### `--dry-run` preview
+
+`sonda run --scenario scenarios/link-traffic.yaml --dry-run` renders the gate plumbing alongside the existing layout:
+
+```
+[config] [2/2] backup_link_throughput
+
+    name:           backup_link_throughput
+    signal:         metrics
+    rate:           1/s
+    duration:       5m
+    generator:      constant (value: 50)
+    encoder:        prometheus_text
+    sink:           stdout
+    while:          upstream='primary_link' op='<' value=1
+    first_open:     ~60s
+```
+
+The `first_open:` line shows the analytical time at which the upstream's value first satisfies the predicate, computed from the upstream generator's shape. When the upstream's generator is non-analytical (`sine`, `uniform`, `csv_replay`, `steady`), `first_open` renders as `<indeterminate -- non-analytical generator>` -- the gate still works at runtime, but no compile-time crossing time is available.
+
+When an entry carries both `after:` and `while:`, both cues render: `phase_offset:` shows the resolved `after_first_fire` time, while `first_open:` shows the gate's first opening. Operators read `max(phase_offset, first_open)` to know when the downstream first emits.
+
+### Supported operators
+
+`while:` accepts only the strict comparison operators `<` and `>`. Non-strict operators (`<=`, `>=`, `==`, `!=`) are rejected at compile time -- equality on a continuous-valued upstream is numerically unsafe and forbidden by design.
+
+### Migrating an `after:`-only cascade to `while:` with recovery
+
+The `link-failover` scenario described above uses `after:` to start a `backup_link_utilization` saturation curve once the primary link drops below `1`. With `after:` the dependent scenario runs to completion regardless of what the primary does next -- if the primary recovers mid-cascade, the backup keeps emitting.
+
+To make the backup track the primary's state continuously, swap `after:` for `while:` on the cascade members that should pause when the primary recovers:
+
+```yaml title="scenarios/link-failover-recovery.yaml"
+version: 2
+
+defaults:
+  rate: 1
+  duration: 5m
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+
+scenarios:
+  - id: primary_link
+    signal_type: metrics
+    name: interface_oper_state
+    generator:
+      type: flap
+      up_duration: 60s
+      down_duration: 30s
+
+  - id: backup_util
+    signal_type: metrics
+    name: backup_link_utilization
+    generator:
+      type: saturation
+      baseline: 20
+      ceiling: 85
+      time_to_saturate: 2m
+    while:
+      ref: primary_link
+      op: "<"
+      value: 1
+    delay:
+      close: 5s
+```
+
+The `delay.close: 5s` debounces flap transitions: a brief recovery on the primary does not immediately tear down `backup_util`, but a sustained recovery longer than 5s does.
+
 ## Pack-backed entries
 
 Reference a [metric pack](../guides/metric-packs.md) directly from a scenarios entry. Sonda

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -503,7 +503,7 @@ curl -s http://localhost:8080/scenarios | jq .
 }
 ```
 
-Each entry carries `id`, `name`, `status` (`running` or `stopped`), and `elapsed_secs`. To see sink health, follow up with `GET /scenarios/{id}/stats` for the scenario you care about.
+Each entry carries `id`, `name`, `status`, and `elapsed_secs`. The `status` field takes one of `pending`, `running`, `paused`, or `finished` (see the [`state` field reference](#scenariosidstats) below for what each value means and the transition note for `pending -> paused`). To see sink health, follow up with `GET /scenarios/{id}/stats` for the scenario you care about.
 
 ### `/scenarios/{id}/stats`
 
@@ -537,7 +537,7 @@ curl -s http://localhost:8080/scenarios/$ID/stats | jq .
 | `bytes_emitted` | integer | Total bytes written to the sink. |
 | `errors` | integer | Encode or sink-write errors observed. |
 | `uptime_secs` | float | Seconds since the scenario was launched. |
-| `state` | string | `running` or `stopped`. |
+| `state` | string | One of `pending`, `running`, `paused`, `finished`. See the [`while:` lifecycle diagram](../configuration/v2-scenarios.md#lifecycle-states). |
 | `in_gap` | bool | `true` while a [gap window](../configuration/scenario-fields.md#gap-window) is suppressing output. |
 | `in_burst` | bool | `true` while a [burst window](../configuration/scenario-fields.md#burst-window) is elevating the rate. |
 | `consecutive_failures` | integer | Sink errors observed since the most recent successful write. Resets to `0` on the next successful write. |
@@ -545,7 +545,10 @@ curl -s http://localhost:8080/scenarios/$ID/stats | jq .
 | `last_sink_error` | string \| null | Text of the most recent sink error, or `null` if none has been observed. |
 | `last_successful_write_at` | integer \| null | Wall-clock time of the most recent successful write, expressed as Unix nanoseconds. `null` until the first write succeeds. |
 
-The four sink-failure fields are the runtime telemetry surface for the [`on_sink_error` policy](../configuration/v2-scenarios.md#sink-error-policy). When `on_sink_error: warn` (the default) is in effect, the runner stays alive on transient sink errors and these counters tell you what's happening; when `on_sink_error: fail` is set, the thread exits on the first error and `state` flips to `stopped`.
+The four sink-failure fields are the runtime telemetry surface for the [`on_sink_error` policy](../configuration/v2-scenarios.md#sink-error-policy). When `on_sink_error: warn` (the default) is in effect, the runner stays alive on transient sink errors and these counters tell you what's happening; when `on_sink_error: fail` is set, the thread exits on the first error and `state` flips to `finished`.
+
+!!! note "`pending -> paused` is a reachable direct transition"
+    A scenario carrying both `after:` and `while:` whose `after:` fires while the gate is closed enters `paused` directly, skipping `running`. Clients building a state-machine assertion should not assume `pending` always precedes `running` -- watch for `paused` from the `pending` state too.
 
 !!! tip "Detecting a wedged sink"
     Compute "degraded" yourself by thresholding `total_sink_failures` and the staleness of `last_successful_write_at`. Pick a staleness window that fits your scenario's rate and your tolerance for transient blips:

--- a/sonda-core/src/compiler/mod.rs
+++ b/sonda-core/src/compiler/mod.rs
@@ -420,7 +420,7 @@ mod delay_duration_opt {
 
     use serde::{Deserialize, Deserializer, Serializer};
 
-    use crate::config::validate::parse_duration;
+    use crate::config::validate::parse_delay_duration;
 
     pub fn serialize<S>(value: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -438,7 +438,7 @@ mod delay_duration_opt {
     {
         let raw: Option<String> = Option::deserialize(deserializer)?;
         match raw {
-            Some(s) => parse_duration(&s)
+            Some(s) => parse_delay_duration(&s)
                 .map(Some)
                 .map_err(serde::de::Error::custom),
             None => Ok(None),

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -1391,6 +1391,66 @@ scenarios:
     }
 
     #[test]
+    fn delay_open_zero_is_accepted() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  duration: 5m
+scenarios:
+  - id: src
+    signal_type: metrics
+    name: src
+    generator: { type: constant, value: 1 }
+  - id: gated
+    signal_type: metrics
+    name: gated
+    generator: { type: constant, value: 1 }
+    while: { ref: src, op: ">", value: 0 }
+    delay: { open: "0s", close: "5s" }
+"#;
+        let file = normalize_yaml(yaml).expect("delay open=0s must parse and normalize");
+        let gated = file
+            .entries
+            .iter()
+            .find(|e| e.id.as_deref() == Some("gated"))
+            .unwrap();
+        let delay = gated.delay_clause.as_ref().expect("delay clause present");
+        assert_eq!(delay.open, Some(std::time::Duration::ZERO));
+        assert_eq!(delay.close, Some(std::time::Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn delay_close_zero_is_accepted() {
+        let yaml = r#"
+version: 2
+defaults:
+  rate: 1
+  duration: 5m
+scenarios:
+  - id: src
+    signal_type: metrics
+    name: src
+    generator: { type: constant, value: 1 }
+  - id: gated
+    signal_type: metrics
+    name: gated
+    generator: { type: constant, value: 1 }
+    while: { ref: src, op: ">", value: 0 }
+    delay: { open: "250ms", close: "0ms" }
+"#;
+        let file = normalize_yaml(yaml).expect("delay close=0ms must parse and normalize");
+        let gated = file
+            .entries
+            .iter()
+            .find(|e| e.id.as_deref() == Some("gated"))
+            .unwrap();
+        let delay = gated.delay_clause.as_ref().expect("delay clause present");
+        assert_eq!(delay.open, Some(std::time::Duration::from_millis(250)));
+        assert_eq!(delay.close, Some(std::time::Duration::ZERO));
+    }
+
+    #[test]
     fn while_inherits_from_defaults() {
         let yaml = r#"
 version: 2

--- a/sonda-core/src/config/validate.rs
+++ b/sonda-core/src/config/validate.rs
@@ -85,6 +85,35 @@ pub fn parse_duration(s: &str) -> Result<Duration, SondaError> {
     Ok(Duration::from_micros((total_ms * 1_000.0) as u64))
 }
 
+/// Parse a `delay:` open/close duration, accepting zero as `Duration::ZERO`.
+///
+/// `parse_duration` rejects zero values because a zero rate or zero scenario
+/// duration is meaningless. The `delay:` clause has the opposite semantics:
+/// `0s` / `0ms` / `0` are valid and mean "no debounce on this transition".
+pub fn parse_delay_duration(s: &str) -> Result<Duration, SondaError> {
+    match parse_duration(s) {
+        Ok(d) => Ok(d),
+        Err(e) => {
+            let trimmed = s.trim();
+            if trimmed.starts_with('-') {
+                return Err(e);
+            }
+            let numeric_str = trimmed
+                .strip_suffix("ms")
+                .or_else(|| trimmed.strip_suffix('h'))
+                .or_else(|| trimmed.strip_suffix('m'))
+                .or_else(|| trimmed.strip_suffix('s'))
+                .unwrap_or(trimmed);
+            if let Ok(v) = numeric_str.parse::<f64>() {
+                if v == 0.0 {
+                    return Ok(Duration::ZERO);
+                }
+            }
+            Err(e)
+        }
+    }
+}
+
 /// Parse an optional phase offset string into a [`Duration`].
 ///
 /// Unlike [`parse_duration`], this function accepts zero values (e.g. `"0s"`)
@@ -881,6 +910,42 @@ mod tests {
     fn parse_duration_unknown_unit_returns_err() {
         let result = parse_duration("10d");
         assert!(result.is_err(), "'10d' must return Err (unknown unit)");
+    }
+
+    #[test]
+    fn parse_delay_duration_accepts_zero_seconds() {
+        let d = parse_delay_duration("0s").expect("'0s' must parse for delay");
+        assert_eq!(d, Duration::ZERO);
+    }
+
+    #[test]
+    fn parse_delay_duration_accepts_zero_milliseconds() {
+        let d = parse_delay_duration("0ms").expect("'0ms' must parse for delay");
+        assert_eq!(d, Duration::ZERO);
+    }
+
+    #[test]
+    fn parse_delay_duration_accepts_bare_zero() {
+        let d = parse_delay_duration("0").expect("'0' must parse for delay");
+        assert_eq!(d, Duration::ZERO);
+    }
+
+    #[test]
+    fn parse_delay_duration_accepts_positive_value() {
+        let d = parse_delay_duration("5s").expect("'5s' must parse for delay");
+        assert_eq!(d.as_secs(), 5);
+    }
+
+    #[test]
+    fn parse_delay_duration_rejects_negative_value() {
+        let result = parse_delay_duration("-1s");
+        assert!(result.is_err(), "negative delay must be rejected");
+    }
+
+    #[test]
+    fn parse_delay_duration_rejects_garbage() {
+        let result = parse_delay_duration("not_a_duration");
+        assert!(result.is_err(), "non-duration string must be rejected");
     }
 
     // ---- validate_config: rate validation ------------------------------------

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -52,7 +52,7 @@ pub use model::metric::ValidatedMetricName;
 pub use scenarios::BuiltinScenario;
 pub use schedule::handle::ScenarioHandle;
 pub use schedule::launch::{launch_scenario, prepare_entries, validate_entry, PreparedEntry};
-pub use schedule::stats::ScenarioStats;
+pub use schedule::stats::{ScenarioState, ScenarioStats};
 
 #[cfg(feature = "config")]
 pub use compiler::prepare::PrepareError;

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -20,7 +20,7 @@ use crate::schedule::handle::ScenarioHandle;
 use crate::schedule::histogram_runner::run_with_sink_gated as run_histogram_with_sink_gated;
 use crate::schedule::log_runner::run_logs_with_sink_gated;
 use crate::schedule::runner::run_with_sink_gated;
-use crate::schedule::stats::ScenarioStats;
+use crate::schedule::stats::{ScenarioState, ScenarioStats};
 use crate::schedule::summary_runner::run_with_sink_gated as run_summary_with_sink_gated;
 use crate::sink::create_sink;
 use crate::{ConfigError, RuntimeError, SondaError};
@@ -238,6 +238,9 @@ pub fn launch_scenario_with_gates(
     // Ensure `running` ordering is visible from the new thread.
     shutdown.store(true, Ordering::SeqCst);
 
+    let stats_for_state = Arc::clone(&stats);
+    let is_gated = gate_ctx.is_some();
+
     let thread = std::thread::Builder::new()
         .name(format!("sonda-{}", name))
         .spawn(move || -> Result<(), SondaError> {
@@ -247,6 +250,19 @@ pub fn launch_scenario_with_gates(
             let _guard = AliveGuard {
                 flag: alive_for_thread,
             };
+
+            // Drop guard writes ScenarioState::Finished on every exit path.
+            let _state_guard = StateGuard {
+                stats: Arc::clone(&stats_for_state),
+            };
+
+            // gated_loop owns Pending/Running/Paused transitions itself.
+            // Non-gated scenarios have nothing else writing Running, so do it here.
+            if !is_gated {
+                if let Ok(mut st) = stats_for_state.write() {
+                    st.state = ScenarioState::Running;
+                }
+            }
 
             // If a start delay is configured, sleep before entering the event
             // loop. This enables phase-offset correlation between scenarios
@@ -332,6 +348,18 @@ struct AliveGuard {
 impl Drop for AliveGuard {
     fn drop(&mut self) {
         self.flag.store(false, Ordering::SeqCst);
+    }
+}
+
+struct StateGuard {
+    stats: Arc<RwLock<ScenarioStats>>,
+}
+
+impl Drop for StateGuard {
+    fn drop(&mut self) {
+        if let Ok(mut st) = self.stats.write() {
+            st.state = ScenarioState::Finished;
+        }
     }
 }
 
@@ -1443,6 +1471,74 @@ mod tests {
         assert!(
             !alive.load(Ordering::SeqCst),
             "AliveGuard Drop must clear the alive flag even when the thread panics"
+        );
+    }
+
+    #[test]
+    fn state_guard_writes_finished_on_drop() {
+        let stats = Arc::new(std::sync::RwLock::new(ScenarioStats::default()));
+        {
+            let mut st = stats.write().unwrap();
+            st.state = ScenarioState::Running;
+        }
+        {
+            let _g = StateGuard {
+                stats: Arc::clone(&stats),
+            };
+        }
+        assert_eq!(stats.read().unwrap().state, ScenarioState::Finished);
+    }
+
+    #[test]
+    fn state_guard_writes_finished_on_thread_panic() {
+        let stats = Arc::new(std::sync::RwLock::new(ScenarioStats::default()));
+        let stats_for_thread = Arc::clone(&stats);
+
+        let thread = std::thread::Builder::new()
+            .name("state-guard-panic".to_string())
+            .spawn(move || {
+                let _g = StateGuard {
+                    stats: stats_for_thread,
+                };
+                let always_none: Option<u32> = None;
+                always_none.expect("intentional panic for StateGuard test");
+            })
+            .expect("spawn must succeed");
+
+        let result = thread.join();
+        assert!(result.is_err(), "thread must panic");
+        assert_eq!(
+            stats.read().unwrap().state,
+            ScenarioState::Finished,
+            "StateGuard Drop must write Finished even on panic"
+        );
+    }
+
+    #[test]
+    fn launch_non_gated_scenario_state_transitions_through_running_to_finished() {
+        let shutdown = Arc::new(AtomicBool::new(true));
+        let entry = metrics_entry("state_lifecycle");
+        let mut handle = launch_scenario("state-id".to_string(), entry, shutdown, None)
+            .expect("launch must succeed");
+
+        let mut saw_running = false;
+        let deadline = std::time::Instant::now() + Duration::from_millis(500);
+        while std::time::Instant::now() < deadline {
+            if handle.stats_snapshot().state == ScenarioState::Running {
+                saw_running = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(saw_running, "non-gated scenario must reach Running");
+
+        handle
+            .join(Some(Duration::from_secs(2)))
+            .expect("join must succeed");
+        assert_eq!(
+            handle.stats_snapshot().state,
+            ScenarioState::Finished,
+            "non-gated scenario must end in Finished"
         );
     }
 

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -98,14 +98,19 @@ pub fn signal_shutdown(shutdown: &AtomicBool) {
     shutdown.store(false, Ordering::SeqCst);
 }
 
-/// Run a compiled scenario file with `while:` / `after:` gating wired in.
+/// Launch a compiled scenario file with `while:` / `after:` gating wired in,
+/// returning the live handles without joining them.
 ///
-/// Pre-builds an `Arc<GateBus>` per metric scenario id, subscribes each
-/// downstream to its upstream's bus, and launches every scenario with the
-/// matching [`GateContext`]. Non-gated entries launch on the existing
-/// non-gated path with no per-tick overhead.
+/// Equivalent to the spawn portion of [`run_multi_compiled`]: pre-builds an
+/// `Arc<GateBus>` per metric scenario id, subscribes each downstream to its
+/// upstream's bus, and launches every scenario with the matching
+/// [`GateContext`]. Returns the launched [`ScenarioHandle`]s so callers can
+/// observe per-scenario stats (for progress displays) before joining.
 #[cfg(feature = "config")]
-pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Result<(), SondaError> {
+pub fn launch_multi_compiled(
+    file: CompiledFile,
+    shutdown: Arc<AtomicBool>,
+) -> Result<Vec<crate::schedule::handle::ScenarioHandle>, SondaError> {
     let CompiledFile { entries, .. } = file;
 
     // Pre-build a bus for every entry that has an explicit id — downstream
@@ -208,6 +213,18 @@ pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Resu
         )?;
         handles.push(handle);
     }
+
+    Ok(handles)
+}
+
+/// Run a compiled scenario file with `while:` / `after:` gating wired in.
+///
+/// Spawns every scenario via [`launch_multi_compiled`] and joins the threads.
+/// Non-gated entries launch on the existing non-gated path with no per-tick
+/// overhead.
+#[cfg(feature = "config")]
+pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Result<(), SondaError> {
+    let handles = launch_multi_compiled(file, shutdown)?;
 
     let mut errors: Vec<String> = Vec::new();
     for mut handle in handles {

--- a/sonda-core/src/schedule/stats.rs
+++ b/sonda-core/src/schedule/stats.rs
@@ -71,10 +71,6 @@ pub struct ScenarioStats {
     #[serde(skip)]
     pub recent_metrics: VecDeque<MetricEvent>,
     /// Lifecycle state of the scenario.
-    ///
-    /// Hidden from serialization in this PR; the server's `state` field
-    /// stays driven from `is_running()` until the surface widens.
-    #[serde(skip)]
     pub state: ScenarioState,
 }
 

--- a/sonda-server/Cargo.toml
+++ b/sonda-server/Cargo.toml
@@ -45,4 +45,5 @@ hyper = "1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls"] }
 libc = "0.2"
 tempfile = "3"
-insta = { workspace = true }
+insta = { workspace = true, features = ["filters", "redactions"] }
+rstest = { workspace = true }

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -30,7 +30,7 @@ use sonda_core::compiler::expand::InMemoryPackResolver;
 use sonda_core::compiler::parse::detect_version;
 use sonda_core::encoder::prometheus::PrometheusText;
 use sonda_core::encoder::Encoder;
-use sonda_core::ScenarioStats;
+use sonda_core::{ScenarioState, ScenarioStats};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -93,7 +93,7 @@ pub struct ScenarioSummary {
     pub id: String,
     /// Human-readable scenario name.
     pub name: String,
-    /// Current status: "running" or "stopped".
+    /// Current status: `pending`, `running`, `paused`, or `finished`.
     pub status: String,
     /// Seconds elapsed since the scenario was launched.
     pub elapsed_secs: f64,
@@ -113,7 +113,7 @@ pub struct ScenarioDetail {
     pub id: String,
     /// Human-readable scenario name.
     pub name: String,
-    /// Current status: "running" or "stopped".
+    /// Current status: `pending`, `running`, `paused`, or `finished`.
     pub status: String,
     /// Seconds elapsed since the scenario was launched.
     pub elapsed_secs: f64,
@@ -191,7 +191,7 @@ pub struct DetailedStatsResponse {
     pub errors: u64,
     /// Seconds elapsed since the scenario was launched.
     pub uptime_secs: f64,
-    /// Current state: `"running"` or `"stopped"`.
+    /// Current state: `"pending"`, `"running"`, `"paused"`, or `"finished"`.
     pub state: String,
     /// Whether the scenario is currently in a gap window (no events emitted).
     pub in_gap: bool,
@@ -235,12 +235,13 @@ fn internal_error(detail: impl std::fmt::Display) -> Response {
 
 // ---- Helpers ----------------------------------------------------------------
 
-/// Derive the status string from whether the scenario handle is still running.
-fn status_string(running: bool) -> String {
-    if running {
-        "running".to_string()
-    } else {
-        "stopped".to_string()
+/// Map [`ScenarioStats::state`] to its lowercase wire string.
+fn state_string(stats: &ScenarioStats) -> &'static str {
+    match stats.state {
+        ScenarioState::Pending => "pending",
+        ScenarioState::Running => "running",
+        ScenarioState::Paused => "paused",
+        ScenarioState::Finished => "finished",
     }
 }
 
@@ -603,11 +604,14 @@ pub async fn list_scenarios(State(state): State<AppState>) -> Result<impl IntoRe
 
     let summaries: Vec<ScenarioSummary> = scenarios
         .iter()
-        .map(|(id, handle)| ScenarioSummary {
-            id: id.clone(),
-            name: handle.name.clone(),
-            status: status_string(handle.is_running()),
-            elapsed_secs: handle.elapsed().as_secs_f64(),
+        .map(|(id, handle)| {
+            let snap = handle.stats_snapshot();
+            ScenarioSummary {
+                id: id.clone(),
+                name: handle.name.clone(),
+                status: state_string(&snap).to_string(),
+                elapsed_secs: handle.elapsed().as_secs_f64(),
+            }
         })
         .collect();
 
@@ -634,12 +638,13 @@ pub async fn get_scenario(
         .get(&id)
         .ok_or_else(|| not_found(format!("scenario not found: {id}")))?;
 
+    let snap = handle.stats_snapshot();
     let detail = ScenarioDetail {
         id: id.clone(),
         name: handle.name.clone(),
-        status: status_string(handle.is_running()),
+        status: state_string(&snap).to_string(),
         elapsed_secs: handle.elapsed().as_secs_f64(),
-        stats: handle.stats_snapshot().into(),
+        stats: snap.into(),
     };
 
     Ok(Json(detail))
@@ -708,7 +713,8 @@ pub async fn delete_scenario(
 ///
 /// Returns all stats fields from the runner thread plus derived fields:
 /// `target_rate` (configured rate from the scenario config), `uptime_secs`
-/// (computed from `handle.elapsed()`), and `state` (from `handle.is_running()`).
+/// (computed from `handle.elapsed()`), and `state` (one of `pending`,
+/// `running`, `paused`, `finished`).
 ///
 /// This is a read-only endpoint that acquires only a read lock on the
 /// scenario map. No write lock is needed.
@@ -728,6 +734,7 @@ pub async fn get_scenario_stats(
         .ok_or_else(|| not_found(format!("scenario not found: {id}")))?;
 
     let snap = handle.stats_snapshot();
+    let state = state_string(&snap).to_string();
     let response = DetailedStatsResponse {
         total_events: snap.total_events,
         current_rate: snap.current_rate,
@@ -735,7 +742,7 @@ pub async fn get_scenario_stats(
         bytes_emitted: snap.bytes_emitted,
         errors: snap.errors,
         uptime_secs: handle.elapsed().as_secs_f64(),
-        state: status_string(handle.is_running()),
+        state,
         in_gap: snap.in_gap,
         in_burst: snap.in_burst,
         consecutive_failures: snap.consecutive_failures,
@@ -1163,6 +1170,9 @@ scenarios:
             1000,
             Duration::from_millis(50),
         );
+        if let Ok(mut s) = h.stats.write() {
+            s.state = ScenarioState::Running;
+        }
         let app = router_with_handles(vec![h]);
 
         // Small delay to ensure elapsed > 0.
@@ -1318,12 +1328,14 @@ scenarios:
         );
     }
 
-    // ---- GET /scenarios/{id}: stopped scenario reports "stopped" --------------
+    // ---- GET /scenarios/{id}: finished scenario reports "finished" ------------
 
-    /// A scenario whose thread has exited reports status "stopped".
     #[tokio::test]
-    async fn get_scenario_stopped_reports_stopped_status() {
-        let h = make_stopped_handle("id-stopped", "stopped_scenario");
+    async fn get_scenario_finished_reports_finished_status() {
+        let h = make_stopped_handle("id-stopped", "finished_scenario");
+        if let Ok(mut s) = h.stats.write() {
+            s.state = ScenarioState::Finished;
+        }
         let app = router_with_handles(vec![h]);
 
         let req = Request::builder()
@@ -1337,8 +1349,8 @@ scenarios:
         let body = body_json(resp).await;
         assert_eq!(
             body["status"].as_str().unwrap(),
-            "stopped",
-            "a finished scenario must have status 'stopped'"
+            "finished",
+            "a finished scenario must have status 'finished'"
         );
     }
 
@@ -1429,18 +1441,19 @@ scenarios:
         assert_eq!(resp.errors, 3);
     }
 
-    // ---- status_string helper ------------------------------------------------
+    // ---- state_string helper -------------------------------------------------
 
-    /// status_string(true) returns "running".
     #[test]
-    fn status_string_true_returns_running() {
-        assert_eq!(status_string(true), "running");
-    }
-
-    /// status_string(false) returns "stopped".
-    #[test]
-    fn status_string_false_returns_stopped() {
-        assert_eq!(status_string(false), "stopped");
+    fn state_string_maps_each_variant_to_lowercase_wire_string() {
+        let mut s = ScenarioStats::default();
+        s.state = ScenarioState::Pending;
+        assert_eq!(state_string(&s), "pending");
+        s.state = ScenarioState::Running;
+        assert_eq!(state_string(&s), "running");
+        s.state = ScenarioState::Paused;
+        assert_eq!(state_string(&s), "paused");
+        s.state = ScenarioState::Finished;
+        assert_eq!(state_string(&s), "finished");
     }
 
     // ---- Serialization: response structs produce valid JSON ------------------
@@ -2548,6 +2561,7 @@ scenarios:
         stats.errors = 2;
         stats.in_gap = false;
         stats.in_burst = true;
+        stats.state = ScenarioState::Running;
         let h = make_handle_with_stats("id-stats-all", "all_fields", 100.0, stats, true);
         let app = router_with_handles(vec![h]);
 
@@ -2686,11 +2700,10 @@ scenarios:
         );
     }
 
-    // ---- After scenario stopped: returns final stats with state "stopped" ----
+    // ---- After scenario finished: returns final stats with state "finished" ----
 
-    /// When a scenario has stopped, GET /scenarios/{id}/stats returns state "stopped".
     #[tokio::test]
-    async fn stats_endpoint_returns_stopped_state_for_finished_scenario() {
+    async fn stats_endpoint_returns_finished_state_for_finished_scenario() {
         let mut stats = ScenarioStats::default();
         stats.total_events = 1000;
         stats.bytes_emitted = 64000;
@@ -2698,17 +2711,18 @@ scenarios:
         stats.errors = 5;
         stats.in_gap = false;
         stats.in_burst = false;
-        let h = make_handle_with_stats("id-stats-stopped", "stopped_test", 200.0, stats, false);
+        stats.state = ScenarioState::Finished;
+        let h = make_handle_with_stats("id-stats-finished", "finished_test", 200.0, stats, false);
         let app = router_with_handles(vec![h]);
 
-        let resp = get_stats_req(app, "id-stats-stopped").await;
+        let resp = get_stats_req(app, "id-stats-finished").await;
         assert_eq!(resp.status(), StatusCode::OK);
 
         let body = body_json(resp).await;
         assert_eq!(
             body["state"].as_str().unwrap(),
-            "stopped",
-            "state must be 'stopped' for a finished scenario"
+            "finished",
+            "state must be 'finished' for a finished scenario"
         );
         assert_eq!(
             body["total_events"].as_u64().unwrap(),
@@ -4110,6 +4124,8 @@ scenarios:
     fn snapshot_settings() -> insta::Settings {
         let mut s = insta::Settings::clone_current();
         s.set_sort_maps(true);
+        s.add_filter(r#"(?m)^\s+"[^"]+": null,\n"#, "");
+        s.add_filter(r#",\n(\s+"[^"]+": null\n)"#, "\n");
         s
     }
 
@@ -4132,6 +4148,51 @@ scenarios:
         };
         snapshot_settings().bind(|| {
             insta::assert_json_snapshot!("detailed_stats_response", resp);
+        });
+    }
+
+    #[rstest::rstest]
+    #[case::pending(ScenarioState::Pending, "pending")]
+    #[case::running(ScenarioState::Running, "running")]
+    #[case::paused(ScenarioState::Paused, "paused")]
+    #[case::finished(ScenarioState::Finished, "finished")]
+    fn detailed_stats_response_state_snapshot(
+        #[case] state: ScenarioState,
+        #[case] wire: &'static str,
+    ) {
+        let mut snap = ScenarioStats::default();
+        snap.total_events = 100;
+        snap.current_rate = if state == ScenarioState::Paused {
+            0.0
+        } else {
+            10.0
+        };
+        snap.bytes_emitted = 4096;
+        snap.state = state;
+        let resp = DetailedStatsResponse {
+            total_events: snap.total_events,
+            current_rate: snap.current_rate,
+            target_rate: 10.0,
+            bytes_emitted: snap.bytes_emitted,
+            errors: 0,
+            uptime_secs: 5.0,
+            state: state_string(&snap).to_string(),
+            in_gap: false,
+            in_burst: false,
+            consecutive_failures: 0,
+            total_sink_failures: 0,
+            last_sink_error: None,
+            last_successful_write_at: None,
+        };
+        assert_eq!(resp.state, wire);
+        snapshot_settings().bind(|| {
+            insta::assert_json_snapshot!(
+                format!("detailed_stats_response_state_{wire}"),
+                resp,
+                {
+                    ".uptime_secs" => "[uptime_secs]",
+                }
+            );
         });
     }
 

--- a/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_finished.snap
+++ b/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_finished.snap
@@ -1,0 +1,18 @@
+---
+source: sonda-server/src/routes/scenarios.rs
+assertion_line: 4189
+expression: resp
+---
+{
+  "total_events": 100,
+  "current_rate": 10.0,
+  "target_rate": 10.0,
+  "bytes_emitted": 4096,
+  "errors": 0,
+  "uptime_secs": "[uptime_secs]",
+  "state": "finished",
+  "in_gap": false,
+  "in_burst": false,
+  "consecutive_failures": 0,
+  "total_sink_failures": 0
+}

--- a/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_paused.snap
+++ b/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_paused.snap
@@ -1,0 +1,18 @@
+---
+source: sonda-server/src/routes/scenarios.rs
+assertion_line: 4189
+expression: resp
+---
+{
+  "total_events": 100,
+  "current_rate": 0.0,
+  "target_rate": 10.0,
+  "bytes_emitted": 4096,
+  "errors": 0,
+  "uptime_secs": "[uptime_secs]",
+  "state": "paused",
+  "in_gap": false,
+  "in_burst": false,
+  "consecutive_failures": 0,
+  "total_sink_failures": 0
+}

--- a/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_pending.snap
+++ b/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_pending.snap
@@ -1,0 +1,18 @@
+---
+source: sonda-server/src/routes/scenarios.rs
+assertion_line: 4189
+expression: resp
+---
+{
+  "total_events": 100,
+  "current_rate": 10.0,
+  "target_rate": 10.0,
+  "bytes_emitted": 4096,
+  "errors": 0,
+  "uptime_secs": "[uptime_secs]",
+  "state": "pending",
+  "in_gap": false,
+  "in_burst": false,
+  "consecutive_failures": 0,
+  "total_sink_failures": 0
+}

--- a/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_running.snap
+++ b/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_running.snap
@@ -1,0 +1,18 @@
+---
+source: sonda-server/src/routes/scenarios.rs
+assertion_line: 4189
+expression: resp
+---
+{
+  "total_events": 100,
+  "current_rate": 10.0,
+  "target_rate": 10.0,
+  "bytes_emitted": 4096,
+  "errors": 0,
+  "uptime_secs": "[uptime_secs]",
+  "state": "running",
+  "in_gap": false,
+  "in_burst": false,
+  "consecutive_failures": 0,
+  "total_sink_failures": 0
+}

--- a/sonda-server/tests/integration.rs
+++ b/sonda-server/tests/integration.rs
@@ -153,16 +153,20 @@ fn full_lifecycle_metrics_and_logs() {
         "logs scenario must be in list"
     );
 
-    // Verify both show as running.
+    // Verify both show as a running-eq state. The list endpoint reads
+    // stats.state which advances asynchronously; the freshly launched
+    // scenarios may briefly report "pending" before the runner thread
+    // posts its first tick.
     for s in scenarios {
         if s["id"].as_str() == Some(metrics_id.as_str())
             || s["id"].as_str() == Some(logs_id.as_str())
         {
-            assert_eq!(
-                s["status"].as_str(),
-                Some("running"),
-                "scenario {} must be running",
-                s["id"]
+            let status = s["status"].as_str().unwrap_or("");
+            assert!(
+                matches!(status, "pending" | "running"),
+                "scenario {} must be pending or running, got {:?}",
+                s["id"],
+                status
             );
         }
     }
@@ -240,5 +244,85 @@ fn full_lifecycle_metrics_and_logs() {
         scenarios.is_empty(),
         "GET /scenarios must return empty list after all scenarios are deleted, got {} entries",
         scenarios.len()
+    );
+}
+
+const NON_GATED_METRIC_YAML: &str = r#"
+version: 2
+defaults:
+  rate: 5
+  duration: 2s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: state_lifecycle
+    signal_type: metrics
+    name: state_lifecycle
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+#[test]
+fn non_gated_scenario_state_transitions_running_to_finished() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("Content-Type", "text/yaml")
+        .body(NON_GATED_METRIC_YAML)
+        .send()
+        .expect("POST scenario must succeed");
+    assert_eq!(resp.status().as_u16(), 201, "POST must return 201");
+    let body: serde_json::Value = resp.json().expect("response must be valid JSON");
+    let id = body["id"]
+        .as_str()
+        .expect("response must have id")
+        .to_string();
+
+    let mut saw_running = false;
+    let deadline = std::time::Instant::now() + Duration::from_millis(1500);
+    while std::time::Instant::now() < deadline {
+        let resp = client
+            .get(format!("{base}/scenarios/{id}/stats"))
+            .send()
+            .expect("GET stats must succeed");
+        assert_eq!(resp.status().as_u16(), 200);
+        let stats: serde_json::Value = resp.json().expect("stats JSON");
+        if stats["state"].as_str() == Some("running") {
+            saw_running = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        saw_running,
+        "non-gated scenario must transition through 'running' state on /stats"
+    );
+
+    let finish_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut last_state = String::new();
+    while std::time::Instant::now() < finish_deadline {
+        let resp = client
+            .get(format!("{base}/scenarios/{id}/stats"))
+            .send()
+            .expect("GET stats must succeed");
+        if resp.status().as_u16() != 200 {
+            break;
+        }
+        let stats: serde_json::Value = resp.json().expect("stats JSON");
+        last_state = stats["state"].as_str().unwrap_or("").to_string();
+        if last_state == "finished" {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert_eq!(
+        last_state, "finished",
+        "non-gated scenario must terminate in 'finished' state after duration"
     );
 }

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -36,3 +36,5 @@ dialoguer = "0.12"
 
 [dev-dependencies]
 tempfile = "3"
+insta = { workspace = true, features = ["filters"] }
+rstest = { workspace = true }

--- a/sonda/src/dry_run.rs
+++ b/sonda/src/dry_run.rs
@@ -1,29 +1,24 @@
-//! Spec §5 `--dry-run` output for v2 scenario files.
-//!
-//! The v2 compiler resolves defaults, expands packs, computes `after:`
-//! crossing times, and assigns clock groups. Users need a readable view of
-//! that resolved representation to debug their scenarios. This module
-//! formats [`Vec<ScenarioEntry>`][sonda_core::ScenarioEntry] — the output
-//! of [`sonda_core::compile_scenario_file`] — in the pretty format the
-//! spec prescribes, plus a stable JSON DTO for machine-readable consumption.
-//!
-//! v1 `--dry-run` output is unchanged. This module is invoked only when
-//! `scenario_loader::load_scenario_entries` reports `Some(2)` for the
-//! version.
+//! `--dry-run` rendering for v2 scenario files: pretty text and stable JSON.
 
+use std::collections::HashMap;
 use std::io::{self, Write};
 
-use sonda_core::config::{
-    HistogramScenarioConfig, LogScenarioConfig, ScenarioConfig, ScenarioEntry,
-    SummaryScenarioConfig,
+use sonda_core::compiler::compile_after::{CompiledEntry, CompiledFile};
+use sonda_core::compiler::timing::{
+    self, constant_crossing_secs, csv_replay_crossing_secs, sawtooth_crossing_secs,
+    sequence_crossing_secs, sine_crossing_secs, spike_crossing_secs, step_crossing_secs,
+    uniform_crossing_secs, Operator, TimingError,
 };
+use sonda_core::compiler::{DelayClause, WhileClause, WhileOp};
+use sonda_core::config::validate::parse_duration;
+use sonda_core::generator::GeneratorConfig;
 
 use crate::sink_format::sink_display;
 
 /// Output format for the dry-run printer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DryRunFormat {
-    /// Human-readable spec §5 format printed to stderr.
+    /// Human-readable text rendering printed to stderr.
     #[default]
     Text,
     /// Stable JSON DTO printed to stdout.
@@ -44,180 +39,29 @@ pub fn parse_format(value: Option<&str>) -> anyhow::Result<DryRunFormat> {
     }
 }
 
-/// Print the spec §5 dry-run output for a list of compiled scenario entries.
+/// Print the dry-run output for a [`CompiledFile`].
 ///
-/// - `source_label` is a user-facing identifier for the scenario file
-///   (typically the path string or `@name`); it is shown verbatim in the
-///   header line.
-/// - `entries` is the fully-compiled runtime input produced by
-///   [`sonda_core::compile_scenario_file`].
-/// - `format` selects between the spec §5 pretty output and the JSON DTO.
-///
-/// Text output goes to stderr; JSON output goes to stdout. This matches the
-/// CLI convention of "data on stdout, diagnostics on stderr".
-pub fn print_dry_run(
+/// Text output goes to stderr; JSON output goes to stdout.
+pub fn print_dry_run_compiled(
     source_label: &str,
-    entries: &[ScenarioEntry],
+    compiled: &CompiledFile,
     format: DryRunFormat,
 ) -> anyhow::Result<()> {
     match format {
         DryRunFormat::Text => {
             let mut out = io::stderr().lock();
-            write_text(&mut out, source_label, entries)?;
+            write_text_compiled(&mut out, source_label, compiled)?;
         }
         DryRunFormat::Json => {
             let mut out = io::stdout().lock();
-            write_json(&mut out, source_label, entries)?;
+            write_json_compiled(&mut out, source_label, compiled)?;
         }
     }
-    Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Text rendering
-// ---------------------------------------------------------------------------
-
-/// Write the spec §5 pretty output.
-///
-/// Separated from [`print_dry_run`] so tests can capture the output
-/// into a `Vec<u8>` for snapshot assertions without mocking stderr.
-pub fn write_text<W: Write>(
-    out: &mut W,
-    source_label: &str,
-    entries: &[ScenarioEntry],
-) -> io::Result<()> {
-    let total = entries.len();
-    let scenario_word = if total == 1 { "scenario" } else { "scenarios" };
-    writeln!(
-        out,
-        "[config] file: {source_label} (version: 2, {total} {scenario_word})"
-    )?;
-
-    for (i, entry) in entries.iter().enumerate() {
-        writeln!(out)?;
-        write_entry_text(out, entry, i + 1, total)?;
-        if i + 1 < total {
-            writeln!(out, "---")?;
-        }
-    }
-
-    writeln!(out)?;
-    writeln!(out, "Validation: OK ({total} {scenario_word})")?;
-    Ok(())
-}
-
-/// Write a single compiled entry in the spec §5 "one block per scenario"
-/// format.
-fn write_entry_text<W: Write>(
-    out: &mut W,
-    entry: &ScenarioEntry,
-    index: usize,
-    total: usize,
-) -> io::Result<()> {
-    let name = entry.base().name.as_str();
-    writeln!(out, "[config] [{index}/{total}] {name}")?;
-    writeln!(out)?;
-    match entry {
-        ScenarioEntry::Metrics(c) => write_metrics_fields(out, c)?,
-        ScenarioEntry::Logs(c) => write_logs_fields(out, c)?,
-        ScenarioEntry::Histogram(c) => write_histogram_fields(out, c)?,
-        ScenarioEntry::Summary(c) => write_summary_fields(out, c)?,
-        // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary;
-        // emit a marker line so future variants render rather than panic.
-        _ => write_field(out, "signal:", "unknown")?,
-    }
-    Ok(())
-}
-
-fn write_metrics_fields<W: Write>(out: &mut W, c: &ScenarioConfig) -> io::Result<()> {
-    write_field(out, "name:", c.name.as_str())?;
-    write_field(out, "signal:", "metrics")?;
-    write_field(out, "rate:", &format!("{}/s", format_rate(c.rate)))?;
-    write_field(
-        out,
-        "duration:",
-        c.duration.as_deref().unwrap_or("indefinite"),
-    )?;
-    write_field(out, "generator:", &generator_display(&c.generator))?;
-    write_field(out, "encoder:", &encoder_display(&c.encoder))?;
-    write_field(out, "sink:", &sink_display(&c.sink))?;
-    write_labels(out, &c.labels)?;
-    write_phase_offset(out, &c.phase_offset)?;
-    write_clock_group(out, &c.clock_group, c.clock_group_is_auto)?;
-    Ok(())
-}
-
-fn write_logs_fields<W: Write>(out: &mut W, c: &LogScenarioConfig) -> io::Result<()> {
-    write_field(out, "name:", c.name.as_str())?;
-    write_field(out, "signal:", "logs")?;
-    write_field(out, "rate:", &format!("{}/s", format_rate(c.rate)))?;
-    write_field(
-        out,
-        "duration:",
-        c.duration.as_deref().unwrap_or("indefinite"),
-    )?;
-    write_field(out, "generator:", &log_generator_display(&c.generator))?;
-    write_field(out, "encoder:", &encoder_display(&c.encoder))?;
-    write_field(out, "sink:", &sink_display(&c.sink))?;
-    write_labels(out, &c.labels)?;
-    write_phase_offset(out, &c.phase_offset)?;
-    write_clock_group(out, &c.clock_group, c.clock_group_is_auto)?;
-    Ok(())
-}
-
-fn write_histogram_fields<W: Write>(out: &mut W, c: &HistogramScenarioConfig) -> io::Result<()> {
-    write_field(out, "name:", c.name.as_str())?;
-    write_field(out, "signal:", "histogram")?;
-    write_field(out, "rate:", &format!("{}/s", format_rate(c.rate)))?;
-    write_field(
-        out,
-        "duration:",
-        c.duration.as_deref().unwrap_or("indefinite"),
-    )?;
-    write_field(out, "distribution:", &format!("{:?}", c.distribution))?;
-    write_field(out, "encoder:", &encoder_display(&c.encoder))?;
-    write_field(out, "sink:", &sink_display(&c.sink))?;
-    write_labels(out, &c.labels)?;
-    write_phase_offset(out, &c.phase_offset)?;
-    write_clock_group(out, &c.clock_group, c.clock_group_is_auto)?;
-    Ok(())
-}
-
-fn write_summary_fields<W: Write>(out: &mut W, c: &SummaryScenarioConfig) -> io::Result<()> {
-    write_field(out, "name:", c.name.as_str())?;
-    write_field(out, "signal:", "summary")?;
-    write_field(out, "rate:", &format!("{}/s", format_rate(c.rate)))?;
-    write_field(
-        out,
-        "duration:",
-        c.duration.as_deref().unwrap_or("indefinite"),
-    )?;
-    write_field(out, "distribution:", &format!("{:?}", c.distribution))?;
-    write_field(out, "encoder:", &encoder_display(&c.encoder))?;
-    write_field(out, "sink:", &sink_display(&c.sink))?;
-    write_labels(out, &c.labels)?;
-    write_phase_offset(out, &c.phase_offset)?;
-    write_clock_group(out, &c.clock_group, c.clock_group_is_auto)?;
     Ok(())
 }
 
 fn write_field<W: Write>(out: &mut W, label: &str, value: &str) -> io::Result<()> {
     writeln!(out, "    {label:<15} {value}")
-}
-
-fn write_labels<W: Write>(
-    out: &mut W,
-    labels: &Option<std::collections::HashMap<String, String>>,
-) -> io::Result<()> {
-    if let Some(ref map) = labels {
-        if !map.is_empty() {
-            let mut pairs: Vec<_> = map.iter().collect();
-            pairs.sort_by_key(|(a, _)| *a);
-            let rendered: Vec<String> = pairs.iter().map(|(k, v)| format!("{k}={v}")).collect();
-            write_field(out, "labels:", &rendered.join(", "))?;
-        }
-    }
-    Ok(())
 }
 
 fn write_phase_offset<W: Write>(out: &mut W, phase_offset: &Option<String>) -> io::Result<()> {
@@ -227,14 +71,6 @@ fn write_phase_offset<W: Write>(out: &mut W, phase_offset: &Option<String>) -> i
     Ok(())
 }
 
-/// Render the `clock_group:` line.
-///
-/// When `is_auto` is `Some(true)` — meaning the v2 compiler synthesized
-/// the value because the entry's `after:` component had no explicit
-/// override — append a trailing ` (auto)` marker so users can tell the
-/// auto-name apart from a value they wrote themselves. Explicit values
-/// (including ones that happen to start with `chain_`) and entries that
-/// never traversed the v2 compiler render bare.
 fn write_clock_group<W: Write>(
     out: &mut W,
     clock_group: &Option<String>,
@@ -250,10 +86,6 @@ fn write_clock_group<W: Write>(
     }
     Ok(())
 }
-
-// ---------------------------------------------------------------------------
-// Field formatters — lightweight shims over the runtime config types
-// ---------------------------------------------------------------------------
 
 fn format_rate(rate: f64) -> String {
     if (rate.fract()).abs() < f64::EPSILON {
@@ -397,9 +229,306 @@ fn encoder_display(enc: &sonda_core::encoder::EncoderConfig) -> String {
     }
 }
 
-// ---------------------------------------------------------------------------
-// JSON rendering
-// ---------------------------------------------------------------------------
+const INDETERMINATE_MARKER: &str = "<indeterminate — non-analytical generator>";
+
+fn write_text_compiled<W: Write>(
+    out: &mut W,
+    source_label: &str,
+    compiled: &CompiledFile,
+) -> io::Result<()> {
+    let entries = &compiled.entries;
+    let total = entries.len();
+    let scenario_word = if total == 1 { "scenario" } else { "scenarios" };
+    writeln!(
+        out,
+        "[config] file: {source_label} (version: 2, {total} {scenario_word})"
+    )?;
+
+    let upstream_index = build_upstream_index(entries);
+
+    for (i, entry) in entries.iter().enumerate() {
+        writeln!(out)?;
+        write_compiled_entry_text(out, entry, &upstream_index, i + 1, total)?;
+        if i + 1 < total {
+            writeln!(out, "---")?;
+        }
+    }
+
+    writeln!(out)?;
+    writeln!(out, "Validation: OK ({total} {scenario_word})")?;
+    Ok(())
+}
+
+fn write_compiled_entry_text<W: Write>(
+    out: &mut W,
+    entry: &CompiledEntry,
+    upstream: &HashMap<&str, &CompiledEntry>,
+    index: usize,
+    total: usize,
+) -> io::Result<()> {
+    writeln!(out, "[config] [{index}/{total}] {}", entry.name)?;
+    writeln!(out)?;
+    write_field(out, "name:", &entry.name)?;
+    write_field(out, "signal:", &entry.signal_type)?;
+    write_field(out, "rate:", &format!("{}/s", format_rate(entry.rate)))?;
+    write_field(
+        out,
+        "duration:",
+        entry.duration.as_deref().unwrap_or("indefinite"),
+    )?;
+
+    match entry.signal_type.as_str() {
+        "metrics" => {
+            if let Some(ref g) = entry.generator {
+                write_field(out, "generator:", &generator_display(g))?;
+            }
+        }
+        "logs" => {
+            if let Some(ref g) = entry.log_generator {
+                write_field(out, "generator:", &log_generator_display(g))?;
+            }
+        }
+        "histogram" | "summary" => {
+            if let Some(ref d) = entry.distribution {
+                write_field(out, "distribution:", &format!("{d:?}"))?;
+            }
+        }
+        _ => {}
+    }
+
+    write_field(out, "encoder:", &encoder_display(&entry.encoder))?;
+    write_field(out, "sink:", &sink_display(&entry.sink))?;
+    write_labels_btree(out, entry.labels.as_ref())?;
+    write_phase_offset(out, &entry.phase_offset)?;
+    write_clock_group(out, &entry.clock_group, Some(entry.clock_group_is_auto))?;
+    write_while_block(out, entry, upstream)?;
+    write_delay_block(out, entry.delay_clause.as_ref())?;
+    Ok(())
+}
+
+fn write_labels_btree<W: Write>(
+    out: &mut W,
+    labels: Option<&std::collections::BTreeMap<String, String>>,
+) -> io::Result<()> {
+    if let Some(map) = labels {
+        if !map.is_empty() {
+            let rendered: Vec<String> = map.iter().map(|(k, v)| format!("{k}={v}")).collect();
+            write_field(out, "labels:", &rendered.join(", "))?;
+        }
+    }
+    Ok(())
+}
+
+fn write_while_block<W: Write>(
+    out: &mut W,
+    entry: &CompiledEntry,
+    upstream: &HashMap<&str, &CompiledEntry>,
+) -> io::Result<()> {
+    let Some(ref clause) = entry.while_clause else {
+        return Ok(());
+    };
+    write_field(out, "while:", &while_clause_display(clause))?;
+    let upstream_entry = upstream.get(clause.ref_id.as_str()).copied();
+    write_field(
+        out,
+        "first_open:",
+        &first_open_display(upstream_entry, clause),
+    )?;
+    Ok(())
+}
+
+fn write_delay_block<W: Write>(out: &mut W, delay: Option<&DelayClause>) -> io::Result<()> {
+    if let Some(delay) = delay {
+        write_field(out, "delay:", &delay_clause_display(delay))?;
+    }
+    Ok(())
+}
+
+fn build_upstream_index(entries: &[CompiledEntry]) -> HashMap<&str, &CompiledEntry> {
+    let mut map: HashMap<&str, &CompiledEntry> = HashMap::with_capacity(entries.len());
+    for entry in entries {
+        if let Some(ref id) = entry.id {
+            map.entry(id.as_str()).or_insert(entry);
+        }
+    }
+    map
+}
+
+fn while_clause_display(clause: &WhileClause) -> String {
+    format!(
+        "upstream='{}' op='{}' value={}",
+        clause.ref_id,
+        while_op_display(&clause.op),
+        format_value(clause.value),
+    )
+}
+
+fn delay_clause_display(delay: &DelayClause) -> String {
+    let open = delay
+        .open
+        .map(|d| format!("{}s", d.as_secs_f64()))
+        .unwrap_or_else(|| "0s".to_string());
+    let close = delay
+        .close
+        .map(|d| format!("{}s", d.as_secs_f64()))
+        .unwrap_or_else(|| "0s".to_string());
+    format!("open={open} close={close}")
+}
+
+fn first_open_display(upstream: Option<&CompiledEntry>, clause: &WhileClause) -> String {
+    let Some(upstream) = upstream else {
+        return INDETERMINATE_MARKER.to_string();
+    };
+    let Some(ref generator) = upstream.generator else {
+        return INDETERMINATE_MARKER.to_string();
+    };
+    let op = match clause.op {
+        WhileOp::LessThan => Operator::LessThan,
+        WhileOp::GreaterThan => Operator::GreaterThan,
+    };
+    match crossing_secs(generator, op, clause.value, upstream.rate) {
+        Ok(secs) => format!("~{}s", format_secs(secs)),
+        Err(_) => INDETERMINATE_MARKER.to_string(),
+    }
+}
+
+fn while_op_display(op: &WhileOp) -> &'static str {
+    match op {
+        WhileOp::LessThan => "<",
+        WhileOp::GreaterThan => ">",
+    }
+}
+
+fn format_value(v: f64) -> String {
+    if v.fract().abs() < f64::EPSILON {
+        format!("{}", v as i64)
+    } else {
+        format!("{v}")
+    }
+}
+
+fn format_secs(secs: f64) -> String {
+    if secs.fract().abs() < f64::EPSILON {
+        format!("{}", secs as i64)
+    } else {
+        format!("{secs:.2}")
+    }
+}
+
+fn crossing_secs(
+    generator: &GeneratorConfig,
+    op: Operator,
+    threshold: f64,
+    rate: f64,
+) -> Result<f64, TimingError> {
+    match generator {
+        GeneratorConfig::Constant { value } => constant_crossing_secs(op, threshold, *value),
+        GeneratorConfig::Uniform { .. } => uniform_crossing_secs(),
+        GeneratorConfig::Sine { .. } => sine_crossing_secs(),
+        GeneratorConfig::CsvReplay { .. } => csv_replay_crossing_secs(),
+        GeneratorConfig::Sawtooth {
+            min,
+            max,
+            period_secs,
+        } => sawtooth_crossing_secs(op, threshold, *min, *max, *period_secs),
+        GeneratorConfig::Sequence { values, repeat } => {
+            sequence_crossing_secs(op, threshold, values, *repeat, rate)
+        }
+        GeneratorConfig::Step {
+            start,
+            step_size,
+            max,
+        } => step_crossing_secs(op, threshold, start.unwrap_or(0.0), *step_size, *max, rate),
+        GeneratorConfig::Spike {
+            baseline,
+            magnitude,
+            duration_secs,
+            ..
+        } => spike_crossing_secs(op, threshold, *baseline, *magnitude, *duration_secs),
+        GeneratorConfig::Flap {
+            up_duration,
+            down_duration,
+            up_value,
+            down_value,
+        } => {
+            let up_secs = duration_or_default(up_duration.as_deref(), 10.0)?;
+            let down_secs = duration_or_default(down_duration.as_deref(), 5.0)?;
+            timing::flap_crossing_secs(
+                op,
+                threshold,
+                up_secs,
+                down_secs,
+                up_value.unwrap_or(1.0),
+                down_value.unwrap_or(0.0),
+            )
+        }
+        GeneratorConfig::Saturation {
+            baseline,
+            ceiling,
+            time_to_saturate,
+        } => sawtooth_crossing_secs(
+            op,
+            threshold,
+            baseline.unwrap_or(0.0),
+            ceiling.unwrap_or(100.0),
+            duration_or_default(time_to_saturate.as_deref(), 5.0 * 60.0)?,
+        ),
+        GeneratorConfig::Leak {
+            baseline,
+            ceiling,
+            time_to_ceiling,
+        } => sawtooth_crossing_secs(
+            op,
+            threshold,
+            baseline.unwrap_or(0.0),
+            ceiling.unwrap_or(100.0),
+            duration_or_default(time_to_ceiling.as_deref(), 10.0 * 60.0)?,
+        ),
+        GeneratorConfig::Degradation {
+            baseline,
+            ceiling,
+            time_to_degrade,
+            ..
+        } => sawtooth_crossing_secs(
+            op,
+            threshold,
+            baseline.unwrap_or(0.0),
+            ceiling.unwrap_or(100.0),
+            duration_or_default(time_to_degrade.as_deref(), 5.0 * 60.0)?,
+        ),
+        GeneratorConfig::Steady { .. } => timing::steady_crossing_secs(),
+        GeneratorConfig::SpikeEvent {
+            baseline,
+            spike_height,
+            spike_duration,
+            ..
+        } => spike_crossing_secs(
+            op,
+            threshold,
+            baseline.unwrap_or(0.0),
+            spike_height.unwrap_or(100.0),
+            duration_or_default(spike_duration.as_deref(), 10.0)?,
+        ),
+        _ => Err(TimingError::Unsupported {
+            message: "unknown generator".to_string(),
+        }),
+    }
+}
+
+fn duration_or_default(input: Option<&str>, default_secs: f64) -> Result<f64, TimingError> {
+    match input {
+        Some(s) => {
+            parse_duration(s)
+                .map(|d| d.as_secs_f64())
+                .map_err(|e| TimingError::InvalidDuration {
+                    field: "duration",
+                    input: s.to_string(),
+                    reason: e.to_string(),
+                })
+        }
+        None => Ok(default_secs),
+    }
+}
 
 /// Stable JSON DTO shape for machine-readable `--dry-run --format=json`.
 ///
@@ -436,17 +565,25 @@ struct ScenarioDto<'a> {
     /// field.
     #[serde(skip_serializing_if = "Option::is_none")]
     clock_group_is_auto: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    while_clause: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    delay_clause: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    first_open: Option<String>,
 }
 
-fn write_json<W: Write>(
+fn write_json_compiled<W: Write>(
     out: &mut W,
     source_label: &str,
-    entries: &[ScenarioEntry],
+    compiled: &CompiledFile,
 ) -> io::Result<()> {
-    let scenarios = entries
+    let upstream = build_upstream_index(&compiled.entries);
+    let scenarios = compiled
+        .entries
         .iter()
         .enumerate()
-        .map(|(i, entry)| to_scenario_dto(i + 1, entry))
+        .map(|(i, entry)| to_compiled_scenario_dto(i + 1, entry, &upstream))
         .collect();
 
     let dto = DryRunDto {
@@ -461,108 +598,66 @@ fn write_json<W: Write>(
     Ok(())
 }
 
-fn to_scenario_dto(index: usize, entry: &ScenarioEntry) -> ScenarioDto<'_> {
-    match entry {
-        ScenarioEntry::Metrics(c) => ScenarioDto {
-            index,
-            name: c.name.as_str(),
-            signal: "metrics",
-            rate: c.rate,
-            duration: c.duration.as_deref(),
-            generator: generator_display(&c.generator),
-            encoder: encoder_display(&c.encoder),
-            sink: sink_display(&c.sink),
-            labels: labels_btree(&c.labels),
-            phase_offset: c.phase_offset.as_deref(),
-            clock_group: c.clock_group.as_deref(),
-            clock_group_is_auto: c.clock_group_is_auto,
-        },
-        ScenarioEntry::Logs(c) => ScenarioDto {
-            index,
-            name: c.name.as_str(),
-            signal: "logs",
-            rate: c.rate,
-            duration: c.duration.as_deref(),
-            generator: log_generator_display(&c.generator),
-            encoder: encoder_display(&c.encoder),
-            sink: sink_display(&c.sink),
-            labels: labels_btree(&c.labels),
-            phase_offset: c.phase_offset.as_deref(),
-            clock_group: c.clock_group.as_deref(),
-            clock_group_is_auto: c.clock_group_is_auto,
-        },
-        ScenarioEntry::Histogram(c) => ScenarioDto {
-            index,
-            name: c.name.as_str(),
-            signal: "histogram",
-            rate: c.rate,
-            duration: c.duration.as_deref(),
-            generator: format!("{:?}", c.distribution),
-            encoder: encoder_display(&c.encoder),
-            sink: sink_display(&c.sink),
-            labels: labels_btree(&c.labels),
-            phase_offset: c.phase_offset.as_deref(),
-            clock_group: c.clock_group.as_deref(),
-            clock_group_is_auto: c.clock_group_is_auto,
-        },
-        ScenarioEntry::Summary(c) => ScenarioDto {
-            index,
-            name: c.name.as_str(),
-            signal: "summary",
-            rate: c.rate,
-            duration: c.duration.as_deref(),
-            generator: format!("{:?}", c.distribution),
-            encoder: encoder_display(&c.encoder),
-            sink: sink_display(&c.sink),
-            labels: labels_btree(&c.labels),
-            phase_offset: c.phase_offset.as_deref(),
-            clock_group: c.clock_group.as_deref(),
-            clock_group_is_auto: c.clock_group_is_auto,
-        },
-        // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary;
-        // borrow schedule-level fields via `base()` so a future variant still
-        // round-trips through the JSON DTO with a marker signal label.
-        other => {
-            let base = other.base();
-            ScenarioDto {
-                index,
-                name: base.name.as_str(),
-                signal: "unknown",
-                rate: base.rate,
-                duration: base.duration.as_deref(),
-                generator: format!("unknown ({other:?})"),
-                encoder: String::from("unknown"),
-                sink: sink_display(&base.sink),
-                labels: labels_btree(&base.labels),
-                phase_offset: base.phase_offset.as_deref(),
-                clock_group: base.clock_group.as_deref(),
-                clock_group_is_auto: base.clock_group_is_auto,
-            }
-        }
+fn to_compiled_scenario_dto<'a>(
+    index: usize,
+    entry: &'a CompiledEntry,
+    upstream: &HashMap<&str, &CompiledEntry>,
+) -> ScenarioDto<'a> {
+    let signal: &'static str = match entry.signal_type.as_str() {
+        "metrics" => "metrics",
+        "logs" => "logs",
+        "histogram" => "histogram",
+        "summary" => "summary",
+        _ => "unknown",
+    };
+    let generator = if let Some(ref g) = entry.generator {
+        generator_display(g)
+    } else if let Some(ref g) = entry.log_generator {
+        log_generator_display(g)
+    } else if let Some(ref d) = entry.distribution {
+        format!("{d:?}")
+    } else {
+        "unknown".to_string()
+    };
+    let labels = entry
+        .labels
+        .as_ref()
+        .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        .unwrap_or_default();
+    let while_clause = entry.while_clause.as_ref().map(while_clause_display);
+    let delay_clause = entry.delay_clause.as_ref().map(delay_clause_display);
+    let first_open = entry.while_clause.as_ref().map(|clause| {
+        let upstream_entry = upstream.get(clause.ref_id.as_str()).copied();
+        first_open_display(upstream_entry, clause)
+    });
+
+    ScenarioDto {
+        index,
+        name: entry.name.as_str(),
+        signal,
+        rate: entry.rate,
+        duration: entry.duration.as_deref(),
+        generator,
+        encoder: encoder_display(&entry.encoder),
+        sink: sink_display(&entry.sink),
+        labels,
+        phase_offset: entry.phase_offset.as_deref(),
+        clock_group: entry.clock_group.as_deref(),
+        clock_group_is_auto: Some(entry.clock_group_is_auto),
+        while_clause,
+        delay_clause,
+        first_open,
     }
 }
-
-fn labels_btree(
-    labels: &Option<std::collections::HashMap<String, String>>,
-) -> std::collections::BTreeMap<String, String> {
-    match labels {
-        Some(map) => map.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
-        None => std::collections::BTreeMap::new(),
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sonda_core::compile_scenario_file;
+    use sonda_core::compile_scenario_file_compiled;
     use sonda_core::compiler::expand::InMemoryPackResolver;
 
-    fn compile(yaml: &str) -> Vec<ScenarioEntry> {
-        compile_scenario_file(yaml, &InMemoryPackResolver::new()).expect("must compile")
+    fn compile(yaml: &str) -> CompiledFile {
+        compile_scenario_file_compiled(yaml, &InMemoryPackResolver::new()).expect("must compile")
     }
 
     #[test]
@@ -589,7 +684,7 @@ mod tests {
 
     #[test]
     fn text_header_includes_file_version_and_count() {
-        let entries = compile(
+        let compiled = compile(
             r#"version: 2
 defaults:
   rate: 1
@@ -604,7 +699,7 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_text(&mut buf, "scn.yaml", &entries).unwrap();
+        write_text_compiled(&mut buf, "scn.yaml", &compiled).unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(out.contains("[config] file: scn.yaml (version: 2, 1 scenario)"));
         assert!(out.contains("Validation: OK (1 scenario)"));
@@ -612,7 +707,7 @@ scenarios:
 
     #[test]
     fn text_pluralizes_count_when_multi_scenario() {
-        let entries = compile(
+        let compiled = compile(
             r#"version: 2
 defaults:
   rate: 1
@@ -633,17 +728,16 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_text(&mut buf, "multi.yaml", &entries).unwrap();
+        write_text_compiled(&mut buf, "multi.yaml", &compiled).unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(out.contains("(version: 2, 2 scenarios)"));
         assert!(out.contains("Validation: OK (2 scenarios)"));
-        // Separator between blocks.
         assert!(out.contains("\n---\n"));
     }
 
     #[test]
     fn text_prints_phase_offset_and_clock_group_for_after_chain() {
-        let entries = compile(
+        let compiled = compile(
             r#"version: 2
 defaults:
   rate: 1
@@ -672,15 +766,12 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_text(&mut buf, "link-failover.yaml", &entries).unwrap();
+        write_text_compiled(&mut buf, "link-failover.yaml", &compiled).unwrap();
         let out = String::from_utf8(buf).unwrap();
-        // backup_util's after-derived offset is 60s (flap up_duration).
         assert!(
             out.contains("phase_offset:") && out.contains("60"),
             "phase_offset line must render, got:\n{out}"
         );
-        // Auto clock_group is `chain_{lowest_lex_id}` across the connected
-        // component; `backup_util` < `primary_link` alphabetically.
         assert!(
             out.contains("chain_backup_util"),
             "auto clock_group must render, got:\n{out}"
@@ -693,7 +784,7 @@ scenarios:
 
     #[test]
     fn json_output_has_stable_shape() {
-        let entries = compile(
+        let compiled = compile(
             r#"version: 2
 defaults:
   rate: 2
@@ -710,7 +801,7 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_json(&mut buf, "scn.yaml", &entries).unwrap();
+        write_json_compiled(&mut buf, "scn.yaml", &compiled).unwrap();
         let json: serde_json::Value = serde_json::from_slice(&buf).expect("json parses");
         assert_eq!(json["file"], "scn.yaml");
         assert_eq!(json["version"], 2);
@@ -718,5 +809,273 @@ scenarios:
         assert_eq!(json["scenarios"][0]["signal"], "metrics");
         assert_eq!(json["scenarios"][0]["rate"], 2.0);
         assert_eq!(json["scenarios"][0]["labels"]["host"], "t0");
+    }
+
+    #[test]
+    fn text_renders_while_block_with_first_open_for_analytical_upstream() {
+        let compiled = compile(
+            r#"version: 2
+defaults:
+  rate: 1
+  duration: 5m
+scenarios:
+  - id: link
+    signal_type: metrics
+    name: link_state
+    generator:
+      type: sawtooth
+      min: 0.0
+      max: 100.0
+      period_secs: 60.0
+
+  - id: traffic
+    signal_type: metrics
+    name: backup_traffic
+    generator:
+      type: constant
+      value: 50.0
+    while:
+      ref: link
+      op: ">"
+      value: 50.0
+"#,
+        );
+        let mut buf = Vec::new();
+        write_text_compiled(&mut buf, "while-analytical.yaml", &compiled).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("while:"),
+            "must render while block, got:\n{out}"
+        );
+        assert!(
+            out.contains("upstream='link' op='>' value=50"),
+            "must render while clause body, got:\n{out}"
+        );
+        assert!(
+            out.contains("first_open:") && out.contains("~30s"),
+            "must render analytical first_open, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn text_renders_indeterminate_marker_for_non_analytical_upstream() {
+        let compiled = compile(
+            r#"version: 2
+defaults:
+  rate: 1
+  duration: 1m
+scenarios:
+  - id: link
+    signal_type: metrics
+    name: link_state
+    generator:
+      type: sine
+      amplitude: 50.0
+      period_secs: 60.0
+      offset: 50.0
+
+  - id: traffic
+    signal_type: metrics
+    name: backup_traffic
+    generator:
+      type: constant
+      value: 50.0
+    while:
+      ref: link
+      op: ">"
+      value: 50.0
+"#,
+        );
+        let mut buf = Vec::new();
+        write_text_compiled(&mut buf, "while-non-analytical.yaml", &compiled).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("<indeterminate — non-analytical generator>"),
+            "non-analytical upstream must render the indeterminate marker, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn text_renders_delay_block_when_present() {
+        let compiled = compile(
+            r#"version: 2
+defaults:
+  rate: 1
+  duration: 5m
+scenarios:
+  - id: link
+    signal_type: metrics
+    name: link_state
+    generator:
+      type: sawtooth
+      min: 0.0
+      max: 100.0
+      period_secs: 60.0
+
+  - id: traffic
+    signal_type: metrics
+    name: backup_traffic
+    generator:
+      type: constant
+      value: 50.0
+    while:
+      ref: link
+      op: ">"
+      value: 50.0
+    delay:
+      open: "5s"
+      close: "10s"
+"#,
+        );
+        let mut buf = Vec::new();
+        write_text_compiled(&mut buf, "while-delay.yaml", &compiled).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("delay:") && out.contains("open=5s") && out.contains("close=10s"),
+            "delay block must render, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn text_renders_both_after_and_while_for_mixed_upstream() {
+        let compiled = compile(
+            r#"version: 2
+defaults:
+  rate: 1
+  duration: 5m
+scenarios:
+  - id: trigger
+    signal_type: metrics
+    name: trigger_metric
+    generator:
+      type: step
+      start: 0.0
+      step_size: 1.0
+
+  - id: link
+    signal_type: metrics
+    name: link_state
+    generator:
+      type: sawtooth
+      min: 0.0
+      max: 100.0
+      period_secs: 60.0
+
+  - id: traffic
+    signal_type: metrics
+    name: backup_traffic
+    generator:
+      type: constant
+      value: 50.0
+    after:
+      ref: trigger
+      op: ">"
+      value: 5.0
+    while:
+      ref: link
+      op: ">"
+      value: 50.0
+"#,
+        );
+        let mut buf = Vec::new();
+        write_text_compiled(&mut buf, "mixed-upstream.yaml", &compiled).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("phase_offset:"),
+            "after-derived phase_offset must render, got:\n{out}"
+        );
+        assert!(
+            out.contains("while:") && out.contains("upstream='link'"),
+            "while block must render, got:\n{out}"
+        );
+        assert!(
+            out.contains("first_open:"),
+            "first_open must render alongside, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn json_dto_includes_while_delay_first_open_for_gated_entry() {
+        let compiled = compile(
+            r#"version: 2
+defaults:
+  rate: 1
+  duration: 5m
+scenarios:
+  - id: link
+    signal_type: metrics
+    name: link_state
+    generator:
+      type: sawtooth
+      min: 0.0
+      max: 100.0
+      period_secs: 60.0
+
+  - id: traffic
+    signal_type: metrics
+    name: backup_traffic
+    generator:
+      type: constant
+      value: 50.0
+    while:
+      ref: link
+      op: ">"
+      value: 50.0
+    delay:
+      open: "5s"
+      close: "10s"
+"#,
+        );
+        let mut buf = Vec::new();
+        write_json_compiled(&mut buf, "while-json.yaml", &compiled).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        let traffic = json["scenarios"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["name"].as_str() == Some("backup_traffic"))
+            .expect("traffic entry must exist");
+        assert_eq!(
+            traffic["while_clause"].as_str().unwrap(),
+            "upstream='link' op='>' value=50"
+        );
+        assert_eq!(
+            traffic["delay_clause"].as_str().unwrap(),
+            "open=5s close=10s"
+        );
+        assert_eq!(traffic["first_open"].as_str().unwrap(), "~30s");
+    }
+
+    #[test]
+    fn json_dto_omits_clauses_when_absent() {
+        let compiled = compile(
+            r#"version: 2
+defaults:
+  rate: 1
+  duration: 100ms
+scenarios:
+  - id: a
+    signal_type: metrics
+    name: metric_a
+    generator:
+      type: constant
+      value: 1.0
+"#,
+        );
+        let mut buf = Vec::new();
+        write_json_compiled(&mut buf, "no-clauses.yaml", &compiled).unwrap();
+        let body = String::from_utf8(buf).unwrap();
+        assert!(
+            !body.contains("while_clause"),
+            "while_clause must be omitted when None, got:\n{body}"
+        );
+        assert!(
+            !body.contains("delay_clause"),
+            "delay_clause must be omitted when None, got:\n{body}"
+        );
+        assert!(
+            !body.contains("first_open"),
+            "first_open must be omitted when None, got:\n{body}"
+        );
     }
 }

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -145,11 +145,9 @@ fn run() -> anyhow::Result<()> {
             let has_gates = scenario_loader::has_while_clause(&compiled);
 
             if cli.dry_run {
-                let entries = sonda_core::compiler::prepare::prepare(compiled)
-                    .map_err(|e| anyhow::anyhow!("{}", e))?;
                 let format = dry_run::parse_format(cli.format.as_deref())?;
                 let label = args.scenario.display().to_string();
-                dry_run::print_dry_run(&label, &entries, format)?;
+                dry_run::print_dry_run_compiled(&label, &compiled, format)?;
                 return Ok(());
             }
 
@@ -157,11 +155,7 @@ fn run() -> anyhow::Result<()> {
                 if verbosity == cli::Verbosity::Verbose {
                     status::print_version();
                 }
-                sonda_core::schedule::multi_runner::run_multi_compiled(
-                    compiled,
-                    Arc::clone(&running),
-                )
-                .map_err(|e| anyhow::anyhow!("{}", e))?;
+                run_compiled_with_progress(compiled, &running, verbosity)?;
             } else {
                 let entries = sonda_core::compiler::prepare::prepare(compiled)
                     .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -437,10 +431,8 @@ fn run_catalog_run(
             let has_gates = scenario_loader::has_while_clause(&compiled);
 
             if cli_opts.dry_run {
-                let entries = sonda_core::compiler::prepare::prepare(compiled)
-                    .map_err(|e| anyhow::anyhow!("{}", e))?;
                 let format = dry_run::parse_format(cli_opts.format.as_deref())?;
-                dry_run::print_dry_run(&args.name, &entries, format)?;
+                dry_run::print_dry_run_compiled(&args.name, &compiled, format)?;
                 return Ok(());
             }
 
@@ -448,11 +440,7 @@ fn run_catalog_run(
                 if verbosity == cli::Verbosity::Verbose {
                     status::print_version();
                 }
-                sonda_core::schedule::multi_runner::run_multi_compiled(
-                    compiled,
-                    Arc::clone(running),
-                )
-                .map_err(|e| anyhow::anyhow!("{}", e))?;
+                run_compiled_with_progress(compiled, running, verbosity)?;
                 return Ok(());
             }
 
@@ -1108,6 +1096,41 @@ fn launch_and_join_prepared(
         status::print_summary_by_clock_group(&grouped, &agg, total_elapsed, verbosity);
     } else {
         status::print_summary(&agg, total_elapsed, verbosity);
+    }
+
+    if !errors.is_empty() {
+        return Err(anyhow::anyhow!("{}", errors.join("; ")));
+    }
+
+    Ok(())
+}
+
+/// Launch a compiled (gated) scenario file and stream live progress to stderr.
+///
+/// Mirrors [`launch_and_join_prepared`] for the gated path: spawns every
+/// scenario via `launch_multi_compiled`, starts a `ProgressDisplay` so PAUSED
+/// transitions surface in non-quiet modes, joins the handles, and returns a
+/// combined error if any scenario failed.
+fn run_compiled_with_progress(
+    compiled: sonda_core::compiler::compile_after::CompiledFile,
+    running: &Arc<AtomicBool>,
+    verbosity: Verbosity,
+) -> anyhow::Result<()> {
+    let handles =
+        sonda_core::schedule::multi_runner::launch_multi_compiled(compiled, Arc::clone(running))
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let progress = maybe_start_progress_multi(&handles, verbosity);
+
+    let mut errors: Vec<String> = Vec::new();
+    for mut handle in handles {
+        if let Err(e) = handle.join(None) {
+            errors.push(e.to_string());
+        }
+    }
+
+    if let Some(p) = progress {
+        p.stop();
     }
 
     if !errors.is_empty() {

--- a/sonda/src/progress.rs
+++ b/sonda/src/progress.rs
@@ -26,7 +26,7 @@ use std::time::{Duration, Instant};
 use owo_colors::OwoColorize;
 use owo_colors::Stream::Stderr;
 
-use sonda_core::schedule::stats::ScenarioStats;
+use sonda_core::schedule::stats::{ScenarioState, ScenarioStats};
 
 /// How often to poll stats and redraw in TTY mode.
 const TTY_POLL_INTERVAL: Duration = Duration::from_millis(200);
@@ -187,6 +187,12 @@ fn run_tty_loop(scenarios: &[MonitoredScenario], stop_flag: &AtomicBool) {
                 continue;
             }
             let stats = read_stats(&scenario.stats);
+            if stats.state == ScenarioState::Paused && scenario.alive.load(Ordering::SeqCst) {
+                let line = format_paused_line_tty(&scenario.name, &stats, elapsed);
+                let _ = write!(stderr, "\x1b[2K{line}\r\n");
+                live_count += 1;
+                continue;
+            }
             if !scenario.alive.load(Ordering::SeqCst) {
                 let banner = format_stopped_line_tty(&scenario.name, &stats, elapsed);
                 new_banners.push(banner);
@@ -232,12 +238,15 @@ fn run_tty_loop(scenarios: &[MonitoredScenario], stop_flag: &AtomicBool) {
 ///
 /// Emits a self-contained status line every [`NON_TTY_INTERVAL`]. No ANSI
 /// escape sequences are used. Each scenario receives a one-shot STOPPED
-/// banner the first iteration after its runner thread exits.
+/// banner the first iteration after its runner thread exits, and a one-shot
+/// PAUSED line on entry into [`ScenarioState::Paused`] so gated cascades
+/// surface the transition without waiting a full interval.
 fn run_non_tty_loop(scenarios: &[MonitoredScenario], stop_flag: &AtomicBool) {
     let start = Instant::now();
     let mut last_emit = Instant::now();
     let check_interval = Duration::from_millis(200);
     let mut banner_emitted: HashSet<String> = HashSet::new();
+    let mut paused_announced: HashSet<String> = HashSet::new();
 
     while !stop_flag.load(Ordering::SeqCst) {
         thread::sleep(check_interval);
@@ -260,6 +269,24 @@ fn run_non_tty_loop(scenarios: &[MonitoredScenario], stop_flag: &AtomicBool) {
             }
         }
 
+        // Detect Paused transitions eagerly. Re-arm when the scenario
+        // leaves Paused so a subsequent close-window emits another line.
+        for scenario in scenarios {
+            if banner_emitted.contains(&scenario.name) {
+                continue;
+            }
+            let stats = read_stats(&scenario.stats);
+            if stats.state == ScenarioState::Paused && scenario.alive.load(Ordering::SeqCst) {
+                if !paused_announced.contains(&scenario.name) {
+                    let line = format_paused_line_plain(&scenario.name, &stats, start.elapsed());
+                    eprintln!("{line}");
+                    paused_announced.insert(scenario.name.clone());
+                }
+            } else {
+                paused_announced.remove(&scenario.name);
+            }
+        }
+
         if last_emit.elapsed() < NON_TTY_INTERVAL {
             continue;
         }
@@ -272,6 +299,9 @@ fn run_non_tty_loop(scenarios: &[MonitoredScenario], stop_flag: &AtomicBool) {
                 continue;
             }
             let stats = read_stats(&scenario.stats);
+            if stats.state == ScenarioState::Paused && scenario.alive.load(Ordering::SeqCst) {
+                continue;
+            }
             let line = format_non_tty_line(&scenario.name, &stats, scenario.target_rate, elapsed);
             eprintln!("{line}");
         }
@@ -325,6 +355,14 @@ fn format_stopped_line_plain(name: &str, stats: &ScenarioStats, elapsed: Duratio
     )
 }
 
+fn format_paused_line_plain(name: &str, stats: &ScenarioStats, elapsed: Duration) -> String {
+    format!(
+        "[progress] {name}  PAUSED  events: {events} | rate: 0.0/s | elapsed: {elapsed_str}",
+        events = stats.total_events,
+        elapsed_str = format_elapsed_plain(elapsed),
+    )
+}
+
 /// Format a one-shot STOPPED banner for TTY output.
 fn format_stopped_line_tty(name: &str, stats: &ScenarioStats, elapsed: Duration) -> String {
     let bold_name = format!("{}", name.if_supports_color(Stderr, |t| t.bold()));
@@ -345,6 +383,21 @@ fn format_stopped_line_tty(name: &str, stats: &ScenarioStats, elapsed: Duration)
     let elapsed_value = format_elapsed(elapsed);
     format!(
         "  {label} {bold_name}{error_clause}  {events_label} {events_value} {pipe} {bytes_label} {bytes_value} {pipe} {elapsed_label} {elapsed_value}"
+    )
+}
+
+fn format_paused_line_tty(name: &str, stats: &ScenarioStats, elapsed: Duration) -> String {
+    let bold_name = format!("{}", name.if_supports_color(Stderr, |t| t.bold()));
+    let label = format!("{}", "PAUSED".if_supports_color(Stderr, |t| t.yellow()));
+    let pipe = format!("{}", "|".if_supports_color(Stderr, |t| t.dimmed()));
+    let events_label = format!("{}", "events:".if_supports_color(Stderr, |t| t.dimmed()));
+    let events_value = format_count(stats.total_events);
+    let rate_label = format!("{}", "rate:".if_supports_color(Stderr, |t| t.dimmed()));
+    let rate_value = format!("{}", "0.0/s".if_supports_color(Stderr, |t| t.dimmed()));
+    let elapsed_label = format!("{}", "elapsed:".if_supports_color(Stderr, |t| t.dimmed()));
+    let elapsed_value = format_elapsed(elapsed);
+    format!(
+        "  {label} {bold_name}  {events_label} {events_value} {pipe} {rate_label} {rate_value} {pipe} {elapsed_label} {elapsed_value}"
     )
 }
 
@@ -855,6 +908,55 @@ mod tests {
         // Strip ANSI for content check
         assert!(strip_ansi(&line).contains("STOPPED"));
         assert!(line.contains("svc"));
+    }
+
+    #[test]
+    fn format_paused_line_plain_includes_paused_label_and_zero_rate() {
+        let mut stats = ScenarioStats::default();
+        stats.total_events = 42;
+        stats.state = ScenarioState::Paused;
+        let line = format_paused_line_plain("svc", &stats, Duration::from_secs(7));
+        assert!(line.contains("PAUSED"), "missing PAUSED in: {line}");
+        assert!(line.contains("svc"));
+        assert!(line.contains("events: 42"));
+        assert!(line.contains("rate: 0.0/s"));
+        assert!(line.contains("elapsed: 7.0s"));
+    }
+
+    #[test]
+    fn format_paused_line_plain_does_not_include_stopped_label() {
+        let stats = ScenarioStats::default();
+        let line = format_paused_line_plain("svc", &stats, Duration::from_secs(1));
+        assert!(!line.contains("STOPPED"));
+    }
+
+    #[test]
+    fn format_paused_line_tty_includes_paused_label_and_zero_rate() {
+        let mut stats = ScenarioStats::default();
+        stats.total_events = 100;
+        stats.state = ScenarioState::Paused;
+        let line = format_paused_line_tty("svc", &stats, Duration::from_secs(3));
+        let plain = strip_ansi(&line);
+        assert!(plain.contains("PAUSED"), "missing PAUSED in: {plain}");
+        assert!(plain.contains("svc"));
+        assert!(plain.contains("rate: 0.0/s"));
+    }
+
+    #[test]
+    fn format_paused_line_tty_distinct_from_stopped() {
+        let stats = ScenarioStats::default();
+        let paused = strip_ansi(&format_paused_line_tty(
+            "svc",
+            &stats,
+            Duration::from_secs(1),
+        ));
+        let stopped = strip_ansi(&format_stopped_line_tty(
+            "svc",
+            &stats,
+            Duration::from_secs(1),
+        ));
+        assert!(paused.contains("PAUSED") && !paused.contains("STOPPED"));
+        assert!(stopped.contains("STOPPED") && !stopped.contains("PAUSED"));
     }
 
     // -----------------------------------------------------------------------

--- a/sonda/tests/cli_while_runtime.rs
+++ b/sonda/tests/cli_while_runtime.rs
@@ -1,4 +1,4 @@
-//! End-to-end CLI test for `sonda run` honoring `while:` clauses.
+//! End-to-end CLI tests for `sonda run` honoring `while:` clauses.
 
 mod common;
 
@@ -43,5 +43,29 @@ fn run_while_cascade_gates_downstream_emission() {
         "while: gate must suppress downstream events; \
          backup_saturation={backup_count}, primary_flap={primary_count}, \
          expected backup < 50% of primary\nstdout:\n{stdout}"
+    );
+}
+
+#[test]
+fn run_while_cascade_progress_emits_paused_line() {
+    let fixture = cli_fixtures_dir().join("while-cascade.v2.yaml");
+    let output = Command::new(sonda_bin())
+        .args(["run", "--scenario"])
+        .arg(&fixture)
+        .output()
+        .expect("must spawn sonda");
+
+    assert!(
+        output.status.success(),
+        "sonda run must succeed; status={:?} stderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("PAUSED"),
+        "stderr must contain a PAUSED progress line for the gated downstream during a flap close-window\n\
+         stderr:\n{stderr}"
     );
 }

--- a/sonda/tests/dry_run_while_snapshots.rs
+++ b/sonda/tests/dry_run_while_snapshots.rs
@@ -1,0 +1,204 @@
+//! Snapshot coverage for `--dry-run` rendering of `while:` / `delay:` clauses.
+
+mod common;
+
+use std::process::Command;
+
+use common::{cli_fixtures_dir, sonda_bin};
+
+fn snapshot_settings() -> insta::Settings {
+    let mut s = insta::Settings::clone_current();
+    s.set_sort_maps(true);
+    // The fixture path varies by host; replace it with a stable token.
+    s.add_filter(
+        r"\[config\] file: [^ ]+ \(version: 2, (\d+ scenarios?)\)",
+        "[config] file: <fixture> (version: 2, $1)",
+    );
+    s
+}
+
+fn dry_run_text(yaml_body: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir must be created");
+    let path = dir.path().join("scenario.yaml");
+    std::fs::write(&path, yaml_body).expect("scenario file must be written");
+    let pack_dir = cli_fixtures_dir().join("catalog-packs");
+    let output = Command::new(sonda_bin())
+        .env_remove("SONDA_SCENARIO_PATH")
+        .env_remove("SONDA_PACK_PATH")
+        .args(["--pack-path"])
+        .arg(&pack_dir)
+        .args(["run", "--scenario"])
+        .arg(&path)
+        .arg("--dry-run")
+        .output()
+        .expect("must spawn sonda");
+    assert!(
+        output.status.success(),
+        "dry-run failed: exit {:?}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stderr).expect("stderr utf-8")
+}
+
+const ANALYTICAL_UPSTREAM: &str = r#"version: 2
+defaults:
+  rate: 5
+  duration: 5m
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: link
+    signal_type: metrics
+    name: link_state
+    generator:
+      type: sawtooth
+      min: 0.0
+      max: 100.0
+      period_secs: 60.0
+  - id: traffic
+    signal_type: metrics
+    name: backup_traffic
+    generator:
+      type: constant
+      value: 50.0
+    while:
+      ref: link
+      op: ">"
+      value: 50.0
+"#;
+
+const NON_ANALYTICAL_UPSTREAM: &str = r#"version: 2
+defaults:
+  rate: 5
+  duration: 1m
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: link
+    signal_type: metrics
+    name: link_state
+    generator:
+      type: sine
+      amplitude: 50.0
+      period_secs: 60.0
+      offset: 50.0
+  - id: traffic
+    signal_type: metrics
+    name: backup_traffic
+    generator:
+      type: constant
+      value: 50.0
+    while:
+      ref: link
+      op: ">"
+      value: 50.0
+"#;
+
+const MIXED_UPSTREAM: &str = r#"version: 2
+defaults:
+  rate: 5
+  duration: 5m
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: trigger
+    signal_type: metrics
+    name: trigger_metric
+    generator:
+      type: step
+      start: 0.0
+      step_size: 1.0
+  - id: link
+    signal_type: metrics
+    name: link_state
+    generator:
+      type: sawtooth
+      min: 0.0
+      max: 100.0
+      period_secs: 60.0
+  - id: traffic
+    signal_type: metrics
+    name: backup_traffic
+    generator:
+      type: constant
+      value: 50.0
+    after:
+      ref: trigger
+      op: ">"
+      value: 5.0
+    while:
+      ref: link
+      op: ">"
+      value: 50.0
+"#;
+
+const DELAY_PRESENT: &str = r#"version: 2
+defaults:
+  rate: 5
+  duration: 5m
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: link
+    signal_type: metrics
+    name: link_state
+    generator:
+      type: sawtooth
+      min: 0.0
+      max: 100.0
+      period_secs: 60.0
+  - id: traffic
+    signal_type: metrics
+    name: backup_traffic
+    generator:
+      type: constant
+      value: 50.0
+    while:
+      ref: link
+      op: ">"
+      value: 50.0
+    delay:
+      open: "5s"
+      close: "10s"
+"#;
+
+#[test]
+fn dry_run_while_with_analytical_upstream() {
+    let stderr = dry_run_text(ANALYTICAL_UPSTREAM);
+    snapshot_settings().bind(|| {
+        insta::assert_snapshot!("while_analytical_upstream", stderr);
+    });
+}
+
+#[test]
+fn dry_run_while_with_non_analytical_upstream() {
+    let stderr = dry_run_text(NON_ANALYTICAL_UPSTREAM);
+    snapshot_settings().bind(|| {
+        insta::assert_snapshot!("while_non_analytical_upstream", stderr);
+    });
+}
+
+#[test]
+fn dry_run_while_with_mixed_upstream() {
+    let stderr = dry_run_text(MIXED_UPSTREAM);
+    snapshot_settings().bind(|| {
+        insta::assert_snapshot!("while_mixed_upstream", stderr);
+    });
+}
+
+#[test]
+fn dry_run_while_with_delay_present() {
+    let stderr = dry_run_text(DELAY_PRESENT);
+    snapshot_settings().bind(|| {
+        insta::assert_snapshot!("while_delay_present", stderr);
+    });
+}

--- a/sonda/tests/snapshots/dry_run_while_snapshots__while_analytical_upstream.snap
+++ b/sonda/tests/snapshots/dry_run_while_snapshots__while_analytical_upstream.snap
@@ -1,0 +1,31 @@
+---
+source: sonda/tests/dry_run_while_snapshots.rs
+assertion_line: 178
+expression: stderr
+---
+[config] file: <fixture> (version: 2, 2 scenarios)
+
+[config] [1/2] link_state
+
+    name:           link_state
+    signal:         metrics
+    rate:           5/s
+    duration:       5m
+    generator:      sawtooth (min: 0, max: 100, period_secs: 60)
+    encoder:        prometheus_text
+    sink:           stdout
+---
+
+[config] [2/2] backup_traffic
+
+    name:           backup_traffic
+    signal:         metrics
+    rate:           5/s
+    duration:       5m
+    generator:      constant (value: 50)
+    encoder:        prometheus_text
+    sink:           stdout
+    while:          upstream='link' op='>' value=50
+    first_open:     ~30s
+
+Validation: OK (2 scenarios)

--- a/sonda/tests/snapshots/dry_run_while_snapshots__while_delay_present.snap
+++ b/sonda/tests/snapshots/dry_run_while_snapshots__while_delay_present.snap
@@ -1,0 +1,32 @@
+---
+source: sonda/tests/dry_run_while_snapshots.rs
+assertion_line: 202
+expression: stderr
+---
+[config] file: <fixture> (version: 2, 2 scenarios)
+
+[config] [1/2] link_state
+
+    name:           link_state
+    signal:         metrics
+    rate:           5/s
+    duration:       5m
+    generator:      sawtooth (min: 0, max: 100, period_secs: 60)
+    encoder:        prometheus_text
+    sink:           stdout
+---
+
+[config] [2/2] backup_traffic
+
+    name:           backup_traffic
+    signal:         metrics
+    rate:           5/s
+    duration:       5m
+    generator:      constant (value: 50)
+    encoder:        prometheus_text
+    sink:           stdout
+    while:          upstream='link' op='>' value=50
+    first_open:     ~30s
+    delay:          open=5s close=10s
+
+Validation: OK (2 scenarios)

--- a/sonda/tests/snapshots/dry_run_while_snapshots__while_mixed_upstream.snap
+++ b/sonda/tests/snapshots/dry_run_while_snapshots__while_mixed_upstream.snap
@@ -1,0 +1,45 @@
+---
+source: sonda/tests/dry_run_while_snapshots.rs
+assertion_line: 194
+expression: stderr
+---
+[config] file: <fixture> (version: 2, 3 scenarios)
+
+[config] [1/3] trigger_metric
+
+    name:           trigger_metric
+    signal:         metrics
+    rate:           5/s
+    duration:       5m
+    generator:      step (start: 0, step_size: 1)
+    encoder:        prometheus_text
+    sink:           stdout
+    clock_group:    chain_traffic (auto)
+---
+
+[config] [2/3] link_state
+
+    name:           link_state
+    signal:         metrics
+    rate:           5/s
+    duration:       5m
+    generator:      sawtooth (min: 0, max: 100, period_secs: 60)
+    encoder:        prometheus_text
+    sink:           stdout
+---
+
+[config] [3/3] backup_traffic
+
+    name:           backup_traffic
+    signal:         metrics
+    rate:           5/s
+    duration:       5m
+    generator:      constant (value: 50)
+    encoder:        prometheus_text
+    sink:           stdout
+    phase_offset:   1.2s
+    clock_group:    chain_traffic (auto)
+    while:          upstream='link' op='>' value=50
+    first_open:     ~30s
+
+Validation: OK (3 scenarios)

--- a/sonda/tests/snapshots/dry_run_while_snapshots__while_non_analytical_upstream.snap
+++ b/sonda/tests/snapshots/dry_run_while_snapshots__while_non_analytical_upstream.snap
@@ -1,0 +1,31 @@
+---
+source: sonda/tests/dry_run_while_snapshots.rs
+assertion_line: 186
+expression: stderr
+---
+[config] file: <fixture> (version: 2, 2 scenarios)
+
+[config] [1/2] link_state
+
+    name:           link_state
+    signal:         metrics
+    rate:           5/s
+    duration:       1m
+    generator:      sine (amplitude: 50, period_secs: 60, offset: 50)
+    encoder:        prometheus_text
+    sink:           stdout
+---
+
+[config] [2/2] backup_traffic
+
+    name:           backup_traffic
+    signal:         metrics
+    rate:           5/s
+    duration:       1m
+    generator:      constant (value: 50)
+    encoder:        prometheus_text
+    sink:           stdout
+    while:          upstream='link' op='>' value=50
+    first_open:     <indeterminate — non-analytical generator>
+
+Validation: OK (2 scenarios)


### PR DESCRIPTION
## Summary

PR 3 of 4 sub-PRs implementing v1 `while:` continuous gating (issue #295). User-facing surface — turns the runtime PR 2 wired into a feature operators can see and use.

**This PR targets `feat/while-clause`, NOT `main`.** Final cohesive merge to main happens after PR 4 (workshop migration) lands.

## What ships

### Server `state` field widening

`state` field on `/scenarios/{id}/stats` and `/scenarios` list endpoints widens from two values (`running|stopped`) to four (`pending|running|paused|finished`). The existing PR #293 derivation (`is_running()`) is replaced with `state_string(stats)` reading from `ScenarioStats::state`.

**Critical fix included** (caught by UAT and addressed in fix-pass): `StateGuard` sibling to `AliveGuard` in `launch.rs` writes `state = Running` at thread start (non-gated path) and `state = Finished` on Drop. Without this, every non-gated scenario reported `state: "pending"` forever — would have shipped a broken contract. `gated_loop` continues to manage `Pending → Running ⇄ Paused → Finished` when a gate context is present.

### CLI `--dry-run` extensions

Per ADR-7 (P+Q hybrid):
- `while:` clauses render verbatim with operator and threshold.
- `first_open: ~Ns` analytical estimate when upstream is analytical (reuses `sonda_core::compiler::timing::*_crossing_secs` — same dispatcher PR 1 uses for `after:`).
- `first_open: <indeterminate — non-analytical generator>` when upstream is `csv_replay` / `sine` / jitter-wrapped / etc. **Explicit marker, not silent omission.**
- `delay:` clauses render verbatim with `open=Ns close=Ns`.

### Progress reporter `PAUSED` line

**Critical fix included** (caught by UAT and addressed in fix-pass): the CLI's `run_multi_compiled` path didn't wire `ProgressDisplay` — the PAUSED line was dead code. `run_compiled_with_progress` in `sonda/src/main.rs` now spawns via `launch_multi_compiled` (new public split returning live handles), wires the existing `ProgressDisplay` (TTY + non-TTY), and joins. Non-TTY progress loop emits one-shot PAUSED on Pending → Paused transitions and re-arms when scenario leaves Paused, so cascades shorter than `NON_TTY_INTERVAL` (5s) still surface gate state.

### `delay: { close: 0s }` accepted

`parse_delay_duration` wraps `parse_duration` and accepts `0s`/`0ms`/`0h`/bare `0` as `Duration::ZERO`. Generic `parse_duration` is unchanged — only the `delay:` clause path is relaxed (per ADR-2 spec: both fields default to `0s`).

### Docs

- New `## Continuous coupling with while:` section in `docs/site/docs/configuration/v2-scenarios.md` with ASCII state diagram, `--dry-run` preview, `after:` + `while:` worked example, and a migration guide synthesizing from `link-failover`.
- API docs in `docs/site/docs/deployment/sonda-server.md` document the four state values and the `pending → paused` direct transition.

## Architectural notes

- `dry_run.rs` operates on `&CompiledFile` (not `&[ScenarioEntry]`) so it can see `while_clause`/`delay_clause`; the entry-based path (`compile_scenario_file → prepare → Vec<ScenarioEntry>`) discards those fields. The CLI's `Run` and `catalog Run` dry-run flows route through the new `print_dry_run_compiled`.
- Mixed-upstream entries (different `after.ref` and `while.ref`) render `phase_offset` and `first_open` as separate lines. Operator computes `max(phase_offset, first_open)`. The `after.upstream/op/value` bracket is consumed by `compile_after`, so the rendered output omits it. **Follow-up issue tracks restoring full ADR-7 mixed-upstream fidelity** by carrying `AfterClause` forward on `CompiledEntry` or running two-phase compile in the CLI.
- `launch_multi_compiled` is a public split of `run_multi_compiled` that returns the live handles. The CLI uses it to wire `ProgressDisplay`; other consumers continue using the joining `run_multi_compiled` wrapper.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace` (**2853 tests pass**, +30 new from this PR vs the 2823 PR 2 baseline)
- [x] `cargo test --workspace --doc` (5/5)
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace --features http,kafka,otlp,remote-write`
- [x] `cargo test -p sonda-core --no-default-features` (the new gate added to orchestration rules after PR #310's CI fix)
- [x] `mkdocs build --strict` (zero warnings, zero errors)
- [x] `@reviewer` (Opus, fix-pass review) — PASS, all 4 BLOCKERs cleanly resolved
- [x] `@uat` (Sonnet) — PASS on all 4 scenarios (state running→finished, PAUSED visible, delay close 0ms, positive delay no regression)
- [x] `@doc` (Opus) — PASS on docs after fix-pass (line 511 + line 571 corrections)

## Acceptance items hit

A5 (four states), A5b (list endpoint), A5c (snapshots), A6 (paused stats fields), A7 (PAUSED progress line), A8a-f (--dry-run rendering), A9 (state JSON), A19 (user docs), A20 (migration guide), A21 (API docs note about pending → paused). A21a (workshop dashboard pre-flight) is PR 4's job.

## Known follow-ups (not blockers)

1. **ADR-7 mixed-upstream `after:` fidelity**: rendered output factually correct but loses upstream identifier. Reviewer accepted with follow-up. Filing separately.
2. `/scenarios` list still uses field name `status` while `/stats` uses `state`. Naming inconsistency. Both populate from `state_string()`. Could rename for consistency in a future PR.
3. POST `/scenarios` response body hardcodes `status: "running"` while subsequent GETs derive from `stats.state` (which can be `Pending` briefly). Pre-existing pattern; flag for future polish.

## Diff

24 files modified + 9 new files (4 server snapshots, 1 new test file, 4 dry-run snapshots). Total ~1500 insertions / 380 deletions.