### PR TITLE
fix(config): validate sink duration fields in --dry-run

### DIFF
--- a/sonda-core/src/config/validate.rs
+++ b/sonda-core/src/config/validate.rs
@@ -3,6 +3,8 @@
 use std::time::Duration;
 
 use crate::model::metric::{is_valid_label_key, is_valid_metric_name};
+use crate::sink::retry::RetryConfig;
+use crate::sink::SinkConfig;
 use crate::{ConfigError, SondaError};
 
 use super::{
@@ -305,6 +307,8 @@ pub fn validate_config(config: &ScenarioConfig) -> Result<(), SondaError> {
     // Encoder precision must not exceed 17 (f64 has ~15-17 significant digits).
     validate_encoder_precision(&config.encoder)?;
 
+    validate_sink_config(&config.base.sink)?;
+
     Ok(())
 }
 
@@ -400,6 +404,8 @@ pub fn validate_log_config(config: &LogScenarioConfig) -> Result<(), SondaError>
 
     // Encoder precision must not exceed 17 (f64 has ~15-17 significant digits).
     validate_encoder_precision(&config.encoder)?;
+
+    validate_sink_config(&config.base.sink)?;
 
     Ok(())
 }
@@ -659,6 +665,8 @@ pub fn validate_histogram_config(config: &HistogramScenarioConfig) -> Result<(),
     validate_jitter(config.base.jitter)?;
     validate_encoder_precision(&config.encoder)?;
 
+    validate_sink_config(&config.base.sink)?;
+
     Ok(())
 }
 
@@ -739,6 +747,93 @@ pub fn validate_summary_config(config: &SummaryScenarioConfig) -> Result<(), Son
     validate_jitter(config.base.jitter)?;
     validate_encoder_precision(&config.encoder)?;
 
+    validate_sink_config(&config.base.sink)?;
+
+    Ok(())
+}
+
+/// Pre-parse every duration-string field on the sink so typos surface at
+/// validation time, not at factory time.
+pub fn validate_sink_config(sink: &SinkConfig) -> Result<(), SondaError> {
+    match sink {
+        SinkConfig::Stdout | SinkConfig::File { .. } | SinkConfig::Udp { .. } => Ok(()),
+        SinkConfig::Tcp { retry, .. } => validate_retry_config_opt(retry.as_ref()),
+        #[cfg(feature = "http")]
+        SinkConfig::HttpPush {
+            max_buffer_age,
+            retry,
+            ..
+        } => {
+            validate_max_buffer_age(max_buffer_age.as_deref())?;
+            validate_retry_config_opt(retry.as_ref())
+        }
+        #[cfg(feature = "remote-write")]
+        SinkConfig::RemoteWrite {
+            max_buffer_age,
+            retry,
+            ..
+        } => {
+            validate_max_buffer_age(max_buffer_age.as_deref())?;
+            validate_retry_config_opt(retry.as_ref())
+        }
+        #[cfg(feature = "kafka")]
+        SinkConfig::Kafka {
+            max_buffer_age,
+            retry,
+            ..
+        } => {
+            validate_max_buffer_age(max_buffer_age.as_deref())?;
+            validate_retry_config_opt(retry.as_ref())
+        }
+        #[cfg(feature = "http")]
+        SinkConfig::Loki {
+            max_buffer_age,
+            retry,
+            ..
+        } => {
+            validate_max_buffer_age(max_buffer_age.as_deref())?;
+            validate_retry_config_opt(retry.as_ref())
+        }
+        #[cfg(feature = "otlp")]
+        SinkConfig::OtlpGrpc {
+            max_buffer_age,
+            retry,
+            ..
+        } => {
+            validate_max_buffer_age(max_buffer_age.as_deref())?;
+            validate_retry_config_opt(retry.as_ref())
+        }
+        #[cfg(not(feature = "http"))]
+        SinkConfig::HttpPushDisabled { .. } => Ok(()),
+        #[cfg(not(feature = "remote-write"))]
+        SinkConfig::RemoteWriteDisabled { .. } => Ok(()),
+        #[cfg(not(feature = "kafka"))]
+        SinkConfig::KafkaDisabled { .. } => Ok(()),
+        #[cfg(not(feature = "http"))]
+        SinkConfig::LokiDisabled { .. } => Ok(()),
+        #[cfg(not(feature = "otlp"))]
+        SinkConfig::OtlpGrpcDisabled { .. } => Ok(()),
+    }
+}
+
+#[cfg(any(
+    feature = "http",
+    feature = "remote-write",
+    feature = "kafka",
+    feature = "otlp"
+))]
+fn validate_max_buffer_age(s: Option<&str>) -> Result<(), SondaError> {
+    if let Some(s) = s {
+        parse_optional_duration(s)?;
+    }
+    Ok(())
+}
+
+fn validate_retry_config_opt(retry: Option<&RetryConfig>) -> Result<(), SondaError> {
+    if let Some(r) = retry {
+        parse_duration(&r.initial_backoff)?;
+        parse_duration(&r.max_backoff)?;
+    }
     Ok(())
 }
 
