### PR TITLE
docs(scenario-fields): add Prometheus/Grafana verification guide to §Gap window

### DIFF
--- a/docs/site/docs/configuration/img/gap-duty-cycle.svg
+++ b/docs/site/docs/configuration/img/gap-duty-cycle.svg
@@ -1,0 +1,112 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 380" role="img" aria-label="Gap duty cycle visualization">
+  <title>Gap duty cycle — count_over_time(interface_oper_state[1s]) — Last 5 minutes</title>
+  <desc>Rectangular duty-cycle wave: ~100s of emission at ~1000 samples/sec, then ~20s gap, repeated. Two and a half full cycles over a 5-minute window.</desc>
+
+  <!-- Self-contained Grafana-style panel mockup: dark slate background,
+       panel chrome, axes, lime duty-cycle wave. No real screenshot needed
+       — this conveys the same teaching point without dragging real labels
+       or a snapshot of a UI that will drift. -->
+
+  <defs>
+    <linearGradient id="fillGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"  stop-color="#a3e635" stop-opacity="0.55"/>
+      <stop offset="100%" stop-color="#a3e635" stop-opacity="0.08"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Panel background -->
+  <rect width="880" height="380" rx="12" fill="#0f172a"/>
+
+  <!-- Panel header -->
+  <rect x="0" y="0" width="880" height="46" rx="12" fill="#111827"/>
+  <rect x="0" y="34" width="880" height="12" fill="#111827"/>
+  <text x="20" y="29" font-family="system-ui, -apple-system, sans-serif"
+        font-size="14" font-weight="700" fill="#e2e8f0">
+    count_over_time(interface_oper_state[1s])
+  </text>
+  <text x="860" y="29" font-family="system-ui, -apple-system, sans-serif"
+        font-size="12" font-weight="600" fill="#94a3b8" text-anchor="end">
+    Last 5 minutes · min step 1s
+  </text>
+
+  <!-- Plot area inset: x=70..850 (780 wide), y=70..330 (260 tall) -->
+
+  <!-- Y-axis grid + labels -->
+  <g font-family="ui-monospace, 'JetBrains Mono', monospace" font-size="11" fill="#64748b">
+    <line x1="70" y1="330" x2="850" y2="330" stroke="#334155" stroke-width="1"/>
+    <line x1="70" y1="265" x2="850" y2="265" stroke="#1e293b" stroke-width="1" stroke-dasharray="2 4"/>
+    <line x1="70" y1="200" x2="850" y2="200" stroke="#1e293b" stroke-width="1" stroke-dasharray="2 4"/>
+    <line x1="70" y1="135" x2="850" y2="135" stroke="#1e293b" stroke-width="1" stroke-dasharray="2 4"/>
+    <line x1="70" y1="70"  x2="850" y2="70"  stroke="#1e293b" stroke-width="1" stroke-dasharray="2 4"/>
+
+    <text x="62" y="334" text-anchor="end">0</text>
+    <text x="62" y="269" text-anchor="end">250</text>
+    <text x="62" y="204" text-anchor="end">500</text>
+    <text x="62" y="139" text-anchor="end">750</text>
+    <text x="62" y="74"  text-anchor="end">1000</text>
+  </g>
+
+  <!-- X-axis (time). 5 min window = 300s. 780px wide / 300s = 2.6 px/s.
+       Marks every 1 minute at x = 70, 226, 382, 538, 694, 850. -->
+  <g font-family="ui-monospace, 'JetBrains Mono', monospace" font-size="11" fill="#64748b">
+    <line x1="70"  y1="330" x2="70"  y2="334" stroke="#475569"/>
+    <line x1="226" y1="330" x2="226" y2="334" stroke="#475569"/>
+    <line x1="382" y1="330" x2="382" y2="334" stroke="#475569"/>
+    <line x1="538" y1="330" x2="538" y2="334" stroke="#475569"/>
+    <line x1="694" y1="330" x2="694" y2="334" stroke="#475569"/>
+    <line x1="850" y1="330" x2="850" y2="334" stroke="#475569"/>
+
+    <text x="70"  y="350" text-anchor="middle">14:30</text>
+    <text x="226" y="350" text-anchor="middle">14:31</text>
+    <text x="382" y="350" text-anchor="middle">14:32</text>
+    <text x="538" y="350" text-anchor="middle">14:33</text>
+    <text x="694" y="350" text-anchor="middle">14:34</text>
+    <text x="850" y="350" text-anchor="middle">14:35</text>
+  </g>
+
+  <!-- Duty cycle path. Period = 120s (2m): 100s emit at ~1000, 20s gap at 0.
+       At 2.6px/s, 100s = 260px emit, 20s = 52px gap.
+       Plot y=70 is value 1000, y=330 is value 0.
+       Starting from x=70 (t=0), three cycles fit roughly in 300s:
+         emit  0..100  → x 70..330
+         gap  100..120 → x 330..382
+         emit 120..220 → x 382..642
+         gap  220..240 → x 642..694
+         emit 240..300 → x 694..850  (truncated at right edge)
+   -->
+  <path d="M 70 70
+           L 330 70 L 330 330
+           L 382 330 L 382 70
+           L 642 70 L 642 330
+           L 694 330 L 694 70
+           L 850 70"
+        fill="none"
+        stroke="#a3e635"
+        stroke-width="2.5"
+        stroke-linejoin="miter"/>
+
+  <!-- Light fill under the wave so the gaps read as "empty" zones. -->
+  <path d="M 70 330
+           L 70 70 L 330 70 L 330 330
+           L 382 330 L 382 70 L 642 70 L 642 330
+           L 694 330 L 694 70 L 850 70 L 850 330
+           Z"
+        fill="url(#fillGrad)"
+        opacity="0.9"/>
+
+  <!-- Gap annotations (callouts on first two gaps) -->
+  <g font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#94a3b8">
+    <line x1="356" y1="280" x2="356" y2="318" stroke="#475569" stroke-dasharray="2 3"/>
+    <text x="356" y="272" text-anchor="middle">20s gap</text>
+    <line x1="668" y1="280" x2="668" y2="318" stroke="#475569" stroke-dasharray="2 3"/>
+    <text x="668" y="272" text-anchor="middle">20s gap</text>
+  </g>
+
+  <!-- Legend chip top-left of plot -->
+  <g transform="translate(82, 84)">
+    <rect width="220" height="22" rx="4" fill="#020617" stroke="#1e293b"/>
+    <line x1="10" y1="11" x2="26" y2="11" stroke="#a3e635" stroke-width="2.5"/>
+    <text x="34" y="15" font-family="ui-monospace, 'JetBrains Mono', monospace"
+          font-size="11" fill="#e2e8f0">samples · 1s buckets</text>
+  </g>
+</svg>

