### PR TITLE
feat(server): 409 Conflict on duplicate `scenario_name` (Sub-PR 3 of v1.6)

### DIFF
--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -93,7 +93,7 @@ scenarios:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `scenario_name` | no | Kebab-case identifier. Defaults to the filename (without `.yaml`, hyphens preserved) if omitted. Used by `@name` shorthand and `sonda catalog run`. |
+| `scenario_name` | no | Kebab-case identifier. Defaults to the filename (without `.yaml`, hyphens preserved) if omitted. Used by `@name` shorthand and `sonda catalog run`. When posted to a running `sonda-server`, this field also acts as a uniqueness key — POSTing two cascades that share an active `scenario_name` returns [`409 Conflict`](../deployment/sonda-server.md#duplicate-scenario_name-returns-409). |
 | `category` | no | Catalog grouping. One of `infrastructure`, `network`, `application`, `observability`. Scenarios without a category render as `uncategorized` and drop out of `--category` filters. |
 | `description` | no | One-line summary shown in the catalog table and JSON output. Keep it under ~60 characters so it fits the table column. |
 

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -327,8 +327,29 @@ shape conversions.
 | Status | Condition | Detail field |
 |--------|-----------|--------------|
 | **400 Bad Request** | Body is not UTF-8, not valid JSON/YAML, missing `version: 2`, or fails compilation. | Parser or compiler error; v1 bodies include the migration hint. |
+| **409 Conflict** | The posted body sets a top-level `scenario_name` that matches an active scenario already in the map. | Identifies the duplicate name and lists the conflicting scenarios. See [Duplicate scenario_name returns 409](#duplicate-scenario_name-returns-409). |
 | **422 Unprocessable Entity** | Body compiles but fails runtime validation (`rate: 0`, zero `duration`, etc.). | Validation error identifying the failing entry. |
 | **500 Internal Server Error** | Scenario thread could not be spawned, or internal state error. | Short internal error; check server logs. |
+
+### Duplicate scenario_name returns 409
+
+When a posted v2 body sets a top-level `scenario_name`, the server scans the active scenario map for any handle that already carries the same `scenario_name` and is in `pending`, `running`, or `paused` state. If at least one match is found the POST is rejected with `409 Conflict`; nothing is launched. The contract is explicit: the operator must `DELETE` the conflicting scenarios first, then re-post. There is no `?force=true` override -- the explicit DELETE is the only way to free the name.
+
+Anonymous bodies (no top-level `scenario_name`) bypass this check entirely. Two consecutive POSTs of the same anonymous body both return 201, mirroring pre-v1.6 behavior. Finished handles are considered stale and never block a new POST -- once every prior cascade with the same name reaches `finished` state, a new cascade with the same name returns 201.
+
+The 409 body lists every active scenario contributing to the conflict so the operator knows which IDs to DELETE:
+
+```json title="Response (409 Conflict)"
+{
+  "error": "scenario_name 'flap-interface' is already running",
+  "conflicting_scenarios": [
+    {"id": "a1b2c3d4-...", "name": "link_status", "state": "running"}
+  ],
+  "hint": "DELETE the conflicting scenarios before posting a new cascade with the same scenario_name"
+}
+```
+
+Each `conflicting_scenarios` entry carries the scenario `id` (use it with `DELETE /scenarios/{id}`), the per-entry `name` (the runtime-launched scenario name, not the file-level `scenario_name`), and the live `state` (one of `pending`, `running`, `paused`). When the body produced multiple entries (multi-entry POST or pack expansion), each launched handle inherits the same file-level `scenario_name` and contributes one item to the array.
 
 ## API Endpoints
 

--- a/sonda-core/benches/while_steady_state.rs
+++ b/sonda-core/benches/while_steady_state.rs
@@ -48,9 +48,16 @@ fn bench_baseline_ungated(c: &mut Criterion) {
         b.iter(|| {
             let entry = metrics_entry("bench", 1000.0, 300);
             let shutdown = Arc::new(AtomicBool::new(true));
-            let mut handle =
-                launch_scenario_with_gates("bench".to_string(), entry, shutdown, None, None, None)
-                    .unwrap();
+            let mut handle = launch_scenario_with_gates(
+                "bench".to_string(),
+                None,
+                entry,
+                shutdown,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
             handle.join(Some(Duration::from_secs(2))).unwrap();
         });
     });
@@ -72,6 +79,7 @@ fn bench_gated_open(c: &mut Criterion) {
             let shutdown = Arc::new(AtomicBool::new(true));
             let mut handle = launch_scenario_with_gates(
                 "gated".to_string(),
+                None,
                 entry,
                 shutdown,
                 None,

--- a/sonda-core/src/compiler/compile_after.rs
+++ b/sonda-core/src/compiler/compile_after.rs
@@ -391,6 +391,10 @@ fn format_cycle(cycle: &[(String, ClauseKind)]) -> String {
 pub struct CompiledFile {
     /// Schema version. Always `2` after compilation.
     pub version: u32,
+    /// File-level `scenario_name` carried verbatim. Pure metadata —
+    /// ignored by every compiler phase, surfaced for runtime conflict checks.
+    #[cfg_attr(feature = "config", serde(skip_serializing_if = "Option::is_none"))]
+    pub scenario_name: Option<String>,
     /// Concrete scenario entries, in source order. Pack-expanded sub-signals
     /// appear consecutively as their parent entry was processed.
     pub entries: Vec<CompiledEntry>,
@@ -527,7 +531,11 @@ pub struct CompiledEntry {
 /// documentation for the one-to-one mapping onto spec §3.4 validation
 /// conditions.
 pub fn compile_after(file: ExpandedFile) -> Result<CompiledFile, CompileAfterError> {
-    let ExpandedFile { version, entries } = file;
+    let ExpandedFile {
+        version,
+        scenario_name,
+        entries,
+    } = file;
 
     let id_to_idx = build_id_index(&entries);
 
@@ -707,6 +715,7 @@ pub fn compile_after(file: ExpandedFile) -> Result<CompiledFile, CompileAfterErr
 
     Ok(CompiledFile {
         version,
+        scenario_name,
         entries: out,
     })
 }

--- a/sonda-core/src/compiler/expand.rs
+++ b/sonda-core/src/compiler/expand.rs
@@ -365,6 +365,10 @@ impl PackResolver for InMemoryPackResolver {
 pub struct ExpandedFile {
     /// Schema version. Always `2` after expansion.
     pub version: u32,
+    /// File-level `scenario_name` carried verbatim. Pure metadata —
+    /// ignored by every compiler phase, surfaced for runtime conflict checks.
+    #[cfg_attr(feature = "config", serde(skip_serializing_if = "Option::is_none"))]
+    pub scenario_name: Option<String>,
     /// All entries with pack expansion applied, in source order.
     ///
     /// Pack entries contribute one entry per metric, in the order metrics
@@ -538,6 +542,7 @@ pub fn expand<R: PackResolver>(
 
     Ok(ExpandedFile {
         version: file.version,
+        scenario_name: file.scenario_name,
         entries,
     })
 }

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -168,6 +168,10 @@ pub enum NormalizeError {
 pub struct NormalizedFile {
     /// Schema version. Always `2` after normalization.
     pub version: u32,
+    /// File-level `scenario_name` carried verbatim. Pure metadata —
+    /// ignored by every compiler phase, surfaced for runtime conflict checks.
+    #[cfg_attr(feature = "config", serde(skip_serializing_if = "Option::is_none"))]
+    pub scenario_name: Option<String>,
     /// The file-level `defaults.labels` map, carried forward verbatim for
     /// later compilation phases to apply at the correct precedence slot.
     ///
@@ -327,6 +331,7 @@ pub fn normalize(file: ScenarioFile) -> Result<NormalizedFile, NormalizeError> {
 
     Ok(NormalizedFile {
         version: file.version,
+        scenario_name: file.scenario_name,
         defaults_labels,
         entries,
     })

--- a/sonda-core/src/compiler/prepare.rs
+++ b/sonda-core/src/compiler/prepare.rs
@@ -162,7 +162,9 @@ pub enum PrepareError {
 /// The short-circuiting semantics match the v2 compiler's other passes —
 /// no partial output is returned on failure.
 pub fn prepare(file: CompiledFile) -> Result<Vec<ScenarioEntry>, PrepareError> {
-    let CompiledFile { version, entries } = file;
+    let CompiledFile {
+        version, entries, ..
+    } = file;
     if version != 2 {
         return Err(PrepareError::UnsupportedVersion { version });
     }
@@ -446,6 +448,7 @@ mod tests {
     fn file_with(entry: CompiledEntry) -> CompiledFile {
         CompiledFile {
             version: 2,
+            scenario_name: None,
             entries: vec![entry],
         }
     }
@@ -524,6 +527,7 @@ mod tests {
     fn prepare_preserves_entry_order() {
         let file = CompiledFile {
             version: 2,
+            scenario_name: None,
             entries: vec![
                 metrics_compiled("first"),
                 logs_compiled("second"),
@@ -544,6 +548,7 @@ mod tests {
     fn prepare_empty_file_returns_empty_vec() {
         let file = CompiledFile {
             version: 2,
+            scenario_name: None,
             entries: vec![],
         };
         let out = prepare(file).expect("empty file must translate cleanly");
@@ -825,6 +830,7 @@ mod tests {
     fn prepare_fails_fast_on_first_bad_entry() {
         let file = CompiledFile {
             version: 2,
+            scenario_name: None,
             entries: vec![
                 metrics_compiled("ok_1"),
                 bare("traces", "bad"),
@@ -854,6 +860,7 @@ mod tests {
     fn prepare_rejects_non_v2_version() {
         let file = CompiledFile {
             version: 3,
+            scenario_name: None,
             entries: vec![metrics_compiled("never_translated")],
         };
         let err = prepare(file).expect_err("version != 2 must fail");
@@ -870,6 +877,7 @@ mod tests {
     fn prepare_version_check_precedes_entry_translation() {
         let file = CompiledFile {
             version: 0,
+            scenario_name: None,
             entries: vec![bare("traces", "would_fail_if_translated")],
         };
         let err = prepare(file).expect_err("version 0 must fail");

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -35,6 +35,9 @@ pub struct ScenarioHandle {
     pub id: String,
     /// Human-readable scenario name (from config).
     pub name: String,
+    /// File-level `scenario_name` from the source YAML, when set. Read-only
+    /// after launch; every handle from the same POST shares this value.
+    pub scenario_name: Option<String>,
     /// Shared shutdown flag. Setting this to `false` signals the runner to exit.
     pub shutdown: Arc<AtomicBool>,
     /// The OS thread running the scenario. `None` after [`ScenarioHandle::join`] consumes it.
@@ -260,6 +263,7 @@ mod tests {
         ScenarioHandle {
             id: id.to_string(),
             name: name.to_string(),
+            scenario_name: None,
             shutdown,
             thread: Some(thread),
             started_at: Instant::now(),
@@ -536,6 +540,7 @@ mod tests {
         let handle = ScenarioHandle {
             id: "test-poisoned".to_string(),
             name: "poisoned".to_string(),
+            scenario_name: None,
             shutdown,
             thread: Some(thread),
             started_at: Instant::now(),
@@ -583,6 +588,7 @@ mod tests {
         let handle = ScenarioHandle {
             id: "test-poisoned-m".to_string(),
             name: "poisoned_metrics".to_string(),
+            scenario_name: None,
             shutdown,
             thread: Some(thread),
             started_at: Instant::now(),

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -199,16 +199,18 @@ pub fn launch_scenario(
     shutdown: Arc<AtomicBool>,
     start_delay: Option<Duration>,
 ) -> Result<ScenarioHandle, SondaError> {
-    launch_scenario_with_gates(id, entry, shutdown, start_delay, None, None)
+    launch_scenario_with_gates(id, None, entry, shutdown, start_delay, None, None)
 }
 
 /// Launch a scenario with optional `while:` / `after:` gating wired in.
 ///
-/// `upstream_bus` is the bus this scenario PUBLISHES into (for downstream
-/// gates to read its values). `gate_ctx` is what THIS scenario consumes
-/// from an upstream bus.
+/// `scenario_name` surfaces on [`ScenarioHandle::scenario_name`]; pass `None`
+/// for anonymous bodies. `upstream_bus` is the bus this scenario PUBLISHES
+/// into (for downstream gates to read). `gate_ctx` is what THIS scenario
+/// consumes from an upstream bus.
 pub fn launch_scenario_with_gates(
     id: String,
+    scenario_name: Option<String>,
     entry: ScenarioEntry,
     shutdown: Arc<AtomicBool>,
     start_delay: Option<Duration>,
@@ -330,6 +332,7 @@ pub fn launch_scenario_with_gates(
     Ok(ScenarioHandle {
         id,
         name,
+        scenario_name,
         shutdown,
         thread: Some(thread),
         started_at,

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -111,7 +111,11 @@ pub fn launch_multi_compiled(
     file: CompiledFile,
     shutdown: Arc<AtomicBool>,
 ) -> Result<Vec<crate::schedule::handle::ScenarioHandle>, SondaError> {
-    let CompiledFile { entries, .. } = file;
+    let CompiledFile {
+        scenario_name,
+        entries,
+        ..
+    } = file;
 
     let bus_ids = while_upstream_ids(&entries);
     let mut buses: HashMap<String, Arc<GateBus>> = HashMap::with_capacity(bus_ids.len());
@@ -200,6 +204,7 @@ pub fn launch_multi_compiled(
         let id = plan.id.unwrap_or_else(|| format!("multi-{idx}"));
         match launch_scenario_with_gates(
             id,
+            scenario_name.clone(),
             plan.entry,
             Arc::clone(&shutdown),
             plan.start_delay,

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -110,6 +110,7 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
     let entry = metrics_entry("downstream", 200.0, 600);
     let mut handle = launch_scenario_with_gates(
         "downstream".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -157,6 +158,7 @@ fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscriptio
     let entry = metrics_entry("d1", 100.0, 300);
     let mut handle = launch_scenario_with_gates(
         "d1".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -198,6 +200,7 @@ fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
     let entry = metrics_entry("d2", 100.0, 300);
     let mut handle = launch_scenario_with_gates(
         "d2".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -234,6 +237,7 @@ fn while_runtime_no_catch_up_burst_on_resume() {
     let entry = metrics_entry("d3", 100.0, 1500);
     let mut handle = launch_scenario_with_gates(
         "d3".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -331,6 +335,7 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
     );
     let mut handle = launch_scenario_with_gates(
         "seq_gated".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -408,6 +413,7 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
     );
     let mut handle = launch_scenario_with_gates(
         "sat_gated".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -471,6 +477,7 @@ fn while_runtime_finished_state_after_duration_expires() {
     let entry = metrics_entry("d4", 50.0, 200);
     let mut handle = launch_scenario_with_gates(
         "d4".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -507,6 +514,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
 
     let mut handle_a = launch_scenario_with_gates(
         "a".to_string(),
+        None,
         metrics_entry("a", 100.0, 500),
         Arc::clone(&shutdown),
         None,
@@ -524,6 +532,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
 
     let mut handle_b = launch_scenario_with_gates(
         "b".to_string(),
+        None,
         metrics_entry("b", 100.0, 500),
         Arc::clone(&shutdown),
         None,
@@ -568,6 +577,7 @@ fn while_runtime_logs_signal_can_be_gated_downstream() {
     let entry = logs_entry("bgp_log", 200.0, 600);
     let mut handle = launch_scenario_with_gates(
         "bgp_log".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -629,6 +639,7 @@ fn while_runtime_delay_open_debounces_pause_to_running_transition() {
     let entry = metrics_entry("debounced", 200.0, 1500);
     let mut handle = launch_scenario_with_gates(
         "debounced".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -688,6 +699,7 @@ fn while_runtime_strict_lt_threshold_gating() {
     let entry = metrics_entry("inv", 100.0, 500);
     let mut handle = launch_scenario_with_gates(
         "inv".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -728,6 +740,7 @@ fn scenario_restart_does_not_leak_gate_bus() {
         let entry = metrics_entry(&format!("ephemeral_{i}"), 50.0, 80);
         let mut handle = launch_scenario_with_gates(
             format!("ephemeral_{i}"),
+            None,
             entry,
             shutdown,
             None,
@@ -777,6 +790,7 @@ fn while_runtime_delay_close_debounces_running_to_paused_transition() {
     let entry = metrics_entry("debounced_close", 200.0, 2000);
     let mut handle = launch_scenario_with_gates(
         "debounced_close".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -854,6 +868,7 @@ fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
     let entry = metrics_entry("after_open", 100.0, 1000);
     let mut handle = launch_scenario_with_gates(
         "after_open".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -925,6 +940,7 @@ fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
     let entry = metrics_entry("after_paused", 100.0, 1500);
     let mut handle = launch_scenario_with_gates(
         "after_paused".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -1007,6 +1023,7 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
     let entry = metrics_entry("absorb", 100.0, 2000);
     let mut handle = launch_scenario_with_gates(
         "absorb".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,
@@ -1066,9 +1083,16 @@ fn while_runtime_steady_within_5pct_of_baseline() {
     fn run_baseline() -> u64 {
         let entry = metrics_entry("baseline", 1000.0, 300);
         let shutdown = Arc::new(AtomicBool::new(true));
-        let mut handle =
-            launch_scenario_with_gates("baseline".to_string(), entry, shutdown, None, None, None)
-                .unwrap();
+        let mut handle = launch_scenario_with_gates(
+            "baseline".to_string(),
+            None,
+            entry,
+            shutdown,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         handle.join(Some(Duration::from_secs(2))).unwrap();
         handle.stats_snapshot().total_events
     }
@@ -1081,6 +1105,7 @@ fn while_runtime_steady_within_5pct_of_baseline() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let mut handle = launch_scenario_with_gates(
             "gated".to_string(),
+            None,
             entry,
             shutdown,
             None,

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -107,6 +107,15 @@ pub struct DeletedScenario {
     pub total_events: u64,
 }
 
+/// One entry in the `conflicting_scenarios` array of a 409 response body.
+#[derive(Debug, Serialize)]
+pub struct ConflictingScenario {
+    pub id: String,
+    pub name: String,
+    /// One of `"pending"`, `"running"`, `"paused"`. Never `"finished"`.
+    pub state: String,
+}
+
 /// Stats sub-object within the scenario detail response.
 ///
 /// This mirrors the fields from [`ScenarioStats`] that are relevant to the
@@ -208,6 +217,20 @@ fn internal_error(detail: impl std::fmt::Display) -> Response {
     (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
 }
 
+const CONFLICT_HINT: &str =
+    "DELETE the conflicting scenarios before posting a new cascade with the same scenario_name";
+
+/// Build a 409 Conflict response listing the active scenarios that share
+/// the posted body's `scenario_name`.
+fn conflict(message: String, scenarios: Vec<ConflictingScenario>) -> Response {
+    let body = json!({
+        "error": message,
+        "conflicting_scenarios": scenarios,
+        "hint": CONFLICT_HINT,
+    });
+    (StatusCode::CONFLICT, Json(body)).into_response()
+}
+
 // ---- Helpers ----------------------------------------------------------------
 
 /// Map [`ScenarioStats::state`] to its lowercase wire string.
@@ -219,6 +242,29 @@ fn state_string(stats: &ScenarioStats) -> &'static str {
         ScenarioState::Finished => "finished",
         _ => "unknown",
     }
+}
+
+/// Scan the active scenario map for entries with matching `scenario_name`
+/// in `pending` / `running` / `paused` state. Finished handles are stale
+/// and skipped. `Err(())` indicates a poisoned lock.
+fn collect_active_conflicts(state: &AppState, name: &str) -> Result<Vec<ConflictingScenario>, ()> {
+    let scenarios = state.scenarios.read().map_err(|_| ())?;
+    let mut conflicts = Vec::new();
+    for (id, handle) in scenarios.iter() {
+        if handle.scenario_name.as_deref() != Some(name) {
+            continue;
+        }
+        let snap = handle.stats_snapshot();
+        let state_str = state_string(&snap);
+        if matches!(state_str, "pending" | "running" | "paused") {
+            conflicts.push(ConflictingScenario {
+                id: id.clone(),
+                name: handle.name.clone(),
+                state: state_str.to_string(),
+            });
+        }
+    }
+    Ok(conflicts)
 }
 
 // ---- Body parsing -----------------------------------------------------------
@@ -340,6 +386,24 @@ pub async fn post_scenario(
     })?;
 
     let ParsedBody::Compiled(compiled) = parsed;
+
+    if let Some(name) = compiled.scenario_name.as_deref() {
+        let conflicts = collect_active_conflicts(&state, name).map_err(|()| {
+            warn!("POST /scenarios: scenarios lock is poisoned");
+            internal_error("internal state lock is poisoned")
+        })?;
+        if !conflicts.is_empty() {
+            warn!(
+                scenario_name = %name,
+                count = conflicts.len(),
+                "POST /scenarios: rejected duplicate scenario_name"
+            );
+            return Err(conflict(
+                format!("scenario_name '{name}' is already running"),
+                conflicts,
+            ));
+        }
+    }
 
     // Derive ScenarioEntry values for the loopback warning helper, which
     // operates on the runtime input shape. prepare_entries doubles as
@@ -720,6 +784,7 @@ mod tests {
         ScenarioHandle {
             id: id.to_string(),
             name: name.to_string(),
+            scenario_name: None,
             shutdown,
             thread: Some(thread),
             started_at: Instant::now(),
@@ -750,6 +815,7 @@ mod tests {
         ScenarioHandle {
             id: id.to_string(),
             name: name.to_string(),
+            scenario_name: None,
             shutdown,
             thread: Some(thread),
             started_at: Instant::now(),
@@ -2377,6 +2443,7 @@ scenarios:
         ScenarioHandle {
             id: id.to_string(),
             name: name.to_string(),
+            scenario_name: None,
             shutdown,
             thread: Some(thread),
             started_at: Instant::now(),
@@ -2790,6 +2857,7 @@ scenarios:
         ScenarioHandle {
             id: id.to_string(),
             name: name.to_string(),
+            scenario_name: None,
             shutdown,
             thread: Some(thread),
             started_at: Instant::now(),
@@ -3149,6 +3217,7 @@ scenarios:
         ScenarioHandle {
             id: id.to_string(),
             name: name.to_string(),
+            scenario_name: None,
             shutdown,
             thread: Some(thread),
             started_at: Instant::now(),
@@ -3176,6 +3245,7 @@ scenarios:
         ScenarioHandle {
             id: id.to_string(),
             name: name.to_string(),
+            scenario_name: None,
             shutdown,
             thread: Some(thread),
             started_at: Instant::now(),

--- a/sonda-server/tests/scenarios.rs
+++ b/sonda-server/tests/scenarios.rs
@@ -1746,3 +1746,252 @@ scenarios:
         );
     }
 }
+
+// ---- 409 Conflict on duplicate scenario_name --------------------------------
+
+const NAMED_FLAP_INTERFACE_YAML: &str = "\
+version: 2
+scenario_name: flap-interface
+defaults:
+  rate: 10
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: link_status
+    signal_type: metrics
+    name: link_status
+    generator:
+      type: constant
+      value: 1.0
+";
+
+const NAMED_FLAP_INTERFACE_SHORT_YAML: &str = "\
+version: 2
+scenario_name: flap-interface-short
+defaults:
+  rate: 10
+  duration: 100ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: link_status_short
+    signal_type: metrics
+    name: link_status_short
+    generator:
+      type: constant
+      value: 1.0
+";
+
+const ANONYMOUS_METRICS_YAML: &str = "\
+version: 2
+defaults:
+  rate: 10
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: anon_metric
+    signal_type: metrics
+    name: anon_metric
+    generator:
+      type: constant
+      value: 1.0
+";
+
+#[test]
+fn post_named_scenario_twice_returns_409() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let first = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(NAMED_FLAP_INTERFACE_YAML)
+        .send()
+        .expect("first POST must succeed");
+    assert_eq!(
+        first.status().as_u16(),
+        201,
+        "first named POST must return 201"
+    );
+    let first_body: serde_json::Value = first.json().expect("first body is JSON");
+    let first_id = first_body["id"]
+        .as_str()
+        .expect("first response must include id")
+        .to_string();
+
+    let second = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(NAMED_FLAP_INTERFACE_YAML)
+        .send()
+        .expect("second POST must succeed at HTTP level");
+
+    assert_eq!(
+        second.status().as_u16(),
+        409,
+        "second POST with the same scenario_name must return 409 Conflict"
+    );
+
+    let body: serde_json::Value = second.json().expect("409 body must be valid JSON");
+    let error = body["error"].as_str().expect("error must be a string");
+    assert!(
+        error.contains("flap-interface"),
+        "error must mention scenario_name, got: {error}"
+    );
+
+    let conflicts = body["conflicting_scenarios"]
+        .as_array()
+        .expect("conflicting_scenarios must be an array");
+    assert!(
+        !conflicts.is_empty(),
+        "conflicting_scenarios must list at least one entry"
+    );
+    let entry = &conflicts[0];
+    assert_eq!(
+        entry["id"].as_str(),
+        Some(first_id.as_str()),
+        "conflicting entry id must match the first launched scenario"
+    );
+    assert!(
+        entry["name"].is_string(),
+        "conflicting entry must include name"
+    );
+    let state = entry["state"].as_str().expect("state must be a string");
+    assert!(
+        matches!(state, "pending" | "running" | "paused"),
+        "conflicting state must be active (not finished), got {state:?}"
+    );
+
+    let hint = body["hint"].as_str().expect("hint must be a string");
+    assert!(
+        hint.contains("DELETE"),
+        "hint must mention DELETE, got: {hint}"
+    );
+}
+
+#[test]
+fn post_named_scenario_after_delete_returns_201() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let first = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(NAMED_FLAP_INTERFACE_YAML)
+        .send()
+        .expect("first POST must succeed");
+    assert_eq!(first.status().as_u16(), 201);
+    let first_body: serde_json::Value = first.json().expect("first body is JSON");
+    let first_id = first_body["id"].as_str().expect("first id is string");
+
+    let delete = client
+        .delete(format!("http://127.0.0.1:{port}/scenarios/{first_id}"))
+        .send()
+        .expect("DELETE must succeed");
+    assert_eq!(
+        delete.status().as_u16(),
+        200,
+        "DELETE must return 200 OK on a known scenario"
+    );
+
+    let second = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(NAMED_FLAP_INTERFACE_YAML)
+        .send()
+        .expect("second POST must succeed at HTTP level");
+    assert_eq!(
+        second.status().as_u16(),
+        201,
+        "POST after DELETE must return 201; previous instance was cleared"
+    );
+}
+
+#[test]
+fn post_anonymous_scenario_twice_returns_201_both_times() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let first = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(ANONYMOUS_METRICS_YAML)
+        .send()
+        .expect("first anonymous POST must succeed");
+    assert_eq!(
+        first.status().as_u16(),
+        201,
+        "first anonymous POST must return 201"
+    );
+
+    let second = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(ANONYMOUS_METRICS_YAML)
+        .send()
+        .expect("second anonymous POST must succeed");
+    assert_eq!(
+        second.status().as_u16(),
+        201,
+        "anonymous bodies bypass the conflict check"
+    );
+}
+
+#[test]
+fn post_named_scenario_with_finished_existing_returns_201() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let first = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(NAMED_FLAP_INTERFACE_SHORT_YAML)
+        .send()
+        .expect("first POST must succeed");
+    assert_eq!(first.status().as_u16(), 201);
+    let first_body: serde_json::Value = first.json().expect("first body is JSON");
+    let first_id = first_body["id"].as_str().expect("first id is string");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let mut observed_finished = false;
+    while std::time::Instant::now() < deadline {
+        let stats = client
+            .get(format!(
+                "http://127.0.0.1:{port}/scenarios/{first_id}/stats"
+            ))
+            .send()
+            .expect("GET /stats must succeed");
+        if stats.status().as_u16() == 200 {
+            let body: serde_json::Value = stats.json().expect("stats body is JSON");
+            if body["state"].as_str() == Some("finished") {
+                observed_finished = true;
+                break;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(
+        observed_finished,
+        "first scenario must reach 'finished' state within the deadline"
+    );
+
+    let second = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(NAMED_FLAP_INTERFACE_SHORT_YAML)
+        .send()
+        .expect("second POST must succeed at HTTP level");
+    assert_eq!(
+        second.status().as_u16(),
+        201,
+        "finished handles are stale; new POST with the same scenario_name must return 201"
+    );
+}


### PR DESCRIPTION
## Summary — sonda v1.6 Sub-PR 3 of 3

Workshop UAT silent-corruption finding: concurrent re-runs of `nobs autocon5 flap-interface` POSTed two cascades with the same `scenario_name`. Both registered; Prometheus rejected the second's samples as "out of order" on the wire. The operator got no warning.

This PR makes `scenario_name` a uniqueness key on the live server. A POST whose top-level `scenario_name` matches an active (`pending` / `running` / `paused`) scenario returns **409 Conflict** with body `{error, conflicting_scenarios[], hint}`. The operator must DELETE the conflicting scenarios before re-posting — there is no `?force=true` override (locked decision).

This is **Sub-PR 3 of 3** on the parent feature branch `feat/while-hardening`. Sub-PR 1 (#315, stale marker) and Sub-PR 2 (#316, `enum:` shorthand + lockdown) are both already on the parent. All three merge cohesively to `main` as **v1.6.0**.

## What ships

### Plumbing — `scenario_name` through every compile phase

```
ScenarioFile          (had it already; user-facing YAML)
  → NormalizedFile    (NEW field, threaded through normalize)
  → ExpandedFile      (NEW field, threaded through expand)
  → CompiledFile      (NEW field, threaded through compile_after)
  → ScenarioHandle    (NEW pub field, populated in launch path)
```

`launch_scenario_with_gates` gains a positional `scenario_name` parameter (immediately after `id`). `launch_multi_compiled` clones `compiled.scenario_name` into every spawned handle in the batch — every scenario from the same POST shares the same name.

### Server logic

`post_scenario` runs the conflict check after `parse_body()` succeeds and before `prepare_entries`. `collect_active_conflicts` acquires `state.scenarios.read()` in a tight scope, builds a `Vec<ConflictingScenario>` (clones strings, no guard escape), drops the lock, and returns. The launch path that follows acquires its own write lock — no nested locking.

Filter: only handles whose `state_string()` returns `pending` / `running` / `paused` contribute to the conflict set. **Finished handles are stale and skipped** — operators can re-post the same name once a previous cascade has expired.

Anonymous bodies (no `scenario_name`) bypass the check entirely.

Response body:

```json
{
  "error": "scenario_name 'flap-interface' is already running",
  "conflicting_scenarios": [
    {"id": "<uuid>", "name": "<entry_name>", "state": "running"}
  ],
  "hint": "DELETE the conflicting scenarios before posting a new cascade with the same scenario_name"
}
```

## Tests

Four new server integration tests in `sonda-server/tests/scenarios.rs`:

- `post_named_scenario_twice_returns_409` — second POST returns 409 with all three response-body keys; `conflicting_scenarios` array carries the first scenario's id and a valid state.
- `post_named_scenario_after_delete_returns_201` — DELETE clears the conflict; second POST returns 201.
- `post_anonymous_scenario_twice_returns_201_both_times` — bodies without `scenario_name` bypass; both POSTs return 201.
- `post_named_scenario_with_finished_existing_returns_201` — uses approach (a): 100ms cascade + poll `/scenarios/{id}/stats` until `state == "finished"`, then re-post the same `scenario_name`. Asserts 201.

## Quality gates — all green

| Gate | Result |
|---|---|
| `cargo build --workspace --all-features` | PASS, 0 warnings |
| `cargo nextest run --workspace --all-features` | **3008/3008** (was 3004; +4 new tests) |
| `cargo test --workspace --doc` | 5/5 |
| `cargo clippy --workspace --all-features -- -D warnings` | PASS |
| `cargo fmt --all -- --check` | PASS |
| `cargo audit` | PASS (1 pre-existing allowed) |
| `cargo test -p sonda-core --no-default-features` | PASS |
| `cargo test -p sonda-server --no-default-features --test scenarios` | 38/38 (was 34; +4) |
| `mkdocs build --strict` | PASS |

## Review trio

- **Reviewer-quick (Sonnet)**: PASS, no issues. Plumbing chain verified end-to-end. Lock scope safe, finished-state filter correct, anonymous bypass correct, no `?force=true` override.
- **UAT (Sonnet)**: PASS — all 4 brief-required scenarios verified through the existing integration test harness (real HTTP requests against a spawned binary on ephemeral port). Plus one minor doc finding addressed inline (cross-link from `v2-scenarios.md` `scenario_name` row to the 409 section in `sonda-server.md`).
- **Doc (Opus)**: PASS, ship as-is. One cosmetic WARNING (error response reference table column header "Detail field" mildly misleading for the 409 row; cross-link rescues comprehension) deferred to a v1.7 doc-table-consolidation sweep.

## Test plan

- [x] Same `scenario_name` posted twice → 409 with correct body shape
- [x] DELETE then re-POST → 201 (conflict cleared)
- [x] Anonymous bodies (no `scenario_name`) → both POSTs succeed
- [x] Finished handles don't block — short cascade, poll to `finished`, re-post → 201
- [x] Plumbing verified end-to-end (parse → normalize → expand → compile_after → ScenarioHandle)
- [x] No nested locks (read lock dropped before launch path acquires write lock)
- [x] Doc cross-link from `v2-scenarios.md` `scenario_name` row to the 409 subsection
- [ ] Final cohesive UAT after `feat/while-hardening` → `main` cohesive merge

## Out of scope (deferred to v1.7 follow-ups)

- `?force=true` query param (locked non-goal)
- Error response reference table column header rename (Doc cosmetic)
- Stale-marker emission on `Paused → Finished` (carried from Sub-PR 1)
- Extending `recent_metrics` beyond the 100-entry cap (carried from Sub-PR 1)
- `compile_after` early `enum:` mutex check (Reviewer NOTE 1 from Sub-PR 2)
- `is_semantic_schema_error` body re-parse perf (Reviewer NOTE 3 from Sub-PR 2)
- Switching `interface_oper_state` examples in `v2-scenarios.md` to use `enum: oper_state` shorthand (Doc finding from Sub-PR 2)
