### PR TITLE
[draft, superseded by refactor] fix(core): flush stale markers on every gated_loop exit path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -433,6 +433,23 @@ fn invoke_close_emit_on_exit(
     Ok(())
 }
 
+fn finish_with_close_emit(
+    schedule: &ParsedSchedule,
+    stats: Option<Arc<RwLock<ScenarioStats>>>,
+    gate_ctx: &mut GateContext,
+    limiter: &mut SinkErrorRateLimiter,
+    sink: &mut dyn Sink,
+) -> Result<(), SondaError> {
+    invoke_close_emit_on_exit(
+        schedule,
+        stats.as_ref(),
+        limiter,
+        gate_ctx.close_emit.as_mut(),
+        sink,
+    )?;
+    finish(stats)
+}
+
 /// Maximum time spent blocked on a gate edge before re-checking shutdown.
 ///
 /// 100ms keeps shutdown responsive while paused without burning CPU on
@@ -509,10 +526,22 @@ pub(crate) fn gated_loop(
     loop {
         // Top-level shutdown / duration check applies in every state.
         if shutdown_requested(shutdown) {
-            return finish(stats);
+            return finish_with_close_emit(
+                schedule,
+                stats,
+                &mut gate_ctx,
+                &mut close_warn_limiter,
+                sink,
+            );
         }
         if duration_expired(schedule, started_at) {
-            return finish(stats);
+            return finish_with_close_emit(
+                schedule,
+                stats,
+                &mut gate_ctx,
+                &mut close_warn_limiter,
+                sink,
+            );
         }
 
         match state {
@@ -578,15 +607,13 @@ pub(crate) fn gated_loop(
                 // Distinguish reasons: user shutdown / duration → Finished;
                 // WhileClose → Paused (debounced by delay.close).
                 if shutdown_requested(shutdown) || duration_expired(schedule, started_at) {
-                    // Close-emit before finish() so `state == Finished` observers see the marker.
-                    invoke_close_emit_on_exit(
+                    return finish_with_close_emit(
                         schedule,
-                        stats.as_ref(),
+                        stats,
+                        &mut gate_ctx,
                         &mut close_warn_limiter,
-                        gate_ctx.close_emit.as_mut(),
                         sink,
-                    )?;
-                    return finish(stats);
+                    );
                 }
                 if exit == SegmentExit::WhileClose
                     && !debounce_close_to_paused(

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -243,9 +243,12 @@ fn make_close_emitter(
     Box::new(move |sink: &mut dyn Sink| -> Result<(), SondaError> {
         let now = SystemTime::now();
 
-        let recent: Vec<MetricEvent> = match stats.read() {
-            Ok(st) => st.recent_metrics.iter().cloned().collect(),
-            Err(p) => p.into_inner().recent_metrics.iter().cloned().collect(),
+        // Drain so a second invocation on the same buffer is a no-op —
+        // gated_loop may now flush on both running→paused and on the final
+        // exit path; without draining here we'd double-emit.
+        let recent: Vec<MetricEvent> = match stats.write() {
+            Ok(mut st) => st.recent_metrics.drain(..).collect(),
+            Err(p) => p.into_inner().recent_metrics.drain(..).collect(),
         };
 
         let mut seen: Vec<MetricEvent> = Vec::new();
@@ -1262,5 +1265,50 @@ mod tests {
                 "static value must not appear when dynamic label overrides it; line: {line}"
             );
         }
+    }
+
+    #[test]
+    fn close_emitter_is_idempotent_on_recent_metrics_buffer() {
+        use crate::encoder::create_encoder;
+        use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
+        use crate::schedule::core_loop::CloseSignal;
+        use crate::schedule::stats::ScenarioStats;
+        use crate::sink::memory::MemorySink;
+        use std::sync::{Arc, RwLock};
+        use std::time::SystemTime;
+
+        let stats = Arc::new(RwLock::new(ScenarioStats::default()));
+        {
+            let mut st = stats.write().unwrap();
+            let name = ValidatedMetricName::new("up").unwrap();
+            let labels = Arc::new(Labels::from_pairs(&[("host", "a")]).unwrap());
+            st.push_metric(MetricEvent::from_parts(
+                name,
+                1.0,
+                labels,
+                SystemTime::now(),
+            ));
+        }
+
+        let encoder = create_encoder(&EncoderConfig::PrometheusText { precision: None }).unwrap();
+        let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
+
+        let mut first = MemorySink::new();
+        emit(&mut first).expect("first call ok");
+        assert!(
+            !first.buffer.is_empty(),
+            "first invocation must emit the recent tuple"
+        );
+        assert!(
+            stats.read().unwrap().recent_metrics.is_empty(),
+            "buffer must be drained after the first invocation"
+        );
+
+        let mut second = MemorySink::new();
+        emit(&mut second).expect("second call ok");
+        assert!(
+            second.buffer.is_empty(),
+            "second invocation with no new tuples must emit nothing"
+        );
     }
 }

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -656,6 +656,285 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
 }
 
 #[test]
+fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
+    let bus = Arc::new(GateBus::new());
+    bus.tick(1.0);
+    let (rx, init) = bus.subscribe(while_gt_zero());
+
+    let capture = CaptureSink::default();
+    let mut sink_handle = capture.clone();
+    let stats = Arc::new(std::sync::RwLock::new(
+        sonda_core::schedule::stats::ScenarioStats::default(),
+    ));
+
+    let config = ScenarioConfig {
+        base: BaseScheduleConfig {
+            name: "paused_finish".to_string(),
+            rate: 100.0,
+            duration: Some("400ms".to_string()),
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            dynamic_labels: None,
+            labels: None,
+            sink: SinkConfig::RemoteWrite {
+                url: "http://example.invalid/api/v1/write".to_string(),
+                batch_size: None,
+                retry: None,
+            },
+            phase_offset: None,
+            clock_group: None,
+            clock_group_is_auto: None,
+            jitter: None,
+            jitter_seed: None,
+            on_sink_error: sonda_core::OnSinkError::Warn,
+        },
+        generator: GeneratorConfig::Constant { value: 1.0 },
+        encoder: EncoderConfig::RemoteWrite,
+    };
+
+    let stats_for_thread = Arc::clone(&stats);
+    let bus_for_thread = Arc::clone(&bus);
+    let runner = thread::spawn(move || {
+        let _ = bus_for_thread;
+        let shutdown = Arc::new(AtomicBool::new(true));
+        sonda_core::schedule::runner::run_with_sink_gated(
+            &config,
+            &mut sink_handle,
+            Some(shutdown.as_ref()),
+            Some(stats_for_thread),
+            None,
+            Some(GateContext {
+                gate_rx: rx,
+                initial: init,
+                delay: Some(DelayClause {
+                    open: Some(Duration::from_millis(0)),
+                    close: Some(Duration::from_millis(0)),
+                    close_stale_marker: None,
+                    close_snap_to: None,
+                }),
+                has_after: false,
+                has_while: true,
+                close_emit: None,
+            }),
+        )
+        .expect("runner must succeed");
+    });
+
+    // Let the scenario run for ~150ms, then close the gate so the loop
+    // commits running → paused well before duration expires (400ms total).
+    thread::sleep(Duration::from_millis(150));
+    bus.tick(0.0);
+    runner.join().expect("runner joined");
+
+    let buf = capture.buf.lock().unwrap().clone();
+    let series = parse_length_prefixed_timeseries(&buf).expect("parse ok");
+    let stale_count = series
+        .iter()
+        .filter(|ts| {
+            ts.samples
+                .iter()
+                .any(|s| s.value.to_bits() == PROMETHEUS_STALE_NAN.to_bits())
+        })
+        .count();
+    assert_eq!(
+        stale_count,
+        1,
+        "expected exactly one stale marker (no duplicate on paused→finished); got {stale_count} \
+         (total series: {})",
+        series.len()
+    );
+}
+
+#[test]
+fn pending_to_finished_via_duration_emits_no_stale_marker() {
+    // Gate closed at start, has_while=true, has_after=false → scenario
+    // transitions Pending → Paused on first iteration without ever running.
+    // Duration expires while Paused; close-emit fires on the new exit path
+    // but the recent_metrics buffer is empty, so no markers reach the wire.
+    let bus = Arc::new(GateBus::new());
+    bus.tick(0.0);
+    let (rx, init) = bus.subscribe(while_gt_zero());
+
+    let capture = CaptureSink::default();
+    let mut sink_handle = capture.clone();
+    let stats = Arc::new(std::sync::RwLock::new(
+        sonda_core::schedule::stats::ScenarioStats::default(),
+    ));
+
+    let config = ScenarioConfig {
+        base: BaseScheduleConfig {
+            name: "never_ran".to_string(),
+            rate: 100.0,
+            duration: Some("200ms".to_string()),
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            dynamic_labels: None,
+            labels: None,
+            sink: SinkConfig::RemoteWrite {
+                url: "http://example.invalid/api/v1/write".to_string(),
+                batch_size: None,
+                retry: None,
+            },
+            phase_offset: None,
+            clock_group: None,
+            clock_group_is_auto: None,
+            jitter: None,
+            jitter_seed: None,
+            on_sink_error: sonda_core::OnSinkError::Warn,
+        },
+        generator: GeneratorConfig::Constant { value: 1.0 },
+        encoder: EncoderConfig::RemoteWrite,
+    };
+
+    let stats_for_thread = Arc::clone(&stats);
+    let bus_for_thread = Arc::clone(&bus);
+    let runner = thread::spawn(move || {
+        let _ = bus_for_thread;
+        let shutdown = Arc::new(AtomicBool::new(true));
+        sonda_core::schedule::runner::run_with_sink_gated(
+            &config,
+            &mut sink_handle,
+            Some(shutdown.as_ref()),
+            Some(stats_for_thread),
+            None,
+            Some(GateContext {
+                gate_rx: rx,
+                initial: init,
+                delay: None,
+                has_after: false,
+                has_while: true,
+                close_emit: None,
+            }),
+        )
+        .expect("runner must succeed");
+    });
+
+    runner.join().expect("runner joined");
+
+    let buf = capture.buf.lock().unwrap().clone();
+    let series = parse_length_prefixed_timeseries(&buf).expect("parse ok");
+    let stale_count = series
+        .iter()
+        .filter(|ts| {
+            ts.samples
+                .iter()
+                .any(|s| s.value.to_bits() == PROMETHEUS_STALE_NAN.to_bits())
+        })
+        .count();
+    assert_eq!(
+        stale_count, 0,
+        "no recent tuples were ever recorded — close-emit must produce zero markers; got {stale_count}"
+    );
+    // Sanity: no running samples either, since the scenario never ran.
+    assert_eq!(
+        series.len(),
+        0,
+        "scenario never reached Running — no series should reach the wire; got {}",
+        series.len()
+    );
+}
+
+#[test]
+fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused() {
+    // Two Running → Paused transitions before duration expires while paused.
+    // Each running → paused drains the recent-metrics buffer (Option B);
+    // paused → finished sees an empty buffer and emits nothing.
+    let bus = Arc::new(GateBus::new());
+    bus.tick(1.0);
+    let (rx, init) = bus.subscribe(while_gt_zero());
+
+    let capture = CaptureSink::default();
+    let mut sink_handle = capture.clone();
+    let stats = Arc::new(std::sync::RwLock::new(
+        sonda_core::schedule::stats::ScenarioStats::default(),
+    ));
+
+    let config = ScenarioConfig {
+        base: BaseScheduleConfig {
+            name: "multi_cycle".to_string(),
+            rate: 100.0,
+            duration: Some("700ms".to_string()),
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            dynamic_labels: None,
+            labels: None,
+            sink: SinkConfig::RemoteWrite {
+                url: "http://example.invalid/api/v1/write".to_string(),
+                batch_size: None,
+                retry: None,
+            },
+            phase_offset: None,
+            clock_group: None,
+            clock_group_is_auto: None,
+            jitter: None,
+            jitter_seed: None,
+            on_sink_error: sonda_core::OnSinkError::Warn,
+        },
+        generator: GeneratorConfig::Constant { value: 1.0 },
+        encoder: EncoderConfig::RemoteWrite,
+    };
+
+    let stats_for_thread = Arc::clone(&stats);
+    let bus_for_thread = Arc::clone(&bus);
+    let runner = thread::spawn(move || {
+        let _ = bus_for_thread;
+        let shutdown = Arc::new(AtomicBool::new(true));
+        sonda_core::schedule::runner::run_with_sink_gated(
+            &config,
+            &mut sink_handle,
+            Some(shutdown.as_ref()),
+            Some(stats_for_thread),
+            None,
+            Some(GateContext {
+                gate_rx: rx,
+                initial: init,
+                delay: Some(DelayClause {
+                    open: Some(Duration::from_millis(0)),
+                    close: Some(Duration::from_millis(0)),
+                    close_stale_marker: None,
+                    close_snap_to: None,
+                }),
+                has_after: false,
+                has_while: true,
+                close_emit: None,
+            }),
+        )
+        .expect("runner must succeed");
+    });
+
+    // Cycle 1: run ~100ms, pause ~50ms.
+    thread::sleep(Duration::from_millis(100));
+    bus.tick(0.0);
+    thread::sleep(Duration::from_millis(50));
+    // Cycle 2: resume, run ~100ms, pause and let duration expire.
+    bus.tick(1.0);
+    thread::sleep(Duration::from_millis(100));
+    bus.tick(0.0);
+    runner.join().expect("runner joined");
+
+    let buf = capture.buf.lock().unwrap().clone();
+    let series = parse_length_prefixed_timeseries(&buf).expect("parse ok");
+    let stale_count = series
+        .iter()
+        .filter(|ts| {
+            ts.samples
+                .iter()
+                .any(|s| s.value.to_bits() == PROMETHEUS_STALE_NAN.to_bits())
+        })
+        .count();
+    assert_eq!(
+        stale_count,
+        2,
+        "expected one stale marker per running→paused transition (2 cycles); got {stale_count} \
+         (total series: {})",
+        series.len()
+    );
+}
+
+#[test]
 fn shutdown_while_gate_open_emits_stale_marker() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);


### PR DESCRIPTION
## Summary

v1.6.0 shipped close-emit on `running → paused` gate-close transitions. v1.6.1 ([#323](https://github.com/davidban77/sonda/pull/323)) extended it to `running → finished` exits via `duration:` expiry or shutdown — but only patched the Running-arm exit site. `gated_loop` has **two more exit paths** that bypass close-emit: the top-of-loop shutdown / duration-expiry checks at the start of every loop iteration. When the loop is in `Pending` or `Paused` and one of those conditions fires, control returns to the top, hits the early return, and `finish(stats)` runs without a flush.

Workshop's multi-cycle cascade pattern hits this exactly: `Running → Paused` (close-emit fires) → next iteration top-of-loop catches duration expiry → returns without flush → Prometheus holds the last "down" sample for the full ~5-min `query.lookback-delta` window. Alerts stay pinned for that whole window.

This patch threads close-emit through every operator-clean exit path from `gated_loop`.

## What changes

- **`sonda-core::schedule::core_loop`** — new private helper `finish_with_close_emit(schedule, stats, gate_ctx, limiter, sink)` that invokes `invoke_close_emit_on_exit` then `finish(stats)`. Three call sites in `gated_loop` route through it: top-of-loop shutdown, top-of-loop duration-expired, and the Running-arm shutdown/duration-after-segment exit (the v1.6.1 site, refactored to use the helper). The Running-arm `WhileClose → Paused` site is unchanged — it's a transition flush, not a finish.
- **`sonda-core::schedule::runner::make_close_emitter`** — the closure now drains `recent_metrics` on read instead of iter+clone. With three flush sites, a sequence like `running → paused (close-emit fires) → paused → finished (close-emit fires again)` is now reachable, and the closure must be idempotent against the same buffer to avoid duplicate stale-NaN samples for the same `(metric_name, label_set)` tuples. Drain-on-read makes a second invocation a no-op.
- **Tests** — three new integration tests in `sonda-core/tests/while_close_stale_marker.rs` and one new unit test in `sonda-core/src/schedule/runner.rs::tests`:
  - `paused_to_finished_via_duration_after_running_emits_stale_marker` — exactly one stale marker (running→paused fires; paused→finished drains an empty buffer).
  - `pending_to_finished_via_duration_emits_no_stale_marker` — zero stale markers (entry never reached Running).
  - `multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused` — exactly two stale markers across two Running ↔ Paused cycles.
  - `close_emitter_is_idempotent_on_recent_metrics_buffer` — closure invoked twice against same stats Arc; first emits, second is empty.

The two existing v1.6.1 regression tests (`duration_expiry_while_gate_open_emits_stale_marker`, `shutdown_while_gate_open_emits_stale_marker`) remain green — they exercise the Running-arm path, which now flows through the same helper.

## Behavior matrix (after this patch)

| Exit cause | Loop state at exit | v1.6.1 close-emit | v1.6.2 close-emit |
|---|---|---|---|
| `WhileClose` (debounce committed) | Running | YES (transition flush) | YES (unchanged) |
| `WhileClose` (cancelled by reopen) | Running | no | no (unchanged) |
| `duration:` expires | Running, gate open | YES (Running-arm) | YES (unchanged) |
| `duration:` expires | Paused (after running→paused) | **no** | **YES** |
| `duration:` expires | Pending (entry never ran) | no | no (empty buffer drains to nothing) |
| User shutdown | Running, gate open | YES (Running-arm) | YES (unchanged) |
| User shutdown | Paused | **no** | **YES** |
| User shutdown | Pending | no | no (empty buffer) |

Bold rows show the behavior change.

## Backward compatibility

- No schema changes. No new fields on `delay.close`. No new sink/encoder/generator. No public API change.
- The drain semantic in `make_close_emitter` is private — the closure is built internally; users never call it. The visible contract ("emit stale markers on operator-clean Running exit when the sink is `remote_write` and `delay.close.stale_marker` is on by default") is unchanged. v1.6.0/1.6.1 had a buggy implementation; this PR makes the implementation match the contract.
- Sinks that opted out (`delay.close.stale_marker: false` or non-`remote_write` without `snap_to`) stay opted out.
- `Cargo.lock` is touched to refresh workspace crate versions to 1.6.1 — release-please updates `Cargo.toml` but not the lock; the next build picks it up. No dependency changes.

## Out of scope

- Server-side end-to-end wire-bytes regression test in `sonda-server/tests/`. Good follow-up but separate PR.
- Refactoring `gated_loop` to a single tail exit point with an explicit `LoopExit` enum. Would make the close-emit invariant unmissable by construction; tracked as v1.7 polish.
- v1.7 polish items already tracked in [#321](https://github.com/davidban77/sonda/issues/321).

## Quality gates

| Gate | Result |
|---|---|
| `cargo build --workspace --all-features` | PASS, 0 warnings |
| `cargo nextest run --workspace --all-features` | 3036/3036 PASS (3 skipped) — 4 new tests |
| `cargo test --workspace --doc` | 5/5 PASS |
| `cargo clippy --workspace --all-features -- -D warnings` | PASS |
| `cargo fmt --all -- --check` | PASS |
| `cargo audit` | PASS (1 pre-existing allowed: `core2` via `rsasl`/`rskafka`) |
| `cargo test -p sonda-core --no-default-features` | PASS (1171 tests) |

## Test plan

- [x] Three new integration tests assert correct stale-marker counts on the new exit paths (Pending → Finished: 0 markers; Paused → Finished after Running: 1 marker; multi-cycle: N markers for N Running → Paused transitions).
- [x] Idempotency unit test in `runner.rs` proves the closure no-ops on a second invocation against an unchanged buffer.
- [x] Existing v1.6 close-emit tests (`while_close_stale_marker.rs` family, 11 tests total) still pass.
- [x] Non-gated scenario test family runs clean — predicate is unchanged.
- [x] End-to-end smoke: `sonda-server` boots with `-F remote-write`, accepts a workshop-shape cascade, scenarios reach `finished` cleanly with no errors logged, mock HTTP receiver captures the expected payloads.
- [ ] CI green on this PR.
- [ ] release-please cuts v1.6.2.
- [ ] After 1.6.2 image lands on ghcr: bump `SONDA_IMAGE` default in workshops repo to 1.6.2 and revert the `4m → 2m` duration workaround.