### PR TITLE
fix(server): route POST /scenarios through gated launch path (PR 3.5 of #295)

### DIFF
--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -203,15 +203,22 @@ pub fn launch_multi_compiled(
     let mut handles = Vec::with_capacity(launches.len());
     for (idx, plan) in launches.into_iter().enumerate() {
         let id = plan.id.unwrap_or_else(|| format!("multi-{idx}"));
-        let handle = launch_scenario_with_gates(
+        match launch_scenario_with_gates(
             id,
             plan.entry,
             Arc::clone(&shutdown),
             plan.start_delay,
             plan.upstream_bus,
             plan.gate_ctx,
-        )?;
-        handles.push(handle);
+        ) {
+            Ok(handle) => handles.push(handle),
+            Err(e) => {
+                for handle in &handles {
+                    handle.stop();
+                }
+                return Err(e);
+            }
+        }
     }
 
     Ok(handles)
@@ -264,6 +271,8 @@ mod tests {
     use crate::generator::{GeneratorConfig, LogGeneratorConfig, TemplateConfig};
     use crate::sink::SinkConfig;
 
+    #[cfg(feature = "config")]
+    use super::launch_multi_compiled;
     use super::{run_multi, signal_shutdown};
 
     /// Build a minimal metrics `ScenarioEntry` that writes to stdout.
@@ -943,5 +952,67 @@ mod tests {
             result.is_ok(),
             "scenarios with clock_group and offsets should complete"
         );
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn launch_multi_compiled_partial_cleanup_stops_already_launched_handles() {
+        use crate::compile_scenario_file_compiled;
+        use crate::compiler::expand::InMemoryPackResolver;
+
+        let yaml = "\
+version: 2
+defaults:
+  rate: 50
+  duration: 10s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: cleanup_a
+    signal_type: metrics
+    name: cleanup_a
+    generator:
+      type: constant
+      value: 1.0
+  - id: cleanup_b
+    signal_type: metrics
+    name: cleanup_b
+    generator:
+      type: constant
+      value: 2.0
+";
+        let resolver = InMemoryPackResolver::new();
+        let compiled =
+            compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
+
+        let shutdown = Arc::new(AtomicBool::new(true));
+        let mut handles =
+            launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        assert_eq!(handles.len(), 2, "must launch both entries");
+        assert!(
+            handles.iter().all(|h| h.is_alive()),
+            "both threads must be alive immediately after launch"
+        );
+
+        for handle in &handles {
+            handle.stop();
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline && handles.iter().any(|h| h.is_alive()) {
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            handles.iter().all(|h| !h.is_alive()),
+            "every handle must exit after stop() — partial-launch cleanup must not leak threads"
+        );
+
+        for handle in &mut handles {
+            handle
+                .join(Some(Duration::from_secs(1)))
+                .expect("join must succeed after stop");
+        }
     }
 }

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -2,12 +2,12 @@
 //!
 //! Implements:
 //! - `POST /scenarios` — start one or more scenarios from a v2 YAML or JSON
-//!   body. Every body is compiled via [`sonda_core::compile_scenario_file`]
-//!   through the v2 pipeline; v1 YAML shapes are rejected with a migration
-//!   hint. A single compiled entry returns the flat `{id, name, status}`
-//!   shape; multi-entry compilations (or explicit multi-scenario bodies)
-//!   return the `{scenarios: [...]}` wrapper. Launches are atomic: all
-//!   entries validate before any threads spawn.
+//!   body. Every body is compiled via [`sonda_core::compile_scenario_file_compiled`]
+//!   and launched through the gated multi-runner so `while:` clauses
+//!   reach the runtime. v1 YAML shapes are rejected with a migration hint.
+//!   A single launched handle returns the flat `{id, name, state}` shape;
+//!   two or more handles return the `{scenarios: [...]}` wrapper. Launches
+//!   are atomic: all entries validate before any threads spawn.
 //! - `GET /scenarios` — list all scenarios with summary information.
 //! - `GET /scenarios/{id}` — inspect a single scenario with full detail and stats.
 //! - `GET /scenarios/{id}/stats` — return detailed live stats for a scenario.
@@ -34,9 +34,11 @@ use sonda_core::{ScenarioState, ScenarioStats};
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use sonda_core::compile_scenario_file;
+use sonda_core::compile_scenario_file_compiled;
+use sonda_core::compiler::compile_after::CompiledFile;
 use sonda_core::config::ScenarioEntry;
-use sonda_core::schedule::launch::{launch_scenario, prepare_entries};
+use sonda_core::schedule::launch::prepare_entries;
+use sonda_core::schedule::multi_runner::launch_multi_compiled;
 
 use crate::routes::sink_warnings::{log_warnings, sink_loopback_warnings};
 use crate::state::AppState;
@@ -46,42 +48,22 @@ use crate::state::AppState;
 /// Response body for a successfully created scenario.
 #[derive(Debug, Serialize)]
 pub struct CreatedScenario {
-    /// Unique identifier for the scenario instance.
     pub id: String,
-    /// Human-readable scenario name from the config.
     pub name: String,
-    /// Always `"running"` for a freshly launched scenario.
-    pub status: &'static str,
+    /// Live state at POST-response time. One of `"pending"`, `"running"`,
+    /// `"paused"`, `"finished"`. Snapshot only — clients should poll
+    /// `/scenarios/{id}` for live state thereafter.
+    pub state: String,
     /// Non-fatal warnings raised while validating the posted body.
-    ///
-    /// Populated, for example, when a sink URL points at `localhost` — which
-    /// resolves to the `sonda-server` container's own loopback rather than
-    /// the operator's host. The scenario still launches; the warnings exist
-    /// so operators can spot the misconfiguration without grepping logs.
-    ///
-    /// Omitted from the JSON response when no warnings were raised so
-    /// clients that predate this field continue to parse cleanly.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub warnings: Vec<String>,
 }
 
 /// Response body for a successfully created multi-scenario batch.
-///
-/// Returned when `POST /scenarios` receives a multi-scenario YAML/JSON body
-/// (one with a top-level `scenarios:` array). Each element describes one
-/// launched scenario.
 #[derive(Debug, Serialize)]
 pub struct CreatedScenariosResponse {
-    /// One entry per launched scenario, in the same order as the input.
     pub scenarios: Vec<CreatedScenario>,
     /// Non-fatal warnings raised while validating the posted body.
-    ///
-    /// Collected across every entry in the batch — one string per flagged
-    /// sink. See [`CreatedScenario::warnings`] for the per-entry shape;
-    /// the batch response aggregates them at the top level so clients do
-    /// not need to walk the `scenarios` array to surface operator hints.
-    ///
-    /// Omitted from the JSON response when no warnings were raised.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub warnings: Vec<String>,
 }
@@ -89,13 +71,10 @@ pub struct CreatedScenariosResponse {
 /// Summary of a single scenario in the list response.
 #[derive(Debug, Serialize)]
 pub struct ScenarioSummary {
-    /// Unique scenario ID.
     pub id: String,
-    /// Human-readable scenario name.
     pub name: String,
-    /// Current status: `pending`, `running`, `paused`, or `finished`.
-    pub status: String,
-    /// Seconds elapsed since the scenario was launched.
+    /// Current state: one of `"pending"`, `"running"`, `"paused"`, `"finished"`.
+    pub state: String,
     pub elapsed_secs: f64,
 }
 
@@ -109,26 +88,22 @@ pub struct ListScenariosResponse {
 /// Detailed view of a single scenario, including live stats.
 #[derive(Debug, Serialize)]
 pub struct ScenarioDetail {
-    /// Unique scenario ID.
     pub id: String,
-    /// Human-readable scenario name.
     pub name: String,
-    /// Current status: `pending`, `running`, `paused`, or `finished`.
-    pub status: String,
-    /// Seconds elapsed since the scenario was launched.
+    /// Current state: one of `"pending"`, `"running"`, `"paused"`, `"finished"`.
+    pub state: String,
     pub elapsed_secs: f64,
-    /// Live statistics from the runner thread.
     pub stats: StatsResponse,
 }
 
 /// Response body for a successfully deleted (stopped) scenario.
 #[derive(Debug, Serialize)]
 pub struct DeletedScenario {
-    /// Unique scenario ID.
     pub id: String,
-    /// Final status: `"stopped"` or `"force_stopped"` if the join timed out.
+    /// Join outcome — `"stopped"` when the runner thread exited, or
+    /// `"force_stopped"` when the join timed out. Distinct from the
+    /// lifecycle state surfaced on `/scenarios/{id}`.
     pub status: String,
-    /// Total number of events emitted over the scenario's lifetime.
     pub total_events: u64,
 }
 
@@ -268,46 +243,15 @@ fn is_yaml_content_type(headers: &HeaderMap) -> bool {
 }
 
 /// The result of parsing a `POST /scenarios` body.
-///
-/// Distinguishes between a compilation that produced exactly one entry
-/// (legacy flat response shape) and one that produced two or more
-/// (`{scenarios: [...]}` wrapper). The handler uses this to decide the
-/// response shape.
 #[derive(Debug)]
 enum ParsedBody {
-    /// A single scenario entry — returned as the flat `{id, name, status}`
-    /// JSON body.
+    /// A compiled v2 scenario file ready for the gated multi-runner.
     ///
-    /// Boxed to avoid a large size difference between variants (clippy
-    /// `large_enum_variant`). `ScenarioEntry` is ~656 bytes while `Vec` is 24.
-    Single(Box<ScenarioEntry>),
-    /// Two or more scenario entries — returned as `{scenarios: [...]}`.
-    Multi(Vec<ScenarioEntry>),
+    /// Boxed to avoid a large size difference between variants
+    /// (clippy `large_enum_variant`).
+    Compiled(Box<CompiledFile>),
 }
 
-/// Parse and compile a POST body into one or more [`ScenarioEntry`] values.
-///
-/// The body must be a v2 scenario (`version: 2` at the top level) serialized
-/// as either YAML or JSON. v1 shapes are rejected up front with a migration
-/// hint so operators are not confused by downstream parse errors.
-///
-/// YAML bodies are fed into [`detect_version`] + [`compile_scenario_file`].
-/// JSON bodies are transcoded to YAML first (via `serde_yaml_ng::to_string`)
-/// because the v2 compiler's front-end is a YAML parser — JSON is a strict
-/// subset of YAML, so the transcoded text parses byte-for-byte identically
-/// to the equivalent hand-written YAML.
-///
-/// Pack references (`pack: <name>`) are resolved against the server's startup
-/// pack catalog (loaded from `SONDA_PACK_PATH`). Bodies referencing a pack
-/// that is not in the catalog surface as a compile error with the missing
-/// pack name and the searched paths.
-///
-/// Returns a descriptive error string on failure. The handler maps all
-/// failures to `400 Bad Request` because the server contract is "POST v2
-/// YAML/JSON"; anything else is ill-formed by contract.
-/// Walk the error source chain and join Display strings with `: `, so a 400
-/// response carries the failing pack name / search path detail instead of a
-/// bare `expand error`.
 fn format_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
     let mut out = err.to_string();
     let mut cause: Option<&(dyn std::error::Error + 'static)> = err.source();
@@ -331,26 +275,18 @@ fn parse_body(
         return Err(format!("body is not a v2 scenario. {V1_REJECTION_HINT}"));
     }
 
-    let entries = compile_scenario_file(&text, pack_resolver).map_err(|e| {
+    let compiled = compile_scenario_file_compiled(&text, pack_resolver).map_err(|e| {
         format!(
             "v2 scenario body failed to compile: {}",
             format_error_chain(&e)
         )
     })?;
 
-    if entries.is_empty() {
+    if compiled.entries.is_empty() {
         return Err("v2 scenario body produced zero entries".to_string());
     }
 
-    if entries.len() == 1 {
-        let entry = entries
-            .into_iter()
-            .next()
-            .expect("len checked above — exactly one entry");
-        Ok(ParsedBody::Single(Box::new(entry)))
-    } else {
-        Ok(ParsedBody::Multi(entries))
-    }
+    Ok(ParsedBody::Compiled(Box::new(compiled)))
 }
 
 /// Convert the raw request body into YAML text for the v2 compiler.
@@ -375,19 +311,16 @@ fn yaml_body_text(body: &[u8], headers: &HeaderMap) -> Result<String, String> {
 
 /// `POST /scenarios` — start scenarios from a v2 YAML or JSON body.
 ///
-/// The body is always compiled through the v2 pipeline via
-/// [`compile_scenario_file`]. v1 YAML shapes (flat single-signal,
-/// top-level `scenarios:` without `version: 2`, `pack:` shorthand) are
-/// rejected with a migration hint.
+/// The body is compiled via [`compile_scenario_file_compiled`] and launched
+/// through the gated multi-runner so `while:` clauses reach the runtime.
+/// v1 YAML shapes are rejected with a migration hint.
 ///
-/// **Single entry after compile**: Returns `201 Created` with the flat
-/// `{"id", "name", "status": "running"}` body.
+/// **One launched handle**: Returns `201 Created` with the flat
+/// `{"id", "name", "state"}` body.
 ///
-/// **Multiple entries after compile** (multi-entry v2 file or a pack
-/// expansion that fanned out): Returns `201 Created` with
-/// `{"scenarios": [{"id", "name", "status"}, ...]}`. All entries are
-/// validated atomically before any are launched — if any entry fails
-/// validation, nothing is launched and the entire request fails.
+/// **Multiple launched handles** (multi-entry body or pack expansion that
+/// fanned out): Returns `201 Created` with `{"scenarios": [...]}`. All
+/// entries validate atomically before any threads spawn.
 ///
 /// # Error responses
 /// - `400 Bad Request` — body cannot be parsed, v1 shape is rejected, or the
@@ -400,98 +333,85 @@ pub async fn post_scenario(
     headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> Result<Response, Response> {
-    // 1. Parse the body, detecting single vs multi-scenario.
     let parsed = parse_body(&body, &headers, &state.pack_resolver).map_err(|msg| {
         warn!(error = %msg, "POST /scenarios: invalid request body");
         bad_request(msg)
     })?;
 
-    // 2. Pre-flight sink check: warn (do not reject) when a sink URL points
-    //    at loopback, which in a containerized server resolves to the
-    //    server's own network namespace rather than the operator's host.
-    //    The warnings are logged and returned in the response — operators
-    //    can ignore them if the loopback target is intentional.
-    let warnings = match &parsed {
-        ParsedBody::Single(entry) => sink_loopback_warnings(std::slice::from_ref(entry.as_ref())),
-        ParsedBody::Multi(entries) => sink_loopback_warnings(entries),
-    };
-    log_warnings("POST /scenarios", &warnings);
+    let ParsedBody::Compiled(compiled) = parsed;
 
-    match parsed {
-        ParsedBody::Single(entry) => post_single_scenario(state, *entry, warnings).await,
-        ParsedBody::Multi(entries) => post_multi_scenario(state, entries, warnings).await,
-    }
-}
-
-/// Handle a single-scenario POST (backward-compatible path).
-///
-/// Uses [`prepare_entries`] for the same expand -> validate -> phase_offset
-/// pipeline as the multi-scenario path. This ensures identical behavior
-/// regardless of whether a scenario is posted alone or inside a `scenarios:`
-/// array.
-async fn post_single_scenario(
-    state: AppState,
-    entry: ScenarioEntry,
-    warnings: Vec<String>,
-) -> Result<Response, Response> {
-    // Use the shared pipeline for expansion, validation, and phase offset.
-    let mut prepared = prepare_entries(vec![entry]).map_err(|e| {
+    // Derive ScenarioEntry values for the loopback warning helper, which
+    // operates on the runtime input shape. prepare_entries doubles as
+    // pre-flight validation — surfacing rate=0, bad phase_offset, etc. as
+    // 422 before any thread spawns.
+    let prepared_entries = sonda_core::compiler::prepare::prepare(compiled.as_ref().clone())
+        .map_err(|e| {
+            warn!(error = %e, "POST /scenarios: prepare failed");
+            unprocessable(e)
+        })?;
+    let prepared = prepare_entries(prepared_entries).map_err(|e| {
         warn!(error = %e, "POST /scenarios: validation failed");
         unprocessable(e)
     })?;
+    let warning_entries: Vec<ScenarioEntry> = prepared.into_iter().map(|p| p.entry).collect();
+    let warnings = sink_loopback_warnings(&warning_entries);
+    log_warnings("POST /scenarios", &warnings);
+    drop(warning_entries);
 
-    // After expansion a single entry may fan out into multiple entries
-    // (e.g. multi-column csv_replay). Launch all of them.
-    let mut created: Vec<CreatedScenario> = Vec::with_capacity(prepared.len());
-    let mut handles_to_store: Vec<(String, sonda_core::ScenarioHandle)> =
-        Vec::with_capacity(prepared.len());
+    launch_compiled(state, *compiled, warnings).await
+}
 
-    for prepared_entry in prepared.drain(..) {
-        let id = Uuid::new_v4().to_string();
-        let name = prepared_entry.entry.base().name.clone();
-        let shutdown = Arc::new(AtomicBool::new(true));
+/// Launch every entry in `compiled` through the gated multi-runner and store
+/// the resulting handles in [`AppState`]. Single-vs-multi response shape is
+/// decided post-launch from the count of returned handles.
+async fn launch_compiled(
+    state: AppState,
+    compiled: CompiledFile,
+    warnings: Vec<String>,
+) -> Result<Response, Response> {
+    let shutdown = Arc::new(AtomicBool::new(true));
+    let mut handles = launch_multi_compiled(compiled, shutdown).map_err(|e| {
+        warn!(error = %e, "POST /scenarios: failed to launch scenarios");
+        match e {
+            sonda_core::SondaError::Config(_) => unprocessable(e),
+            _ => internal_error(e),
+        }
+    })?;
 
-        let handle = launch_scenario(
-            id.clone(),
-            prepared_entry.entry,
-            shutdown,
-            prepared_entry.start_delay,
-        )
-        .map_err(|e| {
-            for (_, ref h) in &handles_to_store {
-                h.stop();
-            }
-            warn!(error = %e, "POST /scenarios: failed to launch scenario");
-            internal_error(e)
-        })?;
-
-        info!(id = %id, name = %name, "scenario launched");
-
-        created.push(CreatedScenario {
-            id: id.clone(),
-            name,
-            status: "running",
-            warnings: Vec::new(),
-        });
-        handles_to_store.push((id, handle));
+    if handles.is_empty() {
+        warn!("POST /scenarios: gated launch produced zero handles");
+        return Err(bad_request(
+            "v2 scenario body produced zero runnable entries",
+        ));
     }
 
-    // Store all handles in shared state.
+    let mut created: Vec<CreatedScenario> = Vec::with_capacity(handles.len());
+    for handle in handles.iter_mut() {
+        let new_id = Uuid::new_v4().to_string();
+        handle.id = new_id.clone();
+        let name = handle.name.clone();
+        let state_str = state_string(&handle.stats_snapshot()).to_string();
+        info!(id = %new_id, name = %name, state = %state_str, "scenario launched");
+        created.push(CreatedScenario {
+            id: new_id,
+            name,
+            state: state_str,
+            warnings: Vec::new(),
+        });
+    }
+
     let mut scenarios = state.scenarios.write().map_err(|e| {
-        for (_, ref h) in &handles_to_store {
-            h.stop();
+        for handle in &handles {
+            handle.stop();
         }
         warn!(error = %e, "POST /scenarios: scenarios lock is poisoned");
         internal_error("internal state lock is poisoned")
     })?;
-    for (id, handle) in handles_to_store {
-        scenarios.insert(id, handle);
+    for (created_entry, handle) in created.iter().zip(handles) {
+        scenarios.insert(created_entry.id.clone(), handle);
     }
     drop(scenarios);
 
-    // Respond based on whether expansion produced a single or multiple
-    // entries. Warnings (if any) attach at the top level in both shapes so
-    // clients see them without walking the `scenarios` array.
     if created.len() == 1 {
         let mut single = created.into_iter().next().expect("len checked above");
         single.warnings = warnings;
@@ -506,89 +426,6 @@ async fn post_single_scenario(
         )
             .into_response())
     }
-}
-
-/// Handle a multi-scenario POST (batch path).
-///
-/// Atomic batch semantics: all entries are expanded, validated, and have their
-/// phase offsets resolved before any are launched. If any entry fails, the
-/// entire request returns an error and nothing is launched.
-async fn post_multi_scenario(
-    state: AppState,
-    entries: Vec<ScenarioEntry>,
-    warnings: Vec<String>,
-) -> Result<Response, Response> {
-    // Reject empty batches.
-    if entries.is_empty() {
-        warn!("POST /scenarios: empty scenarios array");
-        return Err(bad_request("scenarios array must not be empty"));
-    }
-
-    // Expand, validate, and resolve phase offsets atomically.
-    let prepared = prepare_entries(entries).map_err(|e| {
-        warn!(error = %e, "POST /scenarios: multi-scenario validation failed");
-        unprocessable(e)
-    })?;
-
-    // Launch all scenarios and collect response entries.
-    let mut created: Vec<CreatedScenario> = Vec::with_capacity(prepared.len());
-    let mut handles_to_store: Vec<(String, sonda_core::ScenarioHandle)> =
-        Vec::with_capacity(prepared.len());
-
-    for prepared_entry in prepared {
-        let id = Uuid::new_v4().to_string();
-        let name = prepared_entry.entry.base().name.clone();
-        let shutdown = Arc::new(AtomicBool::new(true));
-
-        let handle = launch_scenario(
-            id.clone(),
-            prepared_entry.entry,
-            shutdown,
-            prepared_entry.start_delay,
-        )
-        .map_err(|e| {
-            // If a launch fails, stop any already-launched scenarios.
-            for (_, ref h) in &handles_to_store {
-                h.stop();
-            }
-            warn!(error = %e, "POST /scenarios: failed to launch scenario in batch");
-            internal_error(e)
-        })?;
-
-        info!(id = %id, name = %name, "scenario launched (batch)");
-
-        created.push(CreatedScenario {
-            id: id.clone(),
-            name,
-            status: "running",
-            warnings: Vec::new(),
-        });
-        handles_to_store.push((id, handle));
-    }
-
-    // Store all handles in shared state.
-    let mut scenarios = state.scenarios.write().map_err(|e| {
-        // Stop all launched scenarios before returning the error to prevent
-        // orphaned threads that run indefinitely without a way to stop them.
-        for (_, ref h) in &handles_to_store {
-            h.stop();
-        }
-        warn!(error = %e, "POST /scenarios: scenarios lock is poisoned");
-        internal_error("internal state lock is poisoned")
-    })?;
-    for (id, handle) in handles_to_store {
-        scenarios.insert(id, handle);
-    }
-    drop(scenarios);
-
-    // Respond with 201 Created. Warnings attach at the top level of the
-    // batch response; the per-entry `warnings` field stays empty to keep
-    // the shape predictable for clients.
-    let response_body = CreatedScenariosResponse {
-        scenarios: created,
-        warnings,
-    };
-    Ok((StatusCode::CREATED, Json(response_body)).into_response())
 }
 
 /// `GET /scenarios` — list all scenarios with summary information.
@@ -609,7 +446,7 @@ pub async fn list_scenarios(State(state): State<AppState>) -> Result<impl IntoRe
             ScenarioSummary {
                 id: id.clone(),
                 name: handle.name.clone(),
-                status: state_string(&snap).to_string(),
+                state: state_string(&snap).to_string(),
                 elapsed_secs: handle.elapsed().as_secs_f64(),
             }
         })
@@ -642,7 +479,7 @@ pub async fn get_scenario(
     let detail = ScenarioDetail {
         id: id.clone(),
         name: handle.name.clone(),
-        status: state_string(&snap).to_string(),
+        state: state_string(&snap).to_string(),
         elapsed_secs: handle.elapsed().as_secs_f64(),
         stats: snap.into(),
     };
@@ -1152,7 +989,7 @@ scenarios:
 
         assert!(entry["id"].is_string(), "id must be a string");
         assert!(entry["name"].is_string(), "name must be a string");
-        assert!(entry["status"].is_string(), "status must be a string");
+        assert!(entry["state"].is_string(), "state must be a string");
         assert!(
             entry["elapsed_secs"].is_f64(),
             "elapsed_secs must be a number"
@@ -1190,9 +1027,9 @@ scenarios:
         assert_eq!(body["id"].as_str().unwrap(), "id-detail");
         assert_eq!(body["name"].as_str().unwrap(), "detail_scenario");
         assert_eq!(
-            body["status"].as_str().unwrap(),
+            body["state"].as_str().unwrap(),
             "running",
-            "a live scenario must have status 'running'"
+            "a live scenario must have state 'running'"
         );
         let elapsed = body["elapsed_secs"].as_f64().unwrap();
         assert!(
@@ -1348,9 +1185,9 @@ scenarios:
 
         let body = body_json(resp).await;
         assert_eq!(
-            body["status"].as_str().unwrap(),
+            body["state"].as_str().unwrap(),
             "finished",
-            "a finished scenario must have status 'finished'"
+            "a finished scenario must have state 'finished'"
         );
     }
 
@@ -1464,13 +1301,13 @@ scenarios:
         let s = ScenarioSummary {
             id: "abc".to_string(),
             name: "test".to_string(),
-            status: "running".to_string(),
+            state: "running".to_string(),
             elapsed_secs: 1.5,
         };
         let json = serde_json::to_value(&s).unwrap();
         assert_eq!(json["id"], "abc");
         assert_eq!(json["name"], "test");
-        assert_eq!(json["status"], "running");
+        assert_eq!(json["state"], "running");
         assert_eq!(json["elapsed_secs"], 1.5);
     }
 
@@ -1480,7 +1317,7 @@ scenarios:
         let d = ScenarioDetail {
             id: "xyz".to_string(),
             name: "detail".to_string(),
-            status: "stopped".to_string(),
+            state: "stopped".to_string(),
             elapsed_secs: 42.0,
             stats: StatsResponse {
                 total_events: 100,
@@ -1526,9 +1363,10 @@ scenarios:
             body["name"], "test_metric",
             "response name must match the scenario name"
         );
-        assert_eq!(
-            body["status"], "running",
-            "status must be 'running' for a freshly launched scenario"
+        let s = body["state"].as_str().unwrap_or("");
+        assert!(
+            matches!(s, "pending" | "running"),
+            "state must be 'pending' or 'running' for a freshly launched scenario, got {s:?}"
         );
 
         // Verify the handle was stored in AppState.
@@ -1567,7 +1405,11 @@ scenarios:
             body["name"], "test_logs",
             "response name must match the logs scenario name"
         );
-        assert_eq!(body["status"], "running");
+        let s = body["state"].as_str().unwrap_or("");
+        assert!(
+            matches!(s, "pending" | "running"),
+            "state must be 'pending' or 'running', got {s:?}"
+        );
 
         cleanup_scenarios(&state);
     }
@@ -1591,7 +1433,11 @@ scenarios:
             body["name"], "tagged_metric",
             "name must match the tagged scenario name"
         );
-        assert_eq!(body["status"], "running");
+        let s = body["state"].as_str().unwrap_or("");
+        assert!(
+            matches!(s, "pending" | "running"),
+            "state must be 'pending' or 'running', got {s:?}"
+        );
 
         cleanup_scenarios(&state);
     }
@@ -1766,7 +1612,11 @@ scenarios:
 
         let body = body_json(response).await;
         assert_eq!(body["name"], "json_metric");
-        assert_eq!(body["status"], "running");
+        let s = body["state"].as_str().unwrap_or("");
+        assert!(
+            matches!(s, "pending" | "running"),
+            "state must be 'pending' or 'running', got {s:?}"
+        );
 
         cleanup_scenarios(&state);
     }
@@ -1821,13 +1671,13 @@ scenarios:
         assert!(obj.contains_key("id"), "response must contain key 'id'");
         assert!(obj.contains_key("name"), "response must contain key 'name'");
         assert!(
-            obj.contains_key("status"),
-            "response must contain key 'status'"
+            obj.contains_key("state"),
+            "response must contain key 'state'"
         );
         assert_eq!(
             obj.len(),
             3,
-            "response must contain exactly 3 keys (id, name, status)"
+            "response must contain exactly 3 keys (id, name, state)"
         );
 
         cleanup_scenarios(&state);
@@ -1882,7 +1732,7 @@ scenarios:
 
     // ---- Test: parse_body unit tests -------------------------------------------
 
-    /// `parse_body` accepts a v2 metrics YAML and returns a single entry.
+    /// `parse_body` accepts a v2 metrics YAML and returns a single-entry CompiledFile.
     #[test]
     fn parse_body_accepts_v2_metrics_yaml() {
         let mut headers = HeaderMap::new();
@@ -1893,16 +1743,13 @@ scenarios:
             &InMemoryPackResolver::new(),
         )
         .expect("v2 metrics body must parse");
-        match parsed {
-            ParsedBody::Single(entry) => match *entry {
-                ScenarioEntry::Metrics(c) => assert_eq!(c.name, "test_metric"),
-                other => panic!("expected ScenarioEntry::Metrics, got: {other:?}"),
-            },
-            ParsedBody::Multi(_) => panic!("single-entry v2 body must parse as Single"),
-        }
+        let ParsedBody::Compiled(compiled) = parsed;
+        assert_eq!(compiled.entries.len(), 1);
+        assert_eq!(compiled.entries[0].signal_type, "metrics");
+        assert_eq!(compiled.entries[0].name, "test_metric");
     }
 
-    /// `parse_body` accepts a v2 logs YAML and returns a single Logs entry.
+    /// `parse_body` accepts a v2 logs YAML and returns a single-entry CompiledFile.
     #[test]
     fn parse_body_accepts_v2_logs_yaml() {
         let mut headers = HeaderMap::new();
@@ -1913,13 +1760,10 @@ scenarios:
             &InMemoryPackResolver::new(),
         )
         .expect("v2 logs body must parse");
-        match parsed {
-            ParsedBody::Single(entry) => match *entry {
-                ScenarioEntry::Logs(c) => assert_eq!(c.name, "test_logs"),
-                other => panic!("expected ScenarioEntry::Logs, got: {other:?}"),
-            },
-            ParsedBody::Multi(_) => panic!("single-entry v2 body must parse as Single"),
-        }
+        let ParsedBody::Compiled(compiled) = parsed;
+        assert_eq!(compiled.entries.len(), 1);
+        assert_eq!(compiled.entries[0].signal_type, "logs");
+        assert_eq!(compiled.entries[0].name, "test_logs");
     }
 
     /// `parse_body` rejects a v1 flat metrics YAML (no `version: 2`).
@@ -2006,7 +1850,8 @@ scenarios:
             &InMemoryPackResolver::new(),
         )
         .expect("v2 JSON body must parse");
-        assert!(matches!(parsed, ParsedBody::Single(_)));
+        let ParsedBody::Compiled(compiled) = parsed;
+        assert_eq!(compiled.entries.len(), 1);
     }
 
     /// `parse_body` rejects invalid JSON with a descriptive error.
@@ -2061,13 +1906,13 @@ scenarios:
         let cs = CreatedScenario {
             id: "abc-123".to_string(),
             name: "my_scenario".to_string(),
-            status: "running",
+            state: "running".to_string(),
             warnings: Vec::new(),
         };
         let json = serde_json::to_value(&cs).expect("must serialize");
         assert_eq!(json["id"], "abc-123");
         assert_eq!(json["name"], "my_scenario");
-        assert_eq!(json["status"], "running");
+        assert_eq!(json["state"], "running");
         assert!(
             json.get("warnings").is_none(),
             "empty warnings vec must be omitted from JSON"
@@ -2080,7 +1925,7 @@ scenarios:
         let cs = CreatedScenario {
             id: "abc-123".to_string(),
             name: "my_scenario".to_string(),
-            status: "running",
+            state: "running".to_string(),
             warnings: vec!["loopback warning".to_string()],
         };
         let json = serde_json::to_value(&cs).expect("must serialize");
@@ -3641,9 +3486,10 @@ scenarios:
                 entry["name"].is_string(),
                 "scenario[{i}] must have a name string"
             );
-            assert_eq!(
-                entry["status"], "running",
-                "scenario[{i}] status must be 'running'"
+            let s = entry["state"].as_str().unwrap_or("");
+            assert!(
+                matches!(s, "pending" | "running"),
+                "scenario[{i}] state must be 'pending' or 'running', got {s:?}"
             );
         }
 
@@ -3825,10 +3671,14 @@ scenarios:
             body.get("scenarios").is_none(),
             "single-scenario POST must not return a 'scenarios' wrapper"
         );
-        // Must have the flat {id, name, status} shape.
+        // Must have the flat {id, name, state} shape.
         assert!(body["id"].is_string());
         assert_eq!(body["name"], "test_metric");
-        assert_eq!(body["status"], "running");
+        let s = body["state"].as_str().unwrap_or("");
+        assert!(
+            matches!(s, "pending" | "running"),
+            "state must be 'pending' or 'running', got {s:?}"
+        );
 
         cleanup_scenarios(&state);
     }
@@ -3992,10 +3842,10 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    /// `parse_body` returns `ParsedBody::Multi` for a v2 body that compiles
-    /// into multiple entries.
+    /// `parse_body` returns a multi-entry CompiledFile for a v2 body that
+    /// compiles into multiple entries.
     #[test]
-    fn parse_body_returns_multi_for_v2_scenarios_array() {
+    fn parse_body_returns_multi_entry_compiled_for_v2_scenarios_array() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/x-yaml".parse().unwrap());
         let parsed = parse_body(
@@ -4004,14 +3854,12 @@ scenarios:
             &InMemoryPackResolver::new(),
         )
         .expect("v2 multi YAML body must parse");
-        match parsed {
-            ParsedBody::Multi(entries) => {
-                assert_eq!(entries.len(), 2, "multi YAML must produce 2 entries");
-            }
-            ParsedBody::Single(_) => {
-                panic!("v2 multi YAML must produce ParsedBody::Multi, got Single");
-            }
-        }
+        let ParsedBody::Compiled(compiled) = parsed;
+        assert_eq!(
+            compiled.entries.len(),
+            2,
+            "multi YAML must produce 2 entries"
+        );
     }
 
     /// CreatedScenariosResponse serializes to expected JSON structure.
@@ -4022,13 +3870,13 @@ scenarios:
                 CreatedScenario {
                     id: "id-1".to_string(),
                     name: "s1".to_string(),
-                    status: "running",
+                    state: "running".to_string(),
                     warnings: Vec::new(),
                 },
                 CreatedScenario {
                     id: "id-2".to_string(),
                     name: "s2".to_string(),
-                    status: "running",
+                    state: "running".to_string(),
                     warnings: Vec::new(),
                 },
             ],
@@ -4052,7 +3900,7 @@ scenarios:
             scenarios: vec![CreatedScenario {
                 id: "id-1".to_string(),
                 name: "s1".to_string(),
-                status: "running",
+                state: "running".to_string(),
                 warnings: Vec::new(),
             }],
             warnings: vec!["loopback warning".to_string()],
@@ -4100,7 +3948,11 @@ scenarios:
 
         let body = body_json(response).await;
         assert_eq!(body["name"], "single_offset");
-        assert_eq!(body["status"], "running");
+        let s = body["state"].as_str().unwrap_or("");
+        assert!(
+            matches!(s, "pending" | "running"),
+            "state must be 'pending' or 'running', got {s:?}"
+        );
 
         cleanup_scenarios(&state);
     }

--- a/sonda-server/tests/integration.rs
+++ b/sonda-server/tests/integration.rs
@@ -88,10 +88,10 @@ fn full_lifecycle_metrics_and_logs() {
         Some("test_metric"),
         "metrics scenario name must match"
     );
-    assert_eq!(
-        metrics_body["status"].as_str(),
-        Some("running"),
-        "metrics scenario status must be running"
+    let metrics_state = metrics_body["state"].as_str().unwrap_or("");
+    assert!(
+        matches!(metrics_state, "pending" | "running"),
+        "metrics scenario state must be pending or running, got {metrics_state:?}"
     );
 
     // -- Step 2: POST logs scenario -> 201 --
@@ -118,10 +118,10 @@ fn full_lifecycle_metrics_and_logs() {
         Some("test_log"),
         "logs scenario name must match"
     );
-    assert_eq!(
-        logs_body["status"].as_str(),
-        Some("running"),
-        "logs scenario status must be running"
+    let logs_state = logs_body["state"].as_str().unwrap_or("");
+    assert!(
+        matches!(logs_state, "pending" | "running"),
+        "logs scenario state must be pending or running, got {logs_state:?}"
     );
 
     // -- Step 3: GET /scenarios -> both listed --
@@ -161,12 +161,12 @@ fn full_lifecycle_metrics_and_logs() {
         if s["id"].as_str() == Some(metrics_id.as_str())
             || s["id"].as_str() == Some(logs_id.as_str())
         {
-            let status = s["status"].as_str().unwrap_or("");
+            let state = s["state"].as_str().unwrap_or("");
             assert!(
-                matches!(status, "pending" | "running"),
+                matches!(state, "pending" | "running"),
                 "scenario {} must be pending or running, got {:?}",
                 s["id"],
-                status
+                state
             );
         }
     }

--- a/sonda-server/tests/scenarios.rs
+++ b/sonda-server/tests/scenarios.rs
@@ -92,7 +92,11 @@ fn post_valid_metrics_yaml_returns_201() {
         "response must contain a non-empty scenario ID"
     );
     assert_eq!(body["name"], "integration_metric");
-    assert_eq!(body["status"], "running");
+    let s = body["state"].as_str().unwrap_or("");
+    assert!(
+        matches!(s, "pending" | "running"),
+        "state must be 'pending' or 'running' for a freshly launched scenario, got {s:?}"
+    );
 }
 
 // ---- Test: POST valid logs YAML -> 201 ----------------------------------------
@@ -118,7 +122,11 @@ fn post_valid_logs_yaml_returns_201() {
 
     let body: serde_json::Value = resp.json().expect("response must be valid JSON");
     assert_eq!(body["name"], "integration_logs");
-    assert_eq!(body["status"], "running");
+    let s = body["state"].as_str().unwrap_or("");
+    assert!(
+        matches!(s, "pending" | "running"),
+        "state must be 'pending' or 'running' for a freshly launched scenario, got {s:?}"
+    );
 }
 
 // ---- Test: POST with signal_type: metrics -> 201 (ScenarioEntry format) -------
@@ -263,7 +271,11 @@ fn post_valid_json_returns_201() {
 
     let body: serde_json::Value = resp.json().expect("response must be valid JSON");
     assert_eq!(body["name"], "json_integration");
-    assert_eq!(body["status"], "running");
+    let s = body["state"].as_str().unwrap_or("");
+    assert!(
+        matches!(s, "pending" | "running"),
+        "state must be 'pending' or 'running' for a freshly launched scenario, got {s:?}"
+    );
 }
 
 // ---- Test: Response ID is a valid UUID ----------------------------------------
@@ -374,7 +386,11 @@ fn post_multi_scenario_yaml_returns_201_with_scenarios_array() {
     for entry in scenarios {
         assert!(entry["id"].is_string());
         assert!(entry["name"].is_string());
-        assert_eq!(entry["status"], "running");
+        let s = entry["state"].as_str().unwrap_or("");
+        assert!(
+            matches!(s, "pending" | "running"),
+            "state must be 'pending' or 'running' for a freshly launched scenario, got {s:?}"
+        );
     }
 
     // Verify names match input order.
@@ -629,7 +645,11 @@ fn post_single_scenario_backward_compat() {
     );
     assert!(body["id"].is_string());
     assert_eq!(body["name"], "integration_metric");
-    assert_eq!(body["status"], "running");
+    let s = body["state"].as_str().unwrap_or("");
+    assert!(
+        matches!(s, "pending" | "running"),
+        "state must be 'pending' or 'running' for a freshly launched scenario, got {s:?}"
+    );
 }
 
 // ---- Test: v2 end-to-end acceptance ------------------------------------------
@@ -664,7 +684,11 @@ fn post_v2_yaml_end_to_end_runs_scenario() {
         .expect("response must carry a scenario id")
         .to_string();
     assert_eq!(body["name"], "integration_metric");
-    assert_eq!(body["status"], "running");
+    let s = body["state"].as_str().unwrap_or("");
+    assert!(
+        matches!(s, "pending" | "running"),
+        "state must be 'pending' or 'running' for a freshly launched scenario, got {s:?}"
+    );
 
     // The scenario appears in the GET /scenarios listing.
     let list = client
@@ -1113,4 +1137,473 @@ scenarios:
         detail.contains("v2"),
         "detail must mention v2 requirement, got: {detail}"
     );
+}
+
+// ---- Gated launch through POST /scenarios -----------------------------------
+
+mod gated_scenarios {
+    use super::common;
+    use std::time::{Duration, Instant};
+
+    /// 2-entry cascade: a flap upstream + downstream gated by `while:`.
+    /// `delay: { open: 0s, close: 0s }` strips the debounce so state edges
+    /// land on `/stats` deterministically. Duration 2s leaves a comfortable
+    /// margin for the polling loop.
+    const FLAP_CASCADE_YAML: &str = "\
+version: 2
+defaults:
+  rate: 50
+  duration: 2s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: primary_flap
+    signal_type: metrics
+    name: primary_flap
+    generator:
+      type: flap
+      up_duration: 200ms
+      down_duration: 200ms
+  - id: gated_downstream
+    signal_type: metrics
+    name: gated_downstream
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: primary_flap
+      op: \"<\"
+      value: 1
+    delay:
+      open: 0s
+      close: 0s
+";
+
+    fn poll_state(client: &reqwest::blocking::Client, port: u16, id: &str) -> Option<String> {
+        let resp = client
+            .get(format!("http://127.0.0.1:{port}/scenarios/{id}/stats"))
+            .send()
+            .ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        let body: serde_json::Value = resp.json().ok()?;
+        body["state"].as_str().map(|s| s.to_string())
+    }
+
+    #[test]
+    fn post_gated_cascade_observes_pending_running_paused_states() {
+        let (port, _guard) = common::start_server();
+        let client = common::http_client();
+
+        let resp = client
+            .post(format!("http://127.0.0.1:{port}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(FLAP_CASCADE_YAML)
+            .send()
+            .expect("POST cascade must succeed");
+        assert_eq!(resp.status().as_u16(), 201, "POST must return 201");
+
+        let body: serde_json::Value = resp.json().expect("response must be JSON");
+        let scenarios = body["scenarios"]
+            .as_array()
+            .expect("response must contain scenarios array");
+        assert_eq!(scenarios.len(), 2);
+        let downstream_id = scenarios
+            .iter()
+            .find(|s| s["name"] == "gated_downstream")
+            .expect("downstream entry present in response")["id"]
+            .as_str()
+            .expect("downstream id is a string")
+            .to_string();
+
+        let mut observed: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        let deadline = Instant::now() + Duration::from_millis(1200);
+        while Instant::now() < deadline {
+            if let Some(s) = poll_state(&client, port, &downstream_id) {
+                observed.insert(s);
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        assert!(
+            observed.contains("running"),
+            "downstream must reach 'running' during the upstream's down-phase, observed: {observed:?}"
+        );
+        assert!(
+            observed.contains("paused"),
+            "downstream must reach 'paused' during the upstream's up-phase, observed: {observed:?}"
+        );
+    }
+
+    /// Upstream flap with a long up_duration keeps the gate closed for the
+    /// duration of the test, so the downstream's POST response carries
+    /// `state: "pending"` for its initial snapshot. The upstream's response
+    /// reports `pending` or `running` depending on whether the runner has
+    /// posted its first tick by the time the snapshot is taken.
+    const PENDING_DOWNSTREAM_YAML: &str = "\
+version: 2
+defaults:
+  rate: 50
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: upstream_high
+    signal_type: metrics
+    name: upstream_high
+    generator:
+      type: flap
+      up_duration: 60s
+      down_duration: 1s
+      up_value: 1.0
+      down_value: 0.0
+  - id: downstream_gated
+    signal_type: metrics
+    name: downstream_gated
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream_high
+      op: \"<\"
+      value: 1
+";
+
+    #[test]
+    fn post_gated_downstream_response_reports_pending_state() {
+        let (port, _guard) = common::start_server();
+        let client = common::http_client();
+
+        let resp = client
+            .post(format!("http://127.0.0.1:{port}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(PENDING_DOWNSTREAM_YAML)
+            .send()
+            .expect("POST must succeed");
+        assert_eq!(resp.status().as_u16(), 201);
+
+        let body: serde_json::Value = resp.json().expect("body is JSON");
+        let scenarios = body["scenarios"]
+            .as_array()
+            .expect("multi response carries scenarios array");
+        let downstream = scenarios
+            .iter()
+            .find(|s| s["name"] == "downstream_gated")
+            .expect("downstream present");
+        let state = downstream["state"].as_str().unwrap_or("");
+        assert!(
+            matches!(state, "pending" | "paused"),
+            "downstream must report 'pending' or 'paused' at POST-response time when its upstream \
+             gate has never opened (must NOT be 'running'), got {state:?}"
+        );
+
+        let upstream = scenarios
+            .iter()
+            .find(|s| s["name"] == "upstream_high")
+            .expect("upstream present");
+        let upstream_state = upstream["state"].as_str().unwrap_or("");
+        assert!(
+            matches!(upstream_state, "pending" | "running"),
+            "upstream must report 'pending' or 'running' at POST time, got {upstream_state:?}"
+        );
+    }
+
+    const TWO_ENTRY_YAML: &str = "\
+version: 2
+defaults:
+  rate: 10
+  duration: 500ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: dup_a
+    signal_type: metrics
+    name: dup_a
+    generator:
+      type: constant
+      value: 1.0
+  - id: dup_b
+    signal_type: metrics
+    name: dup_b
+    generator:
+      type: constant
+      value: 2.0
+";
+
+    #[test]
+    fn post_same_yaml_twice_returns_distinct_uuids() {
+        let (port, _guard) = common::start_server();
+        let client = common::http_client();
+
+        let post_once = || -> Vec<String> {
+            let resp = client
+                .post(format!("http://127.0.0.1:{port}/scenarios"))
+                .header("content-type", "application/x-yaml")
+                .body(TWO_ENTRY_YAML)
+                .send()
+                .expect("POST must succeed");
+            assert_eq!(resp.status().as_u16(), 201);
+            let body: serde_json::Value = resp.json().expect("body is JSON");
+            body["scenarios"]
+                .as_array()
+                .expect("scenarios array")
+                .iter()
+                .map(|s| s["id"].as_str().expect("id is string").to_string())
+                .collect()
+        };
+
+        let first = post_once();
+        let second = post_once();
+        let mut all = Vec::new();
+        all.extend(first);
+        all.extend(second);
+        assert_eq!(all.len(), 4);
+        let unique: std::collections::BTreeSet<&String> = all.iter().collect();
+        assert_eq!(unique.len(), 4, "all 4 ids must be distinct, got {all:?}");
+        for id in &all {
+            assert!(
+                uuid::Uuid::parse_str(id).is_ok(),
+                "id must be a valid UUID, got {id}"
+            );
+        }
+
+        let resp = client
+            .get(format!("http://127.0.0.1:{port}/scenarios"))
+            .send()
+            .expect("GET /scenarios must succeed");
+        let body: serde_json::Value = resp.json().expect("body is JSON");
+        let listed: std::collections::BTreeSet<&str> = body["scenarios"]
+            .as_array()
+            .expect("scenarios array")
+            .iter()
+            .filter_map(|s| s["id"].as_str())
+            .collect();
+        for id in &all {
+            assert!(
+                listed.contains(id.as_str()),
+                "posted id {id} must appear in GET /scenarios"
+            );
+        }
+    }
+
+    /// Cover all four signal types using alias generators where applicable —
+    /// proves `launch_multi_compiled`'s desugar+expand+validate pipeline is
+    /// semantically equivalent to the previous non-gated `prepare_entries`
+    /// path.
+    const ALL_SIGNAL_TYPES_YAML: &str = "\
+version: 2
+defaults:
+  rate: 10
+  duration: 500ms
+scenarios:
+  - id: alias_metric
+    signal_type: metrics
+    name: alias_metric
+    generator:
+      type: flap
+      up_duration: 100ms
+      down_duration: 100ms
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+  - id: plain_logs
+    signal_type: logs
+    name: plain_logs
+    log_generator:
+      type: template
+      templates:
+        - message: \"alias log line\"
+          field_pools: {}
+      seed: 0
+    encoder:
+      type: json_lines
+    sink:
+      type: stdout
+  - id: hist_metric
+    signal_type: histogram
+    name: hist_metric
+    distribution:
+      type: exponential
+      rate: 10.0
+    observations_per_tick: 16
+    seed: 1
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+  - id: summary_metric
+    signal_type: summary
+    name: summary_metric
+    distribution:
+      type: normal
+      mean: 0.1
+      stddev: 0.02
+    observations_per_tick: 16
+    seed: 2
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+";
+
+    #[test]
+    fn post_all_signal_types_with_alias_generators_returns_201() {
+        let (port, _guard) = common::start_server();
+        let client = common::http_client();
+
+        let resp = client
+            .post(format!("http://127.0.0.1:{port}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(ALL_SIGNAL_TYPES_YAML)
+            .send()
+            .expect("POST mixed signal types must succeed");
+
+        assert_eq!(
+            resp.status().as_u16(),
+            201,
+            "all four signal types with alias generators must return 201"
+        );
+
+        let body: serde_json::Value = resp.json().expect("response is JSON");
+        let scenarios = body["scenarios"]
+            .as_array()
+            .expect("multi response carries scenarios array");
+        assert_eq!(scenarios.len(), 4);
+        let names: std::collections::BTreeSet<&str> = scenarios
+            .iter()
+            .filter_map(|s| s["name"].as_str())
+            .collect();
+        assert!(names.contains("alias_metric"));
+        assert!(names.contains("plain_logs"));
+        assert!(names.contains("hist_metric"));
+        assert!(names.contains("summary_metric"));
+    }
+
+    /// 2-entry cyclic `while:` body — compile_after rejects with cycle error,
+    /// the handler maps that to 400 Bad Request.
+    const CYCLIC_WHILE_YAML: &str = "\
+version: 2
+defaults:
+  rate: 10
+  duration: 1s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: a
+    signal_type: metrics
+    name: a
+    generator:
+      type: flap
+      up_duration: 100ms
+      down_duration: 100ms
+    while:
+      ref: b
+      op: \"<\"
+      value: 1
+  - id: b
+    signal_type: metrics
+    name: b
+    generator:
+      type: flap
+      up_duration: 100ms
+      down_duration: 100ms
+    while:
+      ref: a
+      op: \"<\"
+      value: 1
+";
+
+    #[test]
+    fn post_cyclic_while_returns_400() {
+        let (port, _guard) = common::start_server();
+        let client = common::http_client();
+
+        let resp = client
+            .post(format!("http://127.0.0.1:{port}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(CYCLIC_WHILE_YAML)
+            .send()
+            .expect("POST cyclic while must reach the server");
+        assert_eq!(
+            resp.status().as_u16(),
+            400,
+            "cyclic while: must surface as 400 Bad Request"
+        );
+    }
+
+    #[test]
+    fn paused_scenario_does_not_mutate_consecutive_failures() {
+        let (port, _guard) = common::start_server();
+        let client = common::http_client();
+
+        let resp = client
+            .post(format!("http://127.0.0.1:{port}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(FLAP_CASCADE_YAML)
+            .send()
+            .expect("POST cascade must succeed");
+        assert_eq!(resp.status().as_u16(), 201);
+
+        let body: serde_json::Value = resp.json().expect("body is JSON");
+        let downstream_id = body["scenarios"]
+            .as_array()
+            .expect("scenarios array")
+            .iter()
+            .find(|s| s["name"] == "gated_downstream")
+            .expect("downstream entry")["id"]
+            .as_str()
+            .expect("downstream id")
+            .to_string();
+
+        // Wait for the downstream to enter `paused` (during upstream's up-phase).
+        let mut found_paused_failures: Option<u64> = None;
+        let deadline = Instant::now() + Duration::from_millis(800);
+        while Instant::now() < deadline {
+            let stats = client
+                .get(format!(
+                    "http://127.0.0.1:{port}/scenarios/{downstream_id}/stats"
+                ))
+                .send()
+                .expect("GET stats must succeed");
+            let body: serde_json::Value = stats.json().expect("stats body is JSON");
+            if body["state"].as_str() == Some("paused") {
+                found_paused_failures = body["consecutive_failures"].as_u64();
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let baseline = found_paused_failures
+            .expect("downstream must reach paused state within 800ms for the assertion to fire");
+
+        // Hold paused for 500ms (longer than the 200ms up-phase, so the
+        // sample window may straddle a transition). The stronger guarantee
+        // is: across consecutive paused samples, the failure counter does
+        // not advance — the runner is not running ticks.
+        std::thread::sleep(Duration::from_millis(500));
+
+        let stats = client
+            .get(format!(
+                "http://127.0.0.1:{port}/scenarios/{downstream_id}/stats"
+            ))
+            .send()
+            .expect("GET stats must succeed");
+        let body: serde_json::Value = stats.json().expect("stats body is JSON");
+        let after = body["consecutive_failures"].as_u64().expect("u64 field");
+        // For a stdout sink, baseline is 0 and after must also be 0.
+        assert_eq!(
+            after, baseline,
+            "consecutive_failures must not advance while paused (baseline={baseline}, after={after})"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

PRs 1+2+3 wired `while:` gating through the CLI. PR 4 UAT exposed that `POST /scenarios` was still calling the **non-gated** launch path (`prepare_entries` + `launch_scenario`) — `while:` clauses parsed correctly but were silently ignored at runtime. Every gated downstream ran continuously instead of transitioning through the state machine.

PR 3.5 routes the server's batch POST through `launch_multi_compiled` (the gated path PR 2 added for the CLI), harmonizes the `status` → `state` wire-name across endpoints, and fixes a partial-launch leak in sonda-core.

### What changed

- **Server**: `parse_body` now returns `ParsedBody::Compiled(Box<CompiledFile>)`; `post_multi_scenario` collapses into `post_scenario` and dispatches through `launch_multi_compiled`. Single-vs-multi response shape decided post-launch from launched-handle count. Per-batch GateBus invariant preserved (no global registry in `AppState`).
- **Wire field harmonization**: `status` → `state` on `CreatedScenario`, `ScenarioSummary`, `ScenarioDetail`. `DeletedScenario.status` deliberately untouched (different semantic — join outcome, not lifecycle state).
- **POST response state honesty**: `CreatedScenario.state` sourced live from `state_string(&handle.stats_snapshot())` per handle. Gated downstreams correctly report `paused`/`pending` at POST time instead of always lying as `running`.
- **Sonda-core fix**: `launch_multi_compiled` now stops already-launched handles before propagating launch errors (prevents thread leaks; benefits CLI silently).
- **Server-side IDs**: post-launch UUID rename per handle preserves pre-3.5 URL semantics regardless of compiler-assigned ids.

### Tests added

New `gated_scenarios` module in `sonda-server/tests/scenarios.rs`:
- `post_gated_cascade_observes_pending_running_paused_states` (load-bearing)
- `post_gated_downstream_response_reports_pending_state`
- `post_same_yaml_twice_returns_distinct_uuids`
- `post_all_signal_types_with_alias_generators_returns_201` (semantic equivalence)
- `post_cyclic_while_returns_400`
- `paused_scenario_does_not_mutate_consecutive_failures`

New positive-path partial-launch cleanup test in `sonda-core::schedule::multi_runner`. Field-rename sweep across existing assertions.

### Acceptance criteria closed

- A1, A1a, A2, A4-Z, A5b, A9 (server now exposes `state` field on list endpoint).
- D1-D5 design decisions locked: post-launch UUID rename, sonda-core partial-launch cleanup, prepare-then-warnings call site, full status→state rename, live state from stats_snapshot.

### Follow-up issues (from Opus reviewer)

1. Partial-launch cleanup test is positive-path only (synthesizing a "fails AFTER entry 0/1 spawn" condition without API change is impossible). Future hardening: extract spawn loop into testable helper.
2. `paused_scenario_does_not_mutate_consecutive_failures` uses stdout sink (consecutive_failures always 0 — trivially passes). Future hardening: use a failing sink.
3. New gated tests are real-clock E2E. Future hardening: add `GateBus::drive_value`-based synchronous unit tests for state-machine assertions.
4. Warnings pipeline runs `prepare_entries` on a clone, separate from `launch_multi_compiled`'s internal pipeline. Future hardening: factor out a single shared "derive ScenarioEntries for warnings" helper.

### Quality gates

| Gate | Result |
|---|---|
| `cargo build --workspace` | PASS |
| `cargo nextest run --workspace` | 2860/2860 PASS |
| `cargo test --workspace --doc` | 5/5 PASS |
| `cargo clippy --workspace -- -D warnings` | PASS |
| `cargo fmt --all -- --check` | PASS |
| `cargo audit` | PASS (1 pre-existing allowed warning) |
| `cargo test -p sonda-core --no-default-features` | PASS |
| `cargo test -p sonda-server --no-default-features --test scenarios` | 32/32 PASS (incl. all 6 new gated tests) |

Bench `while_steady_state` numbers in PR 2 baseline range — no per-tick code paths changed.

### UAT verdict

PASS — gated cascade observably transitions through `pending → running → paused → running → paused → finished` across a 90s run. POST response correctly reports `paused` for gated downstreams whose gate is closed at startup. All four endpoints harmonized to `state`; DELETE-response `status` preserved.

## Test plan

- [x] cargo gate suite (build/nextest/clippy/fmt/audit/doc/feature-subtractive)
- [x] Opus reviewer (architectural class, no Sonnet pre-pass)
- [x] UAT against locally-built sonda:while-clause-v2 image
- [ ] Workshop `flap.py` field-name surface fix (separate commit on workshops/feat/while-clause-migration after this PR merges)
- [ ] PR 4 (workshop YAML migration) re-UAT against new image