### PR TITLE
chore(e2e): migrate fixtures to v2 + update runner for the post-1.9 CLI

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -135,25 +135,25 @@ tasks:
     desc: Send Prometheus text metrics to VictoriaMetrics
     deps: [build:release]
     cmds:
-      - ./target/release/sonda metrics --scenario {{.SCENARIO_DIR}}/vm-prometheus-text.yaml {{.CLI_ARGS}}
+      - ./target/release/sonda run {{.SCENARIO_DIR}}/vm-prometheus-text.yaml {{.CLI_ARGS}}
 
   run:vm-influx:
     desc: Send InfluxDB LP metrics to VictoriaMetrics
     deps: [build:release]
     cmds:
-      - ./target/release/sonda metrics --scenario {{.SCENARIO_DIR}}/vm-influx-lp.yaml {{.CLI_ARGS}}
+      - ./target/release/sonda run {{.SCENARIO_DIR}}/vm-influx-lp.yaml {{.CLI_ARGS}}
 
   run:kafka:
     desc: Send Prometheus text metrics to Kafka topic sonda-e2e-metrics
     deps: [build:release]
     cmds:
-      - ./target/release/sonda metrics --scenario {{.SCENARIO_DIR}}/kafka-prometheus-text.yaml {{.CLI_ARGS}}
+      - ./target/release/sonda run {{.SCENARIO_DIR}}/kafka-prometheus-text.yaml {{.CLI_ARGS}}
 
   run:loki:
     desc: Send log events to Loki (requires stack:up)
     deps: [build:release]
     cmds:
-      - ./target/release/sonda logs --scenario examples/loki-json-lines.yaml {{.CLI_ARGS}}
+      - ./target/release/sonda run examples/loki-json-lines.yaml {{.CLI_ARGS}}
 
   run:constant:
     desc: Run a quick constant metric to stdout
@@ -197,7 +197,7 @@ tasks:
       - echo "Sending sine wave metrics to VictoriaMetrics for 30s..."
       - 'echo "Open Grafana at http://localhost:3000 and explore!"'
       - echo ""
-      - ./target/release/sonda metrics --scenario {{.SCENARIO_DIR}}/demo.yaml
+      - ./target/release/sonda run {{.SCENARIO_DIR}}/demo.yaml
       - echo ""
       - 'echo "Done! Explore metrics in Grafana at http://localhost:3000"'
       - 'echo "Query: demo_sine_wave"'

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -156,7 +156,7 @@ sonda run tests/e2e/scenarios/kafka-prometheus-text.yaml
 curl "http://localhost:8428/api/v1/series?match[]={__name__=%22sonda_e2e_vm_prom_text%22}"
 
 # Verify Kafka received messages
-docker exec sonda-e2e-kafka kafka-console-consumer.sh \
+docker exec sonda-e2e-kafka /opt/kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server 127.0.0.1:9092 \
     --topic sonda-e2e-metrics \
     --from-beginning --timeout-ms 5000

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -149,8 +149,8 @@ Dashboards are great for exploration. For repeatable manual tests, run scenarios
 task stack:up
 
 # Run individual scenarios
-sonda metrics --scenario tests/e2e/scenarios/vm-prometheus-text.yaml
-sonda metrics --scenario tests/e2e/scenarios/kafka-prometheus-text.yaml
+sonda run tests/e2e/scenarios/vm-prometheus-text.yaml
+sonda run tests/e2e/scenarios/kafka-prometheus-text.yaml
 
 # Verify VictoriaMetrics received data
 curl "http://localhost:8428/api/v1/series?match[]={__name__=%22sonda_e2e_vm_prom_text%22}"

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -69,22 +69,27 @@ services:
         condition: service_healthy
 
   kafka:
