### PR TITLE
fix(core): flush stale markers on Running exit (duration/shutdown)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -501,11 +501,11 @@ Pair `while:` with `delay:` to debounce noisy upstream signals.
       close: 1s
 ```
 
-`open` is the duration the upstream value must satisfy the predicate before the gate transitions from closed to open; `close` is the duration the value must violate the predicate before the gate transitions back to closed. Either field defaults to `0s` when omitted. `delay:` requires `while:` -- standalone `delay:` is rejected at compile time. The `close:` field also accepts an extended struct form for stale-marker control on `running → paused` transitions; see [Recovering Prometheus alerts on gate close](#recovering-prometheus-alerts-on-gate-close) below.
+`open` is the duration the upstream value must satisfy the predicate before the gate transitions from closed to open; `close` is the duration the value must violate the predicate before the gate transitions back to closed. Either field defaults to `0s` when omitted. `delay:` requires `while:` -- standalone `delay:` is rejected at compile time. The `close:` field also accepts an extended struct form for stale-marker control; see [Recovering Prometheus alerts on gate close](#recovering-prometheus-alerts-on-gate-close) below.
 
 ### Recovering Prometheus alerts on gate close
 
-Prometheus retains the last-known sample for the lookback-delta window (default 5 minutes) when a series stops emitting. A `while:`-gated downstream that reports `bgp_oper_state=2` ("down") and then pauses keeps the alert firing for that window because Prometheus has no signal that the source is stale. Sonda emits a Prometheus stale-marker sample for every recently-active `(metric_name, label_set)` tuple on every committed `running → paused` transition when the sink is `remote_write`. Downstream alerts resolve immediately on the next scrape cycle.
+Prometheus retains the last-known sample for the lookback-delta window (default 5 minutes) when a series stops emitting. A `while:`-gated downstream that reports `bgp_oper_state=2` ("down") and then pauses keeps the alert firing for that window because Prometheus has no signal that the source is stale. Sonda emits a Prometheus stale-marker sample for every recently-active `(metric_name, label_set)` tuple whenever a `while:`-gated entry exits the `running` state with the gate open — on committed `running → paused` gate-close transitions, and on `running → finished` exits via `duration:` expiry or user-initiated shutdown — when the sink is `remote_write`. Downstream alerts resolve immediately on the next scrape cycle.
 
 The marker is on by default for `remote_write` sinks. The shorthand `close: 5s` keeps working unchanged. The extended form lets you override the stale marker with a literal recovery sample, or opt out of the default emit entirely. The two knobs are mutually exclusive — pick one.
 
@@ -541,7 +541,7 @@ To suppress the default emit entirely, set `stale_marker: false` instead:
 
 Setting both `snap_to` and `stale_marker: false` is a config error — `snap_to` already replaces the stale marker, so the explicit `false` is redundant and likely a mistake. Setting `snap_to` alongside the implicit `stale_marker: true` default lets `snap_to` win silently.
 
-The marker fires only on **committed** `running → paused` transitions. A brief close that gets cancelled by a fresh `WhileOpen` arriving inside the `delay.close.duration` debounce window emits nothing — the gate stayed open. A scenario that hits its `duration:` while paused goes `paused → finished` without an additional close-emit (see the lifecycle states above). The recently-active tuple set is sourced from a runtime buffer capped at 100 events; high-cardinality scenarios that exceed this ceiling under-emit on close. Track scenarios with more than ~100 distinct label sets via per-scenario `/stats` rather than relying on close-emit alone.
+A brief close that gets cancelled by a fresh `WhileOpen` arriving inside the `delay.close.duration` debounce window emits nothing — the gate stayed open. A scenario that hits its `duration:` while already paused goes `paused → finished` without an additional close-emit; the buffer was already flushed on the earlier `running → paused` transition. The recently-active tuple set is sourced from a runtime buffer capped at 100 events; high-cardinality scenarios that exceed this ceiling under-emit on close. Track scenarios with more than ~100 distinct label sets via per-scenario `/stats` rather than relying on close-emit alone.
 
 ### Combining with `after:`
 

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -414,6 +414,25 @@ fn apply_close_emit_policy_flush(
     }
 }
 
+fn invoke_close_emit_on_exit(
+    schedule: &ParsedSchedule,
+    stats: Option<&Arc<RwLock<ScenarioStats>>>,
+    limiter: &mut SinkErrorRateLimiter,
+    close_emit: Option<&mut CloseEmitFn>,
+    sink: &mut dyn Sink,
+) -> Result<(), SondaError> {
+    let Some(emit) = close_emit else {
+        return Ok(());
+    };
+    if let Err(e) = emit(sink) {
+        apply_close_emit_policy(schedule, stats, limiter, e)?;
+    } else {
+        let flush = sink.flush();
+        apply_close_emit_policy_flush(schedule, stats, limiter, flush)?;
+    }
+    Ok(())
+}
+
 /// Maximum time spent blocked on a gate edge before re-checking shutdown.
 ///
 /// 100ms keeps shutdown responsive while paused without burning CPU on
@@ -559,6 +578,14 @@ pub(crate) fn gated_loop(
                 // Distinguish reasons: user shutdown / duration → Finished;
                 // WhileClose → Paused (debounced by delay.close).
                 if shutdown_requested(shutdown) || duration_expired(schedule, started_at) {
+                    // Close-emit before finish() so `state == Finished` observers see the marker.
+                    invoke_close_emit_on_exit(
+                        schedule,
+                        stats.as_ref(),
+                        &mut close_warn_limiter,
+                        gate_ctx.close_emit.as_mut(),
+                        sink,
+                    )?;
                     return finish(stats);
                 }
                 if exit == SegmentExit::WhileClose
@@ -572,24 +599,13 @@ pub(crate) fn gated_loop(
                     continue;
                 }
                 if exit == SegmentExit::WhileClose {
-                    if let Some(emit) = gate_ctx.close_emit.as_mut() {
-                        if let Err(e) = emit(sink) {
-                            apply_close_emit_policy(
-                                schedule,
-                                stats.as_ref(),
-                                &mut close_warn_limiter,
-                                e,
-                            )?;
-                        } else {
-                            let flush = sink.flush();
-                            apply_close_emit_policy_flush(
-                                schedule,
-                                stats.as_ref(),
-                                &mut close_warn_limiter,
-                                flush,
-                            )?;
-                        }
-                    }
+                    invoke_close_emit_on_exit(
+                        schedule,
+                        stats.as_ref(),
+                        &mut close_warn_limiter,
+                        gate_ctx.close_emit.as_mut(),
+                        sink,
+                    )?;
                 }
                 state = ScenarioState::Paused;
                 while_open = false;

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -572,3 +572,170 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
     // Let the runner exit cleanly.
     runner.join().expect("runner joined");
 }
+
+#[test]
+fn duration_expiry_while_gate_open_emits_stale_marker() {
+    let bus = Arc::new(GateBus::new());
+    bus.tick(1.0);
+    let (rx, init) = bus.subscribe(while_gt_zero());
+
+    let capture = CaptureSink::default();
+    let mut sink_handle = capture.clone();
+    let stats = Arc::new(std::sync::RwLock::new(
+        sonda_core::schedule::stats::ScenarioStats::default(),
+    ));
+
+    let config = ScenarioConfig {
+        base: BaseScheduleConfig {
+            name: "duration_expiry".to_string(),
+            rate: 100.0,
+            duration: Some("200ms".to_string()),
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            dynamic_labels: None,
+            labels: None,
+            sink: SinkConfig::RemoteWrite {
+                url: "http://example.invalid/api/v1/write".to_string(),
+                batch_size: None,
+                retry: None,
+            },
+            phase_offset: None,
+            clock_group: None,
+            clock_group_is_auto: None,
+            jitter: None,
+            jitter_seed: None,
+            on_sink_error: sonda_core::OnSinkError::Warn,
+        },
+        generator: GeneratorConfig::Constant { value: 1.0 },
+        encoder: EncoderConfig::RemoteWrite,
+    };
+
+    let stats_for_thread = Arc::clone(&stats);
+    let bus_for_thread = Arc::clone(&bus);
+    let runner = thread::spawn(move || {
+        let _ = bus_for_thread;
+        let shutdown = Arc::new(AtomicBool::new(true));
+        sonda_core::schedule::runner::run_with_sink_gated(
+            &config,
+            &mut sink_handle,
+            Some(shutdown.as_ref()),
+            Some(stats_for_thread),
+            None,
+            Some(GateContext {
+                gate_rx: rx,
+                initial: init,
+                delay: None,
+                has_after: false,
+                has_while: true,
+                close_emit: None,
+            }),
+        )
+        .expect("runner must succeed");
+    });
+
+    runner.join().expect("runner joined");
+
+    let buf = capture.buf.lock().unwrap().clone();
+    let series = parse_length_prefixed_timeseries(&buf).expect("parse ok");
+    let stale_count = series
+        .iter()
+        .filter(|ts| {
+            ts.samples
+                .iter()
+                .any(|s| s.value.to_bits() == PROMETHEUS_STALE_NAN.to_bits())
+        })
+        .count();
+    assert_eq!(
+        stale_count,
+        1,
+        "duration expiry while gate open must emit exactly one stale marker, got {stale_count} \
+         (total series: {})",
+        series.len()
+    );
+}
+
+#[test]
+fn shutdown_while_gate_open_emits_stale_marker() {
+    let bus = Arc::new(GateBus::new());
+    bus.tick(1.0);
+    let (rx, init) = bus.subscribe(while_gt_zero());
+
+    let capture = CaptureSink::default();
+    let mut sink_handle = capture.clone();
+    let stats = Arc::new(std::sync::RwLock::new(
+        sonda_core::schedule::stats::ScenarioStats::default(),
+    ));
+    let shutdown = Arc::new(AtomicBool::new(true));
+
+    let config = ScenarioConfig {
+        base: BaseScheduleConfig {
+            name: "shutdown_during_run".to_string(),
+            rate: 100.0,
+            duration: Some("5000ms".to_string()),
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            dynamic_labels: None,
+            labels: None,
+            sink: SinkConfig::RemoteWrite {
+                url: "http://example.invalid/api/v1/write".to_string(),
+                batch_size: None,
+                retry: None,
+            },
+            phase_offset: None,
+            clock_group: None,
+            clock_group_is_auto: None,
+            jitter: None,
+            jitter_seed: None,
+            on_sink_error: sonda_core::OnSinkError::Warn,
+        },
+        generator: GeneratorConfig::Constant { value: 1.0 },
+        encoder: EncoderConfig::RemoteWrite,
+    };
+
+    let stats_for_thread = Arc::clone(&stats);
+    let bus_for_thread = Arc::clone(&bus);
+    let shutdown_for_thread = Arc::clone(&shutdown);
+    let runner = thread::spawn(move || {
+        let _ = bus_for_thread;
+        sonda_core::schedule::runner::run_with_sink_gated(
+            &config,
+            &mut sink_handle,
+            Some(shutdown_for_thread.as_ref()),
+            Some(stats_for_thread),
+            None,
+            Some(GateContext {
+                gate_rx: rx,
+                initial: init,
+                delay: None,
+                has_after: false,
+                has_while: true,
+                close_emit: None,
+            }),
+        )
+        .expect("runner must succeed");
+    });
+
+    thread::sleep(Duration::from_millis(150));
+    shutdown.store(false, std::sync::atomic::Ordering::SeqCst);
+    runner.join().expect("runner joined");
+
+    let buf = capture.buf.lock().unwrap().clone();
+    let series = parse_length_prefixed_timeseries(&buf).expect("parse ok");
+    let stale_count = series
+        .iter()
+        .filter(|ts| {
+            ts.samples
+                .iter()
+                .any(|s| s.value.to_bits() == PROMETHEUS_STALE_NAN.to_bits())
+        })
+        .count();
+    assert_eq!(
+        stale_count,
+        1,
+        "shutdown while gate open must emit exactly one stale marker, got {stale_count} \
+         (total series: {})",
+        series.len()
+    );
+}


### PR DESCRIPTION
## Summary

Fixes [#322](https://github.com/davidban77/sonda/issues/322). In v1.6.0, the Prometheus stale-NaN marker that clears alerts at the end of a `while:`-gated cascade fires only on committed `running → paused` gate-close transitions. Scenarios that exit `running` via `duration:` expiry or user-initiated shutdown — with the gate still open — terminate without flushing, leaving the last "down" sample visible in Prometheus for the full lookback-delta window (default 5 min). Downstream alerts stay pinned for that whole window.

This patch invokes the same close-emit path on any `running` exit while the gate is open. Behavior across the three exit paths is now consistent.

## What changes

- `sonda-core::schedule::core_loop::gated_loop` now calls `close_emit` on the duration-expiry / shutdown early-return path, in addition to the existing `WhileClose → Paused` path. The two existing helpers (`apply_close_emit_policy` / `apply_close_emit_policy_flush`) and the runner-side `make_close_emitter` closure are unchanged.
- The shared invocation logic is extracted into a private `invoke_close_emit_on_exit` helper next to its siblings; both call sites in `gated_loop` are now one block.
- Two new integration tests in `sonda-core/tests/while_close_stale_marker.rs`: `duration_expiry_while_gate_open_emits_stale_marker` and `shutdown_while_gate_open_emits_stale_marker`. Each asserts exactly one stale-NaN sample (`PROMETHEUS_STALE_NAN.to_bits()`) lands in the captured remote_write byte stream.
- `docs/site/docs/configuration/v2-scenarios.md` — the `delay.close.stale_marker` section now describes the full set of triggers (paused close, duration expiry, shutdown) in one place. Adjacent stale references that implied `running → paused` was the only trigger are corrected.

## Behavior matrix

| Exit cause | Gate state at exit | Final state | v1.6.0 close-emit | v1.6.1 close-emit |
|---|---|---|---|---|
| `WhileClose` (debounce committed) | closed | Paused | YES | YES (unchanged) |
| `WhileClose` (cancelled by reopen) | open | Running | no | no (unchanged) |
| `duration:` expires | open | Finished | **no** | **YES** |
| `duration:` expires | closed | Finished (via Paused) | YES (on the earlier paused transition) | YES (unchanged) |
| User shutdown (`DELETE`, CTRL-C) | open | Finished | **no** | **YES** |
| User shutdown | closed | Finished (via Paused) | YES (on the earlier paused transition) | YES (unchanged) |

Bold rows show the behavior change.

## Backward compatibility

- No schema changes. No new fields on `delay.close`. No new sink, encoder, or generator. No public API change.
- The predicate is `gate_ctx.close_emit.is_some()`. Non-gated scenarios (entries without a `while:` clause) never carry a `close_emit` closure, so they remain bit-for-bit unchanged.
- Sinks that opted out of stale markers (`delay.close.stale_marker: false` or non-`remote_write` sinks without `snap_to`) stay opted out — this patch only changes when the existing closure is invoked, not what it does.
- `Cargo.lock` is touched to refresh the workspace crate versions to 1.6.0 (the v1.6.0 release-please commit updated `Cargo.toml` but not the lock; the next build picks it up). No dependency changes.

## Out of scope

- The `Pending → Finished` and `Paused → Finished` transitions. Both are no-ops for stale-marker emission: `Pending` never enters `running` so the recent-metrics buffer is empty, and `Paused → Finished` already had its buffer flushed on the earlier `running → paused` transition.
- Any change to the `while:` debounce semantics or the close-emit closure construction in `runner.rs`.
- Polish items tracked in [#321](https://github.com/davidban77/sonda/issues/321) (`#[non_exhaustive]` discipline, dedup-loop hardening, encoder sharing).

