### PR TITLE
chore(1.9): final-gate polish — docs sweep, smoke tests, validator rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,28 +195,25 @@ guided prompts. It uses operational vocabulary -- "spike event", "leak", "flap" 
 of raw generator types:
 
 ```bash
-sonda new
+sonda new -o my-scenario.yaml
 ```
 
 ```text
-? What type of signal? metrics
-? Metric name node_cpu_usage_percent
-? What situation should this metric simulate? spike_event - baseline with periodic spikes
-? Baseline value (between spikes) 35
-? Spike height (amount added during spike) 60
-? Events per second (rate) 1
-? Duration (e.g., 30s, 5m, 1h) 60s
-? Output encoding format prometheus_text
-? Where should output be sent? stdout
-? Output file path ./scenarios/node-cpu-usage-percent.yaml
+? Signal type › metrics
+? Scenario id › example
+? Generator › sine
+? Events per second › 1
+? Duration (e.g. 60s, 5m) › 60s
+? Sink › stdout
 
-Wrote scenario to ./scenarios/node-cpu-usage-percent.yaml
+wrote my-scenario.yaml
 ```
 
-The generated YAML is commented, immediately runnable, and ready to drop into a catalog
-directory. See the
-[CLI Reference](https://davidban77.github.io/sonda/configuration/cli-reference/#sonda-new) for
-the full prompt flow and available situations.
+The generated YAML is immediately runnable. Pass `-o <path>` to write to a file
+(omit it to preview on stdout), `--template` to skip prompts and dump a minimal
+file, or `--from <csv>` to scaffold from time-series data. See the
+[CLI Reference](https://davidban77.github.io/sonda/configuration/cli-reference/#sonda-new)
+for every prompt and flag.
 
 ## Multi-signal temporal scenarios
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,51 +181,33 @@ Sink implementations follow a natural progression of complexity:
 
 A metric pack is a reusable bundle of metric names and label schemas that expands into a multi-metric scenario. Packs are a **config-level composition concept** — the `packs/` module resolves a pack reference into N `ScenarioEntry` items before `prepare_entries()` runs. The runtime (scheduler, core loop, runners) has no knowledge of packs; it only sees the expanded entries.
 
-The architecture separates **engine** (in `sonda-core`) from **data** (YAML files) and **discovery** (in the CLI crate):
+The architecture separates **engine** (in `sonda-core`) from **data** (YAML files supplied by the user):
 
-- **sonda-core `packs/` module** — contains the engine types and expansion logic only. No pack YAML is embedded in the library.
-- **`packs/` directory at repo root** — contains the pack YAML files as standalone data. These are not compiled into any crate.
-- **CLI `packs` module** — discovers pack YAML files from the filesystem via a search path and caches the results for the CLI invocation.
+- **sonda-core `packs/` module** — engine types and expansion logic only. No pack YAML is embedded in the library; sonda ships no built-in packs.
+- **User-supplied catalog directory** — pack YAML files (with `kind: composable` at the top level) live alongside runnable scenarios in a catalog directory the user owns. The CLI resolves pack references via the `--catalog <dir>` flag.
 
 Key types (in `sonda-core`):
 
-- **MetricPackDef** — a pack definition: name, description, category, shared labels, and a list of `MetricSpec` entries.
+- **MetricPackDef** — a pack definition: name, description, shared labels, and a list of `MetricSpec` entries.
 - **MetricSpec** — a single metric within a pack: name, optional per-metric labels, optional default generator.
 - **PackScenarioConfig** — user-facing YAML config that references a pack by name and provides rate, duration, sink, encoder, labels, and per-metric overrides.
 - **expand_pack()** — the expansion function. Takes a `MetricPackDef` and a `PackScenarioConfig`, returns `Vec<ScenarioEntry>`. Label merge order: shared → per-metric → user → override. Generator selection: override → spec → constant(0.0).
-
-Key types (in the CLI crate):
-
-- **PackCatalog** — cached directory scan results. Built once per CLI invocation from the search path.
-- **PackEntry** — lightweight metadata (name, description, category, metric count, source path) parsed from YAML without full deserialization.
-
-**Pack discovery search path** (priority order): `--pack-path` CLI flag > `SONDA_PACK_PATH` env var (colon-separated) > `./packs/` relative to CWD > `~/.sonda/packs/`. Name collisions are resolved by first-match-wins.
+- **PackResolver** trait — abstract pack-lookup; `CatalogPackResolver` (CLI-side) scans the `--catalog <dir>` directory, while `InMemoryPackResolver` (test-side) takes pre-built definitions.
 
 Packs like `node_exporter_cpu` contain multiple specs with the same metric name but different label sets (e.g., one `node_cpu_seconds_total` per CPU mode). Overrides key on metric name, so a single override entry applies to all specs sharing that name.
 
 > **Design note:** Packs deliberately do not carry rate, duration, sink, or encoder — those are delivery concerns supplied by the user at run time. This separation means the same pack definition works unchanged across stdout testing, remote-write to production, and Kafka ingest.
 
-### 5.6.1 Scenarios
+### 5.6.1 Catalog discovery
 
-Built-in scenarios are pre-authored YAML files that model common failure and baseline patterns (CPU spike, memory leak, interface flap, etc.). Like packs, scenarios follow the **engine / data / discovery** separation:
+A catalog is any directory containing v2 scenario YAML files. Each file declares its role with a top-level `kind:`:
 
-- **sonda-core `scenarios/` module** — contains only the `BuiltinScenario` metadata struct (name, category, signal_type, description, source_path). No scenario YAML is embedded in the library.
-- **`scenarios/` directory at repo root** — contains the scenario YAML files as standalone data. Each file includes metadata fields (`scenario_name`, `category`, `signal_type`, `description`) in its header alongside the full scenario config.
-- **CLI `scenarios` module** — discovers scenario YAML files from the filesystem via a search path, probes the metadata header, and caches the results in a `ScenarioCatalog` for the CLI invocation. Full YAML content is loaded lazily when a scenario is actually run.
+- **`kind: runnable`** — a scenario you can launch (`sonda run @name --catalog <dir>` or `sonda run path/to/file.yaml`).
+- **`kind: composable`** — a metric pack definition, referenced from a runnable scenario via `pack: <name>` and resolved against the same catalog.
 
-Key types (in `sonda-core`):
+The CLI peeks the frontmatter of every YAML file in `--catalog <dir>`, indexes them by name (file stem, overridable via the `name:` field), and hard-errors on duplicate names. `sonda list --catalog <dir>` prints the index (filterable by `--kind` and `--tag`); `sonda show @name --catalog <dir>` prints the file's raw YAML. There is no built-in catalog, no env-var override, and no implicit search path — `--catalog` is the single discovery surface.
 
-- **BuiltinScenario** — lightweight metadata: name, category, signal_type, description, and the absolute filesystem path to the YAML file.
-
-Key types (in the CLI crate):
-
-- **ScenarioCatalog** — cached directory scan results. Built once per CLI invocation from the search path.
-
-**Scenario discovery search path** (priority order): `--scenario-path` CLI flag > `SONDA_SCENARIO_PATH` env var (colon-separated) > `./scenarios/` relative to CWD > `~/.sonda/scenarios/`. Name collisions are resolved by first-match-wins.
-
-All built-in scenarios use `stdout` as their sink and have a finite `duration`, so they work out of the box with zero configuration. The `scenarios run` subcommand supports rate, duration, sink, encoder, and endpoint overrides.
-
-> **Design note:** Scenarios deliberately live outside the binary so that users can add custom scenarios by dropping YAML files into the search path without recompiling. The same discovery mechanism works for both built-in and user-authored scenarios.
+> **Design note:** Scenarios are first-class artifacts of the system the user models. They live in the user's repo (versioned alongside the alert rules and dashboards they exercise) rather than being pinned to a sonda release.
 
 ### 5.7 Cargo Features
 
@@ -292,16 +274,16 @@ The CLI crate is intentionally thin. Its only responsibilities are:
 - Instantiate the appropriate generator, encoder, and sink from `sonda-core`.
 - Hand control to the `sonda-core` scenario runner.
 
-Primary CLI surface:
+Primary CLI surface (four verbs):
 
 ```
-sonda metrics [OPTIONS] --scenario <file.yaml>
-sonda metrics --name <name> --rate <n> --duration <d> --encoder <enc> [OVERRIDES]
-
-sonda logs [OPTIONS] --scenario <file.yaml>
+sonda run <file-or-@name> [OPTIONS]              # launch a v2 scenario
+sonda list --catalog <dir> [--kind ...] [--tag ...]
+sonda show <@name> --catalog <dir>               # print the raw YAML
+sonda new [--template | --from <csv>] [-o <path>]
 ```
 
-The CLI does not contain signal generation logic. Any behavior that is tested or benchmarked belongs in `sonda-core`.
+`sonda run` accepts either a filesystem path to a YAML file or a `@name` shorthand that resolves through `--catalog <dir>`. The CLI does not contain signal generation logic. Any behavior that is tested or benchmarked belongs in `sonda-core`.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -342,7 +342,7 @@ Portability is a primary constraint. Sonda must run on bare metal, in Docker, an
 
 ## 11. MVP Scope
 
-The MVP is complete when the following criteria are met:
+The MVP is complete when the following criteria are met. (Historical wording — the CLI surface collapsed to the four verbs documented in §7 for 1.9; today the equivalent is `sonda run <file>` against a v2 YAML.)
 
 - `sonda metrics --name <n> --rate <r> --duration <d>` generates valid Prometheus text to stdout.
 - Value generators: constant, uniform random (seeded), sine, sawtooth.

--- a/docs/site/docs/configuration/cli-reference.md
+++ b/docs/site/docs/configuration/cli-reference.md
@@ -2,9 +2,6 @@
 
 The `sonda` binary has four verbs: `run`, `list`, `show`, and `new`. `run` executes a [v2 scenario YAML file](v2-scenarios.md), `list` and `show` browse a catalog directory of scenarios and composable packs, and `new` scaffolds a starter file. Anything that used to live behind a per-signal subcommand (`metrics`, `logs`, `histogram`, `summary`) is now a v2 scenario YAML — pick a generator in the file, point `sonda run` at it.
 
-!!! info "1.9 in progress"
-    1.9 collapses the previous 9-verb surface into the four verbs documented here. The wider docs site still references the older surface in places; that rewrite ships alongside the rest of the 1.9 series. This page is the authoritative reference for the CLI shape in 1.9.
-
 ## Global options
 
 ```

--- a/docs/site/docs/configuration/generators.md
+++ b/docs/site/docs/configuration/generators.md
@@ -672,10 +672,6 @@ generator:
 
 Values hold at 35 between spikes, then jump to 95 (35 + 60) for 10 seconds every 30 seconds.
 
-!!! tip "Scaffold a starter"
-    `sonda new` writes a runnable `spike_event` YAML when you pick "spike_event" in the
-    interactive flow — useful for CPU-spike alert rehearsals against node-exporter-shaped labels.
-
 ??? tip "Aliases vs. core generators"
     You can always use the underlying generator directly if you need parameters that the alias
     does not expose. For example, `spike_event` does not expose the `spike` generator's

--- a/docs/site/docs/configuration/generators.md
+++ b/docs/site/docs/configuration/generators.md
@@ -624,10 +624,6 @@ Values ramp linearly from 40 to 95 over 120 seconds with no reset.
     config with an error. A leak that resets mid-run is the `saturation` pattern -- use that
     alias instead if you want repeating fill-and-reset cycles.
 
-!!! tip "Scaffold a starter"
-    `sonda new` writes a runnable `leak` YAML when you pick the "leak" situation in the
-    interactive flow — useful as a starting point for memory-leak alert rehearsals.
-
 ### degradation
 
 Models gradual performance loss with realistic noise -- latency increasing over time, error
@@ -652,10 +648,6 @@ generator:
 ```
 
 Values ramp from 50ms to 500ms over 60 seconds with +/- 20ms of noise on each tick.
-
-!!! tip "Scaffold a starter"
-    `sonda new` writes a ready-to-run `degradation` scenario with HTTP-latency-friendly defaults
-    when you pick the "degradation" situation in the interactive flow.
 
 ### spike_event
 

--- a/docs/site/docs/configuration/generators.md
+++ b/docs/site/docs/configuration/generators.md
@@ -390,6 +390,7 @@ When `columns` is omitted, Sonda reads the CSV header and auto-discovers column 
 
     ```yaml title="Multi-column CSV replay"
     version: 2
+    kind: runnable
 
     defaults:
       rate: 1
@@ -780,6 +781,7 @@ updates cumulative bucket counters, and emits one line per bucket plus `+Inf`, `
 
 ```yaml title="examples/histogram.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -859,6 +861,7 @@ the nearest-rank method.
 
 ```yaml title="examples/summary.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -1052,6 +1055,7 @@ because it wraps any generator transparently.
 
 ```yaml title="examples/jitter-sine.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/configuration/scenario-fields.md
+++ b/docs/site/docs/configuration/scenario-fields.md
@@ -16,6 +16,7 @@ A single v2 entry touching every available field:
 
 ```yaml title="full-example.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 100
@@ -288,6 +289,7 @@ works.
 
 ```yaml title="log-scenario.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 10
@@ -342,6 +344,7 @@ Two metric entries correlated with `phase_offset` + a shared `clock_group:`:
 
 ```yaml title="multi-scenario.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -389,6 +392,7 @@ hand-tuned offsets.
 
 ```yaml title="mixed-signals.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -464,6 +468,7 @@ one entry per metric at compile time:
 
 ```yaml title="pack-scenario.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/configuration/sink-batching.md
+++ b/docs/site/docs/configuration/sink-batching.md
@@ -168,6 +168,7 @@ The batch never fills to `batch_size` at this rate, so the size trigger never fi
 
 ```yaml title="Low-rate scenario with explicit time threshold"
 version: 2
+kind: runnable
 
 defaults:
   rate: 0.05  # one event every 20 seconds

--- a/docs/site/docs/configuration/sinks.md
+++ b/docs/site/docs/configuration/sinks.md
@@ -374,6 +374,7 @@ labels are used as Loki stream labels in the push API envelope.
 
 ```yaml title="Loki sink with top-level labels"
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -1,11 +1,13 @@
 # v2 Scenario Files
 
-The v2 scenario format is Sonda's way to describe one or many signals in a single YAML file.
-One top-level block declares shared defaults; another lists the scenarios. Packs, `after:`
-temporal dependencies, and clock groups all compose inside the same file.
+The v2 scenario format is Sonda's way to describe one or many signals in a single YAML file. One top-level block declares shared defaults; another lists the scenarios. Packs, `after:` temporal dependencies, and clock groups all compose inside the same file.
 
-Every scenario file must declare `version: 2` at the top. Everything else you already know
-about scenarios -- generators, encoders, sinks, labels -- still applies.
+Every scenario file declares two top-level fields:
+
+- **`version: 2`** — the format version. Always `2`.
+- **`kind: runnable`** — a file you can run with `sonda run`. Use `kind: composable` for files that define a [metric pack](../guides/metric-packs.md) used by other scenarios.
+
+Everything else you already know about scenarios — generators, encoders, sinks, labels — still applies.
 
 !!! warning "v1 YAML is no longer accepted"
     Sonda only accepts v2 scenario YAML. Both `sonda run` and the HTTP server
@@ -19,6 +21,7 @@ about scenarios -- generators, encoders, sinks, labels -- still applies.
 
 ```yaml title="hello-v2.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -177,6 +180,7 @@ This is the main ergonomic win over legacy multi-scenario files, where you typed
 
 ```yaml title="defaults-example.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 10
@@ -225,6 +229,7 @@ Set the policy at `defaults:` to apply it to every entry, or per-entry to overri
 
 ```yaml title="sink-error-policy.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 100
@@ -272,9 +277,10 @@ link saturates once the primary drops, and latency degrades once the backup fill
 
 ```yaml title="link-failover.yaml"
 version: 2
+kind: runnable
 
-scenario_name: link-failover
-category: network
+name: link-failover
+tags: [network]
 description: "Edge router link failure with traffic shift to backup"
 
 defaults:
@@ -419,6 +425,7 @@ For continuous gating that pauses and resumes a downstream as the upstream's val
 
 ```yaml title="link-traffic.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -562,6 +569,7 @@ The tradeoff is per-metric specificity: `snap_to:` requires you to choose a reco
 
 ```yaml title="scenarios/bgp-session-cascade.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -638,6 +646,7 @@ To make the backup track the primary's state continuously, swap `after:` for `wh
 
 ```yaml title="link-failover-recovery.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -681,6 +690,7 @@ expands the pack at compile time -- you get one prepared scenario per metric in 
 
 ```yaml title="snmp-interface.v2.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -817,6 +827,7 @@ anything and prints the error alongside a pointer to this guide.
 
     ```yaml title="After (v2)"
     version: 2
+    kind: runnable
 
     defaults:
       rate: 100
@@ -872,6 +883,7 @@ anything and prints the error alongside a pointer to this guide.
 
     ```yaml title="After (v2)"
     version: 2
+    kind: runnable
 
     defaults:
       rate: 10
@@ -925,6 +937,7 @@ anything and prints the error alongside a pointer to this guide.
 
     ```yaml title="After (v2)"
     version: 2
+    kind: runnable
 
     defaults:
       rate: 10
@@ -980,6 +993,7 @@ anything and prints the error alongside a pointer to this guide.
 
     ```yaml title="After (v2)"
     version: 2
+    kind: runnable
 
     defaults:
       rate: 1
@@ -1027,6 +1041,7 @@ anything and prints the error alongside a pointer to this guide.
 
     ```yaml title="After (v2)"
     version: 2
+    kind: runnable
 
     defaults:
       rate: 1

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -89,6 +89,7 @@ Post a [v2 scenario](../configuration/v2-scenarios.md) YAML or JSON body to
       -H "Content-Type: text/yaml" \
       --data-binary @- http://localhost:8080/scenarios <<'EOF'
     version: 2
+    kind: runnable
 
     defaults:
       rate: 10
@@ -120,6 +121,7 @@ Post a [v2 scenario](../configuration/v2-scenarios.md) YAML or JSON body to
       -d @- http://localhost:8080/scenarios <<'EOF'
     {
       "version": 2,
+      "kind": "runnable",
       "defaults": {
         "rate": 10,
         "duration": "30s",
@@ -159,6 +161,7 @@ Post a v2 file with two or more `scenarios:` entries to launch them atomically:
 
     ```yaml title="examples/multi-scenario.yaml"
     version: 2
+    kind: runnable
 
     defaults:
       rate: 10
@@ -201,6 +204,7 @@ Post a v2 file with two or more `scenarios:` entries to launch them atomically:
       -d @- http://localhost:8080/scenarios <<'EOF'
     {
       "version": 2,
+      "kind": "runnable",
       "defaults": {
         "rate": 10,
         "duration": "30s",
@@ -265,6 +269,7 @@ validation, the entire request is rejected and nothing is launched:
 
     ```yaml
     version: 2
+    kind: runnable
 
     defaults:
       rate: 1

--- a/docs/site/docs/guides/alert-testing-correlation.md
+++ b/docs/site/docs/guides/alert-testing-correlation.md
@@ -17,6 +17,7 @@ sonda run examples/multi-metric-correlation.yaml
 
 ```yaml title="examples/multi-metric-correlation.yaml (excerpt)"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/guides/alert-testing-resolution.md
+++ b/docs/site/docs/guides/alert-testing-resolution.md
@@ -21,6 +21,7 @@ sonda run examples/gap-alert-test.yaml
 
 ```yaml title="examples/gap-alert-test.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/guides/alert-testing-thresholds.md
+++ b/docs/site/docs/guides/alert-testing-thresholds.md
@@ -24,6 +24,7 @@ sonda run examples/sine-threshold-test.yaml
 
 ```yaml title="examples/sine-threshold-test.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -84,6 +85,7 @@ sonda run examples/for-duration-test.yaml
 
 ```yaml title="examples/for-duration-test.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -123,6 +125,7 @@ sonda run examples/constant-threshold-test.yaml
 
 ```yaml title="examples/constant-threshold-test.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/guides/capacity-planning.md
+++ b/docs/site/docs/guides/capacity-planning.md
@@ -67,6 +67,7 @@ sonda run examples/capacity-throughput-test.yaml
 
 ```yaml title="examples/capacity-throughput-test.yaml (excerpt)"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1000
@@ -171,6 +172,7 @@ sonda run examples/capacity-cardinality-stress.yaml
 
 ```yaml title="examples/capacity-cardinality-stress.yaml (excerpt)"
 version: 2
+kind: runnable
 
 defaults:
   rate: 50
@@ -310,6 +312,7 @@ sonda run examples/capacity-burst-test.yaml
 
 ```yaml title="examples/capacity-burst-test.yaml (excerpt)"
 version: 2
+kind: runnable
 
 defaults:
   duration: 120s

--- a/docs/site/docs/guides/ci-alert-validation.md
+++ b/docs/site/docs/guides/ci-alert-validation.md
@@ -205,6 +205,7 @@ both the warning threshold (70) and the critical threshold (90) defined in the a
 
 ```yaml title="examples/ci-alert-validation.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -367,6 +368,7 @@ that should trigger it.
 
 ```yaml title="examples/ci-high-memory-alert.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/guides/dynamic-labels.md
+++ b/docs/site/docs/guides/dynamic-labels.md
@@ -96,6 +96,7 @@ in one label. With dynamic labels, one entry does the job.
 
 ```yaml title="examples/dynamic-labels-fleet.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/docs/site/docs/guides/e2e-testing.md
+++ b/docs/site/docs/guides/e2e-testing.md
@@ -44,6 +44,7 @@ sonda run examples/e2e-scenario.yaml
 
 ```yaml title="examples/e2e-scenario.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/guides/grafana-csv-replay.md
+++ b/docs/site/docs/guides/grafana-csv-replay.md
@@ -101,6 +101,7 @@ column, and creates independent metric streams.
 
 ```yaml title="examples/csv-replay-grafana-auto.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -158,6 +159,7 @@ with a hand-authored CSV that has plain headers -- use `columns:` with the `labe
 
 ```yaml title="examples/csv-replay-explicit-labels.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/guides/histogram-alerts.md
+++ b/docs/site/docs/guides/histogram-alerts.md
@@ -104,6 +104,7 @@ works directly with `rate()` and `histogram_quantile()`.
 
 ```yaml title="examples/histogram.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -186,6 +187,7 @@ threshold.
 
 ```yaml title="histogram-degradation.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -252,6 +254,7 @@ per-tick and cannot be aggregated across instances.
 
 ```yaml title="examples/summary.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/guides/log-csv-replay.md
+++ b/docs/site/docs/guides/log-csv-replay.md
@@ -42,6 +42,7 @@ When the header names don't match the conventions, use [explicit `columns:`](#ex
 
 ```yaml title="examples/log-csv-replay.yaml"
 version: 2
+kind: runnable
 
 defaults:
   duration: 60s
@@ -157,6 +158,7 @@ timestamp,severity,message,pod,trace_id
 
 ```yaml title="loki-replay.yaml"
 version: 2
+kind: runnable
 
 defaults:
   duration: 10m

--- a/docs/site/docs/guides/network-automation-testing.md
+++ b/docs/site/docs/guides/network-automation-testing.md
@@ -546,6 +546,7 @@ alerts correctly. Create a BGP session scenario file:
 
 ```yaml title="bgp-session-down.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/guides/network-device-telemetry.md
+++ b/docs/site/docs/guides/network-device-telemetry.md
@@ -75,6 +75,7 @@ sonda --dry-run run examples/network-device-baseline.yaml
 
 ```yaml title="examples/network-device-baseline.yaml (excerpt)"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/guides/pipeline-validation.md
+++ b/docs/site/docs/guides/pipeline-validation.md
@@ -176,18 +176,21 @@ jobs:
       - name: Install Sonda
         run: cargo install sonda
 
+      - name: Scaffold a smoke-test scenario
+        run: sonda -q new --template -o /tmp/ci-smoke.yaml
+
       - name: Smoke test (Prometheus text)
         run: |
-          sonda -q metrics --name ci_smoke --rate 10 --duration 5s \
-            --output /tmp/ci-smoke-prom.txt
+          sonda -q run /tmp/ci-smoke.yaml --rate 10 --duration 5s \
+            --sink file --endpoint /tmp/ci-smoke-prom.txt
           LINES=$(wc -l < /tmp/ci-smoke-prom.txt)
           echo "Produced $LINES lines"
           [ "$LINES" -ge 40 ] || { echo "FAIL: too few lines"; exit 1; }
 
       - name: Smoke test (JSON Lines)
         run: |
-          sonda -q metrics --name ci_smoke --rate 10 --duration 5s \
-            --encoder json_lines --output /tmp/ci-smoke-json.txt
+          sonda -q run /tmp/ci-smoke.yaml --rate 10 --duration 5s \
+            --encoder json_lines --sink file --endpoint /tmp/ci-smoke-json.txt
           LINES=$(wc -l < /tmp/ci-smoke-json.txt)
           echo "Produced $LINES lines"
           [ "$LINES" -ge 40 ] || { echo "FAIL: too few lines"; exit 1; }

--- a/docs/site/docs/guides/pipeline-validation.md
+++ b/docs/site/docs/guides/pipeline-validation.md
@@ -127,6 +127,7 @@ wc -l < /tmp/pipeline-influx.txt
 
 ```yaml title="examples/multi-format-test.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 2
@@ -229,6 +230,7 @@ wc -l < /tmp/pipeline-logs.json
 
 ```yaml title="examples/multi-pipeline-test.yaml"
 version: 2
+kind: runnable
 
 scenarios:
   - signal_type: metrics

--- a/docs/site/docs/guides/recording-rules.md
+++ b/docs/site/docs/guides/recording-rules.md
@@ -50,6 +50,7 @@ sonda run examples/recording-rule-test.yaml &
 
 ```yaml title="examples/recording-rule-test.yaml (key fields)"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -134,6 +135,7 @@ sonda run examples/rate-rule-input.yaml &
 
 ```yaml title="examples/rate-rule-input.yaml (key fields)"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/guides/scenarios.md
+++ b/docs/site/docs/guides/scenarios.md
@@ -1,10 +1,6 @@
 # Catalogs
 
-Sonda discovers your scenario YAML files from a **catalog directory** you point it at. The
-catalog is just a folder of v2 YAML files with a `kind:` header: `kind: runnable` for scenarios
-you run, `kind: composable` for [metric packs](metric-packs.md) you reference from other
-scenarios. Sonda no longer ships any built-in scenario or pack catalog — you own the catalog,
-keep it in your own repo, and point `--catalog <dir>` at it.
+A **catalog** is a directory of v2 YAML files that Sonda discovers via `--catalog <dir>`. Each file declares a `kind:` — `runnable` for scenarios you can run, `composable` for [metric packs](metric-packs.md) other scenarios reference. Sonda doesn't ship a built-in catalog: yours lives in your own repo, versioned next to your alert rules, dashboards, and CI workflows. Scenarios become first-class artifacts of the system they model instead of being pinned to a Sonda release.
 
 ## The minimum
 

--- a/docs/site/docs/guides/synthetic-monitoring.md
+++ b/docs/site/docs/guides/synthetic-monitoring.md
@@ -182,6 +182,7 @@ indefinitely until you stop it with `DELETE /scenarios/{id}`.
 
 ```yaml title="examples/long-running-metrics.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/docs/site/docs/guides/troubleshooting.md
+++ b/docs/site/docs/guides/troubleshooting.md
@@ -197,6 +197,8 @@ Data arrives in chunks or only appears when the scenario ends.
 
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
+| `v2 scenario file requires a top-level 'kind:' field` | The file is missing the `kind:` declaration | Add `kind: runnable` (for files you run) or `kind: composable` (for [metric packs](metric-packs.md)) at the top of the file, alongside `version: 2`. See [v2 Scenario Files](../configuration/v2-scenarios.md). |
+| `unknown kind '<value>': must be 'runnable' or 'composable'` | `kind:` is set to a typo or unsupported value | Use exactly `runnable` or `composable`. |
 | `invalid type` error on a numeric field | Value is quoted as a string in YAML (e.g., `rate: "10"`) | Remove quotes from numeric fields: `rate: 10` |
 | `unknown field` error | Typo in a field name, or field placed at the wrong nesting level | Check indentation. `labels` goes at the scenario level, not inside `sink` |
 | `missing field` error | Required field omitted | Run `sonda --dry-run` to see which field is missing |

--- a/docs/site/docs/guides/tutorial-generators.md
+++ b/docs/site/docs/guides/tutorial-generators.md
@@ -92,6 +92,7 @@ sonda run examples/sequence-alert-test.yaml --duration 10s
 
 ```yaml title="examples/sequence-alert-test.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1
@@ -157,6 +158,7 @@ and clears at t=10s, deterministically, every run.
 
     ```yaml title="examples/csv-replay-metrics.yaml"
     version: 2
+    kind: runnable
 
     defaults:
       rate: 1
@@ -195,6 +197,7 @@ deterministic uniform noise:
 
 ```yaml title="examples/jitter-sine.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/guides/tutorial-logs.md
+++ b/docs/site/docs/guides/tutorial-logs.md
@@ -51,6 +51,7 @@ sonda run examples/log-csv-replay.yaml
 
 ```yaml title="examples/log-csv-replay.yaml"
 version: 2
+kind: runnable
 
 defaults:
   duration: 60s

--- a/docs/site/docs/guides/tutorial-multi-scenario.md
+++ b/docs/site/docs/guides/tutorial-multi-scenario.md
@@ -9,6 +9,7 @@ sonda run examples/multi-scenario.yaml
 
 ```yaml title="examples/multi-scenario.yaml"
 version: 2
+kind: runnable
 
 scenarios:
   - signal_type: metrics
@@ -70,6 +71,7 @@ sonda run examples/multi-metric-correlation.yaml
 
 ```yaml title="examples/multi-metric-correlation.yaml (excerpt)"
 version: 2
+kind: runnable
 
 defaults:
   rate: 1

--- a/docs/site/docs/guides/tutorial-scheduling.md
+++ b/docs/site/docs/guides/tutorial-scheduling.md
@@ -78,6 +78,7 @@ sonda run examples/burst-metrics.yaml --duration 20s
 
 ```yaml title="examples/burst-metrics.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 100

--- a/docs/site/docs/guides/tutorial-server.md
+++ b/docs/site/docs/guides/tutorial-server.md
@@ -111,6 +111,7 @@ scenario you want running until you say otherwise.
 
 ```yaml title="examples/long-running-metrics.yaml"
 version: 2
+kind: runnable
 
 defaults:
   rate: 10

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -18,12 +18,27 @@ Other install paths (Cargo, Docker, source) live in
 
 ## A taste
 
-```yaml title="cpu-sine.yaml"
+Two commands. No YAML to hand-author yet — `sonda new --template` scaffolds a runnable starter file, and `sonda run` plays it back:
+
+```bash title="hello.yaml"
+sonda new --template -o hello.yaml
+sonda run hello.yaml --duration 3s
+```
+
+```text title="stdout (Prometheus exposition)"
+example_metric 1 1777243958972
+example_metric 1 1777243959978
+example_metric 1 1777243960981
+```
+
+Edit `hello.yaml` to shape the signal — swap `constant` for `sine`, add labels, point the sink at a real backend:
+
+```yaml title="hello.yaml (edited)"
 version: 2
 kind: runnable
 defaults:
   rate: 2
-  duration: 2s
+  duration: 5s
   encoder:
     type: prometheus_text
   sink:
@@ -41,20 +56,14 @@ scenarios:
       period_secs: 4
 ```
 
-```bash
-sonda run cpu-sine.yaml
-```
-
-```text title="stdout (Prometheus exposition)"
+```text title="Output"
 cpu_usage{host="web-01"} 50 1777243958972
 cpu_usage{host="web-01"} 85.35533905932738 1777243959525
 cpu_usage{host="web-01"} 100 1777243959982
 cpu_usage{host="web-01"} 85.35533905932738 1777243960481
-cpu_usage{host="web-01"} 50.00000000000001 1777243960974
 ```
 
-One file, shaped values, labeled output -- now replay it from CI, your laptop, or
-`sonda-server`. Don't want to write YAML? `sonda new` scaffolds a starter for you.
+Same file runs from your laptop, from CI, or [posted to `sonda-server` over HTTP](deployment/sonda-server.md). For a guided walkthrough — including pushing to a real Prometheus, Loki, or OTLP backend — see [Getting Started](getting-started.md).
 
 ## Where to next
 

--- a/examples/capacity-burst-test.yaml
+++ b/examples/capacity-burst-test.yaml
@@ -11,7 +11,7 @@
 #   docker compose -f examples/docker-compose-victoriametrics.yml up -d
 #
 # Usage:
-#   sonda run --scenario examples/capacity-burst-test.yaml
+#   sonda run examples/capacity-burst-test.yaml
 
 version: 2
 kind: runnable

--- a/examples/capacity-cardinality-stress.yaml
+++ b/examples/capacity-cardinality-stress.yaml
@@ -13,7 +13,7 @@
 #   docker compose -f examples/docker-compose-victoriametrics.yml up -d
 #
 # Usage:
-#   sonda run --scenario examples/capacity-cardinality-stress.yaml
+#   sonda run examples/capacity-cardinality-stress.yaml
 
 version: 2
 kind: runnable

--- a/examples/capacity-throughput-test.yaml
+++ b/examples/capacity-throughput-test.yaml
@@ -11,7 +11,7 @@
 #   docker compose -f examples/docker-compose-victoriametrics.yml up -d
 #
 # Usage:
-#   sonda run --scenario examples/capacity-throughput-test.yaml
+#   sonda run examples/capacity-throughput-test.yaml
 
 version: 2
 kind: runnable

--- a/examples/cardinality-alert-test.yaml
+++ b/examples/cardinality-alert-test.yaml
@@ -11,7 +11,7 @@
 #   docker compose -f examples/docker-compose-victoriametrics.yml up -d
 #
 # Usage:
-#   sonda metrics --scenario examples/cardinality-alert-test.yaml
+#   sonda run examples/cardinality-alert-test.yaml
 
 version: 2
 kind: runnable

--- a/examples/ci-alert-validation.yaml
+++ b/examples/ci-alert-validation.yaml
@@ -6,7 +6,7 @@
 # vmalert enough evaluation cycles to fire a `for: 5s` alert.
 #
 # Usage:
-#   sonda metrics --scenario examples/ci-alert-validation.yaml
+#   sonda run examples/ci-alert-validation.yaml
 #
 # Requires VictoriaMetrics at localhost:8428.
 

--- a/examples/constant-threshold-test.yaml
+++ b/examples/constant-threshold-test.yaml
@@ -5,7 +5,7 @@
 # so the alert should fire after 5 minutes of continuous breach.
 #
 # Usage:
-#   sonda metrics --scenario examples/constant-threshold-test.yaml
+#   sonda run examples/constant-threshold-test.yaml
 
 version: 2
 kind: runnable

--- a/examples/csv-replay-explicit-labels.yaml
+++ b/examples/csv-replay-explicit-labels.yaml
@@ -11,7 +11,7 @@
 #   - Column 3 (disk_io_mbps): no extra labels
 #
 # Run with:
-#   sonda metrics --scenario examples/csv-replay-explicit-labels.yaml
+#   sonda run examples/csv-replay-explicit-labels.yaml
 
 version: 2
 kind: runnable

--- a/examples/csv-replay-grafana-auto.yaml
+++ b/examples/csv-replay-grafana-auto.yaml
@@ -11,7 +11,7 @@
 # Scenario-level labels (e.g., env: production) are merged as defaults.
 #
 # Run with:
-#   sonda metrics --scenario examples/csv-replay-grafana-auto.yaml
+#   sonda run examples/csv-replay-grafana-auto.yaml
 
 version: 2
 kind: runnable

--- a/examples/csv-replay-metrics.yaml
+++ b/examples/csv-replay-metrics.yaml
@@ -10,7 +10,7 @@
 # the full source span at the derived 0.1/s rate.
 #
 # Run with:
-#   sonda metrics --scenario examples/csv-replay-metrics.yaml
+#   sonda run examples/csv-replay-metrics.yaml
 
 version: 2
 kind: runnable

--- a/examples/csv-replay-multi-column.yaml
+++ b/examples/csv-replay-multi-column.yaml
@@ -8,7 +8,7 @@
 # avoids duplicating the shared configuration.
 #
 # Run with:
-#   sonda metrics --scenario examples/csv-replay-multi-column.yaml
+#   sonda run examples/csv-replay-multi-column.yaml
 
 version: 2
 kind: runnable

--- a/examples/docker-alerts.yaml
+++ b/examples/docker-alerts.yaml
@@ -19,7 +19,7 @@
 #       severity: warning
 #
 # Usage with the CLI:
-#   sonda metrics --scenario examples/docker-alerts.yaml
+#   sonda run examples/docker-alerts.yaml
 #
 # Usage with sonda-server (POST to the running container):
 #   curl -X POST -H "Content-Type: text/yaml" \

--- a/examples/docker-metrics.yaml
+++ b/examples/docker-metrics.yaml
@@ -5,7 +5,7 @@
 # period. Includes a recurring gap to test pipeline gap-fill behavior.
 #
 # Usage with the CLI:
-#   sonda metrics --scenario examples/docker-metrics.yaml
+#   sonda run examples/docker-metrics.yaml
 #
 # Usage with sonda-server (POST to the running container):
 #   curl -X POST -H "Content-Type: text/yaml" \

--- a/examples/dynamic-labels-fleet.yaml
+++ b/examples/dynamic-labels-fleet.yaml
@@ -8,7 +8,7 @@
 # or to exercise high-cardinality query paths in Prometheus / VictoriaMetrics.
 #
 # Usage:
-#   sonda metrics --scenario examples/dynamic-labels-fleet.yaml
+#   sonda run examples/dynamic-labels-fleet.yaml
 
 version: 2
 kind: runnable

--- a/examples/dynamic-labels-logs.yaml
+++ b/examples/dynamic-labels-logs.yaml
@@ -4,7 +4,7 @@
 # rotates through api-0, api-1, api-2 on every emitted log event.
 #
 # Usage:
-#   sonda logs --scenario examples/dynamic-labels-logs.yaml
+#   sonda run examples/dynamic-labels-logs.yaml
 
 version: 2
 kind: runnable

--- a/examples/dynamic-labels-multi.yaml
+++ b/examples/dynamic-labels-multi.yaml
@@ -4,7 +4,7 @@
 # Each label cycles independently, producing hostname x region combinations.
 #
 # Usage:
-#   sonda metrics --scenario examples/dynamic-labels-multi.yaml
+#   sonda run examples/dynamic-labels-multi.yaml
 
 version: 2
 kind: runnable

--- a/examples/dynamic-labels-regions.yaml
+++ b/examples/dynamic-labels-regions.yaml
@@ -5,7 +5,7 @@
 # sequential counters.
 #
 # Usage:
-#   sonda metrics --scenario examples/dynamic-labels-regions.yaml
+#   sonda run examples/dynamic-labels-regions.yaml
 
 version: 2
 kind: runnable

--- a/examples/e2e-scenario.yaml
+++ b/examples/e2e-scenario.yaml
@@ -7,7 +7,7 @@
 #   docker compose -f examples/docker-compose-victoriametrics.yml up -d
 #
 # Usage:
-#   sonda metrics --scenario examples/e2e-scenario.yaml
+#   sonda run examples/e2e-scenario.yaml
 #   sleep 5
 #   curl -s "http://localhost:8428/api/v1/query?query=e2e_pipeline_check" \
 #     | jq '.data.result | length'

--- a/examples/for-duration-test.yaml
+++ b/examples/for-duration-test.yaml
@@ -9,7 +9,7 @@
 # Adjust the number of above-threshold values to match your `for:` duration.
 #
 # Usage:
-#   sonda metrics --scenario examples/for-duration-test.yaml
+#   sonda run examples/for-duration-test.yaml
 
 version: 2
 kind: runnable

--- a/examples/gap-alert-test.yaml
+++ b/examples/gap-alert-test.yaml
@@ -9,7 +9,7 @@
 #   40-60s: gap (no data, alert may resolve)
 #
 # Usage:
-#   sonda metrics --scenario examples/gap-alert-test.yaml
+#   sonda run examples/gap-alert-test.yaml
 
 version: 2
 kind: runnable

--- a/examples/histogram.yaml
+++ b/examples/histogram.yaml
@@ -12,7 +12,7 @@
 # Prerequisites: none -- stdout sink.
 #
 # Run:
-#   sonda histogram --scenario examples/histogram.yaml
+#   sonda run examples/histogram.yaml
 #
 # Observable output: 12 `_bucket` series (default Prometheus bucket set),
 # plus `_count` and `_sum`. Watch the low-le buckets (0.005, 0.01, 0.025)

--- a/examples/http-push-retry.yaml
+++ b/examples/http-push-retry.yaml
@@ -7,9 +7,7 @@
 # Usage:
 #   sonda run examples/http-push-retry.yaml
 #
-# You can override retry settings from the CLI:
-#   sonda run examples/http-push-retry.yaml \
-#     --retry-max-attempts 5 --retry-backoff 200ms --retry-max-backoff 10s
+# Retry settings live in the YAML `retry:` block below — they have no CLI override.
 
 version: 2
 kind: runnable

--- a/examples/http-push-retry.yaml
+++ b/examples/http-push-retry.yaml
@@ -5,10 +5,10 @@
 # retries up to max_attempts times before discarding the batch.
 #
 # Usage:
-#   sonda metrics --scenario examples/http-push-retry.yaml
+#   sonda run examples/http-push-retry.yaml
 #
 # You can override retry settings from the CLI:
-#   sonda metrics --scenario examples/http-push-retry.yaml \
+#   sonda run examples/http-push-retry.yaml \
 #     --retry-max-attempts 5 --retry-backoff 200ms --retry-max-backoff 10s
 
 version: 2

--- a/examples/http-push-sink.yaml
+++ b/examples/http-push-sink.yaml
@@ -5,7 +5,7 @@
 #
 # Then run:
 #
-#   sonda metrics --scenario examples/http-push-sink.yaml
+#   sonda run examples/http-push-sink.yaml
 #
 # Verify with: curl 'http://localhost:8428/api/v1/query?query=cpu_usage'
 

--- a/examples/influx-file.yaml
+++ b/examples/influx-file.yaml
@@ -4,7 +4,7 @@
 # Parent directories are created automatically if they do not exist.
 #
 # Run:
-#   sonda metrics --scenario examples/influx-file.yaml
+#   sonda run examples/influx-file.yaml
 #   cat /tmp/sonda-influx-output.txt
 
 version: 2

--- a/examples/json-tcp.yaml
+++ b/examples/json-tcp.yaml
@@ -4,7 +4,7 @@
 # Start a listener before running:
 #
 #   nc -l 9999 &
-#   sonda metrics --scenario examples/json-tcp.yaml
+#   sonda run examples/json-tcp.yaml
 #
 # Each line is a self-contained JSON object, compatible with Elasticsearch,
 # Loki, and any other NDJSON-based ingest path.

--- a/examples/kafka-sink.yaml
+++ b/examples/kafka-sink.yaml
@@ -10,7 +10,7 @@
 #   auto.create.topics.enable=true (the default for most Kafka distributions).
 #
 # Usage:
-#   sonda metrics --scenario examples/kafka-sink.yaml
+#   sonda run examples/kafka-sink.yaml
 
 version: 2
 kind: runnable

--- a/examples/kafka-tls.yaml
+++ b/examples/kafka-tls.yaml
@@ -12,7 +12,7 @@
 #   enabled and SASL PLAIN authentication configured.
 #
 # Usage:
-#   sonda metrics --scenario examples/kafka-tls.yaml
+#   sonda run examples/kafka-tls.yaml
 
 version: 2
 kind: runnable

--- a/examples/multi-format-test.yaml
+++ b/examples/multi-format-test.yaml
@@ -5,7 +5,7 @@
 # correctly.
 #
 # Usage:
-#   sonda metrics --scenario examples/multi-format-test.yaml
+#   sonda run examples/multi-format-test.yaml
 #   wc -l < /tmp/pipeline-influx.txt
 
 version: 2

--- a/examples/multi-metric-correlation.yaml
+++ b/examples/multi-metric-correlation.yaml
@@ -1,7 +1,7 @@
 # Multi-metric correlation example: testing compound alert rules.
 #
 # Run with:
-#   sonda run --scenario examples/multi-metric-correlation.yaml
+#   sonda run examples/multi-metric-correlation.yaml
 #
 # This scenario models a compound alert rule:
 #   ALERT HighCpuAndMemory

--- a/examples/multi-pipeline-test.yaml
+++ b/examples/multi-pipeline-test.yaml
@@ -4,7 +4,7 @@
 # Metrics go to stdout; logs go to a JSON file for inspection.
 #
 # Usage:
-#   sonda run --scenario examples/multi-pipeline-test.yaml
+#   sonda run examples/multi-pipeline-test.yaml
 #   echo "Exit: $?"
 #   wc -l < /tmp/pipeline-logs.json
 

--- a/examples/multi-scenario.yaml
+++ b/examples/multi-scenario.yaml
@@ -1,7 +1,7 @@
 # Multi-scenario example: metrics and logs running concurrently.
 #
 # Run with:
-#   sonda run --scenario examples/multi-scenario.yaml
+#   sonda run examples/multi-scenario.yaml
 #
 # Both scenarios start at the same time on separate threads and run for 30s.
 # Metrics are written to stdout; log events are written to /tmp/sonda-logs.json.

--- a/examples/network-device-baseline.yaml
+++ b/examples/network-device-baseline.yaml
@@ -5,7 +5,7 @@
 # interface state uses constant (all up), and CPU/memory use sine waves.
 #
 # Run with:
-#   sonda run --scenario examples/network-device-baseline.yaml
+#   sonda run examples/network-device-baseline.yaml
 #
 # All output goes to stdout in Prometheus text format. To push to
 # VictoriaMetrics or another backend, change the sink in each scenario

--- a/examples/network-link-failure.yaml
+++ b/examples/network-link-failure.yaml
@@ -13,7 +13,7 @@
 # creating a cyclic failure/recovery pattern.
 #
 # Run with:
-#   sonda run --scenario examples/network-link-failure.yaml
+#   sonda run examples/network-link-failure.yaml
 
 version: 2
 kind: runnable

--- a/examples/pack-scenario.yaml
+++ b/examples/pack-scenario.yaml
@@ -1,14 +1,14 @@
 # Example: using a metric pack in a scenario file.
 #
-# When `sonda run --scenario` encounters a v2 entry with a `pack:` field,
-# it expands the pack into one metric scenario per metric in the pack.
+# When `sonda run` encounters a v2 entry with a `pack:` field, it expands the
+# pack into one metric scenario per metric in the pack. The pack is resolved
+# from the directory passed via `--catalog <dir>`.
 #
-# This example uses the telegraf_snmp_interface pack with user labels for
+# This example uses the `telegraf_snmp_interface` pack with user labels for
 # a specific device and interface.
 #
-# The pack must be findable on the search path. Run from the repo root
-# (where `./packs/` exists), or set SONDA_PACK_PATH to point to the
-# packs directory, or use `--pack-path ./packs`.
+# Run with:
+#   sonda --catalog sonda-core/tests/fixtures/packs run examples/pack-scenario.yaml
 
 version: 2
 kind: runnable

--- a/examples/pack-with-overrides.yaml
+++ b/examples/pack-with-overrides.yaml
@@ -4,9 +4,8 @@
 # metrics without modifying the pack definition. Here ifOperStatus uses
 # a flap alias to simulate interface up/down toggling.
 #
-# The pack must be findable on the search path. Run from the repo root
-# (where `./packs/` exists), or set SONDA_PACK_PATH to point to the
-# packs directory, or use `--pack-path ./packs`.
+# Run with:
+#   sonda --catalog sonda-core/tests/fixtures/packs run examples/pack-with-overrides.yaml
 
 version: 2
 kind: runnable

--- a/examples/precision-formatting.yaml
+++ b/examples/precision-formatting.yaml
@@ -4,10 +4,7 @@
 # formatted metric values. Omit it to keep full f64 precision.
 #
 # Run all three scenarios together:
-#   sonda run --scenario examples/precision-formatting.yaml
-#
-# Or set precision via CLI flag:
-#   sonda metrics --name cpu_usage --rate 2 --duration 5s --value-mode sine --amplitude 50 --offset 50 --precision 2
+#   sonda run examples/precision-formatting.yaml
 
 version: 2
 kind: runnable

--- a/examples/prometheus-http-push.yaml
+++ b/examples/prometheus-http-push.yaml
@@ -7,7 +7,7 @@
 #
 # Then run:
 #
-#   sonda metrics --scenario examples/prometheus-http-push.yaml
+#   sonda run examples/prometheus-http-push.yaml
 #
 # Verify with: curl 'http://localhost:8428/api/v1/query?query=node_cpu_seconds_total'
 #

--- a/examples/rate-rule-input.yaml
+++ b/examples/rate-rule-input.yaml
@@ -8,7 +8,7 @@
 #   docker compose -f examples/docker-compose-victoriametrics.yml up -d
 #
 # Usage:
-#   sonda metrics --scenario examples/rate-rule-input.yaml
+#   sonda run examples/rate-rule-input.yaml
 #
 # After 2+ minutes, verify the rate:
 #   curl -s "http://localhost:8428/api/v1/query?query=rate(http_requests_total[1m])" \

--- a/examples/remote-write-prometheus.yaml
+++ b/examples/remote-write-prometheus.yaml
@@ -5,7 +5,7 @@
 #     --profile prometheus up -d
 #
 # Usage:
-#   sonda metrics --scenario examples/remote-write-prometheus.yaml
+#   sonda run examples/remote-write-prometheus.yaml
 #
 # Verify data arrived (Prometheus query API):
 #   curl -s "http://localhost:9090/api/v1/query?query=cpu_usage_prom" \

--- a/examples/remote-write-vm.yaml
+++ b/examples/remote-write-vm.yaml
@@ -5,7 +5,7 @@
 #   cargo build --features remote-write -p sonda
 #
 # Usage:
-#   sonda metrics --scenario examples/remote-write-vm.yaml
+#   sonda run examples/remote-write-vm.yaml
 #
 # The encoder produces length-prefixed protobuf TimeSeries, and the
 # remote_write sink batches them into a single WriteRequest, snappy-compresses,

--- a/examples/remote-write-vmagent.yaml
+++ b/examples/remote-write-vmagent.yaml
@@ -9,7 +9,7 @@
 #   docker compose -f examples/docker-compose-victoriametrics.yml up -d
 #
 # Usage:
-#   sonda metrics --scenario examples/remote-write-vmagent.yaml
+#   sonda run examples/remote-write-vmagent.yaml
 #
 # Verify data arrived (query VictoriaMetrics, where vmagent forwards to):
 #   curl -s "http://localhost:8428/api/v1/query?query=cpu_usage_vmagent" \

--- a/examples/sine-threshold-test.yaml
+++ b/examples/sine-threshold-test.yaml
@@ -8,7 +8,7 @@
 #   That's ~20.5% of the cycle, or ~12.3 seconds out of 60.
 #
 # Usage:
-#   sonda metrics --scenario examples/sine-threshold-test.yaml
+#   sonda run examples/sine-threshold-test.yaml
 
 version: 2
 kind: runnable

--- a/examples/summary.yaml
+++ b/examples/summary.yaml
@@ -13,7 +13,7 @@
 # Prerequisites: none -- stdout sink.
 #
 # Run:
-#   sonda summary --scenario examples/summary.yaml
+#   sonda run examples/summary.yaml
 #
 # Observable output: 4 quantile series (0.5, 0.9, 0.95, 0.99) plus
 # `_count` and `_sum`. The p50 should hover near 0.1; p99 should sit

--- a/examples/victoriametrics-metrics.yaml
+++ b/examples/victoriametrics-metrics.yaml
@@ -9,7 +9,7 @@
 #     docker compose -f examples/docker-compose-victoriametrics.yml up -d
 #
 # Usage with the CLI (from the host, targeting the exposed VM port):
-#   sonda metrics --scenario examples/victoriametrics-metrics.yaml
+#   sonda run examples/victoriametrics-metrics.yaml
 #
 # Usage with sonda-server (POST to the running container):
 #   curl -X POST -H "Content-Type: text/yaml" \

--- a/examples/vm-push-scenario.yaml
+++ b/examples/vm-push-scenario.yaml
@@ -4,7 +4,7 @@
 #   docker compose -f examples/docker-compose-victoriametrics.yml up -d
 #
 # Usage:
-#   sonda metrics --scenario examples/vm-push-scenario.yaml
+#   sonda run examples/vm-push-scenario.yaml
 #
 # Verify data arrived:
 #   curl "http://localhost:8428/api/v1/query?query=cpu_usage"

--- a/scripts/validate_docs_commands.py
+++ b/scripts/validate_docs_commands.py
@@ -2,12 +2,15 @@
 """Docs-drift catcher for sonda CLI commands referenced in user-facing documentation.
 
 Walks ``docs/site/docs/**/*.md``, extracts fenced ``bash`` code blocks, finds
-``sonda <subcommand>`` invocations, and verifies two properties:
+``sonda <subcommand>`` invocations against the 1.9 four-verb surface
+(``run`` / ``list`` / ``show`` / ``new``), and verifies two properties:
 
-1. **File existence** — when a command passes ``--scenario <path>`` pointing at a
-   filesystem path (not a ``@builtin-name``), the path must exist on disk.
-2. **Validity** — when the subcommand supports ``--dry-run``, the script invokes
-   ``sonda`` with ``--dry-run`` appended and fails the check on a non-zero exit.
+1. **File existence** — when a command takes a positional file path (e.g.
+   ``sonda run examples/foo.yaml`` or ``sonda new --from examples/data.csv``)
+   pointing at a repo-relative path, the path must exist on disk.
+2. **Validity** — when the subcommand supports ``--dry-run`` (today, only
+   ``run``), the script invokes the binary with ``--dry-run`` injected as a
+   global flag and fails the check on a non-zero exit.
 
 Stdlib-only. Run from the repo root via ``python3 scripts/validate_docs_commands.py``.
 ``--self-test`` runs the inline unit tests without needing a ``sonda`` binary.
@@ -32,32 +35,10 @@ DOCS_GLOB_ROOT = Path("docs/site/docs")
 # `mkdocs build` emits site output under `docs/site/site/`; skip it.
 DOCS_GLOB_EXCLUDE = (Path("docs/site/site"),)
 
-KNOWN_SUBCOMMANDS: frozenset[str] = frozenset(
-    {
-        "metrics",
-        "logs",
-        "histogram",
-        "summary",
-        "run",
-        "catalog",
-        "scenarios",
-        "packs",
-        "import",
-        "init",
-    }
-)
+KNOWN_SUBCOMMANDS: frozenset[str] = frozenset({"run", "list", "show", "new"})
 
-DRY_RUNNABLE_SINGLE: frozenset[str] = frozenset(
-    {"metrics", "logs", "histogram", "summary", "run"}
-)
-
-DRY_RUNNABLE_WITH_ACTION: frozenset[tuple[str, str]] = frozenset(
-    {
-        ("catalog", "run"),
-        ("scenarios", "run"),
-        ("packs", "run"),
-    }
-)
+# Only ``run`` supports ``--dry-run`` in the 1.9 CLI.
+DRY_RUNNABLE_SINGLE: frozenset[str] = frozenset({"run"})
 
 DEFAULT_SONDA_BINARY = Path("target/release/sonda")
 
@@ -65,7 +46,7 @@ DEFAULT_SONDA_BINARY = Path("target/release/sonda")
 # roots. Bare filenames in docs (e.g. `my-scenario.yaml`) are tutorial
 # placeholders the reader creates locally.
 REPO_RELATIVE_PATH_ROOTS: frozenset[str] = frozenset(
-    {"examples", "scenarios", "packs", "docs", "tests"}
+    {"examples", "docs", "tests", "sonda-core"}
 )
 
 DEFAULT_SUBPROCESS_TIMEOUT_S = 30.0
@@ -94,39 +75,25 @@ class ExtractedCommand:
     def subcommand(self) -> str | None:
         """Return the first recognised subcommand token, or ``None``.
 
-        Global flags (``sonda --dry-run metrics ...``) are skipped.
+        Global flags (``sonda --dry-run run ...``) and global-flag values
+        (``sonda --catalog ./dir run ...``) are skipped.
         """
-        for token in self.argv[1:]:
-            if token.startswith("-"):
-                continue
-            return token if token in KNOWN_SUBCOMMANDS else None
-        return None
-
-    @property
-    def action(self) -> str | None:
-        """Return the action verb for ``catalog``/``scenarios``/``packs``,
-        or ``None``. Lets the caller differentiate ``catalog list`` (no
-        dry-run) from ``catalog run`` (dry-run)."""
-        sub = self.subcommand
-        if sub is None or sub not in {"catalog", "scenarios", "packs"}:
-            return None
-        seen_subcommand = False
         skip_next_value = False
         for token in self.argv[1:]:
             if skip_next_value:
                 skip_next_value = False
                 continue
-            if not seen_subcommand:
-                if token == sub:
-                    seen_subcommand = True
-                    continue
-                if token in {"--pack-path", "--scenario-path", "--format"}:
+            if token.startswith("-"):
+                if token in _GLOBAL_FLAGS_WITH_VALUE and "=" not in token:
                     skip_next_value = True
                 continue
-            if token.startswith("-"):
-                continue
-            return token
+            return token if token in KNOWN_SUBCOMMANDS else None
         return None
+
+
+# Global flags that consume the next argv token. Used by ``subcommand`` to
+# skip past a value when looking for the verb.
+_GLOBAL_FLAGS_WITH_VALUE: frozenset[str] = frozenset({"--catalog"})
 
 
 @dataclasses.dataclass
@@ -401,84 +368,92 @@ def is_repo_relative_path(path: str) -> bool:
     return first in REPO_RELATIVE_PATH_ROOTS
 
 
-def extract_scenario_path(argv: Sequence[str]) -> str | None:
-    """Return the ``--scenario`` path value (handles both ``--scenario foo`` and
-    ``--scenario=foo`` forms), or ``None`` if absent."""
-    for idx, tok in enumerate(argv):
-        if tok == "--scenario":
-            if idx + 1 < len(argv):
-                return argv[idx + 1]
-            return None
-        if tok.startswith("--scenario="):
-            return tok[len("--scenario=") :]
+def extract_run_target(argv: Sequence[str]) -> str | None:
+    """Return the positional ``<scenario>`` argument to ``sonda run``.
+
+    Skips global flags before the verb, the verb itself, and any
+    flag-value pairs (``--rate 5``, ``--catalog ./dir``). Returns the
+    first positional token after ``run``, which may be a file path or
+    ``@name``. Returns ``None`` for non-``run`` commands or when no
+    positional argument is present.
+    """
+    seen_run = False
+    skip_next_value = False
+    for tok in argv[1:]:
+        if skip_next_value:
+            skip_next_value = False
+            continue
+        if not seen_run:
+            if tok == "run":
+                seen_run = True
+                continue
+            if tok in _GLOBAL_FLAGS_WITH_VALUE and "=" not in tok:
+                skip_next_value = True
+            continue
+        if tok.startswith("-"):
+            # Heuristic: value-taking flags on `run`. Anything that doesn't
+            # consume a value (e.g. `--dry-run`, `--quiet`) is harmlessly
+            # skipped without consuming the next token.
+            if tok in _RUN_FLAGS_WITH_VALUE and "=" not in tok:
+                skip_next_value = True
+            continue
+        return tok
     return None
 
 
-def extract_import_or_from_file(argv: Sequence[str]) -> str | None:
-    """Return a referenced file path for ``import <file>`` and ``init --from <val>``.
+# Flags on ``sonda run`` that consume the next argv token. Used by
+# ``extract_run_target`` to skip past values when scanning for the
+# positional scenario argument.
+_RUN_FLAGS_WITH_VALUE: frozenset[str] = frozenset(
+    {
+        "--rate",
+        "--duration",
+        "--encoder",
+        "--sink",
+        "--endpoint",
+        "--output",
+        "-o",
+        "--label",
+        "--on-sink-error",
+        "--format",
+        "--catalog",
+    }
+)
 
-    Returns ``None`` for ``init --from @name`` (catalog reference, not a path).
-    """
-    if len(argv) < 2:
-        return None
-    sub = None
-    for tok in argv[1:]:
-        if tok.startswith("-"):
+
+def extract_new_from_file(argv: Sequence[str]) -> str | None:
+    """Return the value of ``--from <path>`` for ``sonda new``, or ``None``."""
+    seen_new = False
+    for idx, tok in enumerate(argv[1:], start=1):
+        if not seen_new:
+            if tok == "new":
+                seen_new = True
             continue
-        sub = tok
-        break
-    if sub == "import":
-        skip_next = False
-        seen_import = False
-        for tok in argv[1:]:
-            if skip_next:
-                skip_next = False
-                continue
-            if not seen_import:
-                if tok == "import":
-                    seen_import = True
-                continue
-            if tok.startswith("-"):
-                if tok in {"-o", "--output", "--columns", "--rate", "--duration"}:
-                    skip_next = True
-                continue
-            return tok
-        return None
-    if sub == "init":
-        for idx, tok in enumerate(argv):
-            if tok == "--from":
-                if idx + 1 < len(argv):
-                    val = argv[idx + 1]
-                    if val.startswith("@"):
-                        return None
-                    return val
-                return None
-            if tok.startswith("--from="):
-                val = tok[len("--from=") :]
-                if val.startswith("@"):
-                    return None
-                return val
-        return None
+        if tok == "--from":
+            if idx + 1 < len(argv):
+                return argv[idx + 1]
+            return None
+        if tok.startswith("--from="):
+            return tok[len("--from=") :]
+    return None
+
+
+def extract_catalog_dir(argv: Sequence[str]) -> str | None:
+    """Return the value passed to the global ``--catalog`` flag, or ``None``."""
+    for idx, tok in enumerate(argv):
+        if tok == "--catalog":
+            if idx + 1 < len(argv):
+                return argv[idx + 1]
+            return None
+        if tok.startswith("--catalog="):
+            return tok[len("--catalog=") :]
     return None
 
 
 def supports_dry_run(cmd: ExtractedCommand) -> bool:
-    """Return True when the command's subcommand (and action, if any) supports ``--dry-run``.
-
-    ``sonda import --run`` qualifies; plain ``sonda import --analyze`` or
-    ``sonda import -o foo.yaml`` does not.
-    """
+    """Return True when the command's subcommand supports ``--dry-run``."""
     sub = cmd.subcommand
-    if sub is None:
-        return False
-    if sub in DRY_RUNNABLE_SINGLE:
-        return True
-    action = cmd.action
-    if action is not None and (sub, action) in DRY_RUNNABLE_WITH_ACTION:
-        return True
-    if sub == "import" and "--run" in cmd.argv:
-        return True
-    return False
+    return sub is not None and sub in DRY_RUNNABLE_SINGLE
 
 
 def validate_command(
@@ -488,40 +463,58 @@ def validate_command(
     subprocess_timeout: float = DEFAULT_SUBPROCESS_TIMEOUT_S,
 ) -> ValidationResult:
     """Run the file-exists + dry-run checks on a single extracted command."""
-    scenario_path = extract_scenario_path(cmd.argv)
-    scenario_is_repo_path = (
-        scenario_path is not None
-        and not scenario_path.startswith("@")
-        and is_repo_relative_path(scenario_path)
-        and scenario_path not in cmd.tutorial_titles
+    run_target = extract_run_target(cmd.argv) if cmd.subcommand == "run" else None
+    target_is_repo_path = (
+        run_target is not None
+        and not run_target.startswith("@")
+        and is_repo_relative_path(run_target)
+        and run_target not in cmd.tutorial_titles
         and not cmd.block_is_tutorial
     )
-    if scenario_is_repo_path:
-        target = (repo_root / scenario_path).resolve()  # type: ignore[arg-type]
+    if target_is_repo_path:
+        target = (repo_root / run_target).resolve()  # type: ignore[arg-type]
         if not target.exists():
             return ValidationResult(
                 command=cmd,
                 ok=False,
                 message=(
-                    f"--scenario path does not exist: {scenario_path} "
+                    f"run target path does not exist: {run_target} "
                     f"(resolved to {target})"
                 ),
             )
 
-    referenced_file = extract_import_or_from_file(cmd.argv)
+    new_from = extract_new_from_file(cmd.argv) if cmd.subcommand == "new" else None
     if (
-        referenced_file is not None
-        and is_repo_relative_path(referenced_file)
-        and referenced_file not in cmd.tutorial_titles
+        new_from is not None
+        and is_repo_relative_path(new_from)
+        and new_from not in cmd.tutorial_titles
         and not cmd.block_is_tutorial
     ):
-        target = (repo_root / referenced_file).resolve()
+        target = (repo_root / new_from).resolve()
         if not target.exists():
             return ValidationResult(
                 command=cmd,
                 ok=False,
                 message=(
-                    f"referenced file does not exist: {referenced_file} "
+                    f"--from file does not exist: {new_from} "
+                    f"(resolved to {target})"
+                ),
+            )
+
+    catalog_dir = extract_catalog_dir(cmd.argv)
+    if (
+        catalog_dir is not None
+        and is_repo_relative_path(catalog_dir)
+        and catalog_dir not in cmd.tutorial_titles
+        and not cmd.block_is_tutorial
+    ):
+        target = (repo_root / catalog_dir).resolve()
+        if not target.exists():
+            return ValidationResult(
+                command=cmd,
+                ok=False,
+                message=(
+                    f"--catalog dir does not exist: {catalog_dir} "
                     f"(resolved to {target})"
                 ),
             )
@@ -530,18 +523,14 @@ def validate_command(
         return ValidationResult(command=cmd, ok=True)
 
     # Skip dry-run on cases that can't fail "for docs drift reasons":
-    # tutorial paths the reader creates, `@name` and `catalog run <name>`
-    # catalog lookups, and tutorial blocks generally.
-    if scenario_path is not None and not scenario_path.startswith("@"):
-        if not scenario_is_repo_path:
+    # tutorial paths the reader creates locally, `@name` catalog lookups,
+    # and tutorial blocks generally.
+    if run_target is not None:
+        if run_target.startswith("@"):
             return ValidationResult(command=cmd, ok=True)
-    if scenario_path is not None and scenario_path.startswith("@"):
-        return ValidationResult(command=cmd, ok=True)
-    if cmd.action == "run" and cmd.subcommand in {"catalog", "scenarios", "packs"}:
-        return ValidationResult(command=cmd, ok=True)
+        if not target_is_repo_path:
+            return ValidationResult(command=cmd, ok=True)
     if cmd.block_is_tutorial:
-        return ValidationResult(command=cmd, ok=True)
-    if referenced_file is not None and not is_repo_relative_path(referenced_file):
         return ValidationResult(command=cmd, ok=True)
 
     if sonda_bin is None:
@@ -590,11 +579,20 @@ def validate_command(
 def _build_dry_run_argv(
     cmd: ExtractedCommand, sonda_bin: Path
 ) -> list[str]:
-    """Replace ``sonda`` with ``sonda_bin`` and inject ``--dry-run`` if absent."""
+    """Replace ``sonda`` with ``sonda_bin`` and inject ``--dry-run`` on the
+    ``run`` subcommand if not already present.
+
+    ``--dry-run`` is a flag on the ``run`` subcommand itself, so it must
+    appear after ``run`` (clap rejects it as a global flag).
+    """
     argv = list(cmd.argv)
     argv[0] = str(sonda_bin)
-    if "--dry-run" not in argv:
-        argv.insert(1, "--dry-run")
+    if "--dry-run" in argv:
+        return argv
+    for i, tok in enumerate(argv):
+        if tok == "run":
+            argv.insert(i + 1, "--dry-run")
+            return argv
     return argv
 
 
@@ -759,7 +757,7 @@ class _ExtractBashBlocksTests(unittest.TestCase):
             "```\n"
             "\n"
             "```bash\n"
-            "sonda metrics --name up --rate 1 --duration 5s\n"
+            "sonda run examples/foo.yaml\n"
             "```\n"
             "\n"
             "```text\n"
@@ -768,25 +766,25 @@ class _ExtractBashBlocksTests(unittest.TestCase):
         )
         blocks = extract_bash_blocks(md)
         self.assertEqual(len(blocks), 1)
-        self.assertIn("sonda metrics", blocks[0][1])
+        self.assertIn("sonda run", blocks[0][1])
 
     def test_indented_bash_block_in_admonition(self) -> None:
         md = (
             "!!! tip\n"
             "    ```bash\n"
-            "    sonda --dry-run metrics --name up --rate 1 --duration 5s\n"
+            "    sonda --quiet run examples/foo.yaml\n"
             "    ```\n"
         )
         blocks = extract_bash_blocks(md)
         self.assertEqual(len(blocks), 1)
-        self.assertIn("sonda --dry-run metrics", blocks[0][1])
+        self.assertIn("sonda --quiet run", blocks[0][1])
 
     def test_empty_fence_info_is_not_bash(self) -> None:
-        md = "```\nsonda metrics --rate 1\n```\n"
+        md = "```\nsonda run foo.yaml\n```\n"
         self.assertEqual(extract_bash_blocks(md), [])
 
     def test_line_number_points_at_first_body_line(self) -> None:
-        md = "line 1\nline 2\n```bash\nsonda metrics\n```\n"
+        md = "line 1\nline 2\n```bash\nsonda run foo.yaml\n```\n"
         blocks = extract_bash_blocks(md)
         self.assertEqual(len(blocks), 1)
         self.assertEqual(blocks[0][0], 4)
@@ -794,16 +792,16 @@ class _ExtractBashBlocksTests(unittest.TestCase):
 
 class _JoinContinuationsTests(unittest.TestCase):
     def test_joins_backslash_continuation(self) -> None:
-        body = "sonda metrics \\\n  --name up --rate 1 --duration 5s"
+        body = "sonda run examples/foo.yaml \\\n  --rate 1 --duration 5s"
         out = join_continuations(body)
         self.assertEqual(len(out), 1)
         self.assertEqual(
-            out[0][1], "sonda metrics --name up --rate 1 --duration 5s"
+            out[0][1], "sonda run examples/foo.yaml --rate 1 --duration 5s"
         )
         self.assertEqual(out[0][0], 0)
 
     def test_two_separate_lines_stay_separate(self) -> None:
-        body = "sonda metrics --rate 1\nsonda logs --rate 5"
+        body = "sonda run foo.yaml\nsonda list --catalog ./dir"
         out = join_continuations(body)
         self.assertEqual(len(out), 2)
         self.assertEqual(out[1][0], 1)
@@ -814,93 +812,86 @@ class _JoinContinuationsTests(unittest.TestCase):
 
 class _StripPromptAndEnvTests(unittest.TestCase):
     def test_strips_dollar_prompt(self) -> None:
-        self.assertEqual(strip_prompt("$ sonda metrics"), "sonda metrics")
+        self.assertEqual(strip_prompt("$ sonda run foo.yaml"), "sonda run foo.yaml")
 
     def test_no_prompt_passthrough(self) -> None:
-        self.assertEqual(strip_prompt("sonda metrics"), "sonda metrics")
+        self.assertEqual(strip_prompt("sonda run foo.yaml"), "sonda run foo.yaml")
 
     def test_strips_single_env_var(self) -> None:
         self.assertEqual(
-            strip_env_prefix("RUST_LOG=debug sonda metrics"),
-            "sonda metrics",
+            strip_env_prefix("RUST_LOG=debug sonda run foo.yaml"),
+            "sonda run foo.yaml",
         )
 
     def test_strips_multiple_env_vars(self) -> None:
         self.assertEqual(
-            strip_env_prefix("RUST_LOG=debug SONDA_FOO=bar sonda metrics"),
-            "sonda metrics",
+            strip_env_prefix("RUST_LOG=debug SONDA_FOO=bar sonda run foo.yaml"),
+            "sonda run foo.yaml",
         )
 
     def test_env_prefix_not_stripped_from_middle(self) -> None:
-        # An env var in the middle is NOT an assignment prefix.
         self.assertEqual(
-            strip_env_prefix("sonda metrics RUST_LOG=debug"),
-            "sonda metrics RUST_LOG=debug",
+            strip_env_prefix("sonda run foo.yaml RUST_LOG=debug"),
+            "sonda run foo.yaml RUST_LOG=debug",
         )
 
 
 class _TrimShellTrailersTests(unittest.TestCase):
     def test_trims_redirect(self) -> None:
         self.assertEqual(
-            _trim_shell_trailers("sonda metrics --rate 1 > /tmp/out.txt"),
-            "sonda metrics --rate 1",
+            _trim_shell_trailers("sonda run foo.yaml > /tmp/out.txt"),
+            "sonda run foo.yaml",
         )
 
     def test_trims_background(self) -> None:
         self.assertEqual(
-            _trim_shell_trailers("sonda metrics --rate 1 &"),
-            "sonda metrics --rate 1",
+            _trim_shell_trailers("sonda run foo.yaml &"),
+            "sonda run foo.yaml",
         )
 
     def test_trims_inline_comment(self) -> None:
         self.assertEqual(
-            _trim_shell_trailers("sonda metrics --rate 1   # comment"),
-            "sonda metrics --rate 1",
+            _trim_shell_trailers("sonda run foo.yaml   # comment"),
+            "sonda run foo.yaml",
         )
 
     def test_preserves_hash_inside_token(self) -> None:
-        # ``--label x=foo#bar`` — hash inside a token (no leading whitespace)
-        # must survive.
         self.assertEqual(
-            _trim_shell_trailers("sonda metrics --label x=foo#bar"),
-            "sonda metrics --label x=foo#bar",
+            _trim_shell_trailers("sonda run --label x=foo#bar foo.yaml"),
+            "sonda run --label x=foo#bar foo.yaml",
         )
 
     def test_preserves_less_than_inside_token(self) -> None:
-        # Our metavar detection strips ``<FILE>`` tokens AFTER shlex, so
-        # trim-shell-trailers must NOT eat the ``<`` when it's embedded in
-        # a token. Leading whitespace before ``<`` DOES signal a redirect.
         self.assertEqual(
-            _trim_shell_trailers("sonda metrics --rate=<FOO>"),
-            "sonda metrics --rate=<FOO>",
+            _trim_shell_trailers("sonda run --rate=<FOO> foo.yaml"),
+            "sonda run --rate=<FOO> foo.yaml",
         )
         self.assertEqual(
-            _trim_shell_trailers("sonda metrics < /tmp/in"),
-            "sonda metrics",
+            _trim_shell_trailers("sonda run foo.yaml < /tmp/in"),
+            "sonda run foo.yaml",
         )
 
     def test_preserves_inside_double_quotes(self) -> None:
-        # Shell operators inside quoted strings are literal.
         self.assertEqual(
-            _trim_shell_trailers('sonda metrics --label "a>b&c"'),
-            'sonda metrics --label "a>b&c"',
+            _trim_shell_trailers('sonda run --label "a>b&c" foo.yaml'),
+            'sonda run --label "a>b&c" foo.yaml',
         )
 
 
 class _CliPlaceholderTokenTests(unittest.TestCase):
     def test_brackets_are_placeholder(self) -> None:
         self.assertTrue(
-            _contains_cli_placeholder_token(("sonda", "metrics", "[OPTIONS]"))
+            _contains_cli_placeholder_token(("sonda", "run", "[OPTIONS]"))
         )
 
     def test_angle_brackets_are_placeholder(self) -> None:
         self.assertTrue(
-            _contains_cli_placeholder_token(("sonda", "run", "--scenario", "<FILE>"))
+            _contains_cli_placeholder_token(("sonda", "run", "<FILE>"))
         )
 
     def test_normal_command_is_not(self) -> None:
         self.assertFalse(
-            _contains_cli_placeholder_token(("sonda", "metrics", "--rate", "1"))
+            _contains_cli_placeholder_token(("sonda", "run", "foo.yaml"))
         )
 
 
@@ -908,22 +899,40 @@ class _ExtractSondaCommandsTests(unittest.TestCase):
     def _extract(self, md: str) -> list[ExtractedCommand]:
         return extract_sonda_commands(Path("/tmp/doc.md"), md)
 
-    def test_finds_basic_invocation(self) -> None:
-        md = "```bash\nsonda metrics --name up --rate 1 --duration 5s\n```\n"
+    def test_finds_run_invocation(self) -> None:
+        md = "```bash\nsonda run examples/foo.yaml --duration 5s\n```\n"
         out = self._extract(md)
         self.assertEqual(len(out), 1)
-        self.assertEqual(out[0].subcommand, "metrics")
+        self.assertEqual(out[0].subcommand, "run")
+
+    def test_finds_list_invocation(self) -> None:
+        md = "```bash\nsonda list --catalog ./my-catalog\n```\n"
+        out = self._extract(md)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].subcommand, "list")
+
+    def test_finds_show_invocation(self) -> None:
+        md = "```bash\nsonda show @cpu-spike --catalog ./my-catalog\n```\n"
+        out = self._extract(md)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].subcommand, "show")
+
+    def test_finds_new_invocation(self) -> None:
+        md = "```bash\nsonda new --template -o foo.yaml\n```\n"
+        out = self._extract(md)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].subcommand, "new")
 
     def test_ignores_non_bash_fences(self) -> None:
