### PR TITLE
docs: remove stale "New in 1.2.0" tip from landing page

### DIFF
--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -7,12 +7,6 @@
 [![CI](https://github.com/davidban77/sonda/actions/workflows/ci.yml/badge.svg)](https://github.com/davidban77/sonda/actions/workflows/ci.yml)
 [![License](https://img.shields.io/crates/l/sonda.svg)](https://github.com/davidban77/sonda/blob/main/LICENSE-MIT)
 
-!!! tip "New in 1.2.0 -- env-var interpolation in v2 scenarios"
-    Reference `${VAR}` and `${VAR:-default}` directly in scenario YAML. One file
-    runs from your laptop on the defaults and from a containerized `sonda-server`
-    on the overrides -- no `sed`, no per-environment fork. See
-    [Environment variable interpolation](configuration/v2-scenarios.md#environment-variable-interpolation).
-
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary

The `!!! tip "New in 1.2.0 — env-var interpolation"` block at the top of `docs/site/docs/index.md` has been unchanged across releases 1.3, 1.4, 1.5, 1.6, and 1.7. By now it reads as a stale marketing line rather than a useful pointer, and it gives a misleading impression of what's "new" to anyone landing on the docs site.

Rather than try to keep it current on every release (which is what failed for ~five minor versions), drop it.

The canonical "what's new" surfaces remain:

- [`CHANGELOG.md`](https://github.com/davidban77/sonda/blob/main/CHANGELOG.md) — release-please maintains this automatically from conventional commits.
- [GitHub releases](https://github.com/davidban77/sonda/releases) — same content, web-rendered, with per-release tag links.

No replacement link is added on the landing page; the four grid cards already give new readers a clear "what to do next" path, which is what an index should optimize for.

## Test plan

- [x] `task site:build` succeeds
- [x] Landing page renders with no orphan markdown