### PR TITLE
fix(core): bump close-emit timestamp past most recent active emission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.6.1"
+version = "1.6.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.6.1"
+version = "1.6.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.6.1"
+version = "1.6.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -543,6 +543,8 @@ Setting both `snap_to` and `stale_marker: false` is a config error — `snap_to`
 
 A brief close that gets cancelled by a fresh `WhileOpen` arriving inside the `delay.close.duration` debounce window emits nothing — the gate stayed open. A scenario that hits its `duration:` while already paused goes `paused → finished` without an additional close-emit; the buffer was already flushed on the earlier `running → paused` transition. The recently-active tuple set is sourced from a runtime buffer capped at 100 events; high-cardinality scenarios that exceed this ceiling under-emit on close. Track scenarios with more than ~100 distinct label sets via per-scenario `/stats` rather than relying on close-emit alone.
 
+Close-emit timestamps are strictly greater than the most recent active-emission timestamp for the same series. This avoids duplicate-timestamp rejection at the receiver — Prometheus and other TSDBs that dedup on `(series, timestamp)` would otherwise drop the recovery sample silently.
+
 #### Prefer `snap_to:` for `remote_write` integrations
 
 The default stale-marker behavior depends on how the receiving Prometheus handles stale-NaN samples ingested via remote-write. Some Prometheus configurations accept the marker into TSDB but do not propagate stale-marker semantics through the query engine for remote-write-ingested samples the way they do for scraped samples. The series stays "live" with the pre-pause value until natural `query.lookback-delta` expiry (around 5 minutes by default), and the alert clearance you expect on the next scrape cycle does not happen.

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -9,7 +9,7 @@
 
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use crate::config::ScenarioConfig;
 use crate::encoder::create_encoder;
@@ -251,6 +251,16 @@ fn make_close_emitter(
             Err(p) => p.into_inner().recent_metrics.drain(..).collect(),
         };
 
+        // Strictly greater than the most recent active-emission ts so receivers
+        // that dedup on (series, ts) at ms precision do not drop the marker.
+        let close_ts = match recent.iter().map(|e| e.timestamp).max() {
+            Some(max_recent) => match max_recent.checked_add(Duration::from_millis(1)) {
+                Some(bumped) => now.max(bumped),
+                None => now,
+            },
+            None => now,
+        };
+
         let mut seen: Vec<MetricEvent> = Vec::new();
         'outer: for event in &recent {
             for kept in &seen {
@@ -267,8 +277,12 @@ fn make_close_emitter(
         let mut buf: Vec<u8> = Vec::with_capacity(256);
         for event in seen {
             buf.clear();
-            let marker =
-                MetricEvent::from_parts(event.name.clone(), value, Arc::clone(&event.labels), now);
+            let marker = MetricEvent::from_parts(
+                event.name.clone(),
+                value,
+                Arc::clone(&event.labels),
+                close_ts,
+            );
             encoder.encode_metric(&marker, &mut buf)?;
             sink.write(&buf)?;
         }
@@ -1310,5 +1324,70 @@ mod tests {
             second.buffer.is_empty(),
             "second invocation with no new tuples must emit nothing"
         );
+    }
+
+    #[test]
+    fn close_emit_timestamp_strictly_after_recent_active_emissions() {
+        use crate::encoder::create_encoder;
+        use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
+        use crate::schedule::core_loop::CloseSignal;
+        use crate::schedule::stats::ScenarioStats;
+        use crate::sink::memory::MemorySink;
+        use std::sync::{Arc, RwLock};
+        use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+        let past_ts = UNIX_EPOCH + Duration::from_millis(1_700_000_000_000);
+        let future_ts = SystemTime::now() + Duration::from_secs(60);
+
+        let stats = Arc::new(RwLock::new(ScenarioStats::default()));
+        {
+            let mut st = stats.write().unwrap();
+            let name = ValidatedMetricName::new("up").unwrap();
+            let labels_a = Arc::new(Labels::from_pairs(&[("host", "a")]).unwrap());
+            let labels_b = Arc::new(Labels::from_pairs(&[("host", "b")]).unwrap());
+            st.push_metric(MetricEvent::from_parts(
+                name.clone(),
+                1.0,
+                labels_a,
+                past_ts,
+            ));
+            st.push_metric(MetricEvent::from_parts(name, 1.0, labels_b, future_ts));
+        }
+
+        let encoder = create_encoder(&EncoderConfig::PrometheusText { precision: None }).unwrap();
+        let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
+
+        let mut sink = MemorySink::new();
+        emit(&mut sink).expect("close-emit must succeed");
+
+        let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
+        let lines: Vec<&str> = output.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(
+            lines.len(),
+            2,
+            "expected one marker line per distinct (name, labels) tuple, got: {output}"
+        );
+
+        let past_ms = past_ts.duration_since(UNIX_EPOCH).unwrap().as_millis() as i128;
+        let future_ms = future_ts.duration_since(UNIX_EPOCH).unwrap().as_millis() as i128;
+
+        for line in &lines {
+            let ts_str = line
+                .rsplit(' ')
+                .next()
+                .expect("Prometheus text line must end with a timestamp token");
+            let close_ms: i128 = ts_str
+                .parse()
+                .unwrap_or_else(|_| panic!("close ts must parse as i128, line: {line}"));
+
+            assert!(
+                close_ms > past_ms,
+                "close ts {close_ms} must be strictly greater than past active ts {past_ms}; line: {line}"
+            );
+            assert!(
+                close_ms > future_ms,
+                "close ts {close_ms} must be strictly greater than future active ts {future_ms}; line: {line}"
+            );
+        }
     }
 }

