### PR TITLE
fix: 409 conflict CI repair + Opus review hardening (Sub-PR 4 of v1.6)

### DIFF
--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -337,6 +337,8 @@ When a posted v2 body sets a top-level `scenario_name`, the server scans the act
 
 Anonymous bodies (no top-level `scenario_name`) bypass this check entirely. Two consecutive POSTs of the same anonymous body both return 201, mirroring pre-v1.6 behavior. Finished handles are considered stale and never block a new POST -- once every prior cascade with the same name reaches `finished` state, a new cascade with the same name returns 201.
 
+The conflict check is best-effort: it acquires a read lock, scans the active scenarios, and releases the lock before launching. Two simultaneous POSTs of the same `scenario_name` can both pass the check if they race within the launch window -- both will register and their Prometheus streams will collide on duplicate timestamps. Workshop-scale and sequential-operator usage are unaffected; high-concurrency callers should serialize POSTs that share a `scenario_name`.
+
 The 409 body lists every active scenario contributing to the conflict so the operator knows which IDs to DELETE:
 
 ```json title="Response (409 Conflict)"

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -1251,6 +1251,7 @@ fn nan_upstream_value_keeps_downstream_paused() {
     let entry = metrics_entry("nan_paused", 200.0, 600);
     let mut handle = launch_scenario_with_gates(
         "nan_paused".to_string(),
+        None,
         entry,
         Arc::clone(&shutdown),
         None,

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -246,7 +246,10 @@ fn state_string(stats: &ScenarioStats) -> &'static str {
 
 /// Scan the active scenario map for entries with matching `scenario_name`
 /// in `pending` / `running` / `paused` state. Finished handles are stale
-/// and skipped. `Err(())` indicates a poisoned lock.
+/// and skipped. Future `ScenarioState` variants (`#[non_exhaustive]`) must
+/// opt in to blocking explicitly — a stalled or errored handle that the
+/// operator can't DELETE shouldn't lock its name forever. `Err(())`
+/// indicates a poisoned lock.
 fn collect_active_conflicts(state: &AppState, name: &str) -> Result<Vec<ConflictingScenario>, ()> {
     let scenarios = state.scenarios.read().map_err(|_| ())?;
     let mut conflicts = Vec::new();
@@ -255,12 +258,16 @@ fn collect_active_conflicts(state: &AppState, name: &str) -> Result<Vec<Conflict
             continue;
         }
         let snap = handle.stats_snapshot();
-        let state_str = state_string(&snap);
-        if matches!(state_str, "pending" | "running" | "paused") {
+        let blocks = match snap.state {
+            ScenarioState::Pending | ScenarioState::Running | ScenarioState::Paused => true,
+            ScenarioState::Finished => false,
+            _ => false,
+        };
+        if blocks {
             conflicts.push(ConflictingScenario {
                 id: id.clone(),
                 name: handle.name.clone(),
-                state: state_str.to_string(),
+                state: state_string(&snap).to_string(),
             });
         }
     }


### PR DESCRIPTION
## Summary

Two follow-ups on the v1.6 feature branch after Sub-PRs #316 and #317 merged:

1. **CI repair** — `launch_scenario_with_gates` gained a 7th positional parameter (`scenario_name`) in #317. A test added in #316 still calls the 6-arg signature, so the parent feature branch's CI went red after both PRs merged. One-line fix: pass `None` as the 2nd argument.

2. **Hardening on the 409 conflict path from #317**:
   - Replace the stringly-typed state filter in `collect_active_conflicts` with a typed `match` on `ScenarioState` so future `#[non_exhaustive]` variants must opt into blocking explicitly.
   - Add a docs note explaining that the conflict check is best-effort: two simultaneous POSTs with the same `scenario_name` can race within the launch window. Workshop-scale and sequential-operator usage are unaffected; high-concurrency callers should serialize.

## Diff

| File | Change |
|---|---|
| `sonda-core/tests/while_runtime.rs` | Add `None` for `scenario_name` in the `nan_upstream_value_keeps_downstream_paused` test's `launch_scenario_with_gates` call (CI repair). |
| `sonda-server/src/routes/scenarios.rs` | Swap `matches!(state_string(&snap), "pending" \| "running" \| "paused")` for a typed `match snap.state { ... }`. The catch-all arm (`_ => false`) is lenient — a future `ScenarioState::Stalled` or `::Errored` variant won't lock its name forever, but a contributor adding the variant must update the match arm explicitly. The wire `state` field on the response still uses `state_string(&snap)`, so operators see the same human-readable strings. |
| `docs/site/docs/deployment/sonda-server.md` | One paragraph in the "Duplicate scenario_name returns 409" subsection describing the best-effort nature of the check. |

## Quality gates

| Gate | Result |
|---|---|
| `cargo build --workspace --all-features` | PASS |
| `cargo nextest run --workspace --all-features` | 3030/3030 |
| `cargo test --workspace --doc` | 5/5 |
| `cargo clippy --workspace --all-features -- -D warnings` | PASS |
| `cargo fmt --all -- --check` | PASS |
| `cargo audit` | PASS (1 pre-existing allowed) |
| `cargo test -p sonda-core --no-default-features` | PASS |
| `cargo test -p sonda-server --no-default-features --test scenarios` | PASS |
| `mkdocs build --strict` | PASS |

The 4 conflict tests from #317 still pass after the typed-match refactor:

- `post_named_scenario_twice_returns_409`
- `post_named_scenario_after_delete_returns_201`
- `post_anonymous_scenario_twice_returns_201_both_times`
- `post_named_scenario_with_finished_existing_returns_201`

The previously-failing CI test now passes:

- `nan_upstream_value_keeps_downstream_paused`

## Test plan

- [x] Local nextest 3030/3030
- [x] Local clippy + fmt + mkdocs --strict clean
- [x] CI on this PR
- [ ] After merge: parent feature branch CI goes green
- [ ] Cohesive `feat/while-hardening → main` PR cuts v1.6.0