-        md = "```text\nsonda metrics --rate 1\n```\n"
+        md = "```text\nsonda run foo.yaml\n```\n"
         self.assertEqual(self._extract(md), [])
 
     def test_ignores_yaml_fences_with_sonda_comments(self) -> None:
-        md = "```yaml\n# sonda run --scenario foo.yaml\nversion: 2\n```\n"
+        md = "```yaml\n# sonda run foo.yaml\nversion: 2\n```\n"
         self.assertEqual(self._extract(md), [])
 
     def test_ignores_json_fences(self) -> None:
-        md = '```json\n{"sonda": "metrics"}\n```\n'
+        md = '```json\n{"sonda": "run"}\n```\n'
         self.assertEqual(self._extract(md), [])
 
     def test_ignores_bare_sonda_in_prose(self) -> None:
@@ -935,21 +944,20 @@ class _ExtractSondaCommandsTests(unittest.TestCase):
         self.assertEqual(self._extract(md), [])
 
     def test_ignores_sonda_version_flag_only(self) -> None:
-        # ``sonda --version`` has no known subcommand → excluded.
         md = "```bash\nsonda --version\n```\n"
         self.assertEqual(self._extract(md), [])
 
-    def test_ignores_commented_sonda_line(self) -> None:
-        md = "```bash\n# sonda init --help\nsonda metrics --name up --rate 1 --duration 5s\n```\n"
-        out = self._extract(md)
-        self.assertEqual(len(out), 1)
-        self.assertEqual(out[0].subcommand, "metrics")
+    def test_ignores_unknown_subcommand(self) -> None:
+        # The retired 1.8 verbs must not be picked up as known subcommands.
+        for verb in ("metrics", "logs", "histogram", "summary", "init", "import", "scenarios", "packs", "catalog"):
+            md = f"```bash\nsonda {verb} foo\n```\n"
+            self.assertEqual(self._extract(md), [], verb)
 
     def test_line_continuation_joined(self) -> None:
         md = (
             "```bash\n"
-            "sonda metrics \\\n"
-            "  --name up --rate 1 --duration 5s\n"
+            "sonda run examples/foo.yaml \\\n"
+            "  --duration 5s\n"
             "```\n"
         )
         out = self._extract(md)
