### PR TITLE
fix(loki): address issues on 1.9.4 cumulative diff (#296)

### DIFF
--- a/.claude/skills/add-sink/SKILL.md
+++ b/.claude/skills/add-sink/SKILL.md
@@ -57,6 +57,17 @@ Use this skill when implementing a new output sink for sonda-core.
 - **`write()` gets pre-encoded data.** Don't re-encode or transform. Just deliver.
 - **`flush()` must be idempotent.** Safe to call multiple times, including after errors.
 
+## Per-event context: `write_log_event`
+
+The `Sink` trait carries a second log-write method, `write_log_event(&mut self, event:
+&LogEvent, encoded: &[u8])`. The default impl ignores the event and forwards the encoded
+bytes to `write()`. **Override it whenever your sink consumes any per-event field (labels,
+severity, timestamp) for delivery routing** — stream selection, partition keys, structured
+envelopes. The Loki sink (`sink/loki.rs`) is the in-tree example: it overrides to promote
+`LogEvent.labels` into the Loki stream label set so each unique label combination becomes
+its own stream. Inheriting the default when you actually need the event context silently
+drops that context at runtime and produces wrong output.
+
 ## Quality Checklist
 
 - [ ] `new()` returns `Result` and handles I/O failures.

--- a/docs/site/docs/configuration/scenario-fields.md
+++ b/docs/site/docs/configuration/scenario-fields.md
@@ -278,8 +278,8 @@ request_count{hostname="web-0",region="eu-west-1",...} 3
     collides with a static label key, the dynamic value wins. Dynamic labels work identically
     for both metric and log scenarios.
 
-!!! info "Loki sinks auto-promote dynamic labels to stream labels"
-    When a `logs` scenario uses a `loki` sink, each unique `dynamic_labels` combination becomes its own Loki stream. A rotation through `peer_address: [10.1.2.2, 10.1.7.2]` produces two streams (`{peer_address="10.1.2.2"}` and `{peer_address="10.1.7.2"}`) — both queryable in Grafana by label. The Loki sink caps unique streams per push at [`max_streams_per_push`](sinks.md#loki) (default 128); higher-cardinality rotations need an explicit raise. See [Dynamic Labels — Loki sinks](../guides/dynamic-labels.md#dynamic-labels-with-the-loki-sink) for a worked BGP-peers example.
+!!! info "Loki sinks turn dynamic labels into separate streams"
+    A Loki **stream** is the unit Loki indexes by — identified by its label set. When a `logs` scenario uses a `loki` sink, each unique `dynamic_labels` combination becomes its own stream. A rotation through `peer_address: [10.1.2.2, 10.1.7.2]` produces two streams (`{peer_address="10.1.2.2"}` and `{peer_address="10.1.7.2"}`) — both queryable in Grafana by label. The Loki sink caps unique streams per push at [`max_streams_per_push`](sinks.md#loki) (default 128); raise the cap if a rotation needs more. See [Dynamic Labels — Loki sinks](../guides/dynamic-labels.md#dynamic-labels-with-the-loki-sink) for a worked BGP-peers example.
 
 ### Temporal fields
 

--- a/docs/site/docs/configuration/sinks.md
+++ b/docs/site/docs/configuration/sinks.md
@@ -359,15 +359,15 @@ sink:
     This sink requires the `http` Cargo feature flag. Pre-built release binaries include this
     feature. If building from source: `cargo build --features http -p sonda`.
 
-Batches log lines and delivers them to Grafana Loki via HTTP POST. Each entry is grouped by combined label set (scenario-level `labels` merged with any per-event `dynamic_labels` overlay) at flush time and emitted as a multi-stream push envelope — one Loki stream per unique label combination.
+Batches log lines and delivers them to Grafana Loki via HTTP POST. A Loki **stream** is the unit Loki indexes by, identified by its label set. At each flush, entries are grouped by their combined label set (scenario-level `labels` merged with any per-event `dynamic_labels`) and sent as a single push containing one stream per unique combination.
 
-Scenario-level `labels:` form the base stream labels. Per-event `dynamic_labels` (when used) auto-promote into the stream label set so a rotation through N values produces N distinct Loki streams, each queryable in Grafana by label. See [Dynamic Labels — Loki sinks](../guides/dynamic-labels.md#dynamic-labels-with-the-loki-sink) for the worked pattern.
+Scenario-level `labels:` form the base stream labels. Per-event `dynamic_labels` (when used) join the stream label set, so a rotation through N values produces N distinct streams — each queryable in Grafana by label. See [Dynamic Labels — Loki sinks](../guides/dynamic-labels.md#dynamic-labels-with-the-loki-sink) for the worked pattern.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `url` | string | yes | -- | Base URL of the Loki instance. |
 | `batch_size` | integer | no | `5` | Size flush threshold in number of log entries. Raise for high-rate scenarios. |
-| `max_streams_per_push` | integer | no | `128` | Hard cap on unique streams per flush. A flush that would emit more streams than the cap fails loudly with the offending count + workaround hint, so high-cardinality `dynamic_labels` configurations surface as a config issue rather than a silent Loki melt. Raise this if your Loki ingester is sized for higher cardinality. |
+| `max_streams_per_push` | integer | no | `128` | Hard cap on unique streams per flush. A flush that would emit more streams than the cap fails with a message naming the offending count and the cap, so high-cardinality `dynamic_labels` configurations surface as a config error instead of overloading the Loki ingester. Raise this if your ingester is sized for higher cardinality. |
 | `max_buffer_age` | duration string | no | `5s` | Time flush threshold. A non-empty batch is flushed once it has been buffered longer than this. Set `"0s"` to disable. See [Sink Batching](sink-batching.md#time-based-flushing). |
 
 ```yaml title="Loki sink with top-level labels"

--- a/docs/site/docs/guides/dynamic-labels.md
+++ b/docs/site/docs/guides/dynamic-labels.md
@@ -249,11 +249,12 @@ scenarios:
     log_generator:
       type: template
       templates:
-        - message: "BGP neighbor {peer_address}: state changed to {state}"
+        - message: "BGP neighbor state changed to {state}"
           field_pools:
-            peer_address: ["10.1.2.2", "10.1.7.2", "10.1.12.2", "10.1.17.2", "10.1.22.2"]
             state: ["established", "active", "open-confirm", "idle"]
 ```
+
+The peer identity rides on the stream label (`peer_address`), not in the message text, so each Loki stream stays consistent with its label set.
 
 ### What lands in Loki
 

--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -213,7 +213,14 @@ JSON encoders pre-round the value before passing it to serde. Precision is valid
 4. Register in `src/sink/mod.rs` factory. The `create_sink()` function accepts an optional
    `labels: Option<&HashMap<String, String>>` parameter. Most sinks ignore this (pass `None`).
    The Loki sink uses it for stream labels, sourced from the scenario-level `labels` config.
-5. Test with a mock or in-memory buffer sink.
+5. **Override `write_log_event` when the sink consumes per-event context.** The default impl
+   discards the `&LogEvent` and forwards the encoded bytes to `write()`. If your sink uses any
+   per-event field (labels, severity, timestamp) for delivery routing — stream selection,
+   partition keys, structured envelopes — you MUST override `write_log_event`. Inheriting the
+   default silently drops that context at runtime and produces wrong output (see `sink/loki.rs`
+   for the in-tree example: it overrides to promote `LogEvent.labels` into the Loki stream
+   label set).
+6. Test with a mock or in-memory buffer sink.
 
 ## Performance Guidelines
 

--- a/sonda-core/src/emit.rs
+++ b/sonda-core/src/emit.rs
@@ -19,7 +19,7 @@ pub fn emit_log(
     let mut sink = create_sink(sink, labels)?;
     let mut buf: Vec<u8> = Vec::new();
     encoder.encode_log(event, &mut buf)?;
-    sink.write(&buf)?;
+    sink.write_log_event(event, &buf)?;
     sink.flush()
 }
 
@@ -161,6 +161,80 @@ mod tests {
         assert!(
             matches!(err, SondaError::Config(_)),
             "invalid retry config must surface as SondaError::Config, got: {err:?}"
+        );
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn emit_log_routes_event_labels_to_loki_sink_stream() {
+        use std::io::{BufRead, BufReader, Read, Write};
+        use std::net::{TcpListener, TcpStream};
+        use std::thread;
+
+        fn read_http_body(stream: &mut TcpStream) -> Vec<u8> {
+            let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+            let mut content_length: usize = 0;
+            loop {
+                let mut line = String::new();
+                reader.read_line(&mut line).expect("header line");
+                if line == "\r\n" || line.is_empty() {
+                    break;
+                }
+                let lower = line.to_lowercase();
+                if let Some(rest) = lower.strip_prefix("content-length:") {
+                    content_length = rest.trim().parse().unwrap_or(0);
+                }
+            }
+            let mut body = vec![0u8; content_length];
+            reader.read_exact(&mut body).expect("body");
+            body
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let url = format!("http://127.0.0.1:{port}");
+
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let body = read_http_body(&mut stream);
+            let resp = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            stream.write_all(resp.as_bytes()).ok();
+            body
+        });
+
+        let labels = Labels::from_pairs(&[("peer_address", "10.1.2.2")]).expect("labels");
+        let event = LogEvent::new(
+            Severity::Info,
+            "bgp event".to_string(),
+            labels,
+            BTreeMap::new(),
+        );
+
+        emit_log(
+            &event,
+            &EncoderConfig::JsonLines { precision: None },
+            &SinkConfig::Loki {
+                url,
+                batch_size: Some(1),
+                max_streams_per_push: None,
+                max_buffer_age: None,
+                retry: None,
+            },
+            None,
+        )
+        .expect("emit_log must succeed");
+
+        let body_bytes = handle.join().expect("mock server");
+        let body = String::from_utf8(body_bytes).expect("UTF-8");
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON envelope");
+
+        let stream_obj = parsed["streams"][0]["stream"]
+            .as_object()
+            .expect("stream object");
+        assert_eq!(
+            stream_obj.get("peer_address").and_then(|v| v.as_str()),
+            Some("10.1.2.2"),
+            "event labels must reach the Loki stream via write_log_event: {body}"
         );
     }
 

--- a/sonda-core/src/sink/loki.rs
+++ b/sonda-core/src/sink/loki.rs
@@ -70,38 +70,24 @@ impl LokiSink {
         })
     }
 
-    /// Overlay wins on key collision so `dynamic_labels` rotation can take
-    /// precedence over constructor labels.
-    fn combine_labels(&self, overlay: &BTreeMap<String, String>) -> BTreeMap<String, String> {
-        let mut combined: BTreeMap<String, String> = self
-            .labels
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-        for (k, v) in overlay {
-            combined.insert(k.clone(), v.clone());
-        }
-        combined
-    }
-
-    fn group_by_labels(&self) -> BTreeMap<BTreeMap<String, String>, Vec<&LokiEntry>> {
-        let mut groups: BTreeMap<BTreeMap<String, String>, Vec<&LokiEntry>> = BTreeMap::new();
+    fn group_by_overlay(&self) -> BTreeMap<&BTreeMap<String, String>, Vec<&LokiEntry>> {
+        let mut groups: BTreeMap<&BTreeMap<String, String>, Vec<&LokiEntry>> = BTreeMap::new();
         for entry in &self.batch {
-            let key = self.combine_labels(&entry.overlay);
-            groups.entry(key).or_default().push(entry);
+            // TODO(perf): LogEvent.labels could be Arc<Labels> so the overlay
+            // doesn't allocate per event; deferred from 1.9.4 scope.
+            groups.entry(&entry.overlay).or_default().push(entry);
         }
         groups
     }
 
-    fn build_envelope(groups: &BTreeMap<BTreeMap<String, String>, Vec<&LokiEntry>>) -> String {
+    fn build_envelope(
+        &self,
+        groups: &BTreeMap<&BTreeMap<String, String>, Vec<&LokiEntry>>,
+    ) -> String {
         let streams = groups
             .iter()
-            .map(|(labels, entries)| {
-                let stream_labels = labels
-                    .iter()
-                    .map(|(k, v)| format!("\"{}\":\"{}\"", escape_json(k), escape_json(v)))
-                    .collect::<Vec<_>>()
-                    .join(",");
+            .map(|(overlay, entries)| {
+                let stream_labels = self.format_stream_labels(overlay);
                 let values = entries
                     .iter()
                     .map(|e| format!("[\"{}\",\"{}\"]", e.timestamp_ns, escape_json(&e.line)))
@@ -118,6 +104,25 @@ impl LokiSink {
         format!("{{\"streams\":[{}]}}", streams)
     }
 
+    /// Merge constructor labels with the per-group overlay and emit them as
+    /// sorted JSON object members. Overlay wins on key collision so
+    /// `dynamic_labels` rotation can take precedence over constructor labels.
+    fn format_stream_labels(&self, overlay: &BTreeMap<String, String>) -> String {
+        let mut combined: BTreeMap<&str, &str> = self
+            .labels
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        for (k, v) in overlay {
+            combined.insert(k.as_str(), v.as_str());
+        }
+        combined
+            .iter()
+            .map(|(k, v)| format!("\"{}\":\"{}\"", escape_json(k), escape_json(v)))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
     fn flush_batch(&mut self) -> Result<(), SondaError> {
         if self.batch.is_empty() {
             return Ok(());
@@ -126,7 +131,7 @@ impl LokiSink {
         // Scoped so `groups`' borrows into `self.batch` drop before we mutate
         // other `self` fields below.
         let body = {
-            let groups = self.group_by_labels();
+            let groups = self.group_by_overlay();
             let stream_count = groups.len();
 
             if stream_count as u32 > self.max_streams_per_push {
@@ -141,7 +146,7 @@ impl LokiSink {
                      raise max_streams_per_push on the sink, or split into per-value scenarios."
                 ))));
             }
-            Self::build_envelope(&groups)
+            self.build_envelope(&groups)
         };
 
         let push_url = format!("{}/loki/api/v1/push", self.url);

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -1364,12 +1364,6 @@ retry:
         );
     }
 
-    // ---------------------------------------------------------------------------
-    // Default `write_log_event` impl on the Sink trait forwards to `write`.
-    // Sinks that don't override the new method (every sink today except Loki in
-    // PR 2) must keep behaving exactly as they did before this PR landed.
-    // ---------------------------------------------------------------------------
-
     #[test]
     fn default_write_log_event_forwards_encoded_bytes_to_write() {
         use crate::model::log::{LogEvent, Severity};

--- a/sonda-server/src/routes/sink_warnings.rs
+++ b/sonda-server/src/routes/sink_warnings.rs
@@ -171,6 +171,8 @@ pub(crate) fn loki_cardinality_warnings(entries: &[ScenarioEntry]) -> Vec<String
     warnings
 }
 
+const PREVIEW_OVERFLOW_THRESHOLD: u64 = 1_000_000;
+
 fn preview_loki_cardinality(
     sink: &SinkConfig,
     entry_name: &str,
@@ -185,33 +187,50 @@ fn preview_loki_cardinality(
             let cap = max_streams_per_push
                 .unwrap_or(sonda_core::sink::loki::DEFAULT_MAX_STREAMS_PER_PUSH);
             let predicted = predicted_loki_stream_count(dyn_labels);
+            let over_cap = match predicted {
+                None => true,
+                Some(n) => n > u64::from(cap),
+            };
+            if !over_cap {
+                return None;
+            }
             let keys: Vec<&str> = dyn_labels.iter().map(|dl| dl.key.as_str()).collect();
+            let count_phrase = match predicted {
+                Some(n) => format!("up to {n} distinct"),
+                None => format!("more than {PREVIEW_OVERFLOW_THRESHOLD} distinct"),
+            };
             Some(format!(
-                "scenario entry '{entry_name}' will produce up to {predicted} distinct \
-                 Loki streams (dynamic_labels: {}). max_streams_per_push is {cap}.",
-                keys.join(", ")
+                "scenario entry '{entry_name}' will produce {count_phrase} \
+                 Loki streams (dynamic_labels: {keys}), exceeding max_streams_per_push ({cap}). \
+                 Either raise max_streams_per_push, reduce dynamic_labels cardinality, \
+                 or reduce batch_size so each flush stays under the cap.",
+                keys = keys.join(", ")
             ))
         }
         _ => None,
     }
 }
 
-fn predicted_loki_stream_count(dyn_labels: &[DynamicLabelConfig]) -> u64 {
-    dyn_labels
-        .iter()
-        .map(|dl| match &dl.strategy {
+fn predicted_loki_stream_count(dyn_labels: &[DynamicLabelConfig]) -> Option<u64> {
+    let mut acc: u64 = 1;
+    for dl in dyn_labels {
+        let n = match &dl.strategy {
             DynamicLabelStrategy::Counter { cardinality, .. } => *cardinality,
             DynamicLabelStrategy::ValuesList { values } => values.len() as u64,
-        })
-        .fold(1u64, lcm)
+        };
+        acc = checked_lcm(acc, n)?;
+        if acc > PREVIEW_OVERFLOW_THRESHOLD {
+            return None;
+        }
+    }
+    Some(acc)
 }
 
-fn lcm(a: u64, b: u64) -> u64 {
+fn checked_lcm(a: u64, b: u64) -> Option<u64> {
     if a == 0 || b == 0 {
-        0
-    } else {
-        a / gcd(a, b) * b
+        return Some(0);
     }
+    a.checked_div(gcd(a, b))?.checked_mul(b)
 }
 
 fn gcd(a: u64, b: u64) -> u64 {
@@ -473,9 +492,10 @@ mod tests {
 
     #[cfg(feature = "http")]
     #[test]
-    fn loki_cardinality_warning_fires_for_logs_loki_dynamic_labels() {
+    fn loki_cardinality_warning_fires_when_predicted_exceeds_cap() {
         let entry = compile_logs_entry(
             "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20\x20\x20max_streams_per_push: 1\n\
              \x20\x20\x20\x20dynamic_labels:\n      - key: peer_address\n\
              \x20\x20\x20\x20\x20\x20\x20\x20values: [\"10.1.2.2\", \"10.1.7.2\"]\n\
              \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
@@ -486,12 +506,30 @@ mod tests {
         assert!(out[0].contains("card_test"));
         assert!(out[0].contains("peer_address"));
         assert!(out[0].contains("up to 2 distinct"));
-        assert!(out[0].contains("max_streams_per_push is 128"));
+        assert!(out[0].contains("max_streams_per_push (1)"));
+        assert!(out[0].contains("exceeding"));
     }
 
     #[cfg(feature = "http")]
     #[test]
-    fn loki_cardinality_warning_uses_explicit_cap() {
+    fn loki_cardinality_warning_silent_when_default_cap_dominates() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: peer_address\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"10.1.2.2\", \"10.1.7.2\"]\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert!(
+            out.is_empty(),
+            "predicted (2) ≤ default cap (128) must not fire: {out:?}"
+        );
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_silent_when_explicit_cap_dominates() {
         let entry = compile_logs_entry(
             "    sink:\n      type: loki\n      url: http://loki:3100\n\
              \x20\x20\x20\x20\x20\x20max_streams_per_push: 32\n\
@@ -501,9 +539,27 @@ mod tests {
              \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
         );
         let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert!(
+            out.is_empty(),
+            "predicted (3) ≤ explicit cap (32) must not fire: {out:?}"
+        );
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_fires_when_explicit_cap_undershoots() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20\x20\x20max_streams_per_push: 2\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: peer_address\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"a\", \"b\", \"c\"]\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
         assert_eq!(out.len(), 1);
-        assert!(out[0].contains("max_streams_per_push is 32"));
-        assert!(out[0].contains("up to 3"));
+        assert!(out[0].contains("max_streams_per_push (2)"));
+        assert!(out[0].contains("up to 3 distinct"));
     }
 
     #[cfg(feature = "http")]
@@ -511,6 +567,7 @@ mod tests {
     fn loki_cardinality_warning_uses_lcm_for_multiple_dynamic_labels() {
         let entry = compile_logs_entry(
             "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20\x20\x20max_streams_per_push: 5\n\
              \x20\x20\x20\x20dynamic_labels:\n      - key: peer\n\
              \x20\x20\x20\x20\x20\x20\x20\x20values: [\"a\", \"b\", \"c\"]\n\
              \x20\x20\x20\x20\x20\x20- key: pod\n\
@@ -521,6 +578,62 @@ mod tests {
         let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
         assert_eq!(out.len(), 1);
         assert!(out[0].contains("up to 6 distinct"), "got: {}", out[0]);
+        assert!(out[0].contains("max_streams_per_push (5)"));
+    }
+
+    #[test]
+    fn predicted_loki_stream_count_saturates_on_overflow() {
+        let dyn_labels = vec![
+            DynamicLabelConfig {
+                key: "a".to_string(),
+                strategy: DynamicLabelStrategy::Counter {
+                    prefix: None,
+                    cardinality: u64::MAX,
+                },
+            },
+            DynamicLabelConfig {
+                key: "b".to_string(),
+                strategy: DynamicLabelStrategy::Counter {
+                    prefix: None,
+                    cardinality: 7,
+                },
+            },
+        ];
+        assert_eq!(predicted_loki_stream_count(&dyn_labels), None);
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_reports_saturation_phrase_on_overflow() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20\x20\x20max_streams_per_push: 1\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: a\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20cardinality: 18446744073709551615\n\
+             \x20\x20\x20\x20\x20\x20- key: b\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20cardinality: 7\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert_eq!(out.len(), 1);
+        assert!(
+            out[0].contains(&format!("more than {PREVIEW_OVERFLOW_THRESHOLD}")),
+            "saturation phrase missing: {}",
+            out[0]
+        );
+    }
+
+    #[test]
+    fn predicted_loki_stream_count_handles_large_but_safe_count() {
+        let dyn_labels = vec![DynamicLabelConfig {
+            key: "a".to_string(),
+            strategy: DynamicLabelStrategy::Counter {
+                prefix: None,
+                cardinality: 5000,
+            },
+        }];
+        assert_eq!(predicted_loki_stream_count(&dyn_labels), Some(5000));
     }
 
     #[cfg(feature = "http")]


### PR DESCRIPTION
Five issues addressed from the review of the cumulative 1.9.4 Loki `dynamic_labels` work.

- **`emit_log`** now routes through `write_log_event`. POST `/events` on a Loki sink no longer drops per-event labels — behaviour matches the scenario path.

- **Cardinality predictor** uses checked multiplication and saturates at 1,000,000. No silent overflow on adversarial input; preview message says *"more than 1,000,000 distinct"* when saturated.

- **Cardinality preview** only fires when predicted stream count exceeds `max_streams_per_push` (or saturates). Healthy submissions no longer emit a warning.

- **`Sink::write_log_event`** override requirement documented in `sonda-core/CLAUDE.md` § *How to Add a New Sink* and in `.claude/skills/add-sink/SKILL.md`. Future sinks that need per-event context (labels, severity, timestamp) have a guide pointing at the Loki sink as the in-tree example.

- **Loki sink grouping** refactored: groups by overlay reference, combined stream-label map built once per group at envelope time rather than cloned per entry. Wire-format output unchanged.

- **BGP example** in `dynamic-labels.md` reworked so the message template no longer references `peer_address` — peer identity lives in the stream label.

- **`scenario-fields.md` and `sinks.md`**: defines *Loki stream* inline at first use, drops jargon.

Refs: #296.