### PR TITLE
feat(sink): distinguish buffered vs delivered writes for /stats (#294)

### DIFF
--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -517,13 +517,16 @@ curl -s http://localhost:8080/scenarios | jq .
       "id": "a1b2c3d4-...",
       "name": "noisy_logs",
       "state": "running",
-      "elapsed_secs": 184.2
+      "elapsed_secs": 184.2,
+      "degraded": false
     }
   ]
 }
 ```
 
-Each entry carries `id`, `name`, `state`, and `elapsed_secs`. The `state` field takes one of `pending`, `running`, `paused`, or `finished` (see the [`state` field reference](#scenariosidstats) below for what each value means and the transition note for `pending -> paused`). To see sink health, follow up with `GET /scenarios/{id}/stats` for the scenario you care about.
+Each entry carries `id`, `name`, `state`, `elapsed_secs`, and `degraded`. The `state` field takes one of `pending`, `running`, `paused`, or `finished` (see the [`state` field reference](#scenariosidstats) below for what each value means and the transition note for `pending -> paused`).
+
+`degraded` is the at-a-glance pipeline-health signal: it is `true` when a scenario has had sink failures (`total_sink_failures > 0`) **and** has not had a successful delivery within the last 30 seconds — or has never delivered. Scan the list for `degraded: true` to spot a scenario whose sink is wedged without thresholding the raw stats fields yourself. For a healthy scenario, or one with failures but recent successful deliveries, `degraded` is `false`. To see the underlying counters for any scenario, follow up with `GET /scenarios/{id}/stats`.
 
 ### `/scenarios/{id}/stats`
 
@@ -560,10 +563,13 @@ curl -s http://localhost:8080/scenarios/$ID/stats | jq .
 | `state` | string | One of `pending`, `running`, `paused`, `finished`. See the [`while:` lifecycle diagram](../configuration/v2-scenarios.md#lifecycle-states). |
 | `in_gap` | bool | `true` while a [gap window](../configuration/scenario-fields.md#gap-window) is suppressing output. |
 | `in_burst` | bool | `true` while a [burst window](../configuration/scenario-fields.md#burst-window) is elevating the rate. |
-| `consecutive_failures` | integer | Sink errors observed since the most recent successful write. Resets to `0` on the next successful write. |
+| `consecutive_failures` | integer | Sink errors observed since the most recent successful *delivery*. Resets to `0` on the next delivery. |
 | `total_sink_failures` | integer | Lifetime sink-error count. Monotonic. |
 | `last_sink_error` | string \| null | Text of the most recent sink error, or `null` if none has been observed. |
-| `last_successful_write_at` | integer \| null | Wall-clock time of the most recent successful write, expressed as Unix nanoseconds. `null` until the first write succeeds. |
+| `last_successful_write_at` | integer \| null | Wall-clock time of the most recent successful *delivery*, expressed as Unix nanoseconds. `null` until the first delivery succeeds. |
+
+!!! info "Delivery-accurate, not buffer-accurate, for batching sinks"
+    The batching sinks — `loki`, `http_push`, `remote_write`, `otlp_grpc`, `kafka` — buffer events and flush them to the backend in batches. `last_successful_write_at` and `consecutive_failures` track actual *delivery* to the destination, not buffering: `last_successful_write_at` advances only when a write triggers a successful flush, and a write that merely buffers neither advances it nor resets `consecutive_failures`. So a batching sink that is buffering but failing to reach its backend shows a *stale* `last_successful_write_at` and a *non-zero* `consecutive_failures` — the honest signal that nothing is landing. Non-batching sinks (`stdout`, `file`, `tcp`, `udp`) deliver synchronously on every write, so the two readings always reflect the latest write.
 
 The four sink-failure fields are the runtime telemetry surface for the [`on_sink_error` policy](../configuration/v2-scenarios.md#sink-error-policy). When `on_sink_error: warn` (the default) is in effect, the runner stays alive on transient sink errors and these counters tell you what's happening; when `on_sink_error: fail` is set, the thread exits on the first error and `state` flips to `finished`.
 
@@ -574,16 +580,15 @@ The four sink-failure fields are the runtime telemetry surface for the [`on_sink
     Earlier Sonda releases reported only `running`, `paused`, and `finished` on `/scenarios/{id}/stats`. The `pending` value is new and arrives when a scenario is waiting on `after:` or on the first eligible upstream tick of a `while:` gate. Before rolling out, grep your Prometheus recording rules and Grafana dashboards for label matchers like `state=~"running|paused|finished"` -- exhaustive enumerations silently drop scenarios in `pending`. Either add `pending` to the alternation (`state=~"pending|running|paused|finished"`) or rewrite the matcher as a negation (`state!="finished"`) so new lifecycle values surface without another patch.
 
 !!! tip "Detecting a wedged sink"
