### PR TITLE
docs(scenarios): recommend snap_to for remote_write integrations

### DIFF
--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -543,6 +543,22 @@ Setting both `snap_to` and `stale_marker: false` is a config error — `snap_to`
 
 A brief close that gets cancelled by a fresh `WhileOpen` arriving inside the `delay.close.duration` debounce window emits nothing — the gate stayed open. A scenario that hits its `duration:` while already paused goes `paused → finished` without an additional close-emit; the buffer was already flushed on the earlier `running → paused` transition. The recently-active tuple set is sourced from a runtime buffer capped at 100 events; high-cardinality scenarios that exceed this ceiling under-emit on close. Track scenarios with more than ~100 distinct label sets via per-scenario `/stats` rather than relying on close-emit alone.
 
+#### Prefer `snap_to:` for `remote_write` integrations
+
+The default stale-marker behavior depends on how the receiving Prometheus handles stale-NaN samples ingested via remote-write. Some Prometheus configurations accept the marker into TSDB but do not propagate stale-marker semantics through the query engine for remote-write-ingested samples the way they do for scraped samples. The series stays "live" with the pre-pause value until natural `query.lookback-delta` expiry (around 5 minutes by default), and the alert clearance you expect on the next scrape cycle does not happen.
+
+If your alerts are not clearing as expected on gate close, prefer `snap_to:` with an explicit recovery value over the default stale marker. The recovery sample is a normal Prometheus sample — stored and queried with consistent semantics across receiver versions and configurations — so the next evaluation sees the recovered value directly and clears the alert immediately.
+
+```yaml title="Recommended for remote_write: explicit recovery value"
+    delay:
+      open: 250ms
+      close:
+        duration: 5s
+        snap_to: 1            # bgp_oper_state=1 means "up"
+```
+
+The tradeoff is per-metric specificity: `snap_to:` requires you to choose a recovery value for each gated metric, which is reasonable for operator-facing signals where "healthy" has an obvious value (`bgp_oper_state=1`, `interface_oper_state=1`, error counters back to `0`). The default `stale_marker` is generic and needs no per-metric tuning, but its end-to-end effect is receiver-dependent. For pipelines that ingest into Prometheus via `remote_write` and drive alerting off the result, `snap_to:` is the more reliable default.
+
 ### Combining with `after:`
 
 `after:` and `while:` compose on the same entry. `after:` defers the scenario's first emission until an upstream crosses a threshold; `while:` then continuously gates the entry on every later edge. Pair them when a downstream should wait for a triggering event AND track the upstream's state thereafter -- a BGP session that opens once a link drops, then pauses every time the link briefly recovers.


### PR DESCRIPTION
## Summary

Adds a recommendation in the \`delay.close\` recovery docs explaining that the default stale-NaN marker is reliable on the wire but receiver-dependent at query time, and recommending \`snap_to:\` with an explicit recovery value as the more reliable default for \`remote_write\` integrations.

## Why

Sonda emits the Prometheus stale-NaN sample (\`0x7ff0000000000002\`) on \`running → paused\` transitions for \`remote_write\` sinks. The bytes leave the process correctly, the receiving Prometheus accepts the POST with HTTP 204, and the marker is stored in TSDB. But on some Prometheus configurations the query engine does not propagate stale-marker semantics through to alert evaluation for samples ingested via remote-write the way it does for scraped samples — series stays live with the pre-pause value until the natural \`query.lookback-delta\` window (~5min default) closes.

\`snap_to:\` writes a regular Prometheus sample with an explicit recovery value (\`bgp_oper_state=1\` for "up", error counters back to \`0\`, etc.). Regular samples have consistent ingest-and-query semantics across receiver versions and configurations. The cost is per-metric specificity — operators choose what "healthy" looks like for each gated series — but for operator-facing signals the answer is usually obvious.

## What changes

One new \`####\` subsection ("Prefer \`snap_to:\` for \`remote_write\` integrations") at the end of the existing "Recovering Prometheus alerts on gate close" section in \`docs/site/docs/configuration/v2-scenarios.md\`. The new subsection covers:

- Why the default \`stale_marker\` behavior depends on the receiver
- The recommendation: prefer \`snap_to:\` with an explicit recovery value
- The tradeoff: per-metric specificity vs receiver-independence
- A copy-pasteable YAML example using \`bgp_oper_state=1\` as the recovery value

No changes to existing prose. The receiver-independence guidance lives alongside the existing \`stale_marker\` / \`snap_to\` / \`stale_marker: false\` walkthroughs without disturbing them.

## Backward compatibility

Docs-only. No code, schema, or config changes. The default \`stale_marker\` behavior is unchanged — operators who are happy with it (and whose receivers handle remote-write stale-NaN consistently) continue to get it implicitly.

## Quality gates

| Gate | Result |
|---|---|
| \`task site:build\` (mkdocs --strict) | PASS, no warnings |
| Existing anchor \`#recovering-prometheus-alerts-on-gate-close\` | unchanged, still resolves |

## Test plan

- [x] mkdocs --strict builds clean.
- [x] New subsection slug-anchors as \`#prefer-snap_to-for-remote_write-integrations\`, no collision with existing anchors.
- [x] Paragraphs are single long lines, matching the rest of the page.
- [x] No internal-history references, version refs, or PR/issue links in the new prose.
- [ ] CI green on this PR.