### PR TITLE
fix(loki): #296 — promote dynamic_labels to Loki stream labels

### DIFF
--- a/.claude/skills/add-sink/SKILL.md
+++ b/.claude/skills/add-sink/SKILL.md
@@ -57,6 +57,17 @@ Use this skill when implementing a new output sink for sonda-core.
 - **`write()` gets pre-encoded data.** Don't re-encode or transform. Just deliver.
 - **`flush()` must be idempotent.** Safe to call multiple times, including after errors.
 
+## Per-event context: `write_log_event`
+
+The `Sink` trait carries a second log-write method, `write_log_event(&mut self, event:
+&LogEvent, encoded: &[u8])`. The default impl ignores the event and forwards the encoded
+bytes to `write()`. **Override it whenever your sink consumes any per-event field (labels,
+severity, timestamp) for delivery routing** — stream selection, partition keys, structured
+envelopes. The Loki sink (`sink/loki.rs`) is the in-tree example: it overrides to promote
+`LogEvent.labels` into the Loki stream label set so each unique label combination becomes
+its own stream. Inheriting the default when you actually need the event context silently
+drops that context at runtime and produces wrong output.
+
 ## Quality Checklist
 
 - [ ] `new()` returns `Result` and handles I/O failures.

--- a/docs/site/docs/configuration/scenario-fields.md
+++ b/docs/site/docs/configuration/scenario-fields.md
@@ -278,6 +278,9 @@ request_count{hostname="web-0",region="eu-west-1",...} 3
     collides with a static label key, the dynamic value wins. Dynamic labels work identically
     for both metric and log scenarios.
 