## Quality gates

| Gate | Result |
|---|---|
| `cargo build --workspace --all-features` | PASS, 0 warnings |
| `cargo nextest run --workspace --all-features` | 3032/3032 PASS (3 skipped) — 2 new tests |
| `cargo test --workspace --doc` | 5/5 PASS |
| `cargo clippy --workspace --all-features -- -D warnings` | PASS |
| `cargo fmt --all -- --check` | PASS |
| `cargo audit` | PASS (1 pre-existing allowed: `core2` via `rsasl`/`rskafka`) |
| `cargo test -p sonda-core --no-default-features` | PASS |
| `mkdocs build --strict` | PASS |

## Test plan

- [x] Two new integration tests assert stale-NaN bytes on the wire for both new exit paths
- [x] Existing v1.6 close-emit tests (`while_close_stale_marker.rs` family) still pass unchanged
- [x] Non-gated scenario test family runs clean (predicate gates the new behavior off)
- [x] Workshop scenario shape (`flap` → `constant=2.0` gated, short duration) exits cleanly under the CLI
- [ ] CI green on this PR
- [ ] release-please cuts v1.6.1
- [ ] After 1.6.1 image lands on ghcr: bump `SONDA_IMAGE` default in workshops repo from 1.6.0 to 1.6.1 (or revert the `4m → 2m` workaround)