### PR TITLE
feat(csv-replay): derive rate from CSV timestamps + default_metric_name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@ tests/e2e/.docker-volumes/
 # MkDocs site build output and Python venv
 docs/site/.venv/
 docs/site/site/
-
-# v2 refactor planning docs (local only)
-docs/v2/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2202,11 +2202,12 @@ dependencies = [
  "serde_yaml_ng",
  "sonda-core",
  "tempfile",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "sonda-core"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "bytes",
  "chrono",
@@ -2226,13 +2227,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tonic",
+ "tracing",
+ "tracing-test",
  "ureq",
  "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "sonda-server"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -2663,6 +2666,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/docs/site/docs/configuration/generators.md
+++ b/docs/site/docs/configuration/generators.md
@@ -19,7 +19,7 @@ values.
 | [`sequence`](#sequence) | Exact `for:` durations, scripted timelines | Whatever you list, tick by tick | `values`, `repeat` |
 | [`step`](#step) | `rate()` and `increase()` testing | Monotonic counter incrementing each tick | `start`, `step_size`, optional `max` |
 | [`spike`](#spike) | Anomaly detection, threshold alerts | Baseline with periodic outlier bursts | `baseline`, `magnitude`, `interval_secs` |
-| [`csv_replay`](#csv_replay) | Bit-for-bit incident reproduction | The recorded values, in order | `file`, `columns` |
+| [`csv_replay`](#csv_replay) | Bit-for-bit incident reproduction | The recorded values, at the recorded cadence | `file`, `timescale`, `default_metric_name` |
 
 For [logs](#log-generators), pick `template` for synthesized messages with field pools
 or `replay` for line-by-line CSV/log-file replay. For latency distributions, see the
@@ -283,22 +283,22 @@ cpu_spike_test{instance="server-01",job="node"} 250 1775195162888
 
 ### csv_replay
 
-Replays numeric values from a CSV file. Use it to reproduce real production metric patterns
-captured from monitoring systems -- including Grafana CSV exports with embedded labels. For a
-step-by-step walkthrough of the Grafana export workflow, see the
-[Grafana CSV Replay](../guides/grafana-csv-replay.md) guide.
+Replays numeric values from a CSV file. Use it to reproduce real production metric patterns captured from monitoring systems -- including Grafana CSV exports with embedded labels. The replay rate is derived from the CSV's column-0 timestamps and the optional `timescale` multiplier, so a 5-minute incident plays back over 5 minutes without manual tuning. For a step-by-step walkthrough of the Grafana export workflow, see the [Grafana CSV Replay](../guides/grafana-csv-replay.md) guide.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `file` | string | yes | -- | Path to the CSV file. |
 | `columns` | list | no | -- | Explicit column specs. Each entry: `{index, name}` with optional `labels`. When absent, columns are auto-discovered from the header. |
 | `repeat` | boolean | no | `true` | When true, cycles back to the start. When false, holds the last value. |
+| `timescale` | float | no | `1.0` | Replay speed multiplier. `2.0` plays 2x faster, `0.5` plays 2x slower. Must be strictly positive. |
+| `default_metric_name` | string | no | -- | Fallback metric name for auto-discovered columns whose header has labels but no `__name__`. Suffixed with `_<column_index>` when multiple columns share the fallback. |
 
-Header rows are auto-detected: if any non-time field on the first data line is non-numeric,
-the line is treated as a header and skipped.
+Header rows are auto-detected: if any non-time field on the first data line is non-numeric, the line is treated as a header and skipped.
 
-When `columns` is omitted, Sonda reads the CSV header and auto-discovers column names and
-labels. If the CSV has no header (all-numeric first row), you must provide explicit `columns`.
+When `columns` is omitted, Sonda reads the CSV header and auto-discovers column names and labels. If the CSV has no header (all-numeric first row), you must provide explicit `columns`.
+
+!!! warning "Scenario `rate:` is overridden for csv_replay"
+    For `csv_replay`, the scenario's `rate:` is always replaced by `timescale / median_delta_t`, where `median_delta_t` is the median interval between consecutive timestamps in column 0 of the CSV. Setting `rate:` in YAML has no effect on emission cadence -- run `sonda --verbose --dry-run` to confirm the derived rate or inspect the startup banner. Use `timescale:` to speed up or slow down replay.
 
 === "Auto-discovery (default)"
 
@@ -389,12 +389,11 @@ one per tick.
     |--------|---------|-------------|--------|
     | `__name__` inside braces | `{__name__="up", job="prom"}` | `up` | `job` |
     | Name before braces | `up{job="prom"}` | `up` | `job` |
-    | Labels only | `{job="prom"}` | none | `job` |
+    | Labels only | `{job="prom"}` | from `default_metric_name` | `job` |
     | Plain name | `cpu_percent` | `cpu_percent` | none |
     | Simple word | `prometheus` | `prometheus` | none |
 
-    Formats 1 and 2 are produced by Grafana. Format 3 (labels only, no metric name) is not
-    compatible with auto-discovery and requires explicit `columns:` instead.
+    Formats 1 and 2 are produced by Grafana. Format 3 (labels only, no metric name) is supported via the `default_metric_name` field on the generator -- see the [Grafana CSV Replay](../guides/grafana-csv-replay.md#labels-only-headers-default_metric_name) guide.
 
 ## Operational aliases
 

--- a/docs/site/docs/guides/csv-import.md
+++ b/docs/site/docs/guides/csv-import.md
@@ -15,17 +15,15 @@ flap, step), and emits a v2 scenario YAML wired to a generator with the right kn
 
 ## Why import instead of replay?
 
-The [csv_replay](grafana-csv-replay.md) generator plays back raw CSV values verbatim. That is
-useful for exact reproduction, but the output is tied to the original file. `sonda import`
-takes a different approach:
+The [csv_replay](grafana-csv-replay.md) generator plays back raw CSV values verbatim. It preserves the original sample interval automatically (the replay rate is derived from the CSV timestamps, not from `rate:`) and supports labels-only Grafana exports via `default_metric_name:`. Use it when you need bit-for-bit fidelity tied to a specific file.
 
-- **Portable** -- the generated YAML uses generators (`steady`, `spike_event`, `leak`, `flap`,
-  `sawtooth`, `step`), so it runs without the original CSV file.
+`sonda import` takes a different approach:
+
+- **Portable** -- the generated YAML uses generators (`steady`, `spike_event`, `leak`, `flap`, `sawtooth`, `step`), so it runs without the original CSV file.
 - **Parameterized** -- you can tune rate, duration, and generator parameters after import.
 - **Shareable** -- the YAML is self-contained. Drop it into a repo, CI pipeline, or Helm chart.
 
-Use `csv_replay` when you need bit-for-bit fidelity. Use `sonda import` when you need the
-*shape* of the data as a reusable scenario.
+Use `csv_replay` when you need bit-for-bit fidelity. Use `sonda import` when you need the *shape* of the data as a reusable scenario that does not depend on the original CSV.
 
 ---
 

--- a/docs/site/docs/guides/grafana-csv-replay.md
+++ b/docs/site/docs/guides/grafana-csv-replay.md
@@ -1,9 +1,6 @@
 # Grafana CSV Export Replay
 
-You have a Grafana dashboard showing a production incident. You want to replay those exact metric
-values through your pipeline -- same shapes, same labels, same timing -- to verify alert rules,
-test recording rules, or validate a new ingest path. Sonda can replay a Grafana CSV export with
-zero manual column mapping.
+You have a Grafana dashboard showing a production incident. You want to replay those exact metric values through your pipeline -- same shapes, same labels, same timing -- to verify alert rules, test recording rules, or validate a new ingest path. Sonda can replay a Grafana CSV export with zero manual column mapping, and the replay preserves the original sample interval automatically.
 
 ---
 
@@ -32,8 +29,67 @@ The exported CSV looks like this:
 1704067260000,1,1
 ```
 
-Each column header encodes the metric name and labels in `{key="value"}` syntax. Sonda parses
-these automatically.
+Each column header encodes the metric name and labels in `{key="value"}` syntax. Sonda parses these automatically.
+
+---
+
+## Replay Speed Is Driven By The CSV, Not By `rate:`
+
+Sonda reads the first column of the CSV as a timestamp series, measures the median interval between samples, and uses that to compute the replay rate. The `rate:` field on a `csv_replay` scenario is **always overridden** by this derived value -- it does not matter what you put in YAML.
+
+This is the most common point of confusion when moving from earlier releases. Before, you had to set `rate: 0.1` by hand to match a 10-second Grafana scrape interval; if you set the wrong rate, a 5-minute incident would play back in 30 seconds.
+
+```csv title="Grafana export with 15s scrape interval"
+"Time","{__name__=""cpu"", instance=""prod-01""}"
+1704067200000,42.1
+1704067215000,43.5
+1704067230000,45.8
+```
+
+```yaml title="examples/csv-replay-grafana-auto.yaml"
+defaults:
+  rate: 1      # ignored for csv_replay -- the CSV's 15s step wins
+scenarios:
+  - signal_type: metrics
+    name: incident_replay
+    generator:
+      type: csv_replay
+      file: examples/grafana-export.csv
+```
+
+```text title="Startup banner shows the derived rate"
+[1/1] ▶ cpu  signal_type: metrics | rate: 0.1/s | ...
+```
+
+The displayed `0.1/s` is the rounded view of `1 / 15` (about 0.0667 samples per second), computed from the CSV. The actual emission cadence matches the 15-second step exactly, not the rounded display value, so the 5-minute incident replays in 5 minutes.
+
+The scenario `name: incident_replay` is replaced with `cpu` because each CSV column expands into its own scenario named after the column's `__name__`. See [Replay With Auto-Discovery](#replay-with-auto-discovery) below for details.
+
+!!! info "How the derivation works"
+    Sonda reads column 0 as a timestamp series, parses each cell as a number, and computes the **median** of consecutive differences across up to the first 100 data rows. Values larger than `1e12` are treated as epoch milliseconds; smaller values are treated as epoch seconds. Both Grafana (ms) and VictoriaMetrics (s) exports are covered. The derived rate is `timescale / median_delta`.
+
+### Speeding up or slowing down with `timescale`
+
+Use `timescale:` to play the recording faster or slower without rewriting the CSV.
+
+| `timescale` | Effect | Use case |
+|-------------|--------|----------|
+| `1.0` (default) | Play at the original speed | Fidelity replay -- 1h of source data plays in 1h |
+| `2.0` | Play 2x faster | Replay 1h in 30min for faster alert-rule iteration |
+| `10.0` | Play 10x faster | Squash an overnight incident into a 5-minute test |
+| `0.5` | Play 2x slower | Stretch a 1-minute event over 2 minutes for visual inspection |
+
+```yaml title="Replay 1 hour of production data in 5 minutes"
+scenarios:
+  - signal_type: metrics
+    name: chaos_replay
+    generator:
+      type: csv_replay
+      file: production-incident.csv
+      timescale: 12.0      # 60 min CSV / 12 = 5 min replay
+```
+
+`timescale` must be a positive finite number. `timescale: 0` or a negative value is rejected at config load with `csv_replay: 'timescale' must be a positive finite number, got 0`.
 
 ---
 
@@ -150,30 +206,65 @@ Per-column labels merge with scenario-level labels, and column labels override o
 
 ## Supported Header Formats
 
-Sonda recognizes five header formats. The first two are what Grafana produces; the others
-support hand-authored CSV files.
+Sonda recognizes five header formats. The first two are what Grafana produces; the others support hand-authored CSV files.
 
 | Format | Example header | Metric name | Labels |
 |--------|---------------|-------------|--------|
 | 1. `__name__` inside braces | `{__name__="up", instance="host", job="prom"}` | `up` | `instance`, `job` |
 | 2. Name before braces | `up{instance="host", job="prom"}` | `up` | `instance`, `job` |
-| 3. Labels only (no name) | `{instance="host", job="prom"}` | none (error with auto-discovery) | `instance`, `job` |
+| 3. Labels only (no name) | `{instance="host", job="prom"}` | from `default_metric_name` | `instance`, `job` |
 | 4. Plain metric name | `cpu_percent` | `cpu_percent` | none |
 | 5. Simple word | `prometheus` | `prometheus` | none |
 
-Format 1 is what Grafana exports by default when you use **Series joined by time**. Format 2
-appears when a Grafana panel has a custom `legendFormat` that puts the metric name outside the
-braces.
+Format 1 is what Grafana exports by default when you use **Series joined by time**. Format 2 appears when a Grafana panel has a custom `legendFormat` that puts the metric name outside the braces. Format 3 is what you get when `legendFormat` strips the metric name entirely (e.g. `{{instance}}` only) -- this is covered by [`default_metric_name`](#labels-only-headers-default_metric_name).
 
-!!! info "Format 3 requires explicit columns"
-    Headers with labels but no `__name__` cannot be used with auto-discovery because there is no
-    metric name to extract. Use `columns:` with an explicit `name:` for each column instead.
+### Labels-only headers: `default_metric_name`
+
+When a Grafana panel uses a `legendFormat` that omits `__name__`, the export looks like this:
+
+```csv title="labels-only export"
+Time,"{instance=""prod-01"",job=""node""}","{instance=""prod-02"",job=""node""}"
+1704067200000,42.1,38.5
+1704067210000,43.2,39.0
+```
+
+Before, you had to hand-write a script to inject `__name__=metric` into every header before sonda could ingest the file. Now, set `default_metric_name:` on the generator and the missing name is filled in automatically.
+
+```yaml title="Replay a labels-only Grafana export"
+scenarios:
+  - signal_type: metrics
+    name: cpu_replay
+    generator:
+      type: csv_replay
+      file: cpu-export.csv
+      default_metric_name: node_cpu_usage
+```
+
+```text title="Output"
+node_cpu_usage_1{instance="prod-01",job="node"} 42.1 1778847012268
+node_cpu_usage_2{instance="prod-02",job="node"} 38.5 1778847012268
+```
+
+Naming rules:
+
+- **One** column without `__name__` -- uses `default_metric_name` verbatim. `default_metric_name: node_cpu_usage` produces `node_cpu_usage`.
+- **Multiple** columns without `__name__` -- each gets the fallback name suffixed with `_<column_index>` to keep series unique. `node_cpu_usage_1`, `node_cpu_usage_2`, and so on.
+- Columns whose header already has `__name__` (or name-before-braces) are unaffected -- they keep their own name and only the nameless columns use the fallback.
 
 ??? tip "Grafana legendFormat and header format"
-    If your Grafana panel has a custom `legendFormat` (e.g., `{{instance}}`), the CSV headers
-    will reflect that format instead of the raw `{__name__=...}` syntax. If the headers no
-    longer include the metric name, switch to `columns:` with explicit names, or clear
-    `legendFormat` before exporting.
+    If your Grafana panel has a custom `legendFormat` (e.g., `{{instance}}`), the CSV headers will reflect that format instead of the raw `{__name__=...}` syntax. You have three options: set `default_metric_name:` on the generator (recommended), clear `legendFormat` before exporting, or switch to `columns:` with explicit `name:` for each column.
+
+---
+
+## Failure modes
+
+| Error message | Cause | Fix |
+|---------------|-------|-----|
+| `csv_replay: 'timescale' must be a positive finite number, got 0` | `timescale: 0`, a negative value, or `NaN`/`Inf`. | Set `timescale` to a positive number, or remove it to use the default `1.0`. |
+| `csv_replay: file "..." has fewer than 2 data rows; cannot derive replay rate` | The CSV only has a header and one data row (or zero). | At least two data rows are required to measure the sample interval. Re-export with a wider time range. |
+| `csv_replay: non-monotonic timestamps in "..." (row N value X <= previous Y)` | A timestamp goes backward or repeats. Common with concatenated exports or paused recordings. | Sort the file by timestamp, deduplicate, or split it at the discontinuity. |
+| `csv_replay: column N has no metric name (header has labels only with no __name__); set 'default_metric_name' on the generator config` | Auto-discovery hit a `{labels...}` header without a metric name. | Add `default_metric_name:` to the generator, or switch to explicit `columns:`. |
+| `generator error: cannot read file "..."` | The CSV path does not exist or is not readable. | Paths are relative to the directory where `sonda` is launched, not to the scenario file. |
 
 ---
 
@@ -185,11 +276,15 @@ braces.
 | `columns` | list | no | -- | Explicit column specs. When absent, columns are auto-discovered from the header. |
 | `columns[].index` | integer | yes | -- | Zero-based column index in the CSV file. |
 | `columns[].name` | string | yes | -- | Metric name for the expanded scenario. |
-| `columns[].labels` | map | no | none | Per-column labels merged with scenario-level labels. Column labels override on conflict. |
+| `columns[].labels` | map | no | none | Per-column labels merged with scenario-level and header-derived labels. Column labels override on conflict. |
 | `repeat` | boolean | no | `true` | Cycle back to start or hold last value. |
+| `timescale` | float | no | `1.0` | Replay speed multiplier. `2.0` plays 2x faster, `0.5` plays 2x slower. Must be strictly positive. |
+| `default_metric_name` | string | no | -- | Fallback metric name for auto-discovered columns whose header has labels but no `__name__`. Suffixed with `_<column_index>` when multiple columns share the fallback. |
 
-For the full CSV replay parameter reference, see
-[Generators: csv_replay](../configuration/generators.md#csv_replay).
+!!! note "The scenario's `rate:` is always overridden"
+    For `csv_replay` scenarios, `rate:` is computed from the CSV's column-0 timestamps and `timescale`. Any value you set in YAML is replaced. Run `sonda --verbose --dry-run` to confirm the derived rate, or inspect the startup banner.
+
+For the full CSV replay parameter reference, see [Generators: csv_replay](../configuration/generators.md#csv_replay).
 
 !!! tip "Want portable scenarios instead of raw replay?"
     `csv_replay` plays back exact values from the file. If you want to extract the *pattern*

--- a/examples/csv-replay-metrics.yaml
+++ b/examples/csv-replay-metrics.yaml
@@ -4,6 +4,11 @@
 # models a production incident: normal baseline (~14%), spike to ~95%,
 # sustained high load, then recovery back to baseline.
 #
+# The CSV has 10-second sample intervals across 50 rows (≈500s total).
+# csv_replay derives its emission rate from the CSV timestamps, so the
+# scenario-level `rate:` becomes informational; `duration: 500s` covers
+# the full source span at the derived 0.1/s rate.
+#
 # Run with:
 #   sonda metrics --scenario examples/csv-replay-metrics.yaml
 
@@ -11,7 +16,7 @@ version: 2
 
 defaults:
   rate: 1
-  duration: 60s
+  duration: 500s
   encoder:
     type: prometheus_text
   sink:

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -24,6 +24,7 @@ serde = { workspace = true }
 serde_yaml_ng = { workspace = true, optional = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = "0.1"
 ureq = { workspace = true, optional = true }
 rskafka = { version = "0.6.0", default-features = false, features = ["transport-tls"], optional = true }
 tokio = { version = "1", features = ["rt", "net", "time", "macros"], optional = true }
@@ -42,6 +43,7 @@ tempfile = "3"
 insta = { workspace = true, features = ["filters"] }
 rstest = { workspace = true }
 criterion = { version = "0.5", default-features = false }
+tracing-test = "0.2"
 
 [[bench]]
 name = "while_steady_state"

--- a/sonda-core/src/config/mod.rs
+++ b/sonda-core/src/config/mod.rs
@@ -712,99 +712,193 @@ fn is_csv_header_line(line: &str) -> bool {
     crate::generator::csv_header::is_header_line(line)
 }
 
-/// Expand a [`ScenarioConfig`] that uses multi-column `csv_replay` into N
-/// independent single-column scenarios.
-///
-/// When the `generator` is `CsvReplay` with `columns: Some(specs)`, this
-/// function returns one `ScenarioConfig` per column spec.
-///
-/// When `columns` is `None`, the function auto-discovers columns from the
-/// CSV file header. **Note:** this performs file I/O — it reads the first
-/// line of the CSV file at `generator.file` to detect the header row.
-/// If the first data line is detected as a header (any non-time field is
-/// non-numeric), column specs are built from the parsed header using
-/// [`crate::generator::csv_header`]. If the first line is all numeric
-/// (no header), an error is returned asking the user to provide explicit
-/// `columns`.
-///
-/// Each expanded config has:
-/// - `name` set to the column spec's `name`.
-/// - `generator.column` set to `Some(spec.index)`.
-/// - `generator.columns` set to `None`.
-/// - Per-column labels merged into `base.labels` (column labels override
-///   scenario-level labels on key conflict).
-/// - All other fields (rate, duration, sink, encoder, gaps, bursts,
-///   jitter, etc.) cloned from the parent.
-///
-/// # Errors
-///
-/// Returns [`SondaError::Config`] if:
-/// - `columns` is an empty list.
-/// - `columns` has duplicate indices or names.
-/// - Auto-discovery finds a column with no metric name and no fallback.
-/// - Auto-discovery finds no header row (all-numeric first line).
-pub fn expand_scenario(config: ScenarioConfig) -> Result<Vec<ScenarioConfig>, SondaError> {
-    // Only the CsvReplay variant can have `columns`.
-    let specs = match &config.generator {
-        GeneratorConfig::CsvReplay { columns, file, .. } => {
-            validate_csv_columns(columns)?;
+fn read_csv_first_lines(path: &str, max_lines: usize) -> Result<Vec<String>, SondaError> {
+    use std::io::BufRead;
 
-            if let Some(ref cols) = columns {
-                cols.clone()
-            } else {
-                // Auto-discover columns from the CSV header.
-                let header_line = read_csv_header(file)?;
+    let file = std::fs::File::open(path).map_err(|e| {
+        SondaError::Generator(crate::GeneratorError::FileRead {
+            path: path.to_string(),
+            source: e,
+        })
+    })?;
+    let reader = std::io::BufReader::new(file);
+    let mut out = Vec::with_capacity(max_lines);
 
-                if !is_csv_header_line(&header_line) {
-                    return Err(SondaError::Config(ConfigError::invalid(
-                        "csv_replay: CSV file has no header row (first data line is all numeric); \
-                         provide explicit 'columns' in the config",
-                    )));
-                }
-
-                let parsed = crate::generator::csv_header::parse_header_row(&header_line)?;
-
-                // Skip column 0 (timestamp).
-                let mut auto_specs = Vec::with_capacity(parsed.len().saturating_sub(1));
-                for (i, ph) in parsed.into_iter().enumerate().skip(1) {
-                    let name = ph.metric_name.ok_or_else(|| {
-                        SondaError::Config(ConfigError::invalid(format!(
-                            "csv_replay: column {} has no metric name \
-                             (header has labels only with no __name__)",
-                            i
-                        )))
-                    })?;
-                    let labels = if ph.labels.is_empty() {
-                        None
-                    } else {
-                        Some(ph.labels)
-                    };
-                    auto_specs.push(CsvColumnSpec {
-                        index: i,
-                        name,
-                        labels,
-                    });
-                }
-
-                if auto_specs.is_empty() {
-                    return Err(SondaError::Config(ConfigError::invalid(
-                        "csv_replay: no data columns found after skipping column 0",
-                    )));
-                }
-
-                auto_specs
-            }
+    for line_result in reader.lines() {
+        let line = line_result.map_err(|e| {
+            SondaError::Generator(crate::GeneratorError::FileRead {
+                path: path.to_string(),
+                source: e,
+            })
+        })?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
         }
+        out.push(line);
+        if out.len() >= max_lines {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+fn parse_csv_timestamp(cell: &str) -> Option<f64> {
+    let v: f64 = cell.trim().parse().ok()?;
+    if !v.is_finite() {
+        return None;
+    }
+    if v > 1e12 {
+        Some(v / 1000.0)
+    } else {
+        Some(v)
+    }
+}
+
+fn compute_csv_delta_seconds(path: &str) -> Result<f64, SondaError> {
+    const MAX_SAMPLE_ROWS: usize = 100;
+
+    let lines = read_csv_first_lines(path, MAX_SAMPLE_ROWS + 1)?;
+    if lines.is_empty() {
+        return Err(SondaError::Config(ConfigError::invalid(format!(
+            "csv_replay: file {:?} has no non-comment, non-empty lines",
+            path
+        ))));
+    }
+
+    let data_lines: &[String] = if is_csv_header_line(&lines[0]) {
+        &lines[1..]
+    } else {
+        &lines[..]
+    };
+
+    let mut timestamps = Vec::with_capacity(data_lines.len());
+    for (row_idx, line) in data_lines.iter().enumerate() {
+        let cell = line.split(',').next().unwrap_or("");
+        let ts = parse_csv_timestamp(cell).ok_or_else(|| {
+            SondaError::Config(ConfigError::invalid(format!(
+                "csv_replay: failed to parse timestamp at data row {}: {:?}",
+                row_idx, cell
+            )))
+        })?;
+        timestamps.push(ts);
+    }
+
+    if timestamps.len() < 2 {
+        return Err(SondaError::Config(ConfigError::invalid(format!(
+            "csv_replay: file {:?} has fewer than 2 data rows; cannot derive replay rate",
+            path
+        ))));
+    }
+
+    let mut deltas = Vec::with_capacity(timestamps.len() - 1);
+    for pair in timestamps.windows(2) {
+        let d = pair[1] - pair[0];
+        if d <= 0.0 {
+            return Err(SondaError::Config(ConfigError::invalid(format!(
+                "csv_replay: non-monotonic timestamps in {:?} \
+                 (row {} value {} <= previous {})",
+                path,
+                deltas.len() + 1,
+                pair[1],
+                pair[0]
+            ))));
+        }
+        deltas.push(d);
+    }
+
+    deltas.sort_by(|a, b| {
+        a.partial_cmp(b)
+            .expect("CSV deltas are finite and positive")
+    });
+    let mid = deltas.len() / 2;
+    let median = if deltas.len() % 2 == 0 {
+        (deltas[mid - 1] + deltas[mid]) / 2.0
+    } else {
+        deltas[mid]
+    };
+
+    if median <= 0.0 || !median.is_finite() {
+        return Err(SondaError::Config(ConfigError::invalid(format!(
+            "csv_replay: derived median Δt is not positive in {:?}",
+            path
+        ))));
+    }
+
+    Ok(median)
+}
+
+/// Expand a `csv_replay` scenario into one config per data column, deriving
+/// `rate` from the CSV's column-0 timestamps (`rate = timescale / median Δt`).
+/// Non-`csv_replay` configs pass through unchanged.
+pub fn expand_scenario(config: ScenarioConfig) -> Result<Vec<ScenarioConfig>, SondaError> {
+    let (file, columns_field, timescale_opt, default_name_opt) = match &config.generator {
+        GeneratorConfig::CsvReplay {
+            file,
+            columns,
+            timescale,
+            default_metric_name,
+            ..
+        } => (
+            file.clone(),
+            columns.clone(),
+            *timescale,
+            default_metric_name.clone(),
+        ),
         _ => return Ok(vec![config]),
     };
+
+    validate_csv_columns(&columns_field)?;
+    let timescale = validate_csv_timescale(timescale_opt)?;
+
+    let header_line = read_csv_header(&file)?;
+    let has_header = is_csv_header_line(&header_line);
+    let parsed_header = if has_header {
+        Some(crate::generator::csv_header::parse_header_row(
+            &header_line,
+        )?)
+    } else {
+        None
+    };
+
+    let specs = if let Some(cols) = columns_field {
+        merge_header_labels_into_specs(cols, parsed_header.as_deref())
+    } else {
+        let parsed = parsed_header.ok_or_else(|| {
+            SondaError::Config(ConfigError::invalid(
+                "csv_replay: CSV file has no header row (first data line is all numeric); \
+                 provide explicit 'columns' in the config",
+            ))
+        })?;
+        auto_discover_specs(parsed, default_name_opt.as_deref())?
+    };
+
+    let delta = compute_csv_delta_seconds(&file)?;
+    let derived_rate = timescale / delta;
+    let user_rate = config.base.rate;
+    if (user_rate - derived_rate).abs() > 1e-9 {
+        tracing::warn!(
+            scenario = %config.base.name,
+            user_rate,
+            derived_rate,
+            csv_delta_secs = delta,
+            timescale,
+            "csv_replay '{}': overriding rate={} with derived rate={} samples/s (CSV Δt={}s, timescale={})",
+            config.base.name,
+            user_rate,
+            derived_rate,
+            delta,
+            timescale,
+        );
+    }
 
     let expanded = specs
         .into_iter()
         .map(|spec| {
             let mut child = config.clone();
             child.base.name = spec.name;
+            child.base.rate = derived_rate;
 
-            // Merge per-column labels into the child's base labels.
             if let Some(ref col_labels) = spec.labels {
                 let merged = child.base.labels.get_or_insert_with(HashMap::new);
                 for (k, v) in col_labels {
@@ -812,7 +906,6 @@ pub fn expand_scenario(config: ScenarioConfig) -> Result<Vec<ScenarioConfig>, So
                 }
             }
 
-            // Replace the generator's column/columns fields.
             if let GeneratorConfig::CsvReplay {
                 ref mut column,
                 ref mut columns,
@@ -827,6 +920,124 @@ pub fn expand_scenario(config: ScenarioConfig) -> Result<Vec<ScenarioConfig>, So
         .collect();
 
     Ok(expanded)
+}
+
+fn validate_csv_timescale(timescale: Option<f64>) -> Result<f64, SondaError> {
+    let ts = timescale.unwrap_or(1.0);
+    if !(ts.is_finite() && ts > 0.0) {
+        return Err(SondaError::Config(ConfigError::invalid(format!(
+            "csv_replay: 'timescale' must be a positive finite number, got {}",
+            ts
+        ))));
+    }
+    Ok(ts)
+}
+
+fn merge_header_labels_into_specs(
+    user_specs: Vec<CsvColumnSpec>,
+    parsed_header: Option<&[crate::generator::csv_header::ParsedColumnHeader]>,
+) -> Vec<CsvColumnSpec> {
+    user_specs
+        .into_iter()
+        .map(|spec| {
+            let header_labels = parsed_header
+                .and_then(|hdr| hdr.get(spec.index))
+                .map(|h| &h.labels);
+            let merged_labels = match (header_labels, spec.labels.as_ref()) {
+                (None, None) => None,
+                (None, Some(user)) => Some(user.clone()),
+                (Some(hdr), None) if hdr.is_empty() => None,
+                (Some(hdr), None) => Some(hdr.clone()),
+                (Some(hdr), Some(user)) => {
+                    let mut out = hdr.clone();
+                    for (k, v) in user {
+                        out.insert(k.clone(), v.clone());
+                    }
+                    Some(out)
+                }
+            };
+            CsvColumnSpec {
+                labels: merged_labels,
+                ..spec
+            }
+        })
+        .collect()
+}
+
+fn auto_discover_specs(
+    parsed: Vec<crate::generator::csv_header::ParsedColumnHeader>,
+    default_metric_name: Option<&str>,
+) -> Result<Vec<CsvColumnSpec>, SondaError> {
+    let nameless: Vec<usize> = parsed
+        .iter()
+        .enumerate()
+        .skip(1)
+        .filter(|(_, ph)| ph.metric_name.is_none())
+        .map(|(i, _)| i)
+        .collect();
+    let needs_suffix = nameless.len() > 1;
+
+    let mut specs = Vec::with_capacity(parsed.len().saturating_sub(1));
+    let mut default_derived_indices = Vec::new();
+    let mut explicit_names = std::collections::HashSet::new();
+    for (i, ph) in parsed.into_iter().enumerate().skip(1) {
+        let (name, derived_from_default) = match ph.metric_name {
+            Some(n) => {
+                explicit_names.insert(n.clone());
+                (n, false)
+            }
+            None => {
+                let base = default_metric_name.ok_or_else(|| {
+                    SondaError::Config(ConfigError::invalid(format!(
+                        "csv_replay: column {} has no metric name \
+                         (header has labels only with no __name__); \
+                         set 'default_metric_name' on the generator config",
+                        i
+                    )))
+                })?;
+                let n = if needs_suffix {
+                    format!("{}_{}", base, i)
+                } else {
+                    base.to_string()
+                };
+                (n, true)
+            }
+        };
+        if derived_from_default {
+            default_derived_indices.push(specs.len());
+        }
+        let labels = if ph.labels.is_empty() {
+            None
+        } else {
+            Some(ph.labels)
+        };
+        specs.push(CsvColumnSpec {
+            index: i,
+            name,
+            labels,
+        });
+    }
+
+    if specs.is_empty() {
+        return Err(SondaError::Config(ConfigError::invalid(
+            "csv_replay: no data columns found after skipping column 0",
+        )));
+    }
+
+    for idx in default_derived_indices {
+        let name = &specs[idx].name;
+        if explicit_names.contains(name) {
+            return Err(SondaError::Config(ConfigError::invalid(format!(
+                "csv_replay: default_metric_name produced '{name}' for column {col} \
+                 which collides with an explicitly named column. Rename the \
+                 conflicting __name__ in the CSV header or set a different \
+                 'default_metric_name'.",
+                col = specs[idx].index
+            ))));
+        }
+    }
+
+    Ok(specs)
 }
 
 /// Expand a [`ScenarioEntry`] that uses multi-column `csv_replay`.
@@ -2236,9 +2447,41 @@ mod expand_tests {
                 column: None,
                 repeat: Some(true),
                 columns,
+                timescale: None,
+                default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
         }
+    }
+
+    fn write_temp_timing_csv(header: &str, data_rows: usize) -> tempfile::NamedTempFile {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
+        if !header.is_empty() {
+            writeln!(tmp, "{}", header).expect("write header");
+        }
+        for i in 0..data_rows {
+            let ts = 1_700_000_000 + (i as u64) * 10;
+            writeln!(tmp, "{ts},42.5,60.0,80.0,99.0").expect("write row");
+        }
+        tmp.flush().expect("flush");
+        tmp
+    }
+
+    fn set_csv_file(config: &mut ScenarioConfig, path: String) {
+        if let GeneratorConfig::CsvReplay { ref mut file, .. } = config.generator {
+            *file = path;
+        }
+    }
+
+    fn config_with_csv(
+        name: &str,
+        columns: Option<Vec<CsvColumnSpec>>,
+    ) -> (ScenarioConfig, tempfile::NamedTempFile) {
+        let tmp = write_temp_timing_csv("Time,cpu,mem,disk,net", 3);
+        let mut config = csv_replay_config(name, columns);
+        set_csv_file(&mut config, tmp.path().to_string_lossy().into_owned());
+        (config, tmp)
     }
 
     // -----------------------------------------------------------------------
@@ -2251,14 +2494,12 @@ mod expand_tests {
     fn auto_discover_from_header_when_no_columns() {
         use std::io::Write;
         let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
-        write!(tmp, "Time,cpu_usage\n1000,42.5\n").expect("write csv");
+        write!(tmp, "Time,cpu_usage\n1700000000,42.5\n1700000010,43.0\n").expect("write csv");
         tmp.flush().expect("flush");
         let path = tmp.path().to_string_lossy().into_owned();
 
         let mut config = csv_replay_config("single_metric", None);
-        if let GeneratorConfig::CsvReplay { ref mut file, .. } = config.generator {
-            *file = path;
-        }
+        set_csv_file(&mut config, path);
         let result = expand_scenario(config).expect("must succeed");
         assert_eq!(result.len(), 1, "should auto-discover 1 data column");
         assert_eq!(result[0].name, "cpu_usage");
@@ -2272,14 +2513,12 @@ mod expand_tests {
     fn no_columns_no_header_returns_error() {
         use std::io::Write;
         let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
-        write!(tmp, "1000,42.5\n2000,55.3\n").expect("write csv");
+        write!(tmp, "1700000000,42.5\n1700000010,55.3\n").expect("write csv");
         tmp.flush().expect("flush");
         let path = tmp.path().to_string_lossy().into_owned();
 
         let mut config = csv_replay_config("all_numeric", None);
-        if let GeneratorConfig::CsvReplay { ref mut file, .. } = config.generator {
-            *file = path;
-        }
+        set_csv_file(&mut config, path);
         let err = expand_scenario(config).expect_err("must fail");
         let msg = err.to_string();
         assert!(
@@ -2338,7 +2577,11 @@ mod expand_tests {
                 labels: None,
             },
         ];
-        let config = csv_replay_config("parent", Some(cols));
+        let (config, _tmp) = config_with_csv("parent", Some(cols));
+        let expected_file = match &config.generator {
+            GeneratorConfig::CsvReplay { file, .. } => file.clone(),
+            _ => unreachable!(),
+        };
         let result = expand_scenario(config).expect("must succeed");
 
         assert_eq!(result.len(), 2, "should produce two expanded configs");
@@ -2351,10 +2594,11 @@ mod expand_tests {
                 columns,
                 file,
                 repeat,
+                ..
             } => {
                 assert_eq!(*column, Some(1));
                 assert!(columns.is_none(), "columns must be None after expansion");
-                assert_eq!(file, "data.csv", "file must be inherited");
+                assert_eq!(file, &expected_file, "file must be inherited");
                 assert_eq!(*repeat, Some(true), "repeat must be inherited");
             }
             other => panic!("expected CsvReplay, got {other:?}"),
@@ -2397,7 +2641,7 @@ mod expand_tests {
                 labels: None,
             },
         ];
-        let config = csv_replay_config("parent", Some(cols));
+        let (config, _tmp) = config_with_csv("parent", Some(cols));
         let result = expand_scenario(config).expect("must succeed");
 
         assert_eq!(result.len(), 3);
@@ -2428,14 +2672,18 @@ mod expand_tests {
             name: "metric_a".to_string(),
             labels: None,
         }];
-        let config = csv_replay_config("parent", Some(cols));
+        let (config, _tmp) = config_with_csv("parent", Some(cols));
         let result = expand_scenario(config).expect("must succeed");
 
         assert_eq!(result.len(), 1);
         let child = &result[0];
 
-        // Schedule fields
-        assert_eq!(child.rate, 10.0, "rate must be inherited");
+        // Schedule fields — rate is overridden by CSV-derived rate.
+        assert!(
+            (child.rate - 0.1).abs() < 1e-9,
+            "rate must be derived from CSV Δt=10s (got {})",
+            child.rate
+        );
         assert_eq!(
             child.duration.as_deref(),
             Some("30s"),
@@ -2466,7 +2714,7 @@ mod expand_tests {
             name: "metric_a".to_string(),
             labels: None,
         }];
-        let mut config = csv_replay_config("parent", Some(cols));
+        let (mut config, _tmp) = config_with_csv("parent", Some(cols));
         config.base.gaps = Some(GapConfig {
             every: "2m".to_string(),
             r#for: "20s".to_string(),
@@ -2639,7 +2887,7 @@ mod expand_tests {
                 labels: None,
             },
         ];
-        let config = csv_replay_config("parent", Some(cols));
+        let (config, _tmp) = config_with_csv("parent", Some(cols));
         let entry = ScenarioEntry::Metrics(config);
         let result = expand_entry(entry).expect("must succeed");
 
@@ -2714,7 +2962,7 @@ mod expand_tests {
                 ),
             },
         ];
-        let config = csv_replay_config("parent", Some(cols));
+        let (config, _tmp) = config_with_csv("parent", Some(cols));
         let result = expand_scenario(config).expect("must succeed");
 
         assert_eq!(result.len(), 2);
@@ -2742,7 +2990,7 @@ mod expand_tests {
                     .collect(),
             ),
         }];
-        let config = csv_replay_config("parent", Some(cols));
+        let (config, _tmp) = config_with_csv("parent", Some(cols));
         let result = expand_scenario(config).expect("must succeed");
 
         assert_eq!(result.len(), 1);
@@ -2762,7 +3010,7 @@ mod expand_tests {
             name: "cpu".to_string(),
             labels: None,
         }];
-        let config = csv_replay_config("parent", Some(cols));
+        let (config, _tmp) = config_with_csv("parent", Some(cols));
         let result = expand_scenario(config).expect("must succeed");
 
         assert_eq!(result.len(), 1);
@@ -2785,7 +3033,11 @@ mod expand_tests {
 
         // Use a simpler header format — format 4 plain names.
         let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
-        write!(tmp, "Time,cpu_usage,mem_usage\n1000,42.5,60.0\n").expect("write csv");
+        write!(
+            tmp,
+            "Time,cpu_usage,mem_usage\n1700000000,42.5,60.0\n1700000010,43.0,61.0\n"
+        )
+        .expect("write csv");
         tmp.flush().expect("flush");
         let path = tmp.path().to_string_lossy().into_owned();
 
@@ -2816,6 +3068,8 @@ mod expand_tests {
                 column: None,
                 repeat: Some(true),
                 columns: None,
+                timescale: None,
+                default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
         };
@@ -2860,7 +3114,7 @@ mod expand_tests {
         let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
         // Use RFC 4180 quoting: "" inside quoted fields becomes "
         let header = r#""Time","{__name__=""up"", instance=""host1"", job=""prom""}","{__name__=""up"", instance=""host2"", job=""node""}""#;
-        write!(tmp, "{header}\n1704067200000,1,1\n").expect("write csv");
+        write!(tmp, "{header}\n1704067200000,1,1\n1704067210000,1,1\n").expect("write csv");
         tmp.flush().expect("flush");
         let path = tmp.path().to_string_lossy().into_owned();
 
@@ -2891,6 +3145,8 @@ mod expand_tests {
                 column: None,
                 repeat: Some(true),
                 columns: None,
+                timescale: None,
+                default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
         };
@@ -2927,7 +3183,7 @@ mod expand_tests {
         use std::io::Write;
 
         let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
-        write!(tmp, "Time\n1000\n").expect("write csv");
+        write!(tmp, "Time\n1700000000\n1700000010\n").expect("write csv");
         tmp.flush().expect("flush");
         let path = tmp.path().to_string_lossy().into_owned();
 
@@ -2954,6 +3210,8 @@ mod expand_tests {
                 column: None,
                 repeat: Some(true),
                 columns: None,
+                timescale: None,
+                default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
         };
@@ -2975,7 +3233,7 @@ mod expand_tests {
         use std::io::Write;
 
         let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
-        write!(tmp, "metric_name\n42.5\n").expect("write csv");
+        write!(tmp, "metric_name\n42.5\n55.0\n").expect("write csv");
         tmp.flush().expect("flush");
         let path = tmp.path().to_string_lossy().into_owned();
 
@@ -3002,6 +3260,8 @@ mod expand_tests {
                 column: None,
                 repeat: Some(true),
                 columns: None,
+                timescale: None,
+                default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
         };
@@ -3041,6 +3301,8 @@ mod expand_tests {
                 column: None,
                 repeat: Some(true),
                 columns: None,
+                timescale: None,
+                default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
         };
@@ -3084,6 +3346,8 @@ mod expand_tests {
                 column: None,
                 repeat: Some(true),
                 columns: None,
+                timescale: None,
+                default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
         };
@@ -3381,5 +3645,362 @@ distribution:
         let result = expand_entry(entry).expect("must succeed");
         assert_eq!(result.len(), 1);
         assert!(matches!(result[0], ScenarioEntry::Summary(_)));
+    }
+
+    // -----------------------------------------------------------------------
+    // rate-derivation tests
+    // -----------------------------------------------------------------------
+
+    fn write_two_col_csv(rows: &[(u64, f64)]) -> tempfile::NamedTempFile {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
+        writeln!(tmp, "Time,cpu_usage").expect("write header");
+        for (ts, v) in rows {
+            writeln!(tmp, "{ts},{v}").expect("write row");
+        }
+        tmp.flush().expect("flush");
+        tmp
+    }
+
+    fn build_csv_replay_scenario(
+        file: String,
+        rate: f64,
+        timescale: Option<f64>,
+        default_metric_name: Option<String>,
+    ) -> ScenarioConfig {
+        ScenarioConfig {
+            base: BaseScheduleConfig {
+                name: "ts_test".to_string(),
+                rate,
+                duration: Some("60s".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+                clock_group_is_auto: None,
+                jitter: None,
+                jitter_seed: None,
+                dynamic_labels: None,
+                on_sink_error: crate::OnSinkError::Warn,
+            },
+            generator: GeneratorConfig::CsvReplay {
+                file,
+                column: None,
+                repeat: Some(true),
+                columns: None,
+                timescale,
+                default_metric_name,
+            },
+            encoder: EncoderConfig::PrometheusText { precision: None },
+        }
+    }
+
+    #[test]
+    fn rate_derived_from_csv_ten_second_steps_yields_point_one() {
+        let tmp = write_two_col_csv(&[
+            (1_700_000_000, 1.0),
+            (1_700_000_010, 2.0),
+            (1_700_000_020, 3.0),
+        ]);
+        let path = tmp.path().to_string_lossy().into_owned();
+        let config = build_csv_replay_scenario(path, 1.0, None, None);
+        let result = expand_scenario(config).expect("must succeed");
+        assert_eq!(result.len(), 1);
+        assert!(
+            (result[0].rate - 0.1).abs() < 1e-9,
+            "expected rate 0.1, got {}",
+            result[0].rate
+        );
+    }
+
+    #[test]
+    fn rate_derived_with_timescale_two_yields_point_two() {
+        let tmp = write_two_col_csv(&[
+            (1_700_000_000, 1.0),
+            (1_700_000_010, 2.0),
+            (1_700_000_020, 3.0),
+        ]);
+        let path = tmp.path().to_string_lossy().into_owned();
+        let config = build_csv_replay_scenario(path, 1.0, Some(2.0), None);
+        let result = expand_scenario(config).expect("must succeed");
+        assert!(
+            (result[0].rate - 0.2).abs() < 1e-9,
+            "expected rate 0.2 (2x speed), got {}",
+            result[0].rate
+        );
+    }
+
+    #[test]
+    fn rate_derived_with_timescale_half_yields_point_zero_five() {
+        let tmp = write_two_col_csv(&[
+            (1_700_000_000, 1.0),
+            (1_700_000_010, 2.0),
+            (1_700_000_020, 3.0),
+        ]);
+        let path = tmp.path().to_string_lossy().into_owned();
+        let config = build_csv_replay_scenario(path, 1.0, Some(0.5), None);
+        let result = expand_scenario(config).expect("must succeed");
+        assert!(
+            (result[0].rate - 0.05).abs() < 1e-9,
+            "expected rate 0.05 (half speed), got {}",
+            result[0].rate
+        );
+    }
+
+    #[test]
+    fn epoch_milliseconds_heuristic_treats_values_above_threshold_as_ms() {
+        let tmp = write_two_col_csv(&[
+            (1_700_000_000_000, 1.0),
+            (1_700_000_010_000, 2.0),
+            (1_700_000_020_000, 3.0),
+        ]);
+        let path = tmp.path().to_string_lossy().into_owned();
+        let config = build_csv_replay_scenario(path, 1.0, None, None);
+        let result = expand_scenario(config).expect("must succeed");
+        assert!(
+            (result[0].rate - 0.1).abs() < 1e-9,
+            "ms epoch should yield 0.1 (10s Δt), got {}",
+            result[0].rate
+        );
+    }
+
+    #[test]
+    fn non_monotonic_timestamps_return_clear_error() {
+        let tmp = write_two_col_csv(&[(1_700_000_010, 1.0), (1_700_000_000, 2.0)]);
+        let path = tmp.path().to_string_lossy().into_owned();
+        let config = build_csv_replay_scenario(path, 1.0, None, None);
+        let err = expand_scenario(config).expect_err("must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("non-monotonic"),
+            "error should mention non-monotonic, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn single_data_row_returns_clear_error() {
+        let tmp = write_two_col_csv(&[(1_700_000_000, 1.0)]);
+        let path = tmp.path().to_string_lossy().into_owned();
+        let config = build_csv_replay_scenario(path, 1.0, None, None);
+        let err = expand_scenario(config).expect_err("must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("fewer than 2 data rows"),
+            "error should mention min rows, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn timescale_zero_returns_validation_error() {
+        let tmp = write_two_col_csv(&[(1_700_000_000, 1.0), (1_700_000_010, 2.0)]);
+        let path = tmp.path().to_string_lossy().into_owned();
+        let config = build_csv_replay_scenario(path, 1.0, Some(0.0), None);
+        let err = expand_scenario(config).expect_err("must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("timescale"),
+            "error should mention timescale, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn timescale_negative_returns_validation_error() {
+        let tmp = write_two_col_csv(&[(1_700_000_000, 1.0), (1_700_000_010, 2.0)]);
+        let path = tmp.path().to_string_lossy().into_owned();
+        let config = build_csv_replay_scenario(path, 1.0, Some(-1.0), None);
+        let err = expand_scenario(config).expect_err("must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("timescale"),
+            "error should mention timescale, got: {msg}"
+        );
+    }
+
+    #[tracing_test::traced_test]
+    #[test]
+    fn user_rate_override_emits_warning() {
+        let tmp = write_two_col_csv(&[(1_700_000_000, 1.0), (1_700_000_010, 2.0)]);
+        let path = tmp.path().to_string_lossy().into_owned();
+        let config = build_csv_replay_scenario(path, 5.0, None, None);
+        let result = expand_scenario(config).expect("must succeed");
+        assert!(
+            (result[0].rate - 0.1).abs() < 1e-9,
+            "rate should be derived (0.1), got {}",
+            result[0].rate
+        );
+        assert!(
+            logs_contain("overriding rate"),
+            "tracing warn should contain 'overriding rate'"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // default-metric-name fallback tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn default_metric_name_used_when_header_lacks_name_single_column() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
+        writeln!(tmp, "Time,{{instance=\"prod-01\"}}").expect("write header");
+        writeln!(tmp, "1700000000,42.5").expect("write row");
+        writeln!(tmp, "1700000010,43.0").expect("write row");
+        tmp.flush().expect("flush");
+        let path = tmp.path().to_string_lossy().into_owned();
+
+        let config = build_csv_replay_scenario(path, 1.0, None, Some("node_cpu".to_string()));
+        let result = expand_scenario(config).expect("must succeed");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "node_cpu");
+        let labels = result[0].labels.as_ref().expect("labels must exist");
+        assert_eq!(labels.get("instance").map(String::as_str), Some("prod-01"));
+    }
+
+    #[test]
+    fn default_metric_name_suffixes_index_when_multiple_columns_lack_name() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
+        writeln!(
+            tmp,
+            "Time,{{instance=\"prod-01\"}},{{instance=\"prod-02\"}}"
+        )
+        .expect("write header");
+        writeln!(tmp, "1700000000,42.5,55.0").expect("write row");
+        writeln!(tmp, "1700000010,43.0,56.0").expect("write row");
+        tmp.flush().expect("flush");
+        let path = tmp.path().to_string_lossy().into_owned();
+
+        let config = build_csv_replay_scenario(path, 1.0, None, Some("node_cpu".to_string()));
+        let result = expand_scenario(config).expect("must succeed");
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].name, "node_cpu_1");
+        assert_eq!(result[1].name, "node_cpu_2");
+
+        let labels0 = result[0].labels.as_ref().expect("labels must exist");
+        assert_eq!(labels0.get("instance").map(String::as_str), Some("prod-01"));
+        let labels1 = result[1].labels.as_ref().expect("labels must exist");
+        assert_eq!(labels1.get("instance").map(String::as_str), Some("prod-02"));
+    }
+
+    #[test]
+    fn missing_default_metric_name_still_errors_when_header_lacks_name() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
+        writeln!(tmp, "Time,{{instance=\"prod-01\"}}").expect("write header");
+        writeln!(tmp, "1700000000,42.5").expect("write row");
+        writeln!(tmp, "1700000010,43.0").expect("write row");
+        tmp.flush().expect("flush");
+        let path = tmp.path().to_string_lossy().into_owned();
+
+        let config = build_csv_replay_scenario(path, 1.0, None, None);
+        let err = expand_scenario(config).expect_err("must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("default_metric_name"),
+            "error should hint at default_metric_name, got: {msg}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // header-label merge tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn explicit_columns_merge_header_labels_with_user_spec_labels() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
+        writeln!(tmp, r#""Time","{{instance=""prod-01"", job=""node""}}""#).expect("write header");
+        writeln!(tmp, "1700000000,42.5").expect("write row");
+        writeln!(tmp, "1700000010,43.0").expect("write row");
+        tmp.flush().expect("flush");
+        let path = tmp.path().to_string_lossy().into_owned();
+
+        let cols = vec![CsvColumnSpec {
+            index: 1,
+            name: "cpu".to_string(),
+            labels: Some(
+                [("site".to_string(), "us".to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+        }];
+        let mut config = build_csv_replay_scenario(path, 1.0, None, None);
+        if let GeneratorConfig::CsvReplay {
+            ref mut columns, ..
+        } = config.generator
+        {
+            *columns = Some(cols);
+        }
+
+        let result = expand_scenario(config).expect("must succeed");
+        assert_eq!(result.len(), 1);
+        let labels = result[0].labels.as_ref().expect("labels must exist");
+        assert_eq!(labels.get("instance").map(String::as_str), Some("prod-01"));
+        assert_eq!(labels.get("job").map(String::as_str), Some("node"));
+        assert_eq!(labels.get("site").map(String::as_str), Some("us"));
+    }
+
+    #[test]
+    fn explicit_user_spec_labels_override_header_labels_on_key_conflict() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
+        writeln!(tmp, "Time,{{instance=\"prod-01\"}}").expect("write header");
+        writeln!(tmp, "1700000000,42.5").expect("write row");
+        writeln!(tmp, "1700000010,43.0").expect("write row");
+        tmp.flush().expect("flush");
+        let path = tmp.path().to_string_lossy().into_owned();
+
+        let cols = vec![CsvColumnSpec {
+            index: 1,
+            name: "cpu".to_string(),
+            labels: Some(
+                [("instance".to_string(), "user-override".to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+        }];
+        let mut config = build_csv_replay_scenario(path, 1.0, None, None);
+        if let GeneratorConfig::CsvReplay {
+            ref mut columns, ..
+        } = config.generator
+        {
+            *columns = Some(cols);
+        }
+
+        let result = expand_scenario(config).expect("must succeed");
+        let labels = result[0].labels.as_ref().expect("labels must exist");
+        assert_eq!(
+            labels.get("instance").map(String::as_str),
+            Some("user-override")
+        );
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn timescale_field_deserializes_from_yaml() {
+        let yaml = r#"
+name: ts
+rate: 1
+generator:
+  type: csv_replay
+  file: data.csv
+  timescale: 2.5
+  default_metric_name: my_metric
+"#;
+        let config: ScenarioConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        match &config.generator {
+            GeneratorConfig::CsvReplay {
+                timescale,
+                default_metric_name,
+                ..
+            } => {
+                assert_eq!(*timescale, Some(2.5));
+                assert_eq!(default_metric_name.as_deref(), Some("my_metric"));
+            }
+            other => panic!("expected CsvReplay variant, got {other:?}"),
+        }
     }
 }

--- a/sonda-core/src/generator/csv_replay.rs
+++ b/sonda-core/src/generator/csv_replay.rs
@@ -618,6 +618,8 @@ mod tests {
             column: Some(0),
             repeat: Some(true),
             columns: None,
+            timescale: None,
+            default_metric_name: None,
         };
         let gen =
             super::super::create_generator(&config, 1.0).expect("csv_replay factory must succeed");
@@ -636,6 +638,8 @@ mod tests {
             column: None,
             repeat: None,
             columns: None,
+            timescale: None,
+            default_metric_name: None,
         };
         let gen = super::super::create_generator(&config, 1.0)
             .expect("csv_replay factory with defaults must succeed");
@@ -650,6 +654,8 @@ mod tests {
             column: None,
             repeat: None,
             columns: None,
+            timescale: None,
+            default_metric_name: None,
         };
         let result = super::super::create_generator(&config, 1.0);
         assert!(
@@ -676,6 +682,7 @@ repeat: false
                 column,
                 repeat,
                 columns,
+                ..
             } => {
                 assert_eq!(file, "/some/path.csv");
                 assert_eq!(column, None, "column is serde(skip), should be None");
@@ -698,6 +705,7 @@ repeat: false
                 column,
                 repeat,
                 columns,
+                ..
             } => {
                 assert_eq!(file, "data.csv");
                 assert_eq!(column, None, "column should be None (serde skip)");
@@ -749,6 +757,7 @@ sink:
                 column,
                 repeat,
                 columns,
+                ..
             } => {
                 assert_eq!(file, &csv_path);
                 assert_eq!(*column, None, "column is serde(skip)");
@@ -829,6 +838,8 @@ timestamp,cpu_percent
             column: Some(0),
             repeat: None,
             columns: None,
+            timescale: None,
+            default_metric_name: None,
         };
         let gen = super::super::create_generator(&config, 1.0).expect("factory must succeed");
         // With repeat defaulting to true, tick=2 on a 2-element seq should wrap.

--- a/sonda-core/src/generator/mod.rs
+++ b/sonda-core/src/generator/mod.rs
@@ -245,6 +245,15 @@ pub enum GeneratorConfig {
         /// Defaults to `true`.
         #[cfg_attr(feature = "config", serde(default))]
         repeat: Option<bool>,
+        /// Replay speed multiplier (default `1.0`). `2.0` plays 2× faster,
+        /// `0.5` plays 2× slower. Must be strictly positive.
+        #[cfg_attr(feature = "config", serde(default))]
+        timescale: Option<f64>,
+        /// Fallback metric name for auto-discovered columns whose header has
+        /// no `__name__`. Suffixed with `_<index>` when multiple such columns
+        /// share the fallback.
+        #[cfg_attr(feature = "config", serde(default))]
+        default_metric_name: Option<String>,
     },
     /// A monotonic step counter: `start + tick * step_size`, with optional wrap-around.
     ///
@@ -575,6 +584,7 @@ pub fn create_generator(
             column,
             repeat,
             columns,
+            ..
         } => {
             if columns.is_some() {
                 return Err(SondaError::Config(ConfigError::invalid(
@@ -1087,6 +1097,8 @@ mod tests {
                 name: "cpu".to_string(),
                 labels: None,
             }]),
+            timescale: None,
+            default_metric_name: None,
         };
         let result = create_generator(&config, 1.0);
         match result {

--- a/sonda-core/tests/csv_replay_roundtrip.rs
+++ b/sonda-core/tests/csv_replay_roundtrip.rs
@@ -1,0 +1,152 @@
+//! Round-trip integration test for the `csv_replay` fidelity feature.
+//!
+//! The flow synthesizes a CSV with a known sine pattern, runs it through
+//! `expand_scenario`, instantiates the generator from the expanded config,
+//! and asserts that the replayed values and derived emission rate match the
+//! source data within numerical tolerance.
+
+#![cfg(feature = "config")]
+
+mod common;
+
+use std::io::Write;
+
+use sonda_core::config::{expand_scenario, BaseScheduleConfig, ScenarioConfig};
+use sonda_core::encoder::EncoderConfig;
+use sonda_core::generator::{create_generator, GeneratorConfig};
+use sonda_core::sink::SinkConfig;
+use sonda_core::OnSinkError;
+
+fn make_sine_csv(samples: usize, step_secs: u64) -> tempfile::NamedTempFile {
+    let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
+    writeln!(tmp, "Time,sine_value").expect("write header");
+    let start_ts: u64 = 1_700_000_000;
+    for i in 0..samples {
+        let ts = start_ts + (i as u64) * step_secs;
+        let theta = (i as f64) * std::f64::consts::TAU / (samples as f64);
+        let value = theta.sin() * 10.0 + 50.0;
+        writeln!(tmp, "{ts},{:.6}", value).expect("write row");
+    }
+    tmp.flush().expect("flush");
+    tmp
+}
+
+fn build_scenario(file: String, timescale: Option<f64>) -> ScenarioConfig {
+    ScenarioConfig {
+        base: BaseScheduleConfig {
+            name: "roundtrip".to_string(),
+            rate: 1.0,
+            duration: Some("60s".to_string()),
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            labels: None,
+            sink: SinkConfig::Stdout,
+            phase_offset: None,
+            clock_group: None,
+            clock_group_is_auto: None,
+            jitter: None,
+            jitter_seed: None,
+            dynamic_labels: None,
+            on_sink_error: OnSinkError::Warn,
+        },
+        generator: GeneratorConfig::CsvReplay {
+            file,
+            column: None,
+            repeat: Some(true),
+            columns: None,
+            timescale,
+            default_metric_name: None,
+        },
+        encoder: EncoderConfig::PrometheusText { precision: None },
+    }
+}
+
+#[test]
+fn round_trip_sine_replay_matches_source_values_at_timescale_one() {
+    const SAMPLES: usize = 60;
+    const STEP_SECS: u64 = 10;
+    let tmp = make_sine_csv(SAMPLES, STEP_SECS);
+    let path = tmp.path().to_string_lossy().into_owned();
+
+    let config = build_scenario(path.clone(), Some(1.0));
+    let expanded = expand_scenario(config).expect("expand must succeed");
+    assert_eq!(expanded.len(), 1);
+    let child = &expanded[0];
+
+    let expected_rate = 1.0 / (STEP_SECS as f64);
+    assert!(
+        (child.rate - expected_rate).abs() < 1e-9,
+        "derived rate must equal 1/Δt: expected {}, got {}",
+        expected_rate,
+        child.rate
+    );
+
+    let gen =
+        create_generator(&child.generator, child.rate).expect("create_generator must succeed");
+    let expected: Vec<f64> = (0..SAMPLES)
+        .map(|i| {
+            let theta = (i as f64) * std::f64::consts::TAU / (SAMPLES as f64);
+            theta.sin() * 10.0 + 50.0
+        })
+        .collect();
+    for (i, want) in expected.iter().enumerate() {
+        let got = gen.value(i as u64);
+        let want_rounded: f64 = format!("{:.6}", want).parse().unwrap();
+        assert!(
+            (got - want_rounded).abs() < 1e-9,
+            "tick {}: expected ~{}, got {}",
+            i,
+            want_rounded,
+            got
+        );
+    }
+}
+
+#[test]
+fn round_trip_with_timescale_two_doubles_emission_rate() {
+    let tmp = make_sine_csv(10, 10);
+    let path = tmp.path().to_string_lossy().into_owned();
+
+    let config = build_scenario(path, Some(2.0));
+    let expanded = expand_scenario(config).expect("expand must succeed");
+    assert!(
+        (expanded[0].rate - 0.2).abs() < 1e-9,
+        "timescale=2.0 must double rate to 0.2, got {}",
+        expanded[0].rate
+    );
+}
+
+#[test]
+fn round_trip_with_timescale_half_halves_emission_rate() {
+    let tmp = make_sine_csv(10, 10);
+    let path = tmp.path().to_string_lossy().into_owned();
+
+    let config = build_scenario(path, Some(0.5));
+    let expanded = expand_scenario(config).expect("expand must succeed");
+    assert!(
+        (expanded[0].rate - 0.05).abs() < 1e-9,
+        "timescale=0.5 must halve rate to 0.05, got {}",
+        expanded[0].rate
+    );
+}
+
+#[test]
+fn round_trip_preserves_value_count_and_ordering() {
+    let tmp = make_sine_csv(8, 5);
+    let path = tmp.path().to_string_lossy().into_owned();
+
+    let config = build_scenario(path, None);
+    let expanded = expand_scenario(config).expect("expand must succeed");
+    let gen = create_generator(&expanded[0].generator, expanded[0].rate)
+        .expect("create_generator must succeed");
+
+    let v0 = gen.value(0);
+    let v1 = gen.value(1);
+    let v_wrap = gen.value(8);
+    assert!(
+        (v_wrap - v0).abs() < 1e-12,
+        "with repeat=true, tick 8 must wrap to value at tick 0: {v_wrap} vs {v0}"
+    );
+    assert_ne!(v0, v1, "consecutive samples must differ");
+}

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -33,6 +33,7 @@ ctrlc = "3"
 owo-colors = { version = "4", features = ["supports-colors"] }
 serde_json = { workspace = true }
 dialoguer = "0.12"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -46,6 +46,16 @@ fn main() {
 /// Separated from `main` so errors can be returned with `?` and printed
 /// uniformly.
 fn run() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_target(false)
+        .without_time()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .init();
+
     // Register Ctrl+C handler. The runner loop checks `running` each tick so
     // it can exit gracefully instead of being killed mid-write.
     let running = Arc::new(AtomicBool::new(true));

--- a/sonda/src/status.rs
+++ b/sonda/src/status.rs
@@ -771,6 +771,7 @@ fn generator_display(gen: &GeneratorConfig) -> String {
             column,
             repeat,
             columns,
+            ..
         } => {
             let rpt = if repeat.unwrap_or(true) {
                 "repeat"
@@ -1216,6 +1217,8 @@ mod tests {
             column: Some(2),
             repeat: Some(false),
             columns: None,
+            timescale: None,
+            default_metric_name: None,
         };
         assert_eq!(
             generator_display(&config),
@@ -1230,6 +1233,8 @@ mod tests {
             column: None,
             repeat: None,
             columns: None,
+            timescale: None,
+            default_metric_name: None,
         };
         assert_eq!(
             generator_display(&config),
@@ -1255,6 +1260,8 @@ mod tests {
                     labels: None,
                 },
             ]),
+            timescale: None,
+            default_metric_name: None,
         };
         assert_eq!(
             generator_display(&config),

--- a/sonda/tests/example_scenarios.rs
+++ b/sonda/tests/example_scenarios.rs
@@ -465,6 +465,10 @@ fn csv_replay_grafana_auto_yaml_expands_to_two_scenarios() {
 #[test]
 fn csv_replay_explicit_labels_yaml_expands_with_per_column_labels() {
     let yaml = read_example("examples/csv-replay-explicit-labels.yaml");
+    let absolute_csv = workspace_file("examples/sample-multi-column.csv")
+        .to_string_lossy()
+        .into_owned();
+    let yaml = yaml.replace("examples/sample-multi-column.csv", &absolute_csv);
     let compiled = compile_ok("csv-replay-explicit-labels.yaml", &yaml);
     assert_eq!(compiled.len(), 1, "compile produces one csv_replay entry");
 


### PR DESCRIPTION
## Summary

Fixes two latent bugs in the Grafana CSV → sonda replay workflow that made it unusable for true round-trip replay:

- **Bug 1**: Auto-discovery errored on Grafana exports with labels-only headers (no `__name__`). New `default_metric_name` field on `csv_replay` fills in the missing name; auto-suffixes `_<index>` when multiple labels-only columns share the fallback.
- **Bug 2**: `csv_replay` ignored CSV timestamps entirely and cycled values at the user-supplied `rate:`, so a 5-minute hill in the source compressed to whatever the YAML rate dictated. `expand_scenario` now parses the timestamp column, computes median Δt, and overrides the rate to `timescale / Δt`. A `tracing::warn!` line announces the override on stderr.

Header labels from the CSV are also auto-merged into per-column `columns:` specs so users don't have to redeclare every label set.

## Round-trip UAT result

- 10-min Phase A: step counter → VictoriaMetrics → `rate()` → CSV export (67 rows, Δt=10s)
- Phase C: csv_replay → VM under `source="replay"`
- **Pearson r = 1.00000000** (exact match)
- Max relative deviation: **0.000000%**
- Rate-override warn fired correctly on stderr

## Compatibility note

The feature has not shipped to users yet — this is the first release of csv_replay rate semantics, treated as a normal feature addition rather than a breaking change.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo nextest run --workspace` — 2952 tests passing (2931 baseline + 21 new)
- [x] `cargo test --workspace --doc` — 5/5 doc tests passing
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p sonda-core --no-default-features --no-run` clean
- [x] `cargo audit` — only pre-existing yanked `core2` (via rskafka), unrelated
- [x] Round-trip UAT (Pearson r = 1.0, see `planning/csv-replay-fidelity/uat-plan.md`)
- [x] Architectural review (PASS WITH NOTES; all WARNINGs addressed in fix-pass)
- [x] User-facing docs updated: `csv-import.md`, `grafana-csv-replay.md`, `configuration/generators.md`