### PR TITLE
feat(compiler): 1.9a — require kind: frontmatter on v2 YAML; add tags:

### DIFF
--- a/examples/alertmanager/alerting-scenario.yaml
+++ b/examples/alertmanager/alerting-scenario.yaml
@@ -21,6 +21,7 @@
 #   curl -s http://localhost:8880/api/v1/alerts | jq .
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 2

--- a/examples/basic-metrics.yaml
+++ b/examples/basic-metrics.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1000

--- a/examples/burst-metrics.yaml
+++ b/examples/burst-metrics.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 100

--- a/examples/capacity-burst-test.yaml
+++ b/examples/capacity-burst-test.yaml
@@ -14,6 +14,7 @@
 #   sonda run --scenario examples/capacity-burst-test.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   duration: 120s

--- a/examples/capacity-cardinality-stress.yaml
+++ b/examples/capacity-cardinality-stress.yaml
@@ -16,6 +16,7 @@
 #   sonda run --scenario examples/capacity-cardinality-stress.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 50

--- a/examples/capacity-throughput-test.yaml
+++ b/examples/capacity-throughput-test.yaml
@@ -14,6 +14,7 @@
 #   sonda run --scenario examples/capacity-throughput-test.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1000

--- a/examples/cardinality-alert-test.yaml
+++ b/examples/cardinality-alert-test.yaml
@@ -14,6 +14,7 @@
 #   sonda metrics --scenario examples/cardinality-alert-test.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/cardinality-spike.yaml
+++ b/examples/cardinality-spike.yaml
@@ -12,6 +12,7 @@
 #   cargo run -- metrics --scenario examples/cardinality-spike.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/ci-alert-validation.yaml
+++ b/examples/ci-alert-validation.yaml
@@ -11,6 +11,7 @@
 # Requires VictoriaMetrics at localhost:8428.
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/constant-threshold-test.yaml
+++ b/examples/constant-threshold-test.yaml
@@ -8,6 +8,7 @@
 #   sonda metrics --scenario examples/constant-threshold-test.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/csv-replay-explicit-labels.yaml
+++ b/examples/csv-replay-explicit-labels.yaml
@@ -14,6 +14,7 @@
 #   sonda metrics --scenario examples/csv-replay-explicit-labels.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/csv-replay-grafana-auto.yaml
+++ b/examples/csv-replay-grafana-auto.yaml
@@ -14,6 +14,7 @@
 #   sonda metrics --scenario examples/csv-replay-grafana-auto.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/csv-replay-metrics.yaml
+++ b/examples/csv-replay-metrics.yaml
@@ -13,6 +13,7 @@
 #   sonda metrics --scenario examples/csv-replay-metrics.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/csv-replay-multi-column.yaml
+++ b/examples/csv-replay-multi-column.yaml
@@ -11,6 +11,7 @@
 #   sonda metrics --scenario examples/csv-replay-multi-column.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/docker-alerts.yaml
+++ b/examples/docker-alerts.yaml
@@ -27,6 +27,7 @@
 #     http://localhost:8080/scenarios
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/docker-metrics.yaml
+++ b/examples/docker-metrics.yaml
@@ -13,6 +13,7 @@
 #     http://localhost:8080/scenarios
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/dynamic-labels-fleet.yaml
+++ b/examples/dynamic-labels-fleet.yaml
@@ -11,6 +11,7 @@
 #   sonda metrics --scenario examples/dynamic-labels-fleet.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/dynamic-labels-logs.yaml
+++ b/examples/dynamic-labels-logs.yaml
@@ -7,6 +7,7 @@
 #   sonda logs --scenario examples/dynamic-labels-logs.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 5

--- a/examples/dynamic-labels-multi.yaml
+++ b/examples/dynamic-labels-multi.yaml
@@ -7,6 +7,7 @@
 #   sonda metrics --scenario examples/dynamic-labels-multi.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/dynamic-labels-regions.yaml
+++ b/examples/dynamic-labels-regions.yaml
@@ -8,6 +8,7 @@
 #   sonda metrics --scenario examples/dynamic-labels-regions.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 5

--- a/examples/e2e-scenario.yaml
+++ b/examples/e2e-scenario.yaml
@@ -13,6 +13,7 @@
 #     | jq '.data.result | length'
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/file-sink.yaml
+++ b/examples/file-sink.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 100

--- a/examples/for-duration-test.yaml
+++ b/examples/for-duration-test.yaml
@@ -12,6 +12,7 @@
 #   sonda metrics --scenario examples/for-duration-test.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/gap-alert-test.yaml
+++ b/examples/gap-alert-test.yaml
@@ -12,6 +12,7 @@
 #   sonda metrics --scenario examples/gap-alert-test.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/histogram.yaml
+++ b/examples/histogram.yaml
@@ -20,6 +20,7 @@
 # always equals `_count`.
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/http-push-retry.yaml
+++ b/examples/http-push-retry.yaml
@@ -12,6 +12,7 @@
 #     --retry-max-attempts 5 --retry-backoff 200ms --retry-max-backoff 10s
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/http-push-sink.yaml
+++ b/examples/http-push-sink.yaml
@@ -10,6 +10,7 @@
 # Verify with: curl 'http://localhost:8428/api/v1/query?query=cpu_usage'
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/influx-file.yaml
+++ b/examples/influx-file.yaml
@@ -8,6 +8,7 @@
 #   cat /tmp/sonda-influx-output.txt
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 50

--- a/examples/jitter-sine.yaml
+++ b/examples/jitter-sine.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/json-tcp.yaml
+++ b/examples/json-tcp.yaml
@@ -10,6 +10,7 @@
 # Loki, and any other NDJSON-based ingest path.
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 20

--- a/examples/kafka-json-logs.yaml
+++ b/examples/kafka-json-logs.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/kafka-sink.yaml
+++ b/examples/kafka-sink.yaml
@@ -13,6 +13,7 @@
 #   sonda metrics --scenario examples/kafka-sink.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 100.0

--- a/examples/kafka-tls.yaml
+++ b/examples/kafka-tls.yaml
@@ -15,6 +15,7 @@
 #   sonda metrics --scenario examples/kafka-tls.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 10.0

--- a/examples/log-csv-replay.yaml
+++ b/examples/log-csv-replay.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   duration: 60s

--- a/examples/log-template.yaml
+++ b/examples/log-template.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/loki-json-lines.yaml
+++ b/examples/loki-json-lines.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/long-running-metrics.yaml
+++ b/examples/long-running-metrics.yaml
@@ -1,6 +1,7 @@
 # Long-running scenario — no duration, runs until stopped.
 # Use with sonda-server: POST to start, DELETE to stop.
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/multi-format-test.yaml
+++ b/examples/multi-format-test.yaml
@@ -9,6 +9,7 @@
 #   wc -l < /tmp/pipeline-influx.txt
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 2

--- a/examples/multi-metric-correlation.yaml
+++ b/examples/multi-metric-correlation.yaml
@@ -18,6 +18,7 @@
 # shared timing reference.
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/multi-pipeline-test.yaml
+++ b/examples/multi-pipeline-test.yaml
@@ -9,6 +9,7 @@
 #   wc -l < /tmp/pipeline-logs.json
 
 version: 2
+kind: runnable
 
 scenarios:
   - signal_type: metrics

--- a/examples/multi-scenario.yaml
+++ b/examples/multi-scenario.yaml
@@ -7,6 +7,7 @@
 # Metrics are written to stdout; log events are written to /tmp/sonda-logs.json.
 
 version: 2
+kind: runnable
 
 scenarios:
   - signal_type: metrics

--- a/examples/network-device-baseline.yaml
+++ b/examples/network-device-baseline.yaml
@@ -12,6 +12,7 @@
 # entry to http_push or remote_write.
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/network-link-failure.yaml
+++ b/examples/network-link-failure.yaml
@@ -16,6 +16,7 @@
 #   sonda run --scenario examples/network-link-failure.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/otlp-logs.yaml
+++ b/examples/otlp-logs.yaml
@@ -11,6 +11,7 @@
 # ExportLogsServiceRequest via gRPC.
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 5

--- a/examples/otlp-metrics.yaml
+++ b/examples/otlp-metrics.yaml
@@ -11,6 +11,7 @@
 # ExportMetricsServiceRequest via gRPC.
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/pack-scenario.yaml
+++ b/examples/pack-scenario.yaml
@@ -11,6 +11,7 @@
 # packs directory, or use `--pack-path ./packs`.
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/pack-with-overrides.yaml
+++ b/examples/pack-with-overrides.yaml
@@ -9,6 +9,7 @@
 # packs directory, or use `--pack-path ./packs`.
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/precision-formatting.yaml
+++ b/examples/precision-formatting.yaml
@@ -10,6 +10,7 @@
 #   sonda metrics --name cpu_usage --rate 2 --duration 5s --value-mode sine --amplitude 50 --offset 50 --precision 2
 
 version: 2
+kind: runnable
 
 scenarios:
   # Prometheus text: rounds to 2 decimal places.

--- a/examples/prometheus-http-push.yaml
+++ b/examples/prometheus-http-push.yaml
@@ -16,6 +16,7 @@
 # encoder + sink combo, not just a URL change).
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 100

--- a/examples/rate-rule-input.yaml
+++ b/examples/rate-rule-input.yaml
@@ -15,6 +15,7 @@
 #     | jq '.data.result[0].value[1]'
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/recording-rule-test.yaml
+++ b/examples/recording-rule-test.yaml
@@ -15,6 +15,7 @@
 # See docs/guide-alert-testing.md Section 5 for a detailed walkthrough.
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/remote-write-prometheus.yaml
+++ b/examples/remote-write-prometheus.yaml
@@ -15,6 +15,7 @@
 # When building from source: cargo build --features remote-write -p sonda
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/remote-write-vm.yaml
+++ b/examples/remote-write-vm.yaml
@@ -19,6 +19,7 @@
 #   - Cortex/Mimir: http://localhost:9009/api/v1/push
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/remote-write-vmagent.yaml
+++ b/examples/remote-write-vmagent.yaml
@@ -16,6 +16,7 @@
 #     | jq '.data.result | length'
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/sequence-alert-test.yaml
+++ b/examples/sequence-alert-test.yaml
@@ -10,6 +10,7 @@
 # and resolution behavior.
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/simple-constant.yaml
+++ b/examples/simple-constant.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/sine-threshold-test.yaml
+++ b/examples/sine-threshold-test.yaml
@@ -11,6 +11,7 @@
 #   sonda metrics --scenario examples/sine-threshold-test.yaml
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/spike-alert-test.yaml
+++ b/examples/spike-alert-test.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/step-counter.yaml
+++ b/examples/step-counter.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 2

--- a/examples/summary.yaml
+++ b/examples/summary.yaml
@@ -20,6 +20,7 @@
 # near 0.15 (mean + ~2.3 stddev). `_count` ticks up by 100 every second.
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/examples/tcp-sink.yaml
+++ b/examples/tcp-sink.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/udp-sink.yaml
+++ b/examples/udp-sink.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/victoriametrics-metrics.yaml
+++ b/examples/victoriametrics-metrics.yaml
@@ -27,6 +27,7 @@
 #   and query: sonda_http_request_duration_ms
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/examples/vm-push-scenario.yaml
+++ b/examples/vm-push-scenario.yaml
@@ -10,6 +10,7 @@
 #   curl "http://localhost:8428/api/v1/query?query=cpu_usage"
 
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/packs/node-exporter-cpu.yaml
+++ b/packs/node-exporter-cpu.yaml
@@ -5,6 +5,8 @@
 # default monotonic step counter whose rate reflects typical CPU
 # utilization proportions.
 
+version: 2
+kind: composable
 name: node_exporter_cpu
 description: "Per-CPU mode counters (node_exporter-compatible)"
 category: infrastructure

--- a/packs/node-exporter-memory.yaml
+++ b/packs/node-exporter-memory.yaml
@@ -5,6 +5,8 @@
 # constants that approximate a server with 16 GiB total memory under
 # moderate load.
 
+version: 2
+kind: composable
 name: node_exporter_memory
 description: "Memory gauge metrics (node_exporter-compatible)"
 category: infrastructure

--- a/packs/telegraf-snmp-interface.yaml
+++ b/packs/telegraf-snmp-interface.yaml
@@ -5,6 +5,8 @@
 # schema exactly, so sonda output can replace real device telemetry in
 # dashboards and alert rules.
 
+version: 2
+kind: composable
 name: telegraf_snmp_interface
 description: "Standard SNMP interface metrics (Telegraf-normalized)"
 category: network

--- a/scenarios/cardinality-explosion.yaml
+++ b/scenarios/cardinality-explosion.yaml
@@ -7,6 +7,7 @@
 # limits and cost alerting.
 
 version: 2
+kind: runnable
 
 scenario_name: cardinality-explosion
 category: observability

--- a/scenarios/cpu-spike.yaml
+++ b/scenarios/cpu-spike.yaml
@@ -7,6 +7,7 @@
 # Pattern: baseline ~35% with periodic spikes to ~95%.
 
 version: 2
+kind: runnable
 
 scenario_name: cpu-spike
 category: infrastructure

