### PR TITLE
feat(core): reject stale_marker on non-remote_write sinks; surface snap_to and stale_marker in --dry-run

### DIFF
--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -529,7 +529,7 @@ The marker is on by default for `remote_write` sinks. The shorthand `close: 5s` 
         snap_to: 1            # emit one literal sample with this value before pausing
 ```
 
-`snap_to` replaces the stale marker with a normal sample carrying the supplied value. Use it when the recovery semantics call for an explicit recovered value (`bgp_oper_state=1` for "up") rather than a stale signal. When set, `snap_to` is honored on every sink the configured encoder can serialize to — including `stdout`, `file`, `loki`, and `kafka`. Without `snap_to`, only `remote_write` sinks emit a default close marker; the others stay silent on close.
+`snap_to` replaces the stale marker with a normal sample carrying the supplied value. Use it when the recovery semantics call for an explicit recovered value (`bgp_oper_state=1` for "up") rather than a stale signal. When set, `snap_to` is honored on every sink the configured encoder can serialize to — including `stdout`, `file`, `loki`, and `kafka`. Without `snap_to`, only `remote_write` sinks emit a default close marker; the others stay silent on close. Setting `stale_marker: true` on a non-`remote_write` sink is rejected at normalize time, because the marker is a Prometheus remote-write-specific signal that would otherwise no-op silently — either switch to `sink.type: remote_write`, replace it with `snap_to:` for a sink-agnostic recovery sample, or drop the field. The exception is when `snap_to` is set on the same `close:` block: an explicit `stale_marker: true` paired with `snap_to` is accepted because `snap_to` already wins.
 
 To suppress the default emit entirely, set `stale_marker: false` instead:
 
@@ -546,6 +546,8 @@ Setting both `snap_to` and `stale_marker: false` is a config error — `snap_to`
 A brief close that gets cancelled by a fresh `WhileOpen` arriving inside the `delay.close.duration` debounce window emits nothing — the gate stayed open. A scenario that hits its `duration:` while already paused goes `paused → finished` without an additional close-emit; the buffer was already flushed on the earlier `running → paused` transition. The recently-active tuple set is sourced from a runtime buffer capped at 100 events; high-cardinality scenarios that exceed this ceiling under-emit on close. Track scenarios with more than ~100 distinct label sets via per-scenario `/stats` rather than relying on close-emit alone.
 
 Close-emit timestamps are strictly greater than the most recent active-emission timestamp for the same series. This avoids duplicate-timestamp rejection at the receiver — Prometheus and other TSDBs that dedup on `(series, timestamp)` would otherwise drop the recovery sample silently.
+
+Gate-close emission is the active recovery primitive — Sonda writes a recovery sample (or stale marker) the moment a gate closes. For the passive counterpart, where Prometheus resolves the alert on its own once a metric stops emitting for the lookback-delta window, see [Alert resolution via gaps](../guides/alert-testing-resolution.md). The two compose: gaps drive absence-based recovery on any sink, gate close drives marker-based recovery on `remote_write`.
 
 #### Prefer `snap_to:` for `remote_write` integrations
 

--- a/docs/site/docs/guides/alert-testing-resolution.md
+++ b/docs/site/docs/guides/alert-testing-resolution.md
@@ -55,6 +55,8 @@ you want to validate against.
     "flapping service" pattern -- useful for testing that your alert hysteresis or
     `keep_firing_for` clause actually suppresses the noise.
 
+Gaps drive recovery passively — Prometheus resolves the alert on its own once the metric goes silent for the lookback-delta window. For active recovery, where Sonda emits a stale marker or an explicit recovery value the moment a `while:`-gated entry pauses, see [Recovering Prometheus alerts on gate close](../configuration/v2-scenarios.md#recovering-prometheus-alerts-on-gate-close). Gate close clears alerts on the next scrape rather than waiting for the lookback window, at the cost of being `remote_write`-specific unless you pair it with `snap_to:`.
+
 ## Next
 
 Single-metric resolution is straightforward. Compound rules that depend on two or more

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -148,6 +148,18 @@ pub enum NormalizeError {
          NaN and infinity cannot be emitted as a recovery sample"
     )]
     CloseSnapToIsNan { source_id: String },
+
+    #[error(
+        "entry '{source_id}': delay.close.stale_marker: true requires sink.type: remote_write \
+         — the marker is a Prometheus remote-write-specific signal and silently no-ops on \
+         sink.type: {sink_kind}. \
+         Either set sink.type: remote_write, or replace stale_marker with snap_to: <value> \
+         for a sink-agnostic recovery emit, or drop the field to disable the close-emit entirely."
+    )]
+    CloseStaleMarkerNotSupported {
+        source_id: String,
+        sink_kind: &'static str,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -428,6 +440,15 @@ fn normalize_entry(
                 });
             }
         }
+        if d.close_stale_marker == Some(true)
+            && d.close_snap_to.is_none()
+            && !is_remote_write_sink(&sink)
+        {
+            return Err(NormalizeError::CloseStaleMarkerNotSupported {
+                source_id: diagnostic_label,
+                sink_kind: sink_kind_str(&sink),
+            });
+        }
     }
 
     Ok(NormalizedEntry {
@@ -520,6 +541,47 @@ fn default_encoder_for(signal_type: &str) -> EncoderConfig {
 /// Return the built-in sink default (`stdout`).
 fn default_sink() -> SinkConfig {
     SinkConfig::Stdout
+}
+
+fn is_remote_write_sink(sink: &SinkConfig) -> bool {
+    #[cfg(feature = "remote-write")]
+    {
+        matches!(sink, SinkConfig::RemoteWrite { .. })
+    }
+    #[cfg(not(feature = "remote-write"))]
+    {
+        let _ = sink;
+        false
+    }
+}
+
+fn sink_kind_str(sink: &SinkConfig) -> &'static str {
+    match sink {
+        SinkConfig::Stdout => "stdout",
+        SinkConfig::File { .. } => "file",
+        SinkConfig::Tcp { .. } => "tcp",
+        SinkConfig::Udp { .. } => "udp",
+        #[cfg(feature = "http")]
+        SinkConfig::HttpPush { .. } => "http_push",
+        #[cfg(not(feature = "http"))]
+        SinkConfig::HttpPushDisabled { .. } => "http_push",
+        #[cfg(feature = "remote-write")]
+        SinkConfig::RemoteWrite { .. } => "remote_write",
+        #[cfg(not(feature = "remote-write"))]
+        SinkConfig::RemoteWriteDisabled { .. } => "remote_write",
+        #[cfg(feature = "kafka")]
+        SinkConfig::Kafka { .. } => "kafka",
+        #[cfg(not(feature = "kafka"))]
+        SinkConfig::KafkaDisabled { .. } => "kafka",
+        #[cfg(feature = "http")]
+        SinkConfig::Loki { .. } => "loki",
+        #[cfg(not(feature = "http"))]
+        SinkConfig::LokiDisabled { .. } => "loki",
+        #[cfg(feature = "otlp")]
+        SinkConfig::OtlpGrpc { .. } => "otlp_grpc",
+        #[cfg(not(feature = "otlp"))]
+        SinkConfig::OtlpGrpcDisabled { .. } => "otlp_grpc",
+    }
 }
 
 /// Merge a file-level labels map with an entry-level labels map.
@@ -1615,6 +1677,156 @@ scenarios:
             }
             other => panic!("expected CloseSnapToIsNan, got {other:?}"),
         }
+    }
+
+    #[rustfmt::skip]
+    #[rstest::rstest]
+    #[case::stdout("sink: { type: stdout }",                            "stdout")]
+    #[case::file("sink: { type: file, path: /tmp/out.txt }",            "file")]
+    #[case::tcp("sink: { type: tcp, address: '127.0.0.1:9999' }",       "tcp")]
+    #[case::udp("sink: { type: udp, address: '127.0.0.1:9999' }",       "udp")]
+    fn close_stale_marker_true_rejected_on_non_remote_write_sink(
+        #[case] sink_yaml: &str,
+        #[case] expected_kind: &str,
+    ) {
+        let yaml = format!(r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 1m
+  {sink_yaml}
+scenarios:
+  - id: src
+    signal_type: metrics
+    name: src
+    generator: {{ type: constant, value: 1 }}
+  - id: gated
+    signal_type: metrics
+    name: gated
+    generator: {{ type: constant, value: 1 }}
+    while: {{ ref: src, op: ">", value: 0 }}
+    delay:
+      close:
+        duration: 5s
+        stale_marker: true
+"#);
+        let err = normalize_yaml(&yaml)
+            .expect_err("stale_marker: true on non-remote_write sink must fail");
+        match err {
+            NormalizeError::CloseStaleMarkerNotSupported {
+                source_id,
+                sink_kind,
+            } => {
+                assert_eq!(source_id, "gated");
+                assert_eq!(sink_kind, expected_kind);
+            }
+            other => panic!("expected CloseStaleMarkerNotSupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn close_stale_marker_true_with_snap_to_is_accepted_on_non_remote_write_sink() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 1m
+  sink: { type: stdout }
+scenarios:
+  - id: src
+    signal_type: metrics
+    name: src
+    generator: { type: constant, value: 1 }
+  - id: gated
+    signal_type: metrics
+    name: gated
+    generator: { type: constant, value: 1 }
+    while: { ref: src, op: ">", value: 0 }
+    delay:
+      close:
+        duration: 5s
+        snap_to: 1.0
+        stale_marker: true
+"#;
+        let file = normalize_yaml(yaml)
+            .expect("snap_to: <v> + stale_marker: true must pass — snap_to wins silently");
+        let gated = file
+            .entries
+            .iter()
+            .find(|e| e.id.as_deref() == Some("gated"))
+            .unwrap();
+        let delay = gated.delay_clause.as_ref().expect("delay clause present");
+        assert_eq!(delay.close_snap_to, Some(1.0));
+        assert_eq!(delay.close_stale_marker, Some(true));
+    }
+
+    #[test]
+    fn close_stale_marker_unset_is_accepted_on_non_remote_write_sink() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 1m
+  sink: { type: stdout }
+scenarios:
+  - id: src
+    signal_type: metrics
+    name: src
+    generator: { type: constant, value: 1 }
+  - id: gated
+    signal_type: metrics
+    name: gated
+    generator: { type: constant, value: 1 }
+    while: { ref: src, op: ">", value: 0 }
+    delay: { open: "0s", close: "5s" }
+"#;
+        let file = normalize_yaml(yaml).expect("default (None) stale_marker must pass");
+        let gated = file
+            .entries
+            .iter()
+            .find(|e| e.id.as_deref() == Some("gated"))
+            .unwrap();
+        let delay = gated.delay_clause.as_ref().expect("delay clause present");
+        assert_eq!(delay.close_stale_marker, None);
+    }
+
+    #[cfg(feature = "remote-write")]
+    #[test]
+    fn close_stale_marker_true_is_accepted_on_remote_write_sink() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 1m
+  sink: { type: remote_write, url: "http://localhost:8428/api/v1/write" }
+scenarios:
+  - id: src
+    signal_type: metrics
+    name: src
+    generator: { type: constant, value: 1 }
+  - id: gated
+    signal_type: metrics
+    name: gated
+    generator: { type: constant, value: 1 }
+    while: { ref: src, op: ">", value: 0 }
+    delay:
+      close:
+        duration: 5s
+        stale_marker: true
+"#;
+        let file =
+            normalize_yaml(yaml).expect("stale_marker: true on remote_write sink must be accepted");
+        let gated = file
+            .entries
+            .iter()
+            .find(|e| e.id.as_deref() == Some("gated"))
+            .unwrap();
+        let delay = gated.delay_clause.as_ref().expect("delay clause present");
+        assert_eq!(delay.close_stale_marker, Some(true));
     }
 
     #[test]

--- a/sonda/src/dry_run.rs
+++ b/sonda/src/dry_run.rs
@@ -423,7 +423,14 @@ fn delay_clause_display(delay: &DelayClause) -> String {
         .close
         .map(|d| format!("{}s", d.as_secs_f64()))
         .unwrap_or_else(|| "0s".to_string());
-    format!("open={open} close={close}")
+    let mut out = format!("open={open} close={close}");
+    if let Some(v) = delay.close_snap_to {
+        out.push_str(&format!(" snap_to={}", format_value(v)));
+    }
+    if let Some(b) = delay.close_stale_marker {
+        out.push_str(&format!(" stale_marker={b}"));
+    }
+    out
 }
 
 fn first_open_display(upstream: Option<&CompiledEntry>, clause: &WhileClause) -> String {
@@ -993,6 +1000,50 @@ scenarios:
         assert!(
             out.contains("delay:") && out.contains("open=5s") && out.contains("close=10s"),
             "delay block must render, got:\n{out}"
+        );
+    }
+
+    fn delay_with(
+        open_secs: u64,
+        close_secs: u64,
+        snap_to: Option<f64>,
+        stale_marker: Option<bool>,
+    ) -> DelayClause {
+        DelayClause {
+            open: Some(std::time::Duration::from_secs(open_secs)),
+            close: Some(std::time::Duration::from_secs(close_secs)),
+            close_snap_to: snap_to,
+            close_stale_marker: stale_marker,
+        }
+    }
+
+    #[test]
+    fn delay_clause_display_renders_open_close_only_when_no_extras() {
+        let d = delay_with(5, 10, None, None);
+        assert_eq!(delay_clause_display(&d), "open=5s close=10s");
+    }
+
+    #[test]
+    fn delay_clause_display_appends_snap_to_when_set() {
+        let d = delay_with(5, 10, Some(1.0), None);
+        assert_eq!(delay_clause_display(&d), "open=5s close=10s snap_to=1");
+    }
+
+    #[test]
+    fn delay_clause_display_appends_stale_marker_when_set() {
+        let d = delay_with(5, 10, None, Some(false));
+        assert_eq!(
+            delay_clause_display(&d),
+            "open=5s close=10s stale_marker=false"
+        );
+    }
+
+    #[test]
+    fn delay_clause_display_appends_snap_to_and_stale_marker_in_order() {
+        let d = delay_with(0, 5, Some(1.0), Some(true));
+        assert_eq!(
+            delay_clause_display(&d),
+            "open=0s close=5s snap_to=1 stale_marker=true"
         );
     }
 


### PR DESCRIPTION
## Summary

- Reject `delay.close.stale_marker: true` on non-`remote_write` sinks at normalize time. The error names the sink kind and points at `snap_to: <value>` (sink-agnostic) or `sink.type: remote_write` (supported sink) as the fix. Carve-out: if `snap_to:` is also set, the entry is accepted because `snap_to` already wins over the marker.
- `sonda --dry-run run` now appends `snap_to=<v>` and/or `stale_marker=<bool>` to the `delay:` line when those fields are explicitly set; `--format json` carries the same suffix via the shared text helper.
- Docs: `v2-scenarios.md` documents the rejection plus the `snap_to:` carve-out in the existing "Recovering Prometheus alerts on gate close" section, and cross-links out to `alert-testing-resolution.md`; the latter cross-links back. Gaps drive passive recovery on any sink; gate close drives active recovery on `remote_write` (or any sink via `snap_to:`).

Closes the validation/UX and docs items in #321.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace` — 2521 passed (+10)
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p sonda-core --no-default-features` — 1223 passed
- [x] `task site:build` (mkdocs --strict) — clean
- [x] CLI smoke on five real YAMLs: rejection on stdout error message correct, `snap_to+stale_marker` carve-out accepts, default accepts, `snap_to` only renders, `--format json` carries the suffix.