### PR TITLE
docs: visualize wedged-sink failure mode in /stats and /scenarios pages

### DIFF
--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -502,6 +502,8 @@ Response codes:
 
 ## Self-observability via /stats
 
+External monitors — Kubernetes readiness probes, Prometheus alerts, ops dashboards — read these endpoints to answer one question: is the scenario actually delivering data, or is it silently wedged? `GET /scenarios` ships a precomputed `degraded` flag per scenario for at-a-glance checks, and `GET /scenarios/{id}/stats` returns the raw counters underneath so you can set your own thresholds.
+
 `GET /scenarios/{id}/stats` returns live runner telemetry. The four sink-failure fields let external monitors spot a wedged runner without parsing logs, and you choose the threshold that counts as "degraded" for your environment.
 
 ### `/scenarios` list
@@ -526,7 +528,40 @@ curl -s http://localhost:8080/scenarios | jq .
 
 Each entry carries `id`, `name`, `state`, `elapsed_secs`, and `degraded`. The `state` field takes one of `pending`, `running`, `paused`, or `finished` (see the [`state` field reference](#scenariosidstats) below for what each value means and the transition note for `pending -> paused`).
 
-`degraded` is the at-a-glance pipeline-health signal: it is `true` when a scenario has had sink failures (`total_sink_failures > 0`) **and** has not had a successful delivery within the last 30 seconds — or has never delivered. Scan the list for `degraded: true` to spot a scenario whose sink is wedged without thresholding the raw stats fields yourself. For a healthy scenario, or one with failures but recent successful deliveries, `degraded` is `false`. To see the underlying counters for any scenario, follow up with `GET /scenarios/{id}/stats`.
+#### The `degraded` field
+
+`degraded` is the at-a-glance pipeline-health signal — one boolean per scenario that tells you whether its sink is delivering. It is `true` when the scenario has had sink failures (`total_sink_failures > 0`) **and** has not had a successful delivery within the last 30 seconds, or has never delivered at all. A healthy scenario, or one that failed earlier but is delivering again, reads `false`.
+
+```text
+curl /scenarios →
+{
+  "scenarios": [
+    { "id": "abc", "name": "loki-prod",   "state": "running", "degraded": false },
+    { "id": "xyz", "name": "loki-broken", "state": "running", "degraded": true  }
+                                                                            ↑ wedged
+  ]
+}
+```
+
+`degraded = (total_sink_failures > 0) AND (no successful delivery in last 30s, or ever)`.
+
+The win is operator ergonomics: one field replaces a multi-step threshold check. Before, you had to pull the raw counters from `/stats` and threshold them yourself:
+
+```bash title="Threshold the raw stats yourself"
+curl -sS http://localhost:8080/scenarios/$ID/stats |
+  jq 'select(.total_sink_failures > 0)
+      | select(.last_successful_write_at == null
+               or (now * 1e9 - .last_successful_write_at) > 30e9)'
+```
+
+Now the server does that work for you, per scenario, on every list request:
+
+```bash title="Scan the list for degraded scenarios"
+curl -sS http://localhost:8080/scenarios |
+  jq '.scenarios[] | select(.degraded)'
+```
+
+That same one-liner works as a Kubernetes readiness probe, a Prometheus alert input, or a Grafana panel query. If you need a different staleness window than the built-in 30 seconds, threshold the raw fields from `GET /scenarios/{id}/stats` yourself — `degraded` is a convenience over the same underlying counters.
 
 ### `/scenarios/{id}/stats`
 
@@ -551,6 +586,38 @@ curl -s http://localhost:8080/scenarios/$ID/stats | jq .
   "last_successful_write_at": 1714694400000000000
 }
 ```
+
+#### What a wedged batching sink looks like
+
+Five sinks — `loki`, `http_push`, `remote_write`, `otlp_grpc`, `kafka` — pile events into an in-memory buffer and only deliver them in bursts ("flushes"). The other sinks (`stdout`, `file`, `tcp`, `udp`) deliver every event immediately. For the batching group, `total_events` climbs on every *buffered* write, but the delivery-health fields (`last_successful_write_at`, `consecutive_failures`, `total_sink_failures`) only move when a real flush succeeds or fails. That mismatch is the whole reason `/stats` exists: it tells you what's actually landing, not what's queued.
+
+Picture a scenario writing to a Loki backend that has gone unreachable, running under the default [`on_sink_error: warn`](../configuration/v2-scenarios.md#sink-error-policy) policy. Six writes in:
+
+```text
+ write #1   buffer       Ok  →  /stats untouched (only buffered)
+ write #2   buffer       Ok  →  /stats untouched
+ write #3   buffer       Ok  →  /stats untouched
+ write #4   buffer       Ok  →  /stats untouched
+ write #5   buffer+FLUSH Err →  total_sink_failures += 1, consecutive_failures += 1
+ write #6   buffer       Ok  →  /stats untouched
+ ...
+```
+
+`total_events` keeps climbing the whole time — six successful tick results, six increments. But `/stats` tells the honest story:
+
+```json title="curl http://localhost:8080/scenarios/$ID/stats"
+{
+  "total_events": 6,
+  "last_successful_write_at": null,
+  "consecutive_failures": 1,
+  "total_sink_failures": 1,
+  "last_sink_error": "connection refused: http://loki:3100/loki/api/v1/push"
+}
+```
+
+`last_successful_write_at: null` says nothing has *ever* delivered. `consecutive_failures: 1` reflects the one failed flush in this window — buffered writes leave this counter alone; only a failed flush increments it, and only a *successful delivery* resets it to zero. `total_sink_failures: 1` is the same single failure counted as a lifetime total; until the first successful delivery, the two counters stay locked together. Run the scenario longer and both rise in step — once every `max_buffer_age` window (or whenever the batch fills), not on every tick.
+
+This is the shape to look for: rising `total_events`, `last_successful_write_at` stuck at `null` (or stale), `consecutive_failures` non-zero. An operator who sees that pattern knows the backend is unreachable, no matter how high `total_events` climbs. Non-batching sinks deliver synchronously on every write, so for them the delivery-health fields and the event counter always advance together — the wedged-buffer trap doesn't apply.
 
 | Field | Type | Meaning |
 |---|---|---|

--- a/docs/site/docs/guides/synthetic-monitoring.md
+++ b/docs/site/docs/guides/synthetic-monitoring.md
@@ -367,10 +367,17 @@ Key fields to watch:
 
 | Field | What it tells you |
 |-------|-------------------|
-| `total_events` | Running count of emitted events. Should increase steadily. |
+| `total_events` | Running count of emitted events. Should increase steadily. For batching sinks (`loki`, `http_push`, `remote_write`, `otlp_grpc`, `kafka`) this counts *buffered* writes, not deliveries — pair it with the fields below to confirm data is actually landing. |
 | `current_rate` | Actual emission rate. Compare against your scenario's `rate`. |
 | `errors` | Error count. Should be 0 for healthy scenarios. |
 | `uptime` | Time since scenario started. Confirms it hasn't restarted. |
+| `last_successful_write_at` | Wall-clock time (Unix nanos) of the most recent successful delivery. `null` means nothing has ever landed; a stale value means the sink is wedged. |
+| `consecutive_failures` | Failure streak since the last successful delivery. Resets to `0` on the next successful flush. Non-zero with a stale `last_successful_write_at` is the wedged-sink signature. |
+| `total_sink_failures` | Lifetime sink-error count. Monotonic. Useful as a Prometheus alert input (`increase(...)[5m]`). |
+
+The full reference for these fields, including the `last_sink_error` text and the `state`/gap/burst flags, lives in [Self-observability via /stats](../deployment/sonda-server.md#self-observability-via-stats).
+
+If you only check one signal across the whole server, check `degraded` on `GET /scenarios` — it combines the three sink-failure fields above into a single boolean per scenario, true when delivery has stalled for more than 30 seconds. The scripted health check below uses it directly.
 
 ### List all scenarios
 
@@ -383,18 +390,27 @@ curl -s http://localhost:8080/scenarios | jq '.[] | {name, status}'
 If a scenario shows `status: "stopped"` unexpectedly, re-submit it.
 
 ??? tip "Scripting a health check"
-    Wrap the stats check in a simple script that alerts you if events stop flowing:
+    Wrap the check in a script that fails loudly when any scenario stops delivering. Read `degraded` from `GET /scenarios` — totalling `total_events` would silently miss a wedged batching sink, because buffered writes still increment the counter while nothing reaches the backend.
 
     ```bash title="check-sonda.sh"
     #!/bin/bash
-    SONDA_URL="http://localhost:8080"
+    set -euo pipefail
+    SONDA_URL="${SONDA_URL:-http://localhost:8080}"
 
-    for id in $(curl -s "$SONDA_URL/scenarios" | jq -r '.[].id'); do
-      events=$(curl -s "$SONDA_URL/scenarios/$id/stats" | jq '.total_events')
-      name=$(curl -s "$SONDA_URL/scenarios/$id" | jq -r '.name')
-      echo "$name ($id): $events events"
-    done
+    # Pull the list once and read the precomputed degraded flag per scenario.
+    bad=$(curl -sS "$SONDA_URL/scenarios" |
+          jq -r '.scenarios[] | select(.degraded) | "\(.name) (\(.id))"')
+
+    if [[ -n "$bad" ]]; then
+      echo "Degraded scenarios:"
+      echo "$bad"
+      exit 1
+    fi
+
+    echo "All scenarios delivering."
     ```
+
+    Exit code `1` makes this drop-in for a Kubernetes readiness probe, a cron alert, or a CI smoke step. If you need the raw counters (per-scenario rate, failure streak, last delivery timestamp) for a richer report, follow up with `GET /scenarios/$id/stats` on each degraded ID.
 
 ---
 

--- a/docs/site/docs/guides/troubleshooting.md
+++ b/docs/site/docs/guides/troubleshooting.md
@@ -66,6 +66,9 @@ A scenario looks alive (the process is running, no error in the foreground) but 
 
     See [Self-observability via /stats](../deployment/sonda-server.md#self-observability-via-stats).
 
+    !!! warning "`total_events` is not a delivery signal for batching sinks"
+        Batching sinks (`loki`, `http_push`, `remote_write`, `otlp_grpc`, `kafka`) buffer events and only deliver in bursts. `total_events` increments on every *buffered* write, so a rising counter is **not** proof that anything is reaching the backend. Read the delivery-health fields instead: `last_successful_write_at` (stale or `null` means nothing has landed) and `consecutive_failures` (non-zero means a wedged buffer). See [What a wedged batching sink looks like](../deployment/sonda-server.md#what-a-wedged-batching-sink-looks-like) for the full timeline.
+
 - **Use the `degraded` field for monitoring** -- `GET /scenarios` ships a precomputed `degraded: bool` per scenario, true when the scenario has had sink failures and has not delivered in the last 30 seconds. Use it directly for a readiness probe or alert:
 
     ```bash


### PR DESCRIPTION
## What this PR adds

Follow-up to #341. PR #341 shipped the `degraded: bool` field on `GET /scenarios` and made the `/stats` delivery-health fields flush-accurate for batching sinks. The reference content was solid, but a scan of the surrounding doc pages found three pedagogical gaps a sonda newcomer hits — including one stale example that would actively mislead an operator.

This PR is **additive only**. No reference content moved or trimmed. Three files touched:

### `deployment/sonda-server.md`
- Opening framing paragraph above "Self-observability via /stats" — plain-language motivation before any field name.
- New H4 **"The `degraded` field"** under `/scenarios list`, with a 2-scenario ASCII illustration, the formula in plain text, and the before/after operator-workflow contrast — multi-step jq threshold vs `curl /scenarios | jq '.scenarios[] | select(.degraded)'`.
- New H4 **"What a wedged batching sink looks like"** under `/scenarios/{id}/stats`, with a 6-write timeline diagram, the resulting `/stats` JSON snapshot, and prose explaining the buffer-vs-delivery distinction.

### `guides/troubleshooting.md`
- One `!!! warning` admonition inside the `/stats` bullet of "A scenario stopped emitting silently", cross-linking to the new sonda-server.md anchor. Catches the moment of confusion: a reader sees `total_events` rising and second-guesses whether the scenario is broken.

### `guides/synthetic-monitoring.md`
- Extended the "Key fields to watch" table with `last_successful_write_at`, `consecutive_failures`, `total_sink_failures` rows + a batching-sinks caveat on `total_events`.
- New short paragraph pointing at `degraded` as the if-you-only-check-one-thing signal.
- **Rewrote the scripted health-check example** to read `degraded` from `/scenarios`. The previous script totalled `total_events` per scenario — which would silently miss a wedged batching sink, the exact failure mode #341 exists to expose. A reader copy-pasting the old script into a real Kubernetes readiness probe would deploy a check that doesn't catch the bug it claims to catch.

## Verification

- `mkdocs --strict` builds clean — no errors, no warnings, cross-links resolve.
- Each touched page rendered and read top-to-bottom to confirm the additions flow with existing prose. One factual error in the wedged-sink JSON snapshot (`consecutive_failures` value misstated; corrected against the actual counter semantics — buffered writes don't increment it, only failed flushes do).
- ASCII timeline diagrams render as monospace `<pre><code>` blocks with column alignment preserved.
- All new prose paragraphs are single long lines per project style; no internal-history references.