--- a/scenarios/disk-fill.yaml
+++ b/scenarios/disk-fill.yaml
@@ -5,6 +5,7 @@
 # to ~160 GB over 120 seconds. Useful for testing disk-full predictions.
 
 version: 2
+kind: runnable
 
 scenario_name: disk-fill
 category: infrastructure

--- a/scenarios/error-rate-spike.yaml
+++ b/scenarios/error-rate-spike.yaml
@@ -6,6 +6,7 @@
 # and anomaly detection.
 
 version: 2
+kind: runnable
 
 scenario_name: error-rate-spike
 category: application

--- a/scenarios/histogram-latency.yaml
+++ b/scenarios/histogram-latency.yaml
@@ -6,6 +6,7 @@
 # (e.g., p99 latency SLOs) and Grafana heatmap panels.
 
 version: 2
+kind: runnable
 
 scenario_name: histogram-latency
 category: application

--- a/scenarios/interface-flap.yaml
+++ b/scenarios/interface-flap.yaml
@@ -12,6 +12,7 @@
 #   - Ticks 25-29: interface up, traffic normalized
 
 version: 2
+kind: runnable
 
 scenario_name: interface-flap
 category: network

--- a/scenarios/latency-degradation.yaml
+++ b/scenarios/latency-degradation.yaml
@@ -6,6 +6,7 @@
 # Useful for testing latency SLO alerting.
 
 version: 2
+kind: runnable
 
 scenario_name: latency-degradation
 category: application

--- a/scenarios/link-failover.yaml
+++ b/scenarios/link-failover.yaml
@@ -24,6 +24,7 @@
 # it does not cap the total wall-clock.
 
 version: 2
+kind: runnable
 
 scenario_name: link-failover
 category: network

--- a/scenarios/log-storm.yaml
+++ b/scenarios/log-storm.yaml
@@ -6,6 +6,7 @@
 # 5 seconds. Useful for testing log pipeline backpressure and alerting.
 
 version: 2
+kind: runnable
 
 scenario_name: log-storm
 category: application

--- a/scenarios/memory-leak.yaml
+++ b/scenarios/memory-leak.yaml
@@ -5,6 +5,7 @@
 # alert rules on memory growth rate or threshold breaches.
 
 version: 2
+kind: runnable
 
 scenario_name: memory-leak
 category: infrastructure

--- a/scenarios/steady-state.yaml
+++ b/scenarios/steady-state.yaml
@@ -6,6 +6,7 @@
 # scenario should NOT trigger any alerts.
 
 version: 2
+kind: runnable
 
 scenario_name: steady-state
 category: infrastructure