--- a/sonda-core/tests/while_close_workshop_repro.rs
+++ b/sonda-core/tests/while_close_workshop_repro.rs
@@ -1391,3 +1391,227 @@ scenarios:
             .collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn workshop_close_emit_timestamp_strictly_greater_than_active_emissions() {
+    let (url, captured, stop_listener) = spawn_capture_listener();
+
+    let yaml = format!(
+        r#"
+version: 2
+scenario_name: workshop-close-emit-snap-to-ts-ordering
+defaults:
+  rate: 50
+  duration: 1500ms
+  encoder:
+    type: remote_write
+  sink:
+    type: remote_write
+    url: "{url}"
+    batch_size: 1
+scenarios:
+  - id: primary_flap
+    signal_type: metrics
+    name: interface_oper_state
+    generator:
+      type: flap
+      up_duration: 200ms
+      down_duration: 400ms
+      enum: oper_state
+  - id: bgp_oper_state_down
+    signal_type: metrics
+    name: bgp_oper_state
+    generator:
+      type: constant
+      value: 99.0
+    while:
+      ref: primary_flap
+      op: ">"
+      value: 1
+    delay:
+      open: 50ms
+      close:
+        duration: 0s
+        snap_to: 0.0
+    labels:
+      peer_address: "10.1.2.2"
+"#
+    );
+
+    let resolver = InMemoryPackResolver::new();
+    let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
+
+    let shutdown = Arc::new(AtomicBool::new(true));
+    let handles =
+        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+    assert_eq!(handles.len(), 2, "must launch primary + downstream");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut handles = handles;
+    while Instant::now() < deadline && handles.iter().any(|h| h.is_alive()) {
+        thread::sleep(Duration::from_millis(50));
+    }
+    for handle in &mut handles {
+        handle
+            .join(Some(Duration::from_secs(2)))
+            .expect("thread join");
+    }
+
+    thread::sleep(Duration::from_millis(200));
+    stop_listener.store(true, std::sync::atomic::Ordering::SeqCst);
+
+    let captured = captured.lock().unwrap().clone();
+
+    // Partition relies on `constant: 99.0` from the scenario; any future change to the scenario's active value must update this test.
+    let mut active_ts: Vec<i64> = Vec::new();
+    let mut close_ts: Vec<i64> = Vec::new();
+    for (_arrival, ts) in &captured {
+        if label_value(ts, "__name__") != Some("bgp_oper_state") {
+            continue;
+        }
+        for s in &ts.samples {
+            if s.value == 99.0 {
+                active_ts.push(s.timestamp);
+            } else if s.value == 0.0 {
+                close_ts.push(s.timestamp);
+            }
+        }
+    }
+
+    assert!(
+        !active_ts.is_empty(),
+        "expected at least one active-emission sample (value=99.0) for bgp_oper_state"
+    );
+    assert!(
+        !close_ts.is_empty(),
+        "expected at least one close-edge sample (value=0.0 from snap_to) for bgp_oper_state"
+    );
+
+    assert_close_ts_strictly_after_preceding_actives(&active_ts, &close_ts);
+}
+
+#[test]
+fn workshop_close_emit_stale_marker_timestamp_strictly_greater_than_active_emissions() {
+    let (url, captured, stop_listener) = spawn_capture_listener();
+
+    let yaml = format!(
+        r#"
+version: 2
+scenario_name: workshop-close-emit-stale-marker-ts-ordering
+defaults:
+  rate: 50
+  duration: 1500ms
+  encoder:
+    type: remote_write
+  sink:
+    type: remote_write
+    url: "{url}"
+    batch_size: 1
+scenarios:
+  - id: primary_flap
+    signal_type: metrics
+    name: interface_oper_state
+    generator:
+      type: flap
+      up_duration: 200ms
+      down_duration: 400ms
+      enum: oper_state
+  - id: bgp_oper_state_down
+    signal_type: metrics
+    name: bgp_oper_state
+    generator:
+      type: constant
+      value: 99.0
+    while:
+      ref: primary_flap
+      op: ">"
+      value: 1
+    delay:
+      open: 50ms
+      close: 0s
+    labels:
+      peer_address: "10.1.2.2"
+"#
+    );
+
+    let resolver = InMemoryPackResolver::new();
+    let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
+
+    let shutdown = Arc::new(AtomicBool::new(true));
+    let handles =
+        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+    assert_eq!(handles.len(), 2, "must launch primary + downstream");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut handles = handles;
+    while Instant::now() < deadline && handles.iter().any(|h| h.is_alive()) {
+        thread::sleep(Duration::from_millis(50));
+    }
+    for handle in &mut handles {
+        handle
+            .join(Some(Duration::from_secs(2)))
+            .expect("thread join");
+    }
+
+    thread::sleep(Duration::from_millis(200));
+    stop_listener.store(true, std::sync::atomic::Ordering::SeqCst);
+
+    let captured = captured.lock().unwrap().clone();
+
+    // Partition relies on `constant: 99.0` from the scenario; any future change to the scenario's active value must update this test.
+    let mut active_ts: Vec<i64> = Vec::new();
+    let mut stale_ts: Vec<i64> = Vec::new();
+    for (_arrival, ts) in &captured {
+        if label_value(ts, "__name__") != Some("bgp_oper_state") {
+            continue;
+        }
+        for s in &ts.samples {
+            if s.value.to_bits() == PROMETHEUS_STALE_NAN.to_bits() {
+                stale_ts.push(s.timestamp);
+            } else if s.value == 99.0 {
+                active_ts.push(s.timestamp);
+            }
+        }
+    }
+
+    assert!(
+        !active_ts.is_empty(),
+        "expected at least one active-emission sample (value=99.0) for bgp_oper_state"
+    );
+    assert!(
+        !stale_ts.is_empty(),
+        "expected at least one stale-marker close-edge sample for bgp_oper_state"
+    );
+
+    assert_close_ts_strictly_after_preceding_actives(&active_ts, &stale_ts);
+}
+
+fn assert_close_ts_strictly_after_preceding_actives(active_ts: &[i64], close_ts: &[i64]) {
+    let mut events: Vec<(i64, bool)> = Vec::with_capacity(active_ts.len() + close_ts.len());
+    for &t in active_ts {
+        events.push((t, false));
+    }
+    for &t in close_ts {
+        events.push((t, true));
+    }
+    // On equal ts, sort actives before closes so a same-ms collision surfaces as a violation.
+    events.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+
+    let mut max_active_in_batch: Option<i64> = None;
+    for (ts, is_close) in events {
+        if is_close {
+            if let Some(prev_active) = max_active_in_batch {
+                assert!(
+                    ts > prev_active,
+                    "close-edge ts {ts} must be strictly greater than the most recent active-emission ts {prev_active} in the same batch; active_ts={active_ts:?} close_ts={close_ts:?}"
+                );
+            }
+            max_active_in_batch = None;
+        } else {
+            max_active_in_batch = Some(match max_active_in_batch {
+                Some(prev) => prev.max(ts),
+                None => ts,
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary

In `make_close_emitter`'s closure, `SystemTime::now()` for the marker timestamp can land in the same millisecond as the last active-emission tick. Both samples then carry the same ms-precision timestamp; remote_write batches them as duplicates; receivers that dedup on `(series, timestamp)` reject the second sample silently.

For Prometheus, the failure mode is invisible at every layer the operator can see: HTTP 204 returned, OOO counter stays 0 (timestamp isn't strictly older), no 4xx, no log line. The recovery sample is dropped at ingest. Downstream alerts hang to natural `query.lookback-delta` (~5min) instead of clearing on the next scrape cycle.

This patch makes close-emit timestamps strictly greater than every active-emission sample's timestamp for the same series in the drained buffer. Encoder-agnostic — +1ms is the Prometheus remote-write wire quantum (i64 millis) and remains strictly greater for OTLP/Influx encoders that carry sub-ms precision.

## What changes

- **`sonda-core::schedule::runner::make_close_emitter`** — after the drain, compute `close_ts = now.max(max_recent + 1ms)` over the drained buffer's max timestamp. Use `close_ts` instead of bare `now` when constructing each marker via `MetricEvent::from_parts`. `use std::time::Duration;` added to imports.
- **Edge cases**: empty drain (Pending → Finished) → bare `now` (no collision risk); `now > max+1ms` → `now` (clock advanced past tick); `now ≤ max` → `bumped`; `checked_add` overflow → bare `now` (practically unreachable, year 292277...).
- **Tests** — three new tests:
  - Unit: `close_emit_timestamp_strictly_after_recent_active_emissions` (in `runner.rs::tests`) — pushes events with far-past AND far-future timestamps to exercise both `now > bumped` and `now < bumped` branches in one test.
  - Integration: `workshop_close_emit_timestamp_strictly_greater_than_active_emissions` (in `tests/while_close_workshop_repro.rs`) — drives the workshop's snap_to scenario through `multi_runner::launch_multi_compiled` against a TCP listener, asserts per-batch close-edge sample timestamps strictly exceed preceding active-emission timestamps in the same series.
  - Integration: `workshop_close_emit_stale_marker_timestamp_strictly_greater_than_active_emissions` — same shape for the default stale-marker path (NaN bit pattern identifies the close-edge sample).
  - Both integration tests share a helper that merges and sorts samples by `(ts, is_close)` with actives-before-closes tie-breaking on same-ms timestamps. The tie-breaking is load-bearing: same-ms collisions (the original bug) surface as assertion failures.
- **Doc** — one new standalone paragraph in `docs/site/docs/configuration/v2-scenarios.md`, documenting the timestamp guarantee:
  > Close-emit timestamps are strictly greater than the most recent active-emission timestamp for the same series. This avoids duplicate-timestamp rejection at the receiver — Prometheus and other TSDBs that dedup on `(series, timestamp)` would otherwise drop the recovery sample silently.

## Behavior matrix

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| Active tick at `T_ms`, close-emit fires at `T_ms` | Both samples ts=`T_ms`. Receiver drops one. | Active ts=`T_ms`, close ts=`T_ms+1ms`. Both stored. |
| Active tick at `T_ms`, close-emit fires at `T_ms + 5ms` | Both stored (no collision). | Both stored — close ts is bare `now` (= `T_ms + 5ms`). Same wire as pre-fix. |
| No active emissions before close-emit (Pending → Finished) | Bare `now` used. | Bare `now` used (empty drain → `None` arm). Same. |
| Clock skew: `now` jumps backward to before max_recent | Backwards-going timestamp. | `max_recent + 1ms` (forward-progressing). Strictly better. |

No backward compatibility break — no public API changes, no schema changes, no new dependencies. The receiver behavior visible to operators is improved (recovery samples now consistently land in TSDB) and unchanged for the no-collision case.

## Backward compatibility

- No public API change. `make_close_emitter` signature, `CloseSignal` enum, `CloseEmitFn` type alias all unchanged.
- No schema, CLI, or config change.
- No new dependencies.
- Cargo.lock workspace-version refresh (1.6.1 → 1.6.3) catching the lockfile up to `Cargo.toml`. No dep changes.

## Out of scope

- Stale-marker close-emit on log/histogram/summary runners ([#321](https://github.com/davidban77/sonda/issues/321) polish item).
- Receiver-side dedup variations across Prometheus versions (the `snap_to:` recommendation in the docs covers the receiver-independence case).

## Quality gates

| Gate | Result |
|---|---|
| `cargo build --workspace --all-features` | PASS |
| `cargo nextest run --workspace --all-features` | 3046/3046 PASS, 3 skipped (+3 new tests) |
| `cargo test --workspace --doc` | 5/5 PASS |
| `cargo clippy --workspace --all-features -- -D warnings` | PASS |
| `cargo fmt --all -- --check` | PASS |
| `cargo audit` | PASS (1 pre-existing allowed) |
| `cargo test -p sonda-core --no-default-features` | PASS (1173 unit tests + 4 doctests) |
| `mkdocs build --strict` | PASS |

## Test plan

- [x] All 3 new tests pass with `--features remote-write --features config`.
- [x] All existing tests in `while_close_workshop_repro.rs` and `while_close_stale_marker.rs` still pass unchanged.
- [x] Non-gated scenario test family runs clean (the +1ms bump only affects close-emit; non-gated entries don't carry one).
- [x] End-to-end smoke through `sonda-server` binary with the workshop's cascade YAML — server boots, scenarios reach `finished`, no errors.
- [ ] CI green on this PR.
- [ ] release-please cuts v1.6.4.
- [ ] After image lands on ghcr: workshop merges PR #31 (revert duration workaround), bumps `SONDA_IMAGE` to 1.6.4, demo unblocks.