### PR TITLE
fix(sink): add Sink::write_log_event with bytes-only default impl (PR 1/4 for #296)

### DIFF
--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -127,7 +127,7 @@ pub fn run_logs_with_sink_gated(
             buf.clear();
             encoder.encode_log(&event, &mut buf)?;
             let bytes_written = buf.len() as u64;
-            sink.write(&buf)?;
+            sink.write_log_event(&event, &buf)?;
             let delivered = sink.last_write_delivered();
 
             Ok(TickResult {

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -23,6 +23,7 @@ pub mod udp;
 use std::collections::HashMap;
 use std::path::Path;
 
+use crate::model::log::LogEvent;
 use crate::SondaError;
 
 /// A sink consumes encoded bytes and delivers them to a destination.
@@ -39,6 +40,17 @@ pub trait Sink: Send + Sync {
     /// when the most recent `write()` triggered a successful flush.
     fn last_write_delivered(&self) -> bool {
         true
+    }
+
+    /// Write an encoded log event to the sink, with the originating
+    /// [`LogEvent`] alongside for sinks that build their own delivery
+    /// envelope from per-event context (e.g. labels).
+    ///
+    /// The default impl ignores the event reference and forwards to
+    /// [`Sink::write`], preserving the bytes-only contract every existing
+    /// sink relies on. Sinks that need per-event labels override this.
+    fn write_log_event(&mut self, _event: &LogEvent, encoded: &[u8]) -> Result<(), SondaError> {
+        self.write(encoded)
     }
 }
 
@@ -1348,6 +1360,42 @@ retry:
         assert!(
             msg.contains("cargo build -F remote-write"),
             "error must tell the user how to enable the feature, got: {msg}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Default `write_log_event` impl on the Sink trait forwards to `write`.
+    // Sinks that don't override the new method (every sink today except Loki in
+    // PR 2) must keep behaving exactly as they did before this PR landed.
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn default_write_log_event_forwards_encoded_bytes_to_write() {
+        use crate::model::log::{LogEvent, Severity};
+        use crate::model::metric::Labels;
+        use memory::MemorySink;
+        use std::collections::BTreeMap;
+        use std::time::SystemTime;
+
+        let mut sink = MemorySink::new();
+        let event = LogEvent::with_timestamp(
+            SystemTime::UNIX_EPOCH,
+            Severity::Info,
+            "hello".to_string(),
+            Labels::default(),
+            BTreeMap::new(),
+        );
+        let encoded = b"<encoded payload>";
+
+        // MemorySink does not override `write_log_event`, so the call must
+        // route through the default impl and end up appended to `buffer`
+        // exactly as `write(encoded)` would.
+        sink.write_log_event(&event, encoded)
+            .expect("default write_log_event must succeed");
+
+        assert_eq!(
+            sink.buffer, encoded,
+            "default impl must forward the encoded bytes to write() unchanged"
         );
     }
 


### PR DESCRIPTION
Foundation PR for the Loki `dynamic_labels` fix (issue #296). **Pure plumbing — no behaviour change for any existing sink.** Subsequent PRs (2/4, 3/4, 4/4) land on this branch (`release/1.9.4`) to build the actual Loki rewrite on top.

Targets `release/1.9.4`, not `main`. The full 4-PR sequence consolidates there, then merges to main as one 1.9.4 release.

## What changes

1. **New `Sink::write_log_event(&LogEvent, &[u8])` method** on the `Sink` trait, with a default impl that ignores the event reference and forwards to `self.write(encoded)`. Every existing sink (`stdout`, `file`, `tcp`, `udp`, `http_push`, `remote_write`, `kafka`, `loki`, `otlp_grpc`, `memory`, `channel`) keeps working without touching its file — the default impl preserves the bytes-only contract those sinks rely on today.
2. **`log_runner.rs` switches from `sink.write(&buf)` to `sink.write_log_event(&event, &buf)`.** Only call site that carries a `LogEvent` reference; metric/histogram/summary runners are untouched.
3. **One new unit test** confirms the default impl forwards encoded bytes to `write()` unchanged. Uses `MemorySink` (which deliberately does *not* override the new method) as the fixture.

Diff: **2 files, +49 / -1 lines**.

## Why this PR first

This isolates the trait-surface change from the actual fix. If anything breaks on the gates, the failure is contained to plumbing — we know it's the trait change, not the Loki rewrite that lands in PR 2. The next three PRs build on the foundation here without re-touching the trait.

## Gate suite — all green, full features

| Gate | Result |
|---|---|
| `cargo build --workspace --features remote-write,kafka,otlp` | clean |
| `cargo nextest run --workspace --features remote-write,kafka,otlp` | **2629/2629 pass** |
| `cargo test --workspace --doc --features remote-write,kafka,otlp` | 4/4 pass |
| `cargo clippy --workspace --features remote-write,kafka,otlp -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| `cargo audit` | unchanged (pre-existing `core2`/`rskafka` yanked warning, not introduced here) |
| `cargo test -p sonda-core --no-default-features` | **1216/1216 unit + 4/4 doctest** |

The `--no-default-features` gate is especially relevant here — the trait change has to compile cleanly without `http`, since the trait lives outside any feature flag. 1216 unit tests pass on the feature-subtractive build.

## What this PR explicitly does NOT do

- Loki sink does not yet read per-event labels → **PR 2/4**
- No multi-stream Loki push envelope yet → **PR 2/4**
- No cardinality cap (`max_streams_per_push`) yet → **PR 2/4**
- No server-side warning, no docs update → **PR 3/4**
- No e2e fixture proving multi-stream landing → **PR 4/4**

Refs: #296.