-    image: bitnami/kafka:3.9
+    # Official Apache Kafka image (KRaft mode, no ZooKeeper). Env-var naming
+    # follows the upstream property-to-env mapping: `<property>` becomes
+    # `KAFKA_<UPPER_SNAKE>` (no Bitnami-style `KAFKA_CFG_` prefix). The
+    # healthcheck reaches `kafka-topics.sh` via its absolute path in
+    # `/opt/kafka/bin/` (not in $PATH in this image).
+    image: apache/kafka:3.9.2
     container_name: sonda-e2e-kafka
     environment:
-      - KAFKA_CFG_NODE_ID=0
-      - KAFKA_CFG_PROCESS_ROLES=controller,broker
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
-      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_NODE_ID=0
+      - KAFKA_PROCESS_ROLES=controller,broker
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      - KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
     ports:
       - "9094:9094"
     healthcheck:
-      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "127.0.0.1:9092", "--list"]
+      test: ["CMD", "/opt/kafka/bin/kafka-topics.sh", "--bootstrap-server", "127.0.0.1:9092", "--list"]
       interval: 10s
       timeout: 10s
       retries: 10

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -189,7 +189,7 @@ print(total)
 " 2>/dev/null || echo "0"
 }
 
-# Run a single Loki scenario: execute sonda logs, then verify log entries
+# Run a single Loki scenario: execute `sonda run`, then verify log entries
 # arrived in Loki by querying its API with the given label selector.
 # Usage: run_loki_scenario <scenario_file> <label_selector> <description>
 run_loki_scenario() {
@@ -202,8 +202,7 @@ run_loki_scenario() {
     info "  Selector: ${label_selector}"
 
     local timeout_secs=$((SCENARIO_DURATION + 10))
-    "${SONDA_BIN}" logs \
-            --scenario "${scenario_file}" \
+    "${SONDA_BIN}" run "${scenario_file}" \
             --duration "${SCENARIO_DURATION}s" \
             >/dev/null 2>/tmp/sonda-e2e-stderr.log &
     local sonda_pid=$!
@@ -257,8 +256,7 @@ run_kafka_scenario() {
     info "  Topic: ${topic}"
 
     local timeout_secs=$((SCENARIO_DURATION + 10))
-    "${SONDA_BIN}" metrics \
-            --scenario "${scenario_file}" \
+    "${SONDA_BIN}" run "${scenario_file}" \
             --duration "${SCENARIO_DURATION}s" \
             >/dev/null 2>/tmp/sonda-e2e-stderr.log &
     local sonda_pid=$!
@@ -313,8 +311,7 @@ run_scenario() {
     # Run sonda for SCENARIO_DURATION seconds. The scenario YAML also sets duration.
     # Use a background process + wait for portable timeout (macOS has no `timeout`).
     local timeout_secs=$((SCENARIO_DURATION + 10))
-    "${SONDA_BIN}" metrics \
-            --scenario "${scenario_file}" \
+    "${SONDA_BIN}" run "${scenario_file}" \
             --duration "${SCENARIO_DURATION}s" \
             >/dev/null 2>/tmp/sonda-e2e-stderr.log &
     local sonda_pid=$!

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -130,7 +130,7 @@ wait_for_kafka() {
 
     info "Waiting for Kafka broker to be ready (up to ${max_secs}s)..."
     while true; do
-        if docker exec "${KAFKA_CONTAINER}" kafka-topics.sh \
+        if docker exec "${KAFKA_CONTAINER}" /opt/kafka/bin/kafka-topics.sh \
                 --bootstrap-server 127.0.0.1:9092 \
                 --list >/dev/null 2>&1; then
             info "Kafka is healthy."
@@ -150,7 +150,7 @@ wait_for_kafka() {
 query_kafka_count() {
     local topic="$1"
     local count
-    count=$(docker exec "${KAFKA_CONTAINER}" kafka-console-consumer.sh \
+    count=$(docker exec "${KAFKA_CONTAINER}" /opt/kafka/bin/kafka-console-consumer.sh \
         --bootstrap-server 127.0.0.1:9092 \
         --topic "${topic}" \
         --partition 0 \
@@ -387,7 +387,11 @@ fi
 # ---------------------------------------------------------------------------
 
 info "Building sonda (release)..."
-cargo build --release -p sonda --manifest-path "${REPO_ROOT}/Cargo.toml"
+# Feature set matches the production Dockerfile (`-p sonda -F remote-write,kafka,otlp`).
+# Without these the e2e scenarios that target Kafka or remote-write will fail at
+# scenario start with `sink type '...' requires the '...' feature` — the dry-run
+# parses are insensitive to feature gating, only the actual sink push needs it.
+cargo build --release -p sonda --features remote-write,kafka,otlp --manifest-path "${REPO_ROOT}/Cargo.toml"
 info "Build complete: ${SONDA_BIN}"
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/scenarios/demo.yaml
+++ b/tests/e2e/scenarios/demo.yaml
@@ -1,18 +1,26 @@
-name: demo_sine_wave
-rate: 100
-duration: 5m
-generator:
-  type: sine
-  amplitude: 50.0
-  period_secs: 10
-  offset: 50.0
-labels:
-  host: demo
-  env: dev
-encoder:
-  type: prometheus_text
-sink:
-  type: http_push
-  url: "http://localhost:8428/api/v1/import/prometheus"
-  content_type: "text/plain"
-  batch_size: 4096
+version: 2
+kind: runnable
+
+defaults:
+  rate: 100
+  duration: 5m
+  encoder:
+    type: prometheus_text
+  sink:
+    type: http_push
+    url: "http://localhost:8428/api/v1/import/prometheus"
+    content_type: "text/plain"
+    batch_size: 4096
+  labels:
+    host: demo
+    env: dev
+
+scenarios:
+  - id: demo_sine_wave
+    signal_type: metrics
+    name: demo_sine_wave
+    generator:
+      type: sine
+      amplitude: 50.0
+      period_secs: 10
+      offset: 50.0

--- a/tests/e2e/scenarios/kafka-json-lines.yaml
+++ b/tests/e2e/scenarios/kafka-json-lines.yaml
@@ -6,7 +6,7 @@
 #
 # Run this scenario after starting the e2e stack:
 #   docker compose -f tests/e2e/docker-compose.yml up -d
-#   sonda metrics --scenario tests/e2e/scenarios/kafka-json-lines.yaml
+#   sonda run tests/e2e/scenarios/kafka-json-lines.yaml
 #
 # Verify data arrived:
 #   docker exec sonda-e2e-kafka kafka-console-consumer.sh \
@@ -14,25 +14,29 @@
 #     --topic sonda-e2e-json \
 #     --from-beginning \
 #     --timeout-ms 5000
-name: sonda_e2e_kafka_json_lines
-rate: 50
-duration: 5s
+version: 2
+kind: runnable
 
-generator:
-  type: sine
-  amplitude: 10.0
-  period_secs: 10
-  offset: 50.0
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: json_lines
+  sink:
+    type: kafka
+    brokers: "localhost:9094"
+    topic: sonda-e2e-json
+  labels:
+    scenario: kafka-json-lines
+    encoder: json_lines
+    sink: kafka
 
-labels:
-  scenario: kafka-json-lines
-  encoder: json_lines
-  sink: kafka
-
-encoder:
-  type: json_lines
-
-sink:
-  type: kafka
-  brokers: "localhost:9094"
-  topic: sonda-e2e-json
+scenarios:
+  - id: sonda_e2e_kafka_json_lines
+    signal_type: metrics
+    name: sonda_e2e_kafka_json_lines
+    generator:
+      type: sine
+      amplitude: 10.0
+      period_secs: 10
+      offset: 50.0

--- a/tests/e2e/scenarios/kafka-json-lines.yaml
+++ b/tests/e2e/scenarios/kafka-json-lines.yaml
@@ -9,7 +9,7 @@
 #   sonda run tests/e2e/scenarios/kafka-json-lines.yaml
 #
 # Verify data arrived:
-#   docker exec sonda-e2e-kafka kafka-console-consumer.sh \
+#   docker exec sonda-e2e-kafka /opt/kafka/bin/kafka-console-consumer.sh \
 #     --bootstrap-server 127.0.0.1:9092 \
 #     --topic sonda-e2e-json \
 #     --from-beginning \

--- a/tests/e2e/scenarios/kafka-prometheus-text.yaml
+++ b/tests/e2e/scenarios/kafka-prometheus-text.yaml
@@ -6,7 +6,7 @@
 #
 # Run this scenario after starting the e2e stack:
 #   docker compose -f tests/e2e/docker-compose.yml up -d
-#   sonda metrics --scenario tests/e2e/scenarios/kafka-prometheus-text.yaml
+#   sonda run tests/e2e/scenarios/kafka-prometheus-text.yaml
 #
 # Verify data arrived:
 #   docker exec sonda-e2e-kafka kafka-console-consumer.sh \
@@ -14,25 +14,29 @@
 #     --topic sonda-e2e-metrics \
 #     --from-beginning \
 #     --timeout-ms 5000
-name: sonda_e2e_kafka_prom_text
-rate: 50
-duration: 5s
+version: 2
+kind: runnable
 
-generator:
-  type: sine
-  amplitude: 10.0
-  period_secs: 10
-  offset: 50.0
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: kafka
+    brokers: "localhost:9094"
+    topic: sonda-e2e-metrics
+  labels:
+    scenario: kafka-prometheus-text
+    encoder: prometheus_text
+    sink: kafka
 
-labels:
-  scenario: kafka-prometheus-text
-  encoder: prometheus_text
-  sink: kafka
-
-encoder:
-  type: prometheus_text
-
-sink:
-  type: kafka
-  brokers: "localhost:9094"
-  topic: sonda-e2e-metrics
+scenarios:
+  - id: sonda_e2e_kafka_prom_text
+    signal_type: metrics
+    name: sonda_e2e_kafka_prom_text
+    generator:
+      type: sine
+      amplitude: 10.0
+      period_secs: 10
+      offset: 50.0

--- a/tests/e2e/scenarios/kafka-prometheus-text.yaml
+++ b/tests/e2e/scenarios/kafka-prometheus-text.yaml
@@ -9,7 +9,7 @@
 #   sonda run tests/e2e/scenarios/kafka-prometheus-text.yaml
 #
 # Verify data arrived:
-#   docker exec sonda-e2e-kafka kafka-console-consumer.sh \
+#   docker exec sonda-e2e-kafka /opt/kafka/bin/kafka-console-consumer.sh \
 #     --bootstrap-server 127.0.0.1:9092 \
 #     --topic sonda-e2e-metrics \
 #     --from-beginning \

--- a/tests/e2e/scenarios/loki-json-lines.yaml
+++ b/tests/e2e/scenarios/loki-json-lines.yaml
@@ -6,39 +6,43 @@
 #
 # Run this scenario after starting the e2e stack:
 #   docker compose -f tests/e2e/docker-compose.yml up -d
-#   sonda logs --scenario tests/e2e/scenarios/loki-json-lines.yaml
+#   sonda run tests/e2e/scenarios/loki-json-lines.yaml
 #
 # Verify data arrived:
 #   curl -s 'http://localhost:3100/loki/api/v1/query_range' \
 #     --data-urlencode 'query={job="sonda-e2e"}' \
 #     --data-urlencode 'start=1h' --data-urlencode 'limit=10'
-name: sonda_e2e_loki_json_lines
-rate: 50
-duration: 5s
+version: 2
+kind: runnable
 
-generator:
-  type: template
-  templates:
-    - message: "Request from {ip} to {endpoint} status={status}"
-      field_pools:
-        ip: ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
-        endpoint: ["/api/v1/health", "/api/v1/metrics", "/api/v1/logs"]
-        status: ["200", "201", "404", "500"]
-  severity_weights:
-    info: 0.7
-    warn: 0.2
-    error: 0.1
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: json_lines
+  sink:
+    type: loki
+    url: http://localhost:3100
+    batch_size: 50
+  labels:
+    job: sonda-e2e
+    scenario: loki-json-lines
+    encoder: json_lines
+    sink: loki
 
-labels:
-  job: sonda-e2e
-  scenario: loki-json-lines
-  encoder: json_lines
-  sink: loki
-
-encoder:
-  type: json_lines
-
-sink:
-  type: loki
-  url: http://localhost:3100
-  batch_size: 50
+scenarios:
+  - id: sonda_e2e_loki_json_lines
+    signal_type: logs
+    name: sonda_e2e_loki_json_lines
+    log_generator:
+      type: template
+      templates:
+        - message: "Request from {ip} to {endpoint} status={status}"
+          field_pools:
+            ip: ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+            endpoint: ["/api/v1/health", "/api/v1/metrics", "/api/v1/logs"]
+            status: ["200", "201", "404", "500"]
+      severity_weights:
+        info: 0.7
+        warn: 0.2
+        error: 0.1

--- a/tests/e2e/scenarios/vm-influx-lp.yaml
+++ b/tests/e2e/scenarios/vm-influx-lp.yaml
@@ -6,31 +6,35 @@
 #
 # Run this scenario after starting the e2e stack:
 #   docker compose -f tests/e2e/docker-compose.yml up -d
-#   sonda metrics --scenario tests/e2e/scenarios/vm-influx-lp.yaml
+#   sonda run tests/e2e/scenarios/vm-influx-lp.yaml
 #
 # Verify data arrived (VM appends _<field_key> to measurement name):
 #   curl "http://localhost:8428/api/v1/query?query=sonda_e2e_vm_influx_lp_value"
-name: sonda_e2e_vm_influx_lp
-rate: 50
-duration: 5s
+version: 2
+kind: runnable
 
-generator:
-  type: sawtooth
-  min: 0.0
-  max: 100.0
-  period_secs: 10
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: influx_lp
+    field_key: value
+  sink:
+    type: http_push
+    url: "http://localhost:8428/write"
+    content_type: "text/plain"
+    batch_size: 4096
+  labels:
+    scenario: vm-influx-lp
+    encoder: influx_lp
+    sink: http_push
 
-labels:
-  scenario: vm-influx-lp
-  encoder: influx_lp
-  sink: http_push
-
-encoder:
-  type: influx_lp
-  field_key: value
-
-sink:
-  type: http_push
-  url: "http://localhost:8428/write"
-  content_type: "text/plain"
-  batch_size: 4096
+scenarios:
+  - id: sonda_e2e_vm_influx_lp
+    signal_type: metrics
+    name: sonda_e2e_vm_influx_lp
+    generator:
+      type: sawtooth
+      min: 0.0
+      max: 100.0
+      period_secs: 10

--- a/tests/e2e/scenarios/vm-prometheus-text.yaml
+++ b/tests/e2e/scenarios/vm-prometheus-text.yaml
@@ -5,30 +5,34 @@
 #
 # Run this scenario after starting the e2e stack:
 #   docker compose -f tests/e2e/docker-compose.yml up -d
-#   sonda metrics --scenario tests/e2e/scenarios/vm-prometheus-text.yaml
+#   sonda run tests/e2e/scenarios/vm-prometheus-text.yaml
 #
 # Verify data arrived:
 #   curl "http://localhost:8428/api/v1/query?query=sonda_e2e_vm_prom_text"
-name: sonda_e2e_vm_prom_text
-rate: 50
-duration: 5s
+version: 2
+kind: runnable
 
-generator:
-  type: sine
-  amplitude: 10.0
-  period_secs: 10
-  offset: 50.0
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: http_push
+    url: "http://localhost:8428/api/v1/import/prometheus"
+    content_type: "text/plain"
+    batch_size: 4096
+  labels:
+    scenario: vm-prometheus-text
+    encoder: prometheus_text
+    sink: http_push
 
-labels:
-  scenario: vm-prometheus-text
-  encoder: prometheus_text
-  sink: http_push
-
-encoder:
-  type: prometheus_text
-
-sink:
-  type: http_push
-  url: "http://localhost:8428/api/v1/import/prometheus"
-  content_type: "text/plain"
-  batch_size: 4096
+scenarios:
+  - id: sonda_e2e_vm_prom_text
+    signal_type: metrics
+    name: sonda_e2e_vm_prom_text
+    generator:
+      type: sine
+      amplitude: 10.0
+      period_secs: 10
+      offset: 50.0

--- a/tests/e2e/scenarios/vmagent-prometheus-text.yaml
+++ b/tests/e2e/scenarios/vmagent-prometheus-text.yaml
@@ -6,29 +6,33 @@
 #
 # Run this scenario after starting the e2e stack:
 #   docker compose -f tests/e2e/docker-compose.yml up -d
-#   sonda metrics --scenario tests/e2e/scenarios/vmagent-prometheus-text.yaml
+#   sonda run tests/e2e/scenarios/vmagent-prometheus-text.yaml
 #
 # Verify data arrived in VictoriaMetrics (vmagent forwards to VM):
 #   curl "http://localhost:8428/api/v1/query?query=sonda_e2e_vmagent_prom_text"
-name: sonda_e2e_vmagent_prom_text
-rate: 50
-duration: 5s
+version: 2
+kind: runnable
 
-generator:
-  type: constant
-  value: 1.0
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: http_push
+    url: "http://localhost:8429/api/v1/import/prometheus"
+    content_type: "text/plain"
+    batch_size: 4096
+  labels:
+    scenario: vmagent-prometheus-text
+    encoder: prometheus_text
+    sink: http_push
+    via: vmagent
 
-labels:
-  scenario: vmagent-prometheus-text
-  encoder: prometheus_text
-  sink: http_push
-  via: vmagent
-
-encoder:
-  type: prometheus_text
-
-sink:
-  type: http_push
-  url: "http://localhost:8429/api/v1/import/prometheus"
-  content_type: "text/plain"
-  batch_size: 4096
+scenarios:
+  - id: sonda_e2e_vmagent_prom_text
+    signal_type: metrics
+    name: sonda_e2e_vmagent_prom_text
+    generator:
+      type: constant
+      value: 1.0


### PR DESCRIPTION
Closes #352.

## TL;DR

The seven `tests/e2e/scenarios/*.yaml` fixtures were stuck on v1; the runner / Taskfile / e2e doc still called removed `sonda metrics --scenario X` / `sonda logs --scenario X` subcommands. `task e2e`, `./tests/e2e/run.sh`, and every `task run:*` shortcut have been silently broken since 1.9c. This PR migrates the fixtures to v2, switches every invocation to `sonda run <file>`, and **unblocks the docker-compose stack so the full pipeline actually runs end-to-end again**.

## Final verification — actual stack run

```
[PASS]  VictoriaMetrics via Prometheus text format
[PASS]  VictoriaMetrics via InfluxDB line protocol
[PASS]  Kafka via Prometheus text format
[PASS]  Kafka via JSON Lines
[PASS]  Loki via JSON Lines

=== Results ===
  PASS: 5
  FAIL: 0
RESULT: PASS (all 5 scenario(s) passed)
```

Real data lands in VictoriaMetrics (Prom-text + Influx LP), Kafka (Prom-text + JSON lines), and Loki. Stack tears down cleanly.

## Commits in this PR

- **`chore(e2e): migrate fixtures to v2 + update runner for the post-1.9 CLI`** — the original migration: 7 fixtures + run.sh + Taskfile + docs/e2e-tests.md.
- **`chore(e2e): unblock the stack — apache/kafka image, feature-gated release build`** — three latent infrastructure issues surfaced while actually running the e2e against the stack. None were caused by the migration; all were pre-existing rot blocking the AC.

## What's in the diff

### Fixture migration (7 files, parent commit)

| File | Signal | Shape change |
|---|---|---|
| `demo.yaml` | metrics | flat → v2 + `kind: runnable`, `defaults` + `scenarios:[…]` |
| `vm-prometheus-text.yaml` | metrics | same |
| `vm-influx-lp.yaml` | metrics | same |
| `vmagent-prometheus-text.yaml` | metrics | same (still disabled in run.sh — vmagent text-protocol limitation already noted in the script) |
| `kafka-prometheus-text.yaml` | metrics | same |
| `kafka-json-lines.yaml` | metrics | same |
| `loki-json-lines.yaml` | logs | same + `generator:` → `log_generator:` (v2 splits log generators from metric generators) |

Each header comment switches from `sonda metrics --scenario X` / `sonda logs --scenario X` to `sonda run <file>`.

### Runner / Taskfile / docs (parent commit)

- `tests/e2e/run.sh` — `run_loki_scenario`, `run_kafka_scenario`, `run_scenario` call `"${SONDA_BIN}" run "${scenario_file}"`.
- `Taskfile.yml` — `run:vm-prom`, `run:vm-influx`, `run:kafka`, `run:loki`, `demo` all switch to `sonda run`. `run:loki` keeps pointing at `examples/loki-json-lines.yaml` (already valid v2) per its original target.
- `docs/e2e-tests.md` — two `sonda metrics --scenario` examples in §Running Scenarios Manually switch to `sonda run`.

### Stack unblockers (second commit)

**1. Kafka image: bitnami → apache official.** `bitnami/kafka:3.9` no longer pulls (Bitnami withdrew their public registry in 2025). `bitnamilegacy` is a community-mirrored stopgap; the durable answer is the official upstream `apache/kafka:3.9.2`. Env vars drop the `KAFKA_CFG_` prefix (`KAFKA_CFG_NODE_ID` → `KAFKA_NODE_ID`); kafka-client binaries move from `$PATH` to `/opt/kafka/bin/<bin>.sh`. Pinned to 3.9.x to avoid 4.x KRaft cluster-id requirements; updated everywhere those binaries are exec'd (run.sh healthcheck + verification, fixture header comments, docs/e2e-tests.md).

**2. Release build was missing sink features.** `run.sh:390` built with `cargo build --release -p sonda` — no features. Every kafka scenario blew up at sink push with `sink type 'kafka' requires the 'kafka' feature`. Matched the Dockerfile's feature set (`-F remote-write,kafka,otlp`). Dry-run validation didn't catch this — feature gating only fires when a sink actually pushes — exactly why end-to-end runs are non-negotiable.

## Out of scope

- Historical phase docs (`docs/phase-{0..9}-*.md`, `docs/architecture.md`, `docs/guide-alert-testing.md`) — explicit historical references per `CLAUDE.md`, untouched.
- `CHANGELOG.md` — release-please owns it.
- The vmagent fixture stays disabled in `run.sh` for the same vmagent-Prometheus-remote-write reason already noted in the script (unrelated to v2 migration).

## Acceptance criteria (from #352)

- [x] Every YAML in `tests/e2e/scenarios/` parses via `sonda --dry-run` on the post-1.9 CLI.
- [x] **`tests/e2e/run.sh` runs end-to-end against the docker-compose stack without v1-rejection errors** — verified locally, 5/5 scenarios PASS, real data in every backend.
- [x] Taskfile entries pointing at these files work (`task --list` enumerates them; renamed invocations all use `sonda run`).