--- a/sonda-core/src/compile.rs
+++ b/sonda-core/src/compile.rs
@@ -206,6 +206,7 @@ mod tests {
     fn one_shot_compiles_minimal_inline_scenario() {
         let yaml = r#"
 version: 2
+kind: runnable
 
 defaults:
   rate: 10
@@ -242,6 +243,7 @@ scenarios:
     fn yaml_with_while_clause_rejected_with_compiled_path_hint() {
         let yaml = r#"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -283,6 +285,7 @@ scenarios:
     fn yaml_with_delay_clause_rejected_with_compiled_path_hint() {
         let yaml = r#"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -332,6 +335,7 @@ scenarios:
     fn normalize_failure_surfaces_as_normalize_variant() {
         let yaml = r#"
 version: 2
+kind: runnable
 
 scenarios:
   - id: no_rate
@@ -355,6 +359,7 @@ scenarios:
     fn expand_failure_surfaces_as_expand_variant() {
         let yaml = r#"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -377,6 +382,7 @@ scenarios:
     fn compile_after_failure_surfaces_as_compile_after_variant() {
         let yaml = r#"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/src/compiler/compile_after.rs
+++ b/sonda-core/src/compiler/compile_after.rs
@@ -1418,6 +1418,7 @@ mod tests {
     fn unknown_ref_surfaces_available_ids() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: cpu
     signal_type: metrics
@@ -1440,6 +1441,7 @@ scenarios:
     fn self_reference_is_rejected() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: loop
     signal_type: metrics
@@ -1460,6 +1462,7 @@ scenarios:
     fn saturation_greater_than_sets_offset() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: util
     signal_type: metrics
@@ -1488,6 +1491,7 @@ scenarios:
     // Flap `<` crosses at the up_duration boundary (60s → "1m").
     #[case::flap_less_than(r#"
 version: 2
+kind: runnable
 scenarios:
   - id: link
     signal_type: metrics
@@ -1504,6 +1508,7 @@ scenarios:
     // spike_event `<` crosses at the spike_duration boundary (10s).
     #[case::spike_event_less_than(r#"
 version: 2
+kind: runnable
 scenarios:
   - id: burst
     signal_type: metrics
@@ -1520,6 +1525,7 @@ scenarios:
     // Step `>`: ceil((55-0)/10) = 6 ticks, rate=2 -> 3.0s.
     #[case::step_greater_than(r#"
 version: 2
+kind: runnable
 scenarios:
   - id: counter
     signal_type: metrics
@@ -1536,6 +1542,7 @@ scenarios:
     // Sequence `<`: index 2 (value 2) is the first < 3; rate=2 -> 1.0s.
     #[case::sequence_less_than(r#"
 version: 2
+kind: runnable
 scenarios:
   - id: seq
     signal_type: metrics
@@ -1564,6 +1571,7 @@ scenarios:
     fn step_less_than_is_unsupported() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: counter
     signal_type: metrics
@@ -1595,6 +1603,7 @@ scenarios:
     #[rstest::rstest]
     #[case::constant(r#"
 version: 2
+kind: runnable
 scenarios:
   - id: k
     signal_type: metrics
@@ -1610,6 +1619,7 @@ scenarios:
 "#, "constant")]
     #[case::sine(r#"
 version: 2
+kind: runnable
 scenarios:
   - id: wave
     signal_type: metrics
@@ -1625,6 +1635,7 @@ scenarios:
 "#, "sine")]
     #[case::steady(r#"
 version: 2
+kind: runnable
 scenarios:
   - id: base
     signal_type: metrics
@@ -1640,6 +1651,7 @@ scenarios:
 "#, "steady")]
     #[case::uniform(r#"
 version: 2
+kind: runnable
 scenarios:
   - id: u
     signal_type: metrics
@@ -1672,6 +1684,7 @@ scenarios:
     fn transitive_chain_accumulates() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: a
     signal_type: metrics
@@ -1708,6 +1721,7 @@ scenarios:
     fn delay_is_added_to_crossing_time() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: link
     signal_type: metrics
@@ -1729,6 +1743,7 @@ scenarios:
     fn explicit_phase_offset_is_added() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: link
     signal_type: metrics
@@ -1751,6 +1766,7 @@ scenarios:
     fn phase_offset_delay_and_crossing_sum() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: link
     signal_type: metrics
@@ -1778,6 +1794,7 @@ scenarios:
     fn two_entry_cycle_is_detected() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: a
     signal_type: metrics
@@ -1801,6 +1818,7 @@ scenarios:
     fn three_entry_cycle_path_is_returned() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: a
     signal_type: metrics
@@ -1837,6 +1855,7 @@ scenarios:
     fn clock_group_auto_assigned_as_chain_plus_lowest_id() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: alpha
     signal_type: metrics
@@ -1865,6 +1884,7 @@ scenarios:
     fn explicit_clock_group_propagates_to_chain_members() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: alpha
     signal_type: metrics
@@ -1888,6 +1908,7 @@ scenarios:
     fn conflicting_clock_groups_are_rejected() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: alpha
     signal_type: metrics
@@ -1915,6 +1936,7 @@ scenarios:
     fn independent_signals_keep_no_clock_group() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: independent
     signal_type: metrics
@@ -1932,6 +1954,7 @@ scenarios:
         // and the concrete `"x"` wins for the whole component — no conflict.
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: alpha
     signal_type: metrics
@@ -1958,6 +1981,7 @@ scenarios:
         // carries two distinct non-empty values -> ConflictingClockGroup.
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: alpha
     signal_type: metrics
@@ -1985,6 +2009,7 @@ scenarios:
     fn log_signal_can_depend_on_metrics_target() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: err_rate
     signal_type: metrics
@@ -2006,6 +2031,7 @@ scenarios:
     fn metrics_entry_cannot_depend_on_logs_target() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: log_src
     signal_type: logs
@@ -2032,6 +2058,7 @@ scenarios:
     fn flap_alias_produces_expected_up_duration_offset() {
         let yaml_alias = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: link
     signal_type: metrics
@@ -2076,6 +2103,7 @@ metrics:
     fn dotted_pack_ref_resolves() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: dev
     signal_type: metrics
@@ -2120,6 +2148,7 @@ metrics:
 
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: host
     signal_type: metrics
@@ -2158,6 +2187,7 @@ scenarios:
     // `field == "after.delay"`.
     #[case::after_delay(r#"
 version: 2
+kind: runnable
 scenarios:
   - id: src
     signal_type: metrics
@@ -2177,6 +2207,7 @@ scenarios:
     // `CompileAfterError::InvalidDuration` with `field == "phase_offset"`.
     #[case::phase_offset_zero(r#"
 version: 2
+kind: runnable
 scenarios:
   - id: src
     signal_type: metrics
@@ -2198,6 +2229,7 @@ scenarios:
     // mis-classification; this regression anchors the fix.
     #[case::alias_flap_up_duration(r#"
 version: 2
+kind: runnable
 scenarios:
   - id: src
     signal_type: metrics
@@ -2339,6 +2371,7 @@ scenarios:
     fn while_yaml_compiles_and_propagates_clause() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m
@@ -2367,6 +2400,7 @@ scenarios:
     fn defaults_duration_carries_into_while_compiled_entry() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -2395,6 +2429,7 @@ scenarios:
     fn mixed_after_while_cycle_uses_labeled_format() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 10m
@@ -2432,6 +2467,7 @@ scenarios:
     fn pure_after_cycle_keeps_short_arrow_format() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
 scenarios:
@@ -2457,8 +2493,9 @@ scenarios:
     #[test]
     fn deep_while_chain_compiles_quickly() {
         use std::fmt::Write;
-        let mut yaml =
-            String::from("version: 2\ndefaults:\n  rate: 1\n  duration: 1h\nscenarios:\n");
+        let mut yaml = String::from(
+            "version: 2\nkind: runnable\ndefaults:\n  rate: 1\n  duration: 1h\nscenarios:\n",
+        );
         let _ = writeln!(
             yaml,
             "  - id: n0\n    signal_type: metrics\n    name: n0\n    generator: {{ type: constant, value: 1 }}"
@@ -2482,6 +2519,7 @@ scenarios:
     fn self_while_reference_is_rejected_with_while_kind() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m
@@ -2506,6 +2544,7 @@ scenarios:
     fn while_targeting_logs_signal_is_rejected() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m
@@ -2540,6 +2579,7 @@ scenarios:
     fn while_against_nan_constant_is_rejected() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m
@@ -2571,6 +2611,7 @@ scenarios:
     fn while_against_nan_sequence_value_is_rejected() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m
@@ -2606,6 +2647,7 @@ scenarios:
         let yaml = format!(
             r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m
@@ -2644,6 +2686,7 @@ scenarios:
         // the rejection path stays observable alongside csv_replay's.
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m
@@ -2674,6 +2717,7 @@ scenarios:
     fn while_strict_operators_reject_non_strict(#[case] op: &str) {
         let yaml = format!(r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m

--- a/sonda-core/src/compiler/expand.rs
+++ b/sonda-core/src/compiler/expand.rs
@@ -1017,6 +1017,7 @@ mod tests {
     fn expand_produces_one_entry_per_pack_metric() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
 scenarios:
@@ -1036,6 +1037,7 @@ scenarios:
     fn expanded_signal_type_is_metrics() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - signal_type: metrics
@@ -1059,6 +1061,7 @@ scenarios:
     // the clean `{entry_id}.{metric}` shape.
     #[case::user_supplied_entry_id(r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - id: primary
@@ -1070,6 +1073,7 @@ scenarios:
     // `telegraf_snmp_interface_0`.
     #[case::auto_generated_entry_id(r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - signal_type: metrics
@@ -1091,6 +1095,7 @@ scenarios:
     fn two_anonymous_pack_entries_disambiguate_by_index() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - signal_type: metrics
@@ -1147,6 +1152,7 @@ scenarios:
 
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   labels:
@@ -1181,6 +1187,7 @@ scenarios:
         // final map for pack-expanded signals.
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   labels:
@@ -1217,6 +1224,7 @@ scenarios:
 
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   labels:
@@ -1237,6 +1245,7 @@ scenarios:
         // shows up here — not doubled, not missing a defaults key.
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   labels:
@@ -1264,6 +1273,7 @@ scenarios:
     fn override_generator_replaces_pack_generator() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - id: e
@@ -1309,6 +1319,7 @@ scenarios:
 
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - signal_type: metrics
@@ -1329,6 +1340,7 @@ scenarios:
     fn entry_level_after_propagates_to_every_metric() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - id: tail
@@ -1353,6 +1365,7 @@ scenarios:
     fn entry_level_while_propagates_to_every_metric() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1, duration: 5m }
 scenarios:
   - id: head
@@ -1390,6 +1403,7 @@ scenarios:
     fn override_while_replaces_entry_while_for_that_metric() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1, duration: 5m }
 scenarios:
   - id: head
@@ -1435,6 +1449,7 @@ scenarios:
     fn override_after_replaces_entry_after_for_that_metric() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - id: tail
@@ -1476,6 +1491,7 @@ scenarios:
     fn schedule_delivery_fields_propagate_to_every_metric() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 2m
@@ -1521,6 +1537,7 @@ scenarios:
         // runs, the output shape cannot carry unresolved pack references.
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - signal_type: metrics
@@ -1543,6 +1560,7 @@ scenarios:
     fn unknown_override_key_is_an_error() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - signal_type: metrics
@@ -1576,6 +1594,7 @@ scenarios:
     fn unresolvable_pack_is_an_error() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - signal_type: metrics
@@ -1607,6 +1626,7 @@ scenarios:
         resolver.insert("empty", pack);
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - signal_type: metrics
@@ -1626,6 +1646,7 @@ scenarios:
     fn inline_entries_pass_through_untouched() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - id: cpu
     signal_type: metrics
@@ -1653,6 +1674,7 @@ scenarios:
     fn mixed_inline_and_pack_entries_interleave_correctly() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - id: cpu
@@ -1681,6 +1703,7 @@ scenarios:
     fn repeated_metric_names_produce_one_entry_per_spec_instance() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - id: cpu
@@ -1722,6 +1745,7 @@ scenarios:
         // "#{spec_index}" suffix per the module-level auto-ID docs.
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - id: cpu
@@ -1764,6 +1788,7 @@ scenarios:
         // `after.ref` into a pack sub-signal stays ergonomic.
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - id: net
@@ -1794,6 +1819,7 @@ scenarios:
     // this pass must catch the collision.
     #[case::inline_first_then_auto(r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - id: telegraf_snmp_interface_1
@@ -1808,6 +1834,7 @@ scenarios:
     // the collision regardless of source order.
     #[case::auto_first_then_inline(r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - signal_type: metrics
@@ -1861,6 +1888,7 @@ scenarios:
         // first.
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - id: telegraf_snmp_interface_1
@@ -1898,6 +1926,7 @@ scenarios:
     fn pack_by_file_path_is_resolved_through_trait() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults: { rate: 1 }
 scenarios:
   - signal_type: metrics

--- a/sonda-core/src/compiler/mod.rs
+++ b/sonda-core/src/compiler/mod.rs
@@ -81,6 +81,13 @@ use crate::sink::SinkConfig;
 pub struct ScenarioFile {
     /// Schema version. Must be `2`.
     pub version: u32,
+    /// Discriminator declaring whether the file is a runnable scenario
+    /// or a composable pack definition.
+    pub kind: Kind,
+    /// Optional file-level metadata tags surfaced by `sonda list --tag`.
+    /// Carried through normalization unchanged; ignored at runtime.
+    #[cfg_attr(feature = "config", serde(default))]
+    pub tags: Vec<String>,
     /// Catalog display name (kebab-case). When present it overrides the
     /// filename-derived name in the CLI catalog probe. Pure metadata —
     /// ignored by every compiler phase.
@@ -102,7 +109,24 @@ pub struct ScenarioFile {
     #[cfg_attr(feature = "config", serde(default))]
     pub defaults: Option<Defaults>,
     /// One or more scenario entries (inline signals or pack references).
+    /// Empty when `kind: composable` — composable files carry no entries.
+    #[cfg_attr(feature = "config", serde(default))]
     pub scenarios: Vec<Entry>,
+}
+
+/// Discriminator declaring the role of a v2 YAML file.
+///
+/// Required at the top level of every v2 scenario file. `Runnable` files
+/// carry one or more scenario entries (inline or via `pack:` references)
+/// and are executable. `Composable` files are pack definitions; their
+/// body matches [`MetricPackDef`](crate::packs::MetricPackDef) and they
+/// are referenced from runnable files via `pack:`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "config", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "config", serde(rename_all = "lowercase"))]
+pub enum Kind {
+    Runnable,
+    Composable,
 }
 
 /// Shared defaults inherited by all entries in a v2 scenario file.

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -86,7 +86,7 @@
 
 use std::collections::BTreeMap;
 
-use super::{AfterClause, Defaults, DelayClause, Entry, ScenarioFile, WhileClause};
+use super::{AfterClause, Defaults, DelayClause, Entry, Kind, ScenarioFile, WhileClause};
 use crate::config::{
     BurstConfig, CardinalitySpikeConfig, DistributionConfig, DynamicLabelConfig, GapConfig,
     OnSinkError,
@@ -181,6 +181,11 @@ pub enum NormalizeError {
 pub struct NormalizedFile {
     /// Schema version. Always `2` after normalization.
     pub version: u32,
+    /// File kind discriminator carried through normalization.
+    pub kind: Kind,
+    /// File-level tags carried through normalization untouched.
+    #[cfg_attr(feature = "config", serde(skip_serializing_if = "Vec::is_empty"))]
+    pub tags: Vec<String>,
     /// File-level `scenario_name` carried verbatim. Pure metadata —
     /// ignored by every compiler phase, surfaced for runtime conflict checks.
     #[cfg_attr(feature = "config", serde(skip_serializing_if = "Option::is_none"))]
@@ -344,6 +349,8 @@ pub fn normalize(file: ScenarioFile) -> Result<NormalizedFile, NormalizeError> {
 
     Ok(NormalizedFile {
         version: file.version,
+        kind: file.kind,
+        tags: file.tags,
         scenario_name: file.scenario_name,
         defaults_labels,
         entries,
@@ -582,6 +589,7 @@ mod tests {
     fn entry_inherits_rate_and_duration_from_defaults() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -600,6 +608,7 @@ scenarios:
     fn entry_rate_overrides_defaults_rate() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
 scenarios:
@@ -616,6 +625,7 @@ scenarios:
     fn entry_duration_overrides_defaults_duration() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -633,6 +643,7 @@ scenarios:
     fn entry_inherits_encoder_and_sink_from_defaults() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   encoder: { type: influx_lp }
@@ -655,6 +666,7 @@ scenarios:
     fn entry_encoder_overrides_defaults_encoder() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   encoder: { type: influx_lp }
@@ -685,6 +697,7 @@ scenarios:
     #[rstest::rstest]
     #[case::metrics(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu
@@ -693,6 +706,7 @@ scenarios:
 "#, ExpectedEncoder::PrometheusText)]
     #[case::histogram(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: histogram
     name: http_latency
@@ -704,6 +718,7 @@ scenarios:
 "#, ExpectedEncoder::PrometheusText)]
     #[case::summary(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: summary
     name: rpc_latency
@@ -715,6 +730,7 @@ scenarios:
 "#, ExpectedEncoder::PrometheusText)]
     #[case::logs(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: logs
     name: app_logs
@@ -745,6 +761,7 @@ scenarios:
     fn labels_merge_entry_wins_on_conflict() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   labels:
@@ -779,6 +796,7 @@ scenarios:
     fn labels_from_defaults_alone_are_preserved() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   labels:
@@ -798,6 +816,7 @@ scenarios:
     fn entry_labels_preserved_when_defaults_has_no_labels() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
 scenarios:
@@ -817,6 +836,7 @@ scenarios:
     fn no_labels_anywhere_produces_none() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu
@@ -841,6 +861,7 @@ scenarios:
     #[rstest::rstest]
     #[case::inline_uses_name(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu
@@ -848,6 +869,7 @@ scenarios:
 "#, "cpu")]
     #[case::pack_prefers_id(r#"
 version: 2
+kind: runnable
 scenarios:
   - id: snmp_iface
     signal_type: metrics
@@ -855,6 +877,7 @@ scenarios:
 "#, "snmp_iface")]
     #[case::pack_falls_back_to_pack_name(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     pack: telegraf_snmp_interface
@@ -877,6 +900,7 @@ scenarios:
     fn missing_rate_message_mentions_entry_and_hint() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: bare
@@ -901,6 +925,7 @@ scenarios:
     fn shorthand_single_signal_normalizes_through_wrapped_form() {
         let yaml = r#"
 version: 2
+kind: runnable
 name: cpu_usage
 signal_type: metrics
 rate: 5
@@ -919,6 +944,7 @@ generator: { type: constant, value: 42 }
     fn shorthand_logs_signal_picks_json_lines_default() {
         let yaml = r#"
 version: 2
+kind: runnable
 name: app_logs
 signal_type: logs
 rate: 2
@@ -951,6 +977,7 @@ log_generator:
         // If we merged here the pack's job override would be unreachable.
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 10m
@@ -1003,6 +1030,7 @@ scenarios:
         // Present when defaults.labels is set and non-empty.
         let yaml_with = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   labels:
@@ -1025,6 +1053,7 @@ scenarios:
         // None when the file has no defaults block at all.
         let yaml_no_defaults = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu
@@ -1037,6 +1066,7 @@ scenarios:
         // None when defaults exists but has no labels field.
         let yaml_no_labels = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -1056,6 +1086,7 @@ scenarios:
         // defaults_labels must carry the source map verbatim for Phase 3.
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   labels:
@@ -1121,6 +1152,7 @@ scenarios:
     fn multi_scenario_mixed_entries_all_normalize() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -1218,6 +1250,7 @@ scenarios:
     fn after_clause_and_timing_fields_preserved() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
 scenarios:
@@ -1250,6 +1283,7 @@ scenarios:
     fn histogram_fields_preserved() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
 scenarios:
@@ -1268,6 +1302,22 @@ scenarios:
         assert_eq!(entry.observations_per_tick, Some(100));
         assert_eq!(entry.mean_shift_per_sec, Some(0.01));
         assert_eq!(entry.seed, Some(42));
+    }
+
+    #[test]
+    fn tags_survive_normalization() {
+        let yaml = r#"
+version: 2
+kind: runnable
+tags: [network, bgp, incident]
+scenarios:
+  - signal_type: metrics
+    name: x
+    rate: 1
+    generator: { type: constant, value: 1.0 }
+"#;
+        let normalized = normalize_yaml(yaml).expect("normalize must succeed");
+        assert_eq!(normalized.tags, vec!["network", "bgp", "incident"]);
     }
 
     // ======================================================================
@@ -1293,13 +1343,19 @@ scenarios:
 
     #[test]
     fn empty_scenarios_list_normalizes_to_empty_entries() {
-        let yaml = r#"
-version: 2
-scenarios: []
-"#;
-        let file = normalize_yaml(yaml).expect("must normalize empty list");
-        assert_eq!(file.version, 2);
-        assert!(file.entries.is_empty());
+        let file = ScenarioFile {
+            version: 2,
+            kind: Kind::Runnable,
+            tags: Vec::new(),
+            scenario_name: None,
+            category: None,
+            description: None,
+            defaults: None,
+            scenarios: Vec::new(),
+        };
+        let normalized = normalize(file).expect("must normalize empty list");
+        assert_eq!(normalized.version, 2);
+        assert!(normalized.entries.is_empty());
     }
 
     // ======================================================================
@@ -1367,6 +1423,7 @@ scenarios: []
     fn while_without_duration_is_rejected() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
 scenarios:
@@ -1393,6 +1450,7 @@ scenarios:
     fn defaults_duration_satisfies_while_without_duration() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -1416,6 +1474,7 @@ scenarios:
     fn delay_without_while_is_rejected() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m
@@ -1439,6 +1498,7 @@ scenarios:
     fn delay_open_zero_is_accepted() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -1469,6 +1529,7 @@ scenarios:
     fn delay_close_zero_is_accepted() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -1503,6 +1564,7 @@ scenarios:
     fn while_value_non_finite_is_rejected_at_compile(#[case] yaml_value: &str) {
         let yaml = format!(r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m
@@ -1534,6 +1596,7 @@ scenarios:
     fn close_snap_to_non_finite_is_rejected_at_compile(#[case] yaml_value: &str) {
         let yaml = format!(r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m
@@ -1565,6 +1628,7 @@ scenarios:
     fn while_inherits_from_defaults() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m

--- a/sonda-core/src/compiler/parse.rs
+++ b/sonda-core/src/compiler/parse.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashSet;
 
-use super::{Entry, ScenarioFile};
+use super::{Entry, Kind, ScenarioFile};
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -86,6 +86,38 @@ pub enum ParseError {
         /// The field name that is not allowed for this signal type.
         field: String,
     },
+
+    /// The required top-level `kind:` field is missing.
+    #[error(
+        "v2 scenario file requires a top-level 'kind:' field — must be 'runnable' or 'composable'"
+    )]
+    MissingKind,
+
+    /// The `kind:` field holds a value other than `runnable` or `composable`.
+    #[error("unknown kind '{0}': must be 'runnable' or 'composable'")]
+    UnknownKind(String),
+
+    /// A `kind: runnable` file has a `scenarios:` block with no entries.
+    #[error("kind: runnable scenarios block is empty; expected at least one scenario")]
+    RunnableScenariosEmpty,
+
+    /// A `kind: runnable` file has neither a `scenarios:` block nor any
+    /// flat-shorthand fields.
+    #[error(
+        "kind: runnable file has no scenarios; add a 'scenarios:' block or use single-signal shorthand"
+    )]
+    RunnableMissingBody,
+
+    /// A `kind: composable` file carries a `scenarios:` block, which is
+    /// reserved for runnable files.
+    #[error(
+        "kind: composable cannot have a 'scenarios:' block; composable files are pack definitions"
+    )]
+    ComposableHasScenarios,
+
+    /// A `kind: composable` file failed to deserialize as a pack definition.
+    #[error("kind: composable body is not a valid pack definition")]
+    ComposablePackInvalid(#[source] serde_yaml_ng::Error),
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +171,12 @@ pub fn detect_version(yaml: &str) -> Option<u32> {
 #[serde(deny_unknown_fields)]
 struct FlatFile {
     version: u32,
+
+    #[serde(default)]
+    kind: Option<Kind>,
+
+    #[serde(default)]
+    tags: Vec<String>,
 
     // Defaults-level fields (also allowed at top level in shorthand)
     #[serde(default)]
@@ -265,6 +303,8 @@ impl FlatFile {
         // canonical `scenarios:` form consumed by the CLI catalog probe.
         ScenarioFile {
             version: self.version,
+            kind: self.kind.unwrap_or(Kind::Runnable),
+            tags: self.tags,
             scenario_name: None,
             category: None,
             description: None,
@@ -307,14 +347,110 @@ impl FlatFile {
 ///
 /// Returns [`ParseError`] describing the first validation failure found.
 pub fn parse(yaml: &str) -> Result<ScenarioFile, ParseError> {
+    if let Some(v) = detect_version(yaml) {
+        if v != 2 {
+            return Err(ParseError::InvalidVersion(v));
+        }
+    }
+
+    let kind = validate_kind_field(yaml)?;
+
+    if kind == Kind::Composable {
+        return parse_composable(yaml);
+    }
+
     let file = deserialize(yaml)?;
 
     if file.version != 2 {
         return Err(ParseError::InvalidVersion(file.version));
     }
 
+    if file.scenarios.is_empty() {
+        return Err(if has_top_level_scenarios_key(yaml) {
+            ParseError::RunnableScenariosEmpty
+        } else {
+            ParseError::RunnableMissingBody
+        });
+    }
     validate_entries(&file.scenarios)?;
+
     Ok(file)
+}
+
+fn parse_composable(yaml: &str) -> Result<ScenarioFile, ParseError> {
+    if has_top_level_scenarios_key(yaml) {
+        return Err(ParseError::ComposableHasScenarios);
+    }
+
+    #[derive(serde::Deserialize)]
+    struct ComposableHeader {
+        version: u32,
+        #[serde(default)]
+        tags: Vec<String>,
+        #[serde(default)]
+        description: Option<String>,
+    }
+
+    let header: ComposableHeader = serde_yaml_ng::from_str(yaml)?;
+    if header.version != 2 {
+        return Err(ParseError::InvalidVersion(header.version));
+    }
+
+    validate_composable_pack_body(yaml)?;
+
+    Ok(ScenarioFile {
+        version: header.version,
+        kind: Kind::Composable,
+        tags: header.tags,
+        scenario_name: None,
+        category: None,
+        description: header.description,
+        defaults: None,
+        scenarios: Vec::new(),
+    })
+}
+
+/// Probe the raw YAML for a top-level `kind:` field before full
+/// deserialization so missing/unknown values surface as typed errors
+/// (`MissingKind` / `UnknownKind`) rather than generic serde messages.
+fn validate_kind_field(yaml: &str) -> Result<Kind, ParseError> {
+    #[derive(serde::Deserialize)]
+    struct KindProbe {
+        kind: Option<serde_yaml_ng::Value>,
+    }
+
+    let probe: KindProbe = serde_yaml_ng::from_str(yaml)?;
+    let raw = probe.kind.ok_or(ParseError::MissingKind)?;
+
+    match raw {
+        serde_yaml_ng::Value::String(s) if s == "runnable" => Ok(Kind::Runnable),
+        serde_yaml_ng::Value::String(s) if s == "composable" => Ok(Kind::Composable),
+        serde_yaml_ng::Value::String(s) => Err(ParseError::UnknownKind(s)),
+        other => {
+            let rendered = serde_yaml_ng::to_string(&other)
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            Err(ParseError::UnknownKind(rendered))
+        }
+    }
+}
+
+fn has_top_level_scenarios_key(yaml: &str) -> bool {
+    #[derive(serde::Deserialize)]
+    struct ScenariosProbe {
+        scenarios: Option<serde_yaml_ng::Value>,
+    }
+
+    serde_yaml_ng::from_str::<ScenariosProbe>(yaml)
+        .map(|p| p.scenarios.is_some())
+        .unwrap_or(false)
+}
+
+fn validate_composable_pack_body(yaml: &str) -> Result<(), ParseError> {
+    serde_yaml_ng::from_str::<crate::packs::MetricPackDef>(yaml)
+        .map(|_| ())
+        .map_err(ParseError::ComposablePackInvalid)
 }
 
 /// Determine the file shape and deserialize accordingly.
@@ -324,23 +460,34 @@ pub fn parse(yaml: &str) -> Result<ScenarioFile, ParseError> {
 /// peek for the `scenarios` key first. If present, we parse as canonical. If
 /// absent, we parse as flat shorthand. No fallback.
 fn deserialize(yaml: &str) -> Result<ScenarioFile, ParseError> {
-    /// Minimal probe to detect whether the YAML contains a `scenarios` key.
-    /// Intentionally does NOT use `deny_unknown_fields`.
     #[derive(serde::Deserialize)]
     struct ShapeProbe {
         scenarios: Option<serde_yaml_ng::Value>,
+        signal_type: Option<serde_yaml_ng::Value>,
+        generator: Option<serde_yaml_ng::Value>,
+        log_generator: Option<serde_yaml_ng::Value>,
+        distribution: Option<serde_yaml_ng::Value>,
+        pack: Option<serde_yaml_ng::Value>,
     }
 
     let probe: ShapeProbe = serde_yaml_ng::from_str(yaml)?;
 
     if probe.scenarios.is_some() {
-        // Canonical format: top-level `scenarios` array.
         let file: ScenarioFile = serde_yaml_ng::from_str(yaml)?;
-        Ok(file)
-    } else {
-        // Flat single-signal shorthand: no `scenarios` key.
+        return Ok(file);
+    }
+
+    let has_flat_body = probe.signal_type.is_some()
+        || probe.generator.is_some()
+        || probe.log_generator.is_some()
+        || probe.distribution.is_some()
+        || probe.pack.is_some();
+
+    if has_flat_body {
         let flat: FlatFile = serde_yaml_ng::from_str(yaml)?;
         Ok(flat.into_scenario_file())
+    } else {
+        Err(ParseError::RunnableMissingBody)
     }
 }
 
@@ -491,6 +638,7 @@ mod tests {
     fn multi_scenario_with_three_entries() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu_usage
@@ -536,6 +684,7 @@ scenarios:
     fn single_signal_shorthand_inline() {
         let yaml = r#"
 version: 2
+kind: runnable
 name: cpu_usage
 signal_type: metrics
 rate: 1
@@ -563,6 +712,7 @@ generator:
     fn single_signal_shorthand_pack() {
         let yaml = r#"
 version: 2
+kind: runnable
 pack: telegraf_snmp_interface
 rate: 1
 duration: 10s
@@ -590,6 +740,7 @@ labels:
     fn flat_shorthand_never_carries_top_level_metadata() {
         let yaml = r#"
 version: 2
+kind: runnable
 name: cpu_usage
 signal_type: metrics
 rate: 1
@@ -622,6 +773,7 @@ generator:
     fn entry_with_after_clause() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu_usage
@@ -662,6 +814,7 @@ scenarios:
     fn entry_with_after_clause_and_delay() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: source
@@ -697,6 +850,7 @@ scenarios:
     fn histogram_entry_with_distribution_and_buckets() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: histogram
     name: http_request_duration_seconds
@@ -725,6 +879,7 @@ scenarios:
     fn summary_entry_with_distribution_and_quantiles() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: summary
     name: rpc_duration_seconds
@@ -752,6 +907,7 @@ scenarios:
     fn file_with_defaults_block() {
         let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: "60s"
@@ -783,6 +939,7 @@ scenarios:
     fn entry_with_all_optional_fields() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     id: full_entry
@@ -879,6 +1036,7 @@ scenarios:
     #[test]
     fn missing_version_returns_yaml_error() {
         let yaml = r#"
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu
@@ -898,6 +1056,7 @@ scenarios:
     fn duplicate_ids_returns_error() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     id: same_id
@@ -924,6 +1083,7 @@ scenarios:
     fn invalid_signal_type_returns_error() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: traces
     name: some_trace
@@ -943,6 +1103,7 @@ scenarios:
     fn both_generator_and_pack_returns_error() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: mixed
@@ -963,6 +1124,7 @@ scenarios:
     fn neither_generator_nor_pack_returns_error() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: bare_entry
@@ -979,6 +1141,7 @@ scenarios:
     fn pack_with_logs_signal_type_returns_error() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: logs
     pack: some_log_pack
@@ -995,6 +1158,7 @@ scenarios:
     fn logs_without_log_generator_returns_error() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: logs
     name: bare_log
@@ -1011,6 +1175,7 @@ scenarios:
     fn inline_without_name_returns_error() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     generator:
@@ -1029,6 +1194,7 @@ scenarios:
     #[rstest::rstest]
     #[case::starts_with_digit(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     id: 123abc
@@ -1039,6 +1205,7 @@ scenarios:
 "#, "123abc")]
     #[case::contains_dot(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     id: my.id
@@ -1049,6 +1216,7 @@ scenarios:
 "#, "my.id")]
     #[case::empty_string(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     id: ""
@@ -1069,6 +1237,7 @@ scenarios:
     fn invalid_after_op_returns_yaml_error() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: source
@@ -1198,6 +1367,7 @@ scenarios:
     fn histogram_without_distribution_fails() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: histogram
     name: bad_histogram
@@ -1219,6 +1389,7 @@ scenarios:
     fn pack_entry_with_overrides() {
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     pack: telegraf_snmp_interface
@@ -1246,6 +1417,7 @@ scenarios:
     #[rstest::rstest]
     #[case::metrics_with_log_generator(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu
@@ -1260,6 +1432,7 @@ scenarios:
 "#, "metrics", "log_generator")]
     #[case::metrics_with_distribution(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu
@@ -1273,6 +1446,7 @@ scenarios:
 "#, "metrics", "distribution")]
     #[case::logs_with_generator(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: logs
     name: syslog
@@ -1287,6 +1461,7 @@ scenarios:
 "#, "logs", "generator")]
     #[case::logs_with_distribution(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: logs
     name: syslog
@@ -1302,6 +1477,7 @@ scenarios:
 "#, "logs", "distribution")]
     #[case::histogram_with_generator(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: histogram
     name: request_duration
@@ -1315,6 +1491,7 @@ scenarios:
 "#, "histogram", "generator")]
     #[case::histogram_with_log_generator(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: histogram
     name: request_duration
@@ -1330,6 +1507,7 @@ scenarios:
 "#, "histogram", "log_generator")]
     #[case::summary_with_generator(r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: summary
     name: rpc_duration
@@ -1371,6 +1549,7 @@ scenarios:
         // actual problem inside the canonical parse path.
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu
@@ -1412,25 +1591,12 @@ scenarios:
     // ======================================================================
 
     #[test]
-    fn empty_scenarios_list_parses_successfully() {
-        // An empty scenarios array is syntactically valid at the parse level.
-        // Semantic rejection (no runnable entries) is deferred to compilation.
-        let yaml = r#"
-version: 2
-scenarios: []
-"#;
-
-        let file = parse(yaml).expect("empty scenarios list should parse");
-        assert_eq!(file.version, 2);
-        assert!(file.scenarios.is_empty());
-    }
-
-    #[test]
     fn deny_unknown_fields_rejects_typo() {
         // A misspelling of `signal_type` as `signal_typ` must produce a YAML
         // parse error (via deny_unknown_fields), not silently default to None.
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_typ: metrics
     name: cpu
@@ -1469,6 +1635,7 @@ scenarios:
         // `quantiles` must infer `histogram`.
         let yaml = r#"
 version: 2
+kind: runnable
 name: http_request_duration_seconds
 rate: 1
 distribution:
@@ -1495,6 +1662,7 @@ seed: 42
         // `quantiles` must infer `summary`.
         let yaml = r#"
 version: 2
+kind: runnable
 name: rpc_duration_seconds
 rate: 1
 distribution:
@@ -1520,6 +1688,7 @@ seed: 99
         // infer `logs`.
         let yaml = r#"
 version: 2
+kind: runnable
 name: syslog
 rate: 5
 log_generator:
@@ -1548,6 +1717,7 @@ log_generator:
         // in a flat file must produce a YAML parse error.
         let yaml = r#"
 version: 2
+kind: runnable
 name: cpu_usage
 signal_type: metrics
 generator:
@@ -1583,6 +1753,7 @@ defaults:
         // AST exactly as written in the YAML.
         let yaml = r#"
 version: 2
+kind: runnable
 scenario_name: steady-state
 category: infrastructure
 description: "Normal oscillating baseline (sine + jitter)"
@@ -1615,6 +1786,7 @@ scenarios:
         // existing v2 callers are unaffected by the field additions.
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu
@@ -1634,6 +1806,7 @@ scenarios:
     #[rstest::rstest]
     #[case::only_scenario_name(r#"
 version: 2
+kind: runnable
 scenario_name: solo-name
 scenarios:
   - signal_type: metrics
@@ -1645,6 +1818,7 @@ scenarios:
 "#, Some("solo-name"), None,                None)]
     #[case::only_category(r#"
 version: 2
+kind: runnable
 category: network
 scenarios:
   - signal_type: metrics
@@ -1656,6 +1830,7 @@ scenarios:
 "#, None,              Some("network"),     None)]
     #[case::only_description(r#"
 version: 2
+kind: runnable
 description: "terse one-liner"
 scenarios:
   - signal_type: metrics
@@ -1667,6 +1842,7 @@ scenarios:
 "#, None,              None,                Some("terse one-liner"))]
     #[case::name_and_category(r#"
 version: 2
+kind: runnable
 scenario_name: partial
 category: application
 scenarios:
@@ -1697,6 +1873,7 @@ scenarios:
         // to `None`.
         let yaml = r#"
 version: 2
+kind: runnable
 scenario_name: typo-test
 descripton: "misspelled — must be rejected"
 scenarios:
@@ -1728,6 +1905,7 @@ scenarios:
         // silently leak through.
         let yaml = r#"
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu
@@ -1748,5 +1926,262 @@ scenarios:
             msg.contains("category"),
             "error should mention the misplaced field, got: {msg}"
         );
+    }
+
+    // ======================================================================
+    // Kind discriminator (1.9a)
+    // ======================================================================
+
+    #[test]
+    fn kind_runnable_with_scenarios_parses() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    rate: 1
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+        let file = parse(yaml).expect("kind: runnable with scenarios must parse");
+        assert_eq!(file.kind, Kind::Runnable);
+        assert_eq!(file.scenarios.len(), 1);
+        assert!(file.tags.is_empty());
+    }
+
+    #[test]
+    fn kind_runnable_with_flat_shorthand_parses() {
+        let yaml = r#"
+version: 2
+kind: runnable
+name: cpu_usage
+signal_type: metrics
+rate: 1
+generator:
+  type: constant
+  value: 1.0
+"#;
+
+        let file = parse(yaml).expect("kind: runnable flat shorthand must parse");
+        assert_eq!(file.kind, Kind::Runnable);
+        assert_eq!(file.scenarios.len(), 1);
+        assert_eq!(file.scenarios[0].name.as_deref(), Some("cpu_usage"));
+        assert_eq!(file.scenarios[0].signal_type, "metrics");
+    }
+
+    #[test]
+    fn kind_composable_with_pack_body_parses() {
+        let yaml = r#"
+version: 2
+kind: composable
+name: telegraf_snmp_interface
+description: "SNMP interface metrics"
+category: network
+shared_labels:
+  device: ""
+  job: snmp
+metrics:
+  - name: ifOperStatus
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+        let file = parse(yaml).expect("kind: composable with pack body must parse");
+        assert_eq!(file.kind, Kind::Composable);
+        assert!(file.scenarios.is_empty());
+        assert_eq!(file.description.as_deref(), Some("SNMP interface metrics"));
+    }
+
+    #[test]
+    fn missing_kind_returns_error() {
+        let yaml = r#"
+version: 2
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    rate: 1
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+        let err = parse(yaml).expect_err("missing kind must fail");
+        assert!(
+            matches!(err, ParseError::MissingKind),
+            "expected MissingKind, got: {err}"
+        );
+        assert!(
+            err.to_string()
+                .contains("requires a top-level 'kind:' field"),
+            "error must mention the missing field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn unknown_kind_returns_error_with_valid_values() {
+        let yaml = r#"
+version: 2
+kind: foobar
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    rate: 1
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+        let err = parse(yaml).expect_err("unknown kind must fail");
+        assert!(
+            matches!(err, ParseError::UnknownKind(ref k) if k == "foobar"),
+            "expected UnknownKind('foobar'), got: {err}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("must be 'runnable' or 'composable'"),
+            "error must list valid values, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn kind_runnable_with_empty_scenarios_returns_error() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenarios: []
+"#;
+
+        let err = parse(yaml).expect_err("empty scenarios must fail under kind: runnable");
+        assert!(
+            matches!(err, ParseError::RunnableScenariosEmpty),
+            "expected RunnableScenariosEmpty, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("scenarios block is empty"),
+            "error must mention empty block, got: {err}"
+        );
+    }
+
+    #[test]
+    fn kind_runnable_with_no_body_returns_runnable_missing_body() {
+        let yaml = "version: 2\nkind: runnable\n";
+        let err = parse(yaml).expect_err("runnable file with no body must fail");
+        assert!(
+            matches!(err, ParseError::RunnableMissingBody),
+            "expected RunnableMissingBody, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("add a 'scenarios:' block"),
+            "error must suggest adding scenarios block, got: {err}"
+        );
+    }
+
+    #[test]
+    fn kind_composable_with_scenarios_block_returns_error() {
+        let yaml = r#"
+version: 2
+kind: composable
+name: telegraf_snmp_interface
+description: "SNMP interface metrics"
+category: network
+metrics:
+  - name: ifOperStatus
+    generator:
+      type: constant
+      value: 1.0
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    rate: 1
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+        let err = parse(yaml).expect_err("composable with scenarios must fail");
+        assert!(
+            matches!(err, ParseError::ComposableHasScenarios),
+            "expected ComposableHasScenarios, got: {err}"
+        );
+        assert!(
+            err.to_string()
+                .contains("composable cannot have a 'scenarios:' block"),
+            "error must mention the rule, got: {err}"
+        );
+    }
+
+    #[test]
+    fn kind_composable_with_invalid_pack_body_propagates_error() {
+        let yaml = r#"
+version: 2
+kind: composable
+name: incomplete_pack
+"#;
+
+        let err = parse(yaml).expect_err("composable without pack body must fail");
+        assert!(
+            matches!(err, ParseError::ComposablePackInvalid(_)),
+            "expected ComposablePackInvalid, got: {err}"
+        );
+    }
+
+    #[test]
+    fn tags_list_is_carried_through() {
+        let yaml = r#"
+version: 2
+kind: runnable
+tags: [network, bgp, edge]
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    rate: 1
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+        let file = parse(yaml).expect("file with tags must parse");
+        assert_eq!(file.tags, vec!["network", "bgp", "edge"]);
+    }
+
+    #[test]
+    fn tags_absent_defaults_to_empty_vec() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    rate: 1
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+        let file = parse(yaml).expect("file without tags must parse");
+        assert!(file.tags.is_empty());
+    }
+
+    #[test]
+    fn tags_empty_list_is_empty_vec() {
+        let yaml = r#"
+version: 2
+kind: runnable
+tags: []
+scenarios:
+  - signal_type: metrics
+    name: cpu
+    rate: 1
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+        let file = parse(yaml).expect("file with empty tags must parse");
+        assert!(file.tags.is_empty());
     }
 }

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -980,6 +980,7 @@ mod tests {
 
         let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 5
   duration: 1s
@@ -1038,6 +1039,7 @@ scenarios:
 
         let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 50
   duration: 10s

--- a/sonda-core/tests/env_interpolation.rs
+++ b/sonda-core/tests/env_interpolation.rs
@@ -20,6 +20,7 @@ fn yaml_with_var(var_name: &str) -> String {
     format!(
         r#"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -94,6 +95,7 @@ fn required_var_unset_surfaces_as_compile_error() {
     let yaml = format!(
         r#"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -140,6 +142,7 @@ fn env_var_substitution_reaches_http_push_sink_url() {
     let yaml = format!(
         r#"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-bad-after-op.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-bad-after-op.yaml
@@ -1,5 +1,6 @@
 # ERROR: YAML parse error -- unknown variant `==`, expected `<` or `>`
 version: 2
+kind: runnable
 scenarios:
   - id: source
     signal_type: metrics

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-ambiguous-at-t0.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-ambiguous-at-t0.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-ambiguous-pack-ref.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-ambiguous-pack-ref.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-conflicting-clock-group.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-conflicting-clock-group.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-cycle.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-cycle.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-non-metrics-target.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-non-metrics-target.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-out-of-range.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-out-of-range.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-self-reference.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-self-reference.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-unknown-ref.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-unknown-ref.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-unsupported-sine.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-unsupported-sine.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-delay-without-while.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-delay-without-while.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-duplicate-ids.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-duplicate-ids.yaml
@@ -1,5 +1,6 @@
 # ERROR: duplicate entry id: 'my_signal'
 version: 2
+kind: runnable
 scenarios:
   - id: my_signal
     signal_type: metrics

--- a/sonda-core/tests/fixtures/v2-examples/invalid-expand-unknown-override.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-expand-unknown-override.yaml
@@ -2,6 +2,7 @@
 # expansion rejects this with ExpandError::UnknownOverrideKey identifying
 # the offending key, the pack name, and the list of valid metric names.
 version: 2
+kind: runnable
 defaults:
   rate: 1
 scenarios:

--- a/sonda-core/tests/fixtures/v2-examples/invalid-generator-and-pack.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-generator-and-pack.yaml
@@ -1,5 +1,6 @@
 # ERROR: entry 0: must have either 'generator' or 'pack', not both
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu_usage

--- a/sonda-core/tests/fixtures/v2-examples/invalid-missing-name.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-missing-name.yaml
@@ -1,5 +1,6 @@
 # ERROR: entry 0: inline signal must have 'name'
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-missing-rate.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-missing-rate.yaml
@@ -1,6 +1,7 @@
 # Missing `rate` — neither the entry nor `defaults:` sets it.
 # Normalization must reject this with a diagnostic identifying the entry.
 version: 2
+kind: runnable
 scenarios:
   - signal_type: metrics
     name: cpu

--- a/sonda-core/tests/fixtures/v2-examples/invalid-pack-with-logs.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-pack-with-logs.yaml
@@ -1,5 +1,6 @@
 # ERROR: entry 0: pack entries must have signal_type 'metrics'
 version: 2
+kind: runnable
 scenarios:
   - signal_type: logs
     pack: telegraf_snmp_interface

--- a/sonda-core/tests/fixtures/v2-examples/invalid-while-mixed-cycle.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-while-mixed-cycle.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-while-not-yet-supported.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-while-not-yet-supported.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/invalid-while-without-duration.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-while-without-duration.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/valid-compile-cross-signal-type.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-compile-cross-signal-type.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/valid-compile-pack-dotted-ref.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-compile-pack-dotted-ref.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/valid-compile-phase-offset-and-delay.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-compile-phase-offset-and-delay.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/valid-compile-sequence-target.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-compile-sequence-target.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 2

--- a/sonda-core/tests/fixtures/v2-examples/valid-compile-step-target.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-compile-step-target.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 2

--- a/sonda-core/tests/fixtures/v2-examples/valid-compile-transitive-chain.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-compile-transitive-chain.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/valid-defaults-label-merge.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-defaults-label-merge.yaml
@@ -4,6 +4,7 @@
 # overridden by the entry, `device` and `interface` remain.
 # The second entry overrides `rate` and uses `defaults.labels` as-is.
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m

--- a/sonda-core/tests/fixtures/v2-examples/valid-defaults-logs-default-encoder.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-defaults-logs-default-encoder.yaml
@@ -2,6 +2,7 @@
 # `defaults.rate` flows into the entry; the encoder becomes `json_lines`
 # via the built-in signal-type default.
 version: 2
+kind: runnable
 defaults:
   rate: 5
 scenarios:

--- a/sonda-core/tests/fixtures/v2-examples/valid-defaults-pack-entry.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-defaults-pack-entry.yaml
@@ -17,6 +17,7 @@
 # those labels would also contain `job` and `env` inherited from
 # `defaults.labels`.
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 10m

--- a/sonda-core/tests/fixtures/v2-examples/valid-expand-anonymous-pack.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-expand-anonymous-pack.yaml
@@ -3,6 +3,7 @@
 # expanded metrics remain addressable through sub-signal ids
 # (e.g. `telegraf_snmp_interface_0.ifOperStatus`).
 version: 2
+kind: runnable
 defaults:
   rate: 1
 scenarios:

--- a/sonda-core/tests/fixtures/v2-examples/valid-expand-multiple-packs.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-expand-multiple-packs.yaml
@@ -3,6 +3,7 @@
 # index, producing `{pack_name}_0.{metric}` and `{pack_name}_1.{metric}`
 # sub-signal IDs. No entry-level `id` is set on either.
 version: 2
+kind: runnable
 defaults:
   rate: 1
 scenarios:

--- a/sonda-core/tests/fixtures/v2-examples/valid-expand-pack-with-overrides.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-expand-pack-with-overrides.yaml
@@ -3,6 +3,7 @@
 # the §2.2 precedence chain. Used as the canonical pack-expansion snapshot
 # target (Phase 3 compilation).
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 2m

--- a/sonda-core/tests/fixtures/v2-examples/valid-histogram.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-histogram.yaml
@@ -1,5 +1,6 @@
 # Histogram signal with normal distribution and custom buckets.
 version: 2
+kind: runnable
 name: http_request_duration_seconds
 signal_type: histogram
 rate: 10

--- a/sonda-core/tests/fixtures/v2-examples/valid-multi-scenario.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-multi-scenario.yaml
@@ -2,6 +2,7 @@
 # All entries inherit rate, duration, encoder, and sink from defaults.
 # Entry-level values override defaults.
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m

--- a/sonda-core/tests/fixtures/v2-examples/valid-pack-in-scenarios.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-pack-in-scenarios.yaml
@@ -2,6 +2,7 @@
 # The id field creates dotted sub-signal IDs like primary_uplink.ifOperStatus
 # that can be referenced by after: clauses.
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 10m

--- a/sonda-core/tests/fixtures/v2-examples/valid-pack-shorthand.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-pack-shorthand.yaml
@@ -1,6 +1,7 @@
 # Pack shorthand: uses a metric pack instead of an inline generator.
 # The pack expands into one concrete signal per metric in the pack definition.
 version: 2
+kind: runnable
 pack: telegraf_snmp_interface
 signal_type: metrics
 rate: 1

--- a/sonda-core/tests/fixtures/v2-examples/valid-single-metric.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/valid-single-metric.yaml
@@ -1,6 +1,7 @@
 # Simplest v2 file: a single metric using the flat shorthand (no scenarios: key).
 # The parser wraps this into a one-entry scenarios list automatically.
 version: 2
+kind: runnable
 name: cpu_usage
 signal_type: metrics
 rate: 1

--- a/sonda-core/tests/fixtures/v2-parity/burst-only.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/burst-only.yaml
@@ -2,6 +2,7 @@
 # row 7.2 — `bursts` window settings (every/for/multiplier) must round-trip
 # unchanged through the v2 translator on a log-signal entry.
 version: 2
+kind: runnable
 
 scenarios:
   - signal_type: logs

--- a/sonda-core/tests/fixtures/v2-parity/csv-replay-columns.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/csv-replay-columns.yaml
@@ -4,6 +4,7 @@
 # is intentionally a non-existent stub: the translator-semantic test only
 # inspects compiled shape and never opens the file.
 version: 2
+kind: runnable
 
 scenarios:
   - signal_type: metrics

--- a/sonda-core/tests/fixtures/v2-parity/encoder-precision.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/encoder-precision.yaml
@@ -2,6 +2,7 @@
 # row 5.7 — the optional encoder `precision:` field must round-trip unchanged
 # through the v2 translator.
 version: 2
+kind: runnable
 
 scenarios:
   - signal_type: metrics

--- a/sonda-core/tests/fixtures/v2-parity/gap-and-burst.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/gap-and-burst.yaml
@@ -2,6 +2,7 @@
 # row 7.3 — when both `gaps` and `bursts` are set, `gaps` overrides `bursts`
 # during the gap window (runtime contract preserved by the v2 translator).
 version: 2
+kind: runnable
 
 scenarios:
   - signal_type: metrics

--- a/sonda-core/tests/fixtures/v2-parity/gap-only.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/gap-only.yaml
@@ -2,6 +2,7 @@
 # row 7.1 — `gaps` window settings (every/for) must round-trip unchanged
 # through the v2 translator.
 version: 2
+kind: runnable
 
 scenarios:
   - signal_type: metrics

--- a/sonda-core/tests/fixtures/v2-parity/influx-field-key.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/influx-field-key.yaml
@@ -2,6 +2,7 @@
 # row 5.2 — the `influx_lp` encoder's custom `field_key:` must round-trip
 # unchanged through the v2 translator.
 version: 2
+kind: runnable
 
 scenarios:
   - signal_type: metrics

--- a/sonda-core/tests/fixtures/v2-parity/link-failover.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/link-failover.yaml
@@ -4,6 +4,7 @@
 # `v2_story_parity.rs::link_failover_runtime_parity` under shortened test-
 # window offsets; compile-level timing math is checked in the same suite.
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-parity/mixed-signal-types.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/mixed-signal-types.yaml
@@ -2,6 +2,7 @@
 # row 1.6 — multiple signal types (metrics + logs + histogram) in one file
 # must translate side-by-side without cross-contamination between entries.
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/fixtures/v2-parity/node-exporter-cpu.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/node-exporter-cpu.yaml
@@ -1,6 +1,7 @@
 # Parity fixture: v2 scenario using the node_exporter_cpu pack (8 per-mode
 # metrics). No overrides — tests the straight expansion path.
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 30s

--- a/sonda-core/tests/fixtures/v2-parity/node-exporter-memory.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/node-exporter-memory.yaml
@@ -2,6 +2,7 @@
 # memory gauge metrics). Has a per-metric label override to exercise the
 # label-merge parity path.
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 30s

--- a/sonda-core/tests/fixtures/v2-parity/tcp-retry.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/tcp-retry.yaml
@@ -2,6 +2,7 @@
 # row 6.12 — TCP sink `retry` block (max_attempts + initial_backoff +
 # max_backoff) must round-trip unchanged through the v2 translator.
 version: 2
+kind: runnable
 
 scenarios:
   - signal_type: metrics

--- a/sonda-core/tests/fixtures/v2-parity/telegraf-snmp-interface.yaml
+++ b/sonda-core/tests/fixtures/v2-parity/telegraf-snmp-interface.yaml
@@ -3,6 +3,7 @@
 # of signals as the v1 `expand_pack` path given equivalent user-provided
 # config.
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 60s

--- a/sonda-core/tests/pack_parity.rs
+++ b/sonda-core/tests/pack_parity.rs
@@ -381,6 +381,7 @@ fn compile_after_on_pack_override_applies_per_metric() {
 
     let yaml = r#"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -432,6 +433,7 @@ fn compile_after_pack_entry_level_propagates_to_all_sub_signals() {
 
     let yaml = r#"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda-core/tests/snapshots/fixture_examples__valid_defaults_label_merge_normalizes.snap
+++ b/sonda-core/tests/snapshots/fixture_examples__valid_defaults_label_merge_normalizes.snap
@@ -4,6 +4,7 @@ expression: normalized
 ---
 {
   "version": 2,
+  "kind": "runnable",
   "defaults_labels": {
     "device": "rtr-edge-01",
     "region": "us-west-2"

--- a/sonda-core/tests/snapshots/fixture_examples__valid_defaults_logs_default_encoder_normalizes.snap
+++ b/sonda-core/tests/snapshots/fixture_examples__valid_defaults_logs_default_encoder_normalizes.snap
@@ -4,6 +4,7 @@ expression: normalized
 ---
 {
   "version": 2,
+  "kind": "runnable",
   "entries": [
     {
       "signal_type": "logs",

--- a/sonda-core/tests/snapshots/fixture_examples__valid_defaults_pack_entry_normalizes.snap
+++ b/sonda-core/tests/snapshots/fixture_examples__valid_defaults_pack_entry_normalizes.snap
@@ -4,6 +4,7 @@ expression: normalized
 ---
 {
   "version": 2,
+  "kind": "runnable",
   "defaults_labels": {
     "env": "prod",
     "job": "web"

--- a/sonda-core/tests/translator_semantics.rs
+++ b/sonda-core/tests/translator_semantics.rs
@@ -278,6 +278,7 @@ fn compile_inline(yaml: &str) -> Vec<ScenarioEntry> {
 fn clock_group_is_auto_true_for_synthesized_chain_name() {
     let entries = compile_inline(
         r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -330,6 +331,7 @@ scenarios:
 fn clock_group_is_auto_false_for_explicit_chain_prefix_value() {
     let entries = compile_inline(
         r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -381,6 +383,7 @@ scenarios:
 fn clock_group_is_auto_none_for_standalone_entry_with_no_group() {
     let entries = compile_inline(
         r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 100ms
@@ -407,6 +410,7 @@ scenarios:
 fn clock_group_is_auto_false_for_standalone_entry_with_explicit_group() {
     let entries = compile_inline(
         r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 100ms

--- a/sonda-core/tests/while_close_workshop_repro.rs
+++ b/sonda-core/tests/while_close_workshop_repro.rs
@@ -152,6 +152,7 @@ fn workshop_paused_finished_cascade_emits_stale_marker_via_multi_runner() {
     let yaml = format!(
         r#"
 version: 2
+kind: runnable
 scenario_name: workshop-paused-finished-repro
 defaults:
   rate: 50
@@ -272,6 +273,7 @@ fn workshop_paused_finished_cascade_default_batch_size_emits_stale_marker() {
     let yaml = format!(
         r#"
 version: 2
+kind: runnable
 scenario_name: workshop-paused-finished-default-batch
 defaults:
   rate: 50
@@ -377,6 +379,7 @@ fn workshop_paused_finished_multi_entry_cascade_each_metric_emits_stale_marker()
     let yaml = format!(
         r#"
 version: 2
+kind: runnable
 scenario_name: workshop-multi-entry-cascade
 defaults:
   rate: 50
@@ -599,6 +602,7 @@ fn workshop_paused_finished_real_timescale_emits_stale_marker() {
     let yaml = format!(
         r#"
 version: 2
+kind: runnable
 scenario_name: workshop-real-timescale-repro
 defaults:
   rate: 5
@@ -769,6 +773,7 @@ fn workshop_paused_finished_through_server_binary_emits_stale_marker() {
     let yaml = format!(
         r#"
 version: 2
+kind: runnable
 scenario_name: workshop-via-server-binary
 defaults:
   rate: 50
@@ -1013,6 +1018,7 @@ fn workshop_cascade_with_baseline_scenarios_emits_stale_marker() {
     // ------------------------------------------------------------------
     let mut baseline_yaml = String::from(
         "version: 2\n\
+         kind: runnable\n\
          scenario_name: workshop-baseline-srl2\n\
          defaults:\n  \
            rate: 20\n  \
@@ -1167,6 +1173,7 @@ fn workshop_cascade_with_baseline_scenarios_emits_stale_marker() {
     let cascade_yaml = format!(
         r#"
 version: 2
+kind: runnable
 scenario_name: workshop-cascade-incident
 defaults:
   rate: 50
@@ -1399,6 +1406,7 @@ fn workshop_close_emit_timestamp_strictly_greater_than_active_emissions() {
     let yaml = format!(
         r#"
 version: 2
+kind: runnable
 scenario_name: workshop-close-emit-snap-to-ts-ordering
 defaults:
   rate: 50
@@ -1497,6 +1505,7 @@ fn workshop_close_emit_stale_marker_timestamp_strictly_greater_than_active_emiss
     let yaml = format!(
         r#"
 version: 2
+kind: runnable
 scenario_name: workshop-close-emit-stale-marker-ts-ordering
 defaults:
   rate: 50
@@ -1627,6 +1636,7 @@ fn assert_close_ts_strictly_after_preceding_actives(active_ts: &[i64], close_ts:
 fn workshop_snap_to_yaml_parses_into_delay_clause() {
     let yaml = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 30s
@@ -1706,6 +1716,7 @@ fn workshop_snap_to_zero_reaches_wire_via_multi_runner() {
     let yaml = format!(
         r#"
 version: 2
+kind: runnable
 scenario_name: workshop-snap-to-multi-runner
 defaults:
   rate: 50
@@ -1869,6 +1880,7 @@ fn workshop_snap_to_zero_reaches_wire_via_server_binary() {
     let yaml = format!(
         r#"
 version: 2
+kind: runnable
 scenario_name: workshop-snap-to-via-server
 defaults:
   rate: 50

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -1150,6 +1150,7 @@ fn close_emit_conflict_compile_error_when_snap_to_and_stale_marker_false() {
 
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 5
   duration: 1s
@@ -1203,6 +1204,7 @@ fn delay_close_legacy_shorthand_still_deserializes() {
 
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 5
   duration: 1s
@@ -1296,6 +1298,7 @@ fn delay_close_extended_form_deserializes_all_fields() {
 
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 5
   duration: 1s

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -963,6 +963,7 @@ mod tests {
     /// Valid v2 body for a metrics scenario with a short duration.
     const VALID_METRICS_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 200ms
@@ -982,6 +983,7 @@ scenarios:
     /// Valid v2 body for a logs scenario with a short duration.
     const VALID_LOGS_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 200ms
@@ -1004,6 +1006,7 @@ scenarios:
     /// Valid v2 body with an explicit `signal_type: metrics` entry.
     const VALID_TAGGED_METRICS_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 200ms
@@ -1023,6 +1026,7 @@ scenarios:
     /// v2 body with `rate: 0` — must be rejected by runtime validation.
     const ZERO_RATE_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   duration: 1s
   encoder:
@@ -1756,6 +1760,7 @@ scenarios:
     async fn post_with_json_content_type_returns_201() {
         let json_body = serde_json::json!({
             "version": 2,
+            "kind": "runnable",
             "defaults": {
                 "rate": 10,
                 "duration": "200ms",
@@ -1876,6 +1881,7 @@ scenarios:
     async fn post_yaml_with_negative_rate_returns_422() {
         let yaml = "\
 version: 2
+kind: runnable
 defaults:
   duration: 1s
   encoder:
@@ -2002,6 +2008,7 @@ scenarios:
         headers.insert("content-type", "application/json".parse().unwrap());
         let json = serde_json::json!({
             "version": 2,
+            "kind": "runnable",
             "defaults": {
                 "rate": 10,
                 "duration": "200ms",
@@ -3577,6 +3584,7 @@ scenarios:
     /// v2 body for a valid multi-scenario batch with two entries.
     const VALID_MULTI_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 200ms
@@ -3607,6 +3615,7 @@ scenarios:
     /// "phase_offset resolved" without running afoul of that validation.
     const MULTI_YAML_WITH_PHASE_OFFSET: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 200ms
@@ -3705,6 +3714,7 @@ scenarios:
     async fn post_multi_scenario_json_returns_201() {
         let json_body = serde_json::json!({
             "version": 2,
+            "kind": "runnable",
             "defaults": {
                 "rate": 10,
                 "duration": "200ms",
@@ -3750,7 +3760,7 @@ scenarios:
     /// Empty v2 scenarios array returns 400 with a descriptive error.
     #[tokio::test]
     async fn post_multi_scenario_empty_array_returns_400() {
-        let yaml = "version: 2\nscenarios: []\n";
+        let yaml = "version: 2\nkind: runnable\nscenarios: []\n";
         let (app, _state) = test_router();
         let response = post_scenarios(app, "application/x-yaml", yaml).await;
 
@@ -3773,6 +3783,7 @@ scenarios:
     async fn post_multi_scenario_invalid_entry_returns_422_nothing_launched() {
         let yaml = "\
 version: 2
+kind: runnable
 defaults:
   duration: 200ms
   encoder:
@@ -3973,6 +3984,7 @@ scenarios:
     async fn post_multi_scenario_mixed_signal_types() {
         let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 200ms
@@ -4098,6 +4110,7 @@ scenarios:
     async fn post_single_scenario_with_phase_offset_returns_201() {
         let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 200ms

--- a/sonda-server/src/routes/sink_warnings.rs
+++ b/sonda-server/src/routes/sink_warnings.rs
@@ -232,6 +232,7 @@ mod tests {
     fn compile_single_entry_with_sink(sink_yaml: &str) -> ScenarioEntry {
         let yaml = format!(
             "version: 2\n\
+             kind: runnable\n\
              defaults:\n\
              \x20\x20rate: 10\n\
              \x20\x20duration: 500ms\n\

--- a/sonda-server/tests/integration.rs
+++ b/sonda-server/tests/integration.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 /// Minimal v2 metrics scenario YAML that runs at a low rate with stdout sink.
 const METRICS_YAML: &str = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 30s
@@ -32,6 +33,7 @@ scenarios:
 /// Minimal v2 logs scenario YAML that runs at a low rate with stdout sink.
 const LOGS_YAML: &str = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 30s
@@ -249,6 +251,7 @@ fn full_lifecycle_metrics_and_logs() {
 
 const NON_GATED_METRIC_YAML: &str = r#"
 version: 2
+kind: runnable
 defaults:
   rate: 5
   duration: 2s

--- a/sonda-server/tests/scenarios.rs
+++ b/sonda-server/tests/scenarios.rs
@@ -8,6 +8,7 @@ mod common;
 /// Valid v2 metrics YAML (short duration for quick tests).
 const VALID_METRICS_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 500ms
@@ -27,6 +28,7 @@ scenarios:
 /// Valid v2 logs YAML (short duration for quick tests).
 const VALID_LOGS_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 500ms
@@ -49,6 +51,7 @@ scenarios:
 /// Valid v2 metrics YAML with an explicit `signal_type: metrics` entry.
 const VALID_TAGGED_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 500ms
@@ -193,6 +196,7 @@ fn post_yaml_with_zero_rate_returns_422() {
 
     let zero_rate_yaml = "\
 version: 2
+kind: runnable
 defaults:
   duration: 1s
   encoder:
@@ -240,6 +244,7 @@ fn post_valid_json_returns_201() {
 
     let json_body = serde_json::json!({
         "version": 2,
+        "kind": "runnable",
         "defaults": {
             "rate": 10,
             "duration": "500ms",
@@ -331,6 +336,7 @@ fn post_empty_body_returns_400() {
 /// Valid v2 multi-scenario YAML with two metrics entries.
 const VALID_MULTI_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 500ms
@@ -408,6 +414,7 @@ fn post_multi_scenario_json_returns_201() {
 
     let json_body = serde_json::json!({
         "version": 2,
+        "kind": "runnable",
         "defaults": {
             "rate": 10,
             "duration": "500ms",
@@ -466,7 +473,7 @@ fn post_multi_scenario_empty_array_returns_400() {
     let resp = client
         .post(format!("http://127.0.0.1:{port}/scenarios"))
         .header("content-type", "application/x-yaml")
-        .body("version: 2\nscenarios: []\n")
+        .body("version: 2\nkind: runnable\nscenarios: []\n")
         .send()
         .expect("POST must succeed at HTTP level");
 
@@ -490,6 +497,7 @@ fn post_multi_scenario_invalid_entry_returns_422() {
 
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   duration: 500ms
   encoder:
@@ -777,6 +785,7 @@ fn post_tcp_localhost_sink_returns_warning() {
 
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 500ms
@@ -844,6 +853,7 @@ fn post_tcp_real_hostname_sink_has_no_warnings() {
 
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 500ms
@@ -907,6 +917,7 @@ fn post_udp_localhost_sink_returns_warning() {
 
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 500ms
@@ -949,6 +960,7 @@ fn post_multi_scenario_mixed_sinks_returns_one_warning() {
 
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 500ms
@@ -1026,6 +1038,7 @@ fn post_tcp_127_0_0_1_sink_returns_warning() {
 
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 500ms
@@ -1067,6 +1080,7 @@ fn post_tcp_ipv6_loopback_sink_returns_warning() {
 
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 500ms
@@ -1151,6 +1165,7 @@ mod gated_scenarios {
     /// margin for the polling loop.
     const FLAP_CASCADE_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 50
   duration: 2s
@@ -1245,6 +1260,7 @@ scenarios:
     /// posted its first tick by the time the snapshot is taken.
     const PENDING_DOWNSTREAM_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 50
   duration: 30s
@@ -1315,6 +1331,7 @@ scenarios:
 
     const TWO_ENTRY_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 500ms
@@ -1399,6 +1416,7 @@ scenarios:
     /// path.
     const ALL_SIGNAL_TYPES_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 500ms
@@ -1491,6 +1509,7 @@ scenarios:
     /// the handler maps that to 400 Bad Request.
     const CYCLIC_WHILE_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 1s
@@ -1612,6 +1631,7 @@ scenarios:
     /// reaches `paused` after the upstream's gate closes.
     const STALE_MARKER_CASCADE_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 50
   duration: 2s
@@ -1691,6 +1711,7 @@ scenarios:
     /// is rejected at compile time and surfaces as 422 from the server.
     const CONFLICTING_DELAY_CLOSE_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 5
   duration: 1s
@@ -1748,6 +1769,7 @@ scenarios:
 
     const OP_LE_WHILE_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 5
   duration: 1s
@@ -1804,6 +1826,7 @@ scenarios:
 
     const NAN_VALUE_WHILE_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 30s
@@ -1861,6 +1884,7 @@ scenarios:
 
 const NAMED_FLAP_INTERFACE_YAML: &str = "\
 version: 2
+kind: runnable
 scenario_name: flap-interface
 defaults:
   rate: 10
@@ -1880,6 +1904,7 @@ scenarios:
 
 const NAMED_FLAP_INTERFACE_SHORT_YAML: &str = "\
 version: 2
+kind: runnable
 scenario_name: flap-interface-short
 defaults:
   rate: 10
@@ -1899,6 +1924,7 @@ scenarios:
 
 const ANONYMOUS_METRICS_YAML: &str = "\
 version: 2
+kind: runnable
 defaults:
   rate: 10
   duration: 5s

--- a/sonda/src/config.rs
+++ b/sonda/src/config.rs
@@ -5630,6 +5630,7 @@ mod tests {
     /// pointing at it. Each call gets a unique directory keyed by `suffix`.
     fn temp_summary_scenario(suffix: &str) -> (sonda_core::BuiltinScenario, std::path::PathBuf) {
         let yaml = r#"version: 2
+kind: runnable
 scenario_name: test-summary
 category: test
 description: Test summary scenario
@@ -5928,6 +5929,7 @@ metrics:
         std::fs::write(
             &scenario_path,
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 100ms
@@ -5986,6 +5988,7 @@ metrics:
         std::fs::write(
             &scenario_path,
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 100ms
@@ -6020,6 +6023,7 @@ scenarios:
         std::fs::write(
             &scenario_path,
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 100ms

--- a/sonda/src/dry_run.rs
+++ b/sonda/src/dry_run.rs
@@ -735,6 +735,7 @@ mod tests {
     fn text_header_includes_file_version_and_count() {
         let compiled = compile(
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 100ms
@@ -758,6 +759,7 @@ scenarios:
     fn text_pluralizes_count_when_multi_scenario() {
         let compiled = compile(
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 100ms
@@ -788,6 +790,7 @@ scenarios:
     fn text_prints_phase_offset_and_clock_group_for_after_chain() {
         let compiled = compile(
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -835,6 +838,7 @@ scenarios:
     fn json_output_has_stable_shape() {
         let compiled = compile(
             r#"version: 2
+kind: runnable
 defaults:
   rate: 2
   duration: 500ms
@@ -864,6 +868,7 @@ scenarios:
     fn text_renders_while_block_with_first_open_for_analytical_upstream() {
         let compiled = compile(
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -910,6 +915,7 @@ scenarios:
     fn text_renders_indeterminate_marker_for_non_analytical_upstream() {
         let compiled = compile(
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1m
@@ -948,6 +954,7 @@ scenarios:
     fn text_renders_delay_block_when_present() {
         let compiled = compile(
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -989,6 +996,7 @@ scenarios:
     fn text_renders_both_after_and_while_for_mixed_upstream() {
         let compiled = compile(
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -1051,6 +1059,7 @@ scenarios:
     fn json_dto_includes_while_delay_first_open_for_gated_entry() {
         let compiled = compile(
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 5m
@@ -1103,6 +1112,7 @@ scenarios:
     fn json_dto_omits_clauses_when_absent() {
         let compiled = compile(
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 100ms

--- a/sonda/src/import/yaml_gen.rs
+++ b/sonda/src/import/yaml_gen.rs
@@ -193,6 +193,7 @@ pub fn render_yaml(specs: &[ScenarioSpec], rate: f64, duration: &str) -> String 
 
     let mut out = String::with_capacity(specs.len() * 512 + 256);
     out.push_str("version: 2\n");
+    out.push_str("kind: runnable\n");
     out.push('\n');
     out.push_str("defaults:\n");
     out.push_str(&format!("  rate: {}\n", format_rate(rate)));

--- a/sonda/src/init/yaml_gen.rs
+++ b/sonda/src/init/yaml_gen.rs
@@ -280,7 +280,7 @@ fn render_single_metric(answers: &MetricAnswers, delivery: &DeliveryAnswers) -> 
         &[],
     );
 
-    out.push_str("version: 2\n\n");
+    out.push_str("version: 2\nkind: runnable\n\n");
     // Labels on a single-entry file live at the entry level so CLI `--label`
     // merges work consistently; defaults.labels stays empty.
     write_defaults_block(&mut out, delivery, &BTreeMap::new());
@@ -329,7 +329,7 @@ fn render_pack_scenario(answers: &PackAnswers, delivery: &DeliveryAnswers) -> St
         &[],
     );
 
-    out.push_str("version: 2\n\n");
+    out.push_str("version: 2\nkind: runnable\n\n");
     write_defaults_block(&mut out, delivery, &BTreeMap::new());
 
     out.push_str("scenarios:\n");
@@ -354,7 +354,7 @@ fn render_logs_scenario(answers: &LogAnswers, delivery: &DeliveryAnswers) -> Str
         &[],
     );
 
-    out.push_str("version: 2\n\n");
+    out.push_str("version: 2\nkind: runnable\n\n");
     write_defaults_block(&mut out, delivery, &BTreeMap::new());
 
     out.push_str("scenarios:\n");
@@ -406,7 +406,7 @@ fn render_histogram_scenario(answers: &HistogramAnswers, delivery: &DeliveryAnsw
         &[],
     );
 
-    out.push_str("version: 2\n\n");
+    out.push_str("version: 2\nkind: runnable\n\n");
     write_defaults_block(&mut out, delivery, &BTreeMap::new());
 
     out.push_str("scenarios:\n");
@@ -470,7 +470,7 @@ fn render_summary_scenario(answers: &SummaryAnswers, delivery: &DeliveryAnswers)
         &[],
     );
 
-    out.push_str("version: 2\n\n");
+    out.push_str("version: 2\nkind: runnable\n\n");
     write_defaults_block(&mut out, delivery, &BTreeMap::new());
 
     out.push_str("scenarios:\n");
@@ -660,6 +660,10 @@ mod tests {
             "missing `version: 2`, got:\n{yaml}"
         );
         assert!(
+            yaml.contains("kind: runnable"),
+            "missing `kind: runnable`, got:\n{yaml}"
+        );
+        assert!(
             yaml.contains("defaults:"),
             "missing `defaults:`, got:\n{yaml}"
         );
@@ -676,11 +680,12 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         let version_pos = stripped.find("version: 2").expect("has version");
+        let kind_pos = stripped.find("kind: runnable").expect("has kind");
         let defaults_pos = stripped.find("defaults:").expect("has defaults");
         let scenarios_pos = stripped.find("scenarios:").expect("has scenarios");
         assert!(
-            version_pos < defaults_pos && defaults_pos < scenarios_pos,
-            "ordering violated: version/defaults/scenarios in:\n{stripped}"
+            version_pos < kind_pos && kind_pos < defaults_pos && defaults_pos < scenarios_pos,
+            "ordering violated: version/kind/defaults/scenarios in:\n{stripped}"
         );
     }
 

--- a/sonda/src/scenario_loader.rs
+++ b/sonda/src/scenario_loader.rs
@@ -287,6 +287,7 @@ mod tests {
             &dir,
             "v2.yaml",
             r#"version: 2
+kind: runnable
 defaults:
   rate: 5
   duration: 200ms
@@ -339,6 +340,7 @@ metrics:
             &scenario_dir,
             "v2-pack.yaml",
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 100ms
@@ -367,6 +369,7 @@ scenarios:
             &scenarios_dir,
             "my-scenario.yaml",
             r#"version: 2
+kind: runnable
 scenario_name: my-scenario
 category: test
 description: test
@@ -536,6 +539,7 @@ duration: 100ms
             &dir,
             "broken.yaml",
             r#"version: 2
+kind: runnable
 defaults:
   rate: 1
 scenarios:

--- a/sonda/src/scenarios.rs
+++ b/sonda/src/scenarios.rs
@@ -623,6 +623,7 @@ sink:
             &dir,
             "log-storm.yaml",
             r#"version: 2
+kind: runnable
 scenario_name: log-storm
 category: application
 description: "v2 log storm"
@@ -644,6 +645,7 @@ scenarios:
             &dir,
             "histogram-latency.yaml",
             r#"version: 2
+kind: runnable
 scenario_name: histogram-latency
 category: application
 description: "v2 histogram latency"
@@ -665,6 +667,7 @@ scenarios:
             &dir,
             "mixed.yaml",
             r#"version: 2
+kind: runnable
 scenario_name: mixed
 category: infrastructure
 signal_type: metrics
@@ -742,6 +745,7 @@ sink:
             &dir,
             "empty.yaml",
             r#"version: 2
+kind: runnable
 scenario_name: empty
 category: infrastructure
 description: "v2 with empty scenarios list"
@@ -763,6 +767,7 @@ scenarios: []
             &dir,
             "link-failure.yaml",
             r#"version: 2
+kind: runnable
 scenario_name: link-failure
 category: network
 description: "v2 multi-signal link failure"
@@ -788,6 +793,7 @@ scenarios:
             &dir,
             "interface-flap.yaml",
             r#"version: 2
+kind: runnable
 scenario_name: interface-flap
 category: network
 description: "v2 two-entry multi boundary"
@@ -811,6 +817,7 @@ scenarios:
             &dir,
             "solo.yaml",
             r#"version: 2
+kind: runnable
 scenario_name: solo
 category: infrastructure
 description: "v2 single entry falls through to first-entry branch"

--- a/sonda/tests/cli_while_runtime.rs
+++ b/sonda/tests/cli_while_runtime.rs
@@ -56,6 +56,7 @@ fn op_le_returns_nonzero_on_cli() {
         .expect("create temp YAML fixture");
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 1s
@@ -113,6 +114,7 @@ fn dry_run_renders_flap_enum_oper_state_defaults() {
         .expect("create temp YAML fixture");
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 30s
@@ -154,6 +156,7 @@ fn dry_run_rejects_flap_enum_with_explicit_values() {
         .expect("create temp YAML fixture");
     let yaml = "\
 version: 2
+kind: runnable
 defaults:
   rate: 1
   duration: 30s

--- a/sonda/tests/dry_run_while_snapshots.rs
+++ b/sonda/tests/dry_run_while_snapshots.rs
@@ -42,6 +42,7 @@ fn dry_run_text(yaml_body: &str) -> String {
 }
 
 const ANALYTICAL_UPSTREAM: &str = r#"version: 2
+kind: runnable
 defaults:
   rate: 5
   duration: 5m
@@ -71,6 +72,7 @@ scenarios:
 "#;
 
 const NON_ANALYTICAL_UPSTREAM: &str = r#"version: 2
+kind: runnable
 defaults:
   rate: 5
   duration: 1m
@@ -100,6 +102,7 @@ scenarios:
 "#;
 
 const MIXED_UPSTREAM: &str = r#"version: 2
+kind: runnable
 defaults:
   rate: 5
   duration: 5m
@@ -140,6 +143,7 @@ scenarios:
 "#;
 
 const DELAY_PRESENT: &str = r#"version: 2
+kind: runnable
 defaults:
   rate: 5
   duration: 5m

--- a/sonda/tests/fixtures/basic.yaml
+++ b/sonda/tests/fixtures/basic.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 100

--- a/sonda/tests/fixtures/cli/broken-self-ref.v2.yaml
+++ b/sonda/tests/fixtures/cli/broken-self-ref.v2.yaml
@@ -2,6 +2,7 @@
 # v2 compile errors surface through the CLI with a useful diagnostic
 # (non-zero exit + stderr mentions the source path and/or SelfReference).
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda/tests/fixtures/cli/catalog-packs/tiny-pack.yaml
+++ b/sonda/tests/fixtures/cli/catalog-packs/tiny-pack.yaml
@@ -1,3 +1,5 @@
+version: 2
+kind: composable
 name: tiny_pack
 description: "Catalog test pack"
 category: network

--- a/sonda/tests/fixtures/cli/catalog-scenarios/scn-a.yaml
+++ b/sonda/tests/fixtures/cli/catalog-scenarios/scn-a.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 scenario_name: scn-a
 category: network
 description: "Catalog test scenario A"

--- a/sonda/tests/fixtures/cli/catalog-scenarios/scn-b.yaml
+++ b/sonda/tests/fixtures/cli/catalog-scenarios/scn-b.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 scenario_name: scn-b
 category: infrastructure
 description: "Catalog test scenario B"

--- a/sonda/tests/fixtures/cli/inline.v2.yaml
+++ b/sonda/tests/fixtures/cli/inline.v2.yaml
@@ -1,6 +1,7 @@
 # v2 single-signal file with `defaults:` + `scenarios:`. CLI tests use
 # this to verify `sonda run` dispatches v2 files through the v2 compiler.
 version: 2
+kind: runnable
 
 defaults:
   rate: 5

--- a/sonda/tests/fixtures/cli/multi-after-chain.v2.yaml
+++ b/sonda/tests/fixtures/cli/multi-after-chain.v2.yaml
@@ -2,6 +2,7 @@
 # pretty dry-run output path — the second entry's `phase_offset:` and
 # auto-assigned `clock_group:` annotations must render.
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda/tests/fixtures/cli/pack-backed.v2.yaml
+++ b/sonda/tests/fixtures/cli/pack-backed.v2.yaml
@@ -2,6 +2,7 @@
 # the `tiny_pack` metric `pack_metric_a` gets its generator overridden
 # inline, so dry-run output should tag that metric's generator line.
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/sonda/tests/fixtures/cli/while-cascade.v2.yaml
+++ b/sonda/tests/fixtures/cli/while-cascade.v2.yaml
@@ -4,6 +4,7 @@
 # (the gate machinery is reachable through the operator-facing path,
 # not just the library API).
 version: 2
+kind: runnable
 
 defaults:
   rate: 5

--- a/sonda/tests/fixtures/log-template-with-labels.yaml
+++ b/sonda/tests/fixtures/log-template-with-labels.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/sonda/tests/fixtures/log-template.yaml
+++ b/sonda/tests/fixtures/log-template.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/sonda/tests/fixtures/with-labels.yaml
+++ b/sonda/tests/fixtures/with-labels.yaml
@@ -1,4 +1,5 @@
 version: 2
+kind: runnable
 
 defaults:
   rate: 100

--- a/sonda/tests/init_v2_output.rs
+++ b/sonda/tests/init_v2_output.rs
@@ -50,6 +50,10 @@ fn dry_run_emitted(out_path: &std::path::Path) {
 fn assert_v2_shape(yaml: &str) {
     assert!(yaml.contains("version: 2"), "missing version: 2:\n{yaml}");
     assert!(
+        yaml.contains("kind: runnable"),
+        "missing kind: runnable:\n{yaml}"
+    );
+    assert!(
         yaml.contains("defaults:"),
         "missing defaults block:\n{yaml}"
     );

--- a/sonda/tests/pack_yaml_validation.rs
+++ b/sonda/tests/pack_yaml_validation.rs
@@ -71,6 +71,28 @@ fn all_pack_yamls_parse_as_metric_pack_def() {
 }
 
 #[test]
+fn all_pack_yamls_parse_via_compiler_as_composable() {
+    use sonda_core::compiler::{parse::parse, Kind};
+
+    for entry in std::fs::read_dir(packs_dir()).expect("must read packs/") {
+        let path = entry.expect("entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+            continue;
+        }
+        let content = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {}", path.display(), e));
+        let file = parse(&content)
+            .unwrap_or_else(|e| panic!("{} must parse via compiler::parse: {e}", path.display()));
+        assert_eq!(
+            file.kind,
+            Kind::Composable,
+            "{} must have kind: composable",
+            path.display()
+        );
+    }
+}
+
+#[test]
 fn all_pack_names_are_snake_case() {
     let dir = packs_dir();
     for entry in std::fs::read_dir(&dir).expect("must read packs/ directory") {


### PR DESCRIPTION
## Summary

First of five sub-PRs composing the 1.9 release. Adds two top-level fields to the v2 scenario schema and migrates every YAML file in the repo plus every inline test YAML string to include the new mandatory field.

- **`kind: runnable | composable`** — required, no default.
- **`tags: [String]`** — optional file-level metadata. Survives normalization. Will drive \`sonda list --tag\` filtering in 1.9c.

## Schema rules

Five parse-time validation rules with typed errors:

| Condition | Error |
|---|---|
| missing \`kind:\` | \`MissingKind\` |
| unknown \`kind\` value | \`UnknownKind\` |
| \`kind: runnable\` + empty \`scenarios: []\` | \`RunnableScenariosEmpty\` |
| \`kind: runnable\` + no body at all | \`RunnableMissingBody\` |
| \`kind: composable\` + \`scenarios:\` block | \`ComposableHasScenarios\` |
| \`kind: composable\` + invalid pack body | \`ComposablePackInvalid\` (preserves \`#[source]\` chain to \`serde_yaml_ng::Error\`) |

After this PR every catalog file shares a unified header (\`version: 2\` / \`kind: ...\` / \`name: ...\` / \`description: ...\` / \`tags: ...\`). 1.9c's \`sonda list\` will rely on this unification.

## Migration

- **141 YAML files** swept: 80 in \`examples/\`, \`scenarios/\`, \`packs/\` (catalog) and 61 test fixtures.
- **263 inline YAML insertions** across 20 Rust test files (\`r#\"version: 2 ...\"#\` patterns).
- **5 JSON-literal updates** in sonda-server tests (\`\"kind\": \"runnable\"\`).
- Pack YAMLs in \`packs/\` pick up both \`version: 2\` and \`kind: composable\`.
- Flat-shorthand support preserved: \`signal_type:\`/\`generator:\`/\`pack:\` + \`kind: runnable\` parses as a one-element scenarios list.

## Out of scope (later sub-PRs on release/1.9)

- 1.9b: move pattern detector to \`sonda-core/analysis\`
- 1.9c: collapse CLI surface to 5 verbs (the big breaking change)
- 1.9d: trim \`sonda-server\` catalog endpoints
- 1.9e: minimal \`cli-reference.md\` update

The full 1.9 release event is the eventual \`release/1.9 → main\` merge.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo nextest run --workspace\` — **2973 tests passing** (2960 baseline + 13 net)
- [x] \`cargo test --workspace --doc\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test -p sonda-core --no-default-features --no-run\` clean
- [x] \`cargo audit\` — only pre-existing yanked \`core2\` (via rskafka), unrelated
- [x] Migrated \`examples/basic-metrics.yaml\` runs cleanly through \`sonda run --dry-run\`
- [x] Missing-\`kind:\` YAML produces clear error pointing at the field

## Related

- Targets \`release/1.9\` (not \`main\`)
- Reviewer NIT follow-up: #352