@@ -957,225 +965,120 @@ class _ExtractSondaCommandsTests(unittest.TestCase):
         self.assertIn("--duration", " ".join(out[0].argv))
 
     def test_strips_prompt_and_env_prefix(self) -> None:
-        md = "```bash\n$ RUST_LOG=debug sonda metrics --rate 1\n```\n"
+        md = "```bash\n$ RUST_LOG=debug sonda run foo.yaml\n```\n"
         out = self._extract(md)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].argv[0], "sonda")
-        self.assertEqual(out[0].subcommand, "metrics")
+        self.assertEqual(out[0].subcommand, "run")
 
-    def test_at_name_scenario_passes_through(self) -> None:
-        md = "```bash\nsonda metrics --scenario @cpu-spike --rate 5\n```\n"
+    def test_at_name_run_target_passes_through(self) -> None:
+        md = "```bash\nsonda --catalog ./d run @cpu-spike\n```\n"
         out = self._extract(md)
         self.assertEqual(len(out), 1)
-        self.assertEqual(extract_scenario_path(out[0].argv), "@cpu-spike")
+        self.assertEqual(extract_run_target(out[0].argv), "@cpu-spike")
 
     def test_pipeline_first_sonda_segment_parsed(self) -> None:
         md = (
             "```bash\n"
-            "sonda metrics --rate 1 | curl -s --data-binary @- http://x\n"
+            "sonda run foo.yaml | curl -s --data-binary @- http://x\n"
             "```\n"
         )
         out = self._extract(md)
         self.assertEqual(len(out), 1)
