### PR TITLE
feat(compiler): flap `enum:` shorthand + Phase E schema lockdown (Sub-PR 2 of v1.6)

### DIFF
--- a/docs/site/docs/configuration/generators.md
+++ b/docs/site/docs/configuration/generators.md
@@ -455,6 +455,7 @@ bouncing between healthy and unhealthy.
 | `down_duration` | duration | `"5s"` | How long the signal stays "down" per cycle. |
 | `up_value` | float | `1.0` | Value emitted during the "up" state. |
 | `down_value` | float | `0.0` | Value emitted during the "down" state. |
+| `enum` | string | unset | Domain shorthand for `(up_value, down_value)`. See the table below. Mutually exclusive with explicit `up_value`/`down_value`. |
 
 ```yaml title="Interface flap"
 generator:
@@ -466,9 +467,30 @@ generator:
 At `rate: 1`, this produces 10 ticks of `1.0` followed by 5 ticks of `0.0`, then repeats.
 The number of ticks per state is derived from the duration and the scenario `rate`.
 
+#### `enum:` shorthand
+
+For operator-facing metrics, prefer the `enum:` shorthand over hand-tuned values. It selects a `(up_value, down_value)` pair aligned with gNMI / openconfig conventions so dashboards and alert rules built around standard state codes (UP=1, DOWN=2, ESTABLISHED=6, IDLE=1) keep working unchanged. `enum: oper_state` is the recommended starting point for any interface-state or operational-status metric.
+
+| `enum:` value | `up_value` | `down_value` | Use case |
+|---|---|---|---|
+| `boolean` | 1.0 | 0.0 | Generic boolean -- explicit synonym for the v1.5 default |
+| `link_state` | 1.0 | 0.0 | Synonym of `boolean` |
+| `oper_state` | 1.0 | 2.0 | gNMI / openconfig oper-state (UP=1, DOWN=2) |
+| `admin_state` | 1.0 | 2.0 | gNMI / openconfig admin-state (UP=1, DOWN=2) |
+| `neighbor_state` | 6.0 | 1.0 | BGP neighbor-state (ESTABLISHED=6, IDLE=1) |
+
+```yaml title="Interface oper-state flap"
+generator:
+  type: flap
+  up_duration: "60s"
+  down_duration: "30s"
+  enum: oper_state    # up_value=1.0, down_value=2.0 -- no need to spell them out
+```
+
+`enum:` is mutually exclusive with explicit `up_value` / `down_value`. Combining them is rejected at compile time with the message `flap: 'enum' is mutually exclusive with explicit 'up_value'/'down_value' — pick one`.
+
 ??? tip "Custom values"
-    Use `up_value` and `down_value` to model non-binary signals. For example, a link that
-    alternates between full speed and degraded:
+    When the metric does not match a documented enum, use explicit `up_value` and `down_value` instead. For example, a link that alternates between full speed and degraded throughput:
 
     ```yaml
     generator:

--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -604,6 +604,10 @@ When an entry carries both `after:` and `while:` against different upstreams, bo
 
 `while:` accepts only the strict comparison operators `<` and `>`. Non-strict operators (`<=`, `>=`, `==`, `!=`) are rejected at compile time -- equality on a continuous-valued upstream is numerically unsafe and forbidden by design.
 
+### Value typing
+
+`while.value` accepts either an integer or a float YAML scalar; both are stored as `f64`. `value: 1` and `value: 1.0` are equivalent. Prefer `1.0` (or any explicit decimal form) in scenario files so the YAML reader carries the operator's intent without relying on integer coercion. NaN and infinity (`.nan`, `.inf`, `-.inf`) are rejected at compile time because the strict comparison gate would never resolve deterministically; the same rejection applies to `delay.close.snap_to`.
+
 ### Migrating an `after:`-only cascade to `while:` with recovery
 
 The `link-failover` scenario described above uses `after:` to start a `backup_link_utilization` saturation curve once the primary link drops below `1`. With `after:` the dependent scenario runs to completion regardless of what the primary does next -- if the primary recovers mid-cascade, the backup keeps emitting.

--- a/sonda-core/src/compiler/compile_after.rs
+++ b/sonda-core/src/compiler/compile_after.rs
@@ -891,12 +891,14 @@ fn crossing_secs(
             down_duration,
             up_value,
             down_value,
+            enum_kind,
         } => {
             let up_secs = duration_or_default(up_duration.as_deref(), 10.0, "flap.up_duration")?;
             let down_secs =
                 duration_or_default(down_duration.as_deref(), 5.0, "flap.down_duration")?;
-            let up_val = up_value.unwrap_or(1.0);
-            let down_val = down_value.unwrap_or(0.0);
+            let (up_default, down_default) = enum_kind.map(|e| e.defaults()).unwrap_or((1.0, 0.0));
+            let up_val = up_value.unwrap_or(up_default);
+            let down_val = down_value.unwrap_or(down_default);
             timing::flap_crossing_secs(op, threshold, up_secs, down_secs, up_val, down_val)
         }
         GeneratorConfig::Saturation {

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -135,6 +135,19 @@ pub enum NormalizeError {
          do not also set delay.close.stale_marker: false"
     )]
     CloseEmitConflict { source_id: String },
+
+    #[error(
+        "entry '{source_id}': while.value must be a finite number; \
+         NaN and infinity are rejected because the strict comparison gate \
+         would never resolve deterministically"
+    )]
+    WhileValueIsNan { source_id: String },
+
+    #[error(
+        "entry '{source_id}': delay.close.snap_to must be a finite number; \
+         NaN and infinity cannot be emitted as a recovery sample"
+    )]
+    CloseSnapToIsNan { source_id: String },
 }
 
 // ---------------------------------------------------------------------------
