### PR TITLE
test(e2e): add multi-stream Loki fixture proving dynamic_labels promotion

### DIFF
--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -189,6 +189,27 @@ print(total)
 " 2>/dev/null || echo "0"
 }
 
+# Query Loki for the number of distinct streams matching a label selector.
+# Uses /loki/api/v1/series, which returns one entry per unique label set.
+# Usage: query_loki_stream_count <label_selector>
+query_loki_stream_count() {
+    local selector="$1"
+    local now_ns
+    now_ns=$(python3 -c "import time; print(int(time.time() * 1_000_000_000))")
+    local start_ns=$((now_ns - 3600000000000))
+    local result
+    result=$(curl -s --max-time 10 -G "http://localhost:3100/loki/api/v1/series" \
+        --data-urlencode "match[]=${selector}" \
+        --data-urlencode "start=${start_ns}" \
+        --data-urlencode "end=${now_ns}" \
+        2>/dev/null || echo '{}')
+    echo "${result}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(len(data.get('data', [])))
+" 2>/dev/null || echo "0"
+}
+
 # Run a single Loki scenario: execute `sonda run`, then verify log entries
 # arrived in Loki by querying its API with the given label selector.
 # Usage: run_loki_scenario <scenario_file> <label_selector> <description>
@@ -240,6 +261,63 @@ run_loki_scenario() {
         pass "${description}"
     else
         fail "${description}: no log entries found in Loki for selector '${label_selector}' (count=${count})"
+    fi
+}
+
+# Run a Loki scenario whose `dynamic_labels` rotation should produce N
+# distinct Loki streams, and verify the exact stream count by querying the
+# series endpoint.
+# Usage: run_loki_multi_stream_scenario <scenario_file> <label_selector> <expected_stream_count> <description>
+run_loki_multi_stream_scenario() {
+    local scenario_file="$1"
+    local label_selector="$2"
+    local expected_count="$3"
+    local description="$4"
+
+    info "Running Loki multi-stream scenario: ${description}"
+    info "  File:           ${scenario_file}"
+    info "  Selector:       ${label_selector}"
+    info "  Expect streams: ${expected_count}"
+
+    local timeout_secs=$((SCENARIO_DURATION + 10))
+    "${SONDA_BIN}" run "${scenario_file}" \
+            --duration "${SCENARIO_DURATION}s" \
+            >/dev/null 2>/tmp/sonda-e2e-stderr.log &
+    local sonda_pid=$!
+
+    local waited=0
+    while kill -0 "${sonda_pid}" 2>/dev/null && [ "${waited}" -lt "${timeout_secs}" ]; do
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    if kill -0 "${sonda_pid}" 2>/dev/null; then
+        kill "${sonda_pid}" 2>/dev/null
+        wait "${sonda_pid}" 2>/dev/null
+        fail "${description}: sonda timed out after ${timeout_secs}s"
+        return
+    fi
+
+    wait "${sonda_pid}" 2>/dev/null
+    local exit_code=$?
+
+    if [ "${exit_code}" -ne 0 ]; then
+        fail "${description}: sonda exited with code ${exit_code}"
+        return
+    fi
+
+    info "  sonda exited cleanly."
+    info "  Waiting ${INGEST_SETTLE_SECS}s for Loki ingestion to settle..."
+    sleep "${INGEST_SETTLE_SECS}"
+
+    local actual
+    actual=$(query_loki_stream_count "${label_selector}")
+    info "  Loki distinct-stream count: ${actual}"
+
+    if [ "${actual}" = "${expected_count}" ]; then
+        pass "${description}"
+    else
+        fail "${description}: expected ${expected_count} Loki streams matching '${label_selector}', got ${actual}"
     fi
 }
 
@@ -442,6 +520,12 @@ run_loki_scenario \
     "${SCENARIO_DIR}/loki-json-lines.yaml" \
     '{job="sonda-e2e"}' \
     "Loki via JSON Lines"
+
+run_loki_multi_stream_scenario \
+    "${SCENARIO_DIR}/loki-multi-stream.yaml" \
+    '{scenario="loki-multi-stream"}' \
+    3 \
+    "Loki multi-stream — dynamic_labels promotes to per-stream labels"
 
 # NOTE: vmagent scenario is disabled. vmagent's /api/v1/import/prometheus
 # endpoint accepts data (204) but does not relay plain text — it only forwards

--- a/tests/e2e/scenarios/loki-multi-stream.yaml
+++ b/tests/e2e/scenarios/loki-multi-stream.yaml
@@ -1,0 +1,42 @@
+# Scenario: sonda -> Loki, dynamic_labels promotes to per-stream labels
+#
+# Proves that a single scenario with a 3-value `dynamic_labels` rotation
+# produces 3 distinct Loki streams (one per peer_address), each queryable
+# by the rotation key.
+#
+# Run this scenario after starting the e2e stack:
+#   docker compose -f tests/e2e/docker-compose.yml up -d
+#   sonda run tests/e2e/scenarios/loki-multi-stream.yaml
+#
+# Verify N=3 distinct streams arrived:
+#   curl -s -G 'http://localhost:3100/loki/api/v1/series' \
+#     --data-urlencode 'match[]={scenario="loki-multi-stream"}' \
+#     | python3 -c 'import sys,json; print(len(json.load(sys.stdin)["data"]))'
+version: 2
+kind: runnable
+
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: json_lines
+  sink:
+    type: loki
+    url: http://localhost:3100
+  labels:
+    job: sonda-e2e
+    scenario: loki-multi-stream
+
+scenarios:
+  - id: sonda_e2e_loki_multi_stream
+    signal_type: logs
+    name: sonda_e2e_loki_multi_stream
+    dynamic_labels:
+      - key: peer_address
+        values: ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+    log_generator:
+      type: template
+      templates:
+        - message: "BGP neighbor state changed to {state}"
+          field_pools:
+            state: ["established", "active", "idle"]


### PR DESCRIPTION
Regression-tests the 1.9.4 Loki `dynamic_labels` work end-to-end against the docker-compose stack.

- New fixture `tests/e2e/scenarios/loki-multi-stream.yaml` rotates `peer_address` through three values.
- New `query_loki_stream_count` helper in `run.sh` queries `/loki/api/v1/series` and returns the count of distinct streams matching a selector.
- New `run_loki_multi_stream_scenario` helper asserts the exact expected stream count.
- Wired into the test sequence after the existing Loki single-stream scenario, scoped by a distinct `scenario` label so the two assertions don't cross-contaminate.

Full e2e run against the stack: **6/6 scenarios pass** — the new multi-stream scenario produces exactly 3 distinct Loki streams as expected.

Refs: #296.