-        self.assertEqual(out[0].subcommand, "metrics")
+        self.assertEqual(out[0].subcommand, "run")
 
     def test_ignores_cli_syntax_placeholder(self) -> None:
-        md = "```bash\nsonda metrics [OPTIONS]\n```\n"
+        md = "```bash\nsonda run [OPTIONS]\n```\n"
         self.assertEqual(self._extract(md), [])
 
     def test_ignores_cli_angle_bracket_placeholder(self) -> None:
-        md = "```bash\nsonda run --scenario <FILE>\n```\n"
+        md = "```bash\nsonda run <FILE>\n```\n"
         self.assertEqual(self._extract(md), [])
 
     def test_strips_shell_redirect(self) -> None:
-        md = "```bash\nsonda metrics --rate 1 > /tmp/out.txt\n```\n"
+        md = "```bash\nsonda run foo.yaml > /tmp/out.txt\n```\n"
         out = self._extract(md)
         self.assertEqual(len(out), 1)
         self.assertNotIn(">", out[0].argv)
 
     def test_strips_background_ampersand(self) -> None:
-        md = "```bash\nsonda metrics --rate 1 &\n```\n"
+        md = "```bash\nsonda run foo.yaml &\n```\n"
         out = self._extract(md)
         self.assertEqual(len(out), 1)
         self.assertNotIn("&", out[0].argv)
 
     def test_strips_inline_comment(self) -> None:
