### PR TITLE
chore: clear clippy --all-targets lint debt and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: cargo test --workspace --doc
 
       - name: Clippy
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Format check
         run: cargo fmt --all -- --check
@@ -191,7 +191,7 @@ jobs:
         run: cargo test --workspace --all-features --doc
 
       - name: Clippy (all features)
-        run: cargo clippy --workspace --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   docs-commands:
     name: Validate sonda commands in user-facing docs

--- a/sonda-core/src/config/aliases.rs
+++ b/sonda-core/src/config/aliases.rs
@@ -1017,7 +1017,7 @@ generator:
             result.is_err(),
             "leak with time_to_ceiling < duration must fail"
         );
-        let msg = format!("{}", result.err().expect("checked"));
+        let msg = format!("{}", result.expect_err("checked"));
         assert!(
             msg.contains("saturation"),
             "error must suggest using saturation, got: {msg}"

--- a/sonda-core/src/config/mod.rs
+++ b/sonda-core/src/config/mod.rs
@@ -4245,9 +4245,7 @@ generator:
                    1700000005,info,c\n";
         let (_tmp, path) = write_temp_log_csv(csv);
         let config = build_log_scenario(path, None);
-        let err = expand_log_scenario(config)
-            .err()
-            .expect("non-monotonic timestamps must error");
+        let err = expand_log_scenario(config).expect_err("non-monotonic timestamps must error");
         let msg = format!("{err}");
         assert!(
             msg.contains("non-monotonic"),

--- a/sonda-core/src/config/validate.rs
+++ b/sonda-core/src/config/validate.rs
@@ -1537,7 +1537,7 @@ generator:
         for tick in 0..1000 {
             let v = gen.value(tick);
             assert!(
-                v >= 0.0 && v <= 1.0,
+                (0.0..=1.0).contains(&v),
                 "value {v} out of [0,1] at tick {tick}"
             );
         }

--- a/sonda-core/src/encoder/influx.rs
+++ b/sonda-core/src/encoder/influx.rs
@@ -418,6 +418,7 @@ mod tests {
     // --- Output format ---
 
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is a sample metric value, not the PI constant
     fn output_ends_with_newline() {
         let enc = InfluxLineProtocol::new(None, None);
         let labels = Labels::from_pairs(&[("k", "v")]).unwrap();

--- a/sonda-core/src/encoder/json.rs
+++ b/sonda-core/src/encoder/json.rs
@@ -246,6 +246,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is a sample metric value, not the PI constant
     fn roundtrip_value_matches_original_event() {
         let ts = UNIX_EPOCH + Duration::from_millis(1_700_000_000_000);
         let event = make_event("latency", 3.14, &[], ts);

--- a/sonda-core/src/encoder/mod.rs
+++ b/sonda-core/src/encoder/mod.rs
@@ -686,6 +686,7 @@ sink:
     // ---------------------------------------------------------------------------
 
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14159 is a sample display value, not the PI constant
     fn write_value_none_uses_default_display() {
         let mut buf = Vec::new();
         write_value(&mut buf, 1.0, None);
@@ -715,6 +716,7 @@ sink:
     }
 
     #[test]
+    #[allow(clippy::approx_constant)] // -3.14159 is a sample display value, not the PI constant
     fn write_value_precision_with_negative() {
         let mut buf = Vec::new();
         write_value(&mut buf, -3.14159, Some(2));

--- a/sonda-core/src/encoder/otlp.rs
+++ b/sonda-core/src/encoder/otlp.rs
@@ -643,6 +643,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is a sample metric value, not the PI constant
     fn metric_value_is_stored_as_double() {
         let encoder = OtlpEncoder::new();
         let event = make_metric("gauge", 3.14, &[], 1_700_000_000_500);
@@ -1090,7 +1091,7 @@ mod tests {
 
     #[test]
     fn default_creates_valid_encoder() {
-        let encoder = OtlpEncoder::default();
+        let encoder = OtlpEncoder;
         let event = make_metric("test", 1.0, &[], 1_700_000_000_000);
         let mut buf = Vec::new();
         encoder.encode_metric(&event, &mut buf).expect("encode ok");

--- a/sonda-core/src/encoder/prometheus.rs
+++ b/sonda-core/src/encoder/prometheus.rs
@@ -390,6 +390,7 @@ mod tests {
     // --- Output ends with newline ---
 
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is a sample metric value, not the PI constant
     fn output_ends_with_newline() {
         let labels = Labels::from_pairs(&[("k", "v")]).unwrap();
         let event = make_event("metric", 3.14, labels, 999);

--- a/sonda-core/src/encoder/remote_write.rs
+++ b/sonda-core/src/encoder/remote_write.rs
@@ -390,6 +390,7 @@ mod tests {
     // -------------------------------------------------------------------------
 
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is a sample metric value, not the PI constant
     fn sample_has_correct_value_and_timestamp() {
         let encoder = RemoteWriteEncoder::new();
         let event = make_event("gauge_metric", 3.14, &[], 1_700_000_000_500);
@@ -491,7 +492,7 @@ mod tests {
 
     #[test]
     fn default_creates_valid_encoder() {
-        let encoder = RemoteWriteEncoder::default();
+        let encoder = RemoteWriteEncoder;
         let event = make_event("test", 1.0, &[], 1_700_000_000_000);
         let mut buf = Vec::new();
         encoder.encode_metric(&event, &mut buf).expect("encode ok");

--- a/sonda-core/src/generator/csv_replay.rs
+++ b/sonda-core/src/generator/csv_replay.rs
@@ -869,6 +869,7 @@ timestamp,cpu_percent
     // ---- Negative and special float values ------------------------------------
 
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is a sample CSV value, not the PI constant
     fn handles_negative_values() {
         let content = "-1.5\n-2.5\n0.0\n3.14\n";
         let gen = CsvReplayGenerator::from_str(content, 0, true).unwrap();

--- a/sonda-core/src/generator/mod.rs
+++ b/sonda-core/src/generator/mod.rs
@@ -863,7 +863,7 @@ mod tests {
         for tick in 0..1000 {
             let v = gen.value(tick);
             assert!(
-                v >= 0.0 && v <= 1.0,
+                (0.0..=1.0).contains(&v),
                 "uniform value {v} out of [0,1] at tick {tick}"
             );
         }

--- a/sonda-core/src/generator/sawtooth.rs
+++ b/sonda-core/src/generator/sawtooth.rs
@@ -83,7 +83,7 @@ mod tests {
         let v = gen.value(last_tick);
         // fraction = 99/100 = 0.99 → value = 99.0
         assert!(
-            v >= 98.0 && v < 100.0,
+            (98.0..100.0).contains(&v),
             "value near period end should approach max, got {v}"
         );
     }

--- a/sonda-core/src/generator/sequence.rs
+++ b/sonda-core/src/generator/sequence.rs
@@ -338,6 +338,7 @@ mod tests {
     // ---- Floating point edge cases -------------------------------------------
 
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is a sample sequence value, not the PI constant
     fn handles_negative_values() {
         let gen = SequenceGenerator::new(vec![-1.0, -2.5, 0.0, 3.14], true).unwrap();
         assert_eq!(gen.value(0), -1.0);

--- a/sonda-core/src/generator/step.rs
+++ b/sonda-core/src/generator/step.rs
@@ -205,7 +205,7 @@ mod tests {
         for tick in 0..20 {
             let v = gen.value(tick);
             assert!(
-                v >= 0.0 && v < 3.0,
+                (0.0..3.0).contains(&v),
                 "value {v} at tick {tick} must be in [0.0, 3.0)"
             );
         }

--- a/sonda-core/src/generator/uniform.rs
+++ b/sonda-core/src/generator/uniform.rs
@@ -77,7 +77,7 @@ mod tests {
         for tick in 0..10_000 {
             let v = gen.value(tick);
             assert!(
-                v >= 5.0 && v <= 10.0,
+                (5.0..=10.0).contains(&v),
                 "value {v} at tick {tick} is outside [5.0, 10.0]"
             );
         }

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -439,7 +439,7 @@ mod tests {
 
     #[test]
     fn spawn_failed_is_runtime_not_config() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "resource limit");
+        let io_err = std::io::Error::other("resource limit");
         let rt_err = RuntimeError::SpawnFailed(io_err);
         let sonda_err: SondaError = rt_err.into();
         assert!(
@@ -460,10 +460,7 @@ mod tests {
 
     #[test]
     fn runtime_error_display_is_descriptive() {
-        let spawn_err = RuntimeError::SpawnFailed(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "too many threads",
-        ));
+        let spawn_err = RuntimeError::SpawnFailed(std::io::Error::other("too many threads"));
         let msg = format!("{spawn_err}");
         assert!(
             msg.contains("failed to spawn scenario thread"),

--- a/sonda-core/src/model/metric.rs
+++ b/sonda-core/src/model/metric.rs
@@ -512,6 +512,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is a sample metric value, not the PI constant
     fn with_timestamp_stores_name_and_value_correctly() {
         let ts = UNIX_EPOCH + Duration::from_millis(500);
         let labels = Labels::from_pairs(&[("env", "test")]).unwrap();

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -1340,10 +1340,7 @@ mod tests {
 
         let mut tick_fn =
             |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                Err(SondaError::Sink(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "test error",
-                )))
+                Err(SondaError::Sink(std::io::Error::other("test error")))
             };
 
         let result = run_schedule_loop(&schedule, 10.0, None, None, &mut NullSink, &mut tick_fn);
@@ -1413,10 +1410,7 @@ mod tests {
 
         let mut tick_fn =
             |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                Err(SondaError::Sink(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "transient",
-                )))
+                Err(SondaError::Sink(std::io::Error::other("transient")))
             };
 
         let result = run_schedule_loop(&schedule, 50.0, None, None, &mut NullSink, &mut tick_fn);
@@ -1476,17 +1470,14 @@ mod tests {
         let mut tick_fn =
             |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
                 counter += 1;
-                if counter % 2 == 0 {
+                if counter.is_multiple_of(2) {
                     Ok(TickResult {
                         bytes_written: 8,
                         metric_event: None,
                         delivered: true,
                     })
                 } else {
-                    Err(SondaError::Sink(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "alt",
-                    )))
+                    Err(SondaError::Sink(std::io::Error::other("alt")))
                 }
             };
 
@@ -1595,7 +1586,7 @@ mod tests {
     #[test]
     fn rate_limiter_emits_first_error_immediately() {
         let mut limiter = SinkErrorRateLimiter::new();
-        let err = std::io::Error::new(std::io::ErrorKind::Other, "first");
+        let err = std::io::Error::other("first");
         limiter.observe("scenario_a", &err);
         assert!(
             limiter.last_emit.is_some(),
@@ -1606,7 +1597,7 @@ mod tests {
     #[test]
     fn rate_limiter_suppresses_subsequent_errors_within_interval() {
         let mut limiter = SinkErrorRateLimiter::new();
-        let err = std::io::Error::new(std::io::ErrorKind::Other, "boom");
+        let err = std::io::Error::other("boom");
         for _ in 0..1000 {
             limiter.observe("scenario_b", &err);
         }
@@ -1638,8 +1629,7 @@ mod tests {
 
         let mut tick_fn = |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
             match err_kind {
-                ErrKind::Sink => Err(SondaError::Sink(std::io::Error::new(
-                    std::io::ErrorKind::Other,
+                ErrKind::Sink => Err(SondaError::Sink(std::io::Error::other(
                     "matrix",
                 ))),
                 ErrKind::Encoder => Err(SondaError::Encoder(crate::EncoderError::NotSupported(
@@ -1688,10 +1678,7 @@ mod tests {
     fn apply_flush_policy_warn_swallows_sink_error() {
         let mut schedule = minimal_schedule(None);
         schedule.on_sink_error = OnSinkError::Warn;
-        let flush_err = Err(SondaError::Sink(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "flush",
-        )));
+        let flush_err = Err(SondaError::Sink(std::io::Error::other("flush")));
         let out = apply_flush_policy(&schedule, None, flush_err);
         assert!(out.is_ok(), "warn policy must swallow flush sink errors");
     }
@@ -1700,10 +1687,7 @@ mod tests {
     fn apply_flush_policy_fail_propagates_sink_error() {
         let mut schedule = minimal_schedule(None);
         schedule.on_sink_error = OnSinkError::Fail;
-        let flush_err = Err(SondaError::Sink(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "flush",
-        )));
+        let flush_err = Err(SondaError::Sink(std::io::Error::other("flush")));
         let out = apply_flush_policy(&schedule, None, flush_err);
         assert!(matches!(out, Err(SondaError::Sink(_))));
     }

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -1459,8 +1459,7 @@ mod tests {
                 let _guard = AliveGuard {
                     flag: alive_for_thread,
                 };
-                let always_none: Option<u32> = None;
-                always_none.expect("intentional panic for AliveGuard test");
+                panic!("intentional panic for AliveGuard test");
             })
             .expect("spawn must succeed");
 
@@ -1501,8 +1500,7 @@ mod tests {
                 let _g = StateGuard {
                     stats: stats_for_thread,
                 };
-                let always_none: Option<u32> = None;
-                always_none.expect("intentional panic for StateGuard test");
+                panic!("intentional panic for StateGuard test");
             })
             .expect("spawn must succeed");
 

--- a/sonda-core/src/schedule/stats.rs
+++ b/sonda-core/src/schedule/stats.rs
@@ -252,6 +252,7 @@ mod tests {
 
     /// Verifying Serialize works by round-tripping through serde_json.
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is a sample rate value, not the PI constant
     fn serializes_to_json_with_all_fields_present() {
         let s = ScenarioStats {
             total_events: 7,

--- a/sonda-core/src/sink/http.rs
+++ b/sonda-core/src/sink/http.rs
@@ -328,9 +328,8 @@ mod tests {
                 break;
             }
             let lower = line.to_lowercase();
-            if lower.starts_with("content-length:") {
-                let val = lower["content-length:".len()..].trim().to_string();
-                content_length = val.parse().unwrap_or(0);
+            if let Some(rest) = lower.strip_prefix("content-length:") {
+                content_length = rest.trim().parse().unwrap_or(0);
             }
         }
 

--- a/sonda-core/src/sink/loki.rs
+++ b/sonda-core/src/sink/loki.rs
@@ -312,6 +312,29 @@ impl LokiSink {
     }
 }
 
+/// Escape a string for use inside a JSON string value.
+///
+/// Handles the minimal set of characters that must be escaped in JSON:
+/// backslash, double quote, and the ASCII control characters.
+fn escape_json(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 32 => {
+                // Other ASCII control characters as \uXXXX.
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -359,9 +382,8 @@ mod tests {
                 break;
             }
             let lower = line.to_lowercase();
-            if lower.starts_with("content-length:") {
-                let val = lower["content-length:".len()..].trim().to_string();
-                content_length = val.parse().unwrap_or(0);
+            if let Some(rest) = lower.strip_prefix("content-length:") {
+                content_length = rest.trim().parse().unwrap_or(0);
             }
         }
         let mut body = vec![0u8; content_length];
@@ -1500,27 +1522,4 @@ sink:
             "both direct writes group into the single stream"
         );
     }
-}
-
-/// Escape a string for use inside a JSON string value.
-///
-/// Handles the minimal set of characters that must be escaped in JSON:
-/// backslash, double quote, and the ASCII control characters.
-fn escape_json(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '\\' => out.push_str("\\\\"),
-            '"' => out.push_str("\\\""),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if (c as u32) < 32 => {
-                // Other ASCII control characters as \uXXXX.
-                out.push_str(&format!("\\u{:04x}", c as u32));
-            }
-            c => out.push(c),
-        }
-    }
-    out
 }

--- a/sonda-core/tests/common/mod.rs
+++ b/sonda-core/tests/common/mod.rs
@@ -307,7 +307,7 @@ pub fn normalize_timestamps(bytes: &[u8]) -> Vec<u8> {
             while digit_end < after_space.len() && after_space[digit_end].is_ascii_digit() {
                 digit_end += 1;
             }
-            if digit_end >= 11 && digit_end <= 19 && after_space.get(digit_end) == Some(&b'\n') {
+            if (11..=19).contains(&digit_end) && after_space.get(digit_end) == Some(&b'\n') {
                 out.extend_from_slice(b" ___TS___\n");
                 i += 1 + digit_end + 1;
                 continue;

--- a/sonda-core/tests/encoder_sink_matrix.rs
+++ b/sonda-core/tests/encoder_sink_matrix.rs
@@ -267,8 +267,8 @@ fn accept_http_ok(listener: &TcpListener) -> Vec<u8> {
             break;
         }
         let low = line.to_lowercase();
-        if low.starts_with("content-length:") {
-            cl = low["content-length:".len()..].trim().parse().unwrap_or(0);
+        if let Some(rest) = low.strip_prefix("content-length:") {
+            cl = rest.trim().parse().unwrap_or(0);
         }
     }
     let mut body = vec![0u8; cl];

--- a/sonda-core/tests/log_csv_replay_roundtrip.rs
+++ b/sonda-core/tests/log_csv_replay_roundtrip.rs
@@ -125,7 +125,7 @@ fn round_trip_json_lines_encoder_produces_parseable_output() {
     let gen = create_log_generator(&child.generator).expect("create_log_generator must succeed");
     let encoder = create_encoder(&child.encoder).expect("create_encoder must succeed");
 
-    for tick in 0..rows.len() {
+    for (tick, row) in rows.iter().enumerate() {
         let event = gen.generate(tick as u64);
         let mut buf: Vec<u8> = Vec::with_capacity(256);
         encoder
@@ -138,17 +138,14 @@ fn round_trip_json_lines_encoder_produces_parseable_output() {
         let obj = parsed.as_object().expect("JSON must be an object");
         assert_eq!(
             obj.get("message").and_then(|v| v.as_str()),
-            Some(rows[tick].1),
+            Some(row.1),
             "tick {tick}: encoded message mismatch"
         );
         let fields = obj
             .get("fields")
             .and_then(|v| v.as_object())
             .expect("encoded output must include fields");
-        assert_eq!(
-            fields.get("user_id").and_then(|v| v.as_str()),
-            Some(rows[tick].3)
-        );
+        assert_eq!(fields.get("user_id").and_then(|v| v.as_str()), Some(row.3));
     }
 }
 

--- a/sonda-core/tests/sink_error_policy.rs
+++ b/sonda-core/tests/sink_error_policy.rs
@@ -42,9 +42,8 @@ fn read_http_body(stream: &mut TcpStream) -> Vec<u8> {
             break;
         }
         let lower = line.to_lowercase();
-        if lower.starts_with("content-length:") {
-            let val = lower["content-length:".len()..].trim().to_string();
-            content_length = val.parse().unwrap_or(0);
+        if let Some(rest) = lower.strip_prefix("content-length:") {
+            content_length = rest.trim().parse().unwrap_or(0);
         }
     }
     let mut body = vec![0u8; content_length];

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -59,6 +59,8 @@ fn while_gt_zero() -> SubscriptionSpec {
 /// Run a metric scenario directly against the capture sink, bypassing
 /// `launch_scenario_with_gates` (which constructs its own sink from
 /// `SinkConfig`). Returns the captured buffer and the joined thread result.
+// test helper: positional scenario knobs, grouping would churn every caller
+#[allow(clippy::too_many_arguments)]
 fn run_with_capture(
     name: &str,
     rate: f64,

--- a/sonda-core/tests/while_close_workshop_repro.rs
+++ b/sonda-core/tests/while_close_workshop_repro.rs
@@ -23,18 +23,16 @@ use sonda_core::compiler::expand::InMemoryPackResolver;
 use sonda_core::encoder::remote_write::{TimeSeries, WriteRequest, PROMETHEUS_STALE_NAN};
 use sonda_core::schedule::multi_runner::launch_multi_compiled;
 
+type CapturedSeries = Arc<Mutex<Vec<(Instant, TimeSeries)>>>;
+
 /// Spawn an HTTP listener that accepts POSTs, snappy-decodes the body, parses
 /// the protobuf `WriteRequest`, and pushes every `TimeSeries` (with arrival
 /// timestamp) into a shared vector.
-fn spawn_capture_listener() -> (
-    String,
-    Arc<Mutex<Vec<(Instant, TimeSeries)>>>,
-    Arc<AtomicBool>,
-) {
+fn spawn_capture_listener() -> (String, CapturedSeries, Arc<AtomicBool>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
     let port = listener.local_addr().unwrap().port();
     let url = format!("http://127.0.0.1:{port}/api/v1/write");
-    let captured: Arc<Mutex<Vec<(Instant, TimeSeries)>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured: CapturedSeries = Arc::new(Mutex::new(Vec::new()));
     let stop = Arc::new(AtomicBool::new(false));
 
     let captured_for_thread = Arc::clone(&captured);
@@ -854,7 +852,6 @@ scenarios:
     stop_listener.store(true, std::sync::atomic::Ordering::SeqCst);
 
     // Drop the server.
-    drop(&mut guard);
     guard.0.kill().ok();
     guard.0.wait().ok();
 
@@ -1312,7 +1309,6 @@ scenarios:
     thread::sleep(Duration::from_millis(2500));
     stop_listener.store(true, std::sync::atomic::Ordering::SeqCst);
 
-    drop(&mut guard);
     guard.0.kill().ok();
     guard.0.wait().ok();
 

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -356,7 +356,7 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
     let phase1 = handle.recent_metrics();
     let phase1_count = phase1.len();
     assert!(
-        phase1_count >= 2 && phase1_count <= 4,
+        (2..=4).contains(&phase1_count),
         "phase 1 expected ~3 events, got {phase1_count}"
     );
     let last_phase1_value = phase1

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -2698,16 +2698,8 @@ scenarios:
             "running",
             "state must be 'running' for a live scenario"
         );
-        assert_eq!(
-            body["in_gap"].as_bool().unwrap(),
-            false,
-            "in_gap must be false"
-        );
-        assert_eq!(
-            body["in_burst"].as_bool().unwrap(),
-            true,
-            "in_burst must be true"
-        );
+        assert!(!body["in_gap"].as_bool().unwrap(), "in_gap must be false");
+        assert!(body["in_burst"].as_bool().unwrap(), "in_burst must be true");
     }
 
     // ---- /stats endpoint: degraded field --------------------------------------
@@ -2831,14 +2823,12 @@ scenarios:
         assert_eq!(resp.status(), StatusCode::OK);
 
         let body = body_json(resp).await;
-        assert_eq!(
+        assert!(
             body["in_gap"].as_bool().unwrap(),
-            true,
             "in_gap must be true when the scenario is in a gap window"
         );
-        assert_eq!(
-            body["in_burst"].as_bool().unwrap(),
-            false,
+        assert!(
+            !body["in_burst"].as_bool().unwrap(),
             "in_burst must be false when only in_gap is set"
         );
     }
@@ -2989,6 +2979,7 @@ scenarios:
 
     /// DetailedStatsResponse serializes all fields to JSON correctly.
     #[test]
+    #[allow(clippy::approx_constant)] // 3.14 is a sample stat value, not the PI constant
     fn detailed_stats_response_serializes_all_fields() {
         let resp = DetailedStatsResponse {
             total_events: 42,

--- a/sonda-server/tests/events.rs
+++ b/sonda-server/tests/events.rs
@@ -35,9 +35,8 @@ fn read_http_body(stream: &mut TcpStream) -> Vec<u8> {
             break;
         }
         let lower = line.to_lowercase();
-        if lower.starts_with("content-length:") {
-            let val = lower["content-length:".len()..].trim().to_string();
-            content_length = val.parse().unwrap_or(0);
+        if let Some(rest) = lower.strip_prefix("content-length:") {
+            content_length = rest.trim().parse().unwrap_or(0);
         }
     }
     let mut body = vec![0u8; content_length];


### PR DESCRIPTION
## Summary

- CI ran clippy without `--all-targets`, so test code, integration tests, and benches were never linted. Lint debt accumulated there invisibly — `cargo clippy --workspace --all-targets --all-features -- -D warnings` reported ~54 sites across 30 files.
- Every site is fixed: idiomatic rewrites for `io::Error::other`, `strip_prefix`, `Range::contains` / `RangeInclusive::contains`, `assert!` over `assert_eq!(x, true)`, `.unwrap_err()`, `is_multiple_of`, unit-struct `default()`, plus a `type` alias for one complex type and an iterator rewrite for one indexed loop. Two dead `drop(&mut guard)` no-op lines and two `None.expect(...)` panic-trigger ceremonies were simplified.
- `approx_constant` hits are test sample values that resemble pi but are not the constant — suppressed with function-scoped `#[allow]`s rather than changing the literals (which back snapshot/value assertions).
- Both CI clippy steps now pass `--all-targets`, so the gate covers all targets and this debt cannot recur.

No production logic changed; test counts are unchanged (2532 default, 2706 all-features).

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace` — 2532 passed
- [x] `cargo nextest run --workspace --all-features` — 2706 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p sonda-core --no-default-features`