### PR TITLE
docs(deployment): correct --catalog position for Docker; document the dispatch shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,17 @@ cargo install sonda
 **Docker:**
 
 ```bash
+# Run a single scenario file
 docker run --rm -v "$PWD":/work -w /work \
   ghcr.io/davidban77/sonda:latest run my-scenario.yaml
+
+# Run a scenario from a mounted catalog by @name
+docker run --rm -v "$PWD/my-catalog":/catalog \
+  ghcr.io/davidban77/sonda:latest \
+  run @cpu-spike --catalog /catalog
 ```
+
+> `--catalog` lives **after** the subcommand when running through the image's default entrypoint. The host CLI accepts both orderings; the Docker constraint is the dispatch shim that routes `argv[1]` (`run | list | show | new`) to the `sonda` CLI. See [Deployment → Docker](https://davidban77.github.io/sonda/deployment/docker/#running-with-docker) for the full rationale and the `--entrypoint /sonda` escape hatch.
 
 See the [Getting Started](https://davidban77.github.io/sonda/getting-started/) guide for all installation options.
 

--- a/docs/site/docs/deployment/docker.md
+++ b/docs/site/docs/deployment/docker.md
@@ -27,18 +27,23 @@ docker pull ghcr.io/davidban77/sonda:latest
 
 ## Running with Docker
 
-The default entrypoint is `sonda-server`, which starts the HTTP API on port 8080.
-See [Server API](sonda-server.md) for the full endpoint reference.
+The default entrypoint is `sonda-server`, which starts the HTTP API on port 8080. See [Server API](sonda-server.md) for the full endpoint reference.
 
 ```bash
-# Start the server
+# Start the server (default behaviour)
 docker run -p 8080:8080 ghcr.io/davidban77/sonda:latest
 
-# Run the CLI against a mounted catalog (auto-detected as a sonda subcommand)
+# Run the CLI against a mounted catalog by @name
 docker run --rm \
   -v "$PWD/my-catalog":/catalog \
   ghcr.io/davidban77/sonda:latest \
-  --catalog /catalog run @cpu-spike
+  run @cpu-spike --catalog /catalog
+
+# List what's in the mounted catalog
+docker run --rm \
+  -v "$PWD/my-catalog":/catalog \
+  ghcr.io/davidban77/sonda:latest \
+  list --catalog /catalog
 
 # Or run a single file directly
 docker run --rm \
@@ -47,15 +52,27 @@ docker run --rm \
   run /work/cpu-spike.yaml
 ```
 
-!!! info "No `--entrypoint /sonda` needed"
-    The default entrypoint inspects `argv[1]` and `exec`s the sibling `sonda` CLI when
-    it matches a known subcommand (`run`, `list`, `show`, `new`). Recipes that pass
-    `--entrypoint /sonda` still work.
+!!! info "`argv[1]` must be the subcommand"
+    The default entrypoint is `sonda-server`, which inspects `argv[1]` and `exec`s the sibling `sonda` CLI when it matches one of the four subcommands (`run`, `list`, `show`, `new`). That means **global flags like `--catalog` belong after the subcommand** when running through the default entrypoint — `sonda run @x --catalog /catalog`, not `sonda --catalog /catalog run @x`. The host CLI accepts both orderings; the Docker constraint is the dispatch shim, not clap.
 
-The image ships no built-in catalog. Mount a directory of your own scenario and pack YAML
-files (typically `kind: runnable` and `kind: composable` v2 files) at any path inside the
-container and pass `--catalog <path>` to point `sonda` at it. See
-[Catalogs](../guides/scenarios.md) for the directory layout.
+    For invocations that don't start with a subcommand (`--help`, `--version`, or the global-flag-first style), override the entrypoint:
+
+    ```bash
+    # Inspect the 4-verb CLI surface
+    docker run --rm --entrypoint /sonda \
+      ghcr.io/davidban77/sonda:latest --help
+
+    # Global-flag-first form, matching the host CLI
+    docker run --rm --entrypoint /sonda \
+      -v "$PWD/my-catalog":/catalog \
+      ghcr.io/davidban77/sonda:latest \
+      --catalog /catalog list
+    ```
+
+The image ships no built-in catalog. Mount a directory of your own scenario and pack YAML files (typically `kind: runnable` and `kind: composable` v2 files) at any path inside the container and pass `--catalog <path>` to point `sonda` at it. See [Catalogs](../guides/scenarios.md) for the directory layout.
+
+!!! warning "Pre-1.9 env vars are gone"
+    Earlier releases let the image discover scenarios from `SONDA_PACK_PATH=/packs` and `SONDA_SCENARIO_PATH=/scenarios` env vars (with companion `/packs` and `/scenarios` directories baked into the image). Both were dropped in 1.9. Discovery is explicit via `--catalog <dir>` — no env-var fallback, no implicit search path. Old recipes built around `docker run … run @scenario` (expecting `SONDA_PACK_PATH` to do the lookup) will fail with "catalog dir does not exist or is not a directory" or a `@name` resolution error — add `--catalog /catalog` and mount your catalog volume there.
 
 ## Authentication
 


### PR DESCRIPTION
Closes #355.

## Summary

The Docker docs had a `docker run` example that **fails inside the image**. After tracing the dispatch shim and verifying both the host CLI and the in-container behaviour, the fix is two paragraphs of docs + the right example ordering.

## What was broken

\`docs/site/docs/deployment/docker.md\` previously showed:

\`\`\`bash
docker run … ghcr.io/davidban77/sonda:latest \
  --catalog /catalog run @cpu-spike
\`\`\`

The image's default entrypoint is \`sonda-server\`. Before clap parsing, \`sonda-server::main\` inspects \`argv[1]\` and \`exec\`s the sibling \`/sonda\` binary only when it matches one of \`run | list | show | new\` (see \`sonda-server/src/main.rs:130-170\`, \`SONDA_SUBCOMMANDS\` const at line 25). With \`--catalog\` first, the dispatch returns; then \`sonda-server\` tries to clap-parse \`--catalog\` (which isn't one of its flags) and exits with an error.

Both orderings work on the **host CLI** because \`--catalog\` is declared \`global = true\` in \`sonda/src/cli.rs:22\` — verified by running both forms locally:

\`\`\`
$ sonda run @x --catalog /tmp/none      # works, then fails on bad path
$ sonda --catalog /tmp/none run @x      # works, then fails on bad path
\`\`\`

The constraint is purely the Docker dispatch shim, not clap.

## What this PR ships

\`docs/site/docs/deployment/docker.md\` — \"Running with Docker\" section:

- **Fix the example**: \`run @cpu-spike --catalog /catalog\` (subcommand first, global flag after). Added a parallel \`list --catalog /catalog\` example to lock in the pattern.
- **Rewrite the \`!!! info\` admonition** ('argv[1] must be the subcommand') with the dispatch rule explained, plus the \`--entrypoint /sonda\` escape hatch for \`--help\` / \`--version\` / global-flag-first invocations. Satisfies AC1: \`docker run --entrypoint /sonda sonda --help\` shows the 4-verb surface.
- **New \`!!! warning\` 'Pre-1.9 env vars are gone'** so anyone upgrading from pre-1.9 recipes hits a clear migration note instead of the cryptic \"catalog dir does not exist or is not a directory\" error.

\`README.md\` — Docker section:

- Added the \`@name + --catalog\` one-liner alongside the existing single-file example.
- One-line note about the position requirement with a deep link to the Deployment page for the rationale.

## Source-side state (verified, no Rust changes needed)

| Surface | State | Notes |
|---|---|---|
| \`Dockerfile\` | ✅ clean | No \`ENV SONDA_PACK_PATH\`, no \`ENV SONDA_SCENARIO_PATH\`, no \`VOLUME\` declarations |
| \`sonda-server/src\` | ✅ clean | Grep clean for both env var names |
| \`sonda-core/src\` | ✅ clean | Grep clean |
| \`sonda/src\` | ✅ clean | Grep clean |
| \`docs/site/docs/configuration/cli-reference.md\` | ✅ already documents the removal at line 28 |
| \`CHANGELOG.md\` | left untouched — release-please owns it |

The 1.9 release already cleaned up the Rust side; #355 was a docs-only loose end where the published examples still reflected pre-1.9 invocation patterns.

## Acceptance criteria (from #355)

- [x] \`docker run sonda --help\` shows the 4-verb surface — via \`--entrypoint /sonda\` (documented in the rewritten \`!!! info\`).
- [x] A documented one-liner: \`docker run -v ./my-catalog:/catalog sonda run @scenario --catalog /catalog\` runs a scenario — exact form is now in both docker.md and README.
- [x] No dead env vars in the image — verified clean (was already done in 1.9c/1.9d; this PR closes the docs gap).

## Test plan

- [x] \`mkdocs build --strict\` clean
- [x] Verified \`--catalog\` clap behaviour both positions locally with \`cargo run -p sonda\`
- [x] Re-read \`sonda-server/src/main.rs::maybe_dispatch_to_sonda_cli\` to confirm \`argv[1]\` is the only check
- [ ] After merge, deploy hits GitHub Pages; spot-check the new examples render in the page