-        md = "```bash\nsonda metrics --rate 1  # inline comment\n```\n"
+        md = "```bash\nsonda run foo.yaml  # inline comment\n```\n"
         out = self._extract(md)
         self.assertEqual(len(out), 1)
-        self.assertEqual(out[0].argv[-1], "1")
+        self.assertEqual(out[0].argv[-1], "foo.yaml")
 
-    def test_dry_run_global_flag_recognised_as_metrics_subcommand(self) -> None:
-        md = "```bash\nsonda --dry-run metrics --name up --rate 1\n```\n"
+    def test_global_catalog_flag_skipped_when_finding_subcommand(self) -> None:
+        md = "```bash\nsonda --catalog ./d run @cpu-spike\n```\n"
         out = self._extract(md)
         self.assertEqual(len(out), 1)
-        self.assertEqual(out[0].subcommand, "metrics")
-
-    def test_catalog_run_action_detected(self) -> None:
-        md = "```bash\nsonda --dry-run catalog run cpu-spike\n```\n"
-        out = self._extract(md)
-        self.assertEqual(len(out), 1)
-        self.assertEqual(out[0].subcommand, "catalog")
-        self.assertEqual(out[0].action, "run")
-
-    def test_catalog_list_has_no_action_dry_run(self) -> None:
-        md = "```bash\nsonda catalog list\n```\n"
-        out = self._extract(md)
-        self.assertEqual(len(out), 1)
-        self.assertEqual(out[0].subcommand, "catalog")
-        self.assertEqual(out[0].action, "list")
-        self.assertFalse(supports_dry_run(out[0]))
-
-    def test_scenarios_run_action_dry_run(self) -> None:
-        md = "```bash\nsonda scenarios run cpu-spike\n```\n"
-        out = self._extract(md)
-        self.assertEqual(len(out), 1)
-        self.assertTrue(supports_dry_run(out[0]))
-
-    def test_init_subcommand_no_dry_run(self) -> None:
-        md = "```bash\nsonda init --help\n```\n"
-        out = self._extract(md)
-        self.assertEqual(len(out), 1)
-        self.assertEqual(out[0].subcommand, "init")
-        self.assertFalse(supports_dry_run(out[0]))
-
-    def test_import_analyze_no_dry_run(self) -> None:
-        md = "```bash\nsonda import data.csv --analyze\n```\n"
-        out = self._extract(md)
-        self.assertEqual(len(out), 1)
-        self.assertFalse(supports_dry_run(out[0]))
-
-    def test_import_run_has_dry_run(self) -> None:
-        md = "```bash\nsonda import data.csv --run --duration 30s\n```\n"
-        out = self._extract(md)
-        self.assertEqual(len(out), 1)
-        self.assertTrue(supports_dry_run(out[0]))
+        self.assertEqual(out[0].subcommand, "run")
 
 
-class _ExtractScenarioPathTests(unittest.TestCase):
+class _ExtractRunTargetTests(unittest.TestCase):
+    def test_positional_file(self) -> None:
+        argv = ("sonda", "run", "examples/foo.yaml")
+        self.assertEqual(extract_run_target(argv), "examples/foo.yaml")
+
+    def test_positional_at_name(self) -> None:
+        argv = ("sonda", "--catalog", "./d", "run", "@cpu-spike")
+        self.assertEqual(extract_run_target(argv), "@cpu-spike")
+
+    def test_positional_after_value_flags(self) -> None:
+        argv = ("sonda", "run", "--rate", "5", "--duration", "10s", "examples/foo.yaml")
+        self.assertEqual(extract_run_target(argv), "examples/foo.yaml")
+
+    def test_non_run_command_returns_none(self) -> None:
+        argv = ("sonda", "list", "--catalog", "./d")
+        self.assertIsNone(extract_run_target(argv))
+
+
+class _ExtractNewFromFileTests(unittest.TestCase):
+    def test_from_path(self) -> None:
+        argv = ("sonda", "new", "--from", "examples/data.csv")
+        self.assertEqual(extract_new_from_file(argv), "examples/data.csv")
+
+    def test_from_equals_path(self) -> None:
+        argv = ("sonda", "new", "--from=examples/data.csv")
+        self.assertEqual(extract_new_from_file(argv), "examples/data.csv")
+
+    def test_no_from_flag(self) -> None:
+        argv = ("sonda", "new", "--template")
+        self.assertIsNone(extract_new_from_file(argv))
+
+    def test_non_new_command_returns_none(self) -> None:
+        argv = ("sonda", "run", "foo.yaml", "--from", "bar")
+        self.assertIsNone(extract_new_from_file(argv))
+
+
+class _ExtractCatalogDirTests(unittest.TestCase):
     def test_separate_value(self) -> None:
-        argv = ("sonda", "metrics", "--scenario", "foo.yaml")
-        self.assertEqual(extract_scenario_path(argv), "foo.yaml")
+        argv = ("sonda", "--catalog", "./my-catalog", "run", "@foo")
+        self.assertEqual(extract_catalog_dir(argv), "./my-catalog")
 
     def test_equals_value(self) -> None:
-        argv = ("sonda", "metrics", "--scenario=foo.yaml")
-        self.assertEqual(extract_scenario_path(argv), "foo.yaml")
-
-    def test_at_name(self) -> None:
-        argv = ("sonda", "metrics", "--scenario", "@cpu-spike")
-        self.assertEqual(extract_scenario_path(argv), "@cpu-spike")
+        argv = ("sonda", "--catalog=./my-catalog", "list")
+        self.assertEqual(extract_catalog_dir(argv), "./my-catalog")
 
     def test_absent(self) -> None:
-        argv = ("sonda", "metrics", "--rate", "1")
-        self.assertIsNone(extract_scenario_path(argv))
-
-
-class _ExtractImportOrFromFileTests(unittest.TestCase):
-    def test_import_positional(self) -> None:
-        argv = ("sonda", "import", "data.csv", "--analyze")
-        self.assertEqual(extract_import_or_from_file(argv), "data.csv")
-
-    def test_import_with_output_flag_before_positional(self) -> None:
-        # Unusual but valid: -o consumes next arg, then positional follows.
-        argv = ("sonda", "import", "-o", "out.yaml", "data.csv")
-        self.assertEqual(extract_import_or_from_file(argv), "data.csv")
-
-    def test_init_from_path(self) -> None:
-        argv = ("sonda", "init", "--from", "data.csv")
-        self.assertEqual(extract_import_or_from_file(argv), "data.csv")
-
-    def test_init_from_at_name_returns_none(self) -> None:
-        argv = ("sonda", "init", "--from", "@cpu-spike")
-        self.assertIsNone(extract_import_or_from_file(argv))
-
-    def test_init_from_equals_path(self) -> None:
-        argv = ("sonda", "init", "--from=data.csv")
-        self.assertEqual(extract_import_or_from_file(argv), "data.csv")
-
-    def test_metrics_has_no_import_file(self) -> None:
-        argv = ("sonda", "metrics", "--rate", "1")
-        self.assertIsNone(extract_import_or_from_file(argv))
-
-
-class _ExtractTutorialTitlesTests(unittest.TestCase):
-    def test_collects_yaml_title(self) -> None:
-        md = (
-            '```yaml title="examples/foo.yaml"\n'
-            "version: 2\n"
-            "```\n"
-        )
-        self.assertEqual(
-            extract_tutorial_file_titles(md), {"examples/foo.yaml"}
-        )
-
-    def test_collects_multiple_titles(self) -> None:
-        md = (
-            '```yaml title="examples/foo.yaml"\n'
-            "version: 2\n"
-            "```\n"
-            '```bash title="run.sh"\n'
-            "sonda metrics --rate 1\n"
-            "```\n"
-        )
-        self.assertEqual(
-            extract_tutorial_file_titles(md),
-            {"examples/foo.yaml", "run.sh"},
-        )
-
-    def test_no_titles_returns_empty(self) -> None:
-        md = "```yaml\nversion: 2\n```\n"
-        self.assertEqual(extract_tutorial_file_titles(md), set())
-
-    def test_extract_command_carries_titles(self) -> None:
-        md = (
-            '```yaml title="examples/tutorial.yaml"\n'
-            "version: 2\n"
-            "```\n"
-            "```bash\n"
-            "sonda metrics --scenario examples/tutorial.yaml\n"
-            "```\n"
-        )
-        cmds = extract_sonda_commands(Path("/tmp/x.md"), md)
-        self.assertEqual(len(cmds), 1)
-        self.assertIn("examples/tutorial.yaml", cmds[0].tutorial_titles)
-
-    def test_block_marked_tutorial_when_it_mentions_a_title(self) -> None:
-        md = (
-            '```yaml title="examples/rule-a.yaml"\n'
-            "version: 2\n"
-            "```\n"
-            "```bash\n"
-            "sonda metrics --scenario examples/rule-a.yaml\n"
-            "sonda run --scenario examples/rule-cluster.yaml\n"
-            "```\n"
-        )
-        cmds = extract_sonda_commands(Path("/tmp/x.md"), md)
-        self.assertEqual(len(cmds), 2)
-        # Both commands in the block are tagged tutorial because the block
-        # references a path that's declared as a tutorial title.
-        self.assertTrue(cmds[0].block_is_tutorial)
-        self.assertTrue(cmds[1].block_is_tutorial)
-
-    def test_block_not_tutorial_when_it_mentions_no_title(self) -> None:
-        md = (
-            "```bash\n"
-            "sonda metrics --scenario examples/real-file.yaml\n"
-            "```\n"
-        )
-        cmds = extract_sonda_commands(Path("/tmp/x.md"), md)
-        self.assertEqual(len(cmds), 1)
-        self.assertFalse(cmds[0].block_is_tutorial)
+        argv = ("sonda", "run", "foo.yaml")
+        self.assertIsNone(extract_catalog_dir(argv))
 
 
 class _RepoRelativePathTests(unittest.TestCase):
     def test_examples_path_is_repo_relative(self) -> None:
         self.assertTrue(is_repo_relative_path("examples/foo.yaml"))
 