+!!! info "Loki sinks auto-promote dynamic labels to stream labels"
+    When a `logs` scenario uses a `loki` sink, each unique `dynamic_labels` combination becomes its own Loki stream. A rotation through `peer_address: [10.1.2.2, 10.1.7.2]` produces two streams (`{peer_address="10.1.2.2"}` and `{peer_address="10.1.7.2"}`) — both queryable in Grafana by label. The Loki sink caps unique streams per push at [`max_streams_per_push`](sinks.md#loki) (default 128); higher-cardinality rotations need an explicit raise. See [Dynamic Labels — Loki sinks](../guides/dynamic-labels.md#dynamic-labels-with-the-loki-sink) for a worked BGP-peers example.
+
 ### Temporal fields
 
 These fields control when and how entries coordinate inside a multi-entry v2 file (including

--- a/docs/site/docs/configuration/scenario-fields.md
+++ b/docs/site/docs/configuration/scenario-fields.md
@@ -278,8 +278,8 @@ request_count{hostname="web-0",region="eu-west-1",...} 3
     collides with a static label key, the dynamic value wins. Dynamic labels work identically
     for both metric and log scenarios.
 
-!!! info "Loki sinks auto-promote dynamic labels to stream labels"
-    When a `logs` scenario uses a `loki` sink, each unique `dynamic_labels` combination becomes its own Loki stream. A rotation through `peer_address: [10.1.2.2, 10.1.7.2]` produces two streams (`{peer_address="10.1.2.2"}` and `{peer_address="10.1.7.2"}`) — both queryable in Grafana by label. The Loki sink caps unique streams per push at [`max_streams_per_push`](sinks.md#loki) (default 128); higher-cardinality rotations need an explicit raise. See [Dynamic Labels — Loki sinks](../guides/dynamic-labels.md#dynamic-labels-with-the-loki-sink) for a worked BGP-peers example.
+!!! info "Loki sinks turn dynamic labels into separate streams"
+    A Loki **stream** is the unit Loki indexes by — identified by its label set. When a `logs` scenario uses a `loki` sink, each unique `dynamic_labels` combination becomes its own stream. A rotation through `peer_address: [10.1.2.2, 10.1.7.2]` produces two streams (`{peer_address="10.1.2.2"}` and `{peer_address="10.1.7.2"}`) — both queryable in Grafana by label. The Loki sink caps unique streams per push at [`max_streams_per_push`](sinks.md#loki) (default 128); raise the cap if a rotation needs more. See [Dynamic Labels — Loki sinks](../guides/dynamic-labels.md#dynamic-labels-with-the-loki-sink) for a worked BGP-peers example.
 
 ### Temporal fields
 

--- a/docs/site/docs/configuration/sinks.md
+++ b/docs/site/docs/configuration/sinks.md
@@ -359,15 +359,15 @@ sink:
     This sink requires the `http` Cargo feature flag. Pre-built release binaries include this
     feature. If building from source: `cargo build --features http -p sonda`.
 
-Batches log lines and delivers them to Grafana Loki via HTTP POST. Each entry is grouped by combined label set (scenario-level `labels` merged with any per-event `dynamic_labels` overlay) at flush time and emitted as a multi-stream push envelope — one Loki stream per unique label combination.
+Batches log lines and delivers them to Grafana Loki via HTTP POST. A Loki **stream** is the unit Loki indexes by, identified by its label set. At each flush, entries are grouped by their combined label set (scenario-level `labels` merged with any per-event `dynamic_labels`) and sent as a single push containing one stream per unique combination.
 
-Scenario-level `labels:` form the base stream labels. Per-event `dynamic_labels` (when used) auto-promote into the stream label set so a rotation through N values produces N distinct Loki streams, each queryable in Grafana by label. See [Dynamic Labels — Loki sinks](../guides/dynamic-labels.md#dynamic-labels-with-the-loki-sink) for the worked pattern.
+Scenario-level `labels:` form the base stream labels. Per-event `dynamic_labels` (when used) join the stream label set, so a rotation through N values produces N distinct streams — each queryable in Grafana by label. See [Dynamic Labels — Loki sinks](../guides/dynamic-labels.md#dynamic-labels-with-the-loki-sink) for the worked pattern.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `url` | string | yes | -- | Base URL of the Loki instance. |
 | `batch_size` | integer | no | `5` | Size flush threshold in number of log entries. Raise for high-rate scenarios. |
-| `max_streams_per_push` | integer | no | `128` | Hard cap on unique streams per flush. A flush that would emit more streams than the cap fails loudly with the offending count + workaround hint, so high-cardinality `dynamic_labels` configurations surface as a config issue rather than a silent Loki melt. Raise this if your Loki ingester is sized for higher cardinality. |
+| `max_streams_per_push` | integer | no | `128` | Hard cap on unique streams per flush. A flush that would emit more streams than the cap fails with a message naming the offending count and the cap, so high-cardinality `dynamic_labels` configurations surface as a config error instead of overloading the Loki ingester. Raise this if your ingester is sized for higher cardinality. |
 | `max_buffer_age` | duration string | no | `5s` | Time flush threshold. A non-empty batch is flushed once it has been buffered longer than this. Set `"0s"` to disable. See [Sink Batching](sink-batching.md#time-based-flushing). |
 
 ```yaml title="Loki sink with top-level labels"

--- a/docs/site/docs/configuration/sinks.md
+++ b/docs/site/docs/configuration/sinks.md
@@ -359,17 +359,15 @@ sink:
     This sink requires the `http` Cargo feature flag. Pre-built release binaries include this
     feature. If building from source: `cargo build --features http -p sonda`.
 
-Batches log lines and delivers them to Grafana Loki via HTTP POST. Each call to write appends one
-log line, and the batch is flushed when it reaches the configured size.
+Batches log lines and delivers them to Grafana Loki via HTTP POST. Each entry is grouped by combined label set (scenario-level `labels` merged with any per-event `dynamic_labels` overlay) at flush time and emitted as a multi-stream push envelope — one Loki stream per unique label combination.
 
-Stream labels are configured at the **top-level** `labels` field of the scenario, not inside the
-sink block. This is consistent with how labels work for all other signal types. The scenario-level
-labels are used as Loki stream labels in the push API envelope.
+Scenario-level `labels:` form the base stream labels. Per-event `dynamic_labels` (when used) auto-promote into the stream label set so a rotation through N values produces N distinct Loki streams, each queryable in Grafana by label. See [Dynamic Labels — Loki sinks](../guides/dynamic-labels.md#dynamic-labels-with-the-loki-sink) for the worked pattern.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `url` | string | yes | -- | Base URL of the Loki instance. |
 | `batch_size` | integer | no | `5` | Size flush threshold in number of log entries. Raise for high-rate scenarios. |
+| `max_streams_per_push` | integer | no | `128` | Hard cap on unique streams per flush. A flush that would emit more streams than the cap fails loudly with the offending count + workaround hint, so high-cardinality `dynamic_labels` configurations surface as a config issue rather than a silent Loki melt. Raise this if your Loki ingester is sized for higher cardinality. |
 | `max_buffer_age` | duration string | no | `5s` | Time flush threshold. A non-empty batch is flushed once it has been buffered longer than this. Set `"0s"` to disable. See [Sink Batching](sink-batching.md#time-based-flushing). |
 
 ```yaml title="Loki sink with top-level labels"

--- a/docs/site/docs/guides/dynamic-labels.md
+++ b/docs/site/docs/guides/dynamic-labels.md
@@ -249,11 +249,12 @@ scenarios:
     log_generator:
       type: template
       templates:
-        - message: "BGP neighbor {peer_address}: state changed to {state}"
+        - message: "BGP neighbor state changed to {state}"
           field_pools:
-            peer_address: ["10.1.2.2", "10.1.7.2", "10.1.12.2", "10.1.17.2", "10.1.22.2"]
             state: ["established", "active", "open-confirm", "idle"]
 ```
+
+The peer identity rides on the stream label (`peer_address`), not in the message text, so each Loki stream stays consistent with its label set.
 
 ### What lands in Loki
 

--- a/docs/site/docs/guides/dynamic-labels.md
+++ b/docs/site/docs/guides/dynamic-labels.md
@@ -209,6 +209,110 @@ scenarios:
 Each emitted JSON log event carries `pod_name=api-0`, `api-1`, or `api-2` in rotation. Useful
 for testing Loki label indexing or pod-level log aggregation panels.
 
+## Dynamic labels with the Loki sink
+
+Point a scenario with `dynamic_labels:` at a Loki sink and each rotating value becomes its own **Loki stream** — the smallest unit Loki indexes by, identified by its label set. The rotation values auto-promote into the stream label set alongside the scenario's static `labels:`, so a rotation through N values shows up in Grafana as N separate log streams, each queryable by that label.
+
+This is how you build a realistic per-source feed from a single scenario entry: one entry stands in for a fleet of senders, but downstream looks like a fleet — per-source dashboards work, alerts can target a single source, and ingest behaviour exercises real per-stream paths instead of one fat stream.
+
+### Worked example — 20 BGP peers from one scenario
+
+Say you want to test a Grafana dashboard that breaks down BGP neighbor state per peer, or an alert that fires when a *specific* peer flaps. You need 20 distinct log streams that share most of their labels but differ in `peer_address`. One scenario with a 20-element `values` list does it:
+
+```yaml title="examples/bgp-peer-logs.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 60s
+  encoder:
+    type: json_lines
+  sink:
+    type: loki
+    url: http://localhost:3100
+scenarios:
+  - id: srl1_bgp_logs
+    signal_type: logs
+    name: srl1_bgp_logs
+    labels:
+      device: srl1
+      vendor_facility_process: BGP
+    dynamic_labels:
+      - key: peer_address
+        values:
+          - "10.1.2.2"
+          - "10.1.7.2"
+          - "10.1.12.2"
+          - "10.1.17.2"
+          - "10.1.22.2"
+          # ... up to 20 peers
+    log_generator:
+      type: template
+      templates:
+        - message: "BGP neighbor {peer_address}: state changed to {state}"
+          field_pools:
+            peer_address: ["10.1.2.2", "10.1.7.2", "10.1.12.2", "10.1.17.2", "10.1.22.2"]
+            state: ["established", "active", "open-confirm", "idle"]
+```
+
+### What lands in Loki
+
+Loki sees one stream per peer. The label set on each stream is the merge of the scenario's `labels:` with the current `dynamic_labels` value:
+
+```
+{device="srl1", peer_address="10.1.2.2",  vendor_facility_process="BGP"}
+{device="srl1", peer_address="10.1.7.2",  vendor_facility_process="BGP"}
+{device="srl1", peer_address="10.1.12.2", vendor_facility_process="BGP"}
+...
+```
+
+In Grafana's stream selector you'll see 20 distinct streams under `device="srl1"`, one per peer address.
+
+### What queries become possible
+
+Because each peer is its own stream, all the usual LogQL shapes work against the dataset:
+
+```logql
+{peer_address="10.1.2.2"}
+```
+Returns every log line for one specific peer — useful for drilling into a single neighbor.
+
+```logql
+{device="srl1"} |= "established"
+```
+Returns establishment events across all peers on the device — useful for spotting the global pattern.
+
+```logql
+sum by (peer_address) (count_over_time({device="srl1"}[5m]))
+```
+Returns a per-peer event count over the last 5 minutes — the shape you'd graph as "which peers are noisiest right now".
+
+### Cardinality and the per-push cap
+
+Loki indexes by stream, and unique stream count is the dimension that drives ingester memory and index cost. Pushing too many distinct streams in a single request is the classic way to overload an ingester, so the Sonda Loki sink caps unique streams **per push** at `max_streams_per_push` (default `128`). A flush that would exceed the cap fails with a message naming the offending count and the cap.
+
+The cap is per-flush, not lifetime — a scenario that rotates through hundreds of values can still work if each flush stays under the cap (drop `batch_size` on the sink so each push carries fewer entries, hence fewer distinct streams).
+
+If your Loki ingester is sized for higher cardinality, raise the cap on the [Loki sink](../configuration/sinks.md#loki):
+
+```yaml
+sink:
+  type: loki
+  url: http://localhost:3100
+  max_streams_per_push: 512
+```
+
+### Stream-count preview when posting to `sonda-server`
+
+When you POST a scenario to `sonda-server`, the response includes a registration-time preview naming the predicted stream count and the active cap — so high-cardinality misconfigurations surface at submission time, not the first time a flush fails:
+
+```
+scenario entry 'srl1_bgp_logs' will produce up to 20 distinct Loki streams
+(dynamic_labels: peer_address). max_streams_per_push is 128.
+```
+
+See the [`dynamic_labels` field reference](../configuration/scenario-fields.md#dynamic-labels) for the full set of options on the rotating label itself.
+
 ## Runnable examples
 
 | File | Signal | Strategy | What to look for |

--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -213,7 +213,14 @@ JSON encoders pre-round the value before passing it to serde. Precision is valid
 4. Register in `src/sink/mod.rs` factory. The `create_sink()` function accepts an optional
    `labels: Option<&HashMap<String, String>>` parameter. Most sinks ignore this (pass `None`).
    The Loki sink uses it for stream labels, sourced from the scenario-level `labels` config.
-5. Test with a mock or in-memory buffer sink.
+5. **Override `write_log_event` when the sink consumes per-event context.** The default impl
+   discards the `&LogEvent` and forwards the encoded bytes to `write()`. If your sink uses any
+   per-event field (labels, severity, timestamp) for delivery routing — stream selection,
+   partition keys, structured envelopes — you MUST override `write_log_event`. Inheriting the
+   default silently drops that context at runtime and produces wrong output (see `sink/loki.rs`
+   for the in-tree example: it overrides to promote `LogEvent.labels` into the Loki stream
+   label set).
+6. Test with a mock or in-memory buffer sink.
 
 ## Performance Guidelines
 

--- a/sonda-core/src/emit.rs
+++ b/sonda-core/src/emit.rs
@@ -19,7 +19,7 @@ pub fn emit_log(
     let mut sink = create_sink(sink, labels)?;
     let mut buf: Vec<u8> = Vec::new();
     encoder.encode_log(event, &mut buf)?;
-    sink.write(&buf)?;
+    sink.write_log_event(event, &buf)?;
     sink.flush()
 }
 
@@ -161,6 +161,80 @@ mod tests {
         assert!(
             matches!(err, SondaError::Config(_)),
             "invalid retry config must surface as SondaError::Config, got: {err:?}"
+        );
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn emit_log_routes_event_labels_to_loki_sink_stream() {
+        use std::io::{BufRead, BufReader, Read, Write};
+        use std::net::{TcpListener, TcpStream};
+        use std::thread;
+
+        fn read_http_body(stream: &mut TcpStream) -> Vec<u8> {
+            let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+            let mut content_length: usize = 0;
+            loop {
+                let mut line = String::new();
+                reader.read_line(&mut line).expect("header line");
+                if line == "\r\n" || line.is_empty() {
+                    break;
+                }
+                let lower = line.to_lowercase();
+                if let Some(rest) = lower.strip_prefix("content-length:") {
+                    content_length = rest.trim().parse().unwrap_or(0);
+                }
+            }
+            let mut body = vec![0u8; content_length];
+            reader.read_exact(&mut body).expect("body");
+            body
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let url = format!("http://127.0.0.1:{port}");
+
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let body = read_http_body(&mut stream);
+            let resp = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            stream.write_all(resp.as_bytes()).ok();
+            body
+        });
+
+        let labels = Labels::from_pairs(&[("peer_address", "10.1.2.2")]).expect("labels");
+        let event = LogEvent::new(
+            Severity::Info,
+            "bgp event".to_string(),
+            labels,
+            BTreeMap::new(),
+        );
+
+        emit_log(
+            &event,
+            &EncoderConfig::JsonLines { precision: None },
+            &SinkConfig::Loki {
+                url,
+                batch_size: Some(1),
+                max_streams_per_push: None,
+                max_buffer_age: None,
+                retry: None,
+            },
+            None,
+        )
+        .expect("emit_log must succeed");
+
+        let body_bytes = handle.join().expect("mock server");
+        let body = String::from_utf8(body_bytes).expect("UTF-8");
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON envelope");
+
+        let stream_obj = parsed["streams"][0]["stream"]
+            .as_object()
+            .expect("stream object");
+        assert_eq!(
+            stream_obj.get("peer_address").and_then(|v| v.as_str()),
+            Some("10.1.2.2"),
+            "event labels must reach the Loki stream via write_log_event: {body}"
         );
     }
 

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -127,7 +127,7 @@ pub fn run_logs_with_sink_gated(
             buf.clear();
             encoder.encode_log(&event, &mut buf)?;
             let bytes_written = buf.len() as u64;
-            sink.write(&buf)?;
+            sink.write_log_event(&event, &buf)?;
             let delivered = sink.last_write_delivered();
 
             Ok(TickResult {

--- a/sonda-core/src/sink/loki.rs
+++ b/sonda-core/src/sink/loki.rs
@@ -1,80 +1,46 @@
-//! Loki sink — batches encoded log lines and delivers them to Grafana Loki via HTTP POST.
-//!
-//! The sink accumulates (timestamp, log_line) pairs in an internal batch. When the batch
-//! reaches the configured `batch_size`, or when `flush` is called explicitly, the batch
-//! is serialised into the Loki push API JSON envelope and sent as a single HTTP POST
-//! to `{url}/loki/api/v1/push`.
-//!
-//! The Loki push API format:
-//! ```json
-//! {
-//!   "streams": [{
-//!     "stream": { "label1": "value1" },
-//!     "values": [["<unix_nanoseconds>", "<log_line>"]]
-//!   }]
-//! }
-//! ```
+//! Loki sink — batches encoded log lines, groups by (constructor labels +
+//! per-event overlay), and POSTs as a multi-stream push envelope.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use crate::model::log::LogEvent;
 use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
 use crate::SondaError;
 
-/// Default batch size in entries — sized so low-rate scenarios flush within seconds.
 pub const DEFAULT_BATCH_SIZE: usize = 5;
 
-/// Delivers encoded log lines to Grafana Loki via its HTTP push API.
-///
-/// Log lines are accumulated in a batch. When the batch reaches `batch_size` entries,
-/// it is automatically flushed. Call `flush()` at shutdown to deliver any remaining
-/// buffered entries.
-///
-/// Each entry in the batch is a pair of `(unix_nanoseconds, log_line)` strings, which
-/// is the format required by the Loki push API.
+/// Default cap on unique streams per push. Above this, flushes error so
+/// high-cardinality `dynamic_labels` configurations surface as a config
+/// issue rather than a silent Loki melt.
+pub const DEFAULT_MAX_STREAMS_PER_PUSH: u32 = 128;
+
+struct LokiEntry {
+    timestamp_ns: String,
+    line: String,
+    overlay: BTreeMap<String, String>,
+}
+
 pub struct LokiSink {
-    /// The ureq HTTP agent used for all requests.
     client: ureq::Agent,
-    /// Base URL for the Loki instance, e.g. `"http://localhost:3100"`.
     url: String,
-    /// Stream labels sent with every batch, e.g. `{"job": "sonda", "env": "dev"}`.
     labels: HashMap<String, String>,
-    /// Flush threshold in entries. When `batch.len() == batch_size`, the batch is sent.
     batch_size: usize,
-    /// Accumulated entries waiting to be sent: `(unix_nanoseconds, log_line)`.
-    batch: Vec<(String, String)>,
-    /// Optional retry policy for transient failures.
+    max_streams_per_push: u32,
+    batch: Vec<LokiEntry>,
     retry_policy: Option<RetryPolicy>,
-    /// Maximum age a non-empty batch may reach before a time-based flush.
-    /// `Duration::ZERO` disables time-based flushing.
     max_buffer_age: Duration,
-    /// When the batch was last sent — drives the time-based flush check.
     last_flush_at: Instant,
-    /// Whether the most recent `write()` triggered a successful flush rather than only buffering.
     last_write_delivered: bool,
 }
 
 impl LokiSink {
-    /// Create a new `LokiSink`.
-    ///
-    /// # Arguments
-    ///
-    /// - `url` — the base URL of the Loki instance, e.g. `"http://localhost:3100"`.
-    ///   The push endpoint `/loki/api/v1/push` is appended automatically.
-    /// - `labels` — stream labels attached to every log batch.
-    /// - `batch_size` — number of log entries to accumulate before auto-flushing.
-    ///   Use `100` if no override is needed.
-    /// - `max_buffer_age` — maximum age a non-empty batch may reach before a
-    ///   time-based flush. `Duration::ZERO` disables time-based flushing.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if the URL scheme is invalid (not `http://` or `https://`).
     pub fn new(
         url: String,
         labels: HashMap<String, String>,
         batch_size: usize,
+        max_streams_per_push: u32,
         retry_policy: Option<RetryPolicy>,
         max_buffer_age: Duration,
     ) -> Result<Self, SondaError> {
@@ -95,6 +61,7 @@ impl LokiSink {
             url,
             labels,
             batch_size,
+            max_streams_per_push,
             batch: Vec::with_capacity(batch_size),
             retry_policy,
             max_buffer_age,
@@ -103,45 +70,81 @@ impl LokiSink {
         })
     }
 
-    /// Build the Loki push JSON envelope from the current batch.
-    ///
-    /// The format follows the Loki push API specification:
-    /// `{"streams": [{"stream": {...labels}, "values": [["<ns>", "<line>"], ...]}]}`
-    fn build_envelope(&self) -> String {
-        // Build the stream labels object.
-        let stream_labels = self
+    /// Overlay wins on key collision so `dynamic_labels` rotation can take
+    /// precedence over constructor labels.
+    fn combine_labels(&self, overlay: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+        let mut combined: BTreeMap<String, String> = self
             .labels
             .iter()
-            .map(|(k, v)| format!("\"{}\":\"{}\"", escape_json(k), escape_json(v)))
-            .collect::<Vec<_>>()
-            .join(",");
-
-        // Build the values array.
-        let values = self
-            .batch
-            .iter()
-            .map(|(ts, line)| format!("[\"{}\",\"{}\"]", ts, escape_json(line)))
-            .collect::<Vec<_>>()
-            .join(",");
-
-        format!(
-            "{{\"streams\":[{{\"stream\":{{{}}},\"values\":[{}]}}]}}",
-            stream_labels, values
-        )
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        for (k, v) in overlay {
+            combined.insert(k.clone(), v.clone());
+        }
+        combined
     }
 
-    /// POST the current batch to Loki and clear it.
-    ///
-    /// Uses the configured [`RetryPolicy`] for transient failures. When no
-    /// policy is configured, errors are returned immediately. The batch is
-    /// always cleared to prevent unbounded buffer growth.
+    fn group_by_labels(&self) -> BTreeMap<BTreeMap<String, String>, Vec<&LokiEntry>> {
+        let mut groups: BTreeMap<BTreeMap<String, String>, Vec<&LokiEntry>> = BTreeMap::new();
+        for entry in &self.batch {
+            let key = self.combine_labels(&entry.overlay);
+            groups.entry(key).or_default().push(entry);
+        }
+        groups
+    }
+
+    fn build_envelope(groups: &BTreeMap<BTreeMap<String, String>, Vec<&LokiEntry>>) -> String {
+        let streams = groups
+            .iter()
+            .map(|(labels, entries)| {
+                let stream_labels = labels
+                    .iter()
+                    .map(|(k, v)| format!("\"{}\":\"{}\"", escape_json(k), escape_json(v)))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let values = entries
+                    .iter()
+                    .map(|e| format!("[\"{}\",\"{}\"]", e.timestamp_ns, escape_json(&e.line)))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!(
+                    "{{\"stream\":{{{}}},\"values\":[{}]}}",
+                    stream_labels, values
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+
+        format!("{{\"streams\":[{}]}}", streams)
+    }
+
     fn flush_batch(&mut self) -> Result<(), SondaError> {
         if self.batch.is_empty() {
             return Ok(());
         }
 
+        // Scoped so `groups`' borrows into `self.batch` drop before we mutate
+        // other `self` fields below.
+        let body = {
+            let groups = self.group_by_labels();
+            let stream_count = groups.len();
+
+            if stream_count as u32 > self.max_streams_per_push {
+                let batch_len = self.batch.len();
+                let cap = self.max_streams_per_push;
+                drop(groups);
+                self.batch.clear();
+                self.last_flush_at = Instant::now();
+                return Err(SondaError::Sink(std::io::Error::other(format!(
+                    "loki sink: flush would produce {stream_count} streams from {batch_len} entries, \
+                     but max_streams_per_push is {cap}. Reduce dynamic_labels cardinality, \
+                     raise max_streams_per_push on the sink, or split into per-value scenarios."
+                ))));
+            }
+            Self::build_envelope(&groups)
+        };
+
         let push_url = format!("{}/loki/api/v1/push", self.url);
-        let body = self.build_envelope();
 
         // Reset on attempt, not success — the batch is cleared either way below.
         self.last_flush_at = Instant::now();
@@ -239,27 +242,57 @@ impl LokiSink {
 }
 
 impl Sink for LokiSink {
-    /// Append one encoded log line to the internal batch.
-    ///
-    /// The line is paired with the current wall-clock time as a Unix nanosecond
-    /// timestamp string. When the batch reaches `batch_size` entries, the batch
-    /// is automatically flushed to Loki.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if an auto-flush fails.
     fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         let ts_ns = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos()
             .to_string();
+        self.push_entry(ts_ns, data, BTreeMap::new())
+    }
 
+    fn write_log_event(&mut self, event: &LogEvent, encoded: &[u8]) -> Result<(), SondaError> {
+        // Prefer event-time over wall-clock — meaningful for log-replay
+        // scenarios where the generator sets a deterministic timestamp.
+        let ts_ns = event
+            .timestamp
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+            .to_string();
+        let overlay: BTreeMap<String, String> = event
+            .labels
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        self.push_entry(ts_ns, encoded, overlay)
+    }
+
+    fn flush(&mut self) -> Result<(), SondaError> {
+        self.flush_batch()
+    }
+
+    fn last_write_delivered(&self) -> bool {
+        self.last_write_delivered
+    }
+}
+
+impl LokiSink {
+    fn push_entry(
+        &mut self,
+        timestamp_ns: String,
+        data: &[u8],
+        overlay: BTreeMap<String, String>,
+    ) -> Result<(), SondaError> {
         // Strip any trailing newline so log lines are clean in the Loki UI.
         let line = String::from_utf8_lossy(data);
         let line = line.trim_end_matches('\n').to_string();
 
-        self.batch.push((ts_ns, line));
+        self.batch.push(LokiEntry {
+            timestamp_ns,
+            line,
+            overlay,
+        });
 
         let size_reached = self.batch.len() >= self.batch_size;
         let age_reached =
@@ -271,21 +304,6 @@ impl Sink for LokiSink {
         self.last_write_delivered = should_flush;
 
         Ok(())
-    }
-
-    /// Flush any remaining buffered entries to Loki.
-    ///
-    /// Safe to call multiple times. Returns `Ok(())` immediately if the batch is empty.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if the HTTP request fails.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.flush_batch()
-    }
-
-    fn last_write_delivered(&self) -> bool {
-        self.last_write_delivered
     }
 }
 
@@ -356,6 +374,7 @@ mod tests {
             "http://localhost:3100".to_string(),
             HashMap::new(),
             100,
+            u32::MAX,
             None,
             Duration::ZERO,
         );
@@ -368,6 +387,7 @@ mod tests {
             "https://loki.example.com".to_string(),
             HashMap::new(),
             100,
+            u32::MAX,
             None,
             Duration::ZERO,
         );
@@ -380,6 +400,7 @@ mod tests {
             "ftp://loki.example.com".to_string(),
             HashMap::new(),
             100,
+            u32::MAX,
             None,
             Duration::ZERO,
         );
@@ -396,6 +417,7 @@ mod tests {
             "loki.example.com".to_string(),
             HashMap::new(),
             100,
+            u32::MAX,
             None,
             Duration::ZERO,
         );
@@ -404,7 +426,14 @@ mod tests {
 
     #[test]
     fn new_with_empty_url_returns_sink_error() {
-        let result = LokiSink::new(String::new(), HashMap::new(), 100, None, Duration::ZERO);
+        let result = LokiSink::new(
+            String::new(),
+            HashMap::new(),
+            100,
+            u32::MAX,
+            None,
+            Duration::ZERO,
+        );
         assert!(result.is_err(), "empty URL must be rejected");
     }
 
@@ -415,6 +444,7 @@ mod tests {
             bad_url.to_string(),
             HashMap::new(),
             100,
+            u32::MAX,
             None,
             Duration::ZERO,
         );
@@ -440,8 +470,8 @@ mod tests {
         let mut labels = HashMap::new();
         labels.insert("job".to_string(), "sonda".to_string());
 
-        let mut sink =
-            LokiSink::new(url, labels, 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
         sink.write(b"hello loki\n").expect("write");
         sink.flush().expect("flush");
 
@@ -500,8 +530,8 @@ mod tests {
         labels.insert("job".to_string(), "sonda".to_string());
         labels.insert("env".to_string(), "dev".to_string());
 
-        let mut sink =
-            LokiSink::new(url, labels, 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
         sink.write(b"test\n").expect("write");
         sink.flush().expect("flush");
 
@@ -527,8 +557,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
         sink.write(b"line\n").expect("write");
         sink.flush().expect("flush");
 
@@ -551,8 +581,8 @@ mod tests {
     fn write_below_batch_size_does_not_trigger_http_call() {
         let (listener, url) = mock_loki_listener();
 
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 50, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 50, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
 
         // Write 49 lines — one short of the 50-entry threshold.
         for i in 0..49 {
@@ -574,8 +604,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 50, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 50, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
 
         // Write exactly 50 lines → must trigger an auto-flush.
         for i in 0..50 {
@@ -603,8 +633,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
 
         // Write only 3 lines (far below batch_size of 100).
         sink.write(b"alpha\n").expect("write 1");
@@ -627,8 +657,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
         sink.write(b"once\n").expect("write");
         sink.flush().expect("first flush sends data");
         let _body = handle.join().expect("mock server thread panicked");
@@ -649,8 +679,8 @@ mod tests {
         drop(listener);
 
         let url = format!("http://127.0.0.1:{port}");
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
 
         // Empty batch — must return Ok without any network I/O.
         assert!(
@@ -667,8 +697,8 @@ mod tests {
     fn last_write_delivered_is_false_when_write_only_buffers() {
         let (listener, url) = mock_loki_listener();
 
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
         sink.write(b"buffered\n").expect("write buffers");
 
         assert!(
@@ -684,8 +714,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 1, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 1, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
         sink.write(b"flushed\n").expect("write triggers flush");
 
         handle.join().expect("mock server thread panicked");
@@ -704,8 +734,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
         sink.write(b"my log line\n").expect("write with newline");
         sink.flush().expect("flush");
 
@@ -731,8 +761,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 500));
 
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
         sink.write(b"line\n").expect("write buffered");
         let result = sink.flush();
         handle.join().expect("mock server thread panicked");
@@ -749,8 +779,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 400));
 
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
         sink.write(b"line\n").expect("write buffered");
         let result = sink.flush();
         handle.join().expect("mock server thread panicked");
@@ -769,8 +799,8 @@ mod tests {
         drop(listener);
 
         let url = format!("http://127.0.0.1:{port}");
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
         sink.write(b"line\n").expect("write buffered");
         let result = sink.flush();
 
@@ -790,8 +820,8 @@ mod tests {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
         // A log line containing a JSON double-quote character.
         sink.write(b"msg=\"hello world\"").expect("write");
         sink.flush().expect("flush");
@@ -815,8 +845,8 @@ mod tests {
         let mut labels = HashMap::new();
         labels.insert("app".to_string(), r#"my "special" app"#.to_string());
 
-        let mut sink =
-            LokiSink::new(url, labels, 100, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
         sink.write(b"line\n").expect("write");
         sink.flush().expect("flush");
 
@@ -845,8 +875,8 @@ mod tests {
             (first, second)
         });
 
-        let mut sink =
-            LokiSink::new(url, HashMap::new(), 2, None, Duration::ZERO).expect("construct sink");
+        let mut sink = LokiSink::new(url, HashMap::new(), 2, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
 
         // First batch: lines 0-1 → triggers auto-flush at batch_size=2.
         sink.write(b"line 0\n").expect("write 0");
@@ -887,8 +917,15 @@ mod tests {
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
         // batch_size large enough that size never triggers; short max_buffer_age.
-        let mut sink = LokiSink::new(url, HashMap::new(), 10_000, None, Duration::from_millis(50))
-            .expect("construct sink");
+        let mut sink = LokiSink::new(
+            url,
+            HashMap::new(),
+            10_000,
+            u32::MAX,
+            None,
+            Duration::from_millis(50),
+        )
+        .expect("construct sink");
 
         sink.write(b"first\n").expect("write 1");
         thread::sleep(Duration::from_millis(200));
@@ -912,7 +949,7 @@ mod tests {
     fn zero_max_buffer_age_disables_time_based_flush() {
         let (listener, url) = mock_loki_listener();
 
-        let mut sink = LokiSink::new(url, HashMap::new(), 10_000, None, Duration::ZERO)
+        let mut sink = LokiSink::new(url, HashMap::new(), 10_000, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
 
         sink.write(b"first\n").expect("write 1");
@@ -933,8 +970,15 @@ mod tests {
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
         // Small batch_size, max_buffer_age comfortably longer than the test runs.
-        let mut sink = LokiSink::new(url, HashMap::new(), 2, None, Duration::from_secs(60))
-            .expect("construct sink");
+        let mut sink = LokiSink::new(
+            url,
+            HashMap::new(),
+            2,
+            u32::MAX,
+            None,
+            Duration::from_secs(60),
+        )
+        .expect("construct sink");
 
         // Fill the batch immediately — the size trigger fires.
         sink.write(b"a\n").expect("write 1");
@@ -1052,6 +1096,7 @@ max_buffer_age: 10s
         let config = SinkConfig::Loki {
             url: "http://localhost:3100".to_string(),
             batch_size: None,
+            max_streams_per_push: None,
             max_buffer_age: None,
             retry: None,
         };
@@ -1066,6 +1111,7 @@ max_buffer_age: 10s
         let config = SinkConfig::Loki {
             url: "http://localhost:3100".to_string(),
             batch_size: None,
+            max_streams_per_push: None,
             max_buffer_age: Some("garbage".to_string()),
             retry: None,
         };
@@ -1084,6 +1130,7 @@ max_buffer_age: 10s
         let config = SinkConfig::Loki {
             url,
             batch_size: None,
+            max_streams_per_push: None,
             max_buffer_age: None,
             retry: None,
         };
@@ -1112,6 +1159,7 @@ max_buffer_age: 10s
         let config = SinkConfig::Loki {
             url,
             batch_size: None,
+            max_streams_per_push: None,
             max_buffer_age: None,
             retry: None,
         };
@@ -1148,6 +1196,7 @@ max_buffer_age: 10s
         let config = SinkConfig::Loki {
             url,
             batch_size: None,
+            max_streams_per_push: None,
             max_buffer_age: None,
             retry: None,
         };
@@ -1164,6 +1213,7 @@ max_buffer_age: 10s
         let config = SinkConfig::Loki {
             url: "not-http://bad".to_string(),
             batch_size: None,
+            max_streams_per_push: None,
             max_buffer_age: None,
             retry: None,
         };
@@ -1234,6 +1284,216 @@ sink:
             }
             other => panic!("expected Loki sink, got {other:?}"),
         }
+    }
+
+    fn make_log_event(labels: &[(&str, &str)], message: &str) -> crate::model::log::LogEvent {
+        use crate::model::log::{LogEvent, Severity};
+        use crate::model::metric::Labels;
+        use std::collections::BTreeMap;
+        use std::time::SystemTime;
+
+        let labels = Labels::from_pairs(labels).expect("valid label pairs");
+        LogEvent::with_timestamp(
+            SystemTime::UNIX_EPOCH,
+            Severity::Info,
+            message.to_string(),
+            labels,
+            BTreeMap::new(),
+        )
+    }
+
+    fn parse_streams(body: Vec<u8>) -> Vec<serde_json::Value> {
+        let body = String::from_utf8(body).expect("UTF-8");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&body).expect("envelope must be valid JSON");
+        parsed["streams"]
+            .as_array()
+            .expect("'streams' must be an array")
+            .clone()
+    }
+
+    #[test]
+    fn write_log_event_single_stream_when_no_per_event_labels() {
+        let (listener, url) = mock_loki_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
+
+        let mut labels = HashMap::new();
+        labels.insert("job".to_string(), "sonda".to_string());
+
+        let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
+        let event = make_log_event(&[], "hello");
+        sink.write_log_event(&event, b"hello").expect("write");
+        sink.flush().expect("flush");
+
+        let streams = parse_streams(handle.join().expect("mock server"));
+        assert_eq!(streams.len(), 1, "no overlay → exactly one stream");
+        let stream_obj = streams[0]["stream"].as_object().expect("stream object");
+        assert_eq!(stream_obj.len(), 1, "only the constructor label is present");
+        assert_eq!(stream_obj["job"].as_str(), Some("sonda"));
+    }
+
+    #[test]
+    fn write_log_event_multi_stream_grouping_by_event_labels() {
+        let (listener, url) = mock_loki_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
+
+        let mut labels = HashMap::new();
+        labels.insert("device".to_string(), "srl1".to_string());
+
+        let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
+
+        let ev1 = make_log_event(&[("peer_address", "10.1.2.2")], "to peer 1");
+        let ev2 = make_log_event(&[("peer_address", "10.1.7.2")], "to peer 2");
+        let ev1b = make_log_event(&[("peer_address", "10.1.2.2")], "to peer 1 again");
+        sink.write_log_event(&ev1, b"line-a").expect("write 1");
+        sink.write_log_event(&ev2, b"line-b").expect("write 2");
+        sink.write_log_event(&ev1b, b"line-c").expect("write 3");
+        sink.flush().expect("flush");
+
+        let streams = parse_streams(handle.join().expect("mock server"));
+        assert_eq!(
+            streams.len(),
+            2,
+            "two distinct peer_address values must produce two streams"
+        );
+
+        let mut by_peer: std::collections::HashMap<String, usize> = Default::default();
+        for s in &streams {
+            let peer = s["stream"]["peer_address"]
+                .as_str()
+                .expect("peer_address must be a stream label")
+                .to_string();
+            let values_len = s["values"].as_array().expect("values must be array").len();
+            by_peer.insert(peer, values_len);
+            assert_eq!(
+                s["stream"]["device"].as_str(),
+                Some("srl1"),
+                "constructor labels must appear in every stream"
+            );
+        }
+        assert_eq!(by_peer.get("10.1.2.2"), Some(&2), "ev1 + ev1b group");
+        assert_eq!(by_peer.get("10.1.7.2"), Some(&1), "ev2 alone");
+    }
+
+    #[test]
+    fn write_log_event_overlay_overrides_constructor_label_on_conflict() {
+        let (listener, url) = mock_loki_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
+
+        let mut labels = HashMap::new();
+        labels.insert("device".to_string(), "srl1".to_string());
+        labels.insert("region".to_string(), "us-east".to_string());
+
+        let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
+        let event = make_log_event(&[("region", "eu-west")], "overridden");
+        sink.write_log_event(&event, b"line").expect("write");
+        sink.flush().expect("flush");
+
+        let streams = parse_streams(handle.join().expect("mock server"));
+        assert_eq!(streams.len(), 1);
+        let stream_obj = streams[0]["stream"].as_object().expect("stream object");
+        assert_eq!(
+            stream_obj["region"].as_str(),
+            Some("eu-west"),
+            "event overlay must win on key collision with constructor labels"
+        );
+        assert_eq!(
+            stream_obj["device"].as_str(),
+            Some("srl1"),
+            "non-conflicting constructor labels must still pass through"
+        );
+    }
+
+    #[test]
+    fn flush_with_stream_count_at_cap_succeeds() {
+        let (listener, url) = mock_loki_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
+
+        let mut sink = LokiSink::new(url, HashMap::new(), 100, 3, None, Duration::ZERO)
+            .expect("construct sink");
+        for i in 0..3 {
+            let ev = make_log_event(&[("peer", &format!("p{i}"))], "line");
+            sink.write_log_event(&ev, format!("line-{i}").as_bytes())
+                .expect("write");
+        }
+        let flush_result = sink.flush();
+        assert!(
+            flush_result.is_ok(),
+            "exactly-at-cap must succeed: {flush_result:?}"
+        );
+
+        let streams = parse_streams(handle.join().expect("mock server"));
+        assert_eq!(streams.len(), 3, "all three streams must be sent");
+    }
+
+    #[test]
+    fn flush_exceeding_cap_returns_helpful_error_and_clears_batch() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        drop(listener);
+        let url = format!("http://127.0.0.1:{port}");
+
+        let mut sink = LokiSink::new(url, HashMap::new(), 100, 2, None, Duration::ZERO)
+            .expect("construct sink");
+        for i in 0..3 {
+            let ev = make_log_event(&[("peer", &format!("p{i}"))], "line");
+            sink.write_log_event(&ev, format!("line-{i}").as_bytes())
+                .expect("write");
+        }
+        let err = sink.flush().expect_err("over-cap flush must Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("3 streams"),
+            "must report the actual count: {msg}"
+        );
+        assert!(
+            msg.contains("max_streams_per_push is 2"),
+            "must report the cap: {msg}"
+        );
+        assert!(
+            msg.contains("dynamic_labels") || msg.contains("per-value scenarios"),
+            "must point at the workaround: {msg}"
+        );
+
+        assert!(
+            sink.flush().is_ok(),
+            "batch must be cleared after cap error"
+        );
+    }
+
+    #[test]
+    fn direct_write_falls_back_to_constructor_labels_only() {
+        let (listener, url) = mock_loki_listener();
+        let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
+
+        let mut labels = HashMap::new();
+        labels.insert("job".to_string(), "sonda".to_string());
+
+        let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
+            .expect("construct sink");
+        sink.write(b"line via direct write").expect("write");
+        sink.write(b"another line via direct write").expect("write");
+        sink.flush().expect("flush");
+
+        let streams = parse_streams(handle.join().expect("mock server"));
+        assert_eq!(streams.len(), 1, "direct write produces a single stream");
+        assert_eq!(
+            streams[0]["stream"]
+                .as_object()
+                .expect("stream object")
+                .len(),
+            1,
+            "only the constructor label is present"
+        );
+        assert_eq!(streams[0]["stream"]["job"].as_str(), Some("sonda"));
+        assert_eq!(
+            streams[0]["values"].as_array().expect("values").len(),
+            2,
+            "both direct writes group into the single stream"
+        );
     }
 }
 

--- a/sonda-core/src/sink/loki.rs
+++ b/sonda-core/src/sink/loki.rs
@@ -70,38 +70,24 @@ impl LokiSink {
         })
     }
 
-    /// Overlay wins on key collision so `dynamic_labels` rotation can take
-    /// precedence over constructor labels.
-    fn combine_labels(&self, overlay: &BTreeMap<String, String>) -> BTreeMap<String, String> {
-        let mut combined: BTreeMap<String, String> = self
-            .labels
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-        for (k, v) in overlay {
-            combined.insert(k.clone(), v.clone());
-        }
-        combined
-    }
-
-    fn group_by_labels(&self) -> BTreeMap<BTreeMap<String, String>, Vec<&LokiEntry>> {
-        let mut groups: BTreeMap<BTreeMap<String, String>, Vec<&LokiEntry>> = BTreeMap::new();
+    fn group_by_overlay(&self) -> BTreeMap<&BTreeMap<String, String>, Vec<&LokiEntry>> {
+        let mut groups: BTreeMap<&BTreeMap<String, String>, Vec<&LokiEntry>> = BTreeMap::new();
         for entry in &self.batch {
-            let key = self.combine_labels(&entry.overlay);
-            groups.entry(key).or_default().push(entry);
+            // TODO(perf): LogEvent.labels could be Arc<Labels> so the overlay
+            // doesn't allocate per event; deferred from 1.9.4 scope.
+            groups.entry(&entry.overlay).or_default().push(entry);
         }
         groups
     }
 
-    fn build_envelope(groups: &BTreeMap<BTreeMap<String, String>, Vec<&LokiEntry>>) -> String {
+    fn build_envelope(
+        &self,
+        groups: &BTreeMap<&BTreeMap<String, String>, Vec<&LokiEntry>>,
+    ) -> String {
         let streams = groups
             .iter()
-            .map(|(labels, entries)| {
-                let stream_labels = labels
-                    .iter()
-                    .map(|(k, v)| format!("\"{}\":\"{}\"", escape_json(k), escape_json(v)))
-                    .collect::<Vec<_>>()
-                    .join(",");
+            .map(|(overlay, entries)| {
+                let stream_labels = self.format_stream_labels(overlay);
                 let values = entries
                     .iter()
                     .map(|e| format!("[\"{}\",\"{}\"]", e.timestamp_ns, escape_json(&e.line)))
@@ -118,6 +104,25 @@ impl LokiSink {
         format!("{{\"streams\":[{}]}}", streams)
     }
 
+    /// Merge constructor labels with the per-group overlay and emit them as
+    /// sorted JSON object members. Overlay wins on key collision so
+    /// `dynamic_labels` rotation can take precedence over constructor labels.
+    fn format_stream_labels(&self, overlay: &BTreeMap<String, String>) -> String {
+        let mut combined: BTreeMap<&str, &str> = self
+            .labels
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        for (k, v) in overlay {
+            combined.insert(k.as_str(), v.as_str());
+        }
+        combined
+            .iter()
+            .map(|(k, v)| format!("\"{}\":\"{}\"", escape_json(k), escape_json(v)))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
     fn flush_batch(&mut self) -> Result<(), SondaError> {
         if self.batch.is_empty() {
             return Ok(());
@@ -126,7 +131,7 @@ impl LokiSink {
         // Scoped so `groups`' borrows into `self.batch` drop before we mutate
         // other `self` fields below.
         let body = {
-            let groups = self.group_by_labels();
+            let groups = self.group_by_overlay();
             let stream_count = groups.len();
 
             if stream_count as u32 > self.max_streams_per_push {
@@ -141,7 +146,7 @@ impl LokiSink {
                      raise max_streams_per_push on the sink, or split into per-value scenarios."
                 ))));
             }
-            Self::build_envelope(&groups)
+            self.build_envelope(&groups)
         };
 
         let push_url = format!("{}/loki/api/v1/push", self.url);

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -23,6 +23,7 @@ pub mod udp;
 use std::collections::HashMap;
 use std::path::Path;
 
+use crate::model::log::LogEvent;
 use crate::SondaError;
 
 /// A sink consumes encoded bytes and delivers them to a destination.
@@ -39,6 +40,17 @@ pub trait Sink: Send + Sync {
     /// when the most recent `write()` triggered a successful flush.
     fn last_write_delivered(&self) -> bool {
         true
+    }
+
+    /// Write an encoded log event to the sink, with the originating
+    /// [`LogEvent`] alongside for sinks that build their own delivery
+    /// envelope from per-event context (e.g. labels).
+    ///
+    /// The default impl ignores the event reference and forwards to
+    /// [`Sink::write`], preserving the bytes-only contract every existing
+    /// sink relies on. Sinks that need per-event labels override this.
+    fn write_log_event(&mut self, _event: &LogEvent, encoded: &[u8]) -> Result<(), SondaError> {
+        self.write(encoded)
     }
 }
 
@@ -1348,6 +1360,42 @@ retry:
         assert!(
             msg.contains("cargo build -F remote-write"),
             "error must tell the user how to enable the feature, got: {msg}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Default `write_log_event` impl on the Sink trait forwards to `write`.
+    // Sinks that don't override the new method (every sink today except Loki in
+    // PR 2) must keep behaving exactly as they did before this PR landed.
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn default_write_log_event_forwards_encoded_bytes_to_write() {
+        use crate::model::log::{LogEvent, Severity};
+        use crate::model::metric::Labels;
+        use memory::MemorySink;
+        use std::collections::BTreeMap;
+        use std::time::SystemTime;
+
+        let mut sink = MemorySink::new();
+        let event = LogEvent::with_timestamp(
+            SystemTime::UNIX_EPOCH,
+            Severity::Info,
+            "hello".to_string(),
+            Labels::default(),
+            BTreeMap::new(),
+        );
+        let encoded = b"<encoded payload>";
+
+        // MemorySink does not override `write_log_event`, so the call must
+        // route through the default impl and end up appended to `buffer`
+        // exactly as `write(encoded)` would.
+        sink.write_log_event(&event, encoded)
+            .expect("default write_log_event must succeed");
+
+        assert_eq!(
+            sink.buffer, encoded,
+            "default impl must forward the encoded bytes to write() unchanged"
         );
     }
 

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -290,26 +290,23 @@ pub enum SinkConfig {
     KafkaDisabled {},
 
     /// Batch encoded log lines and deliver them to Grafana Loki via HTTP POST.
-    ///
-    /// Each call to `write()` appends one log line to the batch. When the batch
-    /// reaches `batch_size` entries, it is automatically flushed as a single POST
-    /// to `{url}/loki/api/v1/push`. Call `flush()` at shutdown to send any
-    /// remaining buffered entries.
-    ///
-    /// Stream labels are sourced from the scenario-level `labels` configuration
-    /// and passed to [`create_sink()`] via the `labels` parameter, keeping label
-    /// config consistent with all other signal types.
-    ///
-    /// Requires the `http` Cargo feature to be enabled.
+    /// Entries are grouped by combined label set (constructor labels + per-event
+    /// overlay from `dynamic_labels`) into one stream per unique combination.
+    /// Requires the `http` Cargo feature.
     #[cfg(feature = "http")]
     #[cfg_attr(feature = "config", serde(rename = "loki"))]
     Loki {
         /// Base URL of the Loki instance, e.g. `"http://localhost:3100"`.
         url: String,
 
-        /// Flush threshold in log entries. Defaults to `100` if not specified.
+        /// Flush threshold in log entries.
         #[cfg_attr(feature = "config", serde(default))]
         batch_size: Option<usize>,
+
+        /// Hard cap on unique streams per push. Defaults to
+        /// [`DEFAULT_MAX_STREAMS_PER_PUSH`](loki::DEFAULT_MAX_STREAMS_PER_PUSH).
+        #[cfg_attr(feature = "config", serde(default))]
+        max_streams_per_push: Option<u32>,
 
         /// Maximum batch age before a time-based flush, e.g. `"5s"`. Defaults
         /// to `"5s"`; a zero value (e.g. `"0s"`) disables time-based flushing.
@@ -478,10 +475,12 @@ pub fn create_sink(
         SinkConfig::Loki {
             url,
             batch_size,
+            max_streams_per_push,
             max_buffer_age,
             retry: retry_cfg,
         } => {
             let bs = batch_size.unwrap_or(loki::DEFAULT_BATCH_SIZE);
+            let cap = max_streams_per_push.unwrap_or(loki::DEFAULT_MAX_STREAMS_PER_PUSH);
             let loki_labels = labels.cloned().unwrap_or_default();
             let rp = retry_cfg
                 .as_ref()
@@ -496,6 +495,7 @@ pub fn create_sink(
                 url.clone(),
                 loki_labels,
                 bs,
+                cap,
                 rp,
                 buffer_age,
             )?))
@@ -1134,6 +1134,7 @@ headers: {}
         let config = SinkConfig::Loki {
             url: "http://127.0.0.1:19999".to_string(),
             batch_size: None,
+            max_streams_per_push: None,
             max_buffer_age: None,
             retry: None,
         };

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -1364,12 +1364,6 @@ retry:
         );
     }
 
-    // ---------------------------------------------------------------------------
-    // Default `write_log_event` impl on the Sink trait forwards to `write`.
-    // Sinks that don't override the new method (every sink today except Loki in
-    // PR 2) must keep behaving exactly as they did before this PR landed.
-    // ---------------------------------------------------------------------------
-
     #[test]
     fn default_write_log_event_forwards_encoded_bytes_to_write() {
         use crate::model::log::{LogEvent, Severity};

--- a/sonda-core/tests/sink_error_policy.rs
+++ b/sonda-core/tests/sink_error_policy.rs
@@ -117,6 +117,7 @@ fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
         SinkConfig::Loki {
             url,
             batch_size: Some(5),
+            max_streams_per_push: None,
             max_buffer_age: Some("0s".to_string()),
             retry: None,
         },
@@ -180,6 +181,7 @@ fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
         SinkConfig::Loki {
             url: dead_url,
             batch_size: Some(500),
+            max_streams_per_push: None,
             max_buffer_age: Some("250ms".to_string()),
             retry: None,
         },
@@ -228,6 +230,7 @@ fn fail_policy_exits_thread_with_sink_error() {
         SinkConfig::Loki {
             url,
             batch_size: Some(5),
+            max_streams_per_push: None,
             max_buffer_age: Some("0s".to_string()),
             retry: None,
         },

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -40,7 +40,9 @@ use sonda_core::config::ScenarioEntry;
 use sonda_core::schedule::launch::prepare_entries;
 use sonda_core::schedule::multi_runner::launch_multi_compiled;
 
-use crate::routes::sink_warnings::{log_warnings, sink_loopback_warnings};
+use crate::routes::sink_warnings::{
+    log_warnings, loki_cardinality_warnings, sink_loopback_warnings,
+};
 use crate::state::AppState;
 
 // ---- Response types ---------------------------------------------------------
@@ -485,7 +487,8 @@ pub async fn post_scenario(
         unprocessable(e)
     })?;
     let warning_entries: Vec<ScenarioEntry> = prepared.into_iter().map(|p| p.entry).collect();
-    let warnings = sink_loopback_warnings(&warning_entries);
+    let mut warnings = sink_loopback_warnings(&warning_entries);
+    warnings.extend(loki_cardinality_warnings(&warning_entries));
     log_warnings("POST /scenarios", &warnings);
     drop(warning_entries);
 

--- a/sonda-server/src/routes/sink_warnings.rs
+++ b/sonda-server/src/routes/sink_warnings.rs
@@ -171,6 +171,8 @@ pub(crate) fn loki_cardinality_warnings(entries: &[ScenarioEntry]) -> Vec<String
     warnings
 }
 
+const PREVIEW_OVERFLOW_THRESHOLD: u64 = 1_000_000;
+
 fn preview_loki_cardinality(
     sink: &SinkConfig,
     entry_name: &str,
@@ -185,33 +187,50 @@ fn preview_loki_cardinality(
             let cap = max_streams_per_push
                 .unwrap_or(sonda_core::sink::loki::DEFAULT_MAX_STREAMS_PER_PUSH);
             let predicted = predicted_loki_stream_count(dyn_labels);
+            let over_cap = match predicted {
+                None => true,
+                Some(n) => n > u64::from(cap),
+            };
+            if !over_cap {
+                return None;
+            }
             let keys: Vec<&str> = dyn_labels.iter().map(|dl| dl.key.as_str()).collect();
+            let count_phrase = match predicted {
+                Some(n) => format!("up to {n} distinct"),
+                None => format!("more than {PREVIEW_OVERFLOW_THRESHOLD} distinct"),
+            };
             Some(format!(
-                "scenario entry '{entry_name}' will produce up to {predicted} distinct \
-                 Loki streams (dynamic_labels: {}). max_streams_per_push is {cap}.",
-                keys.join(", ")
+                "scenario entry '{entry_name}' will produce {count_phrase} \
+                 Loki streams (dynamic_labels: {keys}), exceeding max_streams_per_push ({cap}). \
+                 Either raise max_streams_per_push, reduce dynamic_labels cardinality, \
+                 or reduce batch_size so each flush stays under the cap.",
+                keys = keys.join(", ")
             ))
         }
         _ => None,
     }
 }
 
-fn predicted_loki_stream_count(dyn_labels: &[DynamicLabelConfig]) -> u64 {
-    dyn_labels
-        .iter()
-        .map(|dl| match &dl.strategy {
+fn predicted_loki_stream_count(dyn_labels: &[DynamicLabelConfig]) -> Option<u64> {
+    let mut acc: u64 = 1;
+    for dl in dyn_labels {
+        let n = match &dl.strategy {
             DynamicLabelStrategy::Counter { cardinality, .. } => *cardinality,
             DynamicLabelStrategy::ValuesList { values } => values.len() as u64,
-        })
-        .fold(1u64, lcm)
+        };
+        acc = checked_lcm(acc, n)?;
+        if acc > PREVIEW_OVERFLOW_THRESHOLD {
+            return None;
+        }
+    }
+    Some(acc)
 }
 
-fn lcm(a: u64, b: u64) -> u64 {
+fn checked_lcm(a: u64, b: u64) -> Option<u64> {
     if a == 0 || b == 0 {
-        0
-    } else {
-        a / gcd(a, b) * b
+        return Some(0);
     }
+    a.checked_div(gcd(a, b))?.checked_mul(b)
 }
 
 fn gcd(a: u64, b: u64) -> u64 {
@@ -473,9 +492,10 @@ mod tests {
 
     #[cfg(feature = "http")]
     #[test]
-    fn loki_cardinality_warning_fires_for_logs_loki_dynamic_labels() {
+    fn loki_cardinality_warning_fires_when_predicted_exceeds_cap() {
         let entry = compile_logs_entry(
             "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20\x20\x20max_streams_per_push: 1\n\
              \x20\x20\x20\x20dynamic_labels:\n      - key: peer_address\n\
              \x20\x20\x20\x20\x20\x20\x20\x20values: [\"10.1.2.2\", \"10.1.7.2\"]\n\
              \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
@@ -486,12 +506,30 @@ mod tests {
         assert!(out[0].contains("card_test"));
         assert!(out[0].contains("peer_address"));
         assert!(out[0].contains("up to 2 distinct"));
-        assert!(out[0].contains("max_streams_per_push is 128"));
+        assert!(out[0].contains("max_streams_per_push (1)"));
+        assert!(out[0].contains("exceeding"));
     }
 
     #[cfg(feature = "http")]
     #[test]
-    fn loki_cardinality_warning_uses_explicit_cap() {
+    fn loki_cardinality_warning_silent_when_default_cap_dominates() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: peer_address\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"10.1.2.2\", \"10.1.7.2\"]\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert!(
+            out.is_empty(),
+            "predicted (2) ≤ default cap (128) must not fire: {out:?}"
+        );
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_silent_when_explicit_cap_dominates() {
         let entry = compile_logs_entry(
             "    sink:\n      type: loki\n      url: http://loki:3100\n\
              \x20\x20\x20\x20\x20\x20max_streams_per_push: 32\n\
@@ -501,9 +539,27 @@ mod tests {
              \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
         );
         let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert!(
+            out.is_empty(),
+            "predicted (3) ≤ explicit cap (32) must not fire: {out:?}"
+        );
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_fires_when_explicit_cap_undershoots() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20\x20\x20max_streams_per_push: 2\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: peer_address\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"a\", \"b\", \"c\"]\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
         assert_eq!(out.len(), 1);
-        assert!(out[0].contains("max_streams_per_push is 32"));
-        assert!(out[0].contains("up to 3"));
+        assert!(out[0].contains("max_streams_per_push (2)"));
+        assert!(out[0].contains("up to 3 distinct"));
     }
 
     #[cfg(feature = "http")]
@@ -511,6 +567,7 @@ mod tests {
     fn loki_cardinality_warning_uses_lcm_for_multiple_dynamic_labels() {
         let entry = compile_logs_entry(
             "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20\x20\x20max_streams_per_push: 5\n\
              \x20\x20\x20\x20dynamic_labels:\n      - key: peer\n\
              \x20\x20\x20\x20\x20\x20\x20\x20values: [\"a\", \"b\", \"c\"]\n\
              \x20\x20\x20\x20\x20\x20- key: pod\n\
@@ -521,6 +578,62 @@ mod tests {
         let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
         assert_eq!(out.len(), 1);
         assert!(out[0].contains("up to 6 distinct"), "got: {}", out[0]);
+        assert!(out[0].contains("max_streams_per_push (5)"));
+    }
+
+    #[test]
+    fn predicted_loki_stream_count_saturates_on_overflow() {
+        let dyn_labels = vec![
+            DynamicLabelConfig {
+                key: "a".to_string(),
+                strategy: DynamicLabelStrategy::Counter {
+                    prefix: None,
+                    cardinality: u64::MAX,
+                },
+            },
+            DynamicLabelConfig {
+                key: "b".to_string(),
+                strategy: DynamicLabelStrategy::Counter {
+                    prefix: None,
+                    cardinality: 7,
+                },
+            },
+        ];
+        assert_eq!(predicted_loki_stream_count(&dyn_labels), None);
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_reports_saturation_phrase_on_overflow() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20\x20\x20max_streams_per_push: 1\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: a\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20cardinality: 18446744073709551615\n\
+             \x20\x20\x20\x20\x20\x20- key: b\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20cardinality: 7\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert_eq!(out.len(), 1);
+        assert!(
+            out[0].contains(&format!("more than {PREVIEW_OVERFLOW_THRESHOLD}")),
+            "saturation phrase missing: {}",
+            out[0]
+        );
+    }
+
+    #[test]
+    fn predicted_loki_stream_count_handles_large_but_safe_count() {
+        let dyn_labels = vec![DynamicLabelConfig {
+            key: "a".to_string(),
+            strategy: DynamicLabelStrategy::Counter {
+                prefix: None,
+                cardinality: 5000,
+            },
+        }];
+        assert_eq!(predicted_loki_stream_count(&dyn_labels), Some(5000));
     }
 
     #[cfg(feature = "http")]

--- a/sonda-server/src/routes/sink_warnings.rs
+++ b/sonda-server/src/routes/sink_warnings.rs
@@ -1,6 +1,6 @@
 //! Sink loopback pre-flight warnings shared by `POST /scenarios` and `POST /events`.
 
-use sonda_core::config::ScenarioEntry;
+use sonda_core::config::{DynamicLabelConfig, DynamicLabelStrategy, ScenarioEntry};
 use sonda_core::sink::SinkConfig;
 use tracing::warn;
 
@@ -148,6 +148,77 @@ pub(crate) fn collect_warnings_for_sink(
 pub(crate) fn log_warnings(route: &str, warnings: &[String]) {
     for message in warnings {
         warn!(message = %message, route = %route, "{}: sink pre-flight warning", route);
+    }
+}
+
+pub(crate) fn loki_cardinality_warnings(entries: &[ScenarioEntry]) -> Vec<String> {
+    let mut warnings = Vec::new();
+    for entry in entries {
+        if !matches!(entry, ScenarioEntry::Logs(_)) {
+            continue;
+        }
+        let base = entry.base();
+        let Some(dyn_labels) = base.dynamic_labels.as_deref() else {
+            continue;
+        };
+        if dyn_labels.is_empty() {
+            continue;
+        }
+        if let Some(msg) = preview_loki_cardinality(&base.sink, &base.name, dyn_labels) {
+            warnings.push(msg);
+        }
+    }
+    warnings
+}
+
+fn preview_loki_cardinality(
+    sink: &SinkConfig,
+    entry_name: &str,
+    dyn_labels: &[DynamicLabelConfig],
+) -> Option<String> {
+    match sink {
+        #[cfg(feature = "http")]
+        SinkConfig::Loki {
+            max_streams_per_push,
+            ..
+        } => {
+            let cap = max_streams_per_push
+                .unwrap_or(sonda_core::sink::loki::DEFAULT_MAX_STREAMS_PER_PUSH);
+            let predicted = predicted_loki_stream_count(dyn_labels);
+            let keys: Vec<&str> = dyn_labels.iter().map(|dl| dl.key.as_str()).collect();
+            Some(format!(
+                "scenario entry '{entry_name}' will produce up to {predicted} distinct \
+                 Loki streams (dynamic_labels: {}). max_streams_per_push is {cap}.",
+                keys.join(", ")
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn predicted_loki_stream_count(dyn_labels: &[DynamicLabelConfig]) -> u64 {
+    dyn_labels
+        .iter()
+        .map(|dl| match &dl.strategy {
+            DynamicLabelStrategy::Counter { cardinality, .. } => *cardinality,
+            DynamicLabelStrategy::ValuesList { values } => values.len() as u64,
+        })
+        .fold(1u64, lcm)
+}
+
+fn lcm(a: u64, b: u64) -> u64 {
+    if a == 0 || b == 0 {
+        0
+    } else {
+        a / gcd(a, b) * b
+    }
+}
+
+fn gcd(a: u64, b: u64) -> u64 {
+    if b == 0 {
+        a
+    } else {
+        gcd(b, a % b)
     }
 }
 
@@ -384,6 +455,114 @@ mod tests {
         let sink = SinkConfig::Stdout;
         let mut out = Vec::new();
         collect_warnings_for_sink(&sink, "events", &mut out);
+        assert!(out.is_empty());
+    }
+
+    fn compile_logs_entry(body_yaml: &str) -> ScenarioEntry {
+        let yaml = format!(
+            "version: 2\nkind: runnable\n\
+             defaults:\n  rate: 10\n  duration: 500ms\n  encoder:\n    type: json_lines\n\
+             scenarios:\n  - id: card_test\n    signal_type: logs\n    name: card_test\n\
+{body_yaml}",
+        );
+        let resolver = InMemoryPackResolver::new();
+        let mut entries = compile_scenario_file(&yaml, &resolver).expect("compile must succeed");
+        assert_eq!(entries.len(), 1, "fixture must compile to one entry");
+        entries.pop().unwrap()
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_fires_for_logs_loki_dynamic_labels() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: peer_address\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"10.1.2.2\", \"10.1.7.2\"]\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert_eq!(out.len(), 1);
+        assert!(out[0].contains("card_test"));
+        assert!(out[0].contains("peer_address"));
+        assert!(out[0].contains("up to 2 distinct"));
+        assert!(out[0].contains("max_streams_per_push is 128"));
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_uses_explicit_cap() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20\x20\x20max_streams_per_push: 32\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: peer_address\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"a\", \"b\", \"c\"]\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert_eq!(out.len(), 1);
+        assert!(out[0].contains("max_streams_per_push is 32"));
+        assert!(out[0].contains("up to 3"));
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_uses_lcm_for_multiple_dynamic_labels() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: peer\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"a\", \"b\", \"c\"]\n\
+             \x20\x20\x20\x20\x20\x20- key: pod\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"x\", \"y\"]\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert_eq!(out.len(), 1);
+        assert!(out[0].contains("up to 6 distinct"), "got: {}", out[0]);
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_does_not_fire_without_dynamic_labels() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: loki\n      url: http://loki:3100\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert!(out.is_empty());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn loki_cardinality_warning_does_not_fire_for_non_loki_sink() {
+        let entry = compile_logs_entry(
+            "    sink:\n      type: stdout\n\
+             \x20\x20\x20\x20dynamic_labels:\n      - key: peer\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20values: [\"a\", \"b\"]\n\
+             \x20\x20\x20\x20log_generator:\n      type: template\n      templates:\n\
+             \x20\x20\x20\x20\x20\x20\x20\x20- message: \"hi\"\n",
+        );
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn loki_cardinality_warning_does_not_fire_for_metrics_entry() {
+        let yaml = "version: 2\nkind: runnable\n\
+                    defaults:\n  rate: 10\n  duration: 500ms\n\
+                    \x20\x20encoder:\n    type: prometheus_text\n\
+                    scenarios:\n  - id: m\n    signal_type: metrics\n    name: m\n\
+                    \x20\x20\x20\x20sink:\n      type: stdout\n\
+                    \x20\x20\x20\x20generator:\n      type: constant\n      value: 1.0\n\
+                    \x20\x20\x20\x20dynamic_labels:\n      - key: peer\n\
+                    \x20\x20\x20\x20\x20\x20\x20\x20values: [\"a\", \"b\"]\n";
+        let resolver = InMemoryPackResolver::new();
+        let mut entries = compile_scenario_file(yaml, &resolver).expect("compile");
+        let entry = entries.pop().unwrap();
+        let out = loki_cardinality_warnings(std::slice::from_ref(&entry));
         assert!(out.is_empty());
     }
 }

--- a/sonda/src/config.rs
+++ b/sonda/src/config.rs
@@ -176,6 +176,7 @@ fn parse_sink_override(name: &str, endpoint: Option<&str>) -> Result<SinkConfig>
                 Ok(SinkConfig::Loki {
                     url: url.to_string(),
                     batch_size: None,
+                    max_streams_per_push: None,
                     max_buffer_age: None,
                     retry: None,
                 })

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -189,6 +189,27 @@ print(total)
 " 2>/dev/null || echo "0"
 }
 
+# Query Loki for the number of distinct streams matching a label selector.
+# Uses /loki/api/v1/series, which returns one entry per unique label set.
+# Usage: query_loki_stream_count <label_selector>
+query_loki_stream_count() {
+    local selector="$1"
+    local now_ns
+    now_ns=$(python3 -c "import time; print(int(time.time() * 1_000_000_000))")
+    local start_ns=$((now_ns - 3600000000000))
+    local result
+    result=$(curl -s --max-time 10 -G "http://localhost:3100/loki/api/v1/series" \
+        --data-urlencode "match[]=${selector}" \
+        --data-urlencode "start=${start_ns}" \
+        --data-urlencode "end=${now_ns}" \
+        2>/dev/null || echo '{}')
+    echo "${result}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(len(data.get('data', [])))
+" 2>/dev/null || echo "0"
+}
+
 # Run a single Loki scenario: execute `sonda run`, then verify log entries
 # arrived in Loki by querying its API with the given label selector.
 # Usage: run_loki_scenario <scenario_file> <label_selector> <description>
@@ -240,6 +261,63 @@ run_loki_scenario() {
         pass "${description}"
     else
         fail "${description}: no log entries found in Loki for selector '${label_selector}' (count=${count})"
+    fi
+}
+
+# Run a Loki scenario whose `dynamic_labels` rotation should produce N
+# distinct Loki streams, and verify the exact stream count by querying the
+# series endpoint.
+# Usage: run_loki_multi_stream_scenario <scenario_file> <label_selector> <expected_stream_count> <description>
+run_loki_multi_stream_scenario() {
+    local scenario_file="$1"
+    local label_selector="$2"
+    local expected_count="$3"
+    local description="$4"
+
+    info "Running Loki multi-stream scenario: ${description}"
+    info "  File:           ${scenario_file}"
+    info "  Selector:       ${label_selector}"
+    info "  Expect streams: ${expected_count}"
+
+    local timeout_secs=$((SCENARIO_DURATION + 10))
+    "${SONDA_BIN}" run "${scenario_file}" \
+            --duration "${SCENARIO_DURATION}s" \
+            >/dev/null 2>/tmp/sonda-e2e-stderr.log &
+    local sonda_pid=$!
+
+    local waited=0
+    while kill -0 "${sonda_pid}" 2>/dev/null && [ "${waited}" -lt "${timeout_secs}" ]; do
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    if kill -0 "${sonda_pid}" 2>/dev/null; then
+        kill "${sonda_pid}" 2>/dev/null
+        wait "${sonda_pid}" 2>/dev/null
+        fail "${description}: sonda timed out after ${timeout_secs}s"
+        return
+    fi
+
+    wait "${sonda_pid}" 2>/dev/null
+    local exit_code=$?
+
+    if [ "${exit_code}" -ne 0 ]; then
+        fail "${description}: sonda exited with code ${exit_code}"
+        return
+    fi
+
+    info "  sonda exited cleanly."
+    info "  Waiting ${INGEST_SETTLE_SECS}s for Loki ingestion to settle..."
+    sleep "${INGEST_SETTLE_SECS}"
+
+    local actual
+    actual=$(query_loki_stream_count "${label_selector}")
+    info "  Loki distinct-stream count: ${actual}"
+
+    if [ "${actual}" = "${expected_count}" ]; then
+        pass "${description}"
+    else
+        fail "${description}: expected ${expected_count} Loki streams matching '${label_selector}', got ${actual}"
     fi
 }
 
@@ -442,6 +520,12 @@ run_loki_scenario \
     "${SCENARIO_DIR}/loki-json-lines.yaml" \
     '{job="sonda-e2e"}' \
     "Loki via JSON Lines"
+
+run_loki_multi_stream_scenario \
+    "${SCENARIO_DIR}/loki-multi-stream.yaml" \
+    '{scenario="loki-multi-stream"}' \
+    3 \
+    "Loki multi-stream — dynamic_labels promotes to per-stream labels"
 
 # NOTE: vmagent scenario is disabled. vmagent's /api/v1/import/prometheus
 # endpoint accepts data (204) but does not relay plain text — it only forwards

--- a/tests/e2e/scenarios/loki-multi-stream.yaml
+++ b/tests/e2e/scenarios/loki-multi-stream.yaml
@@ -1,0 +1,42 @@
+# Scenario: sonda -> Loki, dynamic_labels promotes to per-stream labels
+#
+# Proves that a single scenario with a 3-value `dynamic_labels` rotation
+# produces 3 distinct Loki streams (one per peer_address), each queryable
+# by the rotation key.
+#
+# Run this scenario after starting the e2e stack:
+#   docker compose -f tests/e2e/docker-compose.yml up -d
+#   sonda run tests/e2e/scenarios/loki-multi-stream.yaml
+#
+# Verify N=3 distinct streams arrived:
+#   curl -s -G 'http://localhost:3100/loki/api/v1/series' \
+#     --data-urlencode 'match[]={scenario="loki-multi-stream"}' \
+#     | python3 -c 'import sys,json; print(len(json.load(sys.stdin)["data"]))'
+version: 2
+kind: runnable
+
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: json_lines
+  sink:
+    type: loki
+    url: http://localhost:3100
+  labels:
+    job: sonda-e2e
+    scenario: loki-multi-stream
+
+scenarios:
+  - id: sonda_e2e_loki_multi_stream
+    signal_type: logs
+    name: sonda_e2e_loki_multi_stream
+    dynamic_labels:
+      - key: peer_address
+        values: ["10.0.0.1", "10.0.0.2", "10.0.0.3"]
+    log_generator:
+      type: template
+      templates:
+        - message: "BGP neighbor state changed to {state}"
+          field_pools:
+            state: ["established", "active", "idle"]


### PR DESCRIPTION
Releases the v1.9.4 work to main. Closes #296.

- `dynamic_labels` on a `logs` scenario with a `loki` sink now produce one queryable Loki stream per rotation value. Rotation values that previously appeared only in the log line text now sit on the stream label set and are queryable in Grafana by label.
- New `Sink::write_log_event` trait method with a bytes-only default impl. The Loki sink overrides it; every other sink keeps the existing `write` behaviour unchanged.
- Loki sink groups buffered entries by combined label set at flush time and emits a multi-stream push envelope.
- New `max_streams_per_push` field on the Loki sink (default `128`). Flushes that would exceed the cap fail with a message naming the offending count, the cap, and the workaround.
- `POST /scenarios` returns a registration-time warning naming the predicted stream count and the active cap — fires only when the prediction would exceed the cap or when the predictor saturates.
- `emit_log` (the `POST /events` path) routes through `write_log_event` so single-event POSTs share the same label-promotion behaviour as scenarios.
- Updated guide, sink reference, and field reference docs around dynamic labels with the Loki sink, including a worked BGP-peers example.
- New e2e fixture asserts the multi-stream behaviour against a real Loki instance in the docker-compose stack.

Closes #296.