@@ -390,11 +403,25 @@ fn normalize_entry(
             source_id: diagnostic_label,
         });
     }
+    if let Some(w) = while_clause.as_ref() {
+        if !w.value.is_finite() {
+            return Err(NormalizeError::WhileValueIsNan {
+                source_id: diagnostic_label,
+            });
+        }
+    }
     if let Some(d) = delay_clause.as_ref() {
         if d.close_snap_to.is_some() && d.close_stale_marker == Some(false) {
             return Err(NormalizeError::CloseEmitConflict {
                 source_id: diagnostic_label,
             });
+        }
+        if let Some(v) = d.close_snap_to {
+            if !v.is_finite() {
+                return Err(NormalizeError::CloseSnapToIsNan {
+                    source_id: diagnostic_label,
+                });
+            }
         }
     }
 
@@ -1461,6 +1488,72 @@ scenarios:
         let delay = gated.delay_clause.as_ref().expect("delay clause present");
         assert_eq!(delay.open, Some(std::time::Duration::from_millis(250)));
         assert_eq!(delay.close, Some(std::time::Duration::ZERO));
+    }
+
+    #[rustfmt::skip]
+    #[rstest::rstest]
+    #[case::nan(".nan")]
+    #[case::pos_inf(".inf")]
+    #[case::neg_inf("-.inf")]
+    fn while_value_non_finite_is_rejected_at_compile(#[case] yaml_value: &str) {
+        let yaml = format!(r#"
+version: 2
+defaults:
+  rate: 1
+  duration: 1m
+scenarios:
+  - id: src
+    signal_type: metrics
+    name: src
+    generator: {{ type: constant, value: 1 }}
+  - id: gated
+    signal_type: metrics
+    name: gated
+    generator: {{ type: constant, value: 1 }}
+    while: {{ ref: src, op: ">", value: {yaml_value} }}
+"#);
+        let err = normalize_yaml(&yaml).expect_err("non-finite while.value must fail");
+        match err {
+            NormalizeError::WhileValueIsNan { source_id } => {
+                assert_eq!(source_id, "gated");
+            }
+            other => panic!("expected WhileValueIsNan, got {other:?}"),
+        }
+    }
+
+    #[rustfmt::skip]
+    #[rstest::rstest]
+    #[case::nan(".nan")]
+    #[case::pos_inf(".inf")]
+    #[case::neg_inf("-.inf")]
+    fn close_snap_to_non_finite_is_rejected_at_compile(#[case] yaml_value: &str) {
+        let yaml = format!(r#"
+version: 2
+defaults:
+  rate: 1
+  duration: 1m
+scenarios:
+  - id: src
+    signal_type: metrics
+    name: src
+    generator: {{ type: constant, value: 1 }}
+  - id: gated
+    signal_type: metrics
+    name: gated
+    generator: {{ type: constant, value: 1 }}
+    while: {{ ref: src, op: ">", value: 0 }}
+    delay:
+      close:
+        duration: 5s
+        snap_to: {yaml_value}
+"#);
+        let err = normalize_yaml(&yaml).expect_err("non-finite close.snap_to must fail");
+        match err {
+            NormalizeError::CloseSnapToIsNan { source_id } => {
+                assert_eq!(source_id, "gated");
+            }
+            other => panic!("expected CloseSnapToIsNan, got {other:?}"),
+        }
     }
 
     #[test]

--- a/sonda-core/src/config/aliases.rs
+++ b/sonda-core/src/config/aliases.rs
@@ -66,9 +66,16 @@ pub fn desugar_scenario_config(config: &mut ScenarioConfig) -> Result<(), SondaE
             down_duration,
             up_value,
             down_value,
+            enum_kind,
         } => {
-            let up_val = up_value.unwrap_or(1.0);
-            let down_val = down_value.unwrap_or(0.0);
+            if enum_kind.is_some() && (up_value.is_some() || down_value.is_some()) {
+                return Err(SondaError::Config(ConfigError::invalid(
+                    "flap: 'enum' is mutually exclusive with explicit 'up_value'/'down_value' — pick one",
+                )));
+            }
+            let (up_default, down_default) = enum_kind.map(|e| e.defaults()).unwrap_or((1.0, 0.0));
+            let up_val = up_value.unwrap_or(up_default);
+            let down_val = down_value.unwrap_or(down_default);
 
             let up_dur = up_duration.as_deref().unwrap_or("10s");
             let down_dur = down_duration.as_deref().unwrap_or("5s");
@@ -308,6 +315,149 @@ generator:
                 assert_eq!(*repeat, Some(true));
             }
             other => panic!("expected Sequence, got {other:?}"),
+        }
+    }
+
+    #[rustfmt::skip]
+    #[rstest::rstest]
+    #[case::boolean(       "boolean",        1.0, 0.0)]
+    #[case::link_state(    "link_state",     1.0, 0.0)]
+    #[case::oper_state(    "oper_state",     1.0, 2.0)]
+    #[case::admin_state(   "admin_state",    1.0, 2.0)]
+    #[case::neighbor_state("neighbor_state", 6.0, 1.0)]
+    fn flap_enum_variant_produces_expected_sequence(
+        #[case] enum_name: &str,
+        #[case] expected_up: f64,
+        #[case] expected_down: f64,
+    ) {
+        let yaml = format!(r#"
+name: test_flap_enum
+rate: 1
+generator:
+  type: flap
+  up_duration: "2s"
+  down_duration: "2s"
+  enum: {enum_name}
+"#);
+        let mut config = parse_scenario(&yaml);
+        desugar_scenario_config(&mut config).expect("desugar must succeed");
+
+        match &config.generator {
+            GeneratorConfig::Sequence { values, repeat } => {
+                assert_eq!(values.len(), 4);
+                assert!(
+                    values[..2].iter().all(|v| *v == expected_up),
+                    "up phase must use {expected_up}, got {values:?}"
+                );
+                assert!(
+                    values[2..].iter().all(|v| *v == expected_down),
+                    "down phase must use {expected_down}, got {values:?}"
+                );
+                assert_eq!(*repeat, Some(true));
+            }
+            other => panic!("expected Sequence, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flap_enum_with_explicit_up_value_is_rejected() {
+        let yaml = r#"
+name: test_flap_enum_conflict
+rate: 1
+generator:
+  type: flap
+  up_duration: "2s"
+  down_duration: "2s"
+  enum: oper_state
+  up_value: 7
+"#;
+        let mut config = parse_scenario(yaml);
+        let err = desugar_scenario_config(&mut config).expect_err("conflict must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("mutually exclusive"),
+            "error must use the locked 'mutually exclusive' wording, got: {msg}"
+        );
+        assert!(msg.contains("flap"), "error must mention flap: {msg}");
+    }
+
+    #[test]
+    fn flap_enum_with_explicit_down_value_is_rejected() {
+        let yaml = r#"
+name: test_flap_enum_conflict_down
+rate: 1
+generator:
+  type: flap
+  up_duration: "2s"
+  down_duration: "2s"
+  enum: neighbor_state
+  down_value: 99
+"#;
+        let mut config = parse_scenario(yaml);
+        let err = desugar_scenario_config(&mut config).expect_err("conflict must fail");
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn flap_without_enum_or_explicit_values_uses_v15_defaults() {
+        let yaml = r#"
+name: test_flap_v15_defaults
+rate: 1
+generator:
+  type: flap
+  up_duration: "2s"
+  down_duration: "2s"
+"#;
+        let mut config = parse_scenario(yaml);
+        desugar_scenario_config(&mut config).expect("desugar must succeed");
+
+        match &config.generator {
+            GeneratorConfig::Sequence { values, .. } => {
+                assert!(values[..2].iter().all(|v| *v == 1.0));
+                assert!(values[2..].iter().all(|v| *v == 0.0));
+            }
+            other => panic!("expected Sequence, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flap_explicit_values_without_enum_are_preserved() {
+        let yaml = r#"
+name: test_flap_explicit
+rate: 1
+generator:
+  type: flap
+  up_duration: "2s"
+  down_duration: "2s"
+  up_value: 5
+  down_value: 10
+"#;
+        let mut config = parse_scenario(yaml);
+        desugar_scenario_config(&mut config).expect("desugar must succeed");
+
+        match &config.generator {
+            GeneratorConfig::Sequence { values, .. } => {
+                assert!(values[..2].iter().all(|v| *v == 5.0));
+                assert!(values[2..].iter().all(|v| *v == 10.0));
+            }
+            other => panic!("expected Sequence, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flap_enum_yaml_roundtrip_deserializes_each_variant() {
+        use crate::generator::FlapEnum;
+
+        for (name, expected) in [
+            ("boolean", FlapEnum::Boolean),
+            ("link_state", FlapEnum::LinkState),
+            ("oper_state", FlapEnum::OperState),
+            ("admin_state", FlapEnum::AdminState),
+            ("neighbor_state", FlapEnum::NeighborState),
+        ] {
+            let parsed: FlapEnum =
+                serde_yaml_ng::from_str(name).expect("FlapEnum scalar must deserialize");
+            assert_eq!(parsed, expected, "variant {name} must round-trip");
         }
     }
 
@@ -734,6 +884,7 @@ generator:
             down_duration: None,
             up_value: None,
             down_value: None,
+            enum_kind: None,
         }
         .is_alias());
         assert!(GeneratorConfig::Steady {

--- a/sonda-core/src/generator/mod.rs
+++ b/sonda-core/src/generator/mod.rs
@@ -81,6 +81,43 @@ pub struct CsvColumnSpec {
     pub labels: Option<HashMap<String, String>>,
 }
 
+/// Domain-specific value mapping for the [`GeneratorConfig::Flap`] alias.
+///
+/// The variant selects an `(up_value, down_value)` pair aligned with
+/// gNMI / openconfig conventions:
+///
+/// | Variant | `up_value` | `down_value` | Convention |
+/// |---|---|---|---|
+/// | `Boolean` | 1.0 | 0.0 | Generic boolean |
+/// | `LinkState` | 1.0 | 0.0 | Synonym of `Boolean` |
+/// | `OperState` | 1.0 | 2.0 | gNMI oper-state (UP=1, DOWN=2) |
+/// | `AdminState` | 1.0 | 2.0 | gNMI admin-state (UP=1, DOWN=2) |
+/// | `NeighborState` | 6.0 | 1.0 | BGP neighbor-state (ESTABLISHED=6, IDLE=1) |
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "config",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
+pub enum FlapEnum {
+    Boolean,
+    LinkState,
+    OperState,
+    AdminState,
+    NeighborState,
+}
+
+impl FlapEnum {
+    /// Return the `(up_value, down_value)` pair this variant selects.
+    pub fn defaults(self) -> (f64, f64) {
+        match self {
+            FlapEnum::Boolean | FlapEnum::LinkState => (1.0, 0.0),
+            FlapEnum::OperState | FlapEnum::AdminState => (1.0, 2.0),
+            FlapEnum::NeighborState => (6.0, 1.0),
+        }
+    }
+}
+
 /// Configuration for a value generator, used for YAML deserialization.
 ///
 /// The `type` field selects which generator to instantiate. Additional fields
@@ -235,6 +272,11 @@ pub enum GeneratorConfig {
     /// The number of consecutive up/down ticks is derived from `up_duration` and
     /// `down_duration` relative to the scenario `rate`.
     ///
+    /// The optional `enum:` shorthand selects up/down values aligned with
+    /// common gNMI / openconfig conventions (oper-state, admin-state,
+    /// BGP neighbor-state). Mutually exclusive with explicit `up_value` /
+    /// `down_value`.
+    ///
     /// # Example YAML
     ///
     /// ```yaml
@@ -242,6 +284,7 @@ pub enum GeneratorConfig {
     ///   type: flap
     ///   up_duration: "10s"
     ///   down_duration: "5s"
+    ///   enum: oper_state    # up_value=1.0, down_value=2.0
     /// ```
     #[cfg_attr(feature = "config", serde(rename = "flap"))]
     Flap {
@@ -259,6 +302,14 @@ pub enum GeneratorConfig {
         /// Value emitted during the "down" state. Defaults to `0.0`.
         #[cfg_attr(feature = "config", serde(default))]
         down_value: Option<f64>,
+        /// Domain-specific shorthand selecting `(up_value, down_value)` per
+        /// the [`FlapEnum`] mapping. Mutually exclusive with `up_value` /
+        /// `down_value`.
+        #[cfg_attr(
+            feature = "config",
+            serde(default, rename = "enum", skip_serializing_if = "Option::is_none")
+        )]
+        enum_kind: Option<FlapEnum>,
     },
 
     /// Resource filling up and resetting on a repeating cycle (e.g. disk usage

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -1212,6 +1212,58 @@ scenarios:
 }
 
 #[test]
+fn nan_upstream_value_keeps_downstream_paused() {
+    let bus = Arc::new(GateBus::new());
+    bus.tick(f64::NAN);
+    let (rx, init) = bus.subscribe(while_gt_zero());
+    assert_eq!(
+        init.while_gate_open,
+        Some(false),
+        "NaN upstream must close the gate at subscription"
+    );
+
+    let shutdown = Arc::new(AtomicBool::new(true));
+    let entry = metrics_entry("nan_paused", 200.0, 600);
+    let mut handle = launch_scenario_with_gates(
+        "nan_paused".to_string(),
+        entry,
+        Arc::clone(&shutdown),
+        None,
+        None,
+        Some(GateContext {
+            gate_rx: rx,
+            initial: init,
+            delay: None,
+            has_after: false,
+            has_while: true,
+            close_emit: None,
+        }),
+    )
+    .expect("launch must succeed");
+
+    // Re-publish NaN periodically to confirm the runtime defense holds
+    // across multiple bus updates, not just at subscription.
+    for _ in 0..6 {
+        thread::sleep(Duration::from_millis(50));
+        bus.tick(f64::NAN);
+    }
+
+    let snap = handle.stats_snapshot();
+    assert_eq!(
+        snap.total_events, 0,
+        "NaN upstream must keep downstream paused"
+    );
+    assert!(
+        matches!(snap.state, ScenarioState::Paused),
+        "expected Paused with NaN upstream, got {:?}",
+        snap.state
+    );
+
+    handle.stop();
+    handle.join(Some(Duration::from_secs(2))).ok();
+}
+
+#[test]
 fn delay_close_extended_form_deserializes_all_fields() {
     use sonda_core::compile_scenario_file_compiled;
     use sonda_core::compiler::expand::InMemoryPackResolver;

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -253,6 +253,27 @@ enum ParsedBody {
     Compiled(Box<CompiledFile>),
 }
 
+/// Categorized failure from [`parse_body`].
+///
+/// `Syntactic` covers genuine YAML/JSON syntax errors and content-type
+/// mismatches — surfaced as 400 Bad Request. `Semantic` covers schema
+/// validation failures on otherwise well-formed input (e.g. unsupported
+/// `while.op`, NaN values, conflicting fields) — surfaced as 422
+/// Unprocessable Entity.
+#[derive(Debug)]
+enum ParseFailure {
+    Syntactic(String),
+    Semantic(String),
+}
+
+impl ParseFailure {
+    fn message(&self) -> &str {
+        match self {
+            ParseFailure::Syntactic(m) | ParseFailure::Semantic(m) => m,
+        }
+    }
+}
+
 fn format_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
     let mut out = err.to_string();
     let mut cause: Option<&(dyn std::error::Error + 'static)> = err.source();
@@ -268,26 +289,62 @@ fn parse_body(
     body: &[u8],
     headers: &HeaderMap,
     pack_resolver: &InMemoryPackResolver,
-) -> Result<ParsedBody, String> {
-    let text = yaml_body_text(body, headers)?;
+) -> Result<ParsedBody, ParseFailure> {
+    let text = yaml_body_text(body, headers).map_err(ParseFailure::Syntactic)?;
 
     let version = detect_version(&text);
     if version != Some(2) {
-        return Err(format!("body is not a v2 scenario. {V1_REJECTION_HINT}"));
+        return Err(ParseFailure::Syntactic(format!(
+            "body is not a v2 scenario. {V1_REJECTION_HINT}"
+        )));
     }
 
     let compiled = compile_scenario_file_compiled(&text, pack_resolver).map_err(|e| {
-        format!(
+        let detail = format!(
             "v2 scenario body failed to compile: {}",
             format_error_chain(&e)
-        )
+        );
+        if is_semantic_schema_error(&e, &text) {
+            ParseFailure::Semantic(detail)
+        } else {
+            ParseFailure::Syntactic(detail)
+        }
     })?;
 
     if compiled.entries.is_empty() {
-        return Err("v2 scenario body produced zero entries".to_string());
+        return Err(ParseFailure::Syntactic(
+            "v2 scenario body produced zero entries".to_string(),
+        ));
     }
 
     Ok(ParsedBody::Compiled(Box::new(compiled)))
+}
+
+/// Detect schema-level deserialize failures on otherwise well-formed YAML.
+///
+/// Returns true only when the raw text parses as a generic YAML `Value` but
+/// the AST deserialize step rejects it (e.g. unsupported `while.op`,
+/// `deny_unknown_fields` violations). All other compile failures — YAML
+/// syntax errors, normalize/expand/compile_after/prepare errors — map to
+/// `400 Bad Request` to preserve existing behavior.
+fn is_semantic_schema_error(err: &sonda_core::CompileError, text: &str) -> bool {
+    use sonda_core::compiler::normalize::NormalizeError;
+    use sonda_core::compiler::parse::ParseError;
+    use sonda_core::CompileError;
+
+    match err {
+        CompileError::Parse(ParseError::Yaml(_)) => {
+            serde_yaml_ng::from_str::<serde_yaml_ng::Value>(text).is_ok()
+        }
+        CompileError::Normalize(
+            NormalizeError::WhileValueIsNan { .. }
+            | NormalizeError::CloseSnapToIsNan { .. }
+            | NormalizeError::CloseEmitConflict { .. }
+            | NormalizeError::WhileWithoutDuration { .. }
+            | NormalizeError::DelayWithoutWhile { .. },
+        ) => true,
+        _ => false,
+    }
 }
 
 /// Convert the raw request body into YAML text for the v2 compiler.
@@ -334,9 +391,12 @@ pub async fn post_scenario(
     headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> Result<Response, Response> {
-    let parsed = parse_body(&body, &headers, &state.pack_resolver).map_err(|msg| {
-        warn!(error = %msg, "POST /scenarios: invalid request body");
-        bad_request(msg)
+    let parsed = parse_body(&body, &headers, &state.pack_resolver).map_err(|fail| {
+        warn!(error = %fail.message(), "POST /scenarios: invalid request body");
+        match fail {
+            ParseFailure::Syntactic(m) => bad_request(m),
+            ParseFailure::Semantic(m) => unprocessable(m),
+        }
     })?;
 
     let ParsedBody::Compiled(compiled) = parsed;
@@ -1781,13 +1841,14 @@ generator:
 ";
         let err = parse_body(v1_yaml.as_bytes(), &headers, &InMemoryPackResolver::new())
             .expect_err("v1 flat YAML must be rejected");
+        let msg = err.message();
         assert!(
-            err.contains("v2"),
-            "rejection must mention v2 requirement, got: {err}"
+            msg.contains("v2"),
+            "rejection must mention v2 requirement, got: {msg}"
         );
         assert!(
-            err.contains("v2-scenarios.md") || err.contains("Migrate"),
-            "rejection must include migration hint, got: {err}"
+            msg.contains("v2-scenarios.md") || msg.contains("Migrate"),
+            "rejection must include migration hint, got: {msg}"
         );
     }
 
@@ -1807,9 +1868,10 @@ scenarios:
 ";
         let err = parse_body(v1_multi.as_bytes(), &headers, &InMemoryPackResolver::new())
             .expect_err("v1 multi-scenario YAML must be rejected");
+        let msg = err.message();
         assert!(
-            err.contains("v2"),
-            "rejection must mention v2 requirement, got: {err}"
+            msg.contains("v2"),
+            "rejection must mention v2 requirement, got: {msg}"
         );
     }
 
@@ -1820,7 +1882,7 @@ scenarios:
         headers.insert("content-type", "application/x-yaml".parse().unwrap());
         let err = parse_body(b"not valid: [}{", &headers, &InMemoryPackResolver::new())
             .expect_err("garbage must fail");
-        assert!(!err.is_empty(), "error message must not be empty");
+        assert!(!err.message().is_empty(), "error message must not be empty");
     }
 
     /// `parse_body` accepts a v2 JSON body and transcodes it to YAML internally.
@@ -1862,7 +1924,7 @@ scenarios:
         headers.insert("content-type", "application/json".parse().unwrap());
         let err = parse_body(b"not json", &headers, &InMemoryPackResolver::new())
             .expect_err("invalid JSON must fail");
-        assert!(!err.is_empty(), "error message must not be empty");
+        assert!(!err.message().is_empty(), "error message must not be empty");
     }
 
     /// is_yaml_content_type returns true for application/x-yaml.

--- a/sonda-server/tests/scenarios.rs
+++ b/sonda-server/tests/scenarios.rs
@@ -1745,4 +1745,114 @@ scenarios:
             "error must mention 'snap_to', got: {body}"
         );
     }
+
+    const OP_LE_WHILE_YAML: &str = "\
+version: 2
+defaults:
+  rate: 5
+  duration: 1s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: src
+    signal_type: metrics
+    name: src
+    generator:
+      type: constant
+      value: 1
+  - id: gated
+    signal_type: metrics
+    name: gated
+    generator:
+      type: constant
+      value: 1
+    while:
+      ref: src
+      op: '<='
+      value: 1
+";
+
+    #[test]
+    fn op_le_returns_422_on_post() {
+        let (port, _guard) = common::start_server();
+        let client = common::http_client();
+
+        let resp = client
+            .post(format!("http://127.0.0.1:{port}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(OP_LE_WHILE_YAML)
+            .send()
+            .expect("POST must succeed at HTTP level");
+
+        let status = resp.status().as_u16();
+        assert_eq!(
+            status, 422,
+            "op: '<=' is a schema-level rejection, must surface as 422 (not 400, not 500)"
+        );
+
+        let body = resp.text().expect("response body is UTF-8");
+        assert!(
+            body.contains("unsupported operator")
+                && body.contains("strict")
+                && body.contains("'<'")
+                && body.contains("'>'"),
+            "response body must contain the locked operator-rejection wording, got: {body}"
+        );
+    }
+
+    const NAN_VALUE_WHILE_YAML: &str = "\
+version: 2
+defaults:
+  rate: 1
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: src
+    signal_type: metrics
+    name: src
+    generator:
+      type: constant
+      value: 0.5
+  - id: gated
+    signal_type: metrics
+    name: gated
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: src
+      op: '<'
+      value: .nan
+";
+
+    #[test]
+    fn while_value_nan_returns_422_on_post() {
+        let (port, _guard) = common::start_server();
+        let client = common::http_client();
+
+        let resp = client
+            .post(format!("http://127.0.0.1:{port}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(NAN_VALUE_WHILE_YAML)
+            .send()
+            .expect("POST must succeed at HTTP level");
+
+        let status = resp.status().as_u16();
+        assert_eq!(
+            status, 422,
+            "while.value: NaN is a normalize-stage schema rejection on otherwise well-formed \
+             YAML — must surface as 422 (parity with op:'<=' rejection), got {status}"
+        );
+
+        let body = resp.text().expect("response body is UTF-8");
+        assert!(
+            body.contains("finite") || body.contains("NaN"),
+            "response body must explain why NaN is rejected, got: {body}"
+        );
+    }
 }

--- a/sonda/src/dry_run.rs
+++ b/sonda/src/dry_run.rs
@@ -47,6 +47,7 @@ pub fn print_dry_run_compiled(
     compiled: &CompiledFile,
     format: DryRunFormat,
 ) -> anyhow::Result<()> {
+    validate_alias_invariants(compiled)?;
     match format {
         DryRunFormat::Text => {
             let mut out = io::stderr().lock();
@@ -55,6 +56,30 @@ pub fn print_dry_run_compiled(
         DryRunFormat::Json => {
             let mut out = io::stdout().lock();
             write_json_compiled(&mut out, source_label, compiled)?;
+        }
+    }
+    Ok(())
+}
+
+/// Surface alias-validation errors that would otherwise only fire inside
+/// `prepare_entries` (which dry-run never calls). Today this catches the
+/// `flap` `enum:` mutual-exclusion check; extend here for any future alias
+/// mutex / shape constraint that should reach operators at dry-run time.
+fn validate_alias_invariants(compiled: &CompiledFile) -> anyhow::Result<()> {
+    for entry in &compiled.entries {
+        if let Some(GeneratorConfig::Flap {
+            enum_kind: Some(_),
+            up_value,
+            down_value,
+            ..
+        }) = entry.generator.as_ref()
+        {
+            if up_value.is_some() || down_value.is_some() {
+                let id = entry.id.as_deref().unwrap_or("<anonymous>");
+                return Err(anyhow::anyhow!(
+                    "scenario '{id}': flap: 'enum' is mutually exclusive with explicit 'up_value'/'down_value' — pick one"
+                ));
+            }
         }
     }
     Ok(())
@@ -125,11 +150,13 @@ fn generator_display(gen: &sonda_core::generator::GeneratorConfig) -> String {
             down_duration,
             up_value,
             down_value,
+            enum_kind,
         } => {
             let up_d = up_duration.as_deref().unwrap_or("10s");
             let dn_d = down_duration.as_deref().unwrap_or("5s");
-            let up_v = up_value.unwrap_or(1.0);
-            let dn_v = down_value.unwrap_or(0.0);
+            let (up_default, dn_default) = enum_kind.map(|e| e.defaults()).unwrap_or((1.0, 0.0));
+            let up_v = up_value.unwrap_or(up_default);
+            let dn_v = down_value.unwrap_or(dn_default);
             format!(
                 "flap (up_duration: {up_d}, down_duration: {dn_d}, up_value: {up_v}, down_value: {dn_v})"
             )
@@ -470,16 +497,18 @@ fn crossing_secs(
             down_duration,
             up_value,
             down_value,
+            enum_kind,
         } => {
             let up_secs = duration_or_default(up_duration.as_deref(), 10.0)?;
             let down_secs = duration_or_default(down_duration.as_deref(), 5.0)?;
+            let (up_default, dn_default) = enum_kind.map(|e| e.defaults()).unwrap_or((1.0, 0.0));
             timing::flap_crossing_secs(
                 op,
                 threshold,
                 up_secs,
                 down_secs,
-                up_value.unwrap_or(1.0),
-                down_value.unwrap_or(0.0),
+                up_value.unwrap_or(up_default),
+                down_value.unwrap_or(dn_default),
             )
         }
         GeneratorConfig::Saturation {

--- a/sonda/tests/cli_while_runtime.rs
+++ b/sonda/tests/cli_while_runtime.rs
@@ -2,6 +2,7 @@
 
 mod common;
 
+use std::io::Write;
 use std::process::Command;
 
 use common::{cli_fixtures_dir, sonda_bin};
@@ -43,6 +44,149 @@ fn run_while_cascade_gates_downstream_emission() {
         "while: gate must suppress downstream events; \
          backup_saturation={backup_count}, primary_flap={primary_count}, \
          expected backup < 50% of primary\nstdout:\n{stdout}"
+    );
+}
+
+#[test]
+fn op_le_returns_nonzero_on_cli() {
+    let mut tmp = tempfile::Builder::new()
+        .prefix("op_le_")
+        .suffix(".v2.yaml")
+        .tempfile()
+        .expect("create temp YAML fixture");
+    let yaml = "\
+version: 2
+defaults:
+  rate: 1
+  duration: 1s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: src
+    signal_type: metrics
+    name: src
+    generator:
+      type: constant
+      value: 1
+  - id: gated
+    signal_type: metrics
+    name: gated
+    generator:
+      type: constant
+      value: 1
+    while:
+      ref: src
+      op: '<='
+      value: 1
+";
+    tmp.write_all(yaml.as_bytes()).expect("write fixture");
+    let output = Command::new(sonda_bin())
+        .args(["--quiet", "run", "--scenario"])
+        .arg(tmp.path())
+        .output()
+        .expect("must spawn sonda");
+
+    assert!(
+        !output.status.success(),
+        "sonda run must reject op:'<=' with a non-zero exit; status={:?}",
+        output.status.code(),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unsupported operator")
+            && stderr.contains("strict")
+            && stderr.contains("'<'")
+            && stderr.contains("'>'"),
+        "stderr must contain the locked operator-rejection wording, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn dry_run_renders_flap_enum_oper_state_defaults() {
+    let mut tmp = tempfile::Builder::new()
+        .prefix("flap_enum_")
+        .suffix(".v2.yaml")
+        .tempfile()
+        .expect("create temp YAML fixture");
+    let yaml = "\
+version: 2
+defaults:
+  rate: 1
+  duration: 30s
+scenarios:
+  - id: oper_flap
+    signal_type: metrics
+    name: interface_oper_state
+    generator:
+      type: flap
+      up_duration: 60s
+      down_duration: 30s
+      enum: oper_state
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+";
+    tmp.write_all(yaml.as_bytes()).expect("write fixture");
+    let output = Command::new(sonda_bin())
+        .args(["--dry-run", "run", "--scenario"])
+        .arg(tmp.path())
+        .output()
+        .expect("must spawn sonda");
+
+    assert!(output.status.success(), "dry-run must succeed");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("up_value: 1") && stderr.contains("down_value: 2"),
+        "dry-run must render `enum: oper_state` as up=1, down=2, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn dry_run_rejects_flap_enum_with_explicit_values() {
+    let mut tmp = tempfile::Builder::new()
+        .prefix("flap_mutex_")
+        .suffix(".v2.yaml")
+        .tempfile()
+        .expect("create temp YAML fixture");
+    let yaml = "\
+version: 2
+defaults:
+  rate: 1
+  duration: 30s
+scenarios:
+  - id: bad
+    signal_type: metrics
+    name: bad
+    generator:
+      type: flap
+      up_duration: 5s
+      down_duration: 5s
+      enum: oper_state
+      up_value: 7
+    encoder:
+      type: prometheus_text
+    sink:
+      type: stdout
+";
+    tmp.write_all(yaml.as_bytes()).expect("write fixture");
+    let output = Command::new(sonda_bin())
+        .args(["--dry-run", "run", "--scenario"])
+        .arg(tmp.path())
+        .output()
+        .expect("must spawn sonda");
+
+    assert!(
+        !output.status.success(),
+        "dry-run must reject `enum:` + explicit `up_value` with non-zero exit"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("mutually exclusive"),
+        "stderr must contain the locked mutual-exclusion message, got:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary — sonda v1.6 Sub-PR 2 of 3

Workshop UAT papercut + Phase E schema lockdown bundle. The `flap` generator's default values (`1.0/0.0`) don't match gNMI/openconfig enum conventions, so every `while:` adopter rediscovers the trap of writing explicit `up_value=1, down_value=2` for every BGP oper-state-style metric. This PR ships the canonical mappings as a one-word `enum:` shorthand. Plus three smaller schema lockdowns surfaced in workshop UAT and the v1 ship review.

This is **Sub-PR 2 of 3** on the parent feature branch `feat/while-hardening`. Sub-PR 1 (#315, stale-marker) merged at `87115cf`. Sub-PR 3 (409 on duplicate `scenario_name`) follows on a separate branch. All three merge cohesively to `main` as **v1.6.0**.

## What ships

### Phase B — `flap` `enum:` shorthand

```yaml
- id: primary_link
  generator:
    type: flap
    up_duration: 60s
    down_duration: 30s
    enum: oper_state    # → up_value=1, down_value=2 (gNMI convention)
```

Mapping table (locked by user choice):

| `enum:` value | up_value | down_value |
|---|---|---|
| `boolean` (default) / `link_state` | 1.0 | 0.0 |
| `oper_state` / `admin_state` | 1.0 | 2.0 |
| `neighbor_state` | 6.0 | 1.0 |

Backward-compatible: when `enum:` is absent, behavior matches v1.5 exactly (up=1, down=0). Mutual exclusion: `enum:` + explicit `up_value`/`down_value` is a `ConfigError::invalid` with the literal "mutually exclusive" message — fired at `prepare_entries` AND at `--dry-run` time (see fix-pass below).

### Phase E — schema lockdown

- **E.1**: `value: 1` (int) and `value: 1.0` (float) both parse to `f64`. Documented.
- **E.2**: `op: "<="` rejection reaches BOTH paths with the locked v1.5 message:
  - CLI returns non-zero exit + clear stderr
  - Server returns **HTTP 422** (not 400 — needs a small `ParseFailure { Syntactic, Semantic }` discriminator in `routes/scenarios.rs` to distinguish raw YAML parse errors from schema-level deserialize failures on otherwise well-formed YAML).
- **E.3**: Compile-time NaN/Inf rejection on `WhileClause.value` AND `delay.close.snap_to` (using `is_finite()`). New `NormalizeError::WhileValueIsNan` and `NormalizeError::CloseSnapToIsNan` variants. Six parametric tests cover `.nan` / `.inf` / `-.inf` for each field.
- **E.4**: End-to-end NaN gate test — drives `gated_loop` with `f64::NAN` upstream, asserts downstream stays `Paused`.

## Fix-pass — review agent findings (all addressed)

### From `@reviewer` (Opus, direct)

**1 WARNING (treated as BLOCKER)** + 3 NOTEs. WARNING + NOTE 2 fixed in this PR; NOTEs 1 and 3 deferred to v1.7 follow-ups.

- **WARNING**: `sonda/src/dry_run.rs` Flap arms (`generator_summary` line 123 + `crossing_secs` line 469) captured `enum_kind` in `..` wildcard, so dry-run rendered the boolean default for all enum mappings. Fixed via the same `FlapEnum::defaults()` pattern already used in `aliases.rs` and `compile_after.rs`.
- **NOTE 2**: `is_semantic_schema_error` only matched `CompileError::Parse(Yaml)` cases → `while.value: .nan` returned 400 while `op: "<="` returned 422 (inconsistent). Extended to match `NormalizeError` variants too.

### From `@uat` (Sonnet, end-to-end)

**2 BLOCKERs**, same root cause: dry-run never runs `prepare_entries`, so `desugar_scenario_config`'s mutex check (and enum-derived defaults) are silently bypassed.

- **V1c/d/e**: `enum: oper_state` / `admin_state` / `neighbor_state` rendered `up=1, down=0` (the boolean default) in dry-run. Fixed alongside the Reviewer WARNING.
- **V1.b**: `enum: oper_state + up_value: 7` returned "Validation: OK" silently. Fixed by adding `validate_alias_invariants` in dry-run that runs the mutex check on every Flap entry before rendering.

### From `@doc` (Opus, audit)

**1 must-fix** + 2 nice-to-have. Must-fix overlaps with the dry-run BLOCKERs (already fixed). Nice-to-have (use `enum: oper_state` in `v2-scenarios.md` example blocks) deferred to v1.7.

## Quality gates — all green

| Gate | Result |
|---|---|
| `cargo build --workspace --all-features` | PASS, 0 warnings |
| `cargo nextest run --workspace --all-features` | **3026/3026** (was 3004; +22 new tests) |
| `cargo test --workspace --doc` | 5/5 |
| `cargo clippy --workspace --all-features -- -D warnings` | PASS |
| `cargo fmt --all -- --check` | PASS |
| `cargo audit` | PASS (1 pre-existing allowed) |
| `cargo test -p sonda-core --no-default-features` | PASS |
| `cargo test -p sonda-server --no-default-features --test scenarios` | 36/36 (was 34; +2) |
| `mkdocs build --strict` | PASS |

## Test plan

- [x] Each of 5 `enum:` mappings produces correct desugared values (parametric rstest in `aliases.rs::tests`)
- [x] `enum:` + explicit `up_value` rejected at desugar AND at `--dry-run` time
- [x] `op: "<="` rejected on CLI (non-zero exit) and on server (HTTP 422)
- [x] `while.value: .nan/.inf/-.inf` and `delay.close.snap_to: .nan/.inf/-.inf` rejected at compile (6 parametric tests)
- [x] NaN upstream value at runtime keeps downstream Paused (end-to-end gate test)
- [x] Workshop YAML still parses without `enum:` (backward compat)
- [x] Dry-run renders correct `up_value/down_value` for `enum: oper_state` and `enum: neighbor_state`
- [x] `while.value: .nan` POST returns 422 (parity with `op: "<="`)
- [ ] Final cohesive UAT after Sub-PR 3 lands on the parent feature branch

## Out of scope (Sub-PR 3 + v1.7 follow-ups)

- 409 Conflict on duplicate `scenario_name` (Sub-PR 3)
- `compile_after` early mutex check (Reviewer NOTE 1; v1.7)
- `is_semantic_schema_error` body re-parse perf (Reviewer NOTE 3; v1.7)
- Switching `interface_oper_state` examples in v2-scenarios.md to use `enum: oper_state` shorthand (Doc finding; v1.7)
- Stale-marker emission on `Paused → Finished` (carried from Sub-PR 1; v1.7)
- Extending `recent_metrics` beyond the 100-entry cap (carried from Sub-PR 1; v1.7)