-    def test_scenarios_path_is_repo_relative(self) -> None:
-        self.assertTrue(is_repo_relative_path("scenarios/link-failover.yaml"))
-
     def test_tests_path_is_repo_relative(self) -> None:
         self.assertTrue(is_repo_relative_path("tests/alerts/high-cpu.yaml"))
+
+    def test_sonda_core_path_is_repo_relative(self) -> None:
+        self.assertTrue(is_repo_relative_path("sonda-core/tests/fixtures/packs/foo.yaml"))
 
     def test_bare_filename_is_not_repo_relative(self) -> None:
         self.assertFalse(is_repo_relative_path("my-scenario.yaml"))
@@ -1188,8 +1091,10 @@ class _RepoRelativePathTests(unittest.TestCase):
         self.assertFalse(is_repo_relative_path("~/foo.yaml"))
 
     def test_unknown_root_is_not_repo_relative(self) -> None:
-        # ``mydir/foo.yaml`` — the first segment isn't a known root.
         self.assertFalse(is_repo_relative_path("mydir/foo.yaml"))
+        # The retired 1.8 catalog dirs are no longer treated as repo-relative.
+        self.assertFalse(is_repo_relative_path("scenarios/foo.yaml"))
+        self.assertFalse(is_repo_relative_path("packs/foo.yaml"))
 
     def test_metavar_placeholder_is_not_repo_relative(self) -> None:
         self.assertFalse(is_repo_relative_path("<FILE>"))
@@ -1213,47 +1118,46 @@ class _SupportsDryRunTests(unittest.TestCase):
             raw=raw,
         )
 
-    def test_metrics_yes(self) -> None:
-        self.assertTrue(supports_dry_run(self._cmd("sonda metrics --rate 1")))
-
-    def test_logs_yes(self) -> None:
-        self.assertTrue(supports_dry_run(self._cmd("sonda logs --rate 1")))
-
-    def test_histogram_yes(self) -> None:
-        self.assertTrue(supports_dry_run(self._cmd("sonda histogram --scenario foo")))
-
-    def test_summary_yes(self) -> None:
-        self.assertTrue(supports_dry_run(self._cmd("sonda summary --scenario foo")))
-
     def test_run_yes(self) -> None:
-        self.assertTrue(supports_dry_run(self._cmd("sonda run --scenario foo")))
+        self.assertTrue(supports_dry_run(self._cmd("sonda run foo.yaml")))
 
-    def test_catalog_run_yes(self) -> None:
-        self.assertTrue(supports_dry_run(self._cmd("sonda catalog run foo")))
+    def test_list_no(self) -> None:
+        self.assertFalse(supports_dry_run(self._cmd("sonda list --catalog ./d")))
 
-    def test_catalog_list_no(self) -> None:
-        self.assertFalse(supports_dry_run(self._cmd("sonda catalog list")))
+    def test_show_no(self) -> None:
+        self.assertFalse(supports_dry_run(self._cmd("sonda show @foo --catalog ./d")))
 
-    def test_scenarios_list_no(self) -> None:
-        self.assertFalse(supports_dry_run(self._cmd("sonda scenarios list")))
+    def test_new_no(self) -> None:
+        self.assertFalse(supports_dry_run(self._cmd("sonda new --template")))
 
-    def test_packs_run_yes(self) -> None:
-        self.assertTrue(supports_dry_run(self._cmd("sonda packs run foo")))
 
