### PR TITLE
fix(core): structural refactor of gated_loop to make close-emit unmissable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -414,7 +414,9 @@ fn apply_close_emit_policy_flush(
     }
 }
 
-fn invoke_close_emit_on_exit(
+/// Called on every committed `running → paused` transition AND on the
+/// single tail exit of `gated_loop`.
+fn invoke_close_emit(
     schedule: &ParsedSchedule,
     stats: Option<&Arc<RwLock<ScenarioStats>>>,
     limiter: &mut SinkErrorRateLimiter,
@@ -483,6 +485,55 @@ pub(crate) fn gated_loop(
     sink: &mut dyn Sink,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<(), SondaError> {
+    let mut close_warn_limiter = SinkErrorRateLimiter::new();
+
+    let body_result = gated_loop_body(
+        schedule,
+        rate,
+        shutdown,
+        stats.as_ref(),
+        &mut gate_ctx,
+        &mut close_warn_limiter,
+        sink,
+        tick_fn,
+    );
+
+    match body_result {
+        Ok(LoopExit::Shutdown) => {
+            invoke_close_emit(
+                schedule,
+                stats.as_ref(),
+                &mut close_warn_limiter,
+                gate_ctx.close_emit.as_mut(),
+                sink,
+            )?;
+            finish(stats)
+        }
+        Ok(LoopExit::DurationExpired) => {
+            invoke_close_emit(
+                schedule,
+                stats.as_ref(),
+                &mut close_warn_limiter,
+                gate_ctx.close_emit.as_mut(),
+                sink,
+            )?;
+            finish(stats)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn gated_loop_body(
+    schedule: &ParsedSchedule,
+    rate: f64,
+    shutdown: Option<&AtomicBool>,
+    stats: Option<&Arc<RwLock<ScenarioStats>>>,
+    gate_ctx: &mut GateContext,
+    close_warn_limiter: &mut SinkErrorRateLimiter,
+    sink: &mut dyn Sink,
+    tick_fn: &mut TickFn<'_>,
+) -> Result<LoopExit, SondaError> {
     let started_at = Instant::now();
 
     let mut state = ScenarioState::Pending;
@@ -499,28 +550,20 @@ pub(crate) fn gated_loop(
 
     let mut debounce = DebounceState::from_clause(gate_ctx.delay.as_ref());
 
-    let mut close_warn_limiter = SinkErrorRateLimiter::new();
-
-    // Carry the next tick across pause/resume so generators don't restart.
     let mut next_tick: u64 = 0;
 
-    write_state(&stats, ScenarioState::Pending, false);
+    write_state(stats, ScenarioState::Pending, false);
 
     loop {
-        // Top-level shutdown / duration check applies in every state.
         if shutdown_requested(shutdown) {
-            return finish(stats);
+            return Ok(LoopExit::Shutdown);
         }
         if duration_expired(schedule, started_at) {
-            return finish(stats);
+            return Ok(LoopExit::DurationExpired);
         }
 
         match state {
             ScenarioState::Pending => {
-                // Pending exits when after fires (or no after clause). The
-                // resulting state depends on the gate: open → Running,
-                // closed → Paused (and the delay.open debounce still
-                // applies to the implicit pending→paused entry path).
                 if !after_satisfied {
                     match gate_ctx.gate_rx.recv_timeout(remaining_until(
                         schedule,
@@ -537,7 +580,6 @@ pub(crate) fn gated_loop(
                             while_open = false;
                         }
                         None => {
-                            // Loop top will re-check shutdown / duration.
                             continue;
                         }
                     }
@@ -545,28 +587,26 @@ pub(crate) fn gated_loop(
                 }
                 if !gate_ctx.has_while {
                     state = ScenarioState::Running;
-                    write_state(&stats, ScenarioState::Running, false);
+                    write_state(stats, ScenarioState::Running, false);
                     continue;
                 }
                 if while_open {
                     state = ScenarioState::Running;
-                    write_state(&stats, ScenarioState::Running, false);
+                    write_state(stats, ScenarioState::Running, false);
                 } else {
                     state = ScenarioState::Paused;
-                    write_state(&stats, ScenarioState::Paused, true);
+                    write_state(stats, ScenarioState::Paused, true);
                 }
             }
             ScenarioState::Running => {
-                // Run a fresh schedule segment. Break out on WhileClose,
-                // user shutdown, or duration expiry.
                 let segment_running = Arc::new(AtomicBool::new(true));
                 let last_tick = Arc::new(AtomicU64::new(next_tick));
                 let exit = run_running_segment(
                     schedule,
                     rate,
                     shutdown,
-                    stats.clone(),
-                    &gate_ctx,
+                    stats.cloned(),
+                    gate_ctx,
                     &segment_running,
                     next_tick,
                     Arc::clone(&last_tick),
@@ -575,46 +615,35 @@ pub(crate) fn gated_loop(
                 )?;
                 next_tick = last_tick.load(Ordering::SeqCst);
 
-                // Distinguish reasons: user shutdown / duration → Finished;
-                // WhileClose → Paused (debounced by delay.close).
-                if shutdown_requested(shutdown) || duration_expired(schedule, started_at) {
-                    // Close-emit before finish() so `state == Finished` observers see the marker.
-                    invoke_close_emit_on_exit(
-                        schedule,
-                        stats.as_ref(),
-                        &mut close_warn_limiter,
-                        gate_ctx.close_emit.as_mut(),
-                        sink,
-                    )?;
-                    return finish(stats);
+                if shutdown_requested(shutdown) {
+                    return Ok(LoopExit::Shutdown);
+                }
+                if duration_expired(schedule, started_at) {
+                    return Ok(LoopExit::DurationExpired);
                 }
                 if exit == SegmentExit::WhileClose
                     && !debounce_close_to_paused(
-                        schedule, started_at, shutdown, &gate_ctx, &debounce,
+                        schedule, started_at, shutdown, gate_ctx, &debounce,
                     )
                 {
-                    // A fresh WhileOpen arrived during the close debounce
-                    // — stay Running.
                     while_open = true;
                     continue;
                 }
                 if exit == SegmentExit::WhileClose {
-                    invoke_close_emit_on_exit(
+                    invoke_close_emit(
                         schedule,
-                        stats.as_ref(),
-                        &mut close_warn_limiter,
+                        stats,
+                        close_warn_limiter,
                         gate_ctx.close_emit.as_mut(),
                         sink,
                     )?;
                 }
                 state = ScenarioState::Paused;
                 while_open = false;
-                write_state(&stats, ScenarioState::Paused, true);
+                write_state(stats, ScenarioState::Paused, true);
                 debounce.reset();
             }
             ScenarioState::Paused => {
-                // Block on the gate channel up to PAUSED_POLL_INTERVAL (or
-                // until the next debounce wakeup, whichever is sooner).
                 let now = Instant::now();
                 let mut wakeup = PAUSED_POLL_INTERVAL;
                 if let Some(d) = debounce.next_wakeup(now) {
@@ -646,18 +675,17 @@ pub(crate) fn gated_loop(
                         GateEdge::WhileOpen => {
                             if while_open {
                                 state = ScenarioState::Running;
-                                write_state(&stats, ScenarioState::Running, false);
+                                write_state(stats, ScenarioState::Running, false);
                             }
                         }
-                        GateEdge::WhileClose => {
-                            // Closing while paused is a no-op state-wise.
-                        }
+                        GateEdge::WhileClose => {}
                         GateEdge::AfterFired => {}
                     }
                 }
             }
             ScenarioState::Finished => {
-                return finish(stats);
+                // Structurally dead; kept so `match state` stays exhaustive.
+                return Ok(LoopExit::Shutdown);
             }
         }
     }
@@ -693,11 +721,11 @@ fn remaining_until(schedule: &ParsedSchedule, started_at: Instant, default: Dura
 }
 
 fn write_state(
-    stats: &Option<Arc<RwLock<ScenarioStats>>>,
+    stats: Option<&Arc<RwLock<ScenarioStats>>>,
     state: ScenarioState,
     paused_zero_rate: bool,
 ) {
-    if let Some(ref s) = stats {
+    if let Some(s) = stats {
         if let Ok(mut st) = s.write() {
             st.state = state;
             if paused_zero_rate {
@@ -707,6 +735,12 @@ fn write_state(
     }
 }
 
+// INVARIANT: this function is called from exactly one place — the tail of
+// `gated_loop`. The body (`gated_loop_body`) cannot call it because it has no
+// way to construct a `Result<(), SondaError>` for the outer caller without
+// a LoopExit value. If you find yourself wanting to call `finish` from
+// anywhere else, you are likely re-introducing the v1.6.0/v1.6.1/v1.6.2
+// close-emit-bypass bug. See refactor plan §2 and §7.
 fn finish(stats: Option<Arc<RwLock<ScenarioStats>>>) -> Result<(), SondaError> {
     if let Some(s) = stats {
         if let Ok(mut st) = s.write() {
@@ -723,6 +757,23 @@ enum SegmentExit {
     WhileClose,
     /// User-shutdown flag cleared, or scenario duration expired.
     ShutdownOrDuration,
+}
+
+/// Reason the `gated_loop` body terminated cleanly.
+///
+/// The body cannot call `finish(stats)` directly — it can only return a
+/// `LoopExit`, and the outer `gated_loop` is the sole site that pairs
+/// `invoke_close_emit` with `finish(stats)`. Adding a new clean-exit
+/// reason means adding a variant here; the compiler will then point at
+/// the tail's match and force the contributor to think about close-emit.
+///
+/// Errors are NOT modeled as a variant: they propagate through the body's
+/// `Result<LoopExit, SondaError>` return type so the type system carries
+/// the "did this exit cleanly?" signal end-to-end.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoopExit {
+    Shutdown,
+    DurationExpired,
 }
 
 /// Wait `delay.close` for either a fresh `WhileOpen` (cancel) or the
@@ -941,6 +992,18 @@ mod tests {
         fn flush(&mut self) -> Result<(), SondaError> {
             Ok(())
         }
+    }
+
+    #[test]
+    fn loop_exit_variants_are_exhaustive_for_clean_exits() {
+        fn assert_clean_exit_match(le: LoopExit) {
+            match le {
+                LoopExit::Shutdown => {}
+                LoopExit::DurationExpired => {}
+            }
+        }
+        assert_clean_exit_match(LoopExit::Shutdown);
+        assert_clean_exit_match(LoopExit::DurationExpired);
     }
 
     /// Build a minimal ParsedSchedule for testing.

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -735,12 +735,10 @@ fn write_state(
     }
 }
 
-// INVARIANT: this function is called from exactly one place — the tail of
-// `gated_loop`. The body (`gated_loop_body`) cannot call it because it has no
-// way to construct a `Result<(), SondaError>` for the outer caller without
-// a LoopExit value. If you find yourself wanting to call `finish` from
-// anywhere else, you are likely re-introducing the v1.6.0/v1.6.1/v1.6.2
-// close-emit-bypass bug. See refactor plan §2 and §7.
+// INVARIANT: only callable from the tail of `gated_loop`. The body cannot
+// reach it — `gated_loop_body` returns `Result<LoopExit, _>` by construction
+// and has no way to produce `Result<(), _>` directly. Adding a caller
+// elsewhere bypasses the close-emit flush.
 fn finish(stats: Option<Arc<RwLock<ScenarioStats>>>) -> Result<(), SondaError> {
     if let Some(s) = stats {
         if let Ok(mut st) = s.write() {

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -243,9 +243,12 @@ fn make_close_emitter(
     Box::new(move |sink: &mut dyn Sink| -> Result<(), SondaError> {
         let now = SystemTime::now();
 
-        let recent: Vec<MetricEvent> = match stats.read() {
-            Ok(st) => st.recent_metrics.iter().cloned().collect(),
-            Err(p) => p.into_inner().recent_metrics.iter().cloned().collect(),
+        // gated_loop flushes on the WhileClose commit and on the single tail exit;
+        // drain ensures the tail sees an empty buffer when nothing accrued since
+        // the prior commit.
+        let recent: Vec<MetricEvent> = match stats.write() {
+            Ok(mut st) => st.recent_metrics.drain(..).collect(),
+            Err(p) => p.into_inner().recent_metrics.drain(..).collect(),
         };
 
         let mut seen: Vec<MetricEvent> = Vec::new();
@@ -1262,5 +1265,50 @@ mod tests {
                 "static value must not appear when dynamic label overrides it; line: {line}"
             );
         }
+    }
+
+    #[test]
+    fn close_emitter_is_idempotent_on_recent_metrics_buffer() {
+        use crate::encoder::create_encoder;
+        use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
+        use crate::schedule::core_loop::CloseSignal;
+        use crate::schedule::stats::ScenarioStats;
+        use crate::sink::memory::MemorySink;
+        use std::sync::{Arc, RwLock};
+        use std::time::SystemTime;
+
+        let stats = Arc::new(RwLock::new(ScenarioStats::default()));
+        {
+            let mut st = stats.write().unwrap();
+            let name = ValidatedMetricName::new("up").unwrap();
+            let labels = Arc::new(Labels::from_pairs(&[("host", "a")]).unwrap());
+            st.push_metric(MetricEvent::from_parts(
+                name,
+                1.0,
+                labels,
+                SystemTime::now(),
+            ));
+        }
+
+        let encoder = create_encoder(&EncoderConfig::PrometheusText { precision: None }).unwrap();
+        let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
+
+        let mut first = MemorySink::new();
+        emit(&mut first).expect("first call ok");
+        assert!(
+            !first.buffer.is_empty(),
+            "first invocation must emit the recent tuple"
+        );
+        assert!(
+            stats.read().unwrap().recent_metrics.is_empty(),
+            "buffer must be drained after the first invocation"
+        );
+
+        let mut second = MemorySink::new();
+        emit(&mut second).expect("second call ok");
+        assert!(
+            second.buffer.is_empty(),
+            "second invocation with no new tuples must emit nothing"
+        );
     }
 }

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -656,6 +656,277 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
 }
 
 #[test]
+fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
+    let bus = Arc::new(GateBus::new());
+    bus.tick(1.0);
+    let (rx, init) = bus.subscribe(while_gt_zero());
+
+    let capture = CaptureSink::default();
+    let mut sink_handle = capture.clone();
+    let stats = Arc::new(std::sync::RwLock::new(
+        sonda_core::schedule::stats::ScenarioStats::default(),
+    ));
+
+    let config = ScenarioConfig {
+        base: BaseScheduleConfig {
+            name: "paused_finish".to_string(),
+            rate: 100.0,
+            duration: Some("400ms".to_string()),
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            dynamic_labels: None,
+            labels: None,
+            sink: SinkConfig::RemoteWrite {
+                url: "http://example.invalid/api/v1/write".to_string(),
+                batch_size: None,
+                retry: None,
+            },
+            phase_offset: None,
+            clock_group: None,
+            clock_group_is_auto: None,
+            jitter: None,
+            jitter_seed: None,
+            on_sink_error: sonda_core::OnSinkError::Warn,
+        },
+        generator: GeneratorConfig::Constant { value: 1.0 },
+        encoder: EncoderConfig::RemoteWrite,
+    };
+
+    let stats_for_thread = Arc::clone(&stats);
+    let bus_for_thread = Arc::clone(&bus);
+    let runner = thread::spawn(move || {
+        let _ = bus_for_thread;
+        let shutdown = Arc::new(AtomicBool::new(true));
+        sonda_core::schedule::runner::run_with_sink_gated(
+            &config,
+            &mut sink_handle,
+            Some(shutdown.as_ref()),
+            Some(stats_for_thread),
+            None,
+            Some(GateContext {
+                gate_rx: rx,
+                initial: init,
+                delay: Some(DelayClause {
+                    open: Some(Duration::from_millis(0)),
+                    close: Some(Duration::from_millis(0)),
+                    close_stale_marker: None,
+                    close_snap_to: None,
+                }),
+                has_after: false,
+                has_while: true,
+                close_emit: None,
+            }),
+        )
+        .expect("runner must succeed");
+    });
+
+    // Let the scenario run for ~150ms, then close the gate so the loop
+    // commits running → paused well before duration expires (400ms total).
+    thread::sleep(Duration::from_millis(150));
+    bus.tick(0.0);
+    runner.join().expect("runner joined");
+
+    let buf = capture.buf.lock().unwrap().clone();
+    let series = parse_length_prefixed_timeseries(&buf).expect("parse ok");
+    let stale_count = series
+        .iter()
+        .filter(|ts| {
+            ts.samples
+                .iter()
+                .any(|s| s.value.to_bits() == PROMETHEUS_STALE_NAN.to_bits())
+        })
+        .count();
+    assert_eq!(
+        stale_count,
+        1,
+        "expected exactly one stale marker (no duplicate on paused→finished); got {stale_count} \
+         (total series: {})",
+        series.len()
+    );
+}
+
+#[test]
+fn pending_to_finished_via_duration_emits_no_stale_marker() {
+    let bus = Arc::new(GateBus::new());
+    bus.tick(0.0);
+    let (rx, init) = bus.subscribe(while_gt_zero());
+
+    let capture = CaptureSink::default();
+    let mut sink_handle = capture.clone();
+    let stats = Arc::new(std::sync::RwLock::new(
+        sonda_core::schedule::stats::ScenarioStats::default(),
+    ));
+
+    let config = ScenarioConfig {
+        base: BaseScheduleConfig {
+            name: "never_ran".to_string(),
+            rate: 100.0,
+            duration: Some("200ms".to_string()),
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            dynamic_labels: None,
+            labels: None,
+            sink: SinkConfig::RemoteWrite {
+                url: "http://example.invalid/api/v1/write".to_string(),
+                batch_size: None,
+                retry: None,
+            },
+            phase_offset: None,
+            clock_group: None,
+            clock_group_is_auto: None,
+            jitter: None,
+            jitter_seed: None,
+            on_sink_error: sonda_core::OnSinkError::Warn,
+        },
+        generator: GeneratorConfig::Constant { value: 1.0 },
+        encoder: EncoderConfig::RemoteWrite,
+    };
+
+    let stats_for_thread = Arc::clone(&stats);
+    let bus_for_thread = Arc::clone(&bus);
+    let runner = thread::spawn(move || {
+        let _ = bus_for_thread;
+        let shutdown = Arc::new(AtomicBool::new(true));
+        sonda_core::schedule::runner::run_with_sink_gated(
+            &config,
+            &mut sink_handle,
+            Some(shutdown.as_ref()),
+            Some(stats_for_thread),
+            None,
+            Some(GateContext {
+                gate_rx: rx,
+                initial: init,
+                delay: None,
+                has_after: false,
+                has_while: true,
+                close_emit: None,
+            }),
+        )
+        .expect("runner must succeed");
+    });
+
+    runner.join().expect("runner joined");
+
+    let buf = capture.buf.lock().unwrap().clone();
+    let series = parse_length_prefixed_timeseries(&buf).expect("parse ok");
+    let stale_count = series
+        .iter()
+        .filter(|ts| {
+            ts.samples
+                .iter()
+                .any(|s| s.value.to_bits() == PROMETHEUS_STALE_NAN.to_bits())
+        })
+        .count();
+    assert_eq!(
+        stale_count, 0,
+        "no recent tuples were ever recorded — close-emit must produce zero markers; got {stale_count}"
+    );
+    assert_eq!(
+        series.len(),
+        0,
+        "scenario never reached Running — no series should reach the wire; got {}",
+        series.len()
+    );
+}
+
+#[test]
+fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused() {
+    let bus = Arc::new(GateBus::new());
+    bus.tick(1.0);
+    let (rx, init) = bus.subscribe(while_gt_zero());
+
+    let capture = CaptureSink::default();
+    let mut sink_handle = capture.clone();
+    let stats = Arc::new(std::sync::RwLock::new(
+        sonda_core::schedule::stats::ScenarioStats::default(),
+    ));
+
+    let config = ScenarioConfig {
+        base: BaseScheduleConfig {
+            name: "multi_cycle".to_string(),
+            rate: 100.0,
+            duration: Some("700ms".to_string()),
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            dynamic_labels: None,
+            labels: None,
+            sink: SinkConfig::RemoteWrite {
+                url: "http://example.invalid/api/v1/write".to_string(),
+                batch_size: None,
+                retry: None,
+            },
+            phase_offset: None,
+            clock_group: None,
+            clock_group_is_auto: None,
+            jitter: None,
+            jitter_seed: None,
+            on_sink_error: sonda_core::OnSinkError::Warn,
+        },
+        generator: GeneratorConfig::Constant { value: 1.0 },
+        encoder: EncoderConfig::RemoteWrite,
+    };
+
+    let stats_for_thread = Arc::clone(&stats);
+    let bus_for_thread = Arc::clone(&bus);
+    let runner = thread::spawn(move || {
+        let _ = bus_for_thread;
+        let shutdown = Arc::new(AtomicBool::new(true));
+        sonda_core::schedule::runner::run_with_sink_gated(
+            &config,
+            &mut sink_handle,
+            Some(shutdown.as_ref()),
+            Some(stats_for_thread),
+            None,
+            Some(GateContext {
+                gate_rx: rx,
+                initial: init,
+                delay: Some(DelayClause {
+                    open: Some(Duration::from_millis(0)),
+                    close: Some(Duration::from_millis(0)),
+                    close_stale_marker: None,
+                    close_snap_to: None,
+                }),
+                has_after: false,
+                has_while: true,
+                close_emit: None,
+            }),
+        )
+        .expect("runner must succeed");
+    });
+
+    // Cycle 1: run ~100ms, pause ~50ms.
+    thread::sleep(Duration::from_millis(100));
+    bus.tick(0.0);
+    thread::sleep(Duration::from_millis(50));
+    // Cycle 2: resume, run ~100ms, pause and let duration expire.
+    bus.tick(1.0);
+    thread::sleep(Duration::from_millis(100));
+    bus.tick(0.0);
+    runner.join().expect("runner joined");
+
+    let buf = capture.buf.lock().unwrap().clone();
+    let series = parse_length_prefixed_timeseries(&buf).expect("parse ok");
+    let stale_count = series
+        .iter()
+        .filter(|ts| {
+            ts.samples
+                .iter()
+                .any(|s| s.value.to_bits() == PROMETHEUS_STALE_NAN.to_bits())
+        })
+        .count();
+    assert_eq!(
+        stale_count,
+        2,
+        "expected one stale marker per running→paused transition (2 cycles); got {stale_count} \
+         (total series: {})",
+        series.len()
+    );
+}
+
+#[test]
 fn shutdown_while_gate_open_emits_stale_marker() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -8,8 +8,7 @@
 //! Non-`remote_write` sinks default to no close-emit; `snap_to` opts in.
 //!
 //! The recent-metrics buffer is capped at `MAX_RECENT_METRICS = 100`, so
-//! high-cardinality scenarios under-emit on close. v1.6 ships this as a
-//! known limitation; v1.7 follow-up extends the buffer.
+//! high-cardinality scenarios under-emit on close.
 
 #![cfg(feature = "config")]
 #![cfg(feature = "remote-write")]


### PR DESCRIPTION
## Summary

Three patches in a row to `gated_loop` shipped close-emit-bypass bugs (v1.6.0, v1.6.1, draft v1.6.2 [#325](https://github.com/davidban77/sonda/pull/325)). Every iteration was a sin of omission — a new exit reason needed close-emit, an existing exit path was overlooked, the bypass shipped. The state machine itself is fine; what's fragile is the wiring discipline.

This PR makes the close-emit-before-finish invariant **unmissable by construction**. A future contributor adding a new clean-exit reason cannot ship a bypass even without knowing about close-emit.

This PR supersedes draft [#325](https://github.com/davidban77/sonda/pull/325) — the v1.6.2 patch ships as part of this refactor. Closes [#326](https://github.com/davidban77/sonda/issues/326).

## How the type system enforces it

```
gated_loop()                            ← thin wrapper, the ONLY caller of finish()
├── gated_loop_body() → Result<LoopExit, _>   ← cannot construct Result<(), _>;
│   │                                            cannot reach finish() at all
│   ├── top-of-loop shutdown    → Ok(LoopExit::Shutdown)
│   ├── top-of-loop duration    → Ok(LoopExit::DurationExpired)
│   ├── Running arm post-segment → Ok(LoopExit::*)
│   ├── Running arm WhileClose  → invoke_close_emit() inline (TRANSITION flush)
│   └── Pending/Paused arms     → continue (no return)
│
└── tail (per-variant match — no `|`, no `_ =>`):
    Ok(Shutdown)        → invoke_close_emit + finish
    Ok(DurationExpired) → invoke_close_emit + finish
    Err(e)              → return Err  (skip close-emit, matches today's policy)
```

The body's return type is `Result<LoopExit, SondaError>`. The wrapper's signature requires `Result<(), SondaError>`. The only way to get from one to the other is the wrapper's `match`. The `match` is exhaustive over both variants explicitly (no `|` fall-through, no `_ =>`) — adding a new `LoopExit` variant fails to compile until the wrapper handles it.

A future contributor wanting to skip close-emit on some new exit reason has to actively author an arm that omits it. That makes the bypass visible at review time instead of invisible at runtime.

## What changes

- **`sonda-core::schedule::core_loop`** — introduces private `LoopExit` enum (`Shutdown`, `DurationExpired`); splits `gated_loop` into a thin wrapper + new private `gated_loop_body`; the body returns `Result<LoopExit, SondaError>` and contains zero `finish(stats)` calls. Wrapper has a per-variant tail match. `invoke_close_emit_on_exit` renamed to `invoke_close_emit` (the name now describes what it does — fires on every committed Running→Paused transition AND on the single tail exit). Long-form INVARIANT comment added above `fn finish` as a contributor-facing signpost.
- **`sonda-core::schedule::runner::make_close_emitter`** — adopts the `recent_metrics.drain(..)` semantic from PR #325. Required because the closure now has multiple invocation sites within one run (mid-loop WhileClose + tail); drain ensures the second invocation against an unchanged buffer is a no-op.
- **Tests** — three regression tests imported from PR #325 (`paused_to_finished_via_duration_after_running_emits_stale_marker`, `pending_to_finished_via_duration_emits_no_stale_marker`, `multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused`); one structural signpost test (`loop_exit_variants_are_exhaustive_for_clean_exits`); the closure-idempotency unit test (`close_emitter_is_idempotent_on_recent_metrics_buffer`). All 11 v1.6.x close-emit tests on this branch pass; all 21 `while_runtime` tests pass.

## Behavior matrix — preserved exactly

| Exit cause | Loop state at exit | close-emit fires? |
|---|---|---|
| `WhileClose` (debounce committed) | Running | YES (mid-loop transition flush) |
| `WhileClose` (cancelled by reopen during debounce) | Running | no |
| `duration:` expires | Running, gate open | YES (tail) |
| `duration:` expires | Paused (after running→paused) | YES (tail; buffer drained empty if already flushed) |
| `duration:` expires | Pending (entry never ran) | YES (tail; empty buffer = no-op) |
| User shutdown | Running, gate open | YES (tail) |
| User shutdown | Paused | YES (tail) |
| User shutdown | Pending | YES (tail; empty buffer = no-op) |
| Body returns `Err` | any | no (matches `OnSinkError::Fail` semantics — fail fast, no further sink I/O) |

Same matrix as PR #325 would have shipped. Anyone using v1.6.0/1.6.1/1.6.2-draft and observing alert-clearing behavior should see no change after this lands.

## Backward compatibility

- No public API change. `gated_loop` signature is preserved; `LoopExit` is module-private.
- No schema, CLI, or config change.
- No new dependencies.
- Cargo.lock workspace-version refresh (1.6.0 → 1.6.1) is incidental from running cargo build against the post-release-please Cargo.toml; not part of the fix.

## Out of scope (filed as follow-ups)

- A server-level integration test that captures wire bytes through `POST /scenarios → multi_runner → gated_loop → exit`. Currently infeasible without extending `SinkConfig` with a test-only memory variant or building sink-mocking infrastructure — both exceed the refactor's "no new helpers, no new infra" constraint. The existing `post_cascade_with_extended_delay_close_form_runs_to_paused` test is the API-surface sentinel for now. New issue forthcoming.
- Adding stale-marker close-emit to log/histogram/summary runners ([#321](https://github.com/davidban77/sonda/issues/321) polish item).
- Removing `finish(stats)` in favor of relying on `StateGuard` in `launch.rs`. Defer.

## Quality gates

| Gate | Result |
|---|---|
| `cargo build --workspace --all-features` | PASS |
| `cargo nextest run --workspace --all-features` | 3037/3037 PASS, 3 skipped (+4 new tests) |
| `cargo test --workspace --doc` | 5/5 PASS |
| `cargo clippy --workspace --all-features -- -D warnings` | PASS |
| `cargo fmt --all -- --check` | PASS |
| `cargo audit` | PASS (1 pre-existing allowed: `core2` via `rsasl`/`rskafka`) |
| `cargo test -p sonda-core --no-default-features` | PASS (1172 tests) |

## Test plan

- [x] All v1.6.x close-emit tests pass on the refactored loop (regression contract held).
- [x] All `while_runtime` tests pass (gated state machine semantics unchanged).
- [x] Structural signpost test confirms `LoopExit` variants are exhaustive over clean exits.
- [x] Closure-idempotency test confirms drain semantic prevents double-emit.
- [x] Non-gated scenario test family runs clean.
- [x] End-to-end smoke: `sonda-server -F remote-write` with a workshop-shape cascade YAML, mock HTTP receiver — server boots, scenarios reach `finished`, no errors.
- [ ] CI green on this PR.
- [ ] release-please cuts the next patch version.
- [ ] After image lands on ghcr: bump `SONDA_IMAGE` default in workshops repo.
- [ ] Close [#325](https://github.com/davidban77/sonda/pull/325) (superseded).