### PR TITLE
docs(1.9): collapse user-facing docs to the four-verb CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,18 +196,6 @@ jobs:
   docs-commands:
     name: Validate sonda commands in user-facing docs
     runs-on: ubuntu-latest
-    # TEMPORARY: skip during the 1.9 cycle. The CLI surface collapsed in 1.9c
-    # ahead of the post-1.9 docs rewrite, so docs intentionally lag the binary
-    # until the rewrite lands. REMOVE this `if:` before merging release/1.9
-    # into main — the docs must be in sync at release time.
-    # Handles both push and pull_request triggers (different context vars).
-    if: >-
-      !(
-        github.base_ref == 'release/1.9' ||
-        github.ref_name == 'release/1.9' ||
-        startsWith(github.head_ref, 'feat/1.9') ||
-        startsWith(github.ref_name, 'feat/1.9')
-      )
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ break real pipelines: gaps, micro-bursts, cardinality spikes, and shaped value s
 | **Sinks** | stdout, file, TCP, UDP, HTTP push, Prometheus remote write, Kafka, Loki, OTLP/gRPC |
 | **Scheduling** | configurable rate, duration, gap windows, burst windows, cardinality spikes, dynamic labels, jitter |
 | **Signals** | metrics (gauge, histogram, summary), logs (template and replay modes) |
-| **CSV import** | Analyze CSV files, detect time-series patterns (steady, spike, leak, flap, sawtooth, step), generate portable scenario YAML |
-| **Interactive scaffolding** | `sonda init` guided wizard -- operational vocabulary, metric pack support, commented YAML output |
-| **Built-in scenarios** | 11 curated patterns (cpu-spike, memory-leak, interface-flap, log-storm, and more) |
-| **Metric packs** | 3 reusable metric bundles (telegraf-snmp-interface, node-exporter-cpu, node-exporter-memory) |
+| **CSV import** | `sonda new --from <csv>` analyzes CSV files, detects time-series patterns (steady, spike, leak, flap, sawtooth, step), generates portable scenario YAML |
+| **Interactive scaffolding** | `sonda new` walks signal type → generator → rate → duration → sink and writes commented v2 YAML |
+| **Catalogs** | author your own catalog directory of `kind: runnable` scenarios and `kind: composable` packs; discover with `sonda list --catalog <dir>` and run with `@name` references |
 | **Deployment** | static binary, Docker, Kubernetes (Helm chart) |
 
 ## Quick install