-    def test_init_no(self) -> None:
-        self.assertFalse(supports_dry_run(self._cmd("sonda init --help")))
-
-    def test_import_analyze_no(self) -> None:
-        self.assertFalse(supports_dry_run(self._cmd("sonda import data.csv --analyze")))
-
-    def test_import_with_output_no(self) -> None:
-        self.assertFalse(
-            supports_dry_run(self._cmd("sonda import data.csv -o out.yaml"))
+class _BuildDryRunArgvTests(unittest.TestCase):
+    def _cmd(self, raw: str) -> ExtractedCommand:
+        return ExtractedCommand(
+            file=Path("/tmp/x.md"),
+            line=1,
+            argv=tuple(shlex.split(raw)),
+            raw=raw,
         )
 
-    def test_import_run_yes(self) -> None:
-        self.assertTrue(
-            supports_dry_run(self._cmd("sonda import data.csv --run --duration 30s"))
+    def test_injects_dry_run_after_run_verb(self) -> None:
+        cmd = self._cmd("sonda run foo.yaml")
+        argv = _build_dry_run_argv(cmd, Path("/usr/local/bin/sonda"))
+        self.assertEqual(
+            argv, ["/usr/local/bin/sonda", "run", "--dry-run", "foo.yaml"]
+        )
+
+    def test_does_not_duplicate_existing_dry_run(self) -> None:
+        cmd = self._cmd("sonda run foo.yaml --dry-run")
+        argv = _build_dry_run_argv(cmd, Path("/usr/local/bin/sonda"))
+        self.assertEqual(argv.count("--dry-run"), 1)
+
+    def test_preserves_global_flags_before_run(self) -> None:
+        cmd = self._cmd("sonda --quiet --catalog ./d run @foo")
+        argv = _build_dry_run_argv(cmd, Path("/usr/local/bin/sonda"))
+        self.assertEqual(
+            argv,
+            ["/usr/local/bin/sonda", "--quiet", "--catalog", "./d", "run", "--dry-run", "@foo"],
         )
 
 
@@ -1267,11 +1171,12 @@ def _run_self_tests() -> int:
         _TrimShellTrailersTests,
         _CliPlaceholderTokenTests,
         _ExtractSondaCommandsTests,
-        _ExtractScenarioPathTests,
-        _ExtractImportOrFromFileTests,
-        _ExtractTutorialTitlesTests,
+        _ExtractRunTargetTests,
+        _ExtractNewFromFileTests,
+        _ExtractCatalogDirTests,
         _RepoRelativePathTests,
         _SupportsDryRunTests,
+        _BuildDryRunArgvTests,
     ):
         suite.addTests(loader.loadTestsFromTestCase(cls))
     runner = unittest.TextTestRunner(verbosity=2)

--- a/scripts/validate_docs_commands.py
+++ b/scripts/validate_docs_commands.py
@@ -37,7 +37,9 @@ DOCS_GLOB_EXCLUDE = (Path("docs/site/site"),)
 
 KNOWN_SUBCOMMANDS: frozenset[str] = frozenset({"run", "list", "show", "new"})
 
-# Only ``run`` supports ``--dry-run`` in the 1.9 CLI.
+# ``--dry-run`` is declared as a global flag (``#[arg(long, global = true)]``)
+# but only has an observable effect on ``run``. The validator only injects it
+# for ``run`` commands.
 DRY_RUNNABLE_SINGLE: frozenset[str] = frozenset({"run"})
 
 DEFAULT_SONDA_BINARY = Path("target/release/sonda")
@@ -93,7 +95,7 @@ class ExtractedCommand:
 
 # Global flags that consume the next argv token. Used by ``subcommand`` to
 # skip past a value when looking for the verb.
-_GLOBAL_FLAGS_WITH_VALUE: frozenset[str] = frozenset({"--catalog"})
+_GLOBAL_FLAGS_WITH_VALUE: frozenset[str] = frozenset({"--catalog", "--format"})
 
 
 @dataclasses.dataclass
@@ -579,11 +581,12 @@ def validate_command(
 def _build_dry_run_argv(
     cmd: ExtractedCommand, sonda_bin: Path
 ) -> list[str]:
-    """Replace ``sonda`` with ``sonda_bin`` and inject ``--dry-run`` on the
+    """Replace ``sonda`` with ``sonda_bin`` and inject ``--dry-run`` for the
     ``run`` subcommand if not already present.
 
-    ``--dry-run`` is a flag on the ``run`` subcommand itself, so it must
-    appear after ``run`` (clap rejects it as a global flag).
+    ``--dry-run`` is declared as a clap global flag, so clap accepts it in
+    either position. We inject after the ``run`` verb purely as a stylistic
+    choice so the rendered command reads as ``sonda run --dry-run <args>``.
     """
     argv = list(cmd.argv)
     argv[0] = str(sonda_bin)
@@ -1018,6 +1021,13 @@ class _ExtractSondaCommandsTests(unittest.TestCase):
         out = self._extract(md)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].subcommand, "run")
+
+    def test_global_format_flag_skipped_when_finding_subcommand(self) -> None:
+        md = "```bash\nsonda --dry-run --format json run @cpu-spike\n```\n"
+        out = self._extract(md)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].subcommand, "run")
+        self.assertEqual(extract_run_target(out[0].argv), "@cpu-spike")
 
 
 class _ExtractRunTargetTests(unittest.TestCase):

--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -16,12 +16,11 @@ src/
 ├── packs/
 │   └── mod.rs          ← metric pack engine: MetricPackDef, MetricSpec, PackScenarioConfig,
 │                          MetricOverride, expand_pack(). Engine types and expansion logic only.
-│                          Pack YAML files live outside this crate, in `packs/` at repo root,
-│                          discovered by the CLI via a search path.
-├── scenarios/
-│   └── mod.rs          ← scenario metadata type: BuiltinScenario struct (owned fields + source_path).
-│                          Scenario YAML files live outside this crate, in `scenarios/` at repo root,
-│                          discovered by the CLI via a search path.
+│                          Pack YAML files are user-supplied data; sonda-core does not ship any.
+├── analysis/
+│   └── pattern.rs      ← time-series pattern detection: detect_pattern() → Pattern enum
+│                          (Steady / Spike / Climb / Sawtooth / Flap / Step). Pure statistics,
+│                          consumed by `sonda new --from <csv>`.
 ├── model/
 │   ├── mod.rs          ← module declarations
 │   ├── metric.rs       ← ValidatedMetricName (newtype over Arc<str>, validates once at construction),

--- a/sonda-core/src/analysis/pattern.rs
+++ b/sonda-core/src/analysis/pattern.rs
@@ -1,17 +1,6 @@
-//! Time-series pattern detection for the `import` subcommand.
-//!
-//! Analyzes a `Vec<f64>` of numeric values and classifies the dominant
-//! time-series pattern. This is statistical analysis code that lives in the
-//! CLI crate — it does NOT belong in sonda-core.
-//!
-//! # Supported patterns
-//!
-//! - **Steady**: low variance, no significant trend.
-//! - **Spike**: periodic outliers above a stable baseline.
-//! - **Climb**: monotonic upward trend (leak or saturation).
-//! - **Sawtooth**: repeating climb-reset cycles.
-//! - **Flap**: bimodal distribution (two dominant value clusters).
-//! - **Step**: discrete level changes with plateaus.
+//! Time-series pattern detection. Classifies a `Vec<f64>` into one of:
+//! `Steady`, `Spike`, `Climb`, `Sawtooth`, `Flap`, `Step`. Pure statistics;
+//! no I/O or CLI concerns. Consumed by `sonda new --from <csv>`.
 
 use std::fmt;
 
@@ -745,9 +734,7 @@ fn percentile(sorted: &[f64], p: f64) -> f64 {
 mod tests {
     use super::*;
 
-    // -----------------------------------------------------------------------
     // Pattern::name() — short variant identifiers
-    // -----------------------------------------------------------------------
 
     #[test]
     fn name_returns_steady_for_steady_variant() {
@@ -808,9 +795,7 @@ mod tests {
         assert_eq!(p.name(), "step");
     }
 
-    // -----------------------------------------------------------------------
     // Steady pattern detection
-    // -----------------------------------------------------------------------
 
     #[test]
     fn detect_constant_values_as_steady() {
@@ -841,9 +826,7 @@ mod tests {
         }
     }
 
-    // -----------------------------------------------------------------------
     // Spike pattern detection
-    // -----------------------------------------------------------------------
 
     #[test]
     fn detect_periodic_spikes() {
@@ -870,9 +853,7 @@ mod tests {
         }
     }
 
-    // -----------------------------------------------------------------------
     // Climb pattern detection
-    // -----------------------------------------------------------------------
 
     #[test]
     fn detect_linear_climb() {
@@ -914,9 +895,7 @@ mod tests {
         }
     }
 
-    // -----------------------------------------------------------------------
     // Sawtooth pattern detection
-    // -----------------------------------------------------------------------
 
     #[test]
     fn detect_sawtooth_pattern() {
@@ -945,9 +924,7 @@ mod tests {
         }
     }
 
-    // -----------------------------------------------------------------------
     // Flap pattern detection
-    // -----------------------------------------------------------------------
 
     #[test]
     fn detect_flap_pattern() {
@@ -980,9 +957,7 @@ mod tests {
         }
     }
 
-    // -----------------------------------------------------------------------
     // Step pattern detection
-    // -----------------------------------------------------------------------
 
     #[test]
     fn detect_monotonic_counter_as_step() {
@@ -998,9 +973,7 @@ mod tests {
         }
     }
 
-    // -----------------------------------------------------------------------
     // Edge cases
-    // -----------------------------------------------------------------------
 
     #[test]
     fn empty_values_returns_steady_zero() {
@@ -1037,9 +1010,7 @@ mod tests {
         }
     }
 
-    // -----------------------------------------------------------------------
     // Display implementation
-    // -----------------------------------------------------------------------
 
     #[test]
     fn pattern_display_includes_parameters() {
@@ -1052,9 +1023,7 @@ mod tests {
         assert!(s.contains("50.00"));
     }
 
-    // -----------------------------------------------------------------------
     // Determinism: same input produces same output
-    // -----------------------------------------------------------------------
 
     #[test]
     fn pattern_detection_is_deterministic() {

--- a/sonda-core/src/compiler/mod.rs
+++ b/sonda-core/src/compiler/mod.rs
@@ -91,16 +91,13 @@ pub struct ScenarioFile {
     /// ignored by every compiler phase.
     #[cfg_attr(feature = "config", serde(default))]
     pub scenario_name: Option<String>,
-    /// Catalog category used by `scenarios list --category <name>` and
-    /// `catalog list --category <name>`. Allowed values are enforced by
-    /// the CLI CI validation (`infrastructure`, `network`, `application`,
-    /// `observability`); the AST itself does not constrain the string.
-    /// Pure metadata — ignored by every compiler phase.
+    /// Legacy catalog category. Superseded by `tags` (filtered via
+    /// `sonda list --tag`). Carried through for back-compat with files
+    /// authored before 1.9a; not surfaced by the current CLI.
     #[cfg_attr(feature = "config", serde(default))]
     pub category: Option<String>,
-    /// One-line human-readable description surfaced by
-    /// `scenarios list` / `catalog list` and `scenarios show`. Pure
-    /// metadata — ignored by every compiler phase.
+    /// One-line human-readable description surfaced by `sonda list` and
+    /// `sonda show`. Pure metadata — ignored by every compiler phase.
     #[cfg_attr(feature = "config", serde(default))]
     pub description: Option<String>,
     /// Optional shared defaults inherited by all entries.

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -53,7 +53,7 @@
 //! 5. pack per-metric labels
 //! 6. pack entry-level labels (the entry under `scenarios:`)
 //! 7. override-level labels (`entry.overrides[metric].labels`)
-//! 8. CLI flags (applied at runtime, PR 7 scope)
+//! 8. CLI flags (applied at runtime)
 //!
 //! Eagerly merging levels 2 and 6 into a single map (as we do for inline
 //! entries) would collapse those two layers, making it impossible for pack
@@ -327,13 +327,6 @@ pub struct NormalizedEntry {
 /// All other fields (pack info, histogram parameters, `after` clause,
 /// `phase_offset`, `clock_group`, jitter, gaps, bursts, cardinality spikes,
 /// dynamic labels, etc.) are carried through untouched.
-///
-/// # Errors
-///
-/// Returns [`NormalizeError::MissingRate`] when an entry has no `rate`
-/// defined inline and the `defaults:` block does not supply one either.
-/// The error message identifies the entry by index and, when available,
-/// its `name`, `id`, or `pack` reference.
 pub fn normalize(file: ScenarioFile) -> Result<NormalizedFile, NormalizeError> {
     let defaults = file.defaults;
     let defaults_labels = defaults

--- a/sonda-core/src/compiler/parse.rs
+++ b/sonda-core/src/compiler/parse.rs
@@ -5,8 +5,7 @@
 //! id uniqueness, signal type validity, generator/pack mutual exclusion).
 //!
 //! [`detect_version`] is a lightweight helper that peeks at the `version` field
-//! without fully parsing the file. It will be used by the version dispatch layer
-//! (PR 6) to route between v1 and v2 parsing paths.
+//! without fully parsing the file.
 
 use std::collections::HashSet;
 
@@ -139,16 +138,6 @@ const DISTRIBUTION_SIGNAL_TYPES: &[&str] = &["histogram", "summary"];
 /// Returns `Some(n)` when the top-level mapping contains a `version` key with
 /// an integer value, or `None` when the field is absent or cannot be parsed.
 /// This is intentionally cheap — it deserializes into a minimal struct.
-///
-/// # Examples
-///
-/// ```
-/// use sonda_core::compiler::parse::detect_version;
-///
-/// assert_eq!(detect_version("version: 2\nscenarios: []"), Some(2));
-/// assert_eq!(detect_version("version: 1"), Some(1));
-/// assert_eq!(detect_version("name: cpu_usage\nrate: 1"), None);
-/// ```
 pub fn detect_version(yaml: &str) -> Option<u32> {
     #[derive(serde::Deserialize)]
     struct VersionProbe {
@@ -342,10 +331,6 @@ impl FlatFile {
 /// Note: `after.op` is deserialized as an [`AfterOp`](super::AfterOp) enum.
 /// Invalid operator values (anything other than `"<"` or `">"`) are rejected
 /// by serde during deserialization.
-///
-/// # Errors
-///
-/// Returns [`ParseError`] describing the first validation failure found.
 pub fn parse(yaml: &str) -> Result<ScenarioFile, ParseError> {
     if let Some(v) = detect_version(yaml) {
         if v != 2 {

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -28,11 +28,17 @@ src/
 │                          Every scenario file is compiled through the v2 pipeline
 │                          (`sonda_core::compile_scenario_file`); pre-v2 YAML shapes are
 │                          rejected with a migration hint.
+├── scenario_loader.rs  ← thin loader: reads a YAML path, runs it through
+│                          `compile_scenario_file_compiled`, returns the CompiledFile.
+│                          Shared by `dry_run` and the `run` dispatch in main.rs.
 ├── catalog_dir.rs      ← filesystem catalog discovery: enumerate(dir) walks YAML files
 │                          and peeks frontmatter (kind / name / tags) without full
 │                          deserialization; resolve(dir, name) does @name lookup.
 │                          First-match-wins is a HARD ERROR on duplicate names —
 │                          ambiguity is never silently resolved.
+├── sink_format.rs      ← single source of truth for sink-display rendering shared
+│                          between `dry_run` and `status` (so the "config" view and
+│                          the "start" banner agree on how a sink prints).
 ├── new/
 │   ├── mod.rs          ← `sonda new` subcommand: dispatches between --template,
 │   │                      --from <csv>, and interactive flow; writes to -o <path>

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -5,7 +5,7 @@ This is the binary crate. It is a **thin layer** over sonda-core. No business lo
 ## Responsibility
 
 1. Parse CLI arguments using `clap` (derive API).
-2. Load the YAML scenario file (if provided).
+2. Load the YAML scenario file (file path or `@name` from a catalog directory).
 3. Merge CLI flag overrides onto the loaded config.
 4. Validate the merged config.
 5. Instantiate the generator, encoder, and sink via sonda-core factories.
@@ -19,187 +19,107 @@ in sonda-core.
 
 ```
 src/
-├── main.rs             ← entrypoint, clap setup, orchestration
-├── cli.rs              ← clap arg structs (#[derive(Parser)]), Verbosity enum,
-│                          ScenariosArgs/ScenariosAction for the `scenarios` subcommand,
-│                          PacksArgs/PacksAction for the `packs` subcommand,
-│                          --pack-path and --scenario-path global flags
-├── config.rs           ← config loading: YAML file or @name → merge CLI overrides → ScenarioConfig.
+├── main.rs             ← entrypoint, clap dispatch, orchestration
+├── cli.rs              ← clap arg structs: Commands enum (Run / List / Show / New),
+│                          RunArgs, ListArgs, ShowArgs, NewArgs, Verbosity enum,
+│                          global --catalog and --dry-run / verbosity flags
+├── config.rs           ← config loading: YAML file or @name → catalog peek → v2
+│                          compile pipeline → merge CLI overrides → ScenarioConfig.
 │                          Every scenario file is compiled through the v2 pipeline
-│                          (`sonda_core::compile_scenario_file`); v1 YAML shapes are
-│                          rejected with a migration hint. Includes resolve_scenario_source
-│                          (@name shorthand via ScenarioCatalog), parse_builtin_scenario,
-│                          load_pack_from_catalog.
-├── packs.rs            ← filesystem-based metric pack discovery: PackCatalog, PackEntry,
-│                          build_search_path(). Scans directories for pack YAML files and
-│                          caches results for the CLI invocation.
-│                          Search path (priority): --pack-path > SONDA_PACK_PATH > ./packs/ >
-│                          ~/.sonda/packs/
-├── scenarios.rs        ← filesystem-based scenario discovery: ScenarioCatalog,
-│                          build_search_path(). Scans directories for scenario YAML files
-│                          with metadata (scenario_name, category, signal_type, description).
-│                          Search path (priority): --scenario-path > SONDA_SCENARIO_PATH >
-│                          ./scenarios/ > ~/.sonda/scenarios/
-├── import/
-│   ├── mod.rs          ← `sonda import` subcommand: top-level orchestration (analyze, generate,
-│   │                      run modes), parse_column_list()
-│   ├── csv_reader.rs   ← CSV file reading: header detection via sonda-core csv_header,
-│   │                      numeric data extraction, column selection, ColumnMeta, CsvData
-│   ├── pattern.rs      ← time-series pattern detection (statistical analysis):
-│   │                      detect_pattern() → Pattern enum (Steady, Spike, Climb, Sawtooth,
-│   │                      Flap, Step). All heuristics are in the CLI crate, not sonda-core.
-│   └── yaml_gen.rs     ← YAML scenario generation from detected patterns: pattern_to_spec(),
-│                          render_yaml(). Maps patterns to operational vocabulary aliases
-│                          (steady, spike_event, leak, flap) or base generators (sawtooth, step).
-├── init/
-│   ├── mod.rs          ← `sonda init` subcommand: top-level orchestration (run_init),
-│   │                      InitResult (yaml + run_now flag + InitScenarioType for dispatch),
-│   │                      build_prefill() merges --from data with CLI flags into Prefill,
-│   │                      prefill_from_scenario() extracts fields from @name scenario YAML
-│   │                      (including labels), prefill_from_csv() detects pattern from CSV
-│   │                      and maps to alias (gracefully handles no-numeric-columns),
-│   │                      welcome banner, YAML preview, success summary, run-now prompt
-│   │                      (bypassed by --run-now flag or non-TTY stdin),
-│   │                      print_prefill_summary() shows pre-filled values before prompts
-│   ├── prompts.rs      ← interactive prompt logic using dialoguer: signal type, domain,
-│   │                      approach (single metric vs pack), situation selection,
-│   │                      situation-specific parameters (bypassed with defaults when
-│   │                      situation is prefilled), labels, rate (validated > 0), duration
-│   │                      (validated via parse_duration), encoder, sink.
-│   │                      Histogram and summary prompt flows: distribution model selection,
-│   │                      distribution-specific parameters, observations per tick,
-│   │                      bucket/quantile boundaries, and seed. All distribution-related
-│   │                      prompts are bypassed with sensible defaults when signal_type
-│   │                      is prefilled (non-interactive mode).
-│   │                      default_distribution_params() returns defaults matching the
-│   │                      interactive prompts for each distribution model.
-│   │                      Prefill struct carries optional pre-filled values for each prompt
-│   │                      including log-specific (message_template, severity) and
-│   │                      sink-specific (kafka_brokers, kafka_topic, otlp_signal_type).
-│   │                      Each prompt fn checks prefill — valid value skips the prompt,
-│   │                      invalid value warns and falls through to interactive.
-│   │                      Two-tier sink menu (primary: stdout/http_push/file; advanced:
-│   │                      remote_write/loki/otlp_grpc/kafka/tcp/udp behind "Advanced...").
-│   │                      Prefilled advanced sinks populate extra fields from prefill.
-│   │                      Pack domain filtering (list_by_category, fallback to all).
-│   │                      enforce_encoder_for_sink() auto-overrides encoder for protocol sinks.
-│   │                      prompt_run_now() offers immediate execution after file write.
-│   └── yaml_gen.rs     ← YAML rendering from collected answers: ScenarioKind, MetricAnswers,
-│                          PackAnswers, LogAnswers, HistogramAnswers, SummaryAnswers,
-│                          DeliveryAnswers. InitScenarioType enum
-│                          (SingleMetric/Pack/Logs/Histogram/Summary) for typed dispatch
-│                          in run-now path.
-│                          required_encoder_for_sink() maps sink→encoder constraints.
-│                          render_sink() handles all sink types incl. advanced YAML fields.
-├── yaml_helpers.rs     ← shared YAML formatting and quoting utilities: ParamValue, needs_quoting(),
-│                          escape_yaml_double_quoted(), format_float(), format_rate().
-│                          Used by both init/yaml_gen and import/yaml_gen.
-├── progress.rs         ← live progress display during scenario execution (TTY/non-TTY aware,
-│                          polls ScenarioStats via shared RwLock, all output to stderr)
-└── status.rs           ← colored lifecycle banners (start/stop/config/summary) printed to stderr
+│                          (`sonda_core::compile_scenario_file`); pre-v2 YAML shapes are
+│                          rejected with a migration hint.
+├── catalog_dir.rs      ← filesystem catalog discovery: enumerate(dir) walks YAML files
+│                          and peeks frontmatter (kind / name / tags) without full
+│                          deserialization; resolve(dir, name) does @name lookup.
+│                          First-match-wins is a HARD ERROR on duplicate names —
+│                          ambiguity is never silently resolved.
+├── new/
+│   ├── mod.rs          ← `sonda new` subcommand: dispatches between --template,
+│   │                      --from <csv>, and interactive flow; writes to -o <path>
+│   │                      or stdout
+│   ├── prompts.rs      ← interactive prompt logic using dialoguer: signal type,
+│   │                      scenario id, generator (metrics only), rate, duration, sink
+│   ├── csv_reader.rs   ← CSV file reading for `--from <csv>`: header parsing,
+│   │                      numeric column extraction
+│   └── yaml_gen.rs     ← YAML rendering: minimal_template(), render_from_answers(),
+│                          spec_from_pattern() — maps detected patterns to v2 YAML
+│                          using operational vocabulary aliases (steady, spike_event,
+│                          leak, flap, sawtooth, step)
+├── dry_run.rs          ← compile-and-print path for `sonda --dry-run run`: renders
+│                          either the resolved scenario text or JSON for tooling
+├── progress.rs         ← live progress display during scenario execution (TTY/non-TTY
+│                          aware, polls ScenarioStats via shared RwLock, all output to
+│                          stderr)
+└── status.rs           ← colored lifecycle banners (start/stop/config/summary) printed
+                           to stderr
 ```
 
-This crate should stay small. Seven files plus subdirectory modules for complex features is the
-target. Subdirectories (e.g., `import/`) are an accepted extension when a feature requires
-multiple tightly-coupled files. If top-level file count grows beyond seven or a subdirectory
-exceeds four files, something may belong in sonda-core.
+This crate stays small. Subdirectories (e.g., `new/`) are an accepted extension when a feature
+requires multiple tightly-coupled files.
 
 ## CLI Surface
 
 ```
-sonda [--quiet | --verbose] [--dry-run] metrics --scenario <file.yaml | @builtin-name>
-sonda [--quiet | --verbose] [--dry-run] metrics --name <n> --rate <r> --duration <d> [--encoder <enc>] [--precision <0-17>] [--label k=v]... [--sink <type> --endpoint <url> ...]
-sonda [--quiet | --verbose] [--dry-run] logs --scenario <file.yaml | @builtin-name>
-sonda [--quiet | --verbose] [--dry-run] logs --mode <mode> [--sink <type> --endpoint <url> ...]
-sonda [--quiet | --verbose] [--dry-run] histogram --scenario <file.yaml | @builtin-name>
-sonda [--quiet | --verbose] [--dry-run] run --scenario <multi-scenario.yaml | @builtin-name>
-sonda scenarios list [--category <cat>] [--json]
-sonda scenarios show <name>
-sonda [--quiet | --verbose] [--dry-run] scenarios run <name> [--duration <d>] [--rate <r>] [--sink <type>] [--endpoint <url>] [--encoder <enc>]
-sonda [--pack-path <dir>] packs list [--category <cat>] [--json]
-sonda [--pack-path <dir>] packs show <name>
-sonda [--quiet | --verbose] [--dry-run] packs run <name> [--duration <d>] [--rate <r>] [--sink <type>] [--endpoint <url>] [--encoder <enc>] [--label k=v]...
-sonda import <file.csv> --analyze
-sonda import <file.csv> -o <output.yaml> [--columns <1,3,5>] [--rate <r>] [--duration <d>]
-sonda [--quiet | --verbose] import <file.csv> --run [--columns <1,3,5>] [--rate <r>] [--duration <d>]
-sonda init [--from <@name | path.csv>] [--signal-type <metrics|logs|histogram|summary>] [--domain <cat>] [--situation <alias>] [--metric <name>] [--pack <name>] [--rate <r>] [--duration <d>] [--encoder <enc>] [--sink <type>] [--endpoint <url>] [-o <path>] [--label k=v]... [--run-now] [--message-template <tpl>] [--severity <preset>] [--kafka-brokers <addrs>] [--kafka-topic <topic>] [--otlp-signal-type <type>]
+sonda [GLOBAL FLAGS] run <SCENARIO> [OPTIONS]
+sonda [GLOBAL FLAGS] list --catalog <DIR> [--kind <runnable|composable>] [--tag <TAG>] [--json]
+sonda [GLOBAL FLAGS] show <@NAME> --catalog <DIR>
+sonda [GLOBAL FLAGS] new [--template | --from <CSV>] [-o <PATH>]
 ```
 
-The `--scenario` flag accepts either a filesystem path or a `@name` shorthand that resolves
-a scenario from the filesystem catalog discovered via the scenario search path. Example:
-`sonda metrics --scenario @cpu-spike`.
-
-Every `--scenario` file must be a **v2 scenario** (`version: 2` at the top level). v1 YAML
-shapes — flat single-signal configs, top-level `scenarios:` lists without `version: 2`, and
-`pack:` shorthand files — are rejected with a migration hint. Pack references inside v2
-files (`pack: <name>` under a `scenarios:` entry) are resolved by the `FilesystemPackResolver`
-backed by the CLI's `PackCatalog`.
+`<SCENARIO>` is either a path to a v2 YAML file or `@name` for catalog lookup. Every scenario file
+must declare `version: 2` and `kind: runnable` (pack files declare `kind: composable`). Pre-v2
+shapes are rejected with a migration hint. Pack references inside a v2 file (`pack: <name>` under
+a `scenarios:` entry) are resolved by `CatalogPackResolver`, which reads the `--catalog <dir>`
+directory.
 
 ### Global Flags
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--quiet` | `-q` | Suppress all status banners (start/stop/summary). Errors are still printed to stderr. |
-| `--verbose` | `-v` | Show the resolved scenario config at startup, then run normally with start/stop banners. Mutually exclusive with `--quiet`. |
-| `--dry-run` | | Parse and validate the scenario config, print it, then exit without emitting any events. Orthogonal to `--quiet`/`--verbose` — always prints the resolved config. |
-| `--pack-path` | | Directory containing metric pack YAML files. When set, this is the sole search path for packs -- `SONDA_PACK_PATH`, `./packs/`, and `~/.sonda/packs/` are not consulted. |
-| `--scenario-path` | | Directory containing scenario YAML files. When set, this is the sole search path for scenarios -- `SONDA_SCENARIO_PATH`, `./scenarios/`, and `~/.sonda/scenarios/` are not consulted. |
+| `--quiet` | `-q` | Suppress status banners. Errors still print to stderr. |
+| `--verbose` | `-v` | Show the resolved scenario config at startup. Mutually exclusive with `--quiet`. |
+| `--catalog` | | Directory containing scenario and pack YAML files for `@name` resolution. Mandatory whenever a `@name` reference appears. |
+| `--dry-run` | | `run` subcommand only: parse and validate the scenario, print it, exit without emitting events. Use `--format json` for machine-readable output. |
 
-The verbosity model is captured in the `Verbosity` enum (`Quiet`, `Normal`, `Verbose`), constructed
-from the `--quiet` and `--verbose` flags via `Verbosity::from_flags()`. `--dry-run` is orthogonal.
+There is no `SONDA_CATALOG` env var, no implicit search path, no built-in catalog. `--catalog` is
+the single discovery surface. The verbosity model is captured in the `Verbosity` enum (`Quiet`,
+`Normal`, `Verbose`), constructed from `--quiet` and `--verbose` via `Verbosity::from_flags()`.
 
-The `metrics` subcommand is the MVP entry point. `logs` emits log events. `histogram` generates
-Prometheus-style histogram data. `summary` generates Prometheus-style summary data. `run` runs
-multiple scenarios concurrently from a single v2 YAML file whose `scenarios:` list carries
-`signal_type: metrics`, `logs`, `histogram`, or `summary` entries. Pack references inside a v2
-entry (`pack: <name>`) expand to one runtime entry per pack metric via the v2 compiler's
-expand phase. `scenarios` discovers scenario YAML files from the
-search path (`--scenario-path`, `SONDA_SCENARIO_PATH`, `./scenarios/`, `~/.sonda/scenarios/`):
-`list` to browse, `show` to dump YAML, `run` to execute. `packs` provides access to metric pack
-files: `list` to browse, `show` to dump YAML, `run` to execute with rate/duration/sink/encoder
-overrides. `import` analyzes a CSV file, detects time-series patterns (steady, spike, climb,
-flap, sawtooth, step), and generates a portable scenario YAML using generators instead of
-csv_replay. Three modes: `--analyze` (read-only), `-o` (write YAML), `--run` (generate + execute).
-`init` walks through an interactive prompt flow and generates a commented, runnable scenario YAML.
-Uses operational vocabulary aliases (steady, spike_event, flap, etc.) and supports metric packs
-with domain-filtered selection. Two-tier sink menu (primary + advanced behind "Advanced...") with
-automatic encoder override for protocol sinks (remote_write, otlp_grpc). After writing the file,
-offers immediate execution via the run-now prompt (dispatched by InitScenarioType).
-Supports fully non-interactive mode via CLI flags (`--signal-type`, `--domain`, `--situation`,
-`--metric`, `--rate`, `--duration`, `--encoder`, `--sink`, `-o`, `--run-now`, etc.) and
-pre-filling from built-in scenarios (`--from @name`) or CSV files (`--from path.csv`).
-CLI flags override `--from` values. Pre-filled values skip their interactive prompts; missing
-values prompt as usual (partial non-interactive mode). Situation-specific parameters use
-defaults when the situation is prefilled. Log-specific prompts (message template, severity)
-and sink-specific extra fields (kafka brokers/topic, OTLP signal type) are also prefillable.
-Rate and duration are validated; invalid values warn and fall through.
+### Subcommand summary
 
-Multi-signal temporal scenarios (formerly delivered via the retired `story` subcommand) are
-now expressed directly as v2 scenario YAML files with `after:` clauses on entries, run through
-`sonda run --scenario <file>` or `sonda catalog run <name>`. The v2 compiler resolves `after`
-clauses into concrete `phase_offset` values via the shared timing math in
-`sonda_core::compiler::timing`.
+- **`sonda run <scenario>`** — launch a scenario. Accepts a file path or `@name`. Per-run override
+  flags: `--rate`, `--duration`, `--encoder`, `--sink`, `--endpoint`, `--label`, `-o/--output`,
+  `--on-sink-error`. `--dry-run` parses and prints without emitting. Multi-scenario v2 files
+  (multiple entries under `scenarios:`) run concurrently and respect per-entry `phase_offset`
+  and `after:` clauses; final summary line aggregates totals.
+- **`sonda list --catalog <dir>`** — enumerate every YAML in the catalog. Filters: `--kind`,
+  `--tag`. `--json` emits machine-readable output. No dry-run (the operation is purely
+  observational).
+- **`sonda show <@name> --catalog <dir>`** — print the raw source YAML for a catalog entry,
+  round-trippable through `sonda run`.
+- **`sonda new`** — scaffold a v2 scenario YAML. Default mode is interactive (signal type →
+  scenario id → generator → rate → duration → sink). `--template` dumps a minimal valid YAML
+  with no prompts. `--from <csv>` scaffolds from a CSV using `sonda_core::analysis::pattern`
+  and maps detected patterns to operational vocabulary aliases. `-o <path>` writes to a file;
+  otherwise the YAML is printed to stdout.
 
-All subcommands go through the unified `sonda_core::prepare_entries` +
-`sonda_core::launch_scenario` API introduced in Slice 3.0. No per-signal-type dispatch in main.rs.
-
-The `run` subcommand prints an aggregate summary line after all scenarios complete, showing total
-scenarios, events, bytes, errors, and elapsed time.
-
-### Discovery Search Paths
-
-Both packs and scenarios use the same priority: CLI flag (sole path) > env var (colon-separated) >
-`./packs/` or `./scenarios/` > `~/.sonda/packs/` or `~/.sonda/scenarios/`. Non-existent dirs
-silently skipped. First-match-wins on name collisions. See `packs.rs` and `scenarios.rs` for details.
+All subcommands route through the unified `sonda_core::prepare_entries` + `sonda_core::launch_scenario`
+API. No per-signal-type dispatch in main.rs.
 
 ## Adding a New Subcommand
 
+The CLI is intentionally restricted to four verbs. Adding a fifth verb is an architectural decision
+that should be paired with a written rationale — most workflows are better expressed by adding flags
+to `sonda run` or by extending the catalog metadata that `sonda list` / `sonda show` surface. If
+a new verb is genuinely warranted:
+
 1. Add a variant to the `Commands` enum in `cli.rs`.
 2. Add the corresponding clap derive struct for its flags.
-3. Add a match arm in `main.rs` that:
-   - Loads config.
-   - Calls the appropriate sonda-core runner.
-4. That's it. The actual logic stays in sonda-core.
+3. Add a match arm in `main.rs` that calls the appropriate sonda-core API.
+4. Add the verb to `sonda-server/src/main.rs`'s `SONDA_SUBCOMMANDS` so the dispatch shim
+   forwards it to the sibling `sonda` binary.
+
+The actual logic stays in sonda-core.
 
 ## Error Handling
 
@@ -211,9 +131,11 @@ silently skipped. First-match-wins on name collisions. See `packs.rs` and `scena
 ## Config Precedence
 
 From lowest to highest priority:
-1. YAML scenario file
-2. `SONDA_*` environment variables
-3. CLI flags
+1. YAML scenario file (the `defaults:` block and per-entry fields).
+2. CLI flags (`--rate`, `--duration`, `--encoder`, etc.).
+
+There are no `SONDA_*` env-var overrides for scenario fields. The only env var read by the CLI is
+`SONDA_API_KEY`, which is consumed by `sonda-server`, not the CLI itself.
 
 Example: if the YAML says `rate: 100` and the CLI says `--rate 500`, the effective rate is 500.
 
@@ -223,9 +145,9 @@ This crate depends on:
 - `sonda-core` (workspace dependency)
 - `clap` with derive feature
 - `serde` + `serde_yaml_ng` for config loading
-- `serde_json` for JSON output in `scenarios list`
+- `serde_json` for JSON output (`sonda list --json`, `sonda --dry-run run --format json`)
 - `anyhow` for error handling
 - `owo-colors` for colored terminal output (with `supports-colors` feature for auto-detection)
-- `dialoguer` for interactive terminal prompts in `sonda init` (pure Rust, musl-compatible)
+- `dialoguer` for interactive terminal prompts in `sonda new` (pure Rust, musl-compatible)
 
 It should NOT depend on: `axum`, `tokio`, `hyper`, or any server-related crate.

--- a/sonda/tests/example_smoke.rs
+++ b/sonda/tests/example_smoke.rs
@@ -1,0 +1,323 @@
+//! Smoke tests for critical 1.9 examples.
+//!
+//! Runs the real sonda binary against example YAMLs.
+//! Long-running examples use --duration to keep tests under ~20s.
+
+mod common;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use common::sonda_bin;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("sonda crate must have a parent workspace directory")
+        .to_path_buf()
+}
+
+fn example(name: &str) -> PathBuf {
+    workspace_root().join("examples").join(name)
+}
+
+fn fixtures_packs_dir() -> PathBuf {
+    workspace_root().join("sonda-core/tests/fixtures/packs")
+}
+
+// ---- basic-metrics.yaml -------------------------------------------------------
+
+#[test]
+fn example_basic_metrics_runs_and_emits_prometheus_text() {
+    let output = Command::new(sonda_bin())
+        .current_dir(workspace_root())
+        .args(["--quiet", "run"])
+        .arg(example("basic-metrics.yaml"))
+        .args(["--duration", "200ms"])
+        .output()
+        .expect("sonda binary must launch");
+    assert!(
+        output.status.success(),
+        "exit 0 expected; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "basic-metrics must emit to stdout");
+    assert!(
+        stdout.contains("interface_oper_state"),
+        "must emit metric name in stdout; got: {stdout}"
+    );
+    let data_lines = stdout
+        .lines()
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .count();
+    assert!(data_lines > 0, "must emit at least one metric line");
+}
+
+// ---- csv-replay-metrics.yaml --------------------------------------------------
+
+#[test]
+fn example_csv_replay_metrics_runs_and_emits_csv_values() {
+    let output = Command::new(sonda_bin())
+        .current_dir(workspace_root())
+        .args(["--quiet", "run"])
+        .arg(example("csv-replay-metrics.yaml"))
+        .args(["--duration", "15s"])
+        .output()
+        .expect("sonda binary must launch");
+    assert!(
+        output.status.success(),
+        "exit 0 expected; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "csv-replay-metrics must emit to stdout");
+    assert!(
+        stdout.contains("cpu_replay"),
+        "must emit cpu_replay metric; got: {stdout}"
+    );
+    // The CSV starts at 12.3 then 14.1 -- verify actual values are replayed.
+    assert!(
+        stdout.contains("12.3") || stdout.contains("14.1"),
+        "must replay CSV values (12.3, 14.1, ...); got: {stdout}"
+    );
+}
+
+// ---- log-csv-replay.yaml ------------------------------------------------------
+
+#[test]
+fn example_log_csv_replay_runs_and_emits_json_lines() {
+    let output = Command::new(sonda_bin())
+        .current_dir(workspace_root())
+        .args(["--quiet", "run"])
+        .arg(example("log-csv-replay.yaml"))
+        .args(["--duration", "10s"])
+        .output()
+        .expect("sonda binary must launch");
+    assert!(
+        output.status.success(),
+        "exit 0 expected; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.is_empty(),
+        "log-csv-replay must emit to stdout; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    for line in stdout.lines().filter(|l| !l.is_empty()) {
+        let v: serde_json::Value =
+            serde_json::from_str(line).expect("each log line must be valid JSON");
+        assert!(v.get("timestamp").is_some(), "must have timestamp: {line}");
+        assert!(v.get("message").is_some(), "must have message: {line}");
+        assert!(v.get("severity").is_some(), "must have severity: {line}");
+    }
+    assert!(
+        stdout.contains("GET /api/v1/health") || stdout.contains("POST /api/v1/events"),
+        "must replay CSV messages; got: {stdout}"
+    );
+}
+
+// ---- network-link-failure.yaml ------------------------------------------------
+
+#[test]
+fn example_network_link_failure_runs_multi_scenario_and_emits_all_metrics() {
+    let output = Command::new(sonda_bin())
+        .current_dir(workspace_root())
+        .args(["--quiet", "run"])
+        .arg(example("network-link-failure.yaml"))
+        .args(["--duration", "3s"])
+        .output()
+        .expect("sonda binary must launch");
+    assert!(
+        output.status.success(),
+        "exit 0 expected; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.is_empty(),
+        "network-link-failure must emit to stdout"
+    );
+    // All 6 scenarios must emit at least one line.
+    assert!(
+        stdout.contains("interface_oper_state"),
+        "must emit interface_oper_state"
+    );
+    assert!(
+        stdout.contains("interface_in_octets"),
+        "must emit interface_in_octets"
+    );
+    assert!(
+        stdout.contains("interface_errors"),
+        "must emit interface_errors"
+    );
+    assert!(
+        stdout.contains("device_cpu_percent"),
+        "must emit device_cpu_percent"
+    );
+    // Label propagation: the device label must appear in the output.
+    assert!(
+        stdout.contains("rtr-core-01"),
+        "must include device rtr-core-01 in labels"
+    );
+}
+
+// ---- pack-scenario.yaml via catalog -------------------------------------------
+
+#[test]
+fn example_pack_scenario_expands_via_catalog_and_emits_all_pack_metrics() {
+    let catalog = fixtures_packs_dir();
+    assert!(
+        catalog.exists(),
+        "fixtures packs dir must exist at: {}",
+        catalog.display()
+    );
+
+    let output = Command::new(sonda_bin())
+        .current_dir(workspace_root())
+        .args(["--quiet", "--catalog"])
+        .arg(&catalog)
+        .args(["run"])
+        .arg(example("pack-scenario.yaml"))
+        .args(["--duration", "3s"])
+        .output()
+        .expect("sonda binary must launch");
+
+    assert!(
+        output.status.success(),
+        "exit 0 expected; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "pack-scenario must emit to stdout");
+    // All 5 metrics from telegraf_snmp_interface must appear.
+    assert!(stdout.contains("ifOperStatus"), "must emit ifOperStatus");
+    assert!(stdout.contains("ifHCInOctets"), "must emit ifHCInOctets");
+    assert!(stdout.contains("ifHCOutOctets"), "must emit ifHCOutOctets");
+    assert!(stdout.contains("ifInErrors"), "must emit ifInErrors");
+    assert!(stdout.contains("ifOutErrors"), "must emit ifOutErrors");
+    // Labels from the pack entry must appear.
+    assert!(
+        stdout.contains("rtr-edge-01"),
+        "must include rtr-edge-01 device label"
+    );
+    assert!(
+        stdout.contains("snmp"),
+        "must include job=snmp from pack shared_labels"
+    );
+    // The step generator produces strictly increasing values for ifHCInOctets.
+    let step_values: Vec<f64> = stdout
+        .lines()
+        .filter(|l| l.contains("ifHCInOctets"))
+        .filter_map(|l| {
+            l.split("} ")
+                .nth(1)
+                .and_then(|r| r.split_whitespace().next())
+                .and_then(|v| v.parse().ok())
+        })
+        .collect();
+    assert!(
+        step_values.len() >= 2,
+        "must emit at least 2 ifHCInOctets samples; got: {step_values:?}"
+    );
+    assert!(
+        step_values.windows(2).all(|w| w[1] > w[0]),
+        "ifHCInOctets must produce strictly increasing values; got: {step_values:?}"
+    );
+}
+
+// ---- histogram.yaml -----------------------------------------------------------
+
+#[test]
+fn example_histogram_emits_prometheus_histogram_triplet() {
+    // histogram.yaml has duration: 10s -- run it to completion.
+    let output = Command::new(sonda_bin())
+        .current_dir(workspace_root())
+        .args(["--quiet", "run"])
+        .arg(example("histogram.yaml"))
+        .output()
+        .expect("sonda binary must launch");
+
+    assert!(
+        output.status.success(),
+        "exit 0 expected; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "histogram must emit to stdout");
+
+    let bucket_lines: usize = stdout
+        .lines()
+        .filter(|l| l.contains("http_request_duration_seconds_bucket"))
+        .count();
+    let count_lines: usize = stdout
+        .lines()
+        .filter(|l| l.contains("http_request_duration_seconds_count"))
+        .count();
+    let sum_lines: usize = stdout
+        .lines()
+        .filter(|l| l.contains("http_request_duration_seconds_sum"))
+        .count();
+
+    assert!(bucket_lines > 0, "must emit _bucket series");
+    assert!(count_lines > 0, "must emit _count series");
+    assert!(sum_lines > 0, "must emit _sum series");
+
+    // +Inf bucket value must equal _count at every tick.
+    let inf_values: Vec<u64> = stdout
+        .lines()
+        .filter(|l| l.contains("+Inf"))
+        .filter_map(|l| {
+            l.split("} ")
+                .nth(1)
+                .and_then(|r| r.split_whitespace().next())
+                .and_then(|v| v.parse().ok())
+        })
+        .collect();
+    let count_values: Vec<u64> = stdout
+        .lines()
+        .filter(|l| l.contains("http_request_duration_seconds_count"))
+        .filter_map(|l| {
+            l.split("} ")
+                .nth(1)
+                .and_then(|r| r.split_whitespace().next())
+                .and_then(|v| v.parse().ok())
+        })
+        .collect();
+    assert!(
+        !inf_values.is_empty() && inf_values == count_values,
+        "+Inf bucket must equal _count; inf={inf_values:?} count={count_values:?}"
+    );
+}
+
+// ---- log-template.yaml --------------------------------------------------------
+
+#[test]
+fn example_log_template_emits_structured_json_logs() {
+    let output = Command::new(sonda_bin())
+        .current_dir(workspace_root())
+        .args(["--quiet", "run"])
+        .arg(example("log-template.yaml"))
+        .args(["--duration", "500ms"])
+        .output()
+        .expect("sonda binary must launch");
+
+    assert!(
+        output.status.success(),
+        "exit 0 expected; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "log-template must emit to stdout");
+    let mut line_count = 0usize;
+    for line in stdout.lines().filter(|l| !l.is_empty()) {
+        line_count += 1;
+        let v: serde_json::Value =
+            serde_json::from_str(line).expect("each log line must be valid JSON");
+        assert!(v.get("timestamp").is_some(), "must have timestamp: {line}");
+        assert!(v.get("severity").is_some(), "must have severity: {line}");
+        assert!(v.get("message").is_some(), "must have message: {line}");
+    }
+    assert!(line_count > 0, "must emit at least one log event");
+}


### PR DESCRIPTION
## Summary

Final gate before `release/1.9 → main` (which will trigger the 1.9.0 release-please cut). Acts on findings from a 3-agent gate run (reviewer + doc + UAT, two reviewer rounds) and ships the missing pieces the rest of the 1.9 cycle didn't cover.

- **97 v2 YAML doc snippets** now declare the required `kind: runnable` / `kind: composable` — every one was rejected by the post-1.9a parser. Hero examples in `v2-scenarios.md`, `scenario-fields.md`, `sonda-server.md` POST bodies, every tutorial page.
- **`scripts/validate_docs_commands.py` rewritten** for the 4-verb surface. The old validator silently dropped positional `sonda run <path>` invocations — which is exactly why the `kind:` snippet drift slipped past CI. Now catches 172 doc commands (vs 133 before) with 0 failures. 71 self-tests pass.
- **`sonda/CLAUDE.md`, `sonda-core/CLAUDE.md`, `docs/architecture.md`** rewritten to reflect the actual 1.9 codebase (4-verb CLI, deleted modules dropped, `--catalog` is the single discovery surface, no `--pack-path` / `--scenario-path` / `SONDA_*_PATH`).
- **`README.md` `sonda new` walkthrough** rewritten to match the actual prompts in `sonda/src/new/prompts.rs` (the old text documented the retired `sonda init` situation/baseline/spike-height flow).
- **CI smoke recipe** in `pipeline-validation.md` swapped from the deleted `sonda metrics --name` form to `sonda new --template` + `sonda run`.
- **7 new smoke tests** in `sonda/tests/example_smoke.rs` covering basic-metrics, csv-replay, log-csv-replay, multi-scenario, pack expansion, histogram triplet, and log templating — each runs the real binary and asserts on observable output.
- **43 `examples/*.yaml` headers** swept (`# Run with: sonda metrics --scenario` → `sonda run examples/<file>`); pack-scenario.yaml + pack-with-overrides.yaml now use `--catalog`.
- **Source-comment hygiene**: dropped 20 section-banner `// ----` lines in `analysis/pattern.rs`, the misleading module docstring (claimed the file "does NOT belong in sonda-core" — it does now), `# Errors` / `# Examples` doc blocks in `compiler/parse.rs` + `compiler/normalize.rs`, stale `(PR 6)` / `(PR 7)` refs, and the deleted `scenarios list --category` reference in `compiler/mod.rs`.
- **Docs polish**: `index.md` quickstart reframed to lead with `sonda new --template` + `sonda run`; `troubleshooting.md` gained rows for `MissingKind` / `UnknownKind` errors; `cli-reference.md` lost its stale "1.9 in progress" admonition; `scenarios.md` reframed the "no built-in catalog" intro to lead with the upside.

## Commits

| SHA | What |
|---|---|
| `45eebfc` | docs(1.9) — doc-agent newcomer-UX polish (30 files, 97 snippets) |
| `d50af21` | test(examples) — UAT smoke tests (7 scenarios) |
| `d8a78f5` | chore(1.9) — fix-pass round 1 (CLAUDE.md / architecture / README / pipeline-validation / validator / examples / source-comment hygiene) |
| `6187af7` | chore(1.9) — fix-pass round 2 (validator `--format`, missed `spike_event` tip, `pack-with-overrides.yaml`, retry-flag prose, sonda/CLAUDE.md layout, MVP-scope wrap) |

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo nextest run --workspace` — 2468/2468 pass (+7 smoke tests)
- [x] `cargo test --workspace --doc` — 4/4 pass (one removed: `detect_version` `# Examples` block)
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p sonda-core --no-default-features` — clean
- [x] `cargo audit` — no new advisories (pre-existing `core2` yanked-allowed)
- [x] `python3 scripts/validate_docs_commands.py` — 172/172 pass
- [x] `python3 scripts/validate_docs_commands.py --self-test` — 71/71 pass
- [x] `task site:build` — clean (verified by doc agent)
- [x] Doc-agent verified end-to-end: scaffold quickstart, CSV replay, alert testing all work as documented
- [x] UAT verified: 62/62 example YAMLs validate via `sonda --dry-run run`

After merge, `release/1.9 → main` triggers release-please 1.9.0 bump.