### PR TITLE
fix(core): require duration on after:-gated scenarios

### DIFF
--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -342,6 +342,8 @@ backup ramp crosses 70% a little over two minutes later, which is when `latency_
 degrade. Scenarios linked by `after:` get an auto-assigned `clock_group` so their timers share a
 start reference.
 
+An `after:`-gated entry must declare a `duration:` -- on the entry itself or via `defaults.duration` -- and is rejected at compile time without one. `after:` holds the scenario in `pending` until its upstream crosses the threshold; if that crossing never happens, a scenario with no `duration:` would have no terminal point and sit `pending` for the lifetime of the run.
+
 Use `--dry-run` to see the resolved timing:
 
 ```bash
@@ -421,7 +423,7 @@ For continuous gating that pauses and resumes a downstream as the upstream's val
 
 ## Continuous coupling with `while:`
 
-`after:` is a one-shot trigger -- it fires once and the dependent scenario runs to completion. `while:` is the continuous-coupling counterpart: the gated scenario emits only while the upstream's latest value satisfies the predicate, pauses when the predicate fails, and resumes when the predicate becomes true again. Use `while:` when an event stream should track an upstream signal's lifecycle, not just its first crossing. When a `while:`-gated scenario pauses, downstream alerts on its metrics keep firing for ~5 minutes by default — see [Recovering Prometheus alerts on gate close](#recovering-prometheus-alerts-on-gate-close) for the stale-marker default that resolves them immediately.
+`after:` is a one-shot trigger -- it fires once and the dependent scenario runs to completion. `while:` is the continuous-coupling counterpart: the gated scenario emits only while the upstream's latest value satisfies the predicate, pauses when the predicate fails, and resumes when the predicate becomes true again. A `while:`-gated entry must declare a `duration:` -- on the entry itself or via `defaults.duration` -- and is rejected at compile time without one, because the `paused` state needs a terminal point to bound the scenario's lifetime. Use `while:` when an event stream should track an upstream signal's lifecycle, not just its first crossing. When a `while:`-gated scenario pauses, downstream alerts on its metrics keep firing for ~5 minutes by default — see [Recovering Prometheus alerts on gate close](#recovering-prometheus-alerts-on-gate-close) for the stale-marker default that resolves them immediately.
 
 ```yaml title="link-traffic.yaml"
 version: 2

--- a/sonda-core/src/compile.rs
+++ b/sonda-core/src/compile.rs
@@ -386,6 +386,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: loopy

--- a/sonda-core/src/compiler/compile_after.rs
+++ b/sonda-core/src/compiler/compile_after.rs
@@ -1430,6 +1430,7 @@ scenarios:
     name: errors
     rate: 1
     log_generator: { type: template, templates: [{ message: "hi" }] }
+    duration: 5m
     after: { ref: nonexistent, op: ">", value: 50 }
 "#;
         let err = compile(yaml).expect_err("should fail");
@@ -1448,6 +1449,7 @@ scenarios:
     name: util
     rate: 1
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: loop, op: ">", value: 50 }
 "#;
         let err = compile(yaml).expect_err("self-ref is rejected");
@@ -1474,6 +1476,7 @@ scenarios:
     name: latency
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: util, op: ">", value: 70 }
 "#;
         let compiled = compile(yaml).expect("should compile");
@@ -1503,6 +1506,7 @@ scenarios:
     name: util
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: link, op: "<", value: 1 }
 "#, "1m")]
     // spike_event `<` crosses at the spike_duration boundary (10s).
@@ -1520,6 +1524,7 @@ scenarios:
     name: recovery
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: burst, op: "<", value: 50 }
 "#, "10s")]
     // Step `>`: ceil((55-0)/10) = 6 ticks, rate=2 -> 3.0s.
@@ -1537,6 +1542,7 @@ scenarios:
     name: alert
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: counter, op: ">", value: 55 }
 "#, "3s")]
     // Sequence `<`: index 2 (value 2) is the first < 3; rate=2 -> 1.0s.
@@ -1554,6 +1560,7 @@ scenarios:
     name: alert
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: seq, op: "<", value: 3 }
 "#, "1s")]
     fn follower_phase_offset_matches_expected_crossing(
@@ -1583,6 +1590,7 @@ scenarios:
     name: y
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: counter, op: "<", value: 5 }
 "#;
         let err = compile(yaml).expect_err("step < is unsupported");
@@ -1615,6 +1623,7 @@ scenarios:
     name: y
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: k, op: ">", value: 100 }
 "#, "constant")]
     #[case::sine(r#"
@@ -1631,6 +1640,7 @@ scenarios:
     name: f
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: wave, op: ">", value: 55 }
 "#, "sine")]
     #[case::steady(r#"
@@ -1647,6 +1657,7 @@ scenarios:
     name: f
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: base, op: ">", value: 55 }
 "#, "steady")]
     #[case::uniform(r#"
@@ -1663,6 +1674,7 @@ scenarios:
     name: f
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: u, op: ">", value: 5 }
 "#, "uniform")]
     fn unresolvable_target_generator_is_rejected(
@@ -1696,12 +1708,14 @@ scenarios:
     name: b
     rate: 1
     generator: { type: saturation, baseline: 20, ceiling: 85, time_to_saturate: 120s }
+    duration: 5m
     after: { ref: a, op: "<", value: 1 }
   - id: c
     signal_type: metrics
     name: c
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: b, op: ">", value: 70 }
 "#;
         let compiled = compile(yaml).expect("chain compiles");
@@ -1733,6 +1747,7 @@ scenarios:
     name: b
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: link, op: "<", value: 1, delay: 15s }
 "#;
         let compiled = compile(yaml).expect("compile");
@@ -1756,6 +1771,7 @@ scenarios:
     rate: 1
     generator: { type: constant, value: 1 }
     phase_offset: 10s
+    duration: 5m
     after: { ref: link, op: "<", value: 1 }
 "#;
         let compiled = compile(yaml).expect("compile");
@@ -1779,6 +1795,7 @@ scenarios:
     rate: 1
     generator: { type: constant, value: 1 }
     phase_offset: 10s
+    duration: 5m
     after: { ref: link, op: "<", value: 1, delay: 5s }
 "#;
         let compiled = compile(yaml).expect("compile");
@@ -1801,12 +1818,14 @@ scenarios:
     name: a
     rate: 1
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: b, op: ">", value: 1 }
   - id: b
     signal_type: metrics
     name: b
     rate: 1
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: a, op: ">", value: 1 }
 "#;
         let err = compile(yaml).expect_err("cycle should fail");
@@ -1825,18 +1844,21 @@ scenarios:
     name: a
     rate: 1
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: c, op: ">", value: 1 }
   - id: b
     signal_type: metrics
     name: b
     rate: 1
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: a, op: ">", value: 1 }
   - id: c
     signal_type: metrics
     name: c
     rate: 1
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: b, op: ">", value: 1 }
 "#;
         let err = compile(yaml).expect_err("cycle should fail");
@@ -1867,6 +1889,7 @@ scenarios:
     name: b
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: alpha, op: "<", value: 1 }
 "#;
         let compiled = compile(yaml).expect("compile");
@@ -1897,6 +1920,7 @@ scenarios:
     name: b
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: alpha, op: "<", value: 1 }
 "#;
         let compiled = compile(yaml).expect("compile");
@@ -1922,6 +1946,7 @@ scenarios:
     rate: 1
     clock_group: group_b
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: alpha, op: "<", value: 1 }
 "#;
         let err = compile(yaml).expect_err("conflicting groups fail");
@@ -1968,6 +1993,7 @@ scenarios:
     rate: 1
     clock_group: x
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: alpha, op: "<", value: 1 }
 "#;
         let compiled = compile(yaml).expect("compile");
@@ -1995,6 +2021,7 @@ scenarios:
     rate: 1
     clock_group: x
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: alpha, op: "<", value: 1 }
 "#;
         let err = compile(yaml).expect_err("trailing whitespace must conflict");
@@ -2021,6 +2048,7 @@ scenarios:
     name: app_logs
     rate: 1
     log_generator: { type: template, templates: [{ message: "upstream timeout" }] }
+    duration: 5m
     after: { ref: err_rate, op: ">", value: 10 }
 "#;
         let compiled = compile(yaml).expect("cross-signal after compiles");
@@ -2043,6 +2071,7 @@ scenarios:
     name: f
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: log_src, op: ">", value: 0 }
 "#;
         let err = compile(yaml).expect_err("logs target rejected");
@@ -2070,6 +2099,7 @@ scenarios:
     name: f
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: link, op: "<", value: 1 }
 "#;
         let compiled = compile(yaml_alias).expect("compile");
@@ -2114,6 +2144,7 @@ scenarios:
     name: alert
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: dev.state_flap, op: "<", value: 1 }
 "#;
         let compiled = compile_with_resolver(yaml, &resolver_with_test_pack()).expect("compile");
@@ -2159,6 +2190,7 @@ scenarios:
     name: alert
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: host.cpu_util, op: ">", value: 50 }
 "#;
         let err = compile_with_resolver(yaml, &r).expect_err("bare ref is ambiguous");
@@ -2199,6 +2231,7 @@ scenarios:
     name: b
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: src, op: "<", value: 1, delay: "10seconds" }
 "#, "follower", "after.delay", "10seconds")]
     // `phase_offset: "0s"` is a well-known `parse_duration` rejection
@@ -2220,6 +2253,7 @@ scenarios:
     rate: 1
     phase_offset: "0s"
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: src, op: "<", value: 1 }
 "#, "follower", "phase_offset", "0s")]
     // Invalid alias duration params (e.g. `flap.up_duration: "oops"`) must
@@ -2241,6 +2275,7 @@ scenarios:
     name: b
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: src, op: "<", value: 1 }
 "#, "follower", "flap.up_duration", "oops")]
     fn invalid_duration_surfaces_invalid_duration(
@@ -2438,6 +2473,7 @@ scenarios:
     signal_type: metrics
     name: a
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: b, op: ">", value: 1 }
   - id: b
     signal_type: metrics
@@ -2475,11 +2511,13 @@ scenarios:
     signal_type: metrics
     name: a
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: b, op: ">", value: 1 }
   - id: b
     signal_type: metrics
     name: b
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: a, op: ">", value: 1 }
 "#;
         let err = compile_after_from_yaml(yaml).expect_err("pure-after cycle must fail");

--- a/sonda-core/src/compiler/expand.rs
+++ b/sonda-core/src/compiler/expand.rs
@@ -1341,7 +1341,7 @@ scenarios:
         let yaml = r#"
 version: 2
 kind: runnable
-defaults: { rate: 1 }
+defaults: { rate: 1, duration: 5m }
 scenarios:
   - id: tail
     signal_type: metrics
@@ -1450,7 +1450,7 @@ scenarios:
         let yaml = r#"
 version: 2
 kind: runnable
-defaults: { rate: 1 }
+defaults: { rate: 1, duration: 5m }
 scenarios:
   - id: tail
     signal_type: metrics

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -125,6 +125,13 @@ pub enum NormalizeError {
     WhileWithoutDuration { source_id: String },
 
     #[error(
+        "entry '{source_id}': scenarios with `after:` must have `duration:` set \
+         (either on the entry or via `defaults.duration`).\n\
+         Bounds the scenario's lifetime so pending state has a terminal point."
+    )]
+    AfterWithoutDuration { source_id: String },
+
+    #[error(
         "entry '{source_id}': `delay:` requires `while:` on the same entry. \
          `delay:` debounces `while:` transitions and has no meaning without it."
     )]
@@ -417,6 +424,11 @@ fn normalize_entry(
     }
     if while_clause.is_some() && duration.is_none() {
         return Err(NormalizeError::WhileWithoutDuration {
+            source_id: diagnostic_label,
+        });
+    }
+    if entry.after.is_some() && duration.is_none() {
+        return Err(NormalizeError::AfterWithoutDuration {
             source_id: diagnostic_label,
         });
     }
@@ -1308,6 +1320,7 @@ version: 2
 kind: runnable
 defaults:
   rate: 1
+  duration: 5m
 scenarios:
   - id: src
     signal_type: metrics
@@ -1523,6 +1536,101 @@ scenarios:
         let file = normalize_yaml(yaml).expect("defaults.duration satisfies the gate");
         assert!(file.entries[1].while_clause.is_some());
         assert_eq!(file.entries[1].duration.as_deref(), Some("5m"));
+    }
+
+    #[test]
+    fn after_without_duration_is_rejected() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+scenarios:
+  - id: upstream
+    signal_type: metrics
+    name: upstream
+    duration: 5m
+    generator: { type: constant, value: 1 }
+  - id: downstream
+    signal_type: metrics
+    name: downstream
+    generator: { type: constant, value: 1 }
+    after: { ref: upstream, op: "<", value: 1 }
+"#;
+        let err = normalize_yaml(yaml).expect_err("missing duration must fail");
+        match err {
+            NormalizeError::AfterWithoutDuration { source_id } => {
+                assert_eq!(source_id, "downstream");
+            }
+            other => panic!("expected AfterWithoutDuration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn after_with_entry_duration_is_accepted() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+scenarios:
+  - id: upstream
+    signal_type: metrics
+    name: upstream
+    duration: 5m
+    generator: { type: constant, value: 1 }
+  - id: downstream
+    signal_type: metrics
+    name: downstream
+    duration: 5m
+    generator: { type: constant, value: 1 }
+    after: { ref: upstream, op: "<", value: 1 }
+"#;
+        let file = normalize_yaml(yaml).expect("entry duration satisfies the gate");
+        assert!(file.entries[1].after.is_some());
+        assert_eq!(file.entries[1].duration.as_deref(), Some("5m"));
+    }
+
+    #[test]
+    fn defaults_duration_satisfies_after_without_duration() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 5m
+scenarios:
+  - id: upstream
+    signal_type: metrics
+    name: upstream
+    generator: { type: constant, value: 1 }
+  - id: downstream
+    signal_type: metrics
+    name: downstream
+    generator: { type: constant, value: 1 }
+    after: { ref: upstream, op: "<", value: 1 }
+"#;
+        let file = normalize_yaml(yaml).expect("defaults.duration satisfies the gate");
+        assert!(file.entries[1].after.is_some());
+        assert_eq!(file.entries[1].duration.as_deref(), Some("5m"));
+    }
+
+    #[test]
+    fn non_after_entry_without_duration_is_accepted() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+scenarios:
+  - id: indefinite
+    signal_type: metrics
+    name: indefinite
+    generator: { type: constant, value: 1 }
+"#;
+        let file = normalize_yaml(yaml).expect("indefinite-run scenario is still valid");
+        assert!(file.entries[0].after.is_none());
+        assert!(file.entries[0].duration.is_none());
     }
 
     #[test]

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-ambiguous-at-t0.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-ambiguous-at-t0.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: spiker

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-ambiguous-pack-ref.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-ambiguous-pack-ref.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   # node_exporter_cpu ships 8 `node_cpu_seconds_total` specs differentiated

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-conflicting-clock-group.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-conflicting-clock-group.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: alpha

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-cycle.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-cycle.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: a

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-non-metrics-target.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-non-metrics-target.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: log_src

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-out-of-range.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-out-of-range.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: util

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-self-reference.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-self-reference.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: loop_entry

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-unknown-ref.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-unknown-ref.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: link

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-unsupported-sine.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-unsupported-sine.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: wave


### PR DESCRIPTION
## Summary

- A v2 scenario with an `after:` clause but no `duration:` could sit in `pending` state forever — `after:` holds it pending until the upstream crosses the threshold, and if the upstream finishes before that crossing, the scenario never starts. With no `duration:` it has no terminal point, so it stays `pending` for the whole run: looks alive, effectively dead.
- `after:`-gated scenarios are now rejected at normalize time if they have no resolved `duration:` (entry-level or inherited from `defaults.duration`). This mirrors the rule already enforced for `while:`-gated scenarios — the two are now symmetric.
- The new `NormalizeError::AfterWithoutDuration` names the offending entry and points at both ways to satisfy the rule.
- Docs: `v2-scenarios.md` now states the `after:` requirement explicitly, and — for symmetry — the previously-implicit `while:` + `duration:` requirement is now stated explicitly too.

The bulk of the diff is mechanical test-fixture maintenance: `after:`-using fixtures that incidentally omitted `duration:` now declare one so they reach the compile-after error each test actually targets.

Closes #299.

## Test plan

- [x] `cargo nextest run --workspace` — 2536 passed (+4)
- [x] `cargo nextest run --workspace --all-features` — 2710 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p sonda-core --no-default-features`
- [x] `mkdocs build --strict`
- [x] CLI: `after:` without `duration:` rejected with a clear error; entry-level and `defaults.duration` both satisfy it; plain indefinite-run scenarios unaffected.