### PR TITLE
fix(sink): time-based flush for batching sinks (#297)

### DIFF
--- a/docs/site/docs/configuration/sink-batching.md
+++ b/docs/site/docs/configuration/sink-batching.md
@@ -1,8 +1,26 @@
 # Sink Batching
 
-When you run a Sonda scenario, you might notice that metrics appear in chunks on stdout, or that
-data shows up in VictoriaMetrics in bursts rather than one point at a time. This is batching at
-work -- and it is intentional.
+When you run a Sonda scenario, you might notice that metrics appear in chunks on stdout, or that data shows up in VictoriaMetrics in bursts rather than one point at a time. This is batching at work -- and it is intentional.
+
+## What batching is
+
+A **sink** is where your generated telemetry goes -- your terminal, a file, or a backend like Loki or VictoriaMetrics. Some network sinks (`loki`, `http_push`, `remote_write`, `otlp_grpc`, `kafka`) are *batching* sinks: instead of making one network call per event, they pile events into a buffer and send them together. One big request beats a thousand tiny ones -- that is the efficiency win.
+
+The moment a batching sink empties its buffer and actually sends the events is called a **flush**. So the question every batching sink has to answer is: *when do I flush?*
+
+## When a sink flushes
+
+A batching sink flushes when any one of these triggers trips -- whichever comes first:
+
+```
+A batch flushes when ANY of these trips (whichever first)
+
+  1. SIZE      -- buffer fills to batch_size
+  2. TIME      -- buffer is older than max_buffer_age
+  3. SHUTDOWN  -- the scenario ends
+```
+
+`batch_size` is the size threshold. `max_buffer_age` is the time threshold. The rest of this page walks through both -- but the short version is: a batch can never get larger than `batch_size`, nor staler than `max_buffer_age`.
 
 ## Why batching exists
 
@@ -117,7 +135,34 @@ Four sinks let you tune the batch threshold via the `batch_size` field in the si
 
 `batch_size` alone has a blind spot: a low-rate scenario. If you generate one log line every 20 seconds and `batch_size` is 5 entries, the buffer takes over a minute and a half to fill -- and nothing reaches the backend until it does. To anyone watching Loki or VictoriaMetrics, that looks like a broken pipeline.
 
+Here is that blind spot as a timeline. The scenario produces one event every ~4 seconds with `batch_size: 5`:
+
+```
+SIZE-ONLY FLUSHING -- buffer flushes only when FULL or at shutdown
+
+ events arrive:   e.....e.....e.....e.....e.....e.....e.....
+ buffer count:    1     2     3     4     5 -FLUSH          ...
+ backend sees:    ........................[5 events arrive]
+                  '------ ~20s of total silence ------'
+                       "is my pipeline broken?"
+```
+
 `max_buffer_age` closes that gap. It is a *time* threshold that complements the *size* threshold: a non-empty batch is flushed once it has been buffered longer than `max_buffer_age`, in addition to the existing size-triggered and shutdown flushes. Whichever threshold trips first wins -- the batch can never get larger than `batch_size` or staler than `max_buffer_age`.
+
+Same scenario, same low event rate, now with `max_buffer_age: 5s`:
+
+```
+WITH max_buffer_age -- buffer also flushes when its contents get older than max_buffer_age
+
+ events arrive:   e.....e.....e.....e.....e.....e.....e.....
+ buffer:          1  2 |     1  2 |     1  2 |     1 ...
+                       'FLUSH     'FLUSH     'FLUSH
+                     (age>5s)   (age>5s)   (age>5s)
+ backend sees:    .....#......#......#......#......#
+                  '-- data every ~5s, not every ~20s --'
+```
+
+The batch never fills to `batch_size` at this rate, so the size trigger never fires -- but the time trigger does. Low-rate scenarios deliver promptly instead of buffering invisibly.
 
 `max_buffer_age` is supported by all five application-level sinks -- `http_push`, `loki`, `remote_write`, `otlp_grpc`, and `kafka`. It accepts a duration string -- `"5s"`, `"500ms"`, `"2m"` -- and **defaults to `5s`** when omitted, so low-rate scenarios get prompt first delivery with zero configuration.
 

--- a/docs/site/docs/configuration/sink-batching.md
+++ b/docs/site/docs/configuration/sink-batching.md
@@ -22,10 +22,10 @@ Sonda has two kinds of batching depending on the sink type:
 | `tcp` | OS-level (`BufWriter`) | ~8 KB (fixed) | -- | bytes |
 | `udp` | None (immediate) | -- | -- | -- |
 | `http_push` | Application-level | 4 KiB (configurable) | `5s` (configurable) | bytes |
-| `kafka` | Application-level | 64 KiB (fixed) | -- | bytes |
+| `kafka` | Application-level | 64 KiB (fixed) | `5s` (configurable) | bytes |
 | `loki` | Application-level | 5 entries (configurable) | `5s` (configurable) | entries |
 | `remote_write` | Application-level | 5 entries (configurable) | `5s` (configurable) | entries |
-| `otlp_grpc` | Application-level | 5 entries (configurable) | -- | entries |
+| `otlp_grpc` | Application-level | 5 entries (configurable) | `5s` (configurable) | entries |
 
 ### OS-level buffering (stdout, file, tcp)
 
@@ -45,7 +45,7 @@ Kafka record, or gRPC call.
 This means data does not appear at the destination until one of these happens:
 
 1. The batch fills up and triggers a size-based flush,
-2. A non-empty batch ages past its time threshold and triggers a [time-based flush](#time-based-flushing) (`http_push`, `loki`, `remote_write` only), or
+2. A non-empty batch ages past its time threshold and triggers a [time-based flush](#time-based-flushing) (all five application-level sinks), or
 3. The scenario completes and Sonda flushes the remaining partial batch.
 
 ### No batching (udp)
@@ -119,7 +119,7 @@ Four sinks let you tune the batch threshold via the `batch_size` field in the si
 
 `max_buffer_age` closes that gap. It is a *time* threshold that complements the *size* threshold: a non-empty batch is flushed once it has been buffered longer than `max_buffer_age`, in addition to the existing size-triggered and shutdown flushes. Whichever threshold trips first wins -- the batch can never get larger than `batch_size` or staler than `max_buffer_age`.
 
-`max_buffer_age` is supported by the `http_push`, `loki`, and `remote_write` sinks. It accepts a duration string -- `"5s"`, `"500ms"`, `"2m"` -- and **defaults to `5s`** when omitted, so low-rate scenarios get prompt first delivery with zero configuration.
+`max_buffer_age` is supported by all five application-level sinks -- `http_push`, `loki`, `remote_write`, `otlp_grpc`, and `kafka`. It accepts a duration string -- `"5s"`, `"500ms"`, `"2m"` -- and **defaults to `5s`** when omitted, so low-rate scenarios get prompt first delivery with zero configuration.
 
 ```yaml title="Low-rate scenario with explicit time threshold"
 version: 2

--- a/docs/site/docs/configuration/sink-batching.md
+++ b/docs/site/docs/configuration/sink-batching.md
@@ -15,17 +15,17 @@ throughput.
 
 Sonda has two kinds of batching depending on the sink type:
 
-| Sink | Batching | Default Threshold | Configurable? | Unit |
-|------|----------|-------------------|---------------|------|
-| `stdout` | OS-level (`BufWriter`) | ~8 KB | No | bytes |
-| `file` | OS-level (`BufWriter`) | ~8 KB | No | bytes |
-| `tcp` | OS-level (`BufWriter`) | ~8 KB | No | bytes |
+| Sink | Batching | Size Threshold | Time Threshold | Unit |
+|------|----------|----------------|----------------|------|
+| `stdout` | OS-level (`BufWriter`) | ~8 KB (fixed) | -- | bytes |
+| `file` | OS-level (`BufWriter`) | ~8 KB (fixed) | -- | bytes |
+| `tcp` | OS-level (`BufWriter`) | ~8 KB (fixed) | -- | bytes |
 | `udp` | None (immediate) | -- | -- | -- |
-| `http_push` | Application-level | 4 KiB | Yes | bytes |
-| `kafka` | Application-level | 64 KiB | No | bytes |
-| `loki` | Application-level | 5 entries | Yes | entries |
-| `remote_write` | Application-level | 5 entries | Yes | entries |
-| `otlp_grpc` | Application-level | 5 entries | Yes | entries |
+| `http_push` | Application-level | 4 KiB (configurable) | `5s` (configurable) | bytes |
+| `kafka` | Application-level | 64 KiB (fixed) | -- | bytes |
+| `loki` | Application-level | 5 entries (configurable) | `5s` (configurable) | entries |
+| `remote_write` | Application-level | 5 entries (configurable) | `5s` (configurable) | entries |
+| `otlp_grpc` | Application-level | 5 entries (configurable) | -- | entries |
 
 ### OS-level buffering (stdout, file, tcp)
 
@@ -42,10 +42,11 @@ These sinks manage their own internal buffer. Each call to `write()` appends dat
 When the buffer reaches the configured threshold, the entire batch is sent as a single HTTP POST,
 Kafka record, or gRPC call.
 
-This means data does not appear at the destination until either:
+This means data does not appear at the destination until one of these happens:
 
-1. The batch fills up and triggers an automatic flush, or
-2. The scenario completes and Sonda flushes the remaining partial batch.
+1. The batch fills up and triggers a size-based flush,
+2. A non-empty batch ages past its time threshold and triggers a [time-based flush](#time-based-flushing) (`http_push`, `loki`, `remote_write` only), or
+3. The scenario completes and Sonda flushes the remaining partial batch.
 
 ### No batching (udp)
 
@@ -67,11 +68,6 @@ Four sinks let you tune the batch threshold via the `batch_size` field in the si
       content_type: "text/plain"
       batch_size: 65536  # 64 KiB -- fewer requests at thousands of events/s
     ```
-
-    !!! info "Roadmap"
-        A `flush_interval` field
-        ([#266](https://github.com/davidban77/sonda/issues/266)) will let a partial batch
-        flush on a wall-clock deadline regardless of buffer fill.
 
 === "remote_write"
 
@@ -116,6 +112,58 @@ Four sinks let you tune the batch threshold via the `batch_size` field in the si
     network overhead. For debugging and development, use small batches (e.g., `batch_size: 1`
     for http_push) to see data arrive immediately. For load testing, keep the defaults or
     increase them to reduce request volume.
+
+## Time-based flushing
+
+`batch_size` alone has a blind spot: a low-rate scenario. If you generate one log line every 20 seconds and `batch_size` is 5 entries, the buffer takes over a minute and a half to fill -- and nothing reaches the backend until it does. To anyone watching Loki or VictoriaMetrics, that looks like a broken pipeline.
+
+`max_buffer_age` closes that gap. It is a *time* threshold that complements the *size* threshold: a non-empty batch is flushed once it has been buffered longer than `max_buffer_age`, in addition to the existing size-triggered and shutdown flushes. Whichever threshold trips first wins -- the batch can never get larger than `batch_size` or staler than `max_buffer_age`.
+
+`max_buffer_age` is supported by the `http_push`, `loki`, and `remote_write` sinks. It accepts a duration string -- `"5s"`, `"500ms"`, `"2m"` -- and **defaults to `5s`** when omitted, so low-rate scenarios get prompt first delivery with zero configuration.
+
+```yaml title="Low-rate scenario with explicit time threshold"
+version: 2
+
+defaults:
+  rate: 0.05  # one event every 20 seconds
+  encoder:
+    type: json_lines
+
+scenarios:
+  - signal_type: logs
+    name: slow_audit_logs
+    log_generator:
+      type: template
+      templates:
+        - message: "user {user} performed {action}"
+          field_pools:
+            user: ["alice", "bob"]
+            action: ["login", "logout"]
+    sink:
+      type: loki
+      url: "http://localhost:3100"
+      batch_size: 100        # size threshold -- rarely reached at this rate
+      max_buffer_age: "30s"  # time threshold -- flush a partial batch every 30s
+    labels:
+      job: sonda
+      env: dev
+```
+
+### Disabling time-based flushing
+
+Set `max_buffer_age: "0s"` to turn time-based flushing off. The sink reverts to size-and-shutdown-only flushing -- the behavior you get from `batch_size` by itself. This is the opt-out for high-rate streams that fill a batch in well under five seconds anyway and do not need the extra flush path.
+
+```yaml title="Disable time-based flushing for a high-rate stream"
+sink:
+  type: http_push
+  url: "http://localhost:8428/api/v1/import/prometheus"
+  content_type: "text/plain"
+  batch_size: 65536
+  max_buffer_age: "0s"  # size-and-shutdown flushing only
+```
+
+!!! info "The age is checked on write"
+    `max_buffer_age` is evaluated each time an event is written to the sink. If a sink stops receiving writes entirely -- for example during a long scenario `gap` -- a partially-full batch will not flush until the next write arrives or the scenario stops. This is expected: the timer is driven by writes, not by a background clock.
 
 ## Flush on exit
 

--- a/docs/site/docs/configuration/sinks.md
+++ b/docs/site/docs/configuration/sinks.md
@@ -87,7 +87,8 @@ batch size is reached, then the buffer is flushed as a single POST request.
 |-----------|------|----------|---------|-------------|
 | `url` | string | yes | -- | Target URL for HTTP POST requests. |
 | `content_type` | string | no | `application/octet-stream` | Value for the `Content-Type` header. |
-| `batch_size` | integer | no | `4096` (4 KiB) | Flush threshold in bytes. Raise for high-rate scenarios. |
+| `batch_size` | integer | no | `4096` (4 KiB) | Size flush threshold in bytes. Raise for high-rate scenarios. |
+| `max_buffer_age` | duration string | no | `5s` | Time flush threshold. A non-empty batch is flushed once it has been buffered longer than this. Set `"0s"` to disable. See [Sink Batching](sink-batching.md#time-based-flushing). |
 | `headers` | map | no | none | Extra HTTP headers sent with every request. |
 
 ```yaml title="HTTP push sink"
@@ -146,7 +147,8 @@ HTTP POSTs with the correct protocol headers.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `url` | string | yes | -- | Remote write endpoint URL. |
-| `batch_size` | integer | no | `5` | Flush threshold in number of TimeSeries entries. Raise for high-rate scenarios. |
+| `batch_size` | integer | no | `5` | Size flush threshold in number of TimeSeries entries. Raise for high-rate scenarios. |
+| `max_buffer_age` | duration string | no | `5s` | Time flush threshold. A non-empty batch is flushed once it has been buffered longer than this. Set `"0s"` to disable. See [Sink Batching](sink-batching.md#time-based-flushing). |
 
 ```yaml title="Remote write sink"
 encoder:
@@ -368,7 +370,8 @@ labels are used as Loki stream labels in the push API envelope.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `url` | string | yes | -- | Base URL of the Loki instance. |
-| `batch_size` | integer | no | `5` | Flush threshold in number of log entries. Raise for high-rate scenarios. |
+| `batch_size` | integer | no | `5` | Size flush threshold in number of log entries. Raise for high-rate scenarios. |
+| `max_buffer_age` | duration string | no | `5s` | Time flush threshold. A non-empty batch is flushed once it has been buffered longer than this. Set `"0s"` to disable. See [Sink Batching](sink-batching.md#time-based-flushing). |
 
 ```yaml title="Loki sink with top-level labels"
 version: 2

--- a/docs/site/docs/configuration/sinks.md
+++ b/docs/site/docs/configuration/sinks.md
@@ -190,6 +190,7 @@ static binary compatibility -- no C dependencies or OpenSSL required.
 |-----------|------|----------|---------|-------------|
 | `brokers` | string | yes | -- | Comma-separated broker addresses (e.g. `"broker1:9092,broker2:9092"`). |
 | `topic` | string | yes | -- | Kafka topic name. |
+| `max_buffer_age` | duration string | no | `5s` | Time flush threshold. A non-empty batch is flushed once it has been buffered longer than this. Set `"0s"` to disable. See [Sink Batching](sink-batching.md#time-based-flushing). |
 | `tls` | object | no | none | TLS encryption settings. See [TLS](#kafka-tls). |
 | `sasl` | object | no | none | SASL authentication settings. See [SASL](#kafka-sasl). |
 
@@ -207,10 +208,7 @@ sonda metrics --name cpu --rate 10 --duration 30s \
   --sink kafka --brokers 127.0.0.1:9092 --topic sonda-metrics
 ```
 
-Events are buffered until 64 KiB is accumulated, then published as a single Kafka record to
-partition 0 of the configured topic. Broker-side auto-topic-creation is supported: the sink
-retries metadata lookups, giving the broker time to create the topic if
-`auto.create.topics.enable=true`.
+Events are buffered and published as a single Kafka record to partition 0 of the configured topic. The size threshold is a fixed 64 KiB internal buffer -- it is not user-tunable -- while `max_buffer_age` (default `5s`) is the configurable knob: a non-empty batch is flushed once it has been buffered longer than that. Broker-side auto-topic-creation is supported: the sink retries metadata lookups, giving the broker time to create the topic if `auto.create.topics.enable=true`.
 
 ### TLS { #kafka-tls }
 
@@ -417,7 +415,8 @@ an `ExportMetricsServiceRequest` or `ExportLogsServiceRequest` and sends via gRP
 |-----------|------|----------|---------|-------------|
 | `endpoint` | string | yes | -- | gRPC endpoint URL of the OTEL Collector (e.g. `"http://localhost:4317"`). |
 | `signal_type` | string | yes | -- | `"metrics"` or `"logs"` -- must match the scenario signal type. |
-| `batch_size` | integer | no | `5` | Flush threshold in number of data points or log records. Raise for high-rate scenarios. |
+| `batch_size` | integer | no | `5` | Size flush threshold in number of data points or log records. Raise for high-rate scenarios. |
+| `max_buffer_age` | duration string | no | `5s` | Time flush threshold. A non-empty batch is flushed once it has been buffered longer than this. Set `"0s"` to disable. See [Sink Batching](sink-batching.md#time-based-flushing). |
 
 ```yaml title="OTLP gRPC sink (metrics)"
 encoder:

--- a/sonda-core/src/config/validate.rs
+++ b/sonda-core/src/config/validate.rs
@@ -114,16 +114,15 @@ pub fn parse_delay_duration(s: &str) -> Result<Duration, SondaError> {
     }
 }
 
-/// Parse an optional phase offset string into a [`Duration`].
+/// Parse an optional duration string into a [`Duration`].
 ///
 /// Unlike [`parse_duration`], this function accepts zero values (e.g. `"0s"`)
-/// and returns `None` for them, since a zero offset is semantically equivalent
-/// to no offset.
-pub fn parse_phase_offset(s: &str) -> Result<Option<Duration>, SondaError> {
-    // Try parse_duration first — it handles non-zero values.
+/// and returns `None` for them, since a zero duration is semantically
+/// equivalent to "disabled" / "no delay".
+pub fn parse_optional_duration(s: &str) -> Result<Option<Duration>, SondaError> {
     match parse_duration(s) {
         Ok(d) => Ok(Some(d)),
-        Err(_) => {
+        Err(e) => {
             // Check if it was rejected because the value is zero.
             // Strip any recognized suffix, then parse the numeric part as f64.
             let trimmed = s.trim();
@@ -135,16 +134,27 @@ pub fn parse_phase_offset(s: &str) -> Result<Option<Duration>, SondaError> {
                 .unwrap_or("");
             if let Ok(v) = numeric_str.parse::<f64>() {
                 if v == 0.0 {
-                    return Ok(None); // "0s", "0ms", "0m", "0h", "0.0s" all mean no delay
+                    return Ok(None); // "0s", "0ms", "0m", "0h", "0.0s" all mean disabled
                 }
             }
-            Err(SondaError::Config(ConfigError::invalid(format!(
-                "invalid phase_offset {:?}: {}",
-                s,
-                parse_duration(s).unwrap_err()
-            ))))
+            Err(e)
         }
     }
+}
+
+/// Parse an optional phase offset string into a [`Duration`].
+///
+/// Unlike [`parse_duration`], this function accepts zero values (e.g. `"0s"`)
+/// and returns `None` for them, since a zero offset is semantically equivalent
+/// to no offset.
+pub fn parse_phase_offset(s: &str) -> Result<Option<Duration>, SondaError> {
+    parse_optional_duration(s).map_err(|_| {
+        SondaError::Config(ConfigError::invalid(format!(
+            "invalid phase_offset {:?}: {}",
+            s,
+            parse_duration(s).unwrap_err()
+        )))
+    })
 }
 
 /// Validate a single [`CardinalitySpikeConfig`] for semantic correctness.
@@ -946,6 +956,28 @@ mod tests {
     fn parse_delay_duration_rejects_garbage() {
         let result = parse_delay_duration("not_a_duration");
         assert!(result.is_err(), "non-duration string must be rejected");
+    }
+
+    // ---- parse_optional_duration ---------------------------------------------
+
+    #[test]
+    fn parse_optional_duration_positive_value_is_some() {
+        let d = parse_optional_duration("5s").expect("5s must parse");
+        assert_eq!(d, Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn parse_optional_duration_zero_is_none() {
+        assert_eq!(parse_optional_duration("0s").expect("0s must parse"), None);
+        assert_eq!(
+            parse_optional_duration("0ms").expect("0ms must parse"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_optional_duration_garbage_returns_err() {
+        assert!(parse_optional_duration("garbage").is_err());
     }
 
     // ---- validate_config: rate validation ------------------------------------

--- a/sonda-core/src/sink/http.rs
+++ b/sonda-core/src/sink/http.rs
@@ -5,6 +5,7 @@
 //! the accumulated bytes are sent as a single HTTP POST request.
 
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
@@ -38,6 +39,11 @@ pub struct HttpPushSink {
     batch_size: usize,
     /// Optional retry policy for transient failures.
     retry_policy: Option<RetryPolicy>,
+    /// Maximum age a non-empty batch may reach before a time-based flush.
+    /// `Duration::ZERO` disables time-based flushing.
+    max_buffer_age: Duration,
+    /// When the batch was last sent — drives the time-based flush check.
+    last_flush_at: Instant,
 }
 
 impl HttpPushSink {
@@ -55,6 +61,8 @@ impl HttpPushSink {
     ///   Prometheus remote write.
     /// - `retry_policy` — optional retry policy for transient failures.
     ///   When `None`, errors are returned immediately (no retry).
+    /// - `max_buffer_age` — maximum age a non-empty batch may reach before a
+    ///   time-based flush. `Duration::ZERO` disables time-based flushing.
     ///
     /// # Errors
     ///
@@ -66,6 +74,7 @@ impl HttpPushSink {
         batch_size: usize,
         headers: HashMap<String, String>,
         retry_policy: Option<RetryPolicy>,
+        max_buffer_age: Duration,
     ) -> Result<Self, SondaError> {
         // Validate the URL scheme before accepting the config.
         if !url.starts_with("http://") && !url.starts_with("https://") {
@@ -88,6 +97,8 @@ impl HttpPushSink {
             batch: Vec::with_capacity(batch_size),
             batch_size,
             retry_policy,
+            max_buffer_age,
+            last_flush_at: Instant::now(),
         })
     }
 
@@ -105,6 +116,9 @@ impl HttpPushSink {
         if self.batch.is_empty() {
             return Ok(());
         }
+
+        // Reset on attempt, not success — the batch is cleared either way below.
+        self.last_flush_at = Instant::now();
 
         let result = match &self.retry_policy {
             Some(policy) => {
@@ -233,7 +247,10 @@ impl Sink for HttpPushSink {
     /// fails.
     fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.batch.extend_from_slice(data);
-        if self.batch.len() >= self.batch_size {
+        let size_reached = self.batch.len() >= self.batch_size;
+        let age_reached =
+            !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
+        if size_reached || age_reached {
             self.send_batch()?;
         }
         Ok(())
@@ -325,6 +342,7 @@ mod tests {
             1024,
             HashMap::new(),
             None,
+            Duration::ZERO,
         );
         assert!(result.is_ok(), "http:// URL should be accepted");
     }
@@ -337,6 +355,7 @@ mod tests {
             1024,
             HashMap::new(),
             None,
+            Duration::ZERO,
         );
         assert!(result.is_ok(), "https:// URL should be accepted");
     }
@@ -349,6 +368,7 @@ mod tests {
             1024,
             HashMap::new(),
             None,
+            Duration::ZERO,
         );
         assert!(result.is_err(), "non-http URL must be rejected");
         assert!(
@@ -359,8 +379,14 @@ mod tests {
 
     #[test]
     fn new_with_bare_hostname_returns_sink_error() {
-        let result =
-            HttpPushSink::new("example.com/push", "text/plain", 1024, HashMap::new(), None);
+        let result = HttpPushSink::new(
+            "example.com/push",
+            "text/plain",
+            1024,
+            HashMap::new(),
+            None,
+            Duration::ZERO,
+        );
         assert!(result.is_err(), "URL without scheme must be rejected");
         assert!(
             matches!(result.err().unwrap(), SondaError::Sink(_)),
@@ -370,14 +396,22 @@ mod tests {
 
     #[test]
     fn new_with_empty_url_returns_sink_error() {
-        let result = HttpPushSink::new("", "text/plain", 1024, HashMap::new(), None);
+        let result =
+            HttpPushSink::new("", "text/plain", 1024, HashMap::new(), None, Duration::ZERO);
         assert!(result.is_err(), "empty URL must be rejected");
     }
 
     #[test]
     fn new_error_message_contains_invalid_url() {
         let bad_url = "not-a-url://bad";
-        let result = HttpPushSink::new(bad_url, "text/plain", 1024, HashMap::new(), None);
+        let result = HttpPushSink::new(
+            bad_url,
+            "text/plain",
+            1024,
+            HashMap::new(),
+            None,
+            Duration::ZERO,
+        );
         let err = result.err().expect("should be Err");
         let msg = err.to_string();
         assert!(
@@ -396,8 +430,15 @@ mod tests {
         // We start a server that would panic if it received a connection.
         let (listener, url) = mock_server_listener();
 
-        let mut sink = HttpPushSink::new(&url, "text/plain", 1000, HashMap::new(), None)
-            .expect("construct sink");
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            1000,
+            HashMap::new(),
+            None,
+            Duration::ZERO,
+        )
+        .expect("construct sink");
 
         // Write 300 bytes total — below the 1000-byte threshold.
         for _ in 0..3 {
@@ -421,8 +462,15 @@ mod tests {
         // Accept exactly one request in a background thread.
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        let mut sink = HttpPushSink::new(&url, "text/plain", 100, HashMap::new(), None)
-            .expect("construct sink");
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            100,
+            HashMap::new(),
+            None,
+            Duration::ZERO,
+        )
+        .expect("construct sink");
         // Write exactly batch_size bytes → should auto-flush.
         sink.write(&[b'a'; 100]).expect("write should succeed");
 
@@ -437,8 +485,9 @@ mod tests {
 
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        let mut sink = HttpPushSink::new(&url, "text/plain", 50, HashMap::new(), None)
-            .expect("construct sink");
+        let mut sink =
+            HttpPushSink::new(&url, "text/plain", 50, HashMap::new(), None, Duration::ZERO)
+                .expect("construct sink");
         // Write 80 bytes → exceeds 50-byte threshold → auto-flush.
         sink.write(&[b'z'; 80]).expect("write should succeed");
 
@@ -456,8 +505,15 @@ mod tests {
 
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        let mut sink = HttpPushSink::new(&url, "text/plain", 10_000, HashMap::new(), None)
-            .expect("construct sink");
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            10_000,
+            HashMap::new(),
+            None,
+            Duration::ZERO,
+        )
+        .expect("construct sink");
         // Write 42 bytes — well below 10 000-byte threshold.
         sink.write(b"hello flush").expect("write");
         sink.flush().expect("flush should send remaining data");
@@ -475,6 +531,7 @@ mod tests {
             1024,
             HashMap::new(),
             None,
+            Duration::ZERO,
         )
         .expect("construct sink");
         // Empty batch: flush should return Ok without making any network call.
@@ -488,8 +545,15 @@ mod tests {
         // First flush sends data; second flush is a no-op.
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        let mut sink = HttpPushSink::new(&url, "text/plain", 10_000, HashMap::new(), None)
-            .expect("construct sink");
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            10_000,
+            HashMap::new(),
+            None,
+            Duration::ZERO,
+        )
+        .expect("construct sink");
         sink.write(b"data").expect("write");
         sink.flush().expect("first flush");
 
@@ -509,7 +573,8 @@ mod tests {
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink =
-            HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), None).expect("construct sink");
+            HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), None, Duration::ZERO)
+                .expect("construct sink");
         // batch_size=1 → immediate flush on write.
         let result = sink.write(b"x");
         let _body = handle.join().expect("mock server thread panicked");
@@ -522,7 +587,8 @@ mod tests {
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 400));
 
         let mut sink =
-            HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), None).expect("construct sink");
+            HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), None, Duration::ZERO)
+                .expect("construct sink");
         let result = sink.write(b"x");
         let _body = handle.join().expect("mock server thread panicked");
         // 4xx → warn + discard, but NOT an error from the sink's perspective.
@@ -542,7 +608,8 @@ mod tests {
         });
 
         let mut sink =
-            HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), None).expect("construct sink");
+            HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), None, Duration::ZERO)
+                .expect("construct sink");
         let result = sink.write(b"x");
         handle.join().expect("mock server thread panicked");
         assert!(result.is_err(), "5xx without retry must return Err");
@@ -570,8 +637,15 @@ mod tests {
         })
         .expect("valid retry config");
 
-        let mut sink = HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), Some(policy))
-            .expect("construct sink");
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            1,
+            HashMap::new(),
+            Some(policy),
+            Duration::ZERO,
+        )
+        .expect("construct sink");
         let result = sink.write(b"x");
         handle.join().expect("mock server thread panicked");
         assert!(result.is_ok(), "5xx + successful retry must return Ok");
@@ -595,8 +669,15 @@ mod tests {
         })
         .expect("valid retry config");
 
-        let mut sink = HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), Some(policy))
-            .expect("construct sink");
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            1,
+            HashMap::new(),
+            Some(policy),
+            Duration::ZERO,
+        )
+        .expect("construct sink");
         let result = sink.write(b"x");
         handle.join().expect("mock server thread panicked");
         assert!(result.is_err(), "persistent 5xx must return Err");
@@ -614,8 +695,15 @@ mod tests {
         drop(listener);
 
         let url = format!("http://127.0.0.1:{port}/push");
-        let mut sink = HttpPushSink::new(&url, "text/plain", 10_000, HashMap::new(), None)
-            .expect("construct sink");
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            10_000,
+            HashMap::new(),
+            None,
+            Duration::ZERO,
+        )
+        .expect("construct sink");
         sink.write(b"hello").expect("write buffered ok");
         let result = sink.flush();
         assert!(result.is_err(), "flush to refused port must fail");
@@ -635,8 +723,15 @@ mod tests {
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let payload = b"metric_name{label=\"val\"} 42 1700000000000\n";
-        let mut sink = HttpPushSink::new(&url, "text/plain", 10_000, HashMap::new(), None)
-            .expect("construct sink");
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            10_000,
+            HashMap::new(),
+            None,
+            Duration::ZERO,
+        )
+        .expect("construct sink");
         sink.write(payload).expect("write");
         sink.flush().expect("flush");
 
@@ -649,8 +744,15 @@ mod tests {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        let mut sink = HttpPushSink::new(&url, "text/plain", 10_000, HashMap::new(), None)
-            .expect("construct sink");
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            10_000,
+            HashMap::new(),
+            None,
+            Duration::ZERO,
+        )
+        .expect("construct sink");
         sink.write(b"part1").expect("write 1");
         sink.write(b"part2").expect("write 2");
         sink.write(b"part3").expect("write 3");
@@ -658,6 +760,92 @@ mod tests {
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body, b"part1part2part3");
+    }
+
+    // -------------------------------------------------------------------------
+    // Time-based flush
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn time_based_flush_fires_when_buffer_age_exceeded() {
+        let (listener, url) = mock_server_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
+
+        // batch_size large enough that size never triggers; short max_buffer_age.
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            1_000_000,
+            HashMap::new(),
+            None,
+            Duration::from_millis(50),
+        )
+        .expect("construct sink");
+
+        sink.write(b"first").expect("write 1");
+        thread::sleep(Duration::from_millis(200));
+        // Second write is past max_buffer_age → triggers a time-based flush.
+        sink.write(b"second").expect("write 2");
+
+        let body = handle.join().expect("mock server thread panicked");
+        assert_eq!(
+            body, b"firstsecond",
+            "time-based flush must deliver both buffered writes"
+        );
+    }
+
+    #[test]
+    fn zero_max_buffer_age_disables_time_based_flush() {
+        let (listener, url) = mock_server_listener();
+
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            1_000_000,
+            HashMap::new(),
+            None,
+            Duration::ZERO,
+        )
+        .expect("construct sink");
+
+        sink.write(b"first").expect("write 1");
+        thread::sleep(Duration::from_millis(150));
+        sink.write(b"second").expect("write 2");
+
+        // With time-based flush disabled, no request should have arrived.
+        listener.set_nonblocking(true).expect("set non-blocking");
+        assert!(
+            listener.accept().is_err(),
+            "zero max_buffer_age must disable time-based flush"
+        );
+    }
+
+    #[test]
+    fn size_triggered_flush_resets_the_buffer_age_timer() {
+        let (listener, url) = mock_server_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
+
+        // Small batch_size, max_buffer_age comfortably longer than the test runs.
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            4,
+            HashMap::new(),
+            None,
+            Duration::from_secs(60),
+        )
+        .expect("construct sink");
+
+        // Write exactly batch_size bytes → the size trigger fires.
+        sink.write(b"abcd").expect("write fills batch");
+
+        let body = handle.join().expect("mock server thread panicked");
+        assert_eq!(body, b"abcd", "size-triggered flush must deliver the batch");
+
+        // The size flush reset last_flush_at; a subsequent partial-batch write
+        // must NOT immediately time-flush against the (now closed) listener.
+        sink.write(b"e")
+            .expect("partial write after a size flush must not time-flush immediately");
     }
 
     // -------------------------------------------------------------------------
@@ -751,6 +939,7 @@ batch_size: 8192
             url: "http://localhost:9090/push".to_string(),
             content_type: Some("text/plain".to_string()),
             batch_size: Some(1024),
+            max_buffer_age: None,
             headers: None,
             retry: None,
         };
@@ -770,6 +959,7 @@ batch_size: 8192
             url: "http://127.0.0.1:19998/push".to_string(),
             content_type: None,
             batch_size: None,
+            max_buffer_age: None,
             headers: None,
             retry: None,
         };
@@ -788,6 +978,7 @@ batch_size: 8192
             url: "http://127.0.0.1:19997/push".to_string(),
             content_type: None,
             batch_size: None,
+            max_buffer_age: None,
             headers: None,
             retry: None,
         };
@@ -800,6 +991,7 @@ batch_size: 8192
             url: "not-http://bad".to_string(),
             content_type: None,
             batch_size: None,
+            max_buffer_age: None,
             headers: None,
             retry: None,
         };
@@ -816,6 +1008,7 @@ batch_size: 8192
             url,
             content_type: Some("application/octet-stream".to_string()),
             batch_size: Some(10_000),
+            max_buffer_age: None,
             headers: None,
             retry: None,
         };
@@ -889,8 +1082,15 @@ batch_size: 8192
             "0.1.0".to_string(),
         );
 
-        let mut sink = HttpPushSink::new(&url, "application/x-protobuf", 10_000, custom, None)
-            .expect("construct sink");
+        let mut sink = HttpPushSink::new(
+            &url,
+            "application/x-protobuf",
+            10_000,
+            custom,
+            None,
+            Duration::ZERO,
+        )
+        .expect("construct sink");
         sink.write(b"test-payload").expect("write");
         sink.flush().expect("flush");
 
@@ -921,8 +1121,15 @@ batch_size: 8192
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_capture_headers(&listener, 200));
 
-        let mut sink = HttpPushSink::new(&url, "text/plain", 10_000, HashMap::new(), None)
-            .expect("construct sink");
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            10_000,
+            HashMap::new(),
+            None,
+            Duration::ZERO,
+        )
+        .expect("construct sink");
         sink.write(b"data").expect("write");
         sink.flush().expect("flush");
 
@@ -947,6 +1154,7 @@ batch_size: 8192
             url,
             content_type: Some("application/x-protobuf".to_string()),
             batch_size: Some(10_000),
+            max_buffer_age: None,
             headers: Some(hdr),
             retry: None,
         };

--- a/sonda-core/src/sink/kafka.rs
+++ b/sonda-core/src/sink/kafka.rs
@@ -25,6 +25,7 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use rskafka::{
@@ -70,6 +71,11 @@ pub struct KafkaSink {
     runtime: Runtime,
     /// Optional retry policy for transient failures.
     retry_policy: Option<RetryPolicy>,
+    /// Maximum age a non-empty buffer may reach before a time-based flush.
+    /// `Duration::ZERO` disables time-based flushing.
+    max_buffer_age: Duration,
+    /// When the buffer was last published — drives the time-based flush check.
+    last_flush_at: Instant,
 }
 
 /// Build a `rustls::ClientConfig` for TLS connections to Kafka brokers.
@@ -177,6 +183,8 @@ impl KafkaSink {
     /// - `retry_policy` — optional retry policy for transient produce failures.
     /// - `tls_config` — optional TLS configuration for encrypted connections.
     /// - `sasl_config` — optional SASL authentication configuration.
+    /// - `max_buffer_age` — maximum age a non-empty buffer may reach before a
+    ///   time-based flush. `Duration::ZERO` disables time-based flushing.
     ///
     /// # Errors
     ///
@@ -200,6 +208,7 @@ impl KafkaSink {
         retry_policy: Option<RetryPolicy>,
         tls_config: Option<&KafkaTlsConfig>,
         sasl_config: Option<&KafkaSaslConfig>,
+        max_buffer_age: Duration,
     ) -> Result<Self, SondaError> {
         // Build a minimal single-threaded tokio runtime. This drives all
         // async rskafka calls without making the Sink trait async.
@@ -300,6 +309,8 @@ impl KafkaSink {
             buffer: Vec::with_capacity(KAFKA_BUFFER_SIZE),
             runtime,
             retry_policy,
+            max_buffer_age,
+            last_flush_at: Instant::now(),
         })
     }
 
@@ -314,6 +325,9 @@ impl KafkaSink {
         if self.buffer.is_empty() {
             return Ok(());
         }
+
+        // Reset on attempt, not success — the buffer is cleared either way below.
+        self.last_flush_at = Instant::now();
 
         // Swap out the buffer for a fresh pre-allocated vec. Using replace
         // avoids an intermediate zero-capacity state that take() would produce.
@@ -371,7 +385,10 @@ impl Sink for KafkaSink {
     /// only if the automatic flush fails.
     fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.buffer.extend_from_slice(data);
-        if self.buffer.len() >= KAFKA_BUFFER_SIZE {
+        let size_reached = self.buffer.len() >= KAFKA_BUFFER_SIZE;
+        let age_reached =
+            !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
+        if size_reached || age_reached {
             self.publish_buffer()?;
         }
         Ok(())
@@ -463,11 +480,39 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_kafka_deserializes_with_max_buffer_age() {
+        let yaml =
+            "type: kafka\nbrokers: \"127.0.0.1:9092\"\ntopic: sonda-test\nmax_buffer_age: 10s";
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        match config {
+            SinkConfig::Kafka { max_buffer_age, .. } => {
+                assert_eq!(max_buffer_age.as_deref(), Some("10s"));
+            }
+            other => panic!("expected SinkConfig::Kafka, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_kafka_max_buffer_age_defaults_to_none() {
+        let yaml = "type: kafka\nbrokers: \"127.0.0.1:9092\"\ntopic: sonda-test";
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        match config {
+            SinkConfig::Kafka { max_buffer_age, .. } => {
+                assert!(max_buffer_age.is_none());
+            }
+            other => panic!("expected SinkConfig::Kafka, got {other:?}"),
+        }
+    }
+
     #[test]
     fn sink_config_kafka_is_cloneable() {
         let config = SinkConfig::Kafka {
             brokers: "127.0.0.1:9092".to_string(),
             topic: "sonda-test".to_string(),
+            max_buffer_age: None,
             retry: None,
             tls: None,
             sasl: None,
@@ -484,6 +529,7 @@ mod tests {
         let config = SinkConfig::Kafka {
             brokers: "127.0.0.1:9092".to_string(),
             topic: "sonda-test".to_string(),
+            max_buffer_age: None,
             retry: None,
             tls: None,
             sasl: None,
@@ -509,7 +555,14 @@ mod tests {
     #[ignore = "requires network timeout which is slow; run with --ignored when desired"]
     fn new_with_unreachable_broker_returns_sink_error() {
         // Port 1 is privileged and will always refuse connections.
-        let result = KafkaSink::new("127.0.0.1:1", "sonda-test", None, None, None);
+        let result = KafkaSink::new(
+            "127.0.0.1:1",
+            "sonda-test",
+            None,
+            None,
+            None,
+            Duration::ZERO,
+        );
         match result {
             Err(err) => {
                 let msg = err.to_string();
@@ -526,7 +579,7 @@ mod tests {
     /// attempting any network connection.
     #[test]
     fn new_with_empty_broker_string_returns_error() {
-        let result = KafkaSink::new("", "sonda-test", None, None, None);
+        let result = KafkaSink::new("", "sonda-test", None, None, None, Duration::ZERO);
         match result {
             Err(err) => {
                 let msg = err.to_string();
@@ -543,7 +596,7 @@ mod tests {
     /// entries; this must be caught before any network call.
     #[test]
     fn new_with_whitespace_only_broker_string_returns_error() {
-        let result = KafkaSink::new("  ,  ,  ", "sonda-test", None, None, None);
+        let result = KafkaSink::new("  ,  ,  ", "sonda-test", None, None, None, Duration::ZERO);
         assert!(
             result.is_err(),
             "broker string with only separators must be rejected"

--- a/sonda-core/src/sink/loki.rs
+++ b/sonda-core/src/sink/loki.rs
@@ -16,7 +16,7 @@
 //! ```
 
 use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
@@ -46,6 +46,11 @@ pub struct LokiSink {
     batch: Vec<(String, String)>,
     /// Optional retry policy for transient failures.
     retry_policy: Option<RetryPolicy>,
+    /// Maximum age a non-empty batch may reach before a time-based flush.
+    /// `Duration::ZERO` disables time-based flushing.
+    max_buffer_age: Duration,
+    /// When the batch was last sent — drives the time-based flush check.
+    last_flush_at: Instant,
 }
 
 impl LokiSink {
@@ -58,6 +63,8 @@ impl LokiSink {
     /// - `labels` — stream labels attached to every log batch.
     /// - `batch_size` — number of log entries to accumulate before auto-flushing.
     ///   Use `100` if no override is needed.
+    /// - `max_buffer_age` — maximum age a non-empty batch may reach before a
+    ///   time-based flush. `Duration::ZERO` disables time-based flushing.
     ///
     /// # Errors
     ///
@@ -67,6 +74,7 @@ impl LokiSink {
         labels: HashMap<String, String>,
         batch_size: usize,
         retry_policy: Option<RetryPolicy>,
+        max_buffer_age: Duration,
     ) -> Result<Self, SondaError> {
         if !url.starts_with("http://") && !url.starts_with("https://") {
             return Err(SondaError::Sink(std::io::Error::new(
@@ -87,6 +95,8 @@ impl LokiSink {
             batch_size,
             batch: Vec::with_capacity(batch_size),
             retry_policy,
+            max_buffer_age,
+            last_flush_at: Instant::now(),
         })
     }
 
@@ -129,6 +139,9 @@ impl LokiSink {
 
         let push_url = format!("{}/loki/api/v1/push", self.url);
         let body = self.build_envelope();
+
+        // Reset on attempt, not success — the batch is cleared either way below.
+        self.last_flush_at = Instant::now();
 
         let result = match &self.retry_policy {
             Some(policy) => {
@@ -245,7 +258,10 @@ impl Sink for LokiSink {
 
         self.batch.push((ts_ns, line));
 
-        if self.batch.len() >= self.batch_size {
+        let size_reached = self.batch.len() >= self.batch_size;
+        let age_reached =
+            !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
+        if size_reached || age_reached {
             self.flush_batch()?;
         }
 
@@ -332,6 +348,7 @@ mod tests {
             HashMap::new(),
             100,
             None,
+            Duration::ZERO,
         );
         assert!(result.is_ok(), "http:// URL must be accepted");
     }
@@ -343,6 +360,7 @@ mod tests {
             HashMap::new(),
             100,
             None,
+            Duration::ZERO,
         );
         assert!(result.is_ok(), "https:// URL must be accepted");
     }
@@ -354,6 +372,7 @@ mod tests {
             HashMap::new(),
             100,
             None,
+            Duration::ZERO,
         );
         assert!(result.is_err(), "non-http:// URL must be rejected");
         assert!(
@@ -364,20 +383,32 @@ mod tests {
 
     #[test]
     fn new_with_bare_hostname_returns_sink_error() {
-        let result = LokiSink::new("loki.example.com".to_string(), HashMap::new(), 100, None);
+        let result = LokiSink::new(
+            "loki.example.com".to_string(),
+            HashMap::new(),
+            100,
+            None,
+            Duration::ZERO,
+        );
         assert!(result.is_err(), "URL without scheme must be rejected");
     }
 
     #[test]
     fn new_with_empty_url_returns_sink_error() {
-        let result = LokiSink::new(String::new(), HashMap::new(), 100, None);
+        let result = LokiSink::new(String::new(), HashMap::new(), 100, None, Duration::ZERO);
         assert!(result.is_err(), "empty URL must be rejected");
     }
 
     #[test]
     fn new_error_message_contains_the_bad_url() {
         let bad_url = "not-a-url";
-        let result = LokiSink::new(bad_url.to_string(), HashMap::new(), 100, None);
+        let result = LokiSink::new(
+            bad_url.to_string(),
+            HashMap::new(),
+            100,
+            None,
+            Duration::ZERO,
+        );
         let err = result.err().expect("should be Err");
         let msg = err.to_string();
         assert!(
@@ -400,7 +431,8 @@ mod tests {
         let mut labels = HashMap::new();
         labels.insert("job".to_string(), "sonda".to_string());
 
-        let mut sink = LokiSink::new(url, labels, 100, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, labels, 100, None, Duration::ZERO).expect("construct sink");
         sink.write(b"hello loki\n").expect("write");
         sink.flush().expect("flush");
 
@@ -459,7 +491,8 @@ mod tests {
         labels.insert("job".to_string(), "sonda".to_string());
         labels.insert("env".to_string(), "dev".to_string());
 
-        let mut sink = LokiSink::new(url, labels, 100, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, labels, 100, None, Duration::ZERO).expect("construct sink");
         sink.write(b"test\n").expect("write");
         sink.flush().expect("flush");
 
@@ -485,7 +518,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink = LokiSink::new(url, HashMap::new(), 100, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
         sink.write(b"line\n").expect("write");
         sink.flush().expect("flush");
 
@@ -508,7 +542,8 @@ mod tests {
     fn write_below_batch_size_does_not_trigger_http_call() {
         let (listener, url) = mock_loki_listener();
 
-        let mut sink = LokiSink::new(url, HashMap::new(), 50, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 50, None, Duration::ZERO).expect("construct sink");
 
         // Write 49 lines — one short of the 50-entry threshold.
         for i in 0..49 {
@@ -530,7 +565,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink = LokiSink::new(url, HashMap::new(), 50, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 50, None, Duration::ZERO).expect("construct sink");
 
         // Write exactly 50 lines → must trigger an auto-flush.
         for i in 0..50 {
@@ -558,7 +594,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink = LokiSink::new(url, HashMap::new(), 100, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
 
         // Write only 3 lines (far below batch_size of 100).
         sink.write(b"alpha\n").expect("write 1");
@@ -581,7 +618,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink = LokiSink::new(url, HashMap::new(), 100, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
         sink.write(b"once\n").expect("write");
         sink.flush().expect("first flush sends data");
         let _body = handle.join().expect("mock server thread panicked");
@@ -602,7 +640,8 @@ mod tests {
         drop(listener);
 
         let url = format!("http://127.0.0.1:{port}");
-        let mut sink = LokiSink::new(url, HashMap::new(), 100, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
 
         // Empty batch — must return Ok without any network I/O.
         assert!(
@@ -620,7 +659,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink = LokiSink::new(url, HashMap::new(), 100, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
         sink.write(b"my log line\n").expect("write with newline");
         sink.flush().expect("flush");
 
@@ -646,7 +686,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 500));
 
-        let mut sink = LokiSink::new(url, HashMap::new(), 100, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
         sink.write(b"line\n").expect("write buffered");
         let result = sink.flush();
         handle.join().expect("mock server thread panicked");
@@ -663,7 +704,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 400));
 
-        let mut sink = LokiSink::new(url, HashMap::new(), 100, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
         sink.write(b"line\n").expect("write buffered");
         let result = sink.flush();
         handle.join().expect("mock server thread panicked");
@@ -682,7 +724,8 @@ mod tests {
         drop(listener);
 
         let url = format!("http://127.0.0.1:{port}");
-        let mut sink = LokiSink::new(url, HashMap::new(), 100, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
         sink.write(b"line\n").expect("write buffered");
         let result = sink.flush();
 
@@ -702,7 +745,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink = LokiSink::new(url, HashMap::new(), 100, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
         // A log line containing a JSON double-quote character.
         sink.write(b"msg=\"hello world\"").expect("write");
         sink.flush().expect("flush");
@@ -726,7 +770,8 @@ mod tests {
         let mut labels = HashMap::new();
         labels.insert("app".to_string(), r#"my "special" app"#.to_string());
 
-        let mut sink = LokiSink::new(url, labels, 100, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, labels, 100, None, Duration::ZERO).expect("construct sink");
         sink.write(b"line\n").expect("write");
         sink.flush().expect("flush");
 
@@ -755,7 +800,8 @@ mod tests {
             (first, second)
         });
 
-        let mut sink = LokiSink::new(url, HashMap::new(), 2, None).expect("construct sink");
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 2, None, Duration::ZERO).expect("construct sink");
 
         // First batch: lines 0-1 → triggers auto-flush at batch_size=2.
         sink.write(b"line 0\n").expect("write 0");
@@ -784,6 +830,84 @@ mod tests {
             Some(2),
             "second batch must contain exactly 2 entries"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Time-based flush
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn time_based_flush_fires_when_buffer_age_exceeded() {
+        let (listener, url) = mock_loki_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
+
+        // batch_size large enough that size never triggers; short max_buffer_age.
+        let mut sink = LokiSink::new(url, HashMap::new(), 10_000, None, Duration::from_millis(50))
+            .expect("construct sink");
+
+        sink.write(b"first\n").expect("write 1");
+        thread::sleep(Duration::from_millis(200));
+        // Second write is past max_buffer_age → triggers a time-based flush.
+        sink.write(b"second\n").expect("write 2");
+
+        let body_bytes = handle.join().expect("mock server thread panicked");
+        let body = String::from_utf8(body_bytes).expect("UTF-8");
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        let values = parsed["streams"][0]["values"]
+            .as_array()
+            .expect("values array");
+        assert_eq!(
+            values.len(),
+            2,
+            "time-based flush must deliver both buffered entries"
+        );
+    }
+
+    #[test]
+    fn zero_max_buffer_age_disables_time_based_flush() {
+        let (listener, url) = mock_loki_listener();
+
+        let mut sink = LokiSink::new(url, HashMap::new(), 10_000, None, Duration::ZERO)
+            .expect("construct sink");
+
+        sink.write(b"first\n").expect("write 1");
+        thread::sleep(Duration::from_millis(150));
+        sink.write(b"second\n").expect("write 2");
+
+        // With time-based flush disabled, no request should have arrived.
+        listener.set_nonblocking(true).expect("set non-blocking");
+        assert!(
+            listener.accept().is_err(),
+            "zero max_buffer_age must disable time-based flush"
+        );
+    }
+
+    #[test]
+    fn size_triggered_flush_resets_the_buffer_age_timer() {
+        let (listener, url) = mock_loki_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
+
+        // Small batch_size, max_buffer_age comfortably longer than the test runs.
+        let mut sink = LokiSink::new(url, HashMap::new(), 2, None, Duration::from_secs(60))
+            .expect("construct sink");
+
+        // Fill the batch immediately — the size trigger fires.
+        sink.write(b"a\n").expect("write 1");
+        sink.write(b"b\n").expect("write 2"); // batch_size reached → size flush
+
+        let body_bytes = handle.join().expect("mock server thread panicked");
+        let body = String::from_utf8(body_bytes).expect("UTF-8");
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(
+            parsed["streams"][0]["values"].as_array().map(|v| v.len()),
+            Some(2),
+            "size-triggered flush must deliver the full batch"
+        );
+
+        // The size flush reset last_flush_at; a subsequent partial-batch write
+        // must NOT immediately time-flush against the (now closed) listener.
+        sink.write(b"c\n")
+            .expect("partial write after a size flush must not time-flush immediately");
     }
 
     // -------------------------------------------------------------------------
@@ -841,6 +965,39 @@ batch_size: 50
         );
     }
 
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_loki_deserializes_with_max_buffer_age() {
+        let yaml = r#"
+type: loki
+url: "http://localhost:3100"
+max_buffer_age: 10s
+"#;
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).expect("should deserialize");
+        match config {
+            SinkConfig::Loki { max_buffer_age, .. } => {
+                assert_eq!(max_buffer_age.as_deref(), Some("10s"));
+            }
+            other => panic!("expected Loki variant, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_loki_max_buffer_age_defaults_to_none() {
+        let yaml = "type: loki\nurl: \"http://localhost:3100\"";
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).expect("should deserialize");
+        match config {
+            SinkConfig::Loki { max_buffer_age, .. } => {
+                assert!(
+                    max_buffer_age.is_none(),
+                    "max_buffer_age should default to None"
+                );
+            }
+            other => panic!("expected Loki variant, got {other:?}"),
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Factory: create_sink for Loki config
     // -------------------------------------------------------------------------
@@ -850,11 +1007,27 @@ batch_size: 50
         let config = SinkConfig::Loki {
             url: "http://localhost:3100".to_string(),
             batch_size: None,
+            max_buffer_age: None,
             retry: None,
         };
         assert!(
             create_sink(&config, None).is_ok(),
             "factory must return Ok for valid loki config"
+        );
+    }
+
+    #[test]
+    fn create_sink_loki_with_invalid_max_buffer_age_returns_err() {
+        let config = SinkConfig::Loki {
+            url: "http://localhost:3100".to_string(),
+            batch_size: None,
+            max_buffer_age: Some("garbage".to_string()),
+            retry: None,
+        };
+        let result = create_sink(&config, None);
+        assert!(
+            result.is_err(),
+            "invalid max_buffer_age must cause the factory to fail"
         );
     }
 
@@ -866,6 +1039,7 @@ batch_size: 50
         let config = SinkConfig::Loki {
             url,
             batch_size: None,
+            max_buffer_age: None,
             retry: None,
         };
         let mut labels = HashMap::new();
@@ -893,6 +1067,7 @@ batch_size: 50
         let config = SinkConfig::Loki {
             url,
             batch_size: None,
+            max_buffer_age: None,
             retry: None,
         };
         let mut sink = create_sink(&config, None).expect("factory ok");
@@ -928,6 +1103,7 @@ batch_size: 50
         let config = SinkConfig::Loki {
             url,
             batch_size: None,
+            max_buffer_age: None,
             retry: None,
         };
         let mut sink = create_sink(&config, None).expect("factory ok");
@@ -943,6 +1119,7 @@ batch_size: 50
         let config = SinkConfig::Loki {
             url: "not-http://bad".to_string(),
             batch_size: None,
+            max_buffer_age: None,
             retry: None,
         };
         let result = create_sink(&config, None);

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -327,6 +327,11 @@ pub enum SinkConfig {
         #[cfg_attr(feature = "config", serde(default))]
         batch_size: Option<usize>,
 
+        /// Maximum batch age before a time-based flush, e.g. `"5s"`. Defaults
+        /// to `"5s"`; a zero value (e.g. `"0s"`) disables time-based flushing.
+        #[cfg_attr(feature = "config", serde(default))]
+        max_buffer_age: Option<String>,
+
         /// Optional retry policy for transient failures.
         #[cfg_attr(feature = "config", serde(default))]
         retry: Option<retry::RetryConfig>,
@@ -468,6 +473,7 @@ pub fn create_sink(
             endpoint,
             signal_type,
             batch_size,
+            max_buffer_age,
             retry: retry_cfg,
         } => {
             let bs = batch_size.unwrap_or(otlp_grpc::DEFAULT_BATCH_SIZE);
@@ -490,12 +496,18 @@ pub fn create_sink(
                 .as_ref()
                 .map(retry::RetryPolicy::from_config)
                 .transpose()?;
+            let buffer_age = match max_buffer_age.as_deref() {
+                Some(s) => crate::config::validate::parse_optional_duration(s)?,
+                None => Some(std::time::Duration::from_secs(5)),
+            }
+            .unwrap_or(std::time::Duration::ZERO);
             Ok(Box::new(otlp_grpc::OtlpGrpcSink::new(
                 endpoint,
                 *signal_type,
                 bs,
                 resource_attrs,
                 rp,
+                buffer_age,
             )?))
         }
         #[cfg(not(feature = "http"))]

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -152,6 +152,11 @@ pub enum SinkConfig {
         /// Optional flush threshold in bytes. Defaults to 4 KiB if not specified.
         batch_size: Option<usize>,
 
+        /// Maximum batch age before a time-based flush, e.g. `"5s"`. Defaults
+        /// to `"5s"`; a zero value (e.g. `"0s"`) disables time-based flushing.
+        #[cfg_attr(feature = "config", serde(default))]
+        max_buffer_age: Option<String>,
+
         /// Optional extra HTTP headers to send with every POST request.
         ///
         /// When provided, these headers are sent in addition to the `Content-Type`
@@ -197,6 +202,11 @@ pub enum SinkConfig {
         /// not specified.
         #[cfg_attr(feature = "config", serde(default))]
         batch_size: Option<usize>,
+
+        /// Maximum batch age before a time-based flush, e.g. `"5s"`. Defaults
+        /// to `"5s"`; a zero value (e.g. `"0s"`) disables time-based flushing.
+        #[cfg_attr(feature = "config", serde(default))]
+        max_buffer_age: Option<String>,
 
         /// Optional retry policy for transient failures.
         #[cfg_attr(feature = "config", serde(default))]
@@ -364,6 +374,7 @@ pub fn create_sink(
             url,
             content_type,
             batch_size,
+            max_buffer_age,
             headers,
             retry: retry_cfg,
         } => {
@@ -376,12 +387,20 @@ pub fn create_sink(
                 .as_ref()
                 .map(retry::RetryPolicy::from_config)
                 .transpose()?;
-            Ok(Box::new(http::HttpPushSink::new(url, ct, bs, h, rp)?))
+            let buffer_age = match max_buffer_age.as_deref() {
+                Some(s) => crate::config::validate::parse_optional_duration(s)?,
+                None => Some(std::time::Duration::from_secs(5)),
+            }
+            .unwrap_or(std::time::Duration::ZERO);
+            Ok(Box::new(http::HttpPushSink::new(
+                url, ct, bs, h, rp, buffer_age,
+            )?))
         }
         #[cfg(feature = "remote-write")]
         SinkConfig::RemoteWrite {
             url,
             batch_size,
+            max_buffer_age,
             retry: retry_cfg,
         } => {
             let bs = batch_size.unwrap_or(remote_write::DEFAULT_BATCH_SIZE);
@@ -389,7 +408,14 @@ pub fn create_sink(
                 .as_ref()
                 .map(retry::RetryPolicy::from_config)
                 .transpose()?;
-            Ok(Box::new(remote_write::RemoteWriteSink::new(url, bs, rp)?))
+            let buffer_age = match max_buffer_age.as_deref() {
+                Some(s) => crate::config::validate::parse_optional_duration(s)?,
+                None => Some(std::time::Duration::from_secs(5)),
+            }
+            .unwrap_or(std::time::Duration::ZERO);
+            Ok(Box::new(remote_write::RemoteWriteSink::new(
+                url, bs, rp, buffer_age,
+            )?))
         }
         #[cfg(feature = "kafka")]
         SinkConfig::Kafka {
@@ -1001,6 +1027,7 @@ headers: {}
             url: "http://localhost:9090/push".to_string(),
             content_type: None,
             batch_size: None,
+            max_buffer_age: None,
             headers: Some(hdr),
             retry: None,
         };
@@ -1023,6 +1050,7 @@ headers: {}
             url: "http://127.0.0.1:19999/push".to_string(),
             content_type: None,
             batch_size: None,
+            max_buffer_age: None,
             headers: None,
             retry: None,
         };

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -276,6 +276,11 @@ pub enum SinkConfig {
         #[cfg_attr(feature = "config", serde(default))]
         batch_size: Option<usize>,
 
+        /// Maximum batch age before a time-based flush, e.g. `"5s"`. Defaults
+        /// to `"5s"`; a zero value (e.g. `"0s"`) disables time-based flushing.
+        #[cfg_attr(feature = "config", serde(default))]
+        max_buffer_age: Option<String>,
+
         /// Optional retry policy for transient failures.
         #[cfg_attr(feature = "config", serde(default))]
         retry: Option<retry::RetryConfig>,
@@ -410,6 +415,7 @@ pub fn create_sink(
         SinkConfig::Loki {
             url,
             batch_size,
+            max_buffer_age,
             retry: retry_cfg,
         } => {
             let bs = batch_size.unwrap_or(loki::DEFAULT_BATCH_SIZE);
@@ -418,11 +424,17 @@ pub fn create_sink(
                 .as_ref()
                 .map(retry::RetryPolicy::from_config)
                 .transpose()?;
+            let buffer_age = match max_buffer_age.as_deref() {
+                Some(s) => crate::config::validate::parse_optional_duration(s)?,
+                None => Some(std::time::Duration::from_secs(5)),
+            }
+            .unwrap_or(std::time::Duration::ZERO);
             Ok(Box::new(loki::LokiSink::new(
                 url.clone(),
                 loki_labels,
                 bs,
                 rp,
+                buffer_age,
             )?))
         }
         #[cfg(feature = "otlp")]
@@ -1029,6 +1041,7 @@ headers: {}
         let config = SinkConfig::Loki {
             url: "http://127.0.0.1:19999".to_string(),
             batch_size: None,
+            max_buffer_age: None,
             retry: None,
         };
         let result = create_sink(&config, None);

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -242,6 +242,11 @@ pub enum SinkConfig {
         /// The Kafka topic name to produce records to.
         topic: String,
 
+        /// Maximum batch age before a time-based flush, e.g. `"5s"`. Defaults
+        /// to `"5s"`; a zero value (e.g. `"0s"`) disables time-based flushing.
+        #[cfg_attr(feature = "config", serde(default))]
+        max_buffer_age: Option<String>,
+
         /// Optional retry policy for transient failures.
         #[cfg_attr(feature = "config", serde(default))]
         retry: Option<retry::RetryConfig>,
@@ -426,6 +431,7 @@ pub fn create_sink(
         SinkConfig::Kafka {
             brokers,
             topic,
+            max_buffer_age,
             retry: retry_cfg,
             tls,
             sasl,
@@ -434,12 +440,18 @@ pub fn create_sink(
                 .as_ref()
                 .map(retry::RetryPolicy::from_config)
                 .transpose()?;
+            let buffer_age = match max_buffer_age.as_deref() {
+                Some(s) => crate::config::validate::parse_optional_duration(s)?,
+                None => Some(std::time::Duration::from_secs(5)),
+            }
+            .unwrap_or(std::time::Duration::ZERO);
             Ok(Box::new(kafka::KafkaSink::new(
                 brokers,
                 topic,
                 rp,
                 tls.as_ref(),
                 sasl.as_ref(),
+                buffer_age,
             )?))
         }
         #[cfg(feature = "http")]
@@ -862,6 +874,7 @@ sink:
         let config = SinkConfig::Kafka {
             brokers: "127.0.0.1:9092".to_string(),
             topic: "sonda-test".to_string(),
+            max_buffer_age: None,
             retry: None,
             tls: None,
             sasl: None,
@@ -915,6 +928,7 @@ sink:
         let config = SinkConfig::Kafka {
             brokers: "127.0.0.1:1".to_string(),
             topic: "sonda-test".to_string(),
+            max_buffer_age: None,
             retry: None,
             tls: None,
             sasl: None,
@@ -933,6 +947,7 @@ sink:
         let config = SinkConfig::Kafka {
             brokers: String::new(),
             topic: "sonda-test".to_string(),
+            max_buffer_age: None,
             retry: None,
             tls: None,
             sasl: None,
@@ -941,6 +956,24 @@ sink:
         assert!(
             result.is_err(),
             "create_sink should reject an empty broker string"
+        );
+    }
+
+    #[cfg(feature = "kafka")]
+    #[test]
+    fn create_sink_kafka_with_invalid_max_buffer_age_returns_err() {
+        let config = SinkConfig::Kafka {
+            brokers: "127.0.0.1:9092".to_string(),
+            topic: "sonda-test".to_string(),
+            max_buffer_age: Some("garbage".to_string()),
+            retry: None,
+            tls: None,
+            sasl: None,
+        };
+        let result = create_sink(&config, None);
+        assert!(
+            result.is_err(),
+            "create_sink should reject an unparseable max_buffer_age before connecting"
         );
     }
 

--- a/sonda-core/src/sink/otlp_grpc.rs
+++ b/sonda-core/src/sink/otlp_grpc.rs
@@ -18,6 +18,7 @@
 //! Requires the `otlp` feature flag.
 
 use std::marker::PhantomData;
+use std::time::{Duration, Instant};
 
 use bytes::Buf;
 use prost::Message;
@@ -175,6 +176,11 @@ pub struct OtlpGrpcSink {
     endpoint: String,
     /// Optional retry policy for transient failures.
     retry_policy: Option<RetryPolicy>,
+    /// Maximum age a non-empty batch may reach before a time-based flush.
+    /// `Duration::ZERO` disables time-based flushing.
+    max_buffer_age: Duration,
+    /// When a batch was last sent — drives the time-based flush check.
+    last_flush_at: Instant,
 }
 
 impl OtlpGrpcSink {
@@ -188,6 +194,8 @@ impl OtlpGrpcSink {
     ///   Use [`DEFAULT_BATCH_SIZE`] if no override is needed.
     /// - `resource_attrs` — key-value pairs for the OTLP `Resource` (typically
     ///   from scenario labels).
+    /// - `max_buffer_age` — maximum age a non-empty batch may reach before a
+    ///   time-based flush. `Duration::ZERO` disables time-based flushing.
     ///
     /// # Errors
     ///
@@ -201,6 +209,7 @@ impl OtlpGrpcSink {
         batch_size: usize,
         resource_attrs: Vec<KeyValue>,
         retry_policy: Option<RetryPolicy>,
+        max_buffer_age: Duration,
     ) -> Result<Self, SondaError> {
         // Build a minimal single-threaded tokio runtime.
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -250,6 +259,8 @@ impl OtlpGrpcSink {
             resource_attrs,
             endpoint: endpoint.to_owned(),
             retry_policy,
+            max_buffer_age,
+            last_flush_at: Instant::now(),
         })
     }
 
@@ -275,6 +286,9 @@ impl OtlpGrpcSink {
         if self.metric_batch.is_empty() {
             return Ok(());
         }
+
+        // Reset on attempt, not success — the batch is cleared either way below.
+        self.last_flush_at = Instant::now();
 
         let metrics =
             std::mem::replace(&mut self.metric_batch, Vec::with_capacity(self.batch_size));
@@ -328,6 +342,9 @@ impl OtlpGrpcSink {
         if self.log_batch.is_empty() {
             return Ok(());
         }
+
+        // Reset on attempt, not success — the batch is cleared either way below.
+        self.last_flush_at = Instant::now();
 
         let log_records =
             std::mem::replace(&mut self.log_batch, Vec::with_capacity(self.batch_size));
@@ -447,14 +464,20 @@ impl Sink for OtlpGrpcSink {
             OtlpSignalType::Metrics => {
                 let metrics = otlp::parse_length_prefixed_metrics(data)?;
                 self.metric_batch.extend(metrics);
-                if self.metric_batch.len() >= self.batch_size {
+                let size_reached = self.metric_batch.len() >= self.batch_size;
+                let age_reached = !self.max_buffer_age.is_zero()
+                    && self.last_flush_at.elapsed() >= self.max_buffer_age;
+                if size_reached || age_reached {
                     self.flush_metrics()?;
                 }
             }
             OtlpSignalType::Logs => {
                 let records = otlp::parse_length_prefixed_log_records(data)?;
                 self.log_batch.extend(records);
-                if self.log_batch.len() >= self.batch_size {
+                let size_reached = self.log_batch.len() >= self.batch_size;
+                let age_reached = !self.max_buffer_age.is_zero()
+                    && self.last_flush_at.elapsed() >= self.max_buffer_age;
+                if size_reached || age_reached {
                     self.flush_logs()?;
                 }
             }
@@ -480,7 +503,79 @@ mod tests {
     use crate::encoder::otlp::{
         self, any_value, metric, number_data_point, AnyValue, Gauge, Metric, NumberDataPoint,
     };
-    use crate::sink::SinkConfig;
+    use crate::sink::{create_sink, SinkConfig};
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// Build a sink with a lazy (non-connecting) channel pointed at a dead
+    /// address. `write()` buffers without network I/O; only a triggered flush
+    /// reaches the channel, where it fails — letting tests assert on buffer
+    /// state and on whether a flush was attempted, without a live collector.
+    fn lazy_sink(
+        signal_type: OtlpSignalType,
+        batch_size: usize,
+        max_buffer_age: Duration,
+    ) -> OtlpGrpcSink {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        let channel = runtime.block_on(async {
+            tonic::transport::Endpoint::from_static("http://127.0.0.1:1").connect_lazy()
+        });
+        OtlpGrpcSink {
+            runtime,
+            channel,
+            metric_batch: Vec::with_capacity(batch_size),
+            log_batch: Vec::with_capacity(batch_size),
+            batch_size,
+            signal_type,
+            resource_attrs: vec![],
+            endpoint: "http://127.0.0.1:1".to_string(),
+            retry_policy: None,
+            max_buffer_age,
+            last_flush_at: Instant::now(),
+        }
+    }
+
+    /// Length-prefixed bytes for a single OTLP metric, as the encoder produces.
+    fn one_metric_bytes(name: &str) -> Vec<u8> {
+        let metric = Metric {
+            name: name.to_string(),
+            description: String::new(),
+            unit: String::new(),
+            data: Some(metric::Data::Gauge(Gauge {
+                data_points: vec![NumberDataPoint {
+                    attributes: vec![],
+                    time_unix_nano: 1_700_000_000_000_000_000,
+                    value: Some(number_data_point::Value::AsDouble(1.0)),
+                }],
+            })),
+        };
+        let proto = metric.encode_to_vec();
+        let mut buf = (proto.len() as u32).to_le_bytes().to_vec();
+        buf.extend_from_slice(&proto);
+        buf
+    }
+
+    /// Length-prefixed bytes for a single OTLP log record.
+    fn one_log_bytes() -> Vec<u8> {
+        let record = otlp::LogRecord {
+            time_unix_nano: 1_700_000_000_000_000_000,
+            severity_number: 9,
+            severity_text: "INFO".to_string(),
+            body: Some(AnyValue {
+                value: Some(any_value::Value::StringValue("hello".to_string())),
+            }),
+            attributes: vec![],
+        };
+        let proto = record.encode_to_vec();
+        let mut buf = (proto.len() as u32).to_le_bytes().to_vec();
+        buf.extend_from_slice(&proto);
+        buf
+    }
 
     // -----------------------------------------------------------------------
     // Constants
@@ -609,6 +704,7 @@ signal_type: logs
             endpoint: "http://localhost:4317".to_string(),
             signal_type: OtlpSignalType::Metrics,
             batch_size: Some(100),
+            max_buffer_age: None,
             retry: None,
         };
         let cloned = config.clone();
@@ -724,6 +820,7 @@ signal_type: logs
             DEFAULT_BATCH_SIZE,
             vec![],
             None,
+            Duration::ZERO,
         );
         match result {
             Err(err) => {
@@ -746,6 +843,7 @@ signal_type: logs
             DEFAULT_BATCH_SIZE,
             vec![],
             None,
+            Duration::ZERO,
         );
         assert!(result.is_err(), "invalid endpoint URL must be rejected");
     }
@@ -820,6 +918,150 @@ sink:
                 assert_eq!(endpoint, "http://localhost:4317");
                 assert_eq!(*signal_type, OtlpSignalType::Logs);
                 assert_eq!(*batch_size, Some(50));
+            }
+            other => panic!("expected OtlpGrpc, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Time-based flush
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn time_based_flush_fires_when_buffer_age_exceeded() {
+        // Large batch_size so size never triggers; short max_buffer_age.
+        let mut sink = lazy_sink(
+            OtlpSignalType::Metrics,
+            1_000_000,
+            Duration::from_millis(50),
+        );
+
+        sink.write(&one_metric_bytes("first")).expect("write 1");
+        assert_eq!(sink.metric_batch.len(), 1, "first write only buffers");
+
+        std::thread::sleep(Duration::from_millis(200));
+        // Second write is past max_buffer_age → triggers a time-based flush.
+        // The lazy channel has no peer, so the flush attempt fails.
+        let result = sink.write(&one_metric_bytes("second"));
+        assert!(
+            result.is_err(),
+            "second write past max_buffer_age must attempt a flush"
+        );
+        assert!(
+            sink.metric_batch.is_empty(),
+            "the time-based flush must have drained the batch"
+        );
+    }
+
+    #[test]
+    fn time_based_flush_fires_for_log_signal() {
+        let mut sink = lazy_sink(OtlpSignalType::Logs, 1_000_000, Duration::from_millis(50));
+
+        sink.write(&one_log_bytes()).expect("write 1");
+        assert_eq!(sink.log_batch.len(), 1, "first write only buffers");
+
+        std::thread::sleep(Duration::from_millis(200));
+        let result = sink.write(&one_log_bytes());
+        assert!(
+            result.is_err(),
+            "second log write past max_buffer_age must attempt a flush"
+        );
+        assert!(
+            sink.log_batch.is_empty(),
+            "the time-based flush must have drained the log batch"
+        );
+    }
+
+    #[test]
+    fn zero_max_buffer_age_disables_time_based_flush() {
+        // Large batch_size, zero max_buffer_age — neither trigger should fire.
+        let mut sink = lazy_sink(OtlpSignalType::Metrics, 1_000_000, Duration::ZERO);
+
+        sink.write(&one_metric_bytes("first")).expect("write 1");
+        std::thread::sleep(Duration::from_millis(150));
+        sink.write(&one_metric_bytes("second")).expect("write 2");
+        std::thread::sleep(Duration::from_millis(150));
+        sink.write(&one_metric_bytes("third")).expect("write 3");
+
+        assert_eq!(
+            sink.metric_batch.len(),
+            3,
+            "zero max_buffer_age must disable time-based flush"
+        );
+    }
+
+    #[test]
+    fn size_triggered_flush_still_works_and_resets_the_timer() {
+        // Small batch_size, max_buffer_age longer than the test runs.
+        let mut sink = lazy_sink(OtlpSignalType::Metrics, 2, Duration::from_secs(60));
+
+        sink.write(&one_metric_bytes("a")).expect("write 1 buffers");
+        assert_eq!(sink.metric_batch.len(), 1, "below batch_size: no flush");
+
+        // Second write fills the batch → size-triggered flush attempt.
+        let result = sink.write(&one_metric_bytes("b"));
+        assert!(result.is_err(), "filling the batch must attempt a flush");
+        assert!(
+            sink.metric_batch.is_empty(),
+            "size-triggered flush must drain the batch"
+        );
+
+        // The size flush reset last_flush_at; a subsequent partial write must
+        // not immediately time-flush.
+        sink.write(&one_metric_bytes("c"))
+            .expect("partial write after a size flush must not time-flush immediately");
+        assert_eq!(sink.metric_batch.len(), 1, "partial write only buffers");
+    }
+
+    // -----------------------------------------------------------------------
+    // Factory wiring: create_sink max_buffer_age parsing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn create_sink_otlp_grpc_with_invalid_max_buffer_age_returns_err() {
+        let config = SinkConfig::OtlpGrpc {
+            endpoint: "http://127.0.0.1:1".to_string(),
+            signal_type: OtlpSignalType::Metrics,
+            batch_size: None,
+            max_buffer_age: Some("garbage".to_string()),
+            retry: None,
+        };
+        assert!(
+            create_sink(&config, None).is_err(),
+            "invalid max_buffer_age must cause the factory to fail"
+        );
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_otlp_grpc_deserializes_with_max_buffer_age() {
+        let yaml = r#"
+type: otlp_grpc
+endpoint: "http://localhost:4317"
+signal_type: metrics
+max_buffer_age: 10s
+"#;
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).expect("deser ok");
+        match config {
+            SinkConfig::OtlpGrpc { max_buffer_age, .. } => {
+                assert_eq!(max_buffer_age.as_deref(), Some("10s"));
+            }
+            other => panic!("expected OtlpGrpc, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_otlp_grpc_max_buffer_age_defaults_to_none() {
+        let yaml = r#"
+type: otlp_grpc
+endpoint: "http://localhost:4317"
+signal_type: metrics
+"#;
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).expect("deser ok");
+        match config {
+            SinkConfig::OtlpGrpc { max_buffer_age, .. } => {
+                assert!(max_buffer_age.is_none(), "max_buffer_age defaults to None");
             }
             other => panic!("expected OtlpGrpc, got {other:?}"),
         }

--- a/sonda-core/src/sink/remote_write.rs
+++ b/sonda-core/src/sink/remote_write.rs
@@ -16,6 +16,8 @@
 //!
 //! Requires the `remote-write` feature flag.
 
+use std::time::{Duration, Instant};
+
 use prost::Message;
 
 use crate::encoder::remote_write::{parse_length_prefixed_timeseries, TimeSeries, WriteRequest};
@@ -52,6 +54,11 @@ pub struct RemoteWriteSink {
     batch_size: usize,
     /// Optional retry policy for transient failures.
     retry_policy: Option<RetryPolicy>,
+    /// Maximum age a non-empty batch may reach before a time-based flush.
+    /// `Duration::ZERO` disables time-based flushing.
+    max_buffer_age: Duration,
+    /// When the batch was last sent — drives the time-based flush check.
+    last_flush_at: Instant,
 }
 
 impl RemoteWriteSink {
@@ -63,6 +70,8 @@ impl RemoteWriteSink {
     ///   `http://localhost:8428/api/v1/write`).
     /// - `batch_size` — flush threshold in number of TimeSeries entries.
     ///   Use [`DEFAULT_BATCH_SIZE`] if no override is needed.
+    /// - `max_buffer_age` — maximum age a non-empty batch may reach before a
+    ///   time-based flush. `Duration::ZERO` disables time-based flushing.
     ///
     /// # Errors
     ///
@@ -71,6 +80,7 @@ impl RemoteWriteSink {
         url: &str,
         batch_size: usize,
         retry_policy: Option<RetryPolicy>,
+        max_buffer_age: Duration,
     ) -> Result<Self, SondaError> {
         if !url.starts_with("http://") && !url.starts_with("https://") {
             return Err(SondaError::Sink(std::io::Error::new(
@@ -90,6 +100,8 @@ impl RemoteWriteSink {
             batch: Vec::with_capacity(batch_size),
             batch_size,
             retry_policy,
+            max_buffer_age,
+            last_flush_at: Instant::now(),
         })
     }
 
@@ -102,6 +114,9 @@ impl RemoteWriteSink {
         if self.batch.is_empty() {
             return Ok(());
         }
+
+        // Reset on attempt, not success — the batch is cleared either way below.
+        self.last_flush_at = Instant::now();
 
         // Build one WriteRequest containing all accumulated TimeSeries.
         let write_request = WriteRequest {
@@ -217,7 +232,10 @@ impl Sink for RemoteWriteSink {
         let timeseries_list = parse_length_prefixed_timeseries(data)?;
         self.batch.extend(timeseries_list);
 
-        if self.batch.len() >= self.batch_size {
+        let size_reached = self.batch.len() >= self.batch_size;
+        let age_reached =
+            !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
+        if size_reached || age_reached {
             self.send_batch()?;
         }
 
@@ -231,5 +249,276 @@ impl Sink for RemoteWriteSink {
     /// returns `Ok(())` immediately if the batch is empty.
     fn flush(&mut self) -> Result<(), SondaError> {
         self.send_batch()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::thread;
+
+    use super::*;
+    use crate::encoder::remote_write::RemoteWriteEncoder;
+    use crate::encoder::Encoder;
+    use crate::model::metric::{Labels, MetricEvent};
+    use crate::sink::{create_sink, Sink, SinkConfig};
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    fn mock_server_listener() -> (TcpListener, String) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let port = listener.local_addr().expect("local addr").port();
+        let url = format!("http://127.0.0.1:{port}/api/v1/write");
+        (listener, url)
+    }
+
+    /// Accept one connection, read the full HTTP request, respond with `status`.
+    /// Returns the request body bytes (snappy-compressed protobuf WriteRequest).
+    fn accept_one_and_respond(listener: &TcpListener, status: u16) -> Vec<u8> {
+        let (mut stream, _) = listener.accept().expect("accept");
+        let body = read_http_request_body(&mut stream);
+        let response =
+            format!("HTTP/1.1 {status} OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+        stream.write_all(response.as_bytes()).ok();
+        body
+    }
+
+    fn read_http_request_body(stream: &mut TcpStream) -> Vec<u8> {
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut content_length: usize = 0;
+        loop {
+            let mut line = String::new();
+            reader.read_line(&mut line).expect("read header line");
+            if line == "\r\n" || line.is_empty() {
+                break;
+            }
+            let lower = line.to_lowercase();
+            if let Some(rest) = lower.strip_prefix("content-length:") {
+                content_length = rest.trim().parse().unwrap_or(0);
+            }
+        }
+        let mut body = vec![0u8; content_length];
+        reader.read_exact(&mut body).expect("read body");
+        body
+    }
+
+    /// Decode the snappy-compressed protobuf WriteRequest a server received.
+    fn decode_write_request(body: &[u8]) -> WriteRequest {
+        let proto_bytes = snap::raw::Decoder::new()
+            .decompress_vec(body)
+            .expect("snappy decompress");
+        WriteRequest::decode(proto_bytes.as_slice()).expect("protobuf decode")
+    }
+
+    /// Encode one metric event into length-prefixed TimeSeries bytes the sink
+    /// accepts via `write()`.
+    fn encode_one(name: &str, value: f64) -> Vec<u8> {
+        let labels = Labels::from_pairs(&[("host", "server1")]).expect("valid labels");
+        let event = MetricEvent::new(name.to_string(), value, labels).expect("valid metric name");
+        let mut buf = Vec::new();
+        RemoteWriteEncoder::new()
+            .encode_metric(&event, &mut buf)
+            .expect("encode ok");
+        buf
+    }
+
+    // -------------------------------------------------------------------------
+    // Construction
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn new_with_http_url_succeeds() {
+        let result = RemoteWriteSink::new(
+            "http://127.0.0.1:9999/api/v1/write",
+            5,
+            None,
+            Duration::ZERO,
+        );
+        assert!(result.is_ok(), "http:// URL must be accepted");
+    }
+
+    #[test]
+    fn new_with_invalid_scheme_returns_sink_error() {
+        let result = RemoteWriteSink::new("ftp://example.com/write", 5, None, Duration::ZERO);
+        assert!(result.is_err(), "non-http URL must be rejected");
+        assert!(matches!(result.err().unwrap(), SondaError::Sink(_)));
+    }
+
+    #[test]
+    fn remote_write_sink_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<RemoteWriteSink>();
+    }
+
+    // -------------------------------------------------------------------------
+    // Batch accumulation and explicit flush
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn write_below_batch_size_does_not_trigger_flush() {
+        let (listener, url) = mock_server_listener();
+
+        let mut sink =
+            RemoteWriteSink::new(&url, 100, None, Duration::ZERO).expect("construct sink");
+        sink.write(&encode_one("cpu", 1.0)).expect("write");
+
+        listener.set_nonblocking(true).expect("set non-blocking");
+        assert!(
+            listener.accept().is_err(),
+            "no request should have been sent below batch_size"
+        );
+    }
+
+    #[test]
+    fn explicit_flush_sends_buffered_data() {
+        let (listener, url) = mock_server_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
+
+        let mut sink =
+            RemoteWriteSink::new(&url, 10_000, None, Duration::ZERO).expect("construct sink");
+        sink.write(&encode_one("cpu", 1.0)).expect("write");
+        sink.flush().expect("flush");
+
+        let body = handle.join().expect("mock server thread panicked");
+        let request = decode_write_request(&body);
+        assert_eq!(request.timeseries.len(), 1, "flush must deliver the batch");
+    }
+
+    // -------------------------------------------------------------------------
+    // Time-based flush
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn time_based_flush_fires_when_buffer_age_exceeded() {
+        let (listener, url) = mock_server_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
+
+        // batch_size large enough that size never triggers; short max_buffer_age.
+        let mut sink = RemoteWriteSink::new(&url, 10_000, None, Duration::from_millis(50))
+            .expect("construct sink");
+
+        sink.write(&encode_one("first", 1.0)).expect("write 1");
+        thread::sleep(Duration::from_millis(200));
+        // Second write is past max_buffer_age → triggers a time-based flush.
+        sink.write(&encode_one("second", 2.0)).expect("write 2");
+
+        let body = handle.join().expect("mock server thread panicked");
+        let request = decode_write_request(&body);
+        assert_eq!(
+            request.timeseries.len(),
+            2,
+            "time-based flush must deliver both buffered TimeSeries"
+        );
+    }
+
+    #[test]
+    fn zero_max_buffer_age_disables_time_based_flush() {
+        let (listener, url) = mock_server_listener();
+
+        let mut sink =
+            RemoteWriteSink::new(&url, 10_000, None, Duration::ZERO).expect("construct sink");
+
+        sink.write(&encode_one("first", 1.0)).expect("write 1");
+        thread::sleep(Duration::from_millis(150));
+        sink.write(&encode_one("second", 2.0)).expect("write 2");
+
+        // With time-based flush disabled, no request should have arrived.
+        listener.set_nonblocking(true).expect("set non-blocking");
+        assert!(
+            listener.accept().is_err(),
+            "zero max_buffer_age must disable time-based flush"
+        );
+    }
+
+    #[test]
+    fn size_triggered_flush_resets_the_buffer_age_timer() {
+        let (listener, url) = mock_server_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
+
+        // Small batch_size, max_buffer_age comfortably longer than the test runs.
+        let mut sink =
+            RemoteWriteSink::new(&url, 2, None, Duration::from_secs(60)).expect("construct sink");
+
+        // Fill the batch — the size trigger fires.
+        sink.write(&encode_one("a", 1.0)).expect("write 1");
+        sink.write(&encode_one("b", 2.0)).expect("write 2");
+
+        let body = handle.join().expect("mock server thread panicked");
+        let request = decode_write_request(&body);
+        assert_eq!(
+            request.timeseries.len(),
+            2,
+            "size-triggered flush must deliver the full batch"
+        );
+
+        // The size flush reset last_flush_at; a subsequent partial-batch write
+        // must NOT immediately time-flush against the (now closed) listener.
+        sink.write(&encode_one("c", 3.0))
+            .expect("partial write after a size flush must not time-flush immediately");
+    }
+
+    // -------------------------------------------------------------------------
+    // Factory wiring: create_sink for RemoteWrite config
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn create_sink_remote_write_with_valid_url_returns_ok() {
+        let config = SinkConfig::RemoteWrite {
+            url: "http://127.0.0.1:19999/api/v1/write".to_string(),
+            batch_size: None,
+            max_buffer_age: None,
+            retry: None,
+        };
+        assert!(create_sink(&config, None).is_ok());
+    }
+
+    #[test]
+    fn create_sink_remote_write_with_invalid_max_buffer_age_returns_err() {
+        let config = SinkConfig::RemoteWrite {
+            url: "http://127.0.0.1:19999/api/v1/write".to_string(),
+            batch_size: None,
+            max_buffer_age: Some("garbage".to_string()),
+            retry: None,
+        };
+        assert!(
+            create_sink(&config, None).is_err(),
+            "invalid max_buffer_age must cause the factory to fail"
+        );
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_remote_write_deserializes_with_max_buffer_age() {
+        let yaml = r#"
+type: remote_write
+url: "http://localhost:8428/api/v1/write"
+max_buffer_age: 10s
+"#;
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).expect("should deserialize");
+        match config {
+            SinkConfig::RemoteWrite { max_buffer_age, .. } => {
+                assert_eq!(max_buffer_age.as_deref(), Some("10s"));
+            }
+            other => panic!("expected RemoteWrite variant, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_remote_write_max_buffer_age_defaults_to_none() {
+        let yaml = "type: remote_write\nurl: \"http://localhost:8428/api/v1/write\"";
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).expect("should deserialize");
+        match config {
+            SinkConfig::RemoteWrite { max_buffer_age, .. } => {
+                assert!(
+                    max_buffer_age.is_none(),
+                    "max_buffer_age should default to None"
+                );
+            }
+            other => panic!("expected RemoteWrite variant, got {other:?}"),
+        }
     }
 }

--- a/sonda-core/tests/encoder_sink_matrix.rs
+++ b/sonda-core/tests/encoder_sink_matrix.rs
@@ -289,7 +289,9 @@ fn encoder_http_push_body_matches(#[case] config: EncoderConfig, #[case] ct: &st
     let bytes = encode_event(&config, &test_event());
     let expected = bytes.clone();
     let server = thread::spawn(move || accept_http_ok(&listener));
-    let mut sink = sonda_core::sink::http::HttpPushSink::new(&url, ct, 10_000, HashMap::new(), None).unwrap();
+    let mut sink =
+        sonda_core::sink::http::HttpPushSink::new(&url, ct, 10_000, HashMap::new(), None, Duration::ZERO)
+            .unwrap();
     sink.write(&bytes).unwrap();
     sink.flush().unwrap();
     assert_eq!(server.join().unwrap(), expected);

--- a/sonda-core/tests/encoder_sink_matrix.rs
+++ b/sonda-core/tests/encoder_sink_matrix.rs
@@ -320,6 +320,7 @@ mod kafka_matrix {
         let cfg = sonda_core::sink::SinkConfig::Kafka {
             brokers: String::new(),
             topic: "sonda-test".to_string(),
+            max_buffer_age: None,
             retry: None,
             tls: None,
             sasl: None,

--- a/sonda-core/tests/sink_error_policy.rs
+++ b/sonda-core/tests/sink_error_policy.rs
@@ -117,6 +117,7 @@ fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
         SinkConfig::Loki {
             url,
             batch_size: Some(5),
+            max_buffer_age: Some("0s".to_string()),
             retry: None,
         },
         OnSinkError::Warn,
@@ -177,6 +178,7 @@ fn fail_policy_exits_thread_with_sink_error() {
         SinkConfig::Loki {
             url,
             batch_size: Some(5),
+            max_buffer_age: Some("0s".to_string()),
             retry: None,
         },
         OnSinkError::Fail,

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -167,6 +167,7 @@ fn remote_write_emits_stale_marker_on_running_to_paused() {
         SinkConfig::RemoteWrite {
             url: "http://example.invalid/api/v1/write".to_string(),
             batch_size: None,
+            max_buffer_age: None,
             retry: None,
         },
         EncoderConfig::RemoteWrite,
@@ -213,6 +214,7 @@ fn snap_to_replaces_stale_marker_with_literal_value() {
         SinkConfig::RemoteWrite {
             url: "http://example.invalid/api/v1/write".to_string(),
             batch_size: None,
+            max_buffer_age: None,
             retry: None,
         },
         EncoderConfig::RemoteWrite,
@@ -265,6 +267,7 @@ fn stale_marker_disabled_emits_no_close_sample() {
         SinkConfig::RemoteWrite {
             url: "http://example.invalid/api/v1/write".to_string(),
             batch_size: None,
+            max_buffer_age: None,
             retry: None,
         },
         EncoderConfig::RemoteWrite,
@@ -499,6 +502,7 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
             sink: SinkConfig::RemoteWrite {
                 url: "http://example.invalid/api/v1/write".to_string(),
                 batch_size: None,
+                max_buffer_age: None,
                 retry: None,
             },
             phase_offset: None,
@@ -597,6 +601,7 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
             sink: SinkConfig::RemoteWrite {
                 url: "http://example.invalid/api/v1/write".to_string(),
                 batch_size: None,
+                max_buffer_age: None,
                 retry: None,
             },
             phase_offset: None,
@@ -679,6 +684,7 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
             sink: SinkConfig::RemoteWrite {
                 url: "http://example.invalid/api/v1/write".to_string(),
                 batch_size: None,
+                max_buffer_age: None,
                 retry: None,
             },
             phase_offset: None,
@@ -770,6 +776,7 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
             sink: SinkConfig::RemoteWrite {
                 url: "http://example.invalid/api/v1/write".to_string(),
                 batch_size: None,
+                max_buffer_age: None,
                 retry: None,
             },
             phase_offset: None,
@@ -855,6 +862,7 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
             sink: SinkConfig::RemoteWrite {
                 url: "http://example.invalid/api/v1/write".to_string(),
                 batch_size: None,
+                max_buffer_age: None,
                 retry: None,
             },
             phase_offset: None,
@@ -951,6 +959,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
             sink: SinkConfig::RemoteWrite {
                 url: "http://example.invalid/api/v1/write".to_string(),
                 batch_size: None,
+                max_buffer_age: None,
                 retry: None,
             },
             phase_offset: None,

--- a/sonda/src/config.rs
+++ b/sonda/src/config.rs
@@ -321,6 +321,7 @@ fn build_sink_config(
                         .to_string(),
                     signal_type: parsed_signal,
                     batch_size,
+                    max_buffer_age: None,
                     retry: None,
                 })
             }
@@ -1871,6 +1872,7 @@ fn parse_sink_override(name: &str, endpoint: Option<&str>) -> Result<SinkConfig>
                     endpoint: ep.to_string(),
                     signal_type: sonda_core::sink::otlp_grpc::OtlpSignalType::Metrics,
                     batch_size: None,
+                    max_buffer_age: None,
                     retry: None,
                 })
             }

--- a/sonda/src/config.rs
+++ b/sonda/src/config.rs
@@ -249,6 +249,7 @@ fn build_sink_config(
                         .to_string(),
                     content_type: content_type.map(|s| s.to_string()),
                     batch_size,
+                    max_buffer_age: None,
                     // No --header CLI flag exists; users needing custom headers
                     // must use a YAML scenario file.
                     headers: None,
@@ -271,6 +272,7 @@ fn build_sink_config(
                         .expect("validated: --endpoint required for remote_write")
                         .to_string(),
                     batch_size,
+                    max_buffer_age: None,
                     retry: None,
                 })
             }
@@ -1809,6 +1811,7 @@ fn parse_sink_override(name: &str, endpoint: Option<&str>) -> Result<SinkConfig>
                     url: url.to_string(),
                     content_type: None,
                     batch_size: None,
+                    max_buffer_age: None,
                     headers: None,
                     retry: None,
                 })
@@ -1846,6 +1849,7 @@ fn parse_sink_override(name: &str, endpoint: Option<&str>) -> Result<SinkConfig>
                 Ok(SinkConfig::RemoteWrite {
                     url: url.to_string(),
                     batch_size: None,
+                    max_buffer_age: None,
                     retry: None,
                 })
             }

--- a/sonda/src/config.rs
+++ b/sonda/src/config.rs
@@ -291,6 +291,7 @@ fn build_sink_config(
                         .expect("validated: --endpoint required for loki")
                         .to_string(),
                     batch_size,
+                    max_buffer_age: None,
                     retry: None,
                 })
             }
@@ -1826,6 +1827,7 @@ fn parse_sink_override(name: &str, endpoint: Option<&str>) -> Result<SinkConfig>
                 Ok(SinkConfig::Loki {
                     url: url.to_string(),
                     batch_size: None,
+                    max_buffer_age: None,
                     retry: None,
                 })
             }

--- a/sonda/src/config.rs
+++ b/sonda/src/config.rs
@@ -341,6 +341,7 @@ fn build_sink_config(
                     topic: topic
                         .expect("validated: --topic required for kafka")
                         .to_string(),
+                    max_buffer_age: None,
                     retry: None,
                     tls: None,
                     sasl: None,

--- a/sonda/src/sink_format.rs
+++ b/sonda/src/sink_format.rs
@@ -110,6 +110,7 @@ mod tests {
             url: "http://localhost:9090/write".to_string(),
             content_type: None,
             batch_size: None,
+            max_buffer_age: None,
             headers: None,
             retry: None,
         };


### PR DESCRIPTION
Closes #297.

## Problem

The batching sinks flushed only when the batch reached `batch_size` or on explicit `flush()` (scenario shutdown). A low-rate scenario — e.g. one log every 20s — buffered data for a long time before first delivery, looking like a broken pipeline to anyone watching the backend.

## Fix

Adds `max_buffer_age` to **all five batching sinks**: a time threshold that complements the size threshold. A non-empty batch is flushed once it has been buffered longer than `max_buffer_age`, in addition to the existing size- and shutdown-triggered flushes — whichever trips first wins.

- New optional YAML field `max_buffer_age` (duration string) on `SinkConfig::{Loki, HttpPush, RemoteWrite, OtlpGrpc, Kafka}`.
- Default `5s` when omitted — low-rate scenarios get prompt first delivery with zero config.
- `"0s"` disables time-based flushing (size-and-shutdown only).
- Implemented as **check-on-write** (no background threads): the batch age is evaluated each time an event is written.

## Phased commits (single PR)

1. `470ddc6` — Loki sink + `parse_optional_duration` extraction in `validate.rs`.
2. `db05a4e` — http_push + remote_write sinks (replicates the Phase 1 pattern; also adds a test module to `remote_write.rs`, which had none).
3. `2676ff2` — docs: `sinks.md` field references + a new "Time-based flushing" section in `sink-batching.md`.
4. `8329058` — otlp_grpc sink (dual metric/log batches, one shared `last_flush_at`).
5. `816ea15` — kafka sink (fixed 64 KiB size threshold unchanged; `max_buffer_age` added as an orthogonal trigger).
6. `9ed9f62` — docs: extend the field tables and batching table to otlp_grpc + kafka.

## Verification

- **Opus staff review** — PASS on the loki/http_push/remote_write change, PASS on otlp_grpc, PASS on kafka. Cross-phase consistency, the shared `parse_optional_duration` extraction, every constructor call site, and the new test modules all verified.
- **UAT** — PASS across all five sinks (field accepted, default, `"0s"`, invalid-value rejection, docs parity).
- **Live smoke test** against VictoriaMetrics + Loki + Kafka + an OTel Collector — PASS. Low-rate scenarios (`rate: 0.5`, large/fixed `batch_size`, `max_buffer_age: "3s"`) delivered first data at ~4s (loki) / ~9s (http_push) / ~11s (remote_write) / ~1-4s (otlp_grpc) / ~5s (kafka) — all well before the 30s scenario shutdown. Control runs with `"0s"` confirmed no mid-run delivery. Normal-rate scenarios and existing `examples/*.yaml` confirmed unregressed.
- Gates: `build` / `clippy -D warnings` / `fmt --check` / `nextest` (2918 pass) / doctests / `--no-default-features` / `audit` — all green.

## Notes

- `kafka`'s `write()`-path behavior could not be unit-tested — `rskafka`'s `PartitionClient` has no offline constructor and the repo has no Kafka mock infra. The `write()` logic is byte-identical to the pattern behavior-tested across the other four sinks, and the live behavior is verified by the smoke test against a real broker.
- `--dry-run` does not catch an invalid `max_buffer_age` — it is parsed at sink-construction time, consistent with the existing `retry` duration fields. Tracked separately as #339.
- `otlp` and `kafka` are non-default Cargo features; building the `otlp_grpc`/`kafka` sinks requires `--features otlp,kafka` (pre-built binaries and Docker images include them).