@@ -2757,5 +2852,437 @@ generator:
         let mut config = make_summary_config();
         config.base.name = "123-invalid".to_string();
         assert!(validate_summary_config(&config).is_err());
+    }
+
+    // ---- validate_sink_config ------------------------------------------------
+
+    use crate::sink::retry::RetryConfig;
+
+    fn good_retry() -> RetryConfig {
+        RetryConfig {
+            max_attempts: 3,
+            initial_backoff: "100ms".to_string(),
+            max_backoff: "5s".to_string(),
+        }
+    }
+
+    #[test]
+    fn validate_sink_config_stdout_is_ok() {
+        assert!(validate_sink_config(&SinkConfig::Stdout).is_ok());
+    }
+
+    #[test]
+    fn validate_sink_config_file_is_ok() {
+        let sink = SinkConfig::File {
+            path: "/tmp/x".to_string(),
+        };
+        assert!(validate_sink_config(&sink).is_ok());
+    }
+
+    #[test]
+    fn validate_sink_config_udp_is_ok() {
+        let sink = SinkConfig::Udp {
+            address: "127.0.0.1:9999".to_string(),
+        };
+        assert!(validate_sink_config(&sink).is_ok());
+    }
+
+    #[test]
+    fn validate_sink_config_tcp_with_no_retry_is_ok() {
+        let sink = SinkConfig::Tcp {
+            address: "127.0.0.1:9999".to_string(),
+            retry: None,
+        };
+        assert!(validate_sink_config(&sink).is_ok());
+    }
+
+    #[test]
+    fn validate_sink_config_tcp_with_good_retry_is_ok() {
+        let sink = SinkConfig::Tcp {
+            address: "127.0.0.1:9999".to_string(),
+            retry: Some(good_retry()),
+        };
+        assert!(validate_sink_config(&sink).is_ok());
+    }
+
+    #[test]
+    fn validate_sink_config_tcp_with_garbage_initial_backoff_returns_err() {
+        let sink = SinkConfig::Tcp {
+            address: "127.0.0.1:9999".to_string(),
+            retry: Some(RetryConfig {
+                max_attempts: 3,
+                initial_backoff: "garbage".to_string(),
+                max_backoff: "5s".to_string(),
+            }),
+        };
+        let result = validate_sink_config(&sink);
+        let msg = err_msg(result);
+        assert!(
+            msg.contains("garbage"),
+            "error must mention the offending value, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_sink_config_tcp_with_garbage_max_backoff_returns_err() {
+        let sink = SinkConfig::Tcp {
+            address: "127.0.0.1:9999".to_string(),
+            retry: Some(RetryConfig {
+                max_attempts: 3,
+                initial_backoff: "100ms".to_string(),
+                max_backoff: "garbage".to_string(),
+            }),
+        };
+        let result = validate_sink_config(&sink);
+        let msg = err_msg(result);
+        assert!(
+            msg.contains("garbage"),
+            "error must mention the offending value, got: {msg}"
+        );
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn validate_sink_config_http_push_with_good_durations_is_ok() {
+        let sink = SinkConfig::HttpPush {
+            url: "http://localhost:9090/push".to_string(),
+            content_type: None,
+            batch_size: None,
+            max_buffer_age: Some("5s".to_string()),
+            headers: None,
+            retry: Some(good_retry()),
+        };
+        assert!(validate_sink_config(&sink).is_ok());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn validate_sink_config_http_push_with_zero_buffer_age_is_ok() {
+        let sink = SinkConfig::HttpPush {
+            url: "http://localhost:9090/push".to_string(),
+            content_type: None,
+            batch_size: None,
+            max_buffer_age: Some("0s".to_string()),
+            headers: None,
+            retry: None,
+        };
+        assert!(validate_sink_config(&sink).is_ok());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn validate_sink_config_http_push_with_garbage_max_buffer_age_returns_err() {
+        let sink = SinkConfig::HttpPush {
+            url: "http://localhost:9090/push".to_string(),
+            content_type: None,
+            batch_size: None,
+            max_buffer_age: Some("garbage".to_string()),
+            headers: None,
+            retry: None,
+        };
+        let result = validate_sink_config(&sink);
+        let msg = err_msg(result);
+        assert!(
+            msg.contains("garbage"),
+            "error must mention the offending value, got: {msg}"
+        );
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn validate_sink_config_http_push_with_garbage_initial_backoff_returns_err() {
+        let sink = SinkConfig::HttpPush {
+            url: "http://localhost:9090/push".to_string(),
+            content_type: None,
+            batch_size: None,
+            max_buffer_age: None,
+            headers: None,
+            retry: Some(RetryConfig {
+                max_attempts: 3,
+                initial_backoff: "garbage".to_string(),
+                max_backoff: "5s".to_string(),
+            }),
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn validate_sink_config_http_push_with_garbage_max_backoff_returns_err() {
+        let sink = SinkConfig::HttpPush {
+            url: "http://localhost:9090/push".to_string(),
+            content_type: None,
+            batch_size: None,
+            max_buffer_age: None,
+            headers: None,
+            retry: Some(RetryConfig {
+                max_attempts: 3,
+                initial_backoff: "100ms".to_string(),
+                max_backoff: "garbage".to_string(),
+            }),
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn validate_sink_config_loki_with_good_durations_is_ok() {
+        let sink = SinkConfig::Loki {
+            url: "http://localhost:3100".to_string(),
+            batch_size: None,
+            max_streams_per_push: None,
+            max_buffer_age: Some("5s".to_string()),
+            retry: Some(good_retry()),
+        };
+        assert!(validate_sink_config(&sink).is_ok());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn validate_sink_config_loki_with_garbage_max_buffer_age_returns_err() {
+        let sink = SinkConfig::Loki {
+            url: "http://localhost:3100".to_string(),
+            batch_size: None,
+            max_streams_per_push: None,
+            max_buffer_age: Some("garbage".to_string()),
+            retry: None,
+        };
+        let result = validate_sink_config(&sink);
+        let msg = err_msg(result);
+        assert!(
+            msg.contains("garbage"),
+            "error must mention the offending value, got: {msg}"
+        );
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn validate_sink_config_loki_with_garbage_initial_backoff_returns_err() {
+        let sink = SinkConfig::Loki {
+            url: "http://localhost:3100".to_string(),
+            batch_size: None,
+            max_streams_per_push: None,
+            max_buffer_age: None,
+            retry: Some(RetryConfig {
+                max_attempts: 3,
+                initial_backoff: "garbage".to_string(),
+                max_backoff: "5s".to_string(),
+            }),
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn validate_sink_config_loki_with_garbage_max_backoff_returns_err() {
+        let sink = SinkConfig::Loki {
+            url: "http://localhost:3100".to_string(),
+            batch_size: None,
+            max_streams_per_push: None,
+            max_buffer_age: None,
+            retry: Some(RetryConfig {
+                max_attempts: 3,
+                initial_backoff: "100ms".to_string(),
+                max_backoff: "garbage".to_string(),
+            }),
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    #[cfg(feature = "remote-write")]
+    #[test]
+    fn validate_sink_config_remote_write_with_good_durations_is_ok() {
+        let sink = SinkConfig::RemoteWrite {
+            url: "http://localhost:8428/api/v1/write".to_string(),
+            batch_size: None,
+            max_buffer_age: Some("5s".to_string()),
+            retry: Some(good_retry()),
+        };
+        assert!(validate_sink_config(&sink).is_ok());
+    }
+
+    #[cfg(feature = "remote-write")]
+    #[test]
+    fn validate_sink_config_remote_write_with_garbage_max_buffer_age_returns_err() {
+        let sink = SinkConfig::RemoteWrite {
+            url: "http://localhost:8428/api/v1/write".to_string(),
+            batch_size: None,
+            max_buffer_age: Some("garbage".to_string()),
+            retry: None,
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    #[cfg(feature = "remote-write")]
+    #[test]
+    fn validate_sink_config_remote_write_with_garbage_initial_backoff_returns_err() {
+        let sink = SinkConfig::RemoteWrite {
+            url: "http://localhost:8428/api/v1/write".to_string(),
+            batch_size: None,
+            max_buffer_age: None,
+            retry: Some(RetryConfig {
+                max_attempts: 3,
+                initial_backoff: "garbage".to_string(),
+                max_backoff: "5s".to_string(),
+            }),
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    #[cfg(feature = "remote-write")]
+    #[test]
+    fn validate_sink_config_remote_write_with_garbage_max_backoff_returns_err() {
+        let sink = SinkConfig::RemoteWrite {
+            url: "http://localhost:8428/api/v1/write".to_string(),
+            batch_size: None,
+            max_buffer_age: None,
+            retry: Some(RetryConfig {
+                max_attempts: 3,
+                initial_backoff: "100ms".to_string(),
+                max_backoff: "garbage".to_string(),
+            }),
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    #[cfg(feature = "kafka")]
+    #[test]
+    fn validate_sink_config_kafka_with_good_durations_is_ok() {
+        let sink = SinkConfig::Kafka {
+            brokers: "127.0.0.1:9092".to_string(),
+            topic: "sonda-test".to_string(),
+            max_buffer_age: Some("5s".to_string()),
+            retry: Some(good_retry()),
+            tls: None,
+            sasl: None,
+        };
+        assert!(validate_sink_config(&sink).is_ok());
+    }
+
+    #[cfg(feature = "kafka")]
+    #[test]
+    fn validate_sink_config_kafka_with_garbage_max_buffer_age_returns_err() {
+        let sink = SinkConfig::Kafka {
+            brokers: "127.0.0.1:9092".to_string(),
+            topic: "sonda-test".to_string(),
+            max_buffer_age: Some("garbage".to_string()),
+            retry: None,
+            tls: None,
+            sasl: None,
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    #[cfg(feature = "kafka")]
+    #[test]
+    fn validate_sink_config_kafka_with_garbage_initial_backoff_returns_err() {
+        let sink = SinkConfig::Kafka {
+            brokers: "127.0.0.1:9092".to_string(),
+            topic: "sonda-test".to_string(),
+            max_buffer_age: None,
+            retry: Some(RetryConfig {
+                max_attempts: 3,
+                initial_backoff: "garbage".to_string(),
+                max_backoff: "5s".to_string(),
+            }),
+            tls: None,
+            sasl: None,
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    #[cfg(feature = "kafka")]
+    #[test]
+    fn validate_sink_config_kafka_with_garbage_max_backoff_returns_err() {
+        let sink = SinkConfig::Kafka {
+            brokers: "127.0.0.1:9092".to_string(),
+            topic: "sonda-test".to_string(),
+            max_buffer_age: None,
+            retry: Some(RetryConfig {
+                max_attempts: 3,
+                initial_backoff: "100ms".to_string(),
+                max_backoff: "garbage".to_string(),
+            }),
+            tls: None,
+            sasl: None,
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    #[cfg(feature = "otlp")]
+    #[test]
+    fn validate_sink_config_otlp_grpc_with_good_durations_is_ok() {
+        let sink = SinkConfig::OtlpGrpc {
+            endpoint: "http://localhost:4317".to_string(),
+            signal_type: crate::sink::otlp_grpc::OtlpSignalType::Metrics,
+            batch_size: None,
+            max_buffer_age: Some("5s".to_string()),
+            retry: Some(good_retry()),
+        };
+        assert!(validate_sink_config(&sink).is_ok());
+    }
+
+    #[cfg(feature = "otlp")]
+    #[test]
+    fn validate_sink_config_otlp_grpc_with_garbage_max_buffer_age_returns_err() {
+        let sink = SinkConfig::OtlpGrpc {
+            endpoint: "http://localhost:4317".to_string(),
+            signal_type: crate::sink::otlp_grpc::OtlpSignalType::Metrics,
+            batch_size: None,
+            max_buffer_age: Some("garbage".to_string()),
+            retry: None,
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    #[cfg(feature = "otlp")]
+    #[test]
+    fn validate_sink_config_otlp_grpc_with_garbage_initial_backoff_returns_err() {
+        let sink = SinkConfig::OtlpGrpc {
+            endpoint: "http://localhost:4317".to_string(),
+            signal_type: crate::sink::otlp_grpc::OtlpSignalType::Metrics,
+            batch_size: None,
+            max_buffer_age: None,
+            retry: Some(RetryConfig {
+                max_attempts: 3,
+                initial_backoff: "garbage".to_string(),
+                max_backoff: "5s".to_string(),
+            }),
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    #[cfg(feature = "otlp")]
+    #[test]
+    fn validate_sink_config_otlp_grpc_with_garbage_max_backoff_returns_err() {
+        let sink = SinkConfig::OtlpGrpc {
+            endpoint: "http://localhost:4317".to_string(),
+            signal_type: crate::sink::otlp_grpc::OtlpSignalType::Metrics,
+            batch_size: None,
+            max_buffer_age: None,
+            retry: Some(RetryConfig {
+                max_attempts: 3,
+                initial_backoff: "100ms".to_string(),
+                max_backoff: "garbage".to_string(),
+            }),
+        };
+        assert!(validate_sink_config(&sink).is_err());
+    }
+
+    // ---- end-to-end: validate_config rejects bad sink durations -------------
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn validate_config_rejects_bad_sink_max_buffer_age() {
+        let mut config = minimal_config_with_rate(10.0);
+        config.base.sink = SinkConfig::HttpPush {
+            url: "http://localhost:9090/push".to_string(),
+            content_type: None,
+            batch_size: None,
+            max_buffer_age: Some("garbage".to_string()),
+            headers: None,
+            retry: None,
+        };
+        assert!(validate_config(&config).is_err());
     }
 }

--- a/sonda/src/dry_run.rs
+++ b/sonda/src/dry_run.rs
@@ -10,7 +10,7 @@ use sonda_core::compiler::timing::{
     uniform_crossing_secs, Operator, TimingError,
 };
 use sonda_core::compiler::{DelayClause, WhileClause, WhileOp};
-use sonda_core::config::validate::parse_duration;
+use sonda_core::config::validate::{parse_duration, validate_sink_config};
 use sonda_core::generator::GeneratorConfig;
 
 use crate::sink_format::sink_display;
@@ -61,10 +61,10 @@ pub fn print_dry_run_compiled(
     Ok(())
 }
 
-/// Surface alias-validation errors that would otherwise only fire inside
-/// `prepare_entries` (which dry-run never calls). Today this catches the
-/// `flap` `enum:` mutual-exclusion check; extend here for any future alias
-/// mutex / shape constraint that should reach operators at dry-run time.
+/// Surface alias-validation and sink-config errors that would otherwise only
+/// fire inside `prepare_entries` (which dry-run never calls) or the sink
+/// factory at run time. Extend here for any future invariant that should
+/// reach operators at dry-run time.
 fn validate_alias_invariants(compiled: &CompiledFile) -> anyhow::Result<()> {
     for entry in &compiled.entries {
         if let Some(GeneratorConfig::Flap {
@@ -81,6 +81,10 @@ fn validate_alias_invariants(compiled: &CompiledFile) -> anyhow::Result<()> {
                 ));
             }
         }
+        validate_sink_config(&entry.sink).map_err(|e| {
+            let id = entry.id.as_deref().unwrap_or("<anonymous>");
+            anyhow::anyhow!("scenario '{id}': {e}")
+        })?;
     }
     Ok(())
 }
@@ -1140,5 +1144,98 @@ scenarios:
             !body.contains("first_open"),
             "first_open must be omitted when None, got:\n{body}"
         );
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn dry_run_rejects_bad_sink_max_buffer_age() {
+        let compiled = compile(
+            r#"version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 100ms
+scenarios:
+  - id: bad
+    signal_type: metrics
+    name: metric_a
+    generator:
+      type: constant
+      value: 1.0
+    sink:
+      type: http_push
+      url: "http://localhost:9090/push"
+      max_buffer_age: "garbage"
+"#,
+        );
+        let err = validate_alias_invariants(&compiled).expect_err("must reject garbage duration");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("garbage"),
+            "error must mention offending value, got: {msg}"
+        );
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn dry_run_rejects_bad_sink_retry_initial_backoff() {
+        let compiled = compile(
+            r#"version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 100ms
+scenarios:
+  - id: bad
+    signal_type: metrics
+    name: metric_a
+    generator:
+      type: constant
+      value: 1.0
+    sink:
+      type: http_push
+      url: "http://localhost:9090/push"
+      retry:
+        max_attempts: 3
+        initial_backoff: "garbage"
+        max_backoff: "5s"
+"#,
+        );
+        let err =
+            validate_alias_invariants(&compiled).expect_err("must reject garbage initial_backoff");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("garbage"),
+            "error must mention offending value, got: {msg}"
+        );
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn dry_run_accepts_valid_sink_durations() {
+        let compiled = compile(
+            r#"version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 100ms
+scenarios:
+  - id: ok
+    signal_type: metrics
+    name: metric_a
+    generator:
+      type: constant
+      value: 1.0
+    sink:
+      type: http_push
+      url: "http://localhost:9090/push"
+      max_buffer_age: "5s"
+      retry:
+        max_attempts: 3
+        initial_backoff: "100ms"
+        max_backoff: "5s"
+"#,
+        );
+        assert!(validate_alias_invariants(&compiled).is_ok());
     }
 }


### PR DESCRIPTION
Closes #339.

`--dry-run` now rejects typos in sink duration-string fields:

- `max_buffer_age` on `loki`, `http_push`, `remote_write`, `kafka`, `otlp_grpc`
- `retry.initial_backoff` and `retry.max_backoff` on every sink that carries a `retry` block

Same parse function the sink factory uses runs during validation, so the dry-run reject message matches what a real run would produce.

Tests cover every sink variant × every duration field × both valid and garbage values, feature-gated to match the factory variants.

Closes #339.