@@ -40,104 +39,146 @@ cargo install sonda
 **Docker:**
 
 ```bash
-docker run --rm ghcr.io/davidban77/sonda:latest metrics --name up --rate 5 --duration 10s
+docker run --rm -v "$PWD":/work -w /work \
+  ghcr.io/davidban77/sonda:latest run my-scenario.yaml
 ```
 
 See the [Getting Started](https://davidban77.github.io/sonda/getting-started/) guide for all installation options.
 
-## Your first metric
+## Your first scenario
 
-Emit a constant value -- the simplest signal for health-check or baseline testing:
+Sonda runs YAML scenario files. Scaffold one with `sonda new --template`, save it, and run it:
 
 ```bash
-sonda metrics --name up --rate 1 --duration 5s --value 1
+sonda new --template -o hello.yaml
+sonda run hello.yaml --duration 5s
 ```
 
 ```text
-up 1 1775518552355
-up 1 1775518553360
-up 1 1775518554360
+example_metric 1 1775518552355
+example_metric 1 1775518553360
+example_metric 1 1775518554360
 ```
 
-Shape the signal with a sine wave, labels, and any of the eight built-in generators:
+Each stdout line is Prometheus exposition format: `metric_name value timestamp_ms`. The
+template gives you a one-line constant value at 1 event per second; edit the `generator:`
+block to swap in a sine wave, labels, and any of the eight built-in generators:
 
-```bash
-sonda metrics --name cpu_usage --rate 2 --duration 5s \
-  --value-mode sine --amplitude 50 --period-secs 10 --offset 50 \
-  --label host=web-01
+```yaml title="cpu-sine.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+  labels:
+    host: web-01
+scenarios:
+  - id: cpu_usage
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: sine
+      amplitude: 50.0
+      offset: 50.0
+      period_secs: 10
 ```
 
-Push directly to a backend -- no scenario file needed:
+```bash
+sonda run cpu-sine.yaml
+```
+
+Push to any sink (HTTP, Loki, Kafka, OTLP, Prometheus remote-write) by editing the
+`sink:` block, or override at the command line with `--sink`, `--endpoint`, and `--encoder`:
 
 ```bash
-sonda metrics --name cpu --rate 10 --duration 30s \
+sonda run cpu-sine.yaml \
   --encoder remote_write \
   --sink remote_write --endpoint http://localhost:8428/api/v1/write
 ```
 
-Define complex scenarios in YAML for repeatable runs with `sonda metrics --scenario config.yaml`.
 The [Tutorial](https://davidban77.github.io/sonda/guides/tutorial/) walks through every generator,
 encoder, sink, and scheduling option step by step.
 
-## Built-in scenarios
+## Catalogs and the `@name` shorthand
 
-Sonda ships with 11 pre-built patterns you can run instantly -- no YAML needed:
+Organize your scenarios into a directory and Sonda discovers them as a catalog. Each file
+carries a `kind: runnable` (a scenario you run) or `kind: composable` (a metric pack you
+reference from other scenarios with `pack: <name>`).
 
 ```bash
-sonda scenarios list                       # browse the catalog
-sonda scenarios run cpu-spike              # run a pattern directly
-sonda scenarios show memory-leak           # view the YAML to customize it
-sonda metrics --scenario @cpu-spike        # @name shorthand in any subcommand
+sonda --catalog ./my-catalog list                # browse the catalog
+sonda --catalog ./my-catalog show @cpu-spike     # view the YAML
+sonda --catalog ./my-catalog run @cpu-spike      # run a scenario
 ```
 
-See the [Built-in Scenarios](https://davidban77.github.io/sonda/guides/scenarios/) guide for the
-full catalog and customization workflow.
+See the [Catalogs](https://davidban77.github.io/sonda/guides/scenarios/) guide for the
+directory layout and authoring conventions.
 
 ## Metric packs
 
-Metric packs are reusable bundles of metric names and label schemas that expand into multi-metric
-scenarios. Each pack models a real exporter (Telegraf SNMP, node_exporter) so generated data
-matches the exact schema your dashboards and alert rules expect.
+Metric packs are reusable bundles of metric names and label schemas that expand into
+multi-metric scenarios. Each pack models a real exporter (Telegraf SNMP, node_exporter) so
+generated data matches the exact schema your dashboards and alert rules expect.
 
-Pack YAML files live in the `packs/` directory and are discovered from the filesystem at runtime.
-Run from the repo root, set `SONDA_PACK_PATH`, or use `--pack-path` to point to a custom
-directory:
+Author a pack as a `kind: composable` YAML file in your catalog directory and reference it
+from any runnable scenario:
+
+```yaml title="snmp-edge.yaml"
+version: 2
+kind: runnable
+
+defaults:
+  rate: 1
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+
+scenarios:
+  - signal_type: metrics
+    pack: telegraf_snmp_interface
+    labels:
+      device: rtr-edge-01
+      ifName: GigabitEthernet0/0/0
+      ifIndex: "1"
+```
 
 ```bash
-sonda packs list                                     # browse discovered packs
-sonda packs show telegraf_snmp_interface              # view the raw YAML definition
-sonda packs run telegraf_snmp_interface --rate 1 \
-  --duration 60s --label device=rtr-edge-01           # run a pack directly
+sonda --catalog ./my-catalog run snmp-edge.yaml
 ```
 
 Override the generator for specific metrics without editing the pack definition:
 
 ```yaml
-# scenario.yaml
-pack: node_exporter_cpu
-rate: 1
-duration: 60s
-labels:
-  instance: web-01:9100
-overrides:
-  node_cpu_seconds_total:
-    generator:
-      type: spike
-      baseline: 0.1
-      spike_value: 0.95
-      spike_duration: 5
-      spike_interval: 30
+scenarios:
+  - signal_type: metrics
+    pack: node_exporter_cpu
+    labels:
+      instance: web-01:9100
+    overrides:
+      node_cpu_seconds_total:
+        generator:
+          type: spike
+          baseline: 0.1
+          spike_value: 0.95
+          spike_duration: 5
+          spike_interval: 30
 ```
 
 ## CSV import
 
-Turn any CSV file into a parameterized scenario. `sonda import` analyzes time-series data,
-detects dominant patterns, and generates portable YAML using generators instead of raw CSV replay:
+Turn any CSV file into a parameterized scenario. `sonda new --from <csv>` analyzes
+time-series data, detects dominant patterns, and generates portable YAML using generators
+instead of raw CSV replay:
 
 ```bash
-sonda import data.csv --analyze                    # see detected patterns
-sonda import data.csv -o scenario.yaml             # generate a scenario file
-sonda import data.csv --run --duration 30s         # generate and run immediately
+sonda new --from data.csv -o scenario.yaml         # generate a scenario file
+sonda new --from data.csv                          # preview the YAML on stdout
 ```
 
 Works with Grafana "Series joined by time" exports -- metric names and labels are extracted
@@ -149,27 +190,16 @@ full walkthrough.
 
 ## Interactive scaffolding
 
-Don't want to write YAML by hand? `sonda init` walks you through building a scenario with
+Don't want to write YAML by hand? `sonda new` walks you through building a scenario with
 guided prompts. It uses operational vocabulary -- "spike event", "leak", "flap" -- instead
-of raw generator types, and supports metric packs for multi-metric scenarios:
+of raw generator types:
 
 ```bash
-sonda init
-```
-
-Pre-fill from a built-in scenario or CSV file, or run fully non-interactively with flags:
-
-```bash
-sonda init --from @cpu-spike --rate 5 --duration 2m -o scenario.yaml
-sonda init --signal-type metrics --domain infrastructure --situation steady \
-  --metric cpu_usage --rate 1 --duration 60s --encoder prometheus_text \
-  --sink stdout -o cpu.yaml --run-now
+sonda new
 ```
 
 ```text
 ? What type of signal? metrics
-? What domain? infrastructure
-? How would you like to define metrics? Single metric
 ? Metric name node_cpu_usage_percent
 ? What situation should this metric simulate? spike_event - baseline with periodic spikes
 ? Baseline value (between spikes) 35
@@ -180,17 +210,12 @@ sonda init --signal-type metrics --domain infrastructure --situation steady \
 ? Where should output be sent? stdout
 ? Output file path ./scenarios/node-cpu-usage-percent.yaml
 
-✔ Scenario created
-  name:  node_cpu_usage_percent
-  type:  metrics
-  file:  ./scenarios/node-cpu-usage-percent.yaml
-
-? Run it now? Yes
+Wrote scenario to ./scenarios/node-cpu-usage-percent.yaml
 ```
 
-The generated YAML is commented, immediately runnable, and includes scenario metadata so it
-appears in `sonda scenarios list`. See the
-[CLI Reference](https://davidban77.github.io/sonda/configuration/cli-reference/#sonda-init) for
+The generated YAML is commented, immediately runnable, and ready to drop into a catalog
+directory. See the
+[CLI Reference](https://davidban77.github.io/sonda/configuration/cli-reference/#sonda-new) for
 the full prompt flow and available situations.
 
 ## Multi-signal temporal scenarios
@@ -198,23 +223,18 @@ the full prompt flow and available situations.
 Multi-signal scenarios with temporal causality are expressed directly as
 [v2 scenario files](https://davidban77.github.io/sonda/configuration/v2-scenarios/): define
 several entries and use `after:` clauses to express when one signal starts relative to another
--- Sonda resolves the timing into concrete `phase_offset` values at compile time. The built-in
-`link-failover` scenario is a worked example:
-
-```bash
-sonda catalog run link-failover --duration 5m --sink stdout
-# or from a file
-sonda run --scenario scenarios/link-failover.yaml --duration 5m --sink stdout
-```
+-- Sonda resolves the timing into concrete `phase_offset` values at compile time. See the
+[Network Device Telemetry](https://davidban77.github.io/sonda/guides/network-device-telemetry/)
+guide for a worked link-failover cascade.
 
 ## Documentation
 
 Full documentation is available at **https://davidban77.github.io/sonda/**.
 
-- [**Getting Started**](https://davidban77.github.io/sonda/getting-started/) -- installation, first metric, first log scenario
+- [**Getting Started**](https://davidban77.github.io/sonda/getting-started/) -- installation, first scenario, first log scenario
 - [**Tutorial**](https://davidban77.github.io/sonda/guides/tutorial/) -- generators, encoders, sinks, gaps, bursts, multi-scenario runs
-- [**Configuration Reference**](https://davidban77.github.io/sonda/configuration/scenario-file/) -- scenario files, generators, encoders, sinks
-- [**CLI Reference**](https://davidban77.github.io/sonda/configuration/cli-reference/) -- every flag for `metrics`, `logs`, `histogram`, `summary`, and `run`
+- [**Configuration Reference**](https://davidban77.github.io/sonda/configuration/scenario-fields/) -- scenario files, generators, encoders, sinks
+- [**CLI Reference**](https://davidban77.github.io/sonda/configuration/cli-reference/) -- every flag for `run`, `list`, `show`, `new`
 - [**Deployment**](https://davidban77.github.io/sonda/deployment/docker/) -- Docker, Kubernetes, sonda-server HTTP API
 - [**Guides**](https://davidban77.github.io/sonda/guides/alert-testing/) -- alert testing, pipeline validation, CSV replay, example catalog
 

--- a/docs/site/docs/configuration/cli-reference.md
+++ b/docs/site/docs/configuration/cli-reference.md
@@ -55,7 +55,7 @@ sonda [--catalog <DIR>] [--dry-run] [--format text|json] run <SCENARIO> [OVERRID
 
 ### Run a file
 
-```bash
+```bash title="examples/cpu-spike.yaml"
 sonda run examples/cpu-spike.yaml
 ```
 
@@ -73,7 +73,7 @@ The `@cpu-spike` reference resolves to a YAML file in `~/sonda-catalog/` whose h
 
 CLI flags win over `defaults:` inside the file. Useful for a one-off rate bump or pointing the same scenario at a different sink:
 
-```bash
+```bash title="examples/cpu-spike.yaml"
 sonda run examples/cpu-spike.yaml \
   --rate 500 \
   --duration 10s \
@@ -188,7 +188,7 @@ sonda --catalog <DIR> show <@NAME>
 
 Works for both `kind: runnable` and `kind: composable` entries. Output is the file contents byte-for-byte. For runnable entries, it round-trips through `sonda --dry-run run`:
 
-```bash
+```bash title="/tmp/snap.yaml"
 sonda --catalog ~/sonda-catalog show @cpu-spike > /tmp/snap.yaml
 sonda --dry-run run /tmp/snap.yaml
 ```
@@ -290,7 +290,7 @@ Colors are automatic. Sonda respects [`NO_COLOR`](https://no-color.org) and disa
 
 `--quiet` suppresses banners and progress (errors still print). `--verbose` prints the resolved scenario config at startup, then runs normally. The two flags are mutually exclusive.
 
-```bash
+```bash title="examples/cpu-spike.yaml"
 sonda -q run examples/cpu-spike.yaml > metrics.txt    # quiet for scripts
 sonda -v run examples/cpu-spike.yaml                  # echo config first
 ```

--- a/docs/site/docs/configuration/encoders.md
+++ b/docs/site/docs/configuration/encoders.md
@@ -186,29 +186,12 @@ field that controls how many decimal places appear in metric values.
 - **Default**: omit the field to keep full f64 precision.
 - **Effect**: values are rounded to the specified number of decimal places using standard rounding.
 
-You can set precision in a YAML scenario file or from the CLI with `--precision`:
+Set `precision` on the encoder block in your scenario YAML:
 
-=== "YAML"
-
-    ```yaml title="precision-formatting.yaml"
-    encoder:
-      type: prometheus_text
-      precision: 2    # 99.60573 becomes 99.61
-    ```
-
-=== "CLI"
-
-    ```bash
-    sonda metrics --name cpu_usage --rate 2 --duration 2s \
-      --value-mode sine --amplitude 50 --offset 50 \
-      --label host=web-01 --precision 2
-    ```
-
-The `--precision` flag works with `--encoder` or on its own. When you pass `--precision` without
-`--encoder`, it overrides the precision of whatever encoder your YAML file specifies:
-
-```bash
-sonda metrics --scenario examples/basic-metrics.yaml --precision 2
+```yaml title="precision-formatting.yaml (encoder fragment)"
+encoder:
+  type: prometheus_text
+  precision: 2    # 99.60573 becomes 99.61
 ```
 
 The `syslog`, `remote_write`, and `otlp` encoders do not support `precision`. Syslog encodes log

--- a/docs/site/docs/configuration/generators.md
+++ b/docs/site/docs/configuration/generators.md
@@ -56,8 +56,27 @@ generator:
 
 **Shape:** A flat horizontal line at the configured value.
 
+```yaml title="up-constant.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  duration: 2s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: up
+    signal_type: metrics
+    name: up
+    generator:
+      type: constant
+      value: 1.0
+```
+
 ```bash
-sonda metrics --name up --rate 2 --duration 2s --value 1
+sonda run up-constant.yaml
 ```
 
 ```text title="Output"
@@ -65,8 +84,6 @@ up 1 1774279693496
 up 1 1774279694001
 up 1 1774279694501
 ```
-
-Use `--value` from the CLI to set the constant value directly.
 
 When no generator is configured, the default is `constant` with `value: 0.0`.
 
@@ -91,9 +108,29 @@ generator:
 **Shape:** Oscillates smoothly between 0 and 100 with a 60-second period. At tick 0, the value
 equals the offset.
 
+```yaml title="cpu-sine.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  duration: 2s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu
+    generator:
+      type: sine
+      amplitude: 50.0
+      period_secs: 4
+      offset: 50.0
+```
+
 ```bash
-sonda metrics --name cpu --rate 2 --duration 2s \
-  --value-mode sine --amplitude 50 --period-secs 4 --offset 50
+sonda run cpu-sine.yaml
 ```
 
 ```text title="Output"
@@ -122,9 +159,29 @@ generator:
 
 **Shape:** A linear ramp from 0 to 100 over 60 seconds, then snaps back to 0.
 
+```yaml title="ramp-sawtooth.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  duration: 2s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: ramp
+    signal_type: metrics
+    name: ramp
+    generator:
+      type: sawtooth
+      min: 0.0
+      max: 100.0
+      period_secs: 4
+```
+
 ```bash
-sonda metrics --name ramp --rate 2 --duration 2s \
-  --value-mode sawtooth --min 0 --max 100 --period-secs 4
+sonda run ramp-sawtooth.yaml
 ```
 
 ```text title="Output"
@@ -154,9 +211,29 @@ generator:
 
 **Shape:** Random values scattered between 10 and 90. Same seed produces same sequence.
 
+```yaml title="noise-uniform.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  duration: 2s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: noise
+    signal_type: metrics
+    name: noise
+    generator:
+      type: uniform
+      min: 10.0
+      max: 90.0
+      seed: 42
+```
+
 ```bash
-sonda metrics --name noise --rate 2 --duration 2s \
-  --value-mode uniform --min 10 --max 90 --seed 42
+sonda run noise-uniform.yaml
 ```
 
 ```text title="Output"
@@ -186,7 +263,7 @@ generator:
 last value. With `repeat: false`, the last value is emitted for all subsequent ticks.
 
 ```bash
-sonda metrics --scenario examples/sequence-alert-test.yaml --duration 5s
+sonda run examples/sequence-alert-test.yaml --duration 5s
 ```
 
 ```text title="Output"
@@ -222,7 +299,7 @@ generator:
 grows without bound. With `max`, it wraps back to `start` when it reaches the threshold.
 
 ```bash
-sonda metrics --scenario examples/step-counter.yaml --duration 3s
+sonda run examples/step-counter.yaml --duration 3s
 ```
 
 ```text title="Output"
@@ -263,7 +340,7 @@ generator:
 **Shape:** Holds at 50 for most of the 60-second cycle, then jumps to 250 for 10 seconds.
 
 ```bash
-sonda metrics --scenario examples/spike-alert-test.yaml --duration 5s
+sonda run examples/spike-alert-test.yaml --duration 5s
 ```
 
 ```text title="Output"
@@ -438,8 +515,9 @@ generator:
 
 Values oscillate between 63 and 87 (75 +/- 10, plus up to +/- 2 noise) on a 60-second cycle.
 
-!!! tip "Built-in scenario"
-    Run `sonda metrics --scenario @steady-state` for a ready-to-use version with Prometheus labels.
+!!! tip "Scaffold a starter"
+    `sonda new` walks through signal type → generator → rate → duration → sink and writes a
+    ready-to-run YAML with the `steady` alias prefilled.
 
 ### flap
 
@@ -545,9 +623,9 @@ Values ramp linearly from 40 to 95 over 120 seconds with no reset.
     config with an error. A leak that resets mid-run is the `saturation` pattern -- use that
     alias instead if you want repeating fill-and-reset cycles.
 
-!!! tip "Built-in scenario"
-    Run `sonda metrics --scenario @memory-leak` for a ready-to-use version modeling a process
-    leaking from 40% to 95% over 120 seconds.
+!!! tip "Scaffold a starter"
+    `sonda new` writes a runnable `leak` YAML when you pick the "leak" situation in the
+    interactive flow — useful as a starting point for memory-leak alert rehearsals.
 
 ### degradation
 
@@ -574,9 +652,9 @@ generator:
 
 Values ramp from 50ms to 500ms over 60 seconds with +/- 20ms of noise on each tick.
 
-!!! tip "Built-in scenario"
-    Run `sonda metrics --scenario @latency-degradation` for a ready-to-use version with HTTP
-    latency labels.
+!!! tip "Scaffold a starter"
+    `sonda new` writes a ready-to-run `degradation` scenario with HTTP-latency-friendly defaults
+    when you pick the "degradation" situation in the interactive flow.
 
 ### spike_event
 
@@ -601,8 +679,9 @@ generator:
 
 Values hold at 35 between spikes, then jump to 95 (35 + 60) for 10 seconds every 30 seconds.
 
-!!! tip "Built-in scenario"
-    Run `sonda metrics --scenario @cpu-spike` for a ready-to-use version with node exporter labels.
+!!! tip "Scaffold a starter"
+    `sonda new` writes a runnable `spike_event` YAML when you pick "spike_event" in the
+    interactive flow — useful for CPU-spike alert rehearsals against node-exporter-shaped labels.
 
 ??? tip "Aliases vs. core generators"
     You can always use the underlying generator directly if you need parameters that the alias
@@ -638,9 +717,10 @@ Think of it this way: a counter tells you *how many* requests happened. A histog
     distribution, updates cumulative bucket counters, and emits the result in Prometheus format.
     The output is indistinguishable from a real instrumented service.
 
-Histogram and summary generators use dedicated subcommands (`sonda histogram`, `sonda summary`)
-and their own top-level scenario format -- not the `generator.type` field used by metric generators.
-For a hands-on walkthrough of testing latency alerts, see the
+Histograms and summaries are v2 scenario entries with `signal_type: histogram` or
+`signal_type: summary` and a `distribution:` block in place of the metric `generator:` block.
+Run them with `sonda run` just like any other scenario. For a hands-on walkthrough of testing
+latency alerts, see the
 [Histograms, Summaries, and Latency Alerts](../guides/histogram-alerts.md) guide.
 
 ### histogram
@@ -727,7 +807,7 @@ default buckets, that is 14 series per tick. All bucket counters are cumulative 
 increasing across ticks.
 
 ```bash
-sonda histogram --scenario examples/histogram.yaml
+sonda run examples/histogram.yaml
 ```
 
 ```text title="Output (first tick, abbreviated)"
@@ -807,7 +887,7 @@ quantiles, that is 6 series per tick. Quantile values are fresh per-tick snapsho
 that tick's observations. `_count` and `_sum` are cumulative.
 
 ```bash
-sonda summary --scenario examples/summary.yaml
+sonda run examples/summary.yaml
 ```
 
 ```text title="Output (first tick)"
@@ -877,8 +957,8 @@ real metrics rarely distribute evenly.
 
 ## Log generators
 
-Log generators produce structured log events instead of numeric values. They are used with the
-`sonda logs` subcommand.
+Log generators produce structured log events instead of numeric values. They live on a v2
+`signal_type: logs` entry under the `log_generator:` key (not `generator:`).
 
 ### template
 
@@ -934,7 +1014,7 @@ log_generator:
 Auto-discovery of column roles is case-insensitive: `timestamp` / `ts` / `time` → timestamp; `severity` / `level` → severity; `message` / `msg` / `log` → message. Every other header becomes a field column on every emitted `LogEvent`.
 
 ```bash
-sonda -q logs --scenario examples/log-csv-replay.yaml --duration 11s
+sonda -q run examples/log-csv-replay.yaml --duration 11s
 ```
 
 ```text title="Output"
@@ -997,7 +1077,7 @@ scenarios:
 ```
 
 ```bash
-sonda metrics --scenario examples/jitter-sine.yaml --duration 3s
+sonda run examples/jitter-sine.yaml --duration 3s
 ```
 
 Without jitter, a sine wave with `offset: 50` outputs exactly `50.0` at tick 0. With

--- a/docs/site/docs/configuration/scenario-fields.md
+++ b/docs/site/docs/configuration/scenario-fields.md
@@ -70,7 +70,7 @@ scenarios:
 ```
 
 ```bash
-sonda run --scenario full-example.yaml
+sonda run full-example.yaml
 ```
 
 ## Field reference
@@ -319,7 +319,7 @@ scenarios:
 ```
 
 ```bash
-sonda run --scenario log-scenario.yaml
+sonda run log-scenario.yaml
 ```
 
 The `labels` / `dynamic_labels` fields work the same way as for metric entries. Static labels
@@ -377,7 +377,7 @@ scenarios:
 ```
 
 ```bash
-sonda run --scenario multi-scenario.yaml
+sonda run multi-scenario.yaml
 ```
 
 The `phase_offset` on `memory_usage` delays it by 3 seconds, so CPU spikes first and memory
@@ -447,7 +447,7 @@ scenarios:
 ```
 
 ```bash
-sonda run --scenario mixed-signals.yaml
+sonda run mixed-signals.yaml
 ```
 
 !!! info "Histogram and summary entries use different fields"
@@ -484,7 +484,7 @@ scenarios:
 ```
 
 ```bash
-sonda run --scenario pack-scenario.yaml
+sonda run pack-scenario.yaml
 ```
 
 Any `labels`, `rate`, `duration`, `encoder`, or `sink` you set on the entry applies to every
@@ -493,21 +493,17 @@ see the [Metric Packs guide](../guides/metric-packs.md) for the full reference.
 
 ## CLI overrides
 
-Any field in a scenario file can be overridden from the command line. CLI flags always take
-precedence over YAML values:
+Any of the common knobs (`rate`, `duration`, `sink`, `endpoint`, `encoder`, `label`,
+`on-sink-error`) can be overridden from the command line. CLI flags always take precedence
+over YAML values:
 
-```bash
-sonda run --scenario scenario.yaml --duration 5s --rate 2
+```bash title="scenario.yaml"
+sonda run scenario.yaml --duration 5s --rate 2
 ```
 
 This loads the file but overrides `duration` and `rate` (applied to every entry) with the CLI
-values.
-
-Per-signal flags like `--precision` also work when using the signal subcommands:
-
-```bash
-sonda metrics --scenario @cpu-spike --precision 2
-```
+values. Encoder-specific knobs like `precision` and pack-specific overrides live in the YAML —
+see [CLI Reference: sonda run](cli-reference.md#sonda-run) for the full override list.
 
 ## What next
 

--- a/docs/site/docs/configuration/sinks.md
+++ b/docs/site/docs/configuration/sinks.md
@@ -38,10 +38,10 @@ sink:
   path: /tmp/sonda-output.txt
 ```
 
-You can also use the `--output` CLI flag as a shorthand:
+You can also use the `-o` CLI flag on `sonda run` as a shorthand for `--sink file --endpoint <path>`:
 
-```bash
-sonda metrics --name cpu --rate 10 --duration 5s --output /tmp/metrics.txt
+```bash title="cpu-scenario.yaml"
+sonda run cpu-scenario.yaml -o /tmp/metrics.txt
 ```
 
 ## tcp
@@ -99,13 +99,13 @@ sink:
   batch_size: 32768
 ```
 
-**CLI equivalent** -- use `--sink http_push` with `--endpoint`, `--content-type`, and
-optionally `--batch-size`:
+**CLI override** -- `sonda run` accepts `--sink http_push` and `--endpoint` to override the file's
+sink type and URL on a one-off run. Settings like `content_type`, `batch_size`, and custom
+`headers:` live in the YAML:
 
-```bash
-sonda metrics --name cpu --rate 10 --duration 30s \
-  --sink http_push --endpoint http://localhost:8428/api/v1/import/prometheus \
-  --content-type "text/plain"
+```bash title="cpu-scenario.yaml"
+sonda run cpu-scenario.yaml \
+  --sink http_push --endpoint http://localhost:8428/api/v1/import/prometheus
 ```
 
 ### Pushing to VictoriaMetrics
@@ -159,10 +159,11 @@ sink:
   batch_size: 5
 ```
 
-**CLI equivalent** -- use `--encoder remote_write --sink remote_write --endpoint`:
+**CLI override** -- `sonda run` accepts `--encoder remote_write`, `--sink remote_write`, and
+`--endpoint <url>` to override the file's sink and encoder on a one-off run:
 
-```bash
-sonda metrics --name cpu --rate 10 --duration 30s \
+```bash title="cpu-scenario.yaml"
+sonda run cpu-scenario.yaml \
   --encoder remote_write \
   --sink remote_write --endpoint http://localhost:8428/api/v1/write
 ```
@@ -201,11 +202,11 @@ sink:
   topic: sonda-metrics
 ```
 
-**CLI equivalent** -- use `--sink kafka --brokers --topic`:
+Kafka brokers and topic live in the YAML; `sonda run` does not expose flags for them. Override
+the sink type from the command line with `--sink kafka` and define the rest in the file:
 
-```bash
-sonda metrics --name cpu --rate 10 --duration 30s \
-  --sink kafka --brokers 127.0.0.1:9092 --topic sonda-metrics
+```bash title="kafka-cpu.yaml"
+sonda run kafka-cpu.yaml
 ```
 
 Events are buffered and published as a single Kafka record to partition 0 of the configured topic. The size threshold is a fixed 64 KiB internal buffer -- it is not user-tunable -- while `max_buffer_age` (default `5s`) is the configurable knob: a non-empty batch is flushed once it has been buffered longer than that. Broker-side auto-topic-creation is supported: the sink retries metadata lookups, giving the broker time to create the topic if `auto.create.topics.enable=true`.
@@ -389,10 +390,11 @@ scenarios:
       env: dev
 ```
 
-**CLI equivalent** -- use `--sink loki --endpoint` and `--label` for stream labels:
+**CLI override** -- `sonda run` accepts `--sink loki`, `--endpoint <url>`, and `--label k=v`
+(repeatable) for stream labels:
 
-```bash
-sonda logs --mode template --rate 10 --duration 30s \
+```bash title="app-logs.yaml"
+sonda run app-logs.yaml \
   --sink loki --endpoint http://localhost:3100 \
   --label job=sonda --label env=dev
 ```
@@ -438,18 +440,13 @@ sink:
   batch_size: 50
 ```
 
-**CLI equivalents:**
+**CLI override** -- `sonda run` accepts `--encoder otlp`, `--sink otlp_grpc`, and `--endpoint <url>`.
+The OTLP `signal_type` is derived from the scenario's `signal_type:`, so it does not need its own
+CLI flag:
 
-```bash
-# Metrics
-sonda metrics --name cpu --rate 10 --duration 30s \
-  --encoder otlp \
-  --sink otlp_grpc --endpoint http://localhost:4317 --signal-type metrics
-
-# Logs (--signal-type defaults to "logs" automatically)
-sonda logs --mode template --rate 10 --duration 30s \
-  --encoder otlp \
-  --sink otlp_grpc --endpoint http://localhost:4317
+```bash title="cpu.yaml"
+sonda run cpu.yaml \
+  --encoder otlp --sink otlp_grpc --endpoint http://localhost:4317
 ```
 
 Scenario-level `labels` are automatically converted to OTLP `Resource` attributes, so they appear
@@ -532,16 +529,5 @@ Not all errors trigger retries. Each sink classifies errors as retryable (transi
     Permanent errors (like a 401 Unauthorized or a malformed request returning 400) are never
     retried. Sonda logs a warning and discards the batch immediately.
 
-### CLI flags
-
-You can also configure retry from the command line with three flags. All three must be provided
-together (all-or-nothing):
-
-```bash
-sonda metrics --name cpu --rate 10 --duration 60s \
-  --sink http_push --endpoint http://localhost:8428/api/v1/import/prometheus \
-  --retry-max-attempts 3 --retry-backoff 100ms --retry-max-backoff 5s
-```
-
-CLI retry flags override any `retry:` block in the YAML scenario file. See
-[CLI Reference](cli-reference.md#retry) for details.
+Retry settings live in the scenario YAML — there is no CLI shortcut for them. Edit the
+`retry:` block inside the sink definition to tune attempts and backoff.

--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -8,10 +8,9 @@ Every scenario file must declare `version: 2` at the top. Everything else you al
 about scenarios -- generators, encoders, sinks, labels -- still applies.
 
 !!! warning "v1 YAML is no longer accepted"
-    Sonda only accepts v2 scenario YAML. The CLI (`sonda run`, `sonda metrics`,
-    `sonda catalog run`, every `--scenario` consumer) and the HTTP server (`POST /scenarios`)
-    both refuse files or bodies without `version: 2` at the top and print a migration hint
-    pointing at this page.
+    Sonda only accepts v2 scenario YAML. Both `sonda run` and the HTTP server
+    (`POST /scenarios`) refuse files or bodies without `version: 2` at the top and print a
+    migration hint pointing at this page.
 
     If you are upgrading from a Sonda release before this change, jump straight to
     [Migrating from v1](#migrating-from-v1).
@@ -41,7 +40,7 @@ scenarios:
 Run it like any other scenario file:
 
 ```bash
-sonda run --scenario hello-v2.yaml
+sonda run hello-v2.yaml
 ```
 
 ```text title="Output"
@@ -64,15 +63,16 @@ demo_cpu 42 1776090152619
 
 ## Catalog metadata
 
-v2 files can carry optional top-level metadata that powers the unified catalog --
-`sonda catalog list`, `sonda catalog show`, and the `--category` filter. The fields sit at
-the root, alongside `version:` and `defaults:`:
+v2 files can carry optional top-level metadata that powers the catalog views --
+`sonda list` and `sonda show` against a `--catalog <dir>`. The fields sit at the root,
+alongside `version:`, `kind:`, and `defaults:`:
 
-```yaml title="scenarios/steady-state.yaml"
+```yaml title="my-catalog/steady-state.yaml"
 version: 2
+kind: runnable
 
-scenario_name: steady-state
-category: infrastructure
+name: steady-state
+tags: [infrastructure, baseline]
 description: "Normal oscillating baseline (sine + jitter)"
 
 scenarios:
@@ -93,29 +93,23 @@ scenarios:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `scenario_name` | no | Kebab-case identifier. Defaults to the filename (without `.yaml`, hyphens preserved) if omitted. Used by `@name` shorthand and `sonda catalog run`. When posted to a running `sonda-server`, this field also acts as a uniqueness key — POSTing two cascades that share an active `scenario_name` returns [`409 Conflict`](../deployment/sonda-server.md#duplicate-scenario_name-returns-409). |
-| `category` | no | Catalog grouping. One of `infrastructure`, `network`, `application`, `observability`. Scenarios without a category render as `uncategorized` and drop out of `--category` filters. |
+| `kind` | yes | `runnable` for runnable scenarios; `composable` for packs. Required at the top level of every v2 file. |
+| `name` | no | Catalog identifier (kebab-case). Defaults to the filename (without `.yaml`, hyphens preserved) if omitted. Used by `@name` shorthand and `sonda run @name`. When posted to a running `sonda-server`, this field also acts as a uniqueness key — POSTing two cascades that share an active `name` returns [`409 Conflict`](../deployment/sonda-server.md#duplicate-scenario_name-returns-409). |
+| `tags` | no | List of strings shown in the catalog table and filterable via `sonda list --tag <t>`. |
 | `description` | no | One-line summary shown in the catalog table and JSON output. Keep it under ~60 characters so it fits the table column. |
 
-The compiler ignores these fields -- they only feed the catalog. `deny_unknown_fields` stays
-in force, so typos like `scenarioName:` or `desc:` are rejected at parse time.
+The compiler ignores `tags:` and `description:` — they only feed the catalog. `deny_unknown_fields`
+stays in force, so typos like `tag:` (singular) or `desc:` are rejected at parse time.
 
-!!! info "Same field names as legacy v1"
-    The retired v1 format used the same top-level field names (`scenario_name`, `category`,
-    `description`). Migrating a v1 file to v2 keeps the metadata as-is -- you add
-    `version: 2` and reshape the body around `defaults:` + `scenarios:`.
-
-Drop a v2 file into any directory on the
-[scenario search path](../guides/scenarios.md#scenario-search-path) and it shows up
-immediately:
+Drop a v2 file into your catalog directory and it shows up immediately:
 
 ```bash
-sonda catalog list --category infrastructure
+sonda --catalog ./my-catalog list --tag infrastructure
 ```
 
 ```text
-NAME           TYPE      CATEGORY         SIGNAL    RUNNABLE   DESCRIPTION
-steady-state   scenario  infrastructure   metrics   yes        Normal oscillating baseline (sine + jitter)
+KIND        NAME           TAGS                      DESCRIPTION
+runnable    steady-state   infrastructure,baseline   Normal oscillating baseline (sine + jitter)
 ...
 ```
 
@@ -135,10 +129,10 @@ defaults:
 
 ```bash
 # Host CLI -- LOKI_URL unset, default wins
-sonda run --scenario examples/loki-json-lines.yaml --duration 1s --dry-run
+sonda run examples/loki-json-lines.yaml --duration 1s --dry-run
 
 # Override -- every ${LOKI_URL} resolves to this value
-LOKI_URL=http://loki:3100 sonda run --scenario examples/loki-json-lines.yaml --duration 1s --dry-run
+LOKI_URL=http://loki:3100 sonda run examples/loki-json-lines.yaml --duration 1s --dry-run
 ```
 
 ### Syntax
@@ -265,7 +259,7 @@ The `noisy_logs` entry tolerates Loki blips. The `canary` entry treats any sink 
 !!! tip "When to pick `fail`"
     Pick `fail` when sink delivery is itself the contract under test -- CI gates that compare metric counts against an expected total, or smoke tests that should abort the moment the backend goes away. Pick `warn` (the default) for everything else: long-running fleets, demo environments, or any scenario where you want runtime self-observability via [`/stats`](../deployment/sonda-server.md#self-observability-via-stats) instead of thread death.
 
-`--on-sink-error <warn|fail>` on every CLI subcommand (`sonda run`, `sonda metrics`, `sonda logs`, `sonda histogram`, `sonda summary`) overrides `defaults.on_sink_error` for one-off invocations -- handy when you want to point a single CI run at a YAML that defaults to `warn`. See [CLI Reference](cli-reference.md#sonda-run).
+`--on-sink-error <warn|fail>` on `sonda run` overrides `defaults.on_sink_error` for one-off invocations -- handy when you want to point a single CI run at a YAML that defaults to `warn`. See [CLI Reference](cli-reference.md#sonda-run).
 
 ## Temporal chains with `after:`
 
@@ -276,7 +270,7 @@ from each generator's shape.
 The built-in `link-failover` scenario is a worked example: a primary interface flaps, a backup
 link saturates once the primary drops, and latency degrades once the backup fills.
 
-```yaml title="scenarios/link-failover.yaml"
+```yaml title="link-failover.yaml"
 version: 2
 
 scenario_name: link-failover
@@ -345,11 +339,11 @@ start reference.
 Use `--dry-run` to see the resolved timing:
 
 ```bash
-sonda run --scenario scenarios/link-failover.yaml --dry-run
+sonda --dry-run run link-failover.yaml
 ```
 
 ```text
-[config] file: scenarios/link-failover.yaml (version: 2, 3 scenarios)
+[config] file: link-failover.yaml (version: 2, 3 scenarios)
 
 [config] [1/3] interface_oper_state
 
@@ -405,10 +399,11 @@ because of the `after:` relationship.
 
     The CLI `--duration` flag (and the body-level `duration` field on `POST /scenarios`) shorten **every entry's `duration` individually**; they do not cap the cascade's total wall-clock. Running the same chain with `--duration 2m` produces `152.308s + 2m ≈ 4m32s`, because every entry now runs for 2m from its own start.
 
-The scenario also ships in the built-in catalog:
+Run it from your catalog the same way as any other scenario — save the YAML under
+`my-catalog/link-failover.yaml`, then:
 
 ```bash
-sonda catalog run link-failover
+sonda --catalog ./my-catalog run @link-failover
 ```
 
 !!! tip "Supported generators in `after:`"
@@ -422,7 +417,7 @@ For continuous gating that pauses and resumes a downstream as the upstream's val
 
 `after:` is a one-shot trigger -- it fires once and the dependent scenario runs to completion. `while:` is the continuous-coupling counterpart: the gated scenario emits only while the upstream's latest value satisfies the predicate, pauses when the predicate fails, and resumes when the predicate becomes true again. Use `while:` when an event stream should track an upstream signal's lifecycle, not just its first crossing. When a `while:`-gated scenario pauses, downstream alerts on its metrics keep firing for ~5 minutes by default — see [Recovering Prometheus alerts on gate close](#recovering-prometheus-alerts-on-gate-close) for the stale-marker default that resolves them immediately.
 
-```yaml title="scenarios/link-traffic.yaml"
+```yaml title="link-traffic.yaml"
 version: 2
 
 defaults:
@@ -607,7 +602,7 @@ The two clauses may also reference different upstreams (e.g. `after:` on a link 
 
 ### `--dry-run` preview
 
-`sonda run --scenario scenarios/link-traffic.yaml --dry-run` renders the gate plumbing alongside the existing layout:
+`sonda --dry-run run link-traffic.yaml` renders the gate plumbing alongside the existing layout:
 
 ```
 [config] [2/2] backup_link_throughput
@@ -641,7 +636,7 @@ The `link-failover` scenario described above uses `after:` to start a `backup_li
 
 To make the backup track the primary's state continuously, swap `after:` for `while:` on the cascade members that should pause when the primary recovers:
 
-```yaml title="scenarios/link-failover-recovery.yaml"
+```yaml title="link-failover-recovery.yaml"
 version: 2
 
 defaults:
@@ -727,55 +722,41 @@ Or let Sonda auto-assign one when you use `after:` -- every scenario in the same
 ends up in the same auto-named group (`chain_<head>`).
 
 The start banner and the grouped run summary both show the `clock_group`. See
-[Status output -- clock groups](cli-reference.md#clock-groups-in-status-output) for what the
-banners look like at runtime.
+[CLI Reference -- Status output](cli-reference.md#status-output) for what the banners look
+like at runtime.
 
-## Scaffolding v2 files with `sonda init`
+## Scaffolding v2 files with `sonda new`
 
-`sonda init` emits v2 YAML by default:
+`sonda new` emits v2 YAML. The fastest path is `--template`, which prints a minimal runnable
+file and exits with no prompts:
 
 ```bash
-sonda init \
-  --signal-type metrics \
-  --domain infrastructure \
-  --metric demo_cpu \
-  --situation spike_event \
-  --rate 5 --duration 30s \
-  --encoder prometheus_text --sink stdout \
-  -o ./scenarios/demo-cpu.yaml
+sonda new --template -o ./my-catalog/demo.yaml
 ```
 
-```yaml title="./scenarios/demo-cpu.yaml"
-# demo_cpu: infrastructure scenario using the 'spike_event' pattern.
-#
-# Generated by `sonda init`. Run with:
-#   sonda run --scenario <this-file>
-
+```yaml title="./my-catalog/demo.yaml"
 version: 2
-
-# Defaults inherited by every entry in scenarios: below.
+kind: runnable
 defaults:
-  rate: 5
-  duration: 30s
+  rate: 1
+  duration: 60s
   encoder:
     type: prometheus_text
   sink:
     type: stdout
 
 scenarios:
-  - signal_type: metrics
-    name: demo_cpu
+  - id: example
+    signal_type: metrics
+    name: example_metric
     generator:
-      type: spike_event
-      baseline: 0.0
-      spike_height: 100.0
-      spike_duration: "10s"
-      spike_interval: "30s"
+      type: constant
+      value: 1.0
 ```
 
-Run the generated file with `sonda run --scenario`. For the full guided scaffolding flow
-(signal types, packs, logs, histograms, summaries), see
-[`sonda init`](cli-reference.md#sonda-init).
+Drop the `--template` flag to walk the interactive flow (signal type → generator → rate →
+duration → sink type → output path), or use `--from <csv>` to seed the scaffold from
+existing CSV data. See [`sonda new`](cli-reference.md#sonda-new) for the full flag reference.
 
 ## Migrating from v1
 
@@ -786,15 +767,13 @@ Every legacy v1 shape maps cleanly to v2. Pick the tab that matches the file you
 When Sonda encounters a file or request body without `version: 2`, it stops before running
 anything and prints the error alongside a pointer to this guide.
 
-=== "CLI (`sonda run`, `sonda metrics`, ...)"
+=== "CLI (`sonda run`)"
 
     ```text title="stderr"
     error: scenario file /path/to/legacy.yaml is not a v2 scenario. Sonda only accepts v2 YAML (`version: 2` at the top level). Migrate this file to v2 — see docs/configuration/v2-scenarios.md for the migration guide.
     ```
 
-    Exit code: `1`. Applies to `sonda run`, `sonda metrics`, `sonda logs`,
-    `sonda histogram`, `sonda summary`, and `sonda catalog run` -- every `--scenario`
-    consumer.
+    Exit code: `1`.
 
 === "Server (`POST /scenarios`)"
 
@@ -1088,8 +1067,8 @@ anything and prints the error alongside a pointer to this guide.
 - **`deny_unknown_fields` is strict.** Typos like `scenarioName:` or `desc:` at the top of a
   v2 file are rejected at parse time with the offending field name in the error. Fix the
   typo and re-run.
-- **`sonda import` already emits v2.** Regenerate any imported scenarios with
-  [`sonda import`](cli-reference.md#sonda-import) if you kept older output around.
+- **`sonda new --from <csv>` emits v2.** Regenerate any older scaffolded scenarios with
+  [`sonda new --from <csv>`](cli-reference.md#sonda-new) if you kept older output around.
 
 ## What next
 

--- a/docs/site/docs/deployment/docker.md
+++ b/docs/site/docs/deployment/docker.md
@@ -34,22 +34,28 @@ See [Server API](sonda-server.md) for the full endpoint reference.
 # Start the server
 docker run -p 8080:8080 ghcr.io/davidban77/sonda:latest
 
-# Run the CLI instead — first argument is auto-detected as a sonda subcommand.
-docker run --rm ghcr.io/davidban77/sonda:latest \
-  metrics --name up --rate 10 --duration 5s
+# Run the CLI against a mounted catalog (auto-detected as a sonda subcommand)
+docker run --rm \
+  -v "$PWD/my-catalog":/catalog \
+  ghcr.io/davidban77/sonda:latest \
+  --catalog /catalog run @cpu-spike
 
-# Mount scenario files from the host
-docker run -p 8080:8080 -v ./examples:/scenarios ghcr.io/davidban77/sonda:latest
+# Or run a single file directly
+docker run --rm \
+  -v "$PWD/scenarios":/work \
+  ghcr.io/davidban77/sonda:latest \
+  run /work/cpu-spike.yaml
 ```
 
 !!! info "No `--entrypoint /sonda` needed"
     The default entrypoint inspects `argv[1]` and `exec`s the sibling `sonda` CLI when
-    it matches a known subcommand. Recipes that pass `--entrypoint /sonda` still work.
+    it matches a known subcommand (`run`, `list`, `show`, `new`). Recipes that pass
+    `--entrypoint /sonda` still work.
 
-The image includes built-in [scenario](../guides/scenarios.md) and
-[pack](../guides/metric-packs.md) YAML files at `/scenarios` and `/packs`, with
-`SONDA_SCENARIO_PATH=/scenarios` and `SONDA_PACK_PATH=/packs` set so all built-in patterns
-work out of the box. Mount a host directory to the same path to add or override scenarios.
+The image ships no built-in catalog. Mount a directory of your own scenario and pack YAML
+files (typically `kind: runnable` and `kind: composable` v2 files) at any path inside the
+container and pass `--catalog <path>` to point `sonda` at it. See
+[Catalogs](../guides/scenarios.md) for the directory layout.
 
 ## Authentication
 
@@ -221,11 +227,32 @@ run from your host CLI. See
 You can also push from the host CLI using a pipe to VictoriaMetrics.
 See [Sinks](../configuration/sinks.md) for all available sink types (`http_push`, `remote_write`, `loki`, etc.).
 
+```yaml title="sonda-demo.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+  labels:
+    job: sonda
+    instance: local
+scenarios:
+  - id: sonda_demo
+    signal_type: metrics
+    name: sonda_demo
+    generator:
+      type: sine
+      amplitude: 40.0
+      period_secs: 30
+      offset: 60.0
+```
+
 ```bash
-sonda metrics \
-  --name sonda_demo --rate 10 --duration 30s \
-  --value-mode sine --amplitude 40 --period-secs 30 --offset 60 \
-  --encoder prometheus_text --label job=sonda --label instance=local \
+sonda run sonda-demo.yaml \
   | curl -s --data-binary @- \
     -H "Content-Type: text/plain" \
     "http://localhost:8428/api/v1/import/prometheus"
@@ -257,7 +284,7 @@ docker compose -f examples/docker-compose-victoriametrics.yml \
 Push a threshold-crossing metric and watch alerts flow through to the webhook:
 
 ```bash
-sonda metrics --scenario examples/alertmanager/alerting-scenario.yaml
+sonda run examples/alertmanager/alerting-scenario.yaml
 ```
 
 See the [Alerting Pipeline](../guides/alerting-pipeline.md) guide for the full walkthrough.

--- a/docs/site/docs/deployment/endpoints.md
+++ b/docs/site/docs/deployment/endpoints.md
@@ -14,13 +14,13 @@ invocation paths, and they resolve `localhost` very differently.
 
 === "Host CLI"
 
-    You run `sonda metrics --scenario file.yaml` on your laptop or a bare host. The
+    You run `sonda run file.yaml` on your laptop or a bare host. The
     scenario runs **in the shell process on your host**. `http://localhost:8428` resolves
     to your host's loopback, which reaches whatever is listening on port 8428 there --
     typically a Compose-published port or a native install.
 
     ```bash
-    sonda metrics --scenario examples/victoriametrics-metrics.yaml
+    sonda run examples/victoriametrics-metrics.yaml
     ```
 
 === "`sonda-server` in a container"
@@ -134,7 +134,7 @@ Service names come from `examples/docker-compose-victoriametrics.yml`. Match the
     ```
 
     ```bash
-    sonda metrics --scenario examples/vm-push-scenario.yaml
+    sonda run examples/vm-push-scenario.yaml
     ```
 
 === "sonda-server (Compose) to VictoriaMetrics (Compose)"

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -13,8 +13,9 @@ cargo run -p sonda-server
 cargo run -p sonda-server -- --port 9090 --bind 127.0.0.1
 ```
 
-See [CLI Reference: sonda-server](../configuration/cli-reference.md#sonda-server) for all `sonda-server` flags.
-Control log verbosity with the `RUST_LOG` environment variable (default: `info`):
+`sonda-server` accepts `--port <PORT>` (default `8080`), `--bind <ADDR>` (default `0.0.0.0`),
+and `--api-key <KEY>` (or `SONDA_API_KEY` env var). Control log verbosity with the `RUST_LOG`
+environment variable (default `info`):
 
 ```bash
 RUST_LOG=debug cargo run -p sonda-server -- --port 8080
@@ -317,10 +318,10 @@ carries the compiler's error message instead. See
 shape conversions.
 
 !!! info "Pack references over HTTP"
-    The server has no filesystem pack catalog. Bodies that reference a named pack
-    (`pack: telegraf_snmp_interface`) compile against an empty in-memory resolver and fail
-    with a pack-not-found error. For now, pack-backed scenarios must run via the CLI or be
-    expanded into per-metric entries before posting.
+    The server compiles posted bodies against an empty pack resolver. Bodies that reference a
+    named pack (`pack: telegraf_snmp_interface`) fail with a pack-not-found error. Inline the
+    pack's metrics into the posted body, or run the scenario via the CLI with
+    `--catalog <dir>` where the pack file lives.
 
 ### Error response reference
 

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -10,7 +10,7 @@ Install Sonda and stream your first synthetic metrics and logs to stdout.
     curl -fsSL https://raw.githubusercontent.com/davidban77/sonda/main/install.sh | sh
     ```
 
-    Pin a version with `SONDA_VERSION=v1.0.1` before the pipe.
+    Pin a version with `SONDA_VERSION=v1.9.0` before the pipe.
 
 === "Cargo"
 
@@ -22,12 +22,14 @@ Install Sonda and stream your first synthetic metrics and logs to stdout.
 
     ```bash
     docker pull ghcr.io/davidban77/sonda:latest
-    docker run --rm ghcr.io/davidban77/sonda:latest \
-      metrics --name cpu_usage --rate 2 --duration 5s
+    docker run --rm \
+      -v "$PWD":/work -w /work \
+      ghcr.io/davidban77/sonda:latest \
+      run my-scenario.yaml
     ```
 
     The default entrypoint runs `sonda-server`, but dispatches to the `sonda` CLI
-    when the first argument is a subcommand (`metrics`, `logs`, `run`, `catalog`, ...).
+    when the first argument is a known subcommand (`run`, `list`, `show`, `new`).
 
 === "From source"
 
@@ -43,26 +45,48 @@ Check it works: `sonda --version` should print the installed version.
 
 ## Your first metric
 
-Generate a constant metric at 2 events per second for 5 seconds:
+Sonda runs YAML scenario files. Scaffold one with `sonda new --template`, save it, and
+run it:
 
 ```bash
-sonda metrics --name cpu_usage --rate 2 --duration 5s
+sonda new --template -o hello.yaml
+```
+
+```yaml title="hello.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+
+scenarios:
+  - id: example
+    signal_type: metrics
+    name: example_metric
+    generator:
+      type: constant
+      value: 1.0
+```
+
+```bash
+sonda run hello.yaml --duration 5s
 ```
 
 ```text title="stderr"
-▶ cpu_usage  signal_type: metrics | rate: 2/s | encoder: prometheus_text | sink: stdout | duration: 5s
+▶ example_metric  signal_type: metrics | rate: 1/s | encoder: prometheus_text | sink: stdout | duration: 5s
 ```
 
 ```text title="stdout"
-cpu_usage 0 1774277933018
-cpu_usage 0 1774277933522
-cpu_usage 0 1774277934023
-cpu_usage 0 1774277934523
-...
-```
-
-```text title="stderr"
-■ cpu_usage  completed in 5.0s | events: 10 | bytes: 240 B | errors: 0
+example_metric 1 1774277933018
+example_metric 1 1774277934023
+example_metric 1 1774277935023
+example_metric 1 1774277936023
+example_metric 1 1774277937023
+■ example_metric  completed in 5.0s | events: 5 | bytes: 130 B | errors: 0
 ```
 
 Each stdout line is Prometheus exposition format: `metric_name value timestamp_ms`.
@@ -71,14 +95,35 @@ progress line between the banners (see
 [CLI Reference -- Live progress](configuration/cli-reference.md#live-progress)).
 
 !!! tip "Suppress banners"
-    `sonda -q metrics ...` (or `--quiet`) silences the banners.
+    `sonda -q run hello.yaml` (or `--quiet`) silences the banners.
 
-The default generator is `constant` at `0.0`. Shape the signal with a sine wave:
+Shape the signal by swapping the `generator:` block for a sine wave with labels:
+
+```yaml title="cpu-sine.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+  labels:
+    host: web-01
+scenarios:
+  - id: cpu_usage
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: sine
+      amplitude: 50.0
+      offset: 50.0
+      period_secs: 10
+```
 
 ```bash
-sonda metrics --name cpu_usage --rate 2 --duration 5s \
-  --value-mode sine --amplitude 50 --period-secs 10 --offset 50 \
-  --label host=web-01
+sonda run cpu-sine.yaml
 ```
 
 ```text title="Output"
@@ -92,12 +137,14 @@ cpu_usage{host="web-01"} 90.45084971874738 1774277940081
 The wave oscillates between 0 and 100 with a 10-second period. The
 [Tutorial -- Generators](guides/tutorial-generators.md) covers all eight generators.
 
-## Using a scenario file
+## A larger scenario
 
-Repeatable runs live in a [v2 YAML file](configuration/v2-scenarios.md):
+The same v2 shape lets you share defaults across many entries and add scheduling like
+gaps and bursts:
 
 ```yaml title="basic-metrics.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1000
@@ -124,10 +171,8 @@ scenarios:
       for: 20s
 ```
 
-Run it:
-
 ```bash
-sonda run --scenario basic-metrics.yaml --duration 3s
+sonda run basic-metrics.yaml --duration 3s
 ```
 
 ```text title="Output"
@@ -139,10 +184,30 @@ interface_oper_state{hostname="t0-a1",zone="eu1"} 10.002094395041146 17742779441
 
 ## Generating logs
 
-Structured log events work the same way:
+Structured log events live on a `signal_type: logs` entry with a `log_generator:` block:
+
+```yaml title="hello-logs.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  duration: 3s
+  encoder:
+    type: json_lines
+  sink:
+    type: stdout
+scenarios:
+  - id: app_logs
+    signal_type: logs
+    name: app_logs
+    log_generator:
+      type: template
+      templates:
+        - message: "synthetic log event"
+```
 
 ```bash
-sonda logs --mode template --rate 2 --duration 3s
+sonda run hello-logs.yaml
 ```
 
 ```json title="Output"
@@ -157,38 +222,58 @@ Field pools, severity weights, and multiple templates are in the
 
 ## Sending to a backend
 
-Push directly from the CLI with `--sink` and `--endpoint` -- no YAML required:
+Edit the `sink:` block in the YAML (or override at the CLI with `--sink`, `--endpoint`,
+and `--encoder`) to push data anywhere:
+
+```yaml title="cpu-remote-write.yaml"
+encoder:
+  type: remote_write
+sink:
+  type: remote_write
+  url: "http://localhost:8428/api/v1/write"
+```
 
 ```bash
-# Push metrics to VictoriaMetrics / Prometheus via remote write
-sonda metrics --name cpu_usage --rate 10 --duration 30s \
-  --encoder remote_write \
-  --sink remote_write --endpoint http://localhost:8428/api/v1/write
-
-# Push logs to Grafana Loki
-sonda logs --mode template --rate 10 --duration 30s \
-  --sink loki --endpoint http://localhost:3100 --label app=myservice
+# Send the same scenario to a different remote-write endpoint without editing the file
+sonda run cpu-remote-write.yaml \
+  --endpoint http://victoriametrics:8428/api/v1/write
 ```
 
 See [Tutorial -- Sinks](guides/tutorial-sinks.md) for every sink type.
+
+## Catalogs and `@name`
+
+When you organize scenarios into a directory, point `--catalog <dir>` at it and refer
+to entries with `@name`:
+
+```bash title="./my-catalog"
+sonda list --catalog ./my-catalog
+sonda show @cpu-spike --catalog ./my-catalog
+sonda run @cpu-spike --catalog ./my-catalog
+```
+
+The catalog is just a directory of v2 YAML files with `kind: runnable` (scenarios you
+can run) or `kind: composable` (packs you reference from other scenarios with
+`pack: <name>`). See [Author your own catalog](guides/scenarios.md) for the layout.
 
 ## What next
 
 The **[Tutorial](guides/tutorial.md)** walks through every generator, encoder, sink, and
 advanced feature step by step. Skip the YAML grind:
 
-- **`sonda init`** -- interactive wizard, or non-interactive with flags like `--situation`
-  and `--from @builtin` ([CLI Reference](configuration/cli-reference.md#sonda-init)).
-- **[Built-in Scenarios](guides/scenarios.md)** -- run curated patterns instantly:
-  `sonda metrics --scenario @cpu-spike`.
-- **[Metric Packs](guides/metric-packs.md)** -- bundles for Telegraf SNMP and node_exporter
-  that match real-world schemas.
-- **[CSV Import](guides/csv-import.md)** -- turn existing CSV data into a portable scenario.
+- **`sonda new`** -- interactive scaffolder for a starter scenario; non-interactive with
+  `--template` or `--from <csv>` ([CLI Reference](configuration/cli-reference.md#sonda-new)).
+- **[Author your own catalog](guides/scenarios.md)** -- organize scenarios and composable
+  packs so you can reference them with `@name`.
+- **[Metric Packs](guides/metric-packs.md)** -- composable bundles for Telegraf SNMP and
+  node_exporter that match real-world schemas.
+- **[CSV Import](guides/csv-import.md)** -- turn existing CSV data into a portable scenario
+  with `sonda new --from <csv>`.
 
 Reference pages:
 
-- [**v2 Scenario Files**](configuration/v2-scenarios.md) -- file shape, defaults, `after:` chains, v1 migration
+- [**v2 Scenario Files**](configuration/v2-scenarios.md) -- file shape, defaults, `after:` chains
 - [**Scenario Fields**](configuration/scenario-fields.md) -- per-entry field reference
-- [**CLI Reference**](configuration/cli-reference.md) -- every flag for `metrics`, `logs`, `run`
+- [**CLI Reference**](configuration/cli-reference.md) -- every flag for `run`, `list`, `show`, `new`
 - [**Docker**](deployment/docker.md) -- containers and Compose
 - [**Troubleshooting**](guides/troubleshooting.md) -- common issues

--- a/docs/site/docs/guides/alert-testing-cardinality.md
+++ b/docs/site/docs/guides/alert-testing-cardinality.md
@@ -9,7 +9,7 @@ unique label values on a recurring schedule, so you can verify the alert fires d
 the spike and resolves after.
 
 ```bash
-sonda metrics --scenario examples/cardinality-alert-test.yaml
+sonda run examples/cardinality-alert-test.yaml
 ```
 
 ```yaml title="examples/cardinality-alert-test.yaml (key fields)"

--- a/docs/site/docs/guides/alert-testing-correlation.md
+++ b/docs/site/docs/guides/alert-testing-correlation.md
@@ -12,7 +12,7 @@ overlap deterministically.
 | `clock_group` | (none) | Groups scenarios under a shared timing reference |
 
 ```bash
-sonda run --scenario examples/multi-metric-correlation.yaml
+sonda run examples/multi-metric-correlation.yaml
 ```
 
 ```yaml title="examples/multi-metric-correlation.yaml (excerpt)"

--- a/docs/site/docs/guides/alert-testing-replay.md
+++ b/docs/site/docs/guides/alert-testing-replay.md
@@ -16,7 +16,7 @@ The [sequence generator](../configuration/generators.md#sequence) steps through 
 explicit list of values, perfect for short, deterministic threshold patterns:
 
 ```bash
-sonda metrics --scenario examples/sequence-alert-test.yaml
+sonda run examples/sequence-alert-test.yaml
 ```
 
 ```yaml title="examples/sequence-alert-test.yaml (key fields)"
@@ -38,7 +38,7 @@ the [Grafana CSV Replay](grafana-csv-replay.md) guide for the full export-and-re
 workflow.
 
 ```bash
-sonda metrics --scenario examples/csv-replay-metrics.yaml
+sonda run examples/csv-replay-metrics.yaml
 ```
 
 ```yaml title="examples/csv-replay-metrics.yaml (key fields)"

--- a/docs/site/docs/guides/alert-testing-resolution.md
+++ b/docs/site/docs/guides/alert-testing-resolution.md
@@ -16,7 +16,7 @@ Gaps occupy the **tail** of each cycle. With `every: 60s` and `for: 20s`, the ga
 from second 40 to second 60 of each cycle.
 
 ```bash
-sonda metrics --scenario examples/gap-alert-test.yaml
+sonda run examples/gap-alert-test.yaml
 ```
 
 ```yaml title="examples/gap-alert-test.yaml"

--- a/docs/site/docs/guides/alert-testing-thresholds.md
+++ b/docs/site/docs/guides/alert-testing-thresholds.md
@@ -19,7 +19,7 @@ about 12 seconds per 60-second cycle -- enough to trigger a bare `> 90` rule on 
 period.
 
 ```bash
-sonda metrics --scenario examples/sine-threshold-test.yaml
+sonda run examples/sine-threshold-test.yaml
 ```
 
 ```yaml title="examples/sine-threshold-test.yaml"
@@ -79,7 +79,7 @@ steps through an explicit list of values, one per tick, so you control the breac
 window down to the second:
 
 ```bash
-sonda metrics --scenario examples/for-duration-test.yaml
+sonda run examples/for-duration-test.yaml
 ```
 
 ```yaml title="examples/for-duration-test.yaml"
@@ -118,7 +118,7 @@ For sustained-breach tests longer than ~30 seconds, the
 [constant generator](../configuration/generators.md#constant) is more practical:
 
 ```bash
-sonda metrics --scenario examples/constant-threshold-test.yaml
+sonda run examples/constant-threshold-test.yaml
 ```
 
 ```yaml title="examples/constant-threshold-test.yaml"

--- a/docs/site/docs/guides/alert-testing.md
+++ b/docs/site/docs/guides/alert-testing.md
@@ -62,7 +62,7 @@ upstream Prometheus). Both land in the stack from
 docker compose -f examples/docker-compose-victoriametrics.yml up -d
 
 # Push test data
-sonda metrics --scenario examples/vm-push-scenario.yaml
+sonda run examples/vm-push-scenario.yaml
 
 # Verify the metric exists (wait ~15s for ingestion)
 curl "http://localhost:8428/api/v1/query?query=cpu_usage"

--- a/docs/site/docs/guides/alerting-pipeline.md
+++ b/docs/site/docs/guides/alerting-pipeline.md
@@ -74,35 +74,39 @@ between 0 and 100 with a 30-second period. It crosses the warning threshold (70)
 threshold (90) twice per cycle, and pushes directly to VictoriaMetrics.
 
 ```bash
-sonda metrics --scenario examples/alertmanager/alerting-scenario.yaml
+sonda run examples/alertmanager/alerting-scenario.yaml
 ```
 
 This runs for 5 minutes at 2 events/second. You'll see alerts fire within the first 30 seconds.
 
 ??? info "What the scenario looks like"
     ```yaml title="examples/alertmanager/alerting-scenario.yaml"
-    name: docker_alert_cpu
-    rate: 2
-    duration: 300s
+    version: 2
+    kind: runnable
 
-    generator:
-      type: sine
-      amplitude: 50.0
-      period_secs: 30
-      offset: 50.0
+    defaults:
+      rate: 2
+      duration: 300s
+      encoder:
+        type: prometheus_text
+      sink:
+        type: http_push
+        url: "${VICTORIAMETRICS_URL:-http://localhost:8428/api/v1/import/prometheus}"
+        content_type: "text/plain"
+      labels:
+        host: docker-alert-demo
+        region: us-east-1
+        service: payment-service
+        env: staging
 
-    labels:
-      host: docker-alert-demo
-      region: us-east-1
-      service: payment-service
-      env: staging
-
-    encoder:
-      type: prometheus_text
-    sink:
-      type: http_push
-      url: "http://localhost:8428/api/v1/import/prometheus"
-      content_type: "text/plain"
+    scenarios:
+      - signal_type: metrics
+        name: docker_alert_cpu
+        generator:
+          type: sine
+          amplitude: 50.0
+          period_secs: 30
+          offset: 50.0
     ```
 
 ---

--- a/docs/site/docs/guides/capacity-planning.md
+++ b/docs/site/docs/guides/capacity-planning.md
@@ -48,7 +48,7 @@ Before you push thousands of events per second at a backend, confirm Sonda gener
 target rate on your hardware. A 5-second stdout run is enough:
 
 ```bash
-sonda -q metrics --name throughput_test --rate 1000 --duration 5s | wc -l
+sonda -q run examples/capacity-throughput-test.yaml --rate 1000 --duration 5s | wc -l
 # ~5000 lines
 ```
 
@@ -62,7 +62,7 @@ This scenario runs 3 metric streams at 1,000 events/sec each -- 3,000 data point
 hitting VictoriaMetrics:
 
 ```bash
-sonda run --scenario examples/capacity-throughput-test.yaml
+sonda run examples/capacity-throughput-test.yaml
 ```
 
 ```yaml title="examples/capacity-throughput-test.yaml (excerpt)"
@@ -116,14 +116,13 @@ curl -s "http://localhost:8428/api/v1/query?query=throughput_memory_bytes" | jq 
 ### Scale the test up
 
 To find your saturation point, increase the rate until you see ingestion errors or data loss.
-Override rates from the CLI without editing the YAML:
+Override the rate from the CLI without editing the YAML:
 
 ```bash
-# 5,000 events/sec on a single stream
-sonda -q metrics --name throughput_test --rate 5000 --duration 30s \
-  --value-mode sine --amplitude 50 --period-secs 60 --offset 100 \
-  --label job=capacity_test --label env=load-test \
-  --output /tmp/throughput-5k.txt
+# 5,000 events/sec on a single stream — uses the throughput-test scenario above
+sonda -q run examples/capacity-throughput-test.yaml \
+  --rate 5000 --duration 30s \
+  -o /tmp/throughput-5k.txt
 
 wc -l < /tmp/throughput-5k.txt
 # ~150000 lines
@@ -167,7 +166,7 @@ This scenario pushes two metrics with overlapping cardinality spikes -- 500 uniq
 and 200 unique endpoints:
 
 ```bash
-sonda run --scenario examples/capacity-cardinality-stress.yaml
+sonda run examples/capacity-cardinality-stress.yaml
 ```
 
 ```yaml title="examples/capacity-cardinality-stress.yaml (excerpt)"
@@ -227,14 +226,41 @@ Track query latency and memory usage at each level:
 | High | 5,000 | ~5,001 | Query timeouts, ingestion backpressure |
 | Extreme | 10,000 | ~10,001 | OOM events, disk I/O saturation |
 
-You can override the cardinality from the CLI for a quick single-metric test:
+The cardinality and spike window live in the scenario YAML. For a quick single-metric
+cardinality test, scaffold a minimal scenario with `sonda new --template`, replace the
+`generator:` block with `type: constant`, add a `cardinality_spikes:` clause, and run it:
+
+```yaml title="cardinality-quick.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+  labels:
+    job: capacity_test
+    env: load-test
+scenarios:
+  - id: cardinality_test
+    signal_type: metrics
+    name: cardinality_test
+    generator:
+      type: constant
+      value: 1.0
+    cardinality_spikes:
+      - label: pod_name
+        every: 60s
+        for: 30s
+        cardinality: 5000
+        strategy: counter
+        prefix: "pod-"
+```
 
 ```bash
-sonda -q metrics --name cardinality_test --rate 50 --duration 60s \
-  --value 1 \
-  --label job=capacity_test --label env=load-test \
-  --spike-label pod_name --spike-every 60s --spike-for 30s \
-  --spike-cardinality 5000 --spike-prefix "pod-"
+sonda -q run cardinality-quick.yaml
 ```
 
 !!! info "Cardinality vs. throughput"
@@ -279,7 +305,7 @@ Rate ──►
 This scenario runs at 500 events/sec with 10x bursts (5,000/sec) every 30 seconds:
 
 ```bash
-sonda run --scenario examples/capacity-burst-test.yaml
+sonda run examples/capacity-burst-test.yaml
 ```
 
 ```yaml title="examples/capacity-burst-test.yaml (excerpt)"
@@ -461,7 +487,7 @@ BEFORE=$(curl -s "http://localhost:8428/api/v1/query?query=process_resident_memo
   | jq -r '.data.result[0].value[1]')
 
 # Run the cardinality stress test
-sonda run --scenario examples/capacity-cardinality-stress.yaml
+sonda run examples/capacity-cardinality-stress.yaml
 
 AFTER=$(curl -s "http://localhost:8428/api/v1/query?query=process_resident_memory_bytes" \
   | jq -r '.data.result[0].value[1]')
@@ -566,10 +592,10 @@ Set resource limits 2x above requests to accommodate bursts.
 | Task | Command |
 |------|---------|
 | Start backend | `docker compose -f examples/docker-compose-victoriametrics.yml up -d` |
-| Validate throughput scenario | `sonda --dry-run run --scenario examples/capacity-throughput-test.yaml` |
-| Run throughput test | `sonda run --scenario examples/capacity-throughput-test.yaml` |
-| Run cardinality stress test | `sonda run --scenario examples/capacity-cardinality-stress.yaml` |
-| Run burst test | `sonda run --scenario examples/capacity-burst-test.yaml` |
+| Validate throughput scenario | `sonda --dry-run run examples/capacity-throughput-test.yaml` |
+| Run throughput test | `sonda run examples/capacity-throughput-test.yaml` |
+| Run cardinality stress test | `sonda run examples/capacity-cardinality-stress.yaml` |
+| Run burst test | `sonda run examples/capacity-burst-test.yaml` |
 | Count series in VM | `curl -s "http://localhost:8428/api/v1/series?match[]=<metric>" \| jq '.data \| length'` |
 | Tear down | `docker compose -f examples/docker-compose-victoriametrics.yml down -v` |
 

--- a/docs/site/docs/guides/ci-alert-validation.md
+++ b/docs/site/docs/guides/ci-alert-validation.md
@@ -102,7 +102,7 @@ jobs:
 
       - name: Push metrics above critical threshold
         run: |
-          sonda -q metrics --scenario examples/ci-alert-validation.yaml
+          sonda -q run examples/ci-alert-validation.yaml
 
       - name: Wait for alert evaluation
         run: sleep 15
@@ -323,7 +323,7 @@ jobs:
           done
 
       - name: Push metrics
-        run: sonda -q metrics --scenario examples/ci-alert-validation.yaml
+        run: sonda -q run examples/ci-alert-validation.yaml
 
       - name: Wait for evaluation
         run: sleep 15
@@ -394,11 +394,11 @@ concurrently:
 
 ```bash
 # Sequential: one scenario per rule
-sonda -q metrics --scenario examples/ci-alert-validation.yaml
-sonda -q metrics --scenario examples/ci-high-memory-alert.yaml
+sonda -q run examples/ci-alert-validation.yaml
+sonda -q run examples/ci-high-memory-alert.yaml
 
 # Concurrent: all rules in one file
-sonda -q run --scenario examples/ci-all-alerts.yaml
+sonda -q run examples/ci-all-alerts.yaml
 ```
 
 ??? tip "Organizing scenarios by rule group"

--- a/docs/site/docs/guides/csv-import.md
+++ b/docs/site/docs/guides/csv-import.md
@@ -7,73 +7,46 @@ do, raw replay locks them to the original timestamps and the original rate.
 
 What you actually want is the *shape* of that incident as a reusable scenario:
 "a CPU spike like the one from the May 14 outage" parameterized on rate and duration,
-checked into the repo next to the alert rules. `sonda import` does that conversion in
-one step. It scans each column, classifies the pattern (steady, spike, leak, sawtooth,
-flap, step), and emits a v2 scenario YAML wired to a generator with the right knobs.
+checked into the repo next to the alert rules. `sonda new --from <csv>` does that
+conversion in one step. It scans each column, classifies the pattern (steady, spike,
+leak, sawtooth, flap, step), and emits a v2 scenario YAML wired to a generator with
+the right knobs.
 
 ---
 
 ## Why import instead of replay?
 
-The [csv_replay](grafana-csv-replay.md) generator plays back raw CSV values verbatim. It preserves the original sample interval automatically (the replay rate is derived from the CSV timestamps, not from `rate:`) and supports labels-only Grafana exports via `default_metric_name:`. Use it when you need bit-for-bit fidelity tied to a specific file.
+The [csv_replay](grafana-csv-replay.md) generator plays back raw CSV values verbatim. It
+preserves the original sample interval automatically (the replay rate is derived from the CSV
+timestamps, not from `rate:`) and supports labels-only Grafana exports via
+`default_metric_name:`. Use it when you need bit-for-bit fidelity tied to a specific file.
 
-`sonda import` takes a different approach:
+`sonda new --from <csv>` takes a different approach:
 
-- **Portable** -- the generated YAML uses generators (`steady`, `spike_event`, `leak`, `flap`, `sawtooth`, `step`), so it runs without the original CSV file.
+- **Portable** -- the generated YAML uses generators (`steady`, `spike_event`, `leak`, `flap`,
+  `sawtooth`, `step`), so it runs without the original CSV file.
 - **Parameterized** -- you can tune rate, duration, and generator parameters after import.
 - **Shareable** -- the YAML is self-contained. Drop it into a repo, CI pipeline, or Helm chart.
 
-Use `csv_replay` when you need bit-for-bit fidelity. Use `sonda import` when you need the *shape* of the data as a reusable scenario that does not depend on the original CSV.
+Use `csv_replay` when you need bit-for-bit fidelity. Use `sonda new --from <csv>` when you
+need the *shape* of the data as a reusable scenario that does not depend on the original CSV.
 
 ---
 
 ## The workflow
 
-`sonda import` has three modes that form a natural pipeline:
+`sonda new --from <csv>` writes a v2 scenario YAML to stdout (or to a file with `-o`). Run the
+result with `sonda run` once you are happy with it:
 
+```text
+CSV file  -->  sonda new --from data.csv  -->  scenario.yaml  -->  sonda run
+              (pattern detection)             (tunable knobs)
 ```
-CSV file  -->  --analyze  -->  -o scenario.yaml  -->  --run
-              (understand)       (generate)          (execute)
-```
 
-### Step 1: Analyze
-
-Start by understanding what the data looks like. `--analyze` is read-only -- it prints
-detected patterns without generating any files.
+### Generate a scenario
 
 ```bash
-sonda import examples/sample-multi-column.csv --analyze
-```
-
-```text title="Output"
-CSV Import Analysis
-============================================================
-
-Column 1 (index 1): cpu_percent
-  Data points: 20
-  Range: [12.30, 96.10]  Mean: 46.27
-  Detected pattern: steady (center=46.27, amplitude=41.90)
-
-Column 2 (index 2): mem_percent
-  Data points: 20
-  Range: [45.20, 86.20]  Mean: 59.88
-  Detected pattern: steady (center=59.88, amplitude=20.50)
-
-Column 3 (index 3): disk_io_mbps
-  Data points: 20
-  Range: [5.00, 65.80]  Mean: 25.04
-  Detected pattern: steady (center=25.04, amplitude=30.40)
-```
-
-Each column shows the metric name (from the header), basic statistics, and the detected
-pattern with extracted parameters.
-
-### Step 2: Generate
-
-Once you know the patterns look right, generate a scenario YAML file:
-
-```bash
-sonda import examples/sample-multi-column.csv -o scenario.yaml
+sonda new --from examples/sample-multi-column.csv -o scenario.yaml
 ```
 
 ```text title="stderr"
@@ -81,10 +54,11 @@ wrote scenario to scenario.yaml
 ```
 
 The generated file is a valid [v2 scenario YAML](../configuration/v2-scenarios.md), ready for
-`sonda run --scenario`:
+`sonda run`:
 
-```yaml title="scenario.yaml (generated)"
+```yaml title="scenario.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -116,18 +90,30 @@ scenarios:
   # ... (one entry per column)
 ```
 
+Each numeric column in the CSV gets its own `scenarios:` entry. The generator alias is chosen
+by pattern detection, so you can edit the output and tune the parameters rather than starting
+from a blank file.
+
 !!! info "Output is always v2"
-    `sonda import` emits v2 YAML regardless of column count. Single-column CSVs produce a
-    one-entry `scenarios:` list; multi-column CSVs produce one entry per column. Shared
-    `rate`, `duration`, `encoder`, and `sink` live in `defaults:`.
+    `sonda new --from <csv>` emits v2 YAML regardless of column count. Single-column CSVs
+    produce a one-entry `scenarios:` list; multi-column CSVs produce one entry per column.
+    Shared `rate`, `duration`, `encoder`, and `sink` live in `defaults:`.
 
-### Step 3: Run
+### Preview to stdout
 
-If you just want to see the output without saving a file, `--run` generates the scenario in
-memory and executes it immediately:
+Omit `-o` to print the generated YAML to stdout without writing a file — useful for quick
+inspection or piping into other tools:
 
 ```bash
-sonda -q import examples/sample-cpu-values.csv --run --duration 3s
+sonda new --from examples/sample-cpu-values.csv
+```
+
+### Run the result
+
+Once the YAML looks right, run it like any other scenario:
+
+```bash
+sonda -q run scenario.yaml --duration 3s
 ```
 
 ```text title="Output"
@@ -141,38 +127,18 @@ cpu_percent 55.42337922089686 1775712697333
 
 ## Grafana CSV exports
 
-`sonda import` understands Grafana's "Series joined by time" CSV format. It parses the
-`{__name__="...", key="value"}` headers to extract metric names and labels automatically.
+`sonda new --from <csv>` understands Grafana's "Series joined by time" CSV format. It parses
+the `{__name__="...", key="value"}` headers to extract metric names and labels automatically.
 
 ```bash
-sonda import examples/grafana-export.csv --analyze
-```
-
-```text title="Output"
-CSV Import Analysis
-============================================================
-
-Column 1 (index 1): up
-  Labels: {instance="localhost:9090", job="prometheus"}
-  Data points: 10
-  Range: [0.00, 1.00]  Mean: 0.80
-  Detected pattern: sawtooth (min=0.00, max=1.00, period=4pts)
-
-Column 2 (index 2): up
-  Labels: {instance="localhost:9100", job="node"}
-  Data points: 10
-  Range: [0.00, 1.00]  Mean: 0.80
-  Detected pattern: sawtooth (min=0.00, max=1.00, period=6pts)
+sonda new --from examples/grafana-export.csv -o grafana-scenario.yaml
 ```
 
 Labels are preserved in the generated YAML:
 
-```bash
-sonda import examples/grafana-export.csv -o grafana-scenario.yaml
-```
-
-```yaml title="grafana-scenario.yaml (generated, first entry)"
+```yaml title="grafana-scenario.yaml (first entry)"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -201,34 +167,6 @@ For details on exporting from Grafana, see the
 
 ---
 
-## Selecting columns
-
-By default, all non-timestamp columns are imported. Use `--columns` to pick specific ones
-by their zero-based index:
-
-```bash
-sonda import examples/sample-multi-column.csv --columns 1,3 --analyze
-```
-
-```text title="Output"
-CSV Import Analysis
-============================================================
-
-Column 1 (index 1): cpu_percent
-  Data points: 20
-  Range: [12.30, 96.10]  Mean: 46.27
-  Detected pattern: steady (center=46.27, amplitude=41.90)
-
-Column 2 (index 3): disk_io_mbps
-  Data points: 20
-  Range: [5.00, 65.80]  Mean: 25.04
-  Detected pattern: steady (center=25.04, amplitude=30.40)
-```
-
-Column 0 is always the timestamp and cannot be selected for import.
-
----
-
 ## Detected patterns
 
 The pattern detector uses statistical analysis to classify each column into one of six
@@ -248,9 +186,9 @@ The detector runs through these in priority order. When the data does not clearl
 more specific pattern, it falls back to **steady**.
 
 !!! info "Pattern detection is heuristic"
-    The detector uses statistical thresholds (linear regression, IQR outlier detection, k-means
-    clustering) to classify patterns. With very short time series (fewer than 10 data points),
-    detection accuracy decreases. For best results, export at least 20-30 data points.
+    The detector uses statistical thresholds (linear regression, IQR outlier detection,
+    k-means clustering) to classify patterns. With very short time series (fewer than 10 data
+    points), detection accuracy decreases. For best results, export at least 20-30 data points.
 
 ---
 
@@ -261,10 +199,10 @@ The generated YAML is a starting point. After import, you can:
 - **Change the sink** -- replace `stdout` with `remote_write`, `loki`, or any other sink.
 - **Adjust parameters** -- tune `amplitude`, `period`, or `baseline` to match your needs.
 - **Add scheduling** -- add `gaps:`, `bursts:`, or `cardinality_spike:` blocks.
-- **Override rate and duration** at generation time:
+- **Override rate and duration at run time:**
 
 ```bash
-sonda import data.csv -o scenario.yaml --rate 10 --duration 5m
+sonda run scenario.yaml --rate 10 --duration 5m
 ```
 
 ---
@@ -272,28 +210,26 @@ sonda import data.csv -o scenario.yaml --rate 10 --duration 5m
 ## CLI reference
 
 ```
-sonda import <FILE> [OPTIONS]
+sonda new [--template] [--from <CSV>] [-o <PATH>]
 ```
 
-| Argument / Flag | Type | Default | Description |
-|-----------------|------|---------|-------------|
-| `<FILE>` | path | -- | CSV file to import. Supports Grafana exports and plain CSV. |
-| `--analyze` | flag | -- | Print detected patterns (read-only). Conflicts with `-o` and `--run`. |
-| `-o, --output <FILE>` | path | -- | Write generated scenario YAML to this path. Conflicts with `--analyze` and `--run`. |
-| `--run` | flag | -- | Generate and immediately execute the scenario. Conflicts with `--analyze` and `-o`. |
-| `--columns <INDICES>` | string | all | Comma-separated column indices (e.g., `1,3,5`). Column 0 is the timestamp. |
-| `--rate <RATE>` | float | `1.0` | Events per second in the generated scenario. |
-| `--duration <DURATION>` | string | `60s` | Duration of the generated scenario (e.g., `60s`, `5m`). |
+| Flag | Description |
+|------|-------------|
+| (no flags) | Interactive flow. Walks through signal type → generator → rate → duration → sink type → output path. |
+| `--template` | Print a minimal valid YAML to stdout and exit. No prompts. |
+| `--from <CSV>` | Seed the scaffold from a CSV file. Runs pattern detection on each numeric column. |
+| `-o <PATH>` | Write the result to a file instead of stdout. |
 
-Exactly one of `--analyze`, `-o`, or `--run` must be specified.
-
-!!! tip "Combine with global flags"
-    `--dry-run`, `--verbose`, and `--quiet` work with `sonda import --run`, just like any
-    other subcommand. Use `sonda --dry-run import data.csv --run` to see the resolved config
-    without emitting events.
+See [CLI Reference: sonda new](../configuration/cli-reference.md#sonda-new) for the full
+reference.
 
 ---
 
 ## Replaying log streams from CSV
 
-`sonda import` is scoped to metric series. If your CSV is a structured log export -- for example a `timestamp,severity,message,trace_id` dump from Loki via `logcli` -- use the `log_csv_replay` generator instead. It replays each row as a `LogEvent`, derives the emission rate from the timestamp column the same way `csv_replay` does for metrics, and routes free-form columns into `LogEvent::fields`. See the [Log CSV Replay](log-csv-replay.md) guide for the end-to-end workflow.
+`sonda new --from <csv>` is scoped to metric series. If your CSV is a structured log export
+-- for example a `timestamp,severity,message,trace_id` dump from Loki via `logcli` -- use the
+`log_csv_replay` generator instead. It replays each row as a `LogEvent`, derives the emission
+rate from the timestamp column the same way `csv_replay` does for metrics, and routes
+free-form columns into `LogEvent::fields`. See the [Log CSV Replay](log-csv-replay.md) guide
+for the end-to-end workflow.

--- a/docs/site/docs/guides/dynamic-labels.md
+++ b/docs/site/docs/guides/dynamic-labels.md
@@ -125,7 +125,7 @@ scenarios:
 Run it:
 
 ```bash
-sonda metrics --scenario examples/dynamic-labels-fleet.yaml
+sonda run examples/dynamic-labels-fleet.yaml
 ```
 
 ```text title="Output (abridged)"
@@ -220,8 +220,8 @@ for testing Loki label indexing or pod-level log aggregation panels.
 Run any of them:
 
 ```bash
-sonda metrics --scenario examples/dynamic-labels-fleet.yaml
-sonda logs --scenario examples/dynamic-labels-logs.yaml
+sonda run examples/dynamic-labels-fleet.yaml
+sonda run examples/dynamic-labels-logs.yaml
 ```
 
 ## Interaction with other fields

--- a/docs/site/docs/guides/e2e-testing.md
+++ b/docs/site/docs/guides/e2e-testing.md
@@ -13,7 +13,7 @@ Every e2e check is the same three steps. The encoder, sink, and backend change; 
 shape does not.
 
 1. **Start the backend** — `docker compose up -d` against an `examples/docker-compose-*.yml` stack.
-2. **Push a known value** — `sonda <signal> --scenario examples/<scenario>.yaml` with a unique metric or log name.
+2. **Push a known value** — `sonda run examples/<scenario>.yaml` with a unique metric or log name.
 3. **Query the backend** — `curl ... | jq ...` and assert the value arrived.
 
 This is the heavier sibling of the [Pipeline Validation](pipeline-validation.md) smoke
@@ -39,7 +39,7 @@ docker compose -f examples/docker-compose-victoriametrics.yml up -d
 ```
 
 ```bash title="Push a known value"
-sonda metrics --scenario examples/e2e-scenario.yaml
+sonda run examples/e2e-scenario.yaml
 ```
 
 ```yaml title="examples/e2e-scenario.yaml"
@@ -155,7 +155,7 @@ Grafana with a pre-provisioned VictoriaMetrics datasource:
 
 ```bash
 docker compose -f examples/docker-compose-victoriametrics.yml up -d
-sonda metrics --scenario examples/vm-push-scenario.yaml
+sonda run examples/vm-push-scenario.yaml
 open http://localhost:3000
 ```
 

--- a/docs/site/docs/guides/examples.md
+++ b/docs/site/docs/guides/examples.md
@@ -4,7 +4,7 @@ The `examples/` directory contains ready-to-run YAML scenario files covering eve
 generator, encoder, and sink combination. Each file works as-is with the `sonda` CLI.
 
 ```bash
-sonda metrics --scenario examples/basic-metrics.yaml
+sonda run examples/basic-metrics.yaml
 ```
 
 ## Basic Metrics
@@ -37,7 +37,7 @@ See [Sinks](../configuration/sinks.md) for configuration details on each sink ty
 | `otlp-metrics.yaml` | metrics | otlp | otlp_grpc | Push sine wave metrics to an OTEL Collector via gRPC* |
 | `otlp-logs.yaml` | logs | otlp | otlp_grpc | Push template logs to an OTEL Collector via gRPC* |
 
-*Requires building from source with `--features otlp`. Pre-built binaries do not include OTLP support. Run with: `cargo run --features otlp -- metrics --scenario examples/otlp-metrics.yaml`
+*Requires building from source with `--features otlp`. Pre-built binaries do not include OTLP support. Run with: `cargo run --features otlp -- run examples/otlp-metrics.yaml`
 
 ## Encoding Formats
 
@@ -67,11 +67,11 @@ See [Sinks](../configuration/sinks.md) for configuration details on each sink ty
 | `histogram.yaml` | histogram | prometheus_text | stdout | Exponential distribution, 100 observations/tick (latency-style histogram) |
 | `summary.yaml` | summary | prometheus_text | stdout | Normal distribution (mean 0.1, stddev 0.02), 100 observations/tick |
 
-Run these with the matching subcommand:
+Run them with `sonda run` — histograms and summaries are just `signal_type:` variants in the v2 YAML:
 
 ```bash
-sonda histogram --scenario examples/histogram.yaml
-sonda summary --scenario examples/summary.yaml
+sonda run examples/histogram.yaml
+sonda run examples/summary.yaml
 ```
 
 See [Generators](../configuration/generators.md) for distribution options.
@@ -83,8 +83,7 @@ See [Generators](../configuration/generators.md) for distribution options.
 | `pack-scenario.yaml` | telegraf_snmp_interface | prometheus_text | stdout | Expand a pack into per-metric scenarios with user-supplied labels |
 | `pack-with-overrides.yaml` | telegraf_snmp_interface | prometheus_text | stdout | Override one metric's generator (`ifOperStatus` -> `flap`) without editing the pack |
 
-Packs must be on the search path. Run from the repo root (where `./packs/` exists), set
-`SONDA_PACK_PATH`, or pass `--pack-path ./packs`. See [Metric Packs](metric-packs.md) for details.
+Packs are `kind: composable` YAML files in a catalog directory you control. Point `sonda run` at that directory with `--catalog <dir>` so `pack: <name>` references resolve. See [Metric Packs](metric-packs.md) for the catalog layout.
 
 ## Dynamic Labels
 
@@ -123,10 +122,10 @@ See the [Capacity Planning](capacity-planning.md) guide for measurement methodol
 | `loki-json-lines.yaml` | template | json_lines | loki | Push log events to a Loki instance |
 | `kafka-json-logs.yaml` | template | json_lines | kafka | Send log events to a Kafka topic |
 
-Run log scenarios with `sonda logs`:
+Run log scenarios with `sonda run` — log entries are just `signal_type: logs` in the v2 YAML:
 
 ```bash
-sonda logs --scenario examples/log-template.yaml
+sonda run examples/log-template.yaml
 ```
 
 ## Docker and VictoriaMetrics
@@ -196,22 +195,15 @@ See [Pipeline Validation](pipeline-validation.md) for usage patterns.
 |------|--------|-------------|
 | `network-device-baseline.yaml` | metrics | Router with 2 uplinks: traffic counters, state, CPU, memory (9 scenarios) |
 | `network-link-failure.yaml` | metrics | 6-scenario link-failure cycle on `rtr-core-01`: Gi0/0/0 down 10s, Gi0/0/1 absorbs, errors + CPU spike, then recovers |
-| `scenarios/link-failover.yaml` | multi | Edge router link failover: primary flaps, backup saturates, latency degrades (3-signal `after:` chain) |
 
 Run with `sonda run`:
 
 ```bash
-sonda run --scenario examples/network-device-baseline.yaml
-sonda run --scenario scenarios/link-failover.yaml
+sonda run examples/network-device-baseline.yaml
+sonda run examples/network-link-failure.yaml
 ```
 
-The `link-failover` scenario also ships in the built-in catalog:
-
-```bash
-sonda catalog run link-failover
-```
-
-See [Network Device Telemetry](network-device-telemetry.md) for the full walkthrough.
+See [Network Device Telemetry](network-device-telemetry.md) for the full walkthrough, including a 3-signal cascade using `after:` that you can author from scratch.
 
 ## Multi-Scenario
 
@@ -224,9 +216,9 @@ See [Network Device Telemetry](network-device-telemetry.md) for the full walkthr
 Run multi-scenario files with `sonda run`:
 
 ```bash
-sonda run --scenario examples/multi-scenario.yaml
+sonda run examples/multi-scenario.yaml
 ```
 
 !!! tip
     Override any scenario field from the CLI. For example, change the duration:
-    `sonda metrics --scenario examples/basic-metrics.yaml --duration 10s`
+    `sonda run examples/basic-metrics.yaml --duration 10s`

--- a/docs/site/docs/guides/grafana-csv-replay.md
+++ b/docs/site/docs/guides/grafana-csv-replay.md
@@ -121,7 +121,7 @@ scenarios:
 ```
 
 ```bash
-sonda metrics --scenario examples/csv-replay-grafana-auto.yaml
+sonda run examples/csv-replay-grafana-auto.yaml
 ```
 
 ```text title="Output"
@@ -190,7 +190,7 @@ scenarios:
 ```
 
 ```bash
-sonda metrics --scenario examples/csv-replay-explicit-labels.yaml
+sonda run examples/csv-replay-explicit-labels.yaml
 ```
 
 ```text title="Output"
@@ -289,7 +289,7 @@ For the full CSV replay parameter reference, see [Generators: csv_replay](../con
 !!! tip "Want portable scenarios instead of raw replay?"
     `csv_replay` plays back exact values from the file. If you want to extract the *pattern*
     from the data and generate a self-contained scenario YAML that does not depend on the
-    original file, use [sonda import](csv-import.md) instead.
+    original file, use [`sonda new --from`](csv-import.md) instead.
 
 !!! tip "Replaying logs instead of metrics?"
     The same workflow works for log events with `log_csv_replay`. Export the window from Loki via `logcli`, run it through `jq` to produce a `timestamp,severity,message,...fields` CSV, and point a logs scenario at the file. The rate-derivation, `timescale`, and override-warn semantics described above apply identically. Walkthrough: [Log CSV Replay](log-csv-replay.md).

--- a/docs/site/docs/guides/histogram-alerts.md
+++ b/docs/site/docs/guides/histogram-alerts.md
@@ -129,7 +129,7 @@ scenarios:
 Run it:
 
 ```bash
-sonda histogram --scenario examples/histogram.yaml
+sonda run examples/histogram.yaml
 ```
 
 ```text title="Output (first tick)"
@@ -211,7 +211,7 @@ scenarios:
 ```
 
 ```bash
-sonda histogram --scenario histogram-degradation.yaml
+sonda run histogram-degradation.yaml
 ```
 
 As Sonda runs, the distribution center drifts higher. After about 40 seconds, most observations
@@ -276,7 +276,7 @@ scenarios:
 ```
 
 ```bash
-sonda summary --scenario examples/summary.yaml
+sonda run examples/summary.yaml
 ```
 
 ```text title="Output (first tick)"

--- a/docs/site/docs/guides/log-csv-replay.md
+++ b/docs/site/docs/guides/log-csv-replay.md
@@ -62,7 +62,7 @@ scenarios:
 ```
 
 ```bash
-sonda -q logs --scenario examples/log-csv-replay.yaml --duration 11s
+sonda -q run examples/log-csv-replay.yaml --duration 11s
 ```
 
 ```text title="Output (first three events)"
@@ -180,7 +180,7 @@ scenarios:
 ```
 
 ```bash
-sonda logs --scenario loki-replay.yaml
+sonda run loki-replay.yaml
 ```
 
 Sonda derives the replay rate from the timestamps in `incident.csv` -- a 10-minute window plays back over 10 minutes -- and ships each event to Loki tagged with `source="replay"`, so you can query the originals and the replay side-by-side.

--- a/docs/site/docs/guides/metric-packs.md
+++ b/docs/site/docs/guides/metric-packs.md
@@ -1,220 +1,52 @@
 # Metric Packs
 
-Metric packs are reusable bundles of metric names and label schemas for specific domains. Instead
-of writing YAML for every individual metric, you reference a pack and get all the right metrics
-pre-filled -- with correct names, labels, and generators that match real-world tooling.
+A metric pack is a reusable bundle of metric names and label schemas, expressed as a
+`kind: composable` v2 YAML file in your [catalog](scenarios.md). Reference a pack from any
+runnable scenario with `pack: <name>` and Sonda expands it into one entry per metric —
+exact names, correct shared labels, and sensible default generators per metric.
 
-Sonda ships with 3 packs covering common observability targets: Telegraf SNMP interface
-metrics, Prometheus node_exporter CPU counters, and node_exporter memory gauges. Pack YAML files
-live in the `packs/` directory and are discovered from the filesystem at runtime.
+Sonda no longer ships any built-in packs; you author your own and check them into a catalog
+directory alongside your scenarios.
 
 ## Why metric packs
 
 When you test dashboards or alert rules, the metric names and label keys matter as much as the
-values. A Grafana dashboard that queries `ifHCInOctets{device="...",ifName="..."}` breaks if the
-metric is called `interface_in_octets` or the label key is `interface` instead of `ifName`.
+values. A Grafana dashboard that queries `ifHCInOctets{device="...",ifName="..."}` breaks if
+the metric is called `interface_in_octets` or the label key is `interface` instead of `ifName`.
 
-Packs solve this by encoding the exact schema your tooling expects. You provide the instance-specific
-labels (which device, which interface), and the pack fills in the metric names, shared labels,
-and default generators.
+Packs solve this by encoding the exact schema your tooling expects. You provide the
+instance-specific labels (which device, which interface), and the pack fills in the metric
+names, shared labels, and default generators.
 
-## Pack search path
+## Browse packs in the catalog
 
-Sonda discovers pack YAML files from the filesystem via a search path:
-
-1. **`--pack-path <dir>`** CLI flag -- when present, only this directory is searched.
-2. **`SONDA_PACK_PATH`** env var -- colon-separated list of directories.
-3. **`./packs/`** relative to the current working directory.
-4. **`~/.sonda/packs/`** in the user's home directory.
-
-Non-existent directories are silently skipped. If the same pack name appears in multiple
-directories, the first match wins (highest-priority path).
-
-When running from the repo root, the included `packs/` directory is found automatically.
-For Docker, the `SONDA_PACK_PATH` env var is set to `/packs` in the image.
-
-## Browse the catalog
-
-List every available pack with `sonda catalog list --type pack`:
+Packs live alongside scenarios in the catalog directory. Filter the listing to just packs with
+`--kind composable`:
 
 ```bash
-sonda catalog list --type pack
+sonda --catalog ~/sonda-catalog list --kind composable
 ```
 
 ```text title="Output"
-NAME                             TYPE       CATEGORY         SIGNAL     RUNNABLE   DESCRIPTION
-node_exporter_memory             pack       infrastructure   metrics    no         Memory gauge metrics (node_exporter-compatible)
-telegraf_snmp_interface          pack       network          metrics    no         Standard SNMP interface metrics (Telegraf-normalized)
-node_exporter_cpu                pack       infrastructure   metrics    no         Per-CPU mode counters (node_exporter-compatible)
-3 entries
+KIND        NAME                       TAGS                    DESCRIPTION
+composable  telegraf_snmp_interface    network,snmp            Standard SNMP interface metrics (Telegraf-normalized)
+composable  node_exporter_cpu          infrastructure,cpu      Per-CPU mode counters (node_exporter-compatible)
+composable  node_exporter_memory       infrastructure,memory   Memory gauge metrics (node_exporter-compatible)
 ```
 
-Packs are marked `RUNNABLE: no` -- they need instance-specific labels before they emit anything
-useful, so a bare `catalog run <pack>` without `--label` flags will produce generic output.
+`sonda list` shows packs as `kind: composable`. They are not directly runnable — you reference
+them from a `kind: runnable` entry via `pack: <name>` and supply instance-specific labels.
 
-Filter by category:
-
-```bash
-sonda catalog list --type pack --category infrastructure
-```
-
-For machine-readable output, add `--json` to get the same
-[stable DTO](../configuration/cli-reference.md#json-output) that scenarios use.
-
-## Run a pack
-
-Pick any pack and run it directly with `sonda catalog run`. You must provide `--rate` and
-typically `--duration`, plus any labels your scenario needs:
-
-```bash
-sonda catalog run telegraf_snmp_interface \
-  --rate 1 --duration 10s \
-  --label device=rtr-edge-01 \
-  --label ifName=GigabitEthernet0/0/0 \
-  --label ifIndex=1
-```
-
-Sonda expands the pack into 5 concurrent metric scenarios -- one per metric in the pack -- and
-runs them all with the same rate, duration, labels, and sink:
-
-```text title="Output (stdout, interleaved)"
-ifOperStatus{device="rtr-edge-01",ifAlias="",ifIndex="1",ifName="GigabitEthernet0/0/0",job="snmp"} 1 1775684637116
-ifHCInOctets{device="rtr-edge-01",ifAlias="",ifIndex="1",ifName="GigabitEthernet0/0/0",job="snmp"} 0 1775684637116
-ifHCInOctets{device="rtr-edge-01",ifAlias="",ifIndex="1",ifName="GigabitEthernet0/0/0",job="snmp"} 125000 1775684638121
-ifHCOutOctets{device="rtr-edge-01",ifAlias="",ifIndex="1",ifName="GigabitEthernet0/0/0",job="snmp"} 0 1775684637116
-ifInErrors{device="rtr-edge-01",ifAlias="",ifIndex="1",ifName="GigabitEthernet0/0/0",job="snmp"} 0 1775684637116
-ifOutErrors{device="rtr-edge-01",ifAlias="",ifIndex="1",ifName="GigabitEthernet0/0/0",job="snmp"} 0 1775684637116
-...
-```
-
-Override the encoder or sink:
-
-```bash
-sonda catalog run node_exporter_memory \
-  --rate 1 --duration 30s \
-  --label instance=web-01 \
-  --encoder json_lines
-
-sonda catalog run telegraf_snmp_interface \
-  --rate 1 --duration 60s \
-  --label device=rtr-core-01 \
-  --label ifName=Ethernet1 \
-  --label ifIndex=1 \
-  --sink remote_write --endpoint http://localhost:8428/api/v1/write
-```
-
-Capture the expanded output to a file with `-o` (shorthand for `--sink file --endpoint <path>`).
-Every metric in the pack writes to the same file:
-
-```bash
-sonda catalog run telegraf_snmp_interface \
-  --rate 1 --duration 10s \
-  --label device=rtr-edge-01 \
-  --label ifName=Gi0/0/0 \
-  --label ifIndex=1 \
-  -o /tmp/snmp.prom
-```
-
-Use `--dry-run` to see the expanded config without emitting data:
-
-```bash
-sonda --dry-run catalog run telegraf_snmp_interface \
-  --rate 1 --duration 10s \
-  --label device=rtr-edge-01 \
-  --label ifName=Gi0/0/0 \
-  --label ifIndex=1
-```
-
-```text title="Output"
-[config] [1/5] ifOperStatus
-
-  name:          ifOperStatus
-  signal:        metrics
-  rate:          1/s
-  duration:      10s
-  generator:     constant (value: 1)
-  encoder:       prometheus_text
-  sink:          stdout
-  labels:        device=rtr-edge-01, ifAlias=, ifIndex=1, ifName=Gi0/0/0, job=snmp
-
-───
-[config] [2/5] ifHCInOctets
-
-  name:          ifHCInOctets
-  signal:        metrics
-  rate:          1/s
-  duration:      10s
-  generator:     step (start: 0, step: 125000)
-  encoder:       prometheus_text
-  sink:          stdout
-  labels:        device=rtr-edge-01, ifAlias=, ifIndex=1, ifName=Gi0/0/0, job=snmp
-
-...
-
-Validation: OK (5 scenarios)
-```
-
-## Inspect a pack
-
-View the raw YAML for any built-in pack:
-
-```bash
-sonda catalog show telegraf_snmp_interface
-```
-
-```yaml title="Output"
-name: telegraf_snmp_interface
-description: "Standard SNMP interface metrics (Telegraf-normalized)"
-category: network
-
-shared_labels:
-  device: ""
-  ifName: ""
-  ifAlias: ""
-  ifIndex: ""
-  job: snmp
-
-metrics:
-  - name: ifOperStatus
-    generator:
-      type: constant
-      value: 1.0
-
-  - name: ifHCInOctets
-    generator:
-      type: step
-      start: 0.0
-      step_size: 125000.0
-
-  - name: ifHCOutOctets
-    generator:
-      type: step
-      start: 0.0
-      step_size: 62500.0
-
-  - name: ifInErrors
-    generator:
-      type: constant
-      value: 0.0
-
-  - name: ifOutErrors
-    generator:
-      type: constant
-      value: 0.0
-```
-
-Save a pack to a file to use as a starting point for a custom pack:
-
-```bash
-sonda catalog show telegraf_snmp_interface > my-snmp-pack.yaml
-```
+For machine-readable output, add `--json` to get the same stable DTO that scenarios use.
 
 ## Use packs in YAML scenario files
 
-For repeatable setups, reference a pack in a YAML file and pass it to `sonda run`:
+The canonical pattern: a `kind: runnable` scenario references a pack inline, and the labels you
+set on the entry apply to every expanded metric.
 
-```yaml title="pack-scenario.yaml"
+```yaml title="snmp-edge.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -235,21 +67,65 @@ scenarios:
 ```
 
 ```bash
-sonda run --scenario pack-scenario.yaml
+sonda --catalog ~/sonda-catalog run snmp-edge.yaml
 ```
 
-The `pack:` field tells Sonda to expand the referenced pack before running. The result is
-identical to running `sonda catalog run` with the same parameters. For a v2 file, set the pack
-inline on a `scenarios:` entry -- see
-[v2 Scenario Files -- Pack-backed entries](../configuration/v2-scenarios.md#pack-backed-entries).
+Sonda expands the pack into five concurrent metric scenarios — one per metric in the pack —
+and runs them all with the same rate, duration, labels, and sink:
+
+```text title="Output (stdout, interleaved)"
+ifOperStatus{device="rtr-edge-01",ifAlias="",ifIndex="1",ifName="GigabitEthernet0/0/0",job="snmp"} 1 1775684637116
+ifHCInOctets{device="rtr-edge-01",ifAlias="",ifIndex="1",ifName="GigabitEthernet0/0/0",job="snmp"} 0 1775684637116
+ifHCInOctets{device="rtr-edge-01",ifAlias="",ifIndex="1",ifName="GigabitEthernet0/0/0",job="snmp"} 125000 1775684638121
+ifHCOutOctets{device="rtr-edge-01",ifAlias="",ifIndex="1",ifName="GigabitEthernet0/0/0",job="snmp"} 0 1775684637116
+ifInErrors{device="rtr-edge-01",ifAlias="",ifIndex="1",ifName="GigabitEthernet0/0/0",job="snmp"} 0 1775684637116
+ifOutErrors{device="rtr-edge-01",ifAlias="",ifIndex="1",ifName="GigabitEthernet0/0/0",job="snmp"} 0 1775684637116
+...
+```
+
+The `pack: <name>` lookup requires `--catalog <dir>` on `sonda run`. To reference a pack file
+by path instead (handy for ad-hoc one-offs), set `pack: ./my-pack.yaml` (anything containing
+`/` or starting with `.`).
+
+Use `--dry-run` to see the expanded config without emitting data:
+
+```bash
+sonda --catalog ~/sonda-catalog --dry-run run snmp-edge.yaml
+```
+
+```text title="Output (abridged)"
+[config] [1/5] ifOperStatus
+  name:          ifOperStatus
+  signal:        metrics
+  rate:          1/s
+  duration:      10s
+  generator:     constant (value: 1)
+  encoder:       prometheus_text
+  sink:          stdout
+  labels:        device=rtr-edge-01, ifAlias=, ifIndex=1, ifName=GigabitEthernet0/0/0, job=snmp
+
+[config] [2/5] ifHCInOctets
+  name:          ifHCInOctets
+  signal:        metrics
+  rate:          1/s
+  duration:      10s
+  generator:     step (start: 0, step: 125000)
+  encoder:       prometheus_text
+  sink:          stdout
+  labels:        device=rtr-edge-01, ifAlias=, ifIndex=1, ifName=GigabitEthernet0/0/0, job=snmp
+...
+
+Validation: OK (5 scenarios)
+```
 
 ### Per-metric overrides
 
 Sometimes you need a different generator for one metric without changing the rest of the pack.
 The `overrides` map lets you replace the generator or add extra labels per metric:
 
-```yaml title="pack-with-overrides.yaml"
+```yaml title="snmp-with-overrides.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -274,7 +150,8 @@ scenarios:
 ```
 
 In this example, `ifOperStatus` uses the [`flap`](../configuration/generators.md#operational-aliases)
-alias to simulate an interface toggling up and down, while all other metrics keep their pack defaults.
+alias to simulate an interface toggling up and down, while all other metrics keep their pack
+defaults.
 
 You can override any metric by name. Each override accepts:
 
@@ -284,8 +161,8 @@ You can override any metric by name. Each override accepts:
 | `labels` | map | Additional labels merged on top of all other label sources for this metric. |
 
 !!! warning "Override key must match a metric name"
-    If an override key does not match any metric in the pack, Sonda returns an error. This catches
-    typos early. Use `sonda catalog show <name>` to check metric names.
+    If an override key does not match any metric in the pack, Sonda returns an error. This
+    catches typos early. Use `sonda show <pack-name> --catalog <dir>` to check metric names.
 
 ### Label merge order
 
@@ -293,153 +170,58 @@ Labels are merged in this order, with later sources winning on key conflicts:
 
 1. Pack `shared_labels` (e.g. `job: snmp`)
 2. Per-metric `labels` in the pack definition (e.g. `mode: user` on `node_cpu_seconds_total`)
-3. Your `labels` in the scenario file or `--label` on the CLI
+3. Your `labels` in the scenario file
 4. Per-metric override `labels` (if any)
 
-## Built-in pack reference
+## Author a pack
 
-### telegraf_snmp_interface
+A pack is a v2 YAML file with `kind: composable` and a top-level `pack:` block describing the
+metric set:
 
-**Category:** network -- **Metrics:** 5
+```yaml title="~/sonda-catalog/my-app-pack.yaml"
+version: 2
+kind: composable
 
-Models the standard interface metrics collected by the Telegraf SNMP input plugin. Metric names
-and label keys match the Telegraf-normalized schema exactly, so Sonda output can replace real
-device telemetry in dashboards and alert rules.
-
-| Metric | Generator | Description |
-|--------|-----------|-------------|
-| `ifOperStatus` | constant (1.0) | Interface operational state (1 = up) |
-| `ifHCInOctets` | step (+125,000/tick) | Ingress byte counter (monotonic) |
-| `ifHCOutOctets` | step (+62,500/tick) | Egress byte counter (monotonic) |
-| `ifInErrors` | constant (0.0) | Ingress error counter |
-| `ifOutErrors` | constant (0.0) | Egress error counter |
-
-**Shared labels:** `device`, `ifName`, `ifAlias`, `ifIndex`, `job` (default: `snmp`)
-
-You should set `device`, `ifName`, and `ifIndex` via `--label` or the `labels:` block in your
-scenario file. Leave `ifAlias` empty or set it to a description string.
-
-### node_exporter_cpu
-
-**Category:** infrastructure -- **Metrics:** 8
-
-Models the per-CPU mode counters exposed by Prometheus node_exporter. Each metric spec represents
-one mode of `node_cpu_seconds_total` with a step counter whose rate reflects typical CPU
-utilization proportions.
-
-| Metric | Labels | Generator | Rate (step/tick) |
-|--------|--------|-----------|-----------------|
-| `node_cpu_seconds_total` | `mode=user` | step | 0.25 |
-| `node_cpu_seconds_total` | `mode=system` | step | 0.10 |
-| `node_cpu_seconds_total` | `mode=idle` | step | 0.55 |
-| `node_cpu_seconds_total` | `mode=iowait` | step | 0.03 |
-| `node_cpu_seconds_total` | `mode=irq` | step | 0.01 |
-| `node_cpu_seconds_total` | `mode=softirq` | step | 0.02 |
-| `node_cpu_seconds_total` | `mode=nice` | step | 0.01 |
-| `node_cpu_seconds_total` | `mode=steal` | step | 0.03 |
-
-**Shared labels:** `instance`, `job` (default: `node_exporter`), `cpu` (default: `"0"`)
-
-Set `instance` to identify the target host. Override `cpu` to simulate multi-core systems.
-
-!!! tip "Testing `rate()` queries"
-    The step sizes sum to 1.0 per tick -- at a rate of 1 event/sec, `rate(node_cpu_seconds_total[1m])`
-    returns the expected per-mode utilization fractions. This makes the pack useful for testing
-    PromQL recording rules and Grafana CPU panels.
-
-### node_exporter_memory
-
-**Category:** infrastructure -- **Metrics:** 5
-
-Models the memory gauge metrics exposed by Prometheus node_exporter. Default values approximate a
-server with 16 GiB total memory under moderate load.
-
-| Metric | Generator | Default value |
-|--------|-----------|---------------|
-| `node_memory_MemTotal_bytes` | constant | 17,179,869,184 (16 GiB) |
-| `node_memory_MemFree_bytes` | constant | 2,147,483,648 (2 GiB) |
-| `node_memory_MemAvailable_bytes` | constant | 8,589,934,592 (8 GiB) |
-| `node_memory_Buffers_bytes` | constant | 536,870,912 (512 MiB) |
-| `node_memory_Cached_bytes` | constant | 5,368,709,120 (5 GiB) |
-
-**Shared labels:** `instance`, `job` (default: `node_exporter`)
-
-Set `instance` to identify the target host.
-
-??? tip "Simulating memory pressure"
-    Override `node_memory_MemFree_bytes` and `node_memory_MemAvailable_bytes` with a `leak` or
-    `degradation` generator to simulate memory pressure over time:
-
-    ```yaml
-    overrides:
-      node_memory_MemAvailable_bytes:
-        generator:
-          type: degradation
-          start: 8589934592.0
-          end: 1073741824.0
-          duration: "300s"
-    ```
-
-## Custom packs
-
-You can create your own pack YAML files and place them on the search path, or reference them
-by file path in a scenario file.
-
-### Pack definition format
-
-A pack definition has the same structure as the built-in packs:
-
-```yaml title="my-app-pack.yaml"
 name: my_app_metrics
+tags: [application]
 description: "Core application metrics"
-category: application
 
-shared_labels:
-  service: ""
-  env: ""
+pack:
+  shared_labels:
+    service: ""
+    env: ""
 
-metrics:
-  - name: http_requests_total
-    generator:
-      type: step
-      start: 0.0
-      step_size: 10.0
+  metrics:
+    - name: http_requests_total
+      generator:
+        type: step
+        start: 0.0
+        step_size: 10.0
 
-  - name: http_request_duration_seconds
-    generator:
-      type: sine
-      amplitude: 0.05
-      period_secs: 60
-      offset: 0.1
+    - name: http_request_duration_seconds
+      generator:
+        type: sine
+        amplitude: 0.05
+        period_secs: 60
+        offset: 0.1
 
-  - name: http_errors_total
-    generator:
-      type: constant
-      value: 0.0
+    - name: http_errors_total
+      generator:
+        type: constant
+        value: 0.0
 ```
 
-### Place on the search path
-
-Drop your pack YAML file into any directory on the search path. For example, create
-`~/.sonda/packs/my-app-pack.yaml` and it will be discovered automatically:
+Drop the file in your catalog directory and it shows up immediately:
 
 ```bash
-sonda catalog list --type pack           # shows my_app_metrics
-sonda catalog run my_app_metrics --rate 1 --duration 60s --label service=api-gateway
+sonda --catalog ~/sonda-catalog list --kind composable
 ```
 
-Or use `--pack-path` to point to a custom directory:
-
-```bash
-sonda --pack-path ./my-packs catalog list --type pack
-```
-
-### Reference by file path
-
-In a scenario file, use a path (containing `/` or starting with `.`) instead of a pack name:
+Reference it from a runnable entry:
 
 ```yaml title="run-my-pack.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -451,32 +233,22 @@ defaults:
 
 scenarios:
   - signal_type: metrics
-    pack: ./my-app-pack.yaml
+    pack: my_app_metrics
     labels:
       service: api-gateway
       env: staging
 ```
 
 ```bash
-sonda run --scenario run-my-pack.yaml
+sonda --catalog ~/sonda-catalog run run-my-pack.yaml
 ```
-
-Sonda detects that the `pack:` value is a file path (because it contains `/`) and reads the
-pack definition from disk.
-
-!!! info "Name vs. file path detection"
-    If the `pack:` value contains `/` or starts with `.`, it is treated as a file path.
-    Otherwise, it is looked up by name on the search path. For example,
-    `pack: telegraf_snmp_interface` resolves via the search path, while
-    `pack: ./telegraf-snmp-interface.yaml` reads from a specific file path.
 
 ### Pack definition fields
 
+The fields under `pack:`:
+
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | yes | Snake_case identifier for the pack. |
-| `description` | string | yes | One-line human-readable description. |
-| `category` | string | yes | Broad grouping (e.g. `network`, `infrastructure`, `application`). |
 | `shared_labels` | map | no | Labels applied to every metric in the pack. Empty values are placeholders for the user to fill. |
 | `metrics` | list | yes | One or more metric specifications. |
 | `metrics[].name` | string | yes | The metric name. |
@@ -485,21 +257,23 @@ pack definition from disk.
 
 ## How packs integrate with the pipeline
 
-When Sonda encounters a `pack:` field in a YAML file (via `sonda run --scenario`) or a pack
-name (via `sonda catalog run`), it:
+When Sonda encounters a `pack:` field in a YAML scenario, it:
 
-1. Resolves the pack definition (built-in catalog or file path).
-2. Calls `expand_pack()` to produce one `ScenarioEntry` per metric in the pack.
+1. Resolves the pack definition (catalog lookup by name, or file path).
+2. Calls `expand_pack()` to produce one entry per metric in the pack.
 3. Feeds those entries into the standard `prepare_entries()` pipeline.
 4. Launches all metrics concurrently, just like a multi-scenario file.
 
-This means every feature that works with multi-scenario runs -- `--dry-run`, `--verbose`,
-`--quiet`, live progress, aggregate summary -- works with packs automatically.
+This means every feature that works with multi-scenario runs — `--dry-run`, `--verbose`,
+`--quiet`, live progress, aggregate summary — works with packs automatically.
 
 ## What next
 
-- [**Network Device Telemetry**](network-device-telemetry.md) -- end-to-end walkthrough using SNMP metrics for dashboard testing
-- [**CLI Reference**](../configuration/cli-reference.md#sonda-catalog) -- full flag reference for `catalog list`, `catalog show`, `catalog run`
-- [**v2 Scenario Files**](../configuration/v2-scenarios.md#pack-backed-entries) -- reference a pack inline from a v2 `scenarios:` entry
-- [**Scenario Fields**](../configuration/scenario-fields.md) -- YAML reference for all scenario fields
-- [**Generators**](../configuration/generators.md) -- all generator types and operational aliases
+- [**Catalogs**](scenarios.md) -- the directory layout that packs and runnable scenarios share.
+- [**Network Device Telemetry**](network-device-telemetry.md) -- end-to-end walkthrough using
+  SNMP-shaped metrics for dashboard testing.
+- [**CLI Reference**](../configuration/cli-reference.md) -- full flag reference for `sonda list`,
+  `sonda show`, `sonda run`.
+- [**v2 Scenario Files -- Pack-backed entries**](../configuration/v2-scenarios.md#pack-backed-entries)
+  -- reference a pack inline from a v2 `scenarios:` entry.
+- [**Generators**](../configuration/generators.md) -- all generator types and operational aliases.

--- a/docs/site/docs/guides/network-automation-testing.md
+++ b/docs/site/docs/guides/network-automation-testing.md
@@ -135,18 +135,16 @@ a backup link that saturates after the primary drops. The first flap crosses `in
 quick one-liner:
 
 ```bash
-# Terminal 1: run the failover scenario from the built-in catalog
-sonda catalog run link-failover
-# or load the YAML directly:
-sonda run --scenario scenarios/link-failover.yaml
+# Terminal 1: run the link-failure scenario from examples/
+sonda run examples/network-link-failure.yaml
 ```
 
 !!! warning "Sink must target VictoriaMetrics"
     The example scenarios default to `stdout`. To push to VictoriaMetrics, change the sink
     in each scenario entry to `http_push` as shown in the
     [Network Device Telemetry](network-device-telemetry.md#push-to-a-monitoring-backend) guide.
-    For a quick single-metric test, create a minimal scenario file with `http_push` and the
-    sequence generator, then run it with `sonda metrics --scenario your-file.yaml`.
+    For a quick single-metric test, scaffold a minimal scenario with `sonda new --template`,
+    swap the sink for `http_push`, then run it with `sonda run your-file.yaml`.
 
 Verify the alert fired in vmalert:
 
@@ -579,11 +577,11 @@ scenarios:
 Then run both scenarios at the same time:
 
 ```bash
-# Terminal 1: link failover (primary flap, backup saturation, latency degradation)
-sonda catalog run link-failover &
+# Terminal 1: link failure scenario from examples/
+sonda run examples/network-link-failure.yaml &
 
 # Terminal 2: BGP session down
-sonda metrics --scenario bgp-session-down.yaml
+sonda run bgp-session-down.yaml
 ```
 
 Both InterfaceDown and BGPSessionDown should fire and trigger their respective workflows
@@ -613,7 +611,7 @@ rm -f examples/alertmanager/network-automation-alerts.yml
 | Task | Command |
 |------|---------|
 | Start alerting stack | `docker compose -f examples/docker-compose-victoriametrics.yml --profile alerting up -d` |
-| Run failover scenario | `sonda catalog run link-failover` |
+| Run failover scenario | `sonda run examples/network-link-failure.yaml` |
 | Check vmalert for InterfaceDown | `curl -s http://localhost:8880/api/v1/alerts \| jq '.data.alerts[]'` |
 | Check Alertmanager alerts | `curl -s http://localhost:9093/api/v2/alerts \| jq '.[].labels'` |
 | Check webhook delivery | `docker compose -f examples/docker-compose-victoriametrics.yml --profile alerting logs webhook-receiver` |

--- a/docs/site/docs/guides/network-device-telemetry.md
+++ b/docs/site/docs/guides/network-device-telemetry.md
@@ -70,7 +70,7 @@ The baseline scenario models `rtr-core-01` in a healthy state: both uplinks carr
 all interfaces up, steady CPU and memory.
 
 ```bash
-sonda --dry-run run --scenario examples/network-device-baseline.yaml
+sonda --dry-run run examples/network-device-baseline.yaml
 ```
 
 ```yaml title="examples/network-device-baseline.yaml (excerpt)"
@@ -123,7 +123,7 @@ plus `device_cpu_percent` and `device_memory_percent`.
 Run it:
 
 ```bash
-sonda run --scenario examples/network-device-baseline.yaml
+sonda run examples/network-device-baseline.yaml
 ```
 
 ```text title="Sample output (interleaved from 9 threads)"
@@ -167,9 +167,9 @@ The interesting part: what happens when a primary link drops? Traffic shifts to 
 the backup saturates as it absorbs double the load, and latency climbs as the backup fills.
 Testing your dashboards and alerts against that cascade is the whole point.
 
-The built-in `link-failover` scenario models the cascade as a 3-signal causal chain. Each signal
-uses a dedicated generator (not a hand-scripted sequence) and the `after:` field tells Sonda to
-delay a signal until the one it depends on crosses a threshold:
+Model the cascade as a 3-signal causal chain. Each signal uses a dedicated generator (not a
+hand-scripted sequence) and the `after:` field tells Sonda to delay a signal until the one it
+depends on crosses a threshold:
 
 | Signal | Generator | Starts when |
 |--------|-----------|-------------|
@@ -182,12 +182,9 @@ each linked signal, so the signals still emit independently but start in the rig
 See the [v2 `after:` chain reference](../configuration/v2-scenarios.md#temporal-chains-with-after)
 for the underlying mechanics.
 
-```yaml title="scenarios/link-failover.yaml (excerpt)"
+```yaml title="link-failover.yaml"
 version: 2
-
-scenario_name: link-failover
-category: network
-description: "Edge router link failure with traffic shift to backup"
+kind: runnable
 
 defaults:
   rate: 1
@@ -226,25 +223,37 @@ scenarios:
       op: "<"
       value: 1
 
-  # ... plus latency_ms, gated on backup_link_utilization > 70
+  - id: latency_ms
+    signal_type: metrics
+    name: latency_ms
+    generator:
+      type: degradation
+      baseline: 5
+      ceiling: 150
+      time_to_degrade: 3m
+    labels:
+      path: backup
+    after:
+      ref: backup_link_utilization
+      op: ">"
+      value: 70
 ```
 
-Run the scenario from the catalog or directly from disk:
+Run the file:
 
 ```bash
-sonda catalog run link-failover
-sonda run --scenario scenarios/link-failover.yaml
+sonda run link-failover.yaml
 ```
 
 Use `--dry-run` to see the resolved `phase_offset` values that Sonda computed from the `after:`
 clauses:
 
 ```bash
-sonda run --scenario scenarios/link-failover.yaml --dry-run
+sonda --dry-run run link-failover.yaml
 ```
 
 ```text title="Output (abridged)"
-[config] file: scenarios/link-failover.yaml (version: 2, 3 scenarios)
+[config] file: link-failover.yaml (version: 2, 3 scenarios)
 
 [config] [1/3] interface_oper_state
     generator:      flap (up_duration: 60s, down_duration: 30s, up_value: 1, down_value: 0)
@@ -270,9 +279,9 @@ auto-assigned `clock_group`, so their timers start from the same reference.
 
 !!! info "Why `after:` instead of aligned sequences?"
     You can express a link failure with the `sequence` generator by hand-aligning values across
-    scenarios -- that is what the built-in [interface-flap](scenarios.md#network) scenario does.
-    `after:` is the v2 equivalent: instead of counting ticks, you declare the causal relationship
-    once and let the compiler do the timing math. The [v2 scenarios guide](../configuration/v2-scenarios.md)
+    scenarios -- which is exactly what `examples/network-link-failure.yaml` does. `after:` is the
+    v2 equivalent: instead of counting ticks, you declare the causal relationship once and let
+    the compiler do the timing math. The [v2 scenarios guide](../configuration/v2-scenarios.md)
     covers the full surface.
 
 ---
@@ -382,7 +391,7 @@ or Prometheus, change the sink in each scenario entry.
     Then modify the scenario sinks to point at VictoriaMetrics and run:
 
     ```bash
-    sonda run --scenario examples/network-device-baseline.yaml
+    sonda run examples/network-device-baseline.yaml
     ```
 
     Verify data arrived:
@@ -559,11 +568,10 @@ Model environmental sensors with sine waves:
 
 | Task | Command |
 |------|---------|
-| Validate baseline scenario | `sonda --dry-run run --scenario examples/network-device-baseline.yaml` |
-| Run baseline (stdout) | `sonda run --scenario examples/network-device-baseline.yaml` |
-| Validate failover scenario | `sonda --dry-run run --scenario scenarios/link-failover.yaml` |
-| Run failover simulation | `sonda run --scenario scenarios/link-failover.yaml` |
-| Run failover from catalog | `sonda catalog run link-failover` |
+| Validate baseline scenario | `sonda --dry-run run examples/network-device-baseline.yaml` |
+| Run baseline (stdout) | `sonda run examples/network-device-baseline.yaml` |
+| Validate failover scenario | `sonda --dry-run run link-failover.yaml` |
+| Run failover simulation | `sonda run link-failover.yaml` |
 
 **Related pages:**
 

--- a/docs/site/docs/guides/pipeline-validation.md
+++ b/docs/site/docs/guides/pipeline-validation.md
@@ -15,11 +15,31 @@ before it reaches the dashboards.
 
 ## Smoke Testing With the CLI
 
-The simplest validation: run Sonda with a known metric, check the exit code, and count the
-output lines. Use `-q` to suppress status banners in scripts:
+The simplest validation: run a one-entry scenario, check the exit code, count the
+output lines. Scaffold a starter file with `sonda new --template`, edit the metric
+name to taste, then run it with `-q` to suppress status banners in scripts:
+
+```yaml title="smoke.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 5
+  duration: 2s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: smoke_test
+    signal_type: metrics
+    name: smoke_test
+    generator:
+      type: constant
+      value: 1.0
+```
 
 ```bash
-sonda -q metrics --name smoke_test --rate 5 --duration 2s > /tmp/smoke.txt
+sonda -q run smoke.yaml > /tmp/smoke.txt
 echo "Exit code: $?"
 wc -l < /tmp/smoke.txt
 ```
@@ -30,10 +50,11 @@ A successful run exits with code `0` and produces approximately `rate * duration
 | Exit code | Meaning |
 |-----------|---------|
 | `0` | Success -- all events emitted |
-| `1` | Error -- missing required flags, bad scenario file, or sink connection failure |
+| `1` | Runtime error -- bad scenario file, sink connection failure, validation reject |
+| `2` | Argument parse error -- unknown flag, missing argument |
 
 !!! tip "Quick validation in scripts"
-    Use the exit code in CI or shell scripts: `sonda -q metrics --name test --rate 1 --duration 1s > /dev/null && echo "OK"`.
+    Use the exit code in CI or shell scripts: `sonda -q run smoke.yaml > /dev/null && echo "OK"`.
 
 Now let's verify that every wire format makes it through your pipeline.
 
@@ -42,12 +63,12 @@ Now let's verify that every wire format makes it through your pipeline.
 ## Multi-Format Validation
 
 Run the same metric through each encoder to verify that every format arrives at its destination.
-This catches encoding regressions and misconfigured parsers.
+This catches encoding regressions and misconfigured parsers. The encoder lives in the YAML; swap the `type:` field to compare formats. Override at the command line with `--encoder` when you need a one-off variant:
 
 === "Prometheus text"
 
     ```bash
-    sonda metrics --name pipeline_test --rate 2 --duration 2s
+    sonda run pipeline-test.yaml
     ```
 
     ```
@@ -58,7 +79,7 @@ This catches encoding regressions and misconfigured parsers.
 === "InfluxDB line protocol"
 
     ```bash
-    sonda metrics --name pipeline_test --rate 2 --duration 2s --encoder influx_lp
+    sonda run pipeline-test.yaml --encoder influx_lp
     ```
 
     ```
@@ -69,17 +90,38 @@ This catches encoding regressions and misconfigured parsers.
 === "JSON Lines"
 
     ```bash
-    sonda metrics --name pipeline_test --rate 2 --duration 2s --encoder json_lines
+    sonda run pipeline-test.yaml --encoder json_lines
     ```
 
     ```json
     {"name":"pipeline_test","value":0.0,"labels":{},"timestamp":"2026-03-23T12:00:00.000Z"}
     ```
 
+The starter `pipeline-test.yaml` is two ticks of the constant generator:
+
+```yaml title="pipeline-test.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  duration: 2s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: pipeline_test
+    signal_type: metrics
+    name: pipeline_test
+    generator:
+      type: constant
+      value: 0.0
+```
+
 To push a specific format to a file for inspection, use a scenario file:
 
 ```bash
-sonda metrics --scenario examples/multi-format-test.yaml
+sonda run examples/multi-format-test.yaml
 wc -l < /tmp/pipeline-influx.txt
 ```
 
@@ -180,7 +222,7 @@ Use `sonda run` to push metrics and logs concurrently from a single YAML file.
 This validates that your pipeline handles multiple signal types at the same time:
 
 ```bash
-sonda run --scenario examples/multi-pipeline-test.yaml
+sonda run examples/multi-pipeline-test.yaml
 echo "Exit: $?"
 wc -l < /tmp/pipeline-logs.json
 ```

--- a/docs/site/docs/guides/recording-rules.md
+++ b/docs/site/docs/guides/recording-rules.md
@@ -45,7 +45,7 @@ The [constant generator](../configuration/generators.md#constant) emits the same
 tick -- perfect for deterministic rule testing:
 
 ```bash
-sonda metrics --scenario examples/recording-rule-test.yaml &
+sonda run examples/recording-rule-test.yaml &
 ```
 
 ```yaml title="examples/recording-rule-test.yaml (key fields)"
@@ -129,7 +129,7 @@ For `rate()` or `irate()` rules, you need a metric whose value increases over ti
 producing a predictable rate.
 
 ```bash
-sonda metrics --scenario examples/rate-rule-input.yaml &
+sonda run examples/rate-rule-input.yaml &
 ```
 
 ```yaml title="examples/rate-rule-input.yaml (key fields)"

--- a/docs/site/docs/guides/scenarios.md
+++ b/docs/site/docs/guides/scenarios.md
@@ -1,70 +1,64 @@
-# Built-in Scenarios
+# Catalogs
 
-Sonda ships with curated scenario patterns you can discover, inspect, and run without writing
-any YAML. Scenario files live on the filesystem and load at runtime through a configurable
-search path, alongside [metric packs](metric-packs.md) in the same unified catalog.
+Sonda discovers your scenario YAML files from a **catalog directory** you point it at. The
+catalog is just a folder of v2 YAML files with a `kind:` header: `kind: runnable` for scenarios
+you run, `kind: composable` for [metric packs](metric-packs.md) you reference from other
+scenarios. Sonda no longer ships any built-in scenario or pack catalog — you own the catalog,
+keep it in your own repo, and point `--catalog <dir>` at it.
 
-## Scenario search path
+## The minimum
 
-Sonda discovers scenario YAML files from the filesystem via a search path:
+```text
+my-catalog/
+├── cpu-spike.yaml          # kind: runnable
+├── memory-leak.yaml        # kind: runnable
+└── prom-text-stdout.yaml   # kind: composable  (a pack)
+```
 
-1. **`--scenario-path <dir>`** CLI flag -- when present, only this directory is searched.
-2. **`SONDA_SCENARIO_PATH`** env var -- colon-separated list of directories.
-3. **`./scenarios/`** relative to the current working directory.
-4. **`~/.sonda/scenarios/`** in the user's home directory.
+```bash
+sonda --catalog ./my-catalog list
+sonda --catalog ./my-catalog show @cpu-spike
+sonda --catalog ./my-catalog run @cpu-spike
+```
 
-Non-existent directories are silently skipped. If the same scenario name appears in multiple
-directories, the first match wins (highest-priority path).
+Files without a recognized `kind:` header are silently skipped. Files with an unparseable YAML
+body print a warning to stderr and are skipped — the listing continues.
 
-When running from the repo root, the included `scenarios/` directory is found automatically.
-For Docker, the `SONDA_SCENARIO_PATH` env var is set to `/scenarios` in the image.
+Two files with the same logical name (`name:` field or filename) are a **hard error** —
+discovery fails with the conflicting paths. Rename one to disambiguate.
 
 ## Browse the catalog
 
-List every scenario and pack with `sonda catalog list`:
+`sonda list` prints a tab-separated table of every entry in the catalog:
 
 ```bash
-sonda catalog list
+sonda --catalog ~/sonda-catalog list
 ```
 
 ```text title="Output"
-NAME                             TYPE       CATEGORY         SIGNAL     RUNNABLE   DESCRIPTION
-cpu-spike                        scenario   infrastructure   metrics    yes        Periodic CPU usage spikes above threshold
-memory-leak                      scenario   infrastructure   metrics    yes        Monotonically growing memory usage (sawtooth)
-interface-flap                   scenario   network          multi      yes        Network interface toggling up/down with traffic shifts
-log-storm                        scenario   application      logs       yes        Error-level log burst with template generation
-histogram-latency                scenario   application      histogram  yes        Request latency histogram (normal distribution)
-telegraf_snmp_interface          pack       network          metrics    no         Standard SNMP interface metrics (Telegraf-normalized)
-node_exporter_cpu                pack       infrastructure   metrics    no         Per-CPU mode counters (node_exporter-compatible)
-14 entries
+KIND        NAME              TAGS                  DESCRIPTION
+runnable    cpu-spike         cpu,infrastructure    CPU spike to 95% for 30 seconds
+runnable    memory-leak       memory,leak           Slow memory leak from baseline to ceiling
+composable  prom-text-stdout  defaults              Shared prometheus_text + stdout defaults
 ```
 
-Restrict to just scenarios:
+Filter by entry kind or tag:
 
 ```bash
-sonda catalog list --type scenario
+sonda --catalog ~/sonda-catalog list --kind runnable
+sonda --catalog ~/sonda-catalog list --tag cpu
 ```
 
-Filter by category:
-
-```bash
-sonda catalog list --category network
-```
-
-Available categories (scenarios and packs share the same set): `infrastructure`, `network`,
-`application`, `observability`.
-
-For machine-readable output, add `--json` to get a stable JSON array. See
-[`catalog list`](../configuration/cli-reference.md#catalog-list) for the DTO schema.
+For machine-readable output, add `--json` to get a stable array on stdout. Each element has
+`name`, `kind`, `description`, `tags`, and the resolved `source` path. Use it as the contract
+when scripting catalog discovery.
 
 ## Run a scenario
 
-The fastest path is `sonda catalog run <name>`, which works for every scenario in the catalog
-regardless of layout (flat single-signal, multi-scenario, or v2):
+`sonda run @name --catalog <dir>` resolves the name in the catalog and runs the entry:
 
 ```bash
-sonda catalog run cpu-spike --rate 5 --duration 10s
-sonda catalog run interface-flap --duration 30s
+sonda --catalog ~/sonda-catalog run @cpu-spike --rate 5 --duration 10s
 ```
 
 ```text title="Output"
@@ -75,55 +69,40 @@ node_cpu_usage_percent{cpu="0",instance="web-01",job="node_exporter"} 95 1775589
 ■ node_cpu_usage_percent  completed in 10.0s | events: 50 | bytes: 4350 B | errors: 0
 ```
 
-The `@name` shorthand also works on `sonda run` and any signal subcommand:
+`sonda run` also accepts a direct filesystem path (no `@`, no `--catalog`) when you want to
+run a one-off file:
 
 ```bash
-sonda run --scenario @interface-flap --duration 30s
-sonda metrics --scenario @cpu-spike --duration 10s --rate 5
-sonda logs    --scenario @log-storm --duration 20s
-sonda histogram --scenario @histogram-latency
+sonda run examples/basic-metrics.yaml
 ```
 
-Use the signal subcommand when you need a per-signal flag like `--precision`, `--value`, or
-`--label` that `catalog run` does not expose:
+CLI overrides (`--duration`, `--rate`, `--sink`, `--endpoint`, `--encoder`, `--label`) win
+over the values inside the file, so you can pin a backend or speed up a long-running scenario
+without editing the YAML.
 
-```bash
-sonda metrics --scenario @cpu-spike \
-  --duration 30s --rate 5 \
-  --sink http_push --endpoint http://localhost:9090/api/v1/write \
-  --label env=staging
-```
-
-!!! tip
-    Use `--dry-run` to validate what a scenario *would* do without emitting any data:
+!!! tip "Validate without emitting"
+    Add `--dry-run` to compile the scenario and print the resolved config — no events are
+    written:
 
     ```bash
-    sonda --dry-run catalog run cpu-spike
-    sonda --dry-run metrics --scenario @cpu-spike
+    sonda --catalog ~/sonda-catalog --dry-run run @cpu-spike
     ```
 
 ## Inspect the YAML
 
-Every scenario in the catalog is a standard YAML file on disk. View it with
-`sonda catalog show`:
+`sonda show @name --catalog <dir>` prints the file contents byte-for-byte:
 
 ```bash
-sonda catalog show cpu-spike
+sonda --catalog ~/sonda-catalog show @cpu-spike
 ```
 
 ```yaml title="Output"
 # CPU spike: periodic CPU usage spikes above threshold.
-#
-# Models a server experiencing recurring CPU spikes using the
-# `spike_event` alias. Useful for testing alert rules that trigger
-# on sustained high CPU usage.
-#
-# Pattern: baseline ~35% with periodic spikes to ~95%.
-
 version: 2
+kind: runnable
 
-scenario_name: cpu-spike
-category: infrastructure
+name: cpu-spike
+tags: [cpu, infrastructure]
 description: "Periodic CPU usage spikes above threshold"
 
 scenarios:
@@ -147,115 +126,24 @@ scenarios:
       type: stdout
 ```
 
-## Customize a built-in
+Pipe the output to a file when you want to fork an entry and customize it:
 
-Built-in scenarios are a starting point. To customize one beyond what the `--duration` / `--rate`
-overrides offer, save the YAML to a file and edit it:
-
-```bash
-sonda catalog show cpu-spike > my-cpu-spike.yaml
-# Edit my-cpu-spike.yaml to change labels, generator params, etc.
-sonda metrics --scenario my-cpu-spike.yaml
+```bash title="my-cpu-spike.yaml"
+sonda --catalog ~/sonda-catalog show @cpu-spike > my-cpu-spike.yaml
+# edit my-cpu-spike.yaml — change labels, generator params, etc.
+sonda run my-cpu-spike.yaml
 ```
 
-This workflow lets you use built-in patterns as templates without starting YAML from scratch.
+## Author your own entries
 
-## The @name shorthand
+A catalog entry is a v2 scenario YAML with a top-level `kind:` field. For runnable entries:
 
-Every subcommand that accepts `--scenario` also supports a `@name` shorthand. Instead of
-pointing to a file on disk, prefix the scenario name with `@` to load a built-in:
-
-=== "metrics"
-
-    ```bash
-    sonda metrics --scenario @cpu-spike --duration 10s
-    ```
-
-=== "logs"
-
-    ```bash
-    sonda logs --scenario @log-storm --duration 10s
-    ```
-
-=== "histogram"
-
-    ```bash
-    sonda histogram --scenario @histogram-latency
-    ```
-
-=== "run"
-
-    ```bash
-    sonda run --scenario @interface-flap
-    ```
-
-The `@name` shorthand works exactly like a file path -- CLI flags still override values in the
-scenario YAML. For example, `--duration 10s` overrides whatever duration the built-in defines.
-
-!!! info
-    `@name` and `sonda catalog run <name>` both resolve the same scenario from the search path.
-    Use `@name` on a signal subcommand when you want the full set of per-signal flags
-    (`--label`, `--precision`, `--value`). Use `catalog run` for a focused, cross-type surface
-    (scenarios and packs) with a small override set. See
-    [`catalog run`](../configuration/cli-reference.md#catalog-run) for the full flag list.
-
-## Scenario catalog
-
-### Infrastructure
-
-| Name | Signal | Generator | What it models |
-|------|--------|-----------|----------------|
-| `cpu-spike` | metrics | `spike_event` | Server CPU surging from ~35% baseline to ~95% for 10s every 30s. Tests threshold alerts. |
-| `memory-leak` | metrics | `leak` | Memory ramping from 40% to 95% over 120s (linear growth). Tests growth-rate alerts. |
-| `disk-fill` | metrics | `step` | Disk usage climbing in fixed increments. Tests capacity alerts. |
-| `steady-state` | metrics | `steady` | Normal oscillating baseline (~75% +/- 10) with noise. Use as a healthy control signal. |
-
-### Network
-
-| Name | Signal | Generator | What it models |
-|------|--------|-----------|----------------|
-| `interface-flap` | multi | sequence | Router interface toggling up/down with matching traffic counters and error spikes. 3 correlated metrics. |
-| `link-failover` | multi | `flap` + `saturation` + `degradation` | Edge router primary link flaps, backup link saturates as it absorbs traffic, latency degrades as backup fills. 3-signal causal chain wired with `after:`. |
-
-### Application
-
-| Name | Signal | Generator | What it models |
-|------|--------|-----------|----------------|
-| `latency-degradation` | metrics | `degradation` | HTTP response latency growing over time with noise. Tests latency SLO alerts. |
-| `error-rate-spike` | metrics | `spike` | Periodic bursts of HTTP 5xx errors. Tests error-rate alerts. |
-| `log-storm` | logs | template | Error-heavy log burst (60% error, 30% warn) with 10x volume spikes. Tests log pipeline backpressure. |
-| `histogram-latency` | histogram | normal distribution | Request latency histogram (mean 100ms, stddev 30ms). Tests p99 SLO alerting and heatmap panels. |
-
-### Observability
-
-| Name | Signal | Generator | What it models |
-|------|--------|-----------|----------------|
-| `cardinality-explosion` | metrics | sine + cardinality spike | 500 unique pod labels injected for 20s every 60s. Tests TSDB cardinality limits. |
-
-## Custom scenarios
-
-You can add your own scenario YAML files to any directory on the search path. For example,
-create `~/.sonda/scenarios/my-scenario.yaml` and it will be discovered automatically:
-
-```bash
-sonda catalog list                          # shows your custom scenario
-sonda metrics --scenario @my-scenario       # @name shorthand on the signal subcommand
-```
-
-Or use `--scenario-path` to point to a custom directory:
-
-```bash
-sonda --scenario-path ./my-scenarios catalog list
-```
-
-Custom scenario files are v2 YAML files. Add the catalog metadata fields at the top for
-catalog display:
-
-```yaml title="~/.sonda/scenarios/my-scenario.yaml"
+```yaml title="~/sonda-catalog/my-scenario.yaml"
 version: 2
+kind: runnable
 
-scenario_name: my-scenario
-category: application
+name: my-scenario
+tags: [application, custom]
 description: "My custom scenario pattern"
 
 scenarios:
@@ -275,20 +163,33 @@ scenarios:
       type: stdout
 ```
 
-The catalog probe reads `signal_type` from the first entry. See
-[v2 catalog metadata](../configuration/v2-scenarios.md#catalog-metadata) for the full field
-reference.
-
 | Field | Required | Description |
 |-------|----------|-------------|
-| `scenario_name` | no | Kebab-case identifier. Defaults to the filename if omitted. Used with `@name` and `sonda catalog run`. |
-| `category` | no | Grouping for `--category` filter. Omitted scenarios render as `uncategorized`. |
-| `description` | no | One-line description shown in `sonda catalog list`. Empty if omitted. |
+| `version` | yes | Must be `2`. |
+| `kind` | yes | `runnable` for runnable scenarios; `composable` for packs (see [Metric Packs](metric-packs.md)). |
+| `name` | no | Catalog identifier. Defaults to the filename (without `.yaml`) if omitted. Used with `@name`. |
+| `tags` | no | Optional list of strings. `sonda list --tag <t>` filters on this. |
+| `description` | no | One-line summary shown in the `sonda list` table and JSON output. |
+
+The compiler ignores `tags:` and `description:` — they only feed the catalog views. Strict
+unknown-field validation stays in force, so typos like `desc:` or `tag:` (singular) are
+rejected at parse time.
+
+After dropping the file in your catalog directory, `sonda list` picks it up on the next run:
+
+```bash
+sonda --catalog ~/sonda-catalog list --tag application
+```
 
 ## What next
 
-- [**Metric Packs**](metric-packs.md) -- pre-built metric bundles for Telegraf SNMP and node_exporter with correct schemas
-- [**Alert Testing**](alert-testing.md) -- end-to-end walkthrough using shaped signals to validate alert rules
-- [**CLI Reference**](../configuration/cli-reference.md#sonda-catalog) -- full flag reference for `sonda catalog`
-- [**Scenario Fields**](../configuration/scenario-fields.md) -- YAML reference for writing your own scenarios from scratch
-- [**v2 Scenario Files**](../configuration/v2-scenarios.md) -- the forward-compatible format with defaults, `after:`, and inline packs
+- [**Metric Packs**](metric-packs.md) -- pre-built metric bundles for Telegraf SNMP and
+  node_exporter, expressed as `kind: composable` catalog entries.
+- [**Alert Testing**](alert-testing.md) -- end-to-end walkthrough using shaped signals to
+  validate alert rules.
+- [**CLI Reference**](../configuration/cli-reference.md) -- full flag reference for `sonda run`,
+  `sonda list`, `sonda show`, and `sonda new`.
+- [**Scenario Fields**](../configuration/scenario-fields.md) -- YAML reference for writing your
+  own scenarios from scratch.
+- [**v2 Scenario Files**](../configuration/v2-scenarios.md) -- the canonical file format with
+  defaults, `after:`, and inline packs.

--- a/docs/site/docs/guides/troubleshooting.md
+++ b/docs/site/docs/guides/troubleshooting.md
@@ -14,16 +14,16 @@ Before diving into specific issues, run these quick checks.
 
 Use `--dry-run` to parse and validate a scenario without emitting any events:
 
-=== "Inline CLI flags"
-
-    ```bash
-    sonda --dry-run metrics --name cpu --rate 10 --duration 30s
-    ```
-
 === "Scenario file"
 
-    ```bash
-    sonda --dry-run run --scenario my-scenario.yaml
+    ```bash title="my-scenario.yaml"
+    sonda --dry-run run my-scenario.yaml
+    ```
+
+=== "Catalog entry"
+
+    ```bash title="./my-catalog"
+    sonda --dry-run --catalog ./my-catalog run @cpu-spike
     ```
 
 If the config is valid, Sonda prints the resolved settings and exits with code `0`. If there's
@@ -34,8 +34,8 @@ an error, it prints the problem to stderr and exits with code `1`.
 Use `--verbose` to print the resolved config at startup, then run normally. This shows exactly
 what Sonda parsed before it starts emitting events:
 
-```bash
-sonda --verbose metrics --name cpu --rate 10 --duration 30s \
+```bash title="my-scenario.yaml"
+sonda --verbose run my-scenario.yaml \
   --sink http_push --endpoint http://localhost:8428/api/v1/import/prometheus
 ```
 
@@ -44,7 +44,8 @@ sonda --verbose metrics --name cpu --rate 10 --duration 30s \
 | Code | Meaning |
 |------|---------|
 | `0` | Success -- scenario completed or `--dry-run` validation passed |
-| `1` | Error -- invalid config, connection failure, or runtime error |
+| `1` | Runtime error -- invalid config, sink unreachable, scenario validation failure |
+| `2` | Argument parse error -- unknown flag, unrecognized subcommand |
 
 ### A scenario stopped emitting silently
 

--- a/docs/site/docs/guides/tutorial-encoders.md
+++ b/docs/site/docs/guides/tutorial-encoders.md
@@ -3,13 +3,35 @@
 Your monitoring backend expects data in a specific wire format. Sonda can speak all of
 them. Encoders are the layer that turns each generated value into bytes.
 
-The same metric looks different in each format:
+The same metric looks different in each format. Pick the encoder in the YAML's `encoder:` block (under `defaults:` or per entry); the `--encoder` flag on `sonda run` overrides whatever the file declares.
+
+Starter scenario used by every tab below:
+
+```yaml title="http-rps.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 3s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+  labels:
+    env: prod
+scenarios:
+  - id: http_rps
+    signal_type: metrics
+    name: http_rps
+    generator:
+      type: constant
+      value: 42.0
+```
 
 === "prometheus_text (default)"
 
     ```bash
-    sonda metrics --name http_rps --rate 1 --duration 3s \
-      --value 42 --label env=prod
+    sonda run http-rps.yaml
     ```
 
     ```text
@@ -19,8 +41,7 @@ The same metric looks different in each format:
 === "influx_lp"
 
     ```bash
-    sonda metrics --name http_rps --rate 1 --duration 3s \
-      --value 42 --label env=prod --encoder influx_lp
+    sonda run http-rps.yaml --encoder influx_lp
     ```
 
     ```text
@@ -30,8 +51,7 @@ The same metric looks different in each format:
 === "json_lines"
 
     ```bash
-    sonda metrics --name http_rps --rate 1 --duration 3s \
-      --value 42 --label env=prod --encoder json_lines
+    sonda run http-rps.yaml --encoder json_lines
     ```
 
     ```json
@@ -40,17 +60,37 @@ The same metric looks different in each format:
 
 === "syslog (logs only)"
 
+    Swap the entry for a log generator and pick the `syslog` encoder in the file:
+
+    ```yaml title="app-logs-syslog.yaml"
+    version: 2
+    kind: runnable
+    defaults:
+      rate: 1
+      duration: 3s
+      encoder:
+        type: syslog
+      sink:
+        type: stdout
+      labels:
+        app: myservice
+    scenarios:
+      - id: app_logs
+        signal_type: logs
+        name: app_logs
+        log_generator:
+          type: template
+          templates:
+            - message: "synthetic log event"
+    ```
+
     ```bash
-    sonda logs --mode template --rate 1 --duration 3s \
-      --encoder syslog --label app=myservice
+    sonda run app-logs-syslog.yaml
     ```
 
     ```text
     <14>1 2026-03-31T21:40:38.941Z sonda sonda - - [sonda app="myservice"] synthetic log event
     ```
-
-The CLI flag is `--encoder` for all signal types. In a YAML scenario, set
-`encoder.type` either at the `defaults:` level or per entry.
 
 ## Pick by what you are testing
 

--- a/docs/site/docs/guides/tutorial-generators.md
+++ b/docs/site/docs/guides/tutorial-generators.md
@@ -17,25 +17,62 @@ Sonda ships eight generators:
 | `spike` | Baseline with periodic spikes | Anomaly detection, alert thresholds |
 | `csv_replay` | Replays values from a CSV file | Reproducing real incidents |
 
-!!! note "YAML-only generators"
-    `sequence`, `step`, `spike`, and `csv_replay` require a scenario file -- they have no
-    CLI flag equivalents. The other four are available via `--value-mode`.
+The generator picks the **shape** of the values; everything else (rate, duration, encoder, sink, labels) lives in the same scenario YAML. Scaffold a starter file with `sonda new --template`, swap the `generator:` block, and run with `sonda run <file>`.
 
 ## constant
 
-The default generator. Set the value with `--value`:
+A fixed value every tick — the simplest "is the pipeline alive?" probe:
+
+```yaml title="up-constant.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 3s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: up
+    signal_type: metrics
+    name: up
+    generator:
+      type: constant
+      value: 1.0
+```
 
 ```bash
-sonda metrics --name up --rate 1 --duration 3s --value 1
+sonda run up-constant.yaml
 ```
 
 ## sine
 
 Produces a smooth wave defined by amplitude, offset (midpoint), and period:
 
+```yaml title="cpu-sine.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  duration: 10s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: cpu_usage
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: sine
+      amplitude: 40.0
+      offset: 50.0
+      period_secs: 30
+```
+
 ```bash
-sonda metrics --name cpu_usage --rate 2 --duration 10s \
-  --value-mode sine --amplitude 40 --offset 50 --period-secs 30
+sonda run cpu-sine.yaml
 ```
 
 This oscillates between 10 and 90, centered on 50, completing one cycle every 30 seconds.
@@ -50,7 +87,7 @@ For testing alert thresholds, you often need values that cross a specific bounda
 specific time. `sequence` gives you that exact control:
 
 ```bash
-sonda metrics --scenario examples/sequence-alert-test.yaml --duration 10s
+sonda run examples/sequence-alert-test.yaml --duration 10s
 ```
 
 ```yaml title="examples/sequence-alert-test.yaml"
@@ -87,31 +124,35 @@ and clears at t=10s, deterministically, every run.
     **sawtooth** -- A linear ramp from 0 to 1 that resets every period. Useful for
     simulating queue fill and drain cycles:
 
-    ```bash
-    sonda metrics --name queue_depth --rate 2 --duration 10s \
-      --value-mode sawtooth --period-secs 5
+    ```yaml
+    generator:
+      type: sawtooth
+      period_secs: 5
     ```
 
-    **uniform** -- Random values drawn uniformly between `--min` and `--max`. Pass
-    `--seed 42` for deterministic replay:
+    **uniform** -- Random values drawn uniformly between `min` and `max`. Set `seed`
+    for deterministic replay:
 
-    ```bash
-    sonda metrics --name jitter_ms --rate 2 --duration 5s \
-      --value-mode uniform --min 1 --max 100
+    ```yaml
+    generator:
+      type: uniform
+      min: 1.0
+      max: 100.0
+      seed: 42
     ```
 
     **step** -- A monotonic counter that increments by `step_size` each tick. Set `max`
     to simulate counter resets, perfect for testing `rate()` and `increase()`:
 
     ```bash
-    sonda metrics --scenario examples/step-counter.yaml --duration 5s
+    sonda run examples/step-counter.yaml --duration 5s
     ```
 
     **csv_replay** -- Replays recorded values from a CSV file. Point it at real
     incident data to reproduce production behavior:
 
     ```bash
-    sonda metrics --scenario examples/csv-replay-metrics.yaml
+    sonda run examples/csv-replay-metrics.yaml
     ```
 
     ```yaml title="examples/csv-replay-metrics.yaml"
@@ -181,7 +222,7 @@ scenarios:
 Run it:
 
 ```bash
-sonda metrics --scenario examples/jitter-sine.yaml
+sonda run examples/jitter-sine.yaml
 ```
 
 This adds noise in the range `[-3.0, +3.0]` to every value. Set `jitter_seed` for

--- a/docs/site/docs/guides/tutorial-logs.md
+++ b/docs/site/docs/guides/tutorial-logs.md
@@ -4,12 +4,10 @@
 
 ## Template mode with field pools
 
-The CLI `--message` flag supports template syntax, but placeholder tokens like `{ip}`
-render as literal text. For dynamic log messages with randomized fields, use a YAML
-scenario:
+Templates render `{field}` placeholders by sampling from a per-field pool. They live in the YAML's `log_generator:` block on a `signal_type: logs` entry:
 
 ```bash
-sonda logs --scenario examples/log-template.yaml --duration 5s
+sonda run examples/log-template.yaml --duration 5s
 ```
 
 ```yaml title="examples/log-template.yaml (excerpt)"
@@ -48,7 +46,7 @@ reference (per-template weights, multi-template fan-out, severity normalisation)
 Replay a structured CSV of real log events. The CSV has a `timestamp` column that drives the emission cadence, plus optional `severity` and `message` columns and any number of free-form field columns.
 
 ```bash
-sonda logs --scenario examples/log-csv-replay.yaml
+sonda run examples/log-csv-replay.yaml
 ```
 
 ```yaml title="examples/log-csv-replay.yaml"
@@ -88,10 +86,30 @@ Sonda derives the replay rate from the median Δt of the timestamp column (3 sec
 
 ## Pair templates with the syslog encoder
 
-Combine template logs with the syslog encoder for RFC 5424 output:
+Combine template logs with the syslog encoder for RFC 5424 output. Swap the `encoder:` block in the YAML, or override at the CLI with `--encoder syslog`:
+
+```yaml title="log-syslog.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  duration: 5s
+  encoder:
+    type: syslog
+  sink:
+    type: stdout
+scenarios:
+  - id: app_logs_syslog
+    signal_type: logs
+    name: app_logs_syslog
+    log_generator:
+      type: template
+      templates:
+        - message: "synthetic log event"
+```
 
 ```bash
-sonda logs --mode template --rate 2 --duration 5s --encoder syslog
+sonda run log-syslog.yaml
 ```
 
 The encoder wraps each generated message in the syslog header:

--- a/docs/site/docs/guides/tutorial-multi-scenario.md
+++ b/docs/site/docs/guides/tutorial-multi-scenario.md
@@ -4,7 +4,7 @@ Production systems emit multiple signals simultaneously. `sonda run` lets you or
 several scenarios concurrently from a single YAML file, each on its own thread.
 
 ```bash
-sonda run --scenario examples/multi-scenario.yaml
+sonda run examples/multi-scenario.yaml
 ```
 
 ```yaml title="examples/multi-scenario.yaml"
@@ -65,7 +65,7 @@ need both signals above threshold for a window before firing.
 Use `phase_offset` to delay a scenario's start relative to its `clock_group` peers:
 
 ```bash
-sonda run --scenario examples/multi-metric-correlation.yaml
+sonda run examples/multi-metric-correlation.yaml
 ```
 
 ```yaml title="examples/multi-metric-correlation.yaml (excerpt)"

--- a/docs/site/docs/guides/tutorial-scheduling.md
+++ b/docs/site/docs/guides/tutorial-scheduling.md
@@ -9,9 +9,30 @@ can test how your pipeline and alerts behave under imperfect conditions.
 Drop all events for a window within a recurring cycle. Useful for simulating network
 partitions or scrape failures:
 
+```yaml title="net-bytes-gaps.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  duration: 20s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: net_bytes
+    signal_type: metrics
+    name: net_bytes
+    generator:
+      type: constant
+      value: 1.0
+    gaps:
+      every: 10s
+      for: 3s
+```
+
 ```bash
-sonda metrics --name net_bytes --rate 2 --duration 20s \
-  --gap-every 10s --gap-for 3s
+sonda run net-bytes-gaps.yaml
 ```
 
 This emits at 2/s, but goes silent for 3 seconds out of every 10-second cycle.
@@ -20,17 +41,39 @@ This emits at 2/s, but goes silent for 3 seconds out of every 10-second cycle.
 
 Temporarily multiply the emission rate. Useful for load spikes or log storms:
 
+```yaml title="req-rate-bursts.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 20s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: req_rate
+    signal_type: metrics
+    name: req_rate
+    generator:
+      type: constant
+      value: 1.0
+    bursts:
+      every: 10s
+      for: 2s
+      multiplier: 5.0
+```
+
 ```bash
-sonda metrics --name req_rate --rate 10 --duration 20s \
-  --burst-every 10s --burst-for 2s --burst-multiplier 5
+sonda run req-rate-bursts.yaml
 ```
 
 This emits at 10/s normally, but spikes to 50/s for 2 seconds every 10-second cycle.
 
-YAML works the same way:
+A larger scenario with shared defaults and labels:
 
 ```bash
-sonda metrics --scenario examples/burst-metrics.yaml --duration 20s
+sonda run examples/burst-metrics.yaml --duration 20s
 ```
 
 ```yaml title="examples/burst-metrics.yaml"

--- a/docs/site/docs/guides/tutorial-sinks.md
+++ b/docs/site/docs/guides/tutorial-sinks.md
@@ -6,49 +6,78 @@ delivery layer.
 
 Sonda supports nine sinks:
 
-| Sink | Description | CLI flag |
-|------|-------------|----------|
-| `stdout` | Print to standard output | _(default)_ |
-| `file` | Write to a file | `--output path` |
-| `tcp` | Stream to a TCP listener | YAML only |
-| `udp` | Send to a UDP endpoint | YAML only |
-| `http_push` | POST batches to an HTTP endpoint | `--sink http_push --endpoint <url>` |
-| `loki` | Push logs to Grafana Loki | `--sink loki --endpoint <url>` |
-| `kafka` | Publish to a Kafka topic | `--sink kafka --brokers <addr> --topic <t>` |
-| `remote_write` | Prometheus remote write protocol | `--sink remote_write --endpoint <url>` |
-| `otlp_grpc` | OTLP/gRPC to an OpenTelemetry Collector | `--sink otlp_grpc --endpoint <url> --signal-type <s>` |
+| Sink | Description | YAML `sink.type` |
+|------|-------------|------------------|
+| `stdout` | Print to standard output | `stdout` (default) |
+| `file` | Write to a file | `file` |
+| `tcp` | Stream to a TCP listener | `tcp` |
+| `udp` | Send to a UDP endpoint | `udp` |
+| `http_push` | POST batches to an HTTP endpoint | `http_push` |
+| `loki` | Push logs to Grafana Loki | `loki` |
+| `kafka` | Publish to a Kafka topic | `kafka` |
+| `remote_write` | Prometheus remote write protocol | `remote_write` |
+| `otlp_grpc` | OTLP/gRPC to an OpenTelemetry Collector | `otlp_grpc` |
+
+Sinks live in the YAML's `sink:` block (under `defaults:` or per entry). Quick CLI overrides exist for the common knobs — `--sink`, `--endpoint`, `--encoder`, and `-o <path>` (shorthand for `--sink file --endpoint <path>`). Anything richer (custom headers, batch size, Kafka brokers, OTLP signal type) goes in the file.
+
+The starter scenario below is reused by every sink section that follows — copy it once, then change the `sink:` block:
+
+```yaml title="cpu-base.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu
+    generator:
+      type: sine
+      amplitude: 50.0
+      offset: 50.0
+      period_secs: 60
+```
 
 ## stdout (default)
 
-No flags needed -- `stdout` is the default sink. Pipe output to any tool:
+No edit needed; the starter above writes to stdout. Pipe the output anywhere:
 
 ```bash
-sonda metrics --name up --rate 10 --duration 5s | wc -l
+sonda run cpu-base.yaml | wc -l
 ```
 
 ## file
 
-Write to a file with `--output`:
+Either set `sink.type: file` in the YAML or use the `-o` shortcut on the CLI:
 
 ```bash
-sonda metrics --name up --rate 10 --duration 5s --output /tmp/metrics.txt
+sonda run cpu-base.yaml -o /tmp/metrics.txt
+```
+
+```yaml title="file sink (YAML)"
+sink:
+  type: file
+  path: /tmp/metrics.txt
 ```
 
 ## http_push
 
-POST batched data to any HTTP endpoint. This is the most universal network sink -- it
-works with any backend that accepts HTTP imports. Use CLI flags for quick ad-hoc runs:
+POST batched data to any HTTP endpoint — the most universal network sink. Use CLI overrides for ad-hoc runs:
 
 ```bash
-sonda metrics --name cpu --rate 10 --duration 30s \
-  --sink http_push --endpoint http://localhost:9090/api/v1/push \
-  --content-type "text/plain; version=0.0.4"
+sonda run cpu-base.yaml \
+  --sink http_push --endpoint http://localhost:9090/api/v1/push
 ```
 
-Or use a scenario file for full control (including custom headers):
+Use a scenario file when you need custom headers or a tuned batch size:
 
 ```bash
-sonda metrics --scenario examples/http-push-sink.yaml
+sonda run examples/http-push-sink.yaml
 ```
 
 ```yaml title="examples/http-push-sink.yaml (key fields)"
@@ -58,9 +87,6 @@ sink:
   content_type: "text/plain; version=0.0.4"
   batch_size: 65536
 ```
-
-The key sink fields are `url`, `content_type`, and `batch_size` (bytes buffered before
-each POST).
 
 ## tcp and udp
 
@@ -76,11 +102,12 @@ Stream raw encoded bytes over a socket. Both are YAML-only.
     Then run:
 
     ```bash
-    sonda metrics --scenario examples/tcp-sink.yaml
+    sonda run examples/tcp-sink.yaml
     ```
 
     ```yaml title="examples/tcp-sink.yaml"
     version: 2
+    kind: runnable
 
     defaults:
       rate: 10
@@ -115,11 +142,12 @@ Stream raw encoded bytes over a socket. Both are YAML-only.
     Then run:
 
     ```bash
-    sonda metrics --scenario examples/udp-sink.yaml
+    sonda run examples/udp-sink.yaml
     ```
 
     ```yaml title="examples/udp-sink.yaml"
     version: 2
+    kind: runnable
 
     defaults:
       rate: 10
@@ -143,24 +171,17 @@ Stream raw encoded bytes over a socket. Both are YAML-only.
 
 ## loki
 
-Push JSON logs to Grafana Loki. The fastest way is a single CLI command:
+Push JSON logs to Grafana Loki. The full file gives you templates and field pools:
 
 ```bash
-sonda logs --mode template --rate 10 --duration 30s \
-  --sink loki --endpoint http://localhost:3100 \
-  --label job=sonda --label env=dev
-```
-
-For richer logs with field pools and severity weights, use a scenario file:
-
-```bash
-sonda logs --scenario examples/loki-json-lines.yaml
+sonda run examples/loki-json-lines.yaml
 ```
 
 ??? example "Full Loki scenario file"
 
     ```yaml title="examples/loki-json-lines.yaml"
     version: 2
+    kind: runnable
 
     defaults:
       rate: 10
@@ -194,20 +215,13 @@ sonda logs --scenario examples/loki-json-lines.yaml
 
 ## kafka
 
-Publish to a Kafka topic. Use CLI flags for a quick test:
+Publish to a Kafka topic. CLI overrides work for the host/topic, but Kafka brokers and ACK mode live in the YAML:
 
 ```bash
-sonda metrics --name cpu --rate 10 --duration 30s \
-  --sink kafka --brokers 127.0.0.1:9092 --topic sonda-metrics
+sonda run examples/kafka-sink.yaml
 ```
 
-Or use a scenario file for full control:
-
-```bash
-sonda metrics --scenario examples/kafka-sink.yaml
-```
-
-??? example "Full Kafka scenario file"
+??? example "Kafka scenario fields"
 
     ```yaml title="examples/kafka-sink.yaml (key fields)"
     sink:
@@ -216,24 +230,23 @@ sonda metrics --scenario examples/kafka-sink.yaml
       topic: sonda-metrics
     ```
 
-    See `examples/kafka-sink.yaml` for the complete file with generator and encoder
+    See `examples/kafka-sink.yaml` for the full file including generator and encoder
     config.
 
 ## remote_write
 
-Prometheus remote write protocol -- native compatibility with VictoriaMetrics, Prometheus,
-Thanos Receive, and Cortex/Mimir. The encoder and sink must both be `remote_write`:
+Prometheus remote write protocol — native compatibility with VictoriaMetrics, Prometheus, Thanos Receive, and Cortex/Mimir. The encoder and sink must both be `remote_write`:
 
 ```bash
-sonda metrics --name cpu --rate 10 --duration 30s \
+sonda run cpu-base.yaml \
   --encoder remote_write \
   --sink remote_write --endpoint http://localhost:8428/api/v1/write
 ```
 
-Or use a scenario file:
+Or run the canonical example file:
 
 ```bash
-sonda metrics --scenario examples/remote-write-vm.yaml
+sonda run examples/remote-write-vm.yaml
 ```
 
 ```yaml title="examples/remote-write-vm.yaml (key fields)"
@@ -247,26 +260,10 @@ sink:
 
 ## otlp_grpc
 
-Push to an OpenTelemetry Collector via gRPC. Use CLI flags for a quick test:
+Push to an OpenTelemetry Collector via gRPC. The encoder must be `otlp` and the sink type `otlp_grpc`. The signal type defaults from the scenario's `signal_type:` but is settable in the file:
 
 ```bash
-sonda metrics --name cpu --rate 10 --duration 30s \
-  --encoder otlp \
-  --sink otlp_grpc --endpoint http://localhost:4317 --signal-type metrics
-```
-
-For logs, `--signal-type` defaults to `logs` automatically:
-
-```bash
-sonda logs --mode template --rate 10 --duration 30s \
-  --encoder otlp \
-  --sink otlp_grpc --endpoint http://localhost:4317
-```
-
-Or use a scenario file:
-
-```bash
-sonda metrics --scenario examples/otlp-metrics.yaml
+sonda run examples/otlp-metrics.yaml
 ```
 
 ```yaml title="examples/otlp-metrics.yaml (key fields)"

--- a/docs/site/docs/guides/tutorial.md
+++ b/docs/site/docs/guides/tutorial.md
@@ -33,5 +33,6 @@ When you have walked through all seven pages you have everything you need to:
 - [**Validate a pipeline change end-to-end**](pipeline-validation.md).
 - [**Plan capacity for high-volume runs**](capacity-planning.md).
 
-If you would rather not write YAML by hand, run **`sonda init`** for an interactive
-wizard, or browse [**Built-in Scenarios**](scenarios.md) for ready-to-run patterns.
+If you would rather not write YAML by hand, run **`sonda new`** for an interactive
+scaffold, or browse the `examples/` directory in the repo for ready-to-run starter
+patterns.

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -18,10 +18,31 @@ Other install paths (Cargo, Docker, source) live in
 
 ## A taste
 
+```yaml title="cpu-sine.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  duration: 2s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+  labels:
+    host: web-01
+scenarios:
+  - id: cpu_usage
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: sine
+      amplitude: 50.0
+      offset: 50.0
+      period_secs: 4
+```
+
 ```bash
-sonda metrics --name cpu_usage --rate 2 --duration 2s \
-  --value-mode sine --amplitude 50 --offset 50 --period-secs 4 \
-  --label host=web-01
+sonda run cpu-sine.yaml
 ```
 
 ```text title="stdout (Prometheus exposition)"
@@ -32,8 +53,8 @@ cpu_usage{host="web-01"} 85.35533905932738 1777243960481
 cpu_usage{host="web-01"} 50.00000000000001 1777243960974
 ```
 
-One command, shaped values, labeled output -- now wire it once in a v2 scenario file
-and replay it from CI, your laptop, or `sonda-server`.
+One file, shaped values, labeled output -- now replay it from CI, your laptop, or
+`sonda-server`. Don't want to write YAML? `sonda new` scaffolds a starter for you.
 
 ## Where to next
 
@@ -43,19 +64,19 @@ and replay it from CI, your laptop, or `sonda-server`.
 
     Install Sonda, stream your first metric, and push to a real backend.
 
--   :material-bookshelf: __[Built-in scenarios](guides/scenarios.md)__
+-   :material-bookshelf: __[Author your own scenarios](guides/scenarios.md)__
 
-    Run curated patterns instantly -- `sonda metrics --scenario @cpu-spike`.
-    Browse the catalog, pin one, customize from there.
+    Organize a catalog directory of runnable scenarios and composable packs;
+    discover them with `sonda list --catalog <dir>` and run with `sonda run @name`.
 
 -   :material-file-document-outline: __[v2 scenario files](configuration/v2-scenarios.md)__
 
-    The canonical file shape: `version: 2`, shared `defaults:`, inline packs,
-    `after:` temporal chains, and env-var interpolation.
+    The canonical file shape: `version: 2`, `kind: runnable`, shared `defaults:`,
+    inline packs, `after:` temporal chains, and env-var interpolation.
 
 -   :material-database-import: __[CSV import](guides/csv-import.md)__
 
     Turn Grafana exports into portable, parameterized scenarios -- one
-    `sonda import` away.
+    `sonda new --from <csv>` away.
 
 </div>

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -88,7 +88,7 @@ nav:
       - Multi-Scenario Runs: guides/tutorial-multi-scenario.md
       - The Server API: guides/tutorial-server.md
     - Catalog & packs:
-      - Built-in Scenarios: guides/scenarios.md
+      - Catalogs: guides/scenarios.md
       - Dynamic Labels: guides/dynamic-labels.md
       - Example Scenarios: guides/examples.md
       - Metric Packs: guides/metric-packs.md


### PR DESCRIPTION
## Summary

Final piece of the 1.9 cycle. Sweeps every doc page (README + 41 \`docs/site\` files) to replace references to the removed CLI surface with the new 4-verb shape, removes all "built-in catalog" framing, and re-enables the docs-commands CI gate.

After this lands on \`release/1.9\`, the next merge is \`release/1.9 → main\` which triggers the 1.9.0 release-please minor bump.

## Substitutions applied (mechanical, comprehensive)

| Old (1.8) | New (1.9) |
|---|---|
| \`sonda metrics --scenario X\` | \`sonda run X\` |
| \`sonda logs --scenario X\` | \`sonda run X\` |
| \`sonda histogram --scenario X\` | \`sonda run X\` |
| \`sonda summary --scenario X\` | \`sonda run X\` |
| \`sonda init\` | \`sonda new\` (interactive) |
| \`sonda import data.csv -o out.yaml\` | \`sonda new --from data.csv -o out.yaml\` |
| \`sonda scenarios list/show/run\` | \`sonda list / show / run @name --catalog <dir>\` |
| \`sonda packs list/show/run\` | \`sonda list/show/run --catalog <dir> [--kind composable]\` |
| \`sonda catalog list/show/run\` | \`sonda list / show / run @name --catalog <dir>\` |
| \`--scenario-path\` / \`--pack-path\` | \`--catalog <dir>\` |
| \`SONDA_SCENARIO_PATH\` / \`SONDA_PACK_PATH\` | (no env var; pass \`--catalog\` explicitly) |
| "Sonda ships with built-in @cpu-spike, @memory-leak, ..." | "Users author their own catalog directory" |

## Restructured pages

- \`guides/scenarios.md\` — "Built-in Scenarios" → "Catalogs" (you author them)
- \`guides/metric-packs.md\` — packs framed as \`kind: composable\` catalog entries
- \`guides/csv-import.md\` — \`sonda import\` workflow → \`sonda new --from <csv>\`
- \`deployment/docker.md\` — Docker workflow rebuilt around \`--catalog\` mounted volumes
- \`deployment/sonda-server.md\` — server no longer has a pack catalog; \`pack:\` references in \`POST /scenarios\` bodies must be inline now
- \`mkdocs.yml\` nav — "Built-in Scenarios" label → "Catalogs" to match the page H1

## CI

\`.github/workflows/ci.yml\`: removed the temporary \`if:\` skip on the \`docs-commands\` job. It now runs unconditionally on every push and PR. **Closes task #44.**

## Verifications (all green)

- [x] Stale-grep returns nothing (except a deliberate "removed in 1.9" migration notice in \`cli-reference.md\`)
- [x] \`task site:build\` (mkdocs \`--strict\`) exits 0 with **ZERO warnings**
- [x] \`python3 scripts/validate_docs_commands.py\`: **133 commands checked, 0 failed**
- [x] 5 spot-checked documented invocations work against the built binary

## Test plan

- [x] Doc agent ran with the comprehensive brief
- [x] Orchestrator-side nav label fix on \`mkdocs.yml\` (small follow-up to the agent's rewrite)
- [x] Re-verified mkdocs strict + docs validator after the nav fix
- [x] Diff: 44 files, 1288 insertions, 1300 deletions

## Related

- Targets \`release/1.9\` (not main)
- Stacks on #353 (1.9a) + #354 (1.9b) + #356 (1.9c) + #357 (1.9d) + #358 (1.9e)
- Closes #44 (CI skip removal)
- Closes the docs-side of #355 (Dockerfile docs; binary side was already done in 1.9c fix-pass)
- After this lands: \`release/1.9 → main\` ships 1.9.0