### PR TITLE
feat(core): mark FlapEnum and CloseSignal as #[non_exhaustive]

### DIFF
--- a/sonda-core/src/generator/mod.rs
+++ b/sonda-core/src/generator/mod.rs
@@ -99,6 +99,7 @@ pub struct CsvColumnSpec {
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "snake_case")
 )]
+#[non_exhaustive]
 pub enum FlapEnum {
     Boolean,
     LinkState,

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -113,6 +113,7 @@ pub(crate) type TickFn<'a> =
 /// Resolved once at runner-build time and captured into the closure; the
 /// gated loop no longer re-derives this on each commit.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub enum CloseSignal {
     /// Emit a Prometheus stale-NaN sample for every recently-active series.
     StaleMarker,


### PR DESCRIPTION
## Summary

- Add `#[non_exhaustive]` to `sonda-core::generator::FlapEnum` and `sonda-core::schedule::core_loop::CloseSignal`.
- Future variant additions on either enum are non-breaking for downstream `sonda-core` consumers from 1.10.0 onward.
- One-time SemVer-affecting churn: external library consumers exhaustively matching on either enum must add a `_` arm to compile against 1.10.0 (downstream-consumer note included in the commit body so release-please surfaces it in the 1.10 release notes).

Closes the forward-compat hygiene items in #321.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace` — 2511 passed, parity with main
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p sonda-core --no-default-features`
- [x] CLI + server smoke: `sonda --version`, `sonda run` on flap and `while:`-gated scenarios, `sonda-server` boot + `/health` — no observable behaviour change.