-    Compute "degraded" yourself by thresholding `total_sink_failures` and the staleness of `last_successful_write_at`. Pick a staleness window that fits your scenario's rate and your tolerance for transient blips:
+    To spot a scenario whose sink is wedged, read the `degraded` field on the [`GET /scenarios`](#scenarios-list) list response — it is `true` when a scenario has had sink failures and no successful delivery in the last 30 seconds:
 
     ```bash
-    # Flag a scenario as degraded when sink failures have happened and
-    # no write has succeeded in the last 30 seconds:
-    curl -sS http://localhost:8080/scenarios/$ID/stats |
-      jq 'select(.total_sink_failures > 0 and (.last_successful_write_at == null or (now*1e9 - .last_successful_write_at) > 30e9))'
+    # List the IDs of every degraded scenario:
+    curl -sS http://localhost:8080/scenarios |
+      jq -r '.scenarios[] | select(.degraded) | .id'
     ```
 
-    A non-empty result means the scenario is degraded by your definition. Wire the same expression into a Kubernetes readiness probe, a Prometheus alert query, or a Grafana panel — the operator owns the threshold.
+    Wire that into a Kubernetes readiness probe, a Prometheus alert query, or a Grafana panel. If you need a different staleness window than the built-in 30 seconds, threshold `total_sink_failures` and the staleness of `last_successful_write_at` from this endpoint yourself.
 
 ## Scrape Integration
 

--- a/docs/site/docs/guides/troubleshooting.md
+++ b/docs/site/docs/guides/troubleshooting.md
@@ -66,14 +66,13 @@ A scenario looks alive (the process is running, no error in the foreground) but 
 
     See [Self-observability via /stats](../deployment/sonda-server.md#self-observability-via-stats).
 
-- **Threshold the raw fields for monitoring** -- to flag a scenario as degraded for an alert or readiness probe, query its `/stats` and combine `total_sink_failures > 0` with a staleness check on `last_successful_write_at`. You pick the window that fits your rate and tolerance for transient blips:
+- **Use the `degraded` field for monitoring** -- `GET /scenarios` ships a precomputed `degraded: bool` per scenario, true when the scenario has had sink failures and has not delivered in the last 30 seconds. Use it directly for a readiness probe or alert:
 
     ```bash
-    curl -sS http://localhost:8080/scenarios/$ID/stats |
-      jq 'select(.total_sink_failures > 0 and (.last_successful_write_at == null or (now*1e9 - .last_successful_write_at) > 30e9))'
+    curl -sS http://localhost:8080/scenarios | jq '.scenarios[] | select(.degraded)'
     ```
 
-    A non-empty result means the scenario has stopped delivering by your definition. The same expression works as a Kubernetes readiness probe or a Prometheus alert input.
+    A non-empty result means at least one scenario has stopped delivering. The same expression works as a Kubernetes readiness probe or a Prometheus alert input. If you need a different staleness window than 30 seconds, you can still threshold the raw fields from the per-scenario `/stats` endpoint -- combine `total_sink_failures > 0` with your own staleness check on `last_successful_write_at`.
 
 The recovery is the default behavior: under `on_sink_error: warn`, the runner keeps ticking while you fix the sink (restart Loki, repair DNS, restore the network path). Once the sink accepts a write, `consecutive_failures` resets to `0` and `last_successful_write_at` advances, so any threshold you set clears automatically. If you want a sink failure to hard-fail the run instead, set `on_sink_error: fail` -- see [Sink-error policy](../configuration/v2-scenarios.md#sink-error-policy).
 

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -72,6 +72,9 @@ pub(crate) struct TickResult {
     ///
     /// Only the metrics runner provides this; the log runner returns `None`.
     pub metric_event: Option<MetricEvent>,
+    /// Whether this tick's write() delivered to the destination, or only
+    /// buffered it (batching sinks). Drives delivery-health stat updates.
+    pub delivered: bool,
 }
 
 /// Context passed to the per-tick callback.
@@ -287,11 +290,13 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
                         st.in_gap = currently_in_gap;
                         st.in_burst = currently_in_burst;
                         st.in_cardinality_spike = currently_in_spike;
-                        st.consecutive_failures = 0;
-                        st.last_successful_write_at = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .map(|d| d.as_nanos() as u64)
-                            .ok();
+                        if result.delivered {
+                            st.consecutive_failures = 0;
+                            st.last_successful_write_at = SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .map(|d| d.as_nanos() as u64)
+                                .ok();
+                        }
                         if let Some(event) = result.metric_event {
                             st.push_metric(event);
                         }
@@ -1031,6 +1036,7 @@ mod tests {
                 Ok(TickResult {
                     bytes_written: 6,
                     metric_event: None,
+                    delivered: true,
                 })
             };
 
@@ -1078,6 +1084,7 @@ mod tests {
                 Ok(TickResult {
                     bytes_written: 0,
                     metric_event: None,
+                    delivered: true,
                 })
             };
 
@@ -1124,6 +1131,7 @@ mod tests {
                 Ok(TickResult {
                     bytes_written: 0,
                     metric_event: None,
+                    delivered: true,
                 })
             };
 
@@ -1163,6 +1171,7 @@ mod tests {
                 Ok(TickResult {
                     bytes_written: 0,
                     metric_event: None,
+                    delivered: true,
                 })
             };
 
@@ -1189,6 +1198,7 @@ mod tests {
                 Ok(TickResult {
                     bytes_written: 42,
                     metric_event: None,
+                    delivered: true,
                 })
             };
 
@@ -1232,6 +1242,7 @@ mod tests {
                 Ok(TickResult {
                     bytes_written: 10,
                     metric_event: Some(event),
+                    delivered: true,
                 })
             };
 
@@ -1287,6 +1298,7 @@ mod tests {
                 Ok(TickResult {
                     bytes_written: 0,
                     metric_event: None,
+                    delivered: true,
                 })
             };
 
@@ -1467,6 +1479,7 @@ mod tests {
                     Ok(TickResult {
                         bytes_written: 8,
                         metric_event: None,
+                        delivered: true,
                     })
                 } else {
                     Err(SondaError::Sink(std::io::Error::new(
@@ -1495,6 +1508,85 @@ mod tests {
         assert!(st.total_sink_failures > 0);
         assert!(st.total_events > 0);
         assert!(st.last_successful_write_at.is_some());
+    }
+
+    #[test]
+    fn buffered_write_does_not_update_delivery_health_stats() {
+        let schedule = minimal_schedule(Some(Duration::from_millis(200)));
+        let stats = Arc::new(RwLock::new(ScenarioStats::default()));
+
+        let mut tick_fn =
+            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
+                Ok(TickResult {
+                    bytes_written: 12,
+                    metric_event: None,
+                    delivered: false,
+                })
+            };
+
+        run_schedule_loop(
+            &schedule,
+            50.0,
+            None,
+            Some(Arc::clone(&stats)),
+            &mut NullSink,
+            &mut tick_fn,
+        )
+        .expect("loop must succeed");
+
+        let st = stats.read().expect("stats lock");
+        assert!(
+            st.total_events > 0,
+            "buffered writes still count as generated events"
+        );
+        assert!(
+            st.bytes_emitted > 0,
+            "buffered writes still count toward bytes_emitted"
+        );
+        assert_eq!(
+            st.last_successful_write_at, None,
+            "a buffered write must not advance last_successful_write_at"
+        );
+        assert_eq!(
+            st.consecutive_failures, 0,
+            "a buffered write must not touch consecutive_failures"
+        );
+    }
+
+    #[test]
+    fn delivered_write_updates_delivery_health_stats() {
+        let schedule = minimal_schedule(Some(Duration::from_millis(200)));
+        let stats = Arc::new(RwLock::new(ScenarioStats::default()));
+
+        let mut tick_fn =
+            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
+                Ok(TickResult {
+                    bytes_written: 12,
+                    metric_event: None,
+                    delivered: true,
+                })
+            };
+
+        run_schedule_loop(
+            &schedule,
+            50.0,
+            None,
+            Some(Arc::clone(&stats)),
+            &mut NullSink,
+            &mut tick_fn,
+        )
+        .expect("loop must succeed");
+
+        let st = stats.read().expect("stats lock");
+        assert!(st.total_events > 0, "delivered writes count as events");
+        assert!(
+            st.last_successful_write_at.is_some(),
+            "a delivered write must advance last_successful_write_at"
+        );
+        assert_eq!(
+            st.consecutive_failures, 0,
+            "a delivered write keeps consecutive_failures at zero"
+        );
     }
 
     // ---- Rate limiter unit tests --------------------------------------------
@@ -1641,6 +1733,7 @@ mod tests {
                 Ok(TickResult {
                     bytes_written: 0,
                     metric_event: None,
+                    delivered: true,
                 })
             };
 
@@ -1673,6 +1766,7 @@ mod tests {
                 Ok(TickResult {
                     bytes_written: 0,
                     metric_event: None,
+                    delivered: true,
                 })
             };
 
@@ -1705,6 +1799,7 @@ mod tests {
         let result = TickResult {
             bytes_written: 100,
             metric_event: Some(event),
+            delivered: true,
         };
 
         assert_eq!(result.bytes_written, 100);

--- a/sonda-core/src/schedule/histogram_runner.rs
+++ b/sonda-core/src/schedule/histogram_runner.rs
@@ -256,10 +256,12 @@ pub fn run_with_sink_gated(
             encoder.encode_metric(&sum_event, &mut buf)?;
             total_bytes += buf.len() as u64;
             sink.write(&buf)?;
+            let delivered = sink.last_write_delivered();
 
             Ok(TickResult {
                 bytes_written: total_bytes,
                 metric_event: Some(count_event),
+                delivered,
             })
         };
 

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -128,10 +128,12 @@ pub fn run_logs_with_sink_gated(
             encoder.encode_log(&event, &mut buf)?;
             let bytes_written = buf.len() as u64;
             sink.write(&buf)?;
+            let delivered = sink.last_write_delivered();
 
             Ok(TickResult {
                 bytes_written,
                 metric_event: None,
+                delivered,
             })
         };
 

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -154,10 +154,12 @@ pub fn run_with_sink_gated(
             encoder.encode_metric(&event, &mut buf)?;
             let bytes_written = buf.len() as u64;
             sink.write(&buf)?;
+            let delivered = sink.last_write_delivered();
 
             Ok(TickResult {
                 bytes_written,
                 metric_event: Some(event),
+                delivered,
             })
         };
 

--- a/sonda-core/src/schedule/stats.rs
+++ b/sonda-core/src/schedule/stats.rs
@@ -12,6 +12,10 @@ use crate::model::metric::MetricEvent;
 /// The buffer is a circular deque: when full, the oldest event is evicted.
 pub const MAX_RECENT_METRICS: usize = 100;
 
+/// How long since the last successful delivery before a failing scenario is
+/// considered degraded, in nanoseconds (30 seconds).
+pub const DEGRADED_STALENESS_NANOS: u64 = 30 * 1_000_000_000;
+
 /// Lifecycle position of a scenario, surfaced for `while:`-gated runs.
 ///
 /// `Pending` covers the pre-`after:` window for chained scenarios; `Running`
@@ -93,6 +97,21 @@ impl ScenarioStats {
     /// oldest-first.
     pub fn drain_recent_metrics(&mut self) -> Vec<MetricEvent> {
         self.recent_metrics.drain(..).collect()
+    }
+
+    /// Whether the scenario looks unhealthy. Returns `true` only when the
+    /// scenario has at least one lifetime sink failure AND there is no
+    /// recent successful delivery (within [`DEGRADED_STALENESS_NANOS`]). A
+    /// scenario that failed once but is now delivering reads `false`.
+    /// `now_unix_nanos` is the current time as Unix nanoseconds.
+    pub fn is_degraded(&self, now_unix_nanos: u64) -> bool {
+        if self.total_sink_failures == 0 {
+            return false;
+        }
+        match self.last_successful_write_at {
+            None => true,
+            Some(last) => now_unix_nanos.saturating_sub(last) > DEGRADED_STALENESS_NANOS,
+        }
     }
 }
 
@@ -473,5 +492,61 @@ mod tests {
             !json.contains("recent_metrics"),
             "recent_metrics must not appear in JSON output (serde skip): {json}"
         );
+    }
+
+    // ---- is_degraded --------------------------------------------------------
+
+    #[test]
+    fn is_degraded_false_when_no_sink_failures() {
+        let s = ScenarioStats {
+            total_sink_failures: 0,
+            last_successful_write_at: None,
+            ..Default::default()
+        };
+        assert!(!s.is_degraded(0));
+        assert!(!s.is_degraded(u64::MAX));
+    }
+
+    #[test]
+    fn is_degraded_false_with_failures_but_recent_delivery() {
+        let now = 1_000_000_000_000_000;
+        let s = ScenarioStats {
+            total_sink_failures: 5,
+            last_successful_write_at: Some(now - 1_000_000_000),
+            ..Default::default()
+        };
+        assert!(!s.is_degraded(now));
+    }
+
+    #[test]
+    fn is_degraded_true_with_failures_and_stale_delivery() {
+        let now = 1_000_000_000_000_000;
+        let s = ScenarioStats {
+            total_sink_failures: 5,
+            last_successful_write_at: Some(now - DEGRADED_STALENESS_NANOS - 1),
+            ..Default::default()
+        };
+        assert!(s.is_degraded(now));
+    }
+
+    #[test]
+    fn is_degraded_true_with_failures_and_no_delivery_ever() {
+        let s = ScenarioStats {
+            total_sink_failures: 1,
+            last_successful_write_at: None,
+            ..Default::default()
+        };
+        assert!(s.is_degraded(1_000_000_000_000_000));
+    }
+
+    #[test]
+    fn is_degraded_false_under_clock_skew() {
+        let last = 1_000_000_000_000_000;
+        let s = ScenarioStats {
+            total_sink_failures: 5,
+            last_successful_write_at: Some(last),
+            ..Default::default()
+        };
+        assert!(!s.is_degraded(last - 1_000_000_000));
     }
 }

--- a/sonda-core/src/schedule/summary_runner.rs
+++ b/sonda-core/src/schedule/summary_runner.rs
@@ -219,10 +219,12 @@ pub fn run_with_sink_gated(
             encoder.encode_metric(&sum_event, &mut buf)?;
             total_bytes += buf.len() as u64;
             sink.write(&buf)?;
+            let delivered = sink.last_write_delivered();
 
             Ok(TickResult {
                 bytes_written: total_bytes,
                 metric_event: Some(count_event),
+                delivered,
             })
         };
 

--- a/sonda-core/src/sink/http.rs
+++ b/sonda-core/src/sink/http.rs
@@ -44,6 +44,8 @@ pub struct HttpPushSink {
     max_buffer_age: Duration,
     /// When the batch was last sent — drives the time-based flush check.
     last_flush_at: Instant,
+    /// Whether the most recent `write()` triggered a successful flush rather than only buffering.
+    last_write_delivered: bool,
 }
 
 impl HttpPushSink {
@@ -99,6 +101,7 @@ impl HttpPushSink {
             retry_policy,
             max_buffer_age,
             last_flush_at: Instant::now(),
+            last_write_delivered: false,
         })
     }
 
@@ -250,9 +253,11 @@ impl Sink for HttpPushSink {
         let size_reached = self.batch.len() >= self.batch_size;
         let age_reached =
             !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
-        if size_reached || age_reached {
+        let should_flush = size_reached || age_reached;
+        if should_flush {
             self.send_batch()?;
         }
+        self.last_write_delivered = should_flush;
         Ok(())
     }
 
@@ -262,6 +267,10 @@ impl Sink for HttpPushSink {
     /// batch is empty.
     fn flush(&mut self) -> Result<(), SondaError> {
         self.send_batch()
+    }
+
+    fn last_write_delivered(&self) -> bool {
+        self.last_write_delivered
     }
 }
 
@@ -561,6 +570,50 @@ mod tests {
 
         // Second flush — batch is now empty, must succeed without panicking.
         assert!(sink.flush().is_ok(), "second flush must also be Ok");
+    }
+
+    // -------------------------------------------------------------------------
+    // last_write_delivered — buffered vs flushed
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn last_write_delivered_is_false_when_write_only_buffers() {
+        let (listener, url) = mock_server_listener();
+
+        let mut sink = HttpPushSink::new(
+            &url,
+            "text/plain",
+            10_000,
+            HashMap::new(),
+            None,
+            Duration::ZERO,
+        )
+        .expect("construct sink");
+        sink.write(b"buffered").expect("write buffers");
+
+        assert!(
+            !sink.last_write_delivered(),
+            "a write that only buffers must report last_write_delivered() == false"
+        );
+        listener.set_nonblocking(true).expect("set non-blocking");
+        assert!(listener.accept().is_err(), "no flush should have fired");
+    }
+
+    #[test]
+    fn last_write_delivered_is_true_when_write_triggers_flush() {
+        let (listener, url) = mock_server_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
+
+        let mut sink =
+            HttpPushSink::new(&url, "text/plain", 4, HashMap::new(), None, Duration::ZERO)
+                .expect("construct sink");
+        sink.write(b"abcd").expect("write triggers flush");
+
+        handle.join().expect("mock server thread panicked");
+        assert!(
+            sink.last_write_delivered(),
+            "a write that triggers a successful flush must report last_write_delivered() == true"
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/sonda-core/src/sink/kafka.rs
+++ b/sonda-core/src/sink/kafka.rs
@@ -76,6 +76,8 @@ pub struct KafkaSink {
     max_buffer_age: Duration,
     /// When the buffer was last published — drives the time-based flush check.
     last_flush_at: Instant,
+    /// Whether the most recent `write()` triggered a successful flush rather than only buffering.
+    last_write_delivered: bool,
 }
 
 /// Build a `rustls::ClientConfig` for TLS connections to Kafka brokers.
@@ -311,6 +313,7 @@ impl KafkaSink {
             retry_policy,
             max_buffer_age,
             last_flush_at: Instant::now(),
+            last_write_delivered: false,
         })
     }
 
@@ -388,9 +391,11 @@ impl Sink for KafkaSink {
         let size_reached = self.buffer.len() >= KAFKA_BUFFER_SIZE;
         let age_reached =
             !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
-        if size_reached || age_reached {
+        let should_flush = size_reached || age_reached;
+        if should_flush {
             self.publish_buffer()?;
         }
+        self.last_write_delivered = should_flush;
         Ok(())
     }
 
@@ -400,6 +405,10 @@ impl Sink for KafkaSink {
     /// buffer is empty.
     fn flush(&mut self) -> Result<(), SondaError> {
         self.publish_buffer()
+    }
+
+    fn last_write_delivered(&self) -> bool {
+        self.last_write_delivered
     }
 }
 

--- a/sonda-core/src/sink/loki.rs
+++ b/sonda-core/src/sink/loki.rs
@@ -51,6 +51,8 @@ pub struct LokiSink {
     max_buffer_age: Duration,
     /// When the batch was last sent — drives the time-based flush check.
     last_flush_at: Instant,
+    /// Whether the most recent `write()` triggered a successful flush rather than only buffering.
+    last_write_delivered: bool,
 }
 
 impl LokiSink {
@@ -97,6 +99,7 @@ impl LokiSink {
             retry_policy,
             max_buffer_age,
             last_flush_at: Instant::now(),
+            last_write_delivered: false,
         })
     }
 
@@ -261,9 +264,11 @@ impl Sink for LokiSink {
         let size_reached = self.batch.len() >= self.batch_size;
         let age_reached =
             !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
-        if size_reached || age_reached {
+        let should_flush = size_reached || age_reached;
+        if should_flush {
             self.flush_batch()?;
         }
+        self.last_write_delivered = should_flush;
 
         Ok(())
     }
@@ -277,6 +282,10 @@ impl Sink for LokiSink {
     /// Returns [`SondaError::Sink`] if the HTTP request fails.
     fn flush(&mut self) -> Result<(), SondaError> {
         self.flush_batch()
+    }
+
+    fn last_write_delivered(&self) -> bool {
+        self.last_write_delivered
     }
 }
 
@@ -647,6 +656,42 @@ mod tests {
         assert!(
             sink.flush().is_ok(),
             "flush on empty batch must return Ok without making a network call"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // last_write_delivered — buffered vs flushed
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn last_write_delivered_is_false_when_write_only_buffers() {
+        let (listener, url) = mock_loki_listener();
+
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
+        sink.write(b"buffered\n").expect("write buffers");
+
+        assert!(
+            !sink.last_write_delivered(),
+            "a write that only buffers must report last_write_delivered() == false"
+        );
+        listener.set_nonblocking(true).expect("set non-blocking");
+        assert!(listener.accept().is_err(), "no flush should have fired");
+    }
+
+    #[test]
+    fn last_write_delivered_is_true_when_write_triggers_flush() {
+        let (listener, url) = mock_loki_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
+
+        let mut sink =
+            LokiSink::new(url, HashMap::new(), 1, None, Duration::ZERO).expect("construct sink");
+        sink.write(b"flushed\n").expect("write triggers flush");
+
+        handle.join().expect("mock server thread panicked");
+        assert!(
+            sink.last_write_delivered(),
+            "a write that triggers a successful flush must report last_write_delivered() == true"
         );
     }
 

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -32,6 +32,14 @@ pub trait Sink: Send + Sync {
 
     /// Flush any buffered data to the destination.
     fn flush(&mut self) -> Result<(), SondaError>;
+
+    /// Whether the most recent `write()` delivered data to the destination,
+    /// or only buffered it. Non-batching sinks deliver on every write, so the
+    /// default is `true`; batching sinks override this to return `true` only
+    /// when the most recent `write()` triggered a successful flush.
+    fn last_write_delivered(&self) -> bool {
+        true
+    }
 }
 
 /// TLS configuration for Kafka broker connections.

--- a/sonda-core/src/sink/otlp_grpc.rs
+++ b/sonda-core/src/sink/otlp_grpc.rs
@@ -181,6 +181,8 @@ pub struct OtlpGrpcSink {
     max_buffer_age: Duration,
     /// When a batch was last sent — drives the time-based flush check.
     last_flush_at: Instant,
+    /// Whether the most recent `write()` triggered a successful flush rather than only buffering.
+    last_write_delivered: bool,
 }
 
 impl OtlpGrpcSink {
@@ -261,6 +263,7 @@ impl OtlpGrpcSink {
             retry_policy,
             max_buffer_age,
             last_flush_at: Instant::now(),
+            last_write_delivered: false,
         })
     }
 
@@ -467,9 +470,11 @@ impl Sink for OtlpGrpcSink {
                 let size_reached = self.metric_batch.len() >= self.batch_size;
                 let age_reached = !self.max_buffer_age.is_zero()
                     && self.last_flush_at.elapsed() >= self.max_buffer_age;
-                if size_reached || age_reached {
+                let should_flush = size_reached || age_reached;
+                if should_flush {
                     self.flush_metrics()?;
                 }
+                self.last_write_delivered = should_flush;
             }
             OtlpSignalType::Logs => {
                 let records = otlp::parse_length_prefixed_log_records(data)?;
@@ -477,9 +482,11 @@ impl Sink for OtlpGrpcSink {
                 let size_reached = self.log_batch.len() >= self.batch_size;
                 let age_reached = !self.max_buffer_age.is_zero()
                     && self.last_flush_at.elapsed() >= self.max_buffer_age;
-                if size_reached || age_reached {
+                let should_flush = size_reached || age_reached;
+                if should_flush {
                     self.flush_logs()?;
                 }
+                self.last_write_delivered = should_flush;
             }
         }
         Ok(())
@@ -494,6 +501,10 @@ impl Sink for OtlpGrpcSink {
             OtlpSignalType::Metrics => self.flush_metrics(),
             OtlpSignalType::Logs => self.flush_logs(),
         }
+    }
+
+    fn last_write_delivered(&self) -> bool {
+        self.last_write_delivered
     }
 }
 
@@ -537,6 +548,7 @@ mod tests {
             retry_policy: None,
             max_buffer_age,
             last_flush_at: Instant::now(),
+            last_write_delivered: false,
         }
     }
 
@@ -1011,6 +1023,37 @@ sink:
         sink.write(&one_metric_bytes("c"))
             .expect("partial write after a size flush must not time-flush immediately");
         assert_eq!(sink.metric_batch.len(), 1, "partial write only buffers");
+    }
+
+    // -----------------------------------------------------------------------
+    // last_write_delivered — buffered case
+    //
+    // Only the buffered case is unit-testable: the lazy channel has no peer,
+    // so a triggered flush always fails. Flushed-success is verified live.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn last_write_delivered_is_false_when_metric_write_only_buffers() {
+        let mut sink = lazy_sink(OtlpSignalType::Metrics, 1_000_000, Duration::ZERO);
+
+        sink.write(&one_metric_bytes("buffered")).expect("write 1");
+
+        assert!(
+            !sink.last_write_delivered(),
+            "a metric write that only buffers must report last_write_delivered() == false"
+        );
+    }
+
+    #[test]
+    fn last_write_delivered_is_false_when_log_write_only_buffers() {
+        let mut sink = lazy_sink(OtlpSignalType::Logs, 1_000_000, Duration::ZERO);
+
+        sink.write(&one_log_bytes()).expect("write 1");
+
+        assert!(
+            !sink.last_write_delivered(),
+            "a log write that only buffers must report last_write_delivered() == false"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/sonda-core/src/sink/remote_write.rs
+++ b/sonda-core/src/sink/remote_write.rs
@@ -59,6 +59,8 @@ pub struct RemoteWriteSink {
     max_buffer_age: Duration,
     /// When the batch was last sent — drives the time-based flush check.
     last_flush_at: Instant,
+    /// Whether the most recent `write()` triggered a successful flush rather than only buffering.
+    last_write_delivered: bool,
 }
 
 impl RemoteWriteSink {
@@ -102,6 +104,7 @@ impl RemoteWriteSink {
             retry_policy,
             max_buffer_age,
             last_flush_at: Instant::now(),
+            last_write_delivered: false,
         })
     }
 
@@ -235,9 +238,11 @@ impl Sink for RemoteWriteSink {
         let size_reached = self.batch.len() >= self.batch_size;
         let age_reached =
             !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
-        if size_reached || age_reached {
+        let should_flush = size_reached || age_reached;
+        if should_flush {
             self.send_batch()?;
         }
+        self.last_write_delivered = should_flush;
 
         Ok(())
     }
@@ -249,6 +254,10 @@ impl Sink for RemoteWriteSink {
     /// returns `Ok(())` immediately if the batch is empty.
     fn flush(&mut self) -> Result<(), SondaError> {
         self.send_batch()
+    }
+
+    fn last_write_delivered(&self) -> bool {
+        self.last_write_delivered
     }
 }
 
@@ -385,6 +394,42 @@ mod tests {
         let body = handle.join().expect("mock server thread panicked");
         let request = decode_write_request(&body);
         assert_eq!(request.timeseries.len(), 1, "flush must deliver the batch");
+    }
+
+    // -------------------------------------------------------------------------
+    // last_write_delivered — buffered vs flushed
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn last_write_delivered_is_false_when_write_only_buffers() {
+        let (listener, url) = mock_server_listener();
+
+        let mut sink =
+            RemoteWriteSink::new(&url, 100, None, Duration::ZERO).expect("construct sink");
+        sink.write(&encode_one("cpu", 1.0)).expect("write buffers");
+
+        assert!(
+            !sink.last_write_delivered(),
+            "a write that only buffers must report last_write_delivered() == false"
+        );
+        listener.set_nonblocking(true).expect("set non-blocking");
+        assert!(listener.accept().is_err(), "no flush should have fired");
+    }
+
+    #[test]
+    fn last_write_delivered_is_true_when_write_triggers_flush() {
+        let (listener, url) = mock_server_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
+
+        let mut sink = RemoteWriteSink::new(&url, 1, None, Duration::ZERO).expect("construct sink");
+        sink.write(&encode_one("cpu", 1.0))
+            .expect("write triggers flush");
+
+        handle.join().expect("mock server thread panicked");
+        assert!(
+            sink.last_write_delivered(),
+            "a write that triggers a successful flush must report last_write_delivered() == true"
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/sonda-core/tests/sink_error_policy.rs
+++ b/sonda-core/tests/sink_error_policy.rs
@@ -166,6 +166,56 @@ fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
 }
 
 #[test]
+fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
+    // Bind then drop a listener so the port is guaranteed free — every flush
+    // against it will fail to connect.
+    let dead_url = {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let port = listener.local_addr().expect("local addr").port();
+        format!("http://127.0.0.1:{port}")
+    };
+
+    let entry = build_log_entry(
+        "warn_dead_url",
+        SinkConfig::Loki {
+            url: dead_url,
+            batch_size: Some(500),
+            max_buffer_age: Some("250ms".to_string()),
+            retry: None,
+        },
+        OnSinkError::Warn,
+    );
+
+    let shutdown = Arc::new(AtomicBool::new(true));
+    let mut handle = launch_scenario(
+        "warn-dead-url".to_string(),
+        entry,
+        Arc::clone(&shutdown),
+        None,
+    )
+    .expect("launch must succeed");
+
+    handle.join(Some(Duration::from_secs(3))).expect("join Ok");
+
+    let snap = handle.stats_snapshot();
+    assert!(
+        snap.total_sink_failures > 0,
+        "flushes against a dead URL must record sink failures, got {}",
+        snap.total_sink_failures
+    );
+    assert!(
+        snap.last_successful_write_at.is_none(),
+        "no write ever delivered — buffered writes must not advance last_successful_write_at, got {:?}",
+        snap.last_successful_write_at
+    );
+    assert!(
+        snap.consecutive_failures > 0,
+        "a buffered write must not reset consecutive_failures, got {}",
+        snap.consecutive_failures
+    );
+}
+
+#[test]
 fn fail_policy_exits_thread_with_sink_error() {
     let (listener, url) = mock_loki_listener();
     let stop = Arc::new(AtomicBool::new(false));

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -19,7 +19,7 @@
 
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
@@ -76,6 +76,8 @@ pub struct ScenarioSummary {
     /// Current state: one of `"pending"`, `"running"`, `"paused"`, `"finished"`.
     pub state: String,
     pub elapsed_secs: f64,
+    /// Whether the scenario has sink failures and no recent successful delivery.
+    pub degraded: bool,
 }
 
 /// Response body for `GET /scenarios`.
@@ -571,6 +573,11 @@ pub async fn list_scenarios(State(state): State<AppState>) -> Result<impl IntoRe
         .read()
         .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
 
+    let now_unix_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+
     let summaries: Vec<ScenarioSummary> = scenarios
         .iter()
         .map(|(id, handle)| {
@@ -580,6 +587,7 @@ pub async fn list_scenarios(State(state): State<AppState>) -> Result<impl IntoRe
                 name: handle.name.clone(),
                 state: state_string(&snap).to_string(),
                 elapsed_secs: handle.elapsed().as_secs_f64(),
+                degraded: snap.is_degraded(now_unix_nanos),
             }
         })
         .collect();
@@ -1128,6 +1136,33 @@ scenarios:
             entry["elapsed_secs"].is_f64(),
             "elapsed_secs must be a number"
         );
+        assert!(entry["degraded"].is_boolean(), "degraded must be a boolean");
+    }
+
+    /// A scenario with no sink failures reports degraded=false in the list.
+    #[tokio::test]
+    async fn list_scenarios_degraded_false_for_healthy_scenario() {
+        let h = make_handle(
+            "id-healthy",
+            "healthy_test",
+            1000,
+            Duration::from_millis(50),
+        );
+        let app = router_with_handles(vec![h]);
+
+        let req = Request::builder()
+            .uri("/scenarios")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = body_json(resp).await;
+        let entry = &body["scenarios"][0];
+
+        assert_eq!(
+            entry["degraded"], false,
+            "a scenario with no sink failures must report degraded=false"
+        );
     }
 
     // ---- GET /scenarios/{id}: correct name, status, elapsed -------------------
@@ -1437,12 +1472,14 @@ scenarios:
             name: "test".to_string(),
             state: "running".to_string(),
             elapsed_secs: 1.5,
+            degraded: false,
         };
         let json = serde_json::to_value(&s).unwrap();
         assert_eq!(json["id"], "abc");
         assert_eq!(json["name"], "test");
         assert_eq!(json["state"], "running");
         assert_eq!(json["elapsed_secs"], 1.5);
+        assert_eq!(json["degraded"], false);
     }
 
     /// ScenarioDetail serializes with nested stats object.


### PR DESCRIPTION
Closes #294.

## Problem

For batching sinks (`loki`, `http_push`, `remote_write`, `otlp_grpc`, `kafka`), `sink.write()` returning `Ok` means *"buffered"*, not *"delivered"* — the real network delivery happens later inside an auto-flush. But `core_loop` was updating `/stats`'s delivery-health fields (`last_successful_write_at`, and the `consecutive_failures = 0` reset) on every `Ok` from `write()`. Result: `/stats` could show `last_successful_write_at: 2s ago, consecutive_failures: 0` while the backend had received nothing for hours. An operator scanning the API would see "healthy" when nothing was being delivered.

## Fix — Option C, trait-method introspection

`Sink` gains a default-method `last_write_delivered(&self) -> bool { true }`. The five batching sinks override it to return `true` only when their most recent `write()` triggered a *successful flush* — not when it merely buffered. `core_loop` consults the bit and updates the delivery-health fields only on real delivery. `total_events` and `bytes_emitted` still count buffered writes (they're real). Non-batching sinks (stdout, file, tcp, udp) keep the default `true` — zero edits, zero behavior change.

`GET /scenarios` ships a precomputed `degraded: bool` per scenario — `true` when the scenario has had sink failures and has not delivered in the last 30s (or has never delivered). Operators get the answer without rolling their own `jq` threshold.

## Phased commits (single PR, like #338)

1. `608f82a` — Phase 1: `Sink::last_write_delivered()` trait method + `delivered` bit on `TickResult` + `core_loop` branches the `Ok` path. Default-`true` means every sink behaves identically — provable no-op for `/stats`.
2. `7d52f55` — Phase 2: the 5 batching sinks override the method. Now `/stats` is delivery-accurate.
3. `a3a114b` — Phase 3: `degraded: bool` on `GET /scenarios`, `ScenarioStats::is_degraded(now)` helper, end-to-end integration test, doc updates.

## Verification

- **Opus staff review** — PASS on Phase 1, PASS on Phase 2, PASS WITH NOTES on Phase 3 (notes addressed inline: doc comment polished, `troubleshooting.md` `jq` recipe replaced).
- **End-to-end integration test** (`sonda-core/tests/sink_error_policy.rs::warn_policy_keeps_delivery_health_gated_on_real_flush`) — Loki sink against a bound-then-dropped port: asserts `total_sink_failures > 0`, `last_successful_write_at.is_none()`, `consecutive_failures > 0`. The pre-fix behavior would have failed the last two assertions.
- **UAT live verification** via `sonda-server` — POST a Loki scenario at `http://127.0.0.1:1` (refused), wait 3s, `GET /scenarios/{id}/stats` returns `total_sink_failures: 25, last_successful_write_at: null, consecutive_failures: 25`; `GET /scenarios` returns `degraded: true`. Docs verified match.
- Gates: `build` / `clippy -D warnings` (workspace + all-features) / `fmt --check` / `nextest` (2931 pass) / doctests / `--no-default-features` — all green.

## Notes

- **`degraded` is on `GET /scenarios` only**, not on `GET /scenarios/{id}` or the `/stats` endpoints. The list endpoint is what the issue asked for. Adding it to `ScenarioDetail` for parity is a small mechanical follow-up — happy to file post-merge.
- **4xx-as-delivered**: an http_push/loki flush that gets a 4xx-except-429 is logged-and-discarded as `Ok(())` and counts as `delivered`. That's the existing behavior and the right scope boundary for #294 — the bug being fixed is a *down* backend (connection refused / 5xx / timeout) falsely showing healthy. A 4xx means the connection works and the sink is functioning; the server actively rejected the payload. Reclassifying 4xx as a delivery-health concern would be a separate semantics change.
- **Kafka `write()` behavior is not unit-tested** — `rskafka`'s `PartitionClient` has no offline constructor and the repo has no Kafka mock infra (same constraint as PR #338 Phase 5). The override is byte-identical to the four unit-tested sinks; the live behavior is covered by the integration test pattern.