### PR TITLE
fix(server): loki cardinality preview + docs sweep (PR 3/4 for #296)

### DIFF
--- a/docs/site/docs/configuration/scenario-fields.md
+++ b/docs/site/docs/configuration/scenario-fields.md
@@ -278,6 +278,9 @@ request_count{hostname="web-0",region="eu-west-1",...} 3
     collides with a static label key, the dynamic value wins. Dynamic labels work identically
     for both metric and log scenarios.
 
+!!! info "Loki sinks auto-promote dynamic labels to stream labels"
+    When a `logs` scenario uses a `loki` sink, each unique `dynamic_labels` combination becomes its own Loki stream. A rotation through `peer_address: [10.1.2.2, 10.1.7.2]` produces two streams (`{peer_address="10.1.2.2"}` and `{peer_address="10.1.7.2"}`) — both queryable in Grafana by label. The Loki sink caps unique streams per push at [`max_streams_per_push`](sinks.md#loki) (default 128); higher-cardinality rotations need an explicit raise. See [Dynamic Labels — Loki sinks](../guides/dynamic-labels.md#dynamic-labels-with-the-loki-sink) for a worked BGP-peers example.
+
 ### Temporal fields
 
 These fields control when and how entries coordinate inside a multi-entry v2 file (including

--- a/docs/site/docs/configuration/sinks.md
+++ b/docs/site/docs/configuration/sinks.md
@@ -359,17 +359,15 @@ sink:
     This sink requires the `http` Cargo feature flag. Pre-built release binaries include this
     feature. If building from source: `cargo build --features http -p sonda`.
 
-Batches log lines and delivers them to Grafana Loki via HTTP POST. Each call to write appends one
-log line, and the batch is flushed when it reaches the configured size.
+Batches log lines and delivers them to Grafana Loki via HTTP POST. Each entry is grouped by combined label set (scenario-level `labels` merged with any per-event `dynamic_labels` overlay) at flush time and emitted as a multi-stream push envelope — one Loki stream per unique label combination.
 
-Stream labels are configured at the **top-level** `labels` field of the scenario, not inside the
-sink block. This is consistent with how labels work for all other signal types. The scenario-level
-labels are used as Loki stream labels in the push API envelope.
+Scenario-level `labels:` form the base stream labels. Per-event `dynamic_labels` (when used) auto-promote into the stream label set so a rotation through N values produces N distinct Loki streams, each queryable in Grafana by label. See [Dynamic Labels — Loki sinks](../guides/dynamic-labels.md#dynamic-labels-with-the-loki-sink) for the worked pattern.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `url` | string | yes | -- | Base URL of the Loki instance. |
 | `batch_size` | integer | no | `5` | Size flush threshold in number of log entries. Raise for high-rate scenarios. |
+| `max_streams_per_push` | integer | no | `128` | Hard cap on unique streams per flush. A flush that would emit more streams than the cap fails loudly with the offending count + workaround hint, so high-cardinality `dynamic_labels` configurations surface as a config issue rather than a silent Loki melt. Raise this if your Loki ingester is sized for higher cardinality. |
 | `max_buffer_age` | duration string | no | `5s` | Time flush threshold. A non-empty batch is flushed once it has been buffered longer than this. Set `"0s"` to disable. See [Sink Batching](sink-batching.md#time-based-flushing). |
 
 ```yaml title="Loki sink with top-level labels"

--- a/docs/site/docs/guides/dynamic-labels.md
+++ b/docs/site/docs/guides/dynamic-labels.md
@@ -209,6 +209,94 @@ scenarios:
 Each emitted JSON log event carries `pod_name=api-0`, `api-1`, or `api-2` in rotation. Useful
 for testing Loki label indexing or pod-level log aggregation panels.
 
+## Dynamic labels with the Loki sink
+
+When the sink is `loki`, each unique `dynamic_labels` combination becomes its own **Loki stream** in the push envelope. The rotation values auto-promote into the stream label set — they're queryable in Grafana the same way scenario-level static labels are.
+
+The pre-1.9.4 trap: the rotation value only appeared inside the log line text, never as a stream label. Querying `{peer_address="10.1.2.2"}` returned nothing because Loki never knew that label existed. Post-1.9.4, the same YAML produces one stream per peer.
+
+### Worked example — 20 BGP peers from one scenario
+
+This is the pattern that previously needed 20 hand-written scenarios (one per peer) to get queryable stream labels. With auto-promotion, it's a single scenario with a 20-element `values` list:
+
+```yaml title="examples/bgp-peer-logs.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 60s
+  encoder:
+    type: json_lines
+  sink:
+    type: loki
+    url: http://localhost:3100
+scenarios:
+  - id: srl1_bgp_logs
+    signal_type: logs
+    name: srl1_bgp_logs
+    labels:
+      device: srl1
+      vendor_facility_process: BGP
+    dynamic_labels:
+      - key: peer_address
+        values:
+          - "10.1.2.2"
+          - "10.1.7.2"
+          - "10.1.12.2"
+          - "10.1.17.2"
+          - "10.1.22.2"
+          # ... up to 20 peers
+    log_generator:
+      type: template
+      templates:
+        - message: "BGP neighbor {peer_address}: state changed to {state}"
+          field_pools:
+            peer_address: ["10.1.2.2", "10.1.7.2", "10.1.12.2", "10.1.17.2", "10.1.22.2"]
+            state: ["established", "active", "open-confirm", "idle"]
+```
+
+Loki sees one stream per peer:
+
+```
+{device="srl1", peer_address="10.1.2.2",  vendor_facility_process="BGP"}
+{device="srl1", peer_address="10.1.7.2",  vendor_facility_process="BGP"}
+{device="srl1", peer_address="10.1.12.2", vendor_facility_process="BGP"}
+...
+```
+
+Grafana queries that previously came back empty now work:
+
+```promql
+# All events for a specific peer
+{peer_address="10.1.2.2"}
+
+# Establishment events across all peers
+{device="srl1"} |= "established"
+
+# Peer state churn — distinct streams matching device
+sum by (peer_address) (count_over_time({device="srl1"}[5m]))
+```
+
+### Cardinality cap — `max_streams_per_push`
+
+The Loki sink refuses pushes that would emit more than [`max_streams_per_push`](../configuration/sinks.md#loki) unique streams (default `128`). The cap is per-flush, not lifetime — high-cardinality rotations work fine if the batch size is small enough that each flush stays under the cap.
+
+When you POST a scenario to `sonda-server`, the server emits a registration-time preview naming the predicted stream count and the active cap, so cardinality issues surface before runtime:
+
+```
+scenario entry 'srl1_bgp_logs' will produce up to 20 distinct Loki streams
+(dynamic_labels: peer_address). max_streams_per_push is 128.
+```
+
+If your scenario genuinely needs more than 128 streams, raise the cap on the sink:
+
+```yaml
+sink:
+  type: loki
+  url: http://localhost:3100
+  max_streams_per_push: 512
+```
+
 ## Runnable examples
 
 | File | Signal | Strategy | What to look for |

--- a/docs/site/docs/guides/dynamic-labels.md
+++ b/docs/site/docs/guides/dynamic-labels.md
@@ -213,11 +213,9 @@ for testing Loki label indexing or pod-level log aggregation panels.
 
 When the sink is `loki`, each unique `dynamic_labels` combination becomes its own **Loki stream** in the push envelope. The rotation values auto-promote into the stream label set — they're queryable in Grafana the same way scenario-level static labels are.
 
-The pre-1.9.4 trap: the rotation value only appeared inside the log line text, never as a stream label. Querying `{peer_address="10.1.2.2"}` returned nothing because Loki never knew that label existed. Post-1.9.4, the same YAML produces one stream per peer.
-
 ### Worked example — 20 BGP peers from one scenario
 
-This is the pattern that previously needed 20 hand-written scenarios (one per peer) to get queryable stream labels. With auto-promotion, it's a single scenario with a 20-element `values` list:
+One scenario with a 20-element `values` list produces 20 distinct Loki streams, one per peer, each queryable by `peer_address`:
 
 ```yaml title="examples/bgp-peer-logs.yaml"
 version: 2
@@ -264,7 +262,7 @@ Loki sees one stream per peer:
 ...
 ```
 
-Grafana queries that previously came back empty now work:
+Standard Grafana queries work against the per-peer streams:
 
 ```promql
 # All events for a specific peer

--- a/docs/site/docs/guides/dynamic-labels.md
+++ b/docs/site/docs/guides/dynamic-labels.md
@@ -211,11 +211,13 @@ for testing Loki label indexing or pod-level log aggregation panels.
 
 ## Dynamic labels with the Loki sink
 
-When the sink is `loki`, each unique `dynamic_labels` combination becomes its own **Loki stream** in the push envelope. The rotation values auto-promote into the stream label set — they're queryable in Grafana the same way scenario-level static labels are.
+Point a scenario with `dynamic_labels:` at a Loki sink and each rotating value becomes its own **Loki stream** — the smallest unit Loki indexes by, identified by its label set. The rotation values auto-promote into the stream label set alongside the scenario's static `labels:`, so a rotation through N values shows up in Grafana as N separate log streams, each queryable by that label.
+
+This is how you build a realistic per-source feed from a single scenario entry: one entry stands in for a fleet of senders, but downstream looks like a fleet — per-source dashboards work, alerts can target a single source, and ingest behaviour exercises real per-stream paths instead of one fat stream.
 
 ### Worked example — 20 BGP peers from one scenario
 
-One scenario with a 20-element `values` list produces 20 distinct Loki streams, one per peer, each queryable by `peer_address`:
+Say you want to test a Grafana dashboard that breaks down BGP neighbor state per peer, or an alert that fires when a *specific* peer flaps. You need 20 distinct log streams that share most of their labels but differ in `peer_address`. One scenario with a 20-element `values` list does it:
 
 ```yaml title="examples/bgp-peer-logs.yaml"
 version: 2
@@ -253,7 +255,9 @@ scenarios:
             state: ["established", "active", "open-confirm", "idle"]
 ```
 
-Loki sees one stream per peer:
+### What lands in Loki
+
+Loki sees one stream per peer. The label set on each stream is the merge of the scenario's `labels:` with the current `dynamic_labels` value:
 
 ```
 {device="srl1", peer_address="10.1.2.2",  vendor_facility_process="BGP"}
@@ -262,31 +266,34 @@ Loki sees one stream per peer:
 ...
 ```
 
-Standard Grafana queries work against the per-peer streams:
+In Grafana's stream selector you'll see 20 distinct streams under `device="srl1"`, one per peer address.
 
-```promql
-# All events for a specific peer
+### What queries become possible
+
+Because each peer is its own stream, all the usual LogQL shapes work against the dataset:
+
+```logql
 {peer_address="10.1.2.2"}
+```
+Returns every log line for one specific peer — useful for drilling into a single neighbor.
 
-# Establishment events across all peers
+```logql
 {device="srl1"} |= "established"
+```
+Returns establishment events across all peers on the device — useful for spotting the global pattern.
 
-# Peer state churn — distinct streams matching device
+```logql
 sum by (peer_address) (count_over_time({device="srl1"}[5m]))
 ```
+Returns a per-peer event count over the last 5 minutes — the shape you'd graph as "which peers are noisiest right now".
 
-### Cardinality cap — `max_streams_per_push`
+### Cardinality and the per-push cap
 
-The Loki sink refuses pushes that would emit more than [`max_streams_per_push`](../configuration/sinks.md#loki) unique streams (default `128`). The cap is per-flush, not lifetime — high-cardinality rotations work fine if the batch size is small enough that each flush stays under the cap.
+Loki indexes by stream, and unique stream count is the dimension that drives ingester memory and index cost. Pushing too many distinct streams in a single request is the classic way to overload an ingester, so the Sonda Loki sink caps unique streams **per push** at `max_streams_per_push` (default `128`). A flush that would exceed the cap fails with a message naming the offending count and the cap.
 
-When you POST a scenario to `sonda-server`, the server emits a registration-time preview naming the predicted stream count and the active cap, so cardinality issues surface before runtime:
+The cap is per-flush, not lifetime — a scenario that rotates through hundreds of values can still work if each flush stays under the cap (drop `batch_size` on the sink so each push carries fewer entries, hence fewer distinct streams).
 
-```
-scenario entry 'srl1_bgp_logs' will produce up to 20 distinct Loki streams
-(dynamic_labels: peer_address). max_streams_per_push is 128.
-```
-
-If your scenario genuinely needs more than 128 streams, raise the cap on the sink:
+If your Loki ingester is sized for higher cardinality, raise the cap on the [Loki sink](../configuration/sinks.md#loki):
 
 ```yaml
 sink:
@@ -294,6 +301,17 @@ sink:
   url: http://localhost:3100
   max_streams_per_push: 512
 ```
+
+### Stream-count preview when posting to `sonda-server`
+
+When you POST a scenario to `sonda-server`, the response includes a registration-time preview naming the predicted stream count and the active cap — so high-cardinality misconfigurations surface at submission time, not the first time a flush fails:
+
+```
+scenario entry 'srl1_bgp_logs' will produce up to 20 distinct Loki streams
+(dynamic_labels: peer_address). max_streams_per_push is 128.
+```
+
+See the [`dynamic_labels` field reference](../configuration/scenario-fields.md#dynamic-labels) for the full set of options on the rotating label itself.
 
 ## Runnable examples
 

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -40,7 +40,9 @@ use sonda_core::config::ScenarioEntry;
 use sonda_core::schedule::launch::prepare_entries;
 use sonda_core::schedule::multi_runner::launch_multi_compiled;
 
-use crate::routes::sink_warnings::{log_warnings, sink_loopback_warnings};
+use crate::routes::sink_warnings::{
+    log_warnings, loki_cardinality_warnings, sink_loopback_warnings,
+};
 use crate::state::AppState;
 
 // ---- Response types ---------------------------------------------------------
@@ -485,7 +487,8 @@ pub async fn post_scenario(
         unprocessable(e)
     })?;
     let warning_entries: Vec<ScenarioEntry> = prepared.into_iter().map(|p| p.entry).collect();
-    let warnings = sink_loopback_warnings(&warning_entries);
+    let mut warnings = sink_loopback_warnings(&warning_entries);
+    warnings.extend(loki_cardinality_warnings(&warning_entries));
     log_warnings("POST /scenarios", &warnings);
     drop(warning_entries);
 

--- a/sonda-server/src/routes/sink_warnings.rs
+++ b/sonda-server/src/routes/sink_warnings.rs
@@ -1,6 +1,6 @@
 //! Sink loopback pre-flight warnings shared by `POST /scenarios` and `POST /events`.
 
-use sonda_core::config::ScenarioEntry;
+use sonda_core::config::{DynamicLabelConfig, DynamicLabelStrategy, ScenarioEntry};
 use sonda_core::sink::SinkConfig;
 use tracing::warn;
 
@@ -148,6 +148,82 @@ pub(crate) fn collect_warnings_for_sink(
 pub(crate) fn log_warnings(route: &str, warnings: &[String]) {
     for message in warnings {
         warn!(message = %message, route = %route, "{}: sink pre-flight warning", route);
+    }
+}
+
+/// One informational warning per logs+loki+`dynamic_labels` entry, naming
+/// the predicted upper bound on distinct Loki streams the scenario will
+/// produce over its lifetime alongside the active `max_streams_per_push`
+/// cap. Lets users see — at registration time — whether their cardinality
+/// will fit before flushes start hitting the cap at runtime.
+pub(crate) fn loki_cardinality_warnings(entries: &[ScenarioEntry]) -> Vec<String> {
+    let mut warnings = Vec::new();
+    for entry in entries {
+        if !matches!(entry, ScenarioEntry::Logs(_)) {
+            continue;
+        }
+        let base = entry.base();
+        let Some(dyn_labels) = base.dynamic_labels.as_deref() else {
+            continue;
+        };
+        if dyn_labels.is_empty() {
+            continue;
+        }
+        if let Some(msg) = preview_loki_cardinality(&base.sink, &base.name, dyn_labels) {
+            warnings.push(msg);
+        }
+    }
+    warnings
+}
+
+fn preview_loki_cardinality(
+    sink: &SinkConfig,
+    entry_name: &str,
+    dyn_labels: &[DynamicLabelConfig],
+) -> Option<String> {
+    match sink {
+        #[cfg(feature = "http")]
+        SinkConfig::Loki {
+            max_streams_per_push,
+            ..
+        } => {
+            let cap = max_streams_per_push
+                .unwrap_or(sonda_core::sink::loki::DEFAULT_MAX_STREAMS_PER_PUSH);
+            let predicted = predicted_loki_stream_count(dyn_labels);
+            let keys: Vec<&str> = dyn_labels.iter().map(|dl| dl.key.as_str()).collect();
+            Some(format!(
+                "scenario entry '{entry_name}' will produce up to {predicted} distinct \
+                 Loki streams (dynamic_labels: {}). max_streams_per_push is {cap}.",
+                keys.join(", ")
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn predicted_loki_stream_count(dyn_labels: &[DynamicLabelConfig]) -> u64 {
+    dyn_labels
+        .iter()
+        .map(|dl| match &dl.strategy {
+            DynamicLabelStrategy::Counter { cardinality, .. } => *cardinality,
+            DynamicLabelStrategy::ValuesList { values } => values.len() as u64,
+        })
+        .fold(1u64, lcm)
+}
+
+fn lcm(a: u64, b: u64) -> u64 {
+    if a == 0 || b == 0 {
+        0
+    } else {
+        a / gcd(a, b) * b
+    }
+}
+
+fn gcd(a: u64, b: u64) -> u64 {
+    if b == 0 {
+        a
+    } else {
+        gcd(b, a % b)
     }
 }
 
@@ -384,6 +460,119 @@ mod tests {
         let sink = SinkConfig::Stdout;
         let mut out = Vec::new();
         collect_warnings_for_sink(&sink, "events", &mut out);
+        assert!(out.is_empty());
+    }
+
+    // ---- loki cardinality preview --------------------------------------
+
+    fn compile_logs_entry(body_yaml: &str) -> ScenarioEntry {
+        let yaml = format!(
+            "version: 2\nkind: runnable\n\
+             defaults:\n  rate: 10\n  duration: 500ms\n  encoder:\n    type: json_lines\n\
+             scenarios:\n  - id: card_test\n    signal_type: logs\n    name: card_test\n\
+{body_yaml}",
+        );
+        let resolver = InMemoryPackResolver::new();
+        let mut entries = compile_scenario_file(&yaml, &resolver).expect("compile must succeed");
+        assert_eq!(entries.len(), 1, "fixture must compile to one entry");
+        entries.pop().unwrap()
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_fires_for_logs_loki_dynamic_labels() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: peer_address\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"10.1.2.2\", \"10.1.7.2\"]\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert_eq!(out.len(), 1);
+        assert!(out[0].contains("card_test"));
+        assert!(out[0].contains("peer_address"));
+        assert!(out[0].contains("up to 2 distinct"));
+        assert!(out[0].contains("max_streams_per_push is 128"));
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_uses_explicit_cap() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20\x20\x20max_streams_per_push: 32\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: peer_address\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"a\", \"b\", \"c\"]\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert_eq!(out.len(), 1);
+        assert!(out[0].contains("max_streams_per_push is 32"));
+        assert!(out[0].contains("up to 3"));
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_uses_lcm_for_multiple_dynamic_labels() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: peer\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"a\", \"b\", \"c\"]\n\
+             \x20\x20\x20\x20\x20\x20- key: pod\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"x\", \"y\"]\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert_eq!(out.len(), 1);
+        // LCM(3, 2) = 6 distinct (peer, pod) combinations.
+        assert!(out[0].contains("up to 6 distinct"), "got: {}", out[0]);
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_does_not_fire_without_dynamic_labels() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert!(out.is_empty());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_does_not_fire_for_non_loki_sink() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: stdout\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: peer\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"a\", \"b\"]\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn loki_cardinality_warning_does_not_fire_for_metrics_entry() {
+        // metrics + dynamic_labels (no Loki sink possible for metrics in
+        // practice) — the cardinality preview is logs-only.
+        let yaml = "version: 2\nkind: runnable\n\
+                    defaults:\n  rate: 10\n  duration: 500ms\n\
+                    \x20\x20encoder:\n    type: prometheus_text\n\
+                    scenarios:\n  - id: m\n    signal_type: metrics\n    name: m\n\
+                    \x20\x20\x20\x20sink:\n      type: stdout\n\
+                    \x20\x20\x20\x20generator:\n      type: constant\n      value: 1.0\n\
+                    \x20\x20\x20\x20dynamic_labels:\n      - key: peer\n\
+                    \x20\x20\x20\x20\x20\x20\x20\x20values: [\"a\", \"b\"]\n";
+        let resolver = InMemoryPackResolver::new();
+        let mut entries = compile_scenario_file(yaml, &resolver).expect("compile");
+        let entry = entries.pop().unwrap();
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
         assert!(out.is_empty());
     }
 }

--- a/sonda-server/src/routes/sink_warnings.rs
+++ b/sonda-server/src/routes/sink_warnings.rs
@@ -151,11 +151,6 @@ pub(crate) fn log_warnings(route: &str, warnings: &[String]) {
     }
 }
 
-/// One informational warning per logs+loki+`dynamic_labels` entry, naming
-/// the predicted upper bound on distinct Loki streams the scenario will
-/// produce over its lifetime alongside the active `max_streams_per_push`
-/// cap. Lets users see — at registration time — whether their cardinality
-/// will fit before flushes start hitting the cap at runtime.
 pub(crate) fn loki_cardinality_warnings(entries: &[ScenarioEntry]) -> Vec<String> {
     let mut warnings = Vec::new();
     for entry in entries {
@@ -463,8 +458,6 @@ mod tests {
         assert!(out.is_empty());
     }
 
-    // ---- loki cardinality preview --------------------------------------
-
     fn compile_logs_entry(body_yaml: &str) -> ScenarioEntry {
         let yaml = format!(
             "version: 2\nkind: runnable\n\
@@ -527,7 +520,6 @@ mod tests {
         );
         let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
         assert_eq!(out.len(), 1);
-        // LCM(3, 2) = 6 distinct (peer, pod) combinations.
         assert!(out[0].contains("up to 6 distinct"), "got: {}", out[0]);
     }
 
@@ -559,8 +551,6 @@ mod tests {
 
     #[test]
     fn loki_cardinality_warning_does_not_fire_for_metrics_entry() {
-        // metrics + dynamic_labels (no Loki sink possible for metrics in
-        // practice) — the cardinality preview is logs-only.
         let yaml = "version: 2\nkind: runnable\n\
                     defaults:\n  rate: 10\n  duration: 500ms\n\
                     \x20\x20encoder:\n    type: prometheus_text\n\


### PR DESCRIPTION
Plan PR 3/4 for issue #296. Lands on \`release/1.9.4\`. Builds on [PR 1 (#375)](https://github.com/davidban77/sonda/pull/375) (Sink trait extension) and [PR 2 (#376)](https://github.com/davidban77/sonda/pull/376) (Loki sink multi-stream auto-promote + cap).

## Server-side cardinality preview

\`POST /scenarios\` now emits one informational warning per logs+loki+dynamic_labels entry, naming the predicted upper bound on distinct Loki streams the scenario will produce over its lifetime, alongside the active \`max_streams_per_push\` cap:

> scenario entry 'srl1_bgp_logs' will produce up to 20 distinct Loki streams (dynamic_labels: peer_address). max_streams_per_push is 128.

Users see at registration time whether their cardinality will fit before flushes start hitting the cap at runtime.

**Multi-label prediction**: uses LCM of per-key value counts as the upper bound, matching the lockstep tick-rotation semantics of \`DynamicLabel::label_value_for_tick\`. Two dynamic_labels {3 values, 2 values} → 6 distinct combinations.

New function \`sink_warnings::loki_cardinality_warnings(entries)\` wired into the existing warning flow alongside \`sink_loopback_warnings\`. The Loki match arm is feature-gated on \`http\` (matching the existing pattern in \`collect_warnings_for_sink\`).

## Tests (6 new, all green)

- Fires for logs+loki+dynamic_labels (basic happy path)
- Uses explicit \`max_streams_per_push\` from sink config
- LCM math: two dynamic_labels {3 values, 2 values} → message contains \"up to 6 distinct\"
- Does not fire without dynamic_labels
- Does not fire for non-loki sink (stdout)
- Does not fire for metrics entries (Loki is logs-only in practice)

## Docs sweep

**\`docs/site/docs/configuration/scenario-fields.md\`** — adds a \`!!! info\` under §Dynamic labels noting Loki auto-promotion, the cap, and pointing at the guide.

**\`docs/site/docs/configuration/sinks.md\`** — \`loki\` section gains the \`max_streams_per_push\` row in the params table, plus a paragraph on multi-stream behaviour.

**\`docs/site/docs/guides/dynamic-labels.md\`** — new section \"Dynamic labels with the Loki sink\" with:
- The 20-BGP-peers worked example showing how one scenario produces N queryable Loki streams (the pattern that previously needed N hand-written scenarios)
- The exact server-side warning users will see at registration time
- Cardinality cap explanation + how to raise it

## Gate suite — all green

| Gate | Result |
|---|---|
| \`cargo build --workspace --features remote-write,kafka,otlp\` | clean |
| \`cargo nextest run --workspace --features …\` | **2641/2641 pass** |
| \`cargo test --workspace --doc --features …\` | 4/4 pass |
| \`cargo clippy --workspace --features … -- -D warnings\` | clean |
| \`cargo fmt --all -- --check\` | clean |
| \`cargo test -p sonda-core --no-default-features\` | **1216/1216 unit pass** |
| \`mkdocs build --strict\` | clean |

## What this PR does NOT do (deferred to PR 4)

E2E fixture proving multi-stream landing in real Loki against the docker-compose stack — that's the last piece, regression-tests the architectural fix end-to-end.

Refs: #296, #375, #376.