--- a/docs/site/docs/configuration/scenario-fields.md
+++ b/docs/site/docs/configuration/scenario-fields.md
@@ -110,6 +110,32 @@ gaps:
 
 This emits events for 1m40s, then goes silent for 20s, then repeats.
 
+!!! tip "Verifying gaps live in Prometheus / Grafana"
+    Gaps are visually unintuitive at default settings. Two common pitfalls trip up first-time users:
+
+    - **Instant queries**: `interface_oper_state` in the Prometheus expression bar uses a 5-minute `lookback_delta`. A series that stopped emitting 10 seconds ago still appears "live" for up to 5 minutes — so a 20-second gap is *invisible* at the default settings.
+    - **Auto step size**: `present_over_time(interface_oper_state[5s])` over a 5-minute range gets evaluated at ~30-second steps in Grafana Explore. A 4-minute run with 240k samples collapses to ~7 dots on the graph. The data is there; the *evaluation cadence* hid it.
+
+    To see the duty cycle with your own eyes, use this query in **Grafana Explore**:
+
+    ```promql
+    count_over_time(interface_oper_state[1s])
+    ```
+
+    With these panel settings:
+
+    - **Min step**: `1s` (otherwise Grafana picks a larger step and smears the gaps)
+    - **Time range**: `Last 5 minutes` (shows two-plus full cycles of the example below)
+    - **View**: Time series (default)
+
+    ![Gap duty cycle in Grafana Explore](img/gap-duty-cycle.svg)
+
+    *Above: `count_over_time(interface_oper_state[1s])` against [`examples/basic-metrics.yaml`](https://github.com/davidban77/sonda/blob/main/examples/basic-metrics.yaml) — which declares `rate: 1000` and `gaps: every: 2m for: 20s`. You see ~100s of ~1000 samples/sec, then 20s of zero, repeating.*
+
+    Why every x-axis point is honest data: `count_over_time(...[1s])` buckets samples into 1-second windows and returns `0` for empty buckets (not null) — no connect-null-values toggle needed. With a 1-second min step Grafana evaluates once per second, so one bucket maps to one x-axis point. What you see is what landed.
+
+    The same trick works for `bursts:` (the rate rises during a burst window) and for any other rate-shaping field. The recurring lesson: when verifying short-window behavior, push your evaluation step *below* the window you're trying to see.
+
 ### Burst window
 
 Bursts create recurring high-rate periods. All three fields must be provided together. If a gap


### PR DESCRIPTION
Closes #363.

## Summary

The `§Gap window` section explains the syntax correctly but offers no guidance on how to **verify** that gaps are firing in a live pipeline. Two pitfalls hide them by default:

1. **Prometheus instant queries** use a 5-minute `lookback_delta`, so a series that stopped emitting 10 seconds ago still looks "live" — a 20-second gap is invisible at the expression-bar default.
2. **Grafana auto step-size** evaluates a 5-minute range at ~30-second steps, collapsing a 240k-sample run to ~7 dots that read as missing data even when they aren't.

The fix is a specific query (`count_over_time(<metric>[1s])`) and a 1-second min step. Obvious once you see it; confusing until you do.

## What this PR adds

A `!!! tip` admonition placed immediately after the existing _"This emits events for 1m40s, then goes silent for 20s, then repeats."_ line, before §Burst window. The admonition covers:

- The two pitfalls (lookback + step-size), each with the actual symptom you see.
- The recommended PromQL: `count_over_time(interface_oper_state[1s])`.
- Grafana Explore settings: **Min step `1s`**, **Time range Last 5 minutes**, time-series view.
- A self-contained chart showing the resulting duty cycle for `examples/basic-metrics.yaml` (`every: 2m for: 20s, rate: 1000` → ~100s of ~1000/s, then 20s of zero, repeating).
- A closing line that the same trick generalizes to `bursts:` and other rate-shaping fields.

## On the image choice — SVG mockup, not a screenshot

The issue suggested a PNG screenshot. I shipped an **SVG mockup** instead, at `docs/site/docs/configuration/img/gap-duty-cycle.svg`. Trade-off explained:

| | Screenshot (PNG) | SVG mockup (this PR) |
|---|---|---|
| Private labels | Risk of leaking hostnames / clusters | None — synthetic data |
| Stale when Grafana UI changes | Yes — re-shoot each time | No — text-editable |
| Renders at any zoom | Pixellates | Crisp |
| File size | ~50–150 KB typical | 3.1 KB |
| Matches Sonda palette | Whatever Grafana theme | Yes (lime + midnight) |
| Re-render to tweak | Requires repro setup | Edit numbers, build |

The mockup is a faithful **structural** representation — Grafana panel header, axis labels, dashed grid, lime stroke with gradient fill under the curve, two annotated `20s gap` callouts — and conveys the same teaching point (rectangular duty cycle = gaps firing correctly) without the screenshot baggage.

If you'd rather have a real screenshot too, happy to add one as a follow-up — but my recommendation is to keep just the mockup so the docs don't bit-rot the next time Grafana ships a UI refresh.

## Numbers match the actual example

The issue's starter text mentioned `every: 30s for: 20s` in one spot and the `basic-metrics.yaml` example (`every: 2m for: 20s`) in another. I went with the **actual file** so the docs stay coherent — the existing §Gap window example block right above already uses `every: 2m for: 20s`. Time range bumped from `Last 2 minutes` (which shows only one cycle for `every: 2m`) to `Last 5 minutes` (shows two-plus cycles, the rectangular pattern is unmistakable).

## Test plan

- [x] `mkdocs build --strict` clean
- [x] SVG parses as valid XML
- [x] Admonition renders in the page at the right anchor (between gap example and §Burst window)
- [x] Numbers cross-checked against `examples/basic-metrics.yaml` (rate=1000, gaps every 2m for 20s) and the existing prose ("emits events for 1m40s, then goes silent for 20s")

## Scope

- Single file edit + one new image. No code, no other docs, no CHANGELOG (release-please owns it).
- Follow-up issue welcome if we want a parallel `§Burst window` verification tip — same pattern, different query (`rate(metric[1s])` to show the multiplier kicking in). Out of scope here per the issue.