### PR TITLE
feat(server): resolve pack: references in posted scenarios via --catalog

### DIFF
--- a/docs/site/docs/configuration/v2-scenarios.md
+++ b/docs/site/docs/configuration/v2-scenarios.md
@@ -342,6 +342,8 @@ backup ramp crosses 70% a little over two minutes later, which is when `latency_
 degrade. Scenarios linked by `after:` get an auto-assigned `clock_group` so their timers share a
 start reference.
 
+An `after:`-gated entry must declare a `duration:` -- on the entry itself or via `defaults.duration` -- and is rejected at compile time without one. `after:` holds the scenario in `pending` until its upstream crosses the threshold; if that crossing never happens, a scenario with no `duration:` would have no terminal point and sit `pending` for the lifetime of the run.
+
 Use `--dry-run` to see the resolved timing:
 
 ```bash
@@ -421,7 +423,7 @@ For continuous gating that pauses and resumes a downstream as the upstream's val
 
 ## Continuous coupling with `while:`
 
-`after:` is a one-shot trigger -- it fires once and the dependent scenario runs to completion. `while:` is the continuous-coupling counterpart: the gated scenario emits only while the upstream's latest value satisfies the predicate, pauses when the predicate fails, and resumes when the predicate becomes true again. Use `while:` when an event stream should track an upstream signal's lifecycle, not just its first crossing. When a `while:`-gated scenario pauses, downstream alerts on its metrics keep firing for ~5 minutes by default — see [Recovering Prometheus alerts on gate close](#recovering-prometheus-alerts-on-gate-close) for the stale-marker default that resolves them immediately.
+`after:` is a one-shot trigger -- it fires once and the dependent scenario runs to completion. `while:` is the continuous-coupling counterpart: the gated scenario emits only while the upstream's latest value satisfies the predicate, pauses when the predicate fails, and resumes when the predicate becomes true again. A `while:`-gated entry must declare a `duration:` -- on the entry itself or via `defaults.duration` -- and is rejected at compile time without one, because the `paused` state needs a terminal point to bound the scenario's lifetime. Use `while:` when an event stream should track an upstream signal's lifecycle, not just its first crossing. When a `while:`-gated scenario pauses, downstream alerts on its metrics keep firing for ~5 minutes by default — see [Recovering Prometheus alerts on gate close](#recovering-prometheus-alerts-on-gate-close) for the stale-marker default that resolves them immediately.
 
 ```yaml title="link-traffic.yaml"
 version: 2

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -205,6 +205,8 @@ helm install sonda ./helm/sonda -f my-values.yaml
 The Deployment template includes a `checksum/scenarios` annotation, so changing scenario
 content in your values file triggers an automatic pod rollout on `helm upgrade`.
 
+You can place `kind: composable` [metric pack](../guides/metric-packs.md) YAMLs in the same `scenarios` map alongside your runnable scenarios. Whenever `scenarios` is populated, the chart points the server's `--catalog` flag at the mounted `/scenarios` directory, so `POST /scenarios` bodies that reference a pack by name (`pack: <name>`) resolve automatically -- no extra configuration. See [Pack references over HTTP](sonda-server.md#pack-references-over-http) for how that resolution works.
+
 See [Scenario Fields](../configuration/scenario-fields.md) for the full YAML schema.
 
 ### API (runtime)

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -14,12 +14,22 @@ cargo run -p sonda-server -- --port 9090 --bind 127.0.0.1
 ```
 
 `sonda-server` accepts `--port <PORT>` (default `8080`), `--bind <ADDR>` (default `0.0.0.0`),
-and `--api-key <KEY>` (or `SONDA_API_KEY` env var). Control log verbosity with the `RUST_LOG`
-environment variable (default `info`):
+`--api-key <KEY>` (or `SONDA_API_KEY` env var), and `--catalog <DIR>` (or `SONDA_CATALOG` env
+var). Control log verbosity with the `RUST_LOG` environment variable (default `info`):
 
 ```bash
 RUST_LOG=debug cargo run -p sonda-server -- --port 8080
 ```
+
+| Flag | Env var | Default | Purpose |
+|------|---------|---------|---------|
+| `--port <PORT>` | -- | `8080` | Port the server listens on |
+| `--bind <ADDR>` | -- | `0.0.0.0` | Bind address |
+| `--api-key <KEY>` | `SONDA_API_KEY` | (unset) | Bearer token for `/scenarios/*` and `/events`. See [Authentication](#authentication). |
+| `--catalog <DIR>` | `SONDA_CATALOG` | (unset) | Directory of scenario and pack YAML files. Lets `POST /scenarios` resolve `pack: <name>` references. See [Pack references over HTTP](#pack-references-over-http). |
+
+When you pass `--catalog`, point it at a directory that holds your `kind: composable` pack YAML
+files. The path must exist -- a missing directory fails the server at startup with a clear error.
 
 Press Ctrl+C for graceful shutdown -- the server signals all running scenarios to stop before
 exiting.
@@ -322,11 +332,15 @@ carries the compiler's error message instead. See
 [Migrating from v1](../configuration/v2-scenarios.md#migrating-from-v1) for side-by-side
 shape conversions.
 
-!!! info "Pack references over HTTP"
-    The server compiles posted bodies against an empty pack resolver. Bodies that reference a
-    named pack (`pack: telegraf_snmp_interface`) fail with a pack-not-found error. Inline the
-    pack's metrics into the posted body, or run the scenario via the CLI with
-    `--catalog <dir>` where the pack file lives.
+### Pack references over HTTP
+
+Start the server with `--catalog <DIR>` (or the `SONDA_CATALOG` env var) and `POST /scenarios` resolves `pack: <name>` references against the `kind: composable` pack YAML files in that directory. Post a body that names a pack -- `pack: telegraf_snmp_interface` -- and the server expands it the same way `sonda run --catalog <dir>` does. You no longer have to inline the pack's metrics into the posted body client-side.
+
+```bash
+sonda-server --port 8080 --catalog /scenarios
+```
+
+Without `--catalog`, a body that references a pack by name is rejected with `400 Bad Request`, and the `detail` field names the unresolved pack. Inlining the pack's metrics directly into the posted body still works as an alternative -- bodies that carry no `pack:` reference are unaffected either way.
 
 ### Error response reference
 

--- a/helm/sonda/templates/deployment.yaml
+++ b/helm/sonda/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
             - {{ .Values.server.port | quote }}
             - "--bind"
             - {{ .Values.server.bind | quote }}
+            {{- if .Values.scenarios }}
+            - "--catalog"
+            - "/scenarios"
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.server.port }}

--- a/helm/sonda/values.yaml
+++ b/helm/sonda/values.yaml
@@ -63,6 +63,9 @@ securityContext: {}
 
 # Scenario YAML files to mount as a ConfigMap.
 # Each key becomes a file under /scenarios in the container.
+# Composable pack files (kind: composable) can be placed in the same map; they
+# are resolved automatically for `pack: <name>` references in posted scenario
+# bodies.
 # Example:
 #   scenarios:
 #     basic-metrics.yaml: |

--- a/sonda-core/src/catalog.rs
+++ b/sonda-core/src/catalog.rs
@@ -3,11 +3,56 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Context, Result};
-use sonda_core::compiler::expand::{
+use crate::compiler::expand::{
     classify_pack_reference, PackResolveError, PackResolveOrigin, PackResolver,
 };
-use sonda_core::packs::MetricPackDef;
+use crate::packs::MetricPackDef;
+
+/// Errors from catalog directory enumeration and `@name` resolution.
+#[derive(Debug, thiserror::Error)]
+pub enum CatalogError {
+    #[error("catalog dir {dir} does not exist or is not a directory")]
+    NotADirectory { dir: String },
+
+    #[error("failed to read catalog dir {dir}")]
+    ReadDir {
+        dir: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to read entry in {dir}")]
+    ReadEntry {
+        dir: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to read {path}")]
+    ReadFile {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("cannot derive name from filename {path}")]
+    InvalidName { path: String },
+
+    #[error("catalog {dir} contains duplicate entry name {name:?}: {first} and {second}")]
+    DuplicateName {
+        dir: String,
+        name: String,
+        first: String,
+        second: String,
+    },
+
+    #[error("unknown catalog entry {name:?} in {dir}; available: {available}")]
+    UnknownEntry {
+        dir: String,
+        name: String,
+        available: String,
+    },
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EntryKind {
@@ -49,19 +94,23 @@ struct CatalogEntryHeader {
 
 /// Walk `dir` and return one [`CatalogEntry`] per YAML file with a
 /// recognized `kind:` header. Files without `kind:` are silently skipped.
-pub fn enumerate(dir: &Path) -> Result<Vec<CatalogEntry>> {
+pub fn enumerate(dir: &Path) -> Result<Vec<CatalogEntry>, CatalogError> {
     if !dir.is_dir() {
-        return Err(anyhow!(
-            "catalog dir {} does not exist or is not a directory",
-            dir.display()
-        ));
+        return Err(CatalogError::NotADirectory {
+            dir: dir.display().to_string(),
+        });
     }
 
     let mut entries: Vec<CatalogEntry> = Vec::new();
-    let read_dir = fs::read_dir(dir)
-        .with_context(|| format!("failed to read catalog dir {}", dir.display()))?;
+    let read_dir = fs::read_dir(dir).map_err(|source| CatalogError::ReadDir {
+        dir: dir.display().to_string(),
+        source,
+    })?;
     for entry in read_dir {
-        let entry = entry.with_context(|| format!("failed to read entry in {}", dir.display()))?;
+        let entry = entry.map_err(|source| CatalogError::ReadEntry {
+            dir: dir.display().to_string(),
+            source,
+        })?;
         let path = entry.path();
         if !is_yaml_file(&path) {
             continue;
@@ -75,13 +124,12 @@ pub fn enumerate(dir: &Path) -> Result<Vec<CatalogEntry>> {
 
     for pair in entries.windows(2) {
         if pair[0].name == pair[1].name {
-            return Err(anyhow!(
-                "catalog {} contains duplicate entry name {:?}: {} and {}",
-                dir.display(),
-                pair[0].name,
-                pair[0].source_path.display(),
-                pair[1].source_path.display(),
-            ));
+            return Err(CatalogError::DuplicateName {
+                dir: dir.display().to_string(),
+                name: pair[0].name.clone(),
+                first: pair[0].source_path.display().to_string(),
+                second: pair[1].source_path.display().to_string(),
+            });
         }
     }
 
@@ -89,7 +137,7 @@ pub fn enumerate(dir: &Path) -> Result<Vec<CatalogEntry>> {
 }
 
 /// Resolve `@name` against `dir` and return the source YAML path.
-pub fn resolve(dir: &Path, name: &str) -> Result<PathBuf> {
+pub fn resolve(dir: &Path, name: &str) -> Result<PathBuf, CatalogError> {
     let all = enumerate(dir)?;
     if let Some(entry) = all.iter().find(|e| e.name == name) {
         return Ok(entry.source_path.clone());
@@ -100,12 +148,11 @@ pub fn resolve(dir: &Path, name: &str) -> Result<PathBuf> {
     } else {
         names.join(", ")
     };
-    Err(anyhow!(
-        "unknown catalog entry {:?} in {}; available: {}",
-        name,
-        dir.display(),
-        available
-    ))
+    Err(CatalogError::UnknownEntry {
+        dir: dir.display().to_string(),
+        name: name.to_string(),
+        available,
+    })
 }
 
 fn is_yaml_file(path: &Path) -> bool {
@@ -118,9 +165,11 @@ fn is_yaml_file(path: &Path) -> bool {
     )
 }
 
-fn peek_entry(path: &Path) -> Result<Option<CatalogEntry>> {
-    let content =
-        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+fn peek_entry(path: &Path) -> Result<Option<CatalogEntry>, CatalogError> {
+    let content = fs::read_to_string(path).map_err(|source| CatalogError::ReadFile {
+        path: path.display().to_string(),
+        source,
+    })?;
     let header: CatalogEntryHeader = match serde_yaml_ng::from_str(&content) {
         Ok(h) => h,
         Err(e) => {
@@ -142,7 +191,9 @@ fn peek_entry(path: &Path) -> Result<Option<CatalogEntry>> {
     let filename_stem = path
         .file_stem()
         .and_then(|s| s.to_str())
-        .ok_or_else(|| anyhow!("cannot derive name from filename {}", path.display()))?
+        .ok_or_else(|| CatalogError::InvalidName {
+            path: path.display().to_string(),
+        })?
         .to_string();
     let name = header
         .scenario_name

--- a/sonda-core/src/compile.rs
+++ b/sonda-core/src/compile.rs
@@ -386,6 +386,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: loopy

--- a/sonda-core/src/compiler/compile_after.rs
+++ b/sonda-core/src/compiler/compile_after.rs
@@ -1430,6 +1430,7 @@ scenarios:
     name: errors
     rate: 1
     log_generator: { type: template, templates: [{ message: "hi" }] }
+    duration: 5m
     after: { ref: nonexistent, op: ">", value: 50 }
 "#;
         let err = compile(yaml).expect_err("should fail");
@@ -1448,6 +1449,7 @@ scenarios:
     name: util
     rate: 1
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: loop, op: ">", value: 50 }
 "#;
         let err = compile(yaml).expect_err("self-ref is rejected");
@@ -1474,6 +1476,7 @@ scenarios:
     name: latency
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: util, op: ">", value: 70 }
 "#;
         let compiled = compile(yaml).expect("should compile");
@@ -1503,6 +1506,7 @@ scenarios:
     name: util
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: link, op: "<", value: 1 }
 "#, "1m")]
     // spike_event `<` crosses at the spike_duration boundary (10s).
@@ -1520,6 +1524,7 @@ scenarios:
     name: recovery
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: burst, op: "<", value: 50 }
 "#, "10s")]
     // Step `>`: ceil((55-0)/10) = 6 ticks, rate=2 -> 3.0s.
@@ -1537,6 +1542,7 @@ scenarios:
     name: alert
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: counter, op: ">", value: 55 }
 "#, "3s")]
     // Sequence `<`: index 2 (value 2) is the first < 3; rate=2 -> 1.0s.
@@ -1554,6 +1560,7 @@ scenarios:
     name: alert
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: seq, op: "<", value: 3 }
 "#, "1s")]
     fn follower_phase_offset_matches_expected_crossing(
@@ -1583,6 +1590,7 @@ scenarios:
     name: y
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: counter, op: "<", value: 5 }
 "#;
         let err = compile(yaml).expect_err("step < is unsupported");
@@ -1615,6 +1623,7 @@ scenarios:
     name: y
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: k, op: ">", value: 100 }
 "#, "constant")]
     #[case::sine(r#"
@@ -1631,6 +1640,7 @@ scenarios:
     name: f
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: wave, op: ">", value: 55 }
 "#, "sine")]
     #[case::steady(r#"
@@ -1647,6 +1657,7 @@ scenarios:
     name: f
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: base, op: ">", value: 55 }
 "#, "steady")]
     #[case::uniform(r#"
@@ -1663,6 +1674,7 @@ scenarios:
     name: f
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: u, op: ">", value: 5 }
 "#, "uniform")]
     fn unresolvable_target_generator_is_rejected(
@@ -1696,12 +1708,14 @@ scenarios:
     name: b
     rate: 1
     generator: { type: saturation, baseline: 20, ceiling: 85, time_to_saturate: 120s }
+    duration: 5m
     after: { ref: a, op: "<", value: 1 }
   - id: c
     signal_type: metrics
     name: c
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: b, op: ">", value: 70 }
 "#;
         let compiled = compile(yaml).expect("chain compiles");
@@ -1733,6 +1747,7 @@ scenarios:
     name: b
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: link, op: "<", value: 1, delay: 15s }
 "#;
         let compiled = compile(yaml).expect("compile");
@@ -1756,6 +1771,7 @@ scenarios:
     rate: 1
     generator: { type: constant, value: 1 }
     phase_offset: 10s
+    duration: 5m
     after: { ref: link, op: "<", value: 1 }
 "#;
         let compiled = compile(yaml).expect("compile");
@@ -1779,6 +1795,7 @@ scenarios:
     rate: 1
     generator: { type: constant, value: 1 }
     phase_offset: 10s
+    duration: 5m
     after: { ref: link, op: "<", value: 1, delay: 5s }
 "#;
         let compiled = compile(yaml).expect("compile");
@@ -1801,12 +1818,14 @@ scenarios:
     name: a
     rate: 1
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: b, op: ">", value: 1 }
   - id: b
     signal_type: metrics
     name: b
     rate: 1
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: a, op: ">", value: 1 }
 "#;
         let err = compile(yaml).expect_err("cycle should fail");
@@ -1825,18 +1844,21 @@ scenarios:
     name: a
     rate: 1
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: c, op: ">", value: 1 }
   - id: b
     signal_type: metrics
     name: b
     rate: 1
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: a, op: ">", value: 1 }
   - id: c
     signal_type: metrics
     name: c
     rate: 1
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: b, op: ">", value: 1 }
 "#;
         let err = compile(yaml).expect_err("cycle should fail");
@@ -1867,6 +1889,7 @@ scenarios:
     name: b
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: alpha, op: "<", value: 1 }
 "#;
         let compiled = compile(yaml).expect("compile");
@@ -1897,6 +1920,7 @@ scenarios:
     name: b
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: alpha, op: "<", value: 1 }
 "#;
         let compiled = compile(yaml).expect("compile");
@@ -1922,6 +1946,7 @@ scenarios:
     rate: 1
     clock_group: group_b
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: alpha, op: "<", value: 1 }
 "#;
         let err = compile(yaml).expect_err("conflicting groups fail");
@@ -1968,6 +1993,7 @@ scenarios:
     rate: 1
     clock_group: x
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: alpha, op: "<", value: 1 }
 "#;
         let compiled = compile(yaml).expect("compile");
@@ -1995,6 +2021,7 @@ scenarios:
     rate: 1
     clock_group: x
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: alpha, op: "<", value: 1 }
 "#;
         let err = compile(yaml).expect_err("trailing whitespace must conflict");
@@ -2021,6 +2048,7 @@ scenarios:
     name: app_logs
     rate: 1
     log_generator: { type: template, templates: [{ message: "upstream timeout" }] }
+    duration: 5m
     after: { ref: err_rate, op: ">", value: 10 }
 "#;
         let compiled = compile(yaml).expect("cross-signal after compiles");
@@ -2043,6 +2071,7 @@ scenarios:
     name: f
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: log_src, op: ">", value: 0 }
 "#;
         let err = compile(yaml).expect_err("logs target rejected");
@@ -2070,6 +2099,7 @@ scenarios:
     name: f
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: link, op: "<", value: 1 }
 "#;
         let compiled = compile(yaml_alias).expect("compile");
@@ -2114,6 +2144,7 @@ scenarios:
     name: alert
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: dev.state_flap, op: "<", value: 1 }
 "#;
         let compiled = compile_with_resolver(yaml, &resolver_with_test_pack()).expect("compile");
@@ -2159,6 +2190,7 @@ scenarios:
     name: alert
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: host.cpu_util, op: ">", value: 50 }
 "#;
         let err = compile_with_resolver(yaml, &r).expect_err("bare ref is ambiguous");
@@ -2199,6 +2231,7 @@ scenarios:
     name: b
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: src, op: "<", value: 1, delay: "10seconds" }
 "#, "follower", "after.delay", "10seconds")]
     // `phase_offset: "0s"` is a well-known `parse_duration` rejection
@@ -2220,6 +2253,7 @@ scenarios:
     rate: 1
     phase_offset: "0s"
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: src, op: "<", value: 1 }
 "#, "follower", "phase_offset", "0s")]
     // Invalid alias duration params (e.g. `flap.up_duration: "oops"`) must
@@ -2241,6 +2275,7 @@ scenarios:
     name: b
     rate: 1
     generator: { type: constant, value: 1 }
+    duration: 5m
     after: { ref: src, op: "<", value: 1 }
 "#, "follower", "flap.up_duration", "oops")]
     fn invalid_duration_surfaces_invalid_duration(
@@ -2438,6 +2473,7 @@ scenarios:
     signal_type: metrics
     name: a
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: b, op: ">", value: 1 }
   - id: b
     signal_type: metrics
@@ -2475,11 +2511,13 @@ scenarios:
     signal_type: metrics
     name: a
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: b, op: ">", value: 1 }
   - id: b
     signal_type: metrics
     name: b
     generator: { type: saturation, baseline: 0, ceiling: 100, time_to_saturate: 60s }
+    duration: 5m
     after: { ref: a, op: ">", value: 1 }
 "#;
         let err = compile_after_from_yaml(yaml).expect_err("pure-after cycle must fail");

--- a/sonda-core/src/compiler/expand.rs
+++ b/sonda-core/src/compiler/expand.rs
@@ -1341,7 +1341,7 @@ scenarios:
         let yaml = r#"
 version: 2
 kind: runnable
-defaults: { rate: 1 }
+defaults: { rate: 1, duration: 5m }
 scenarios:
   - id: tail
     signal_type: metrics
@@ -1450,7 +1450,7 @@ scenarios:
         let yaml = r#"
 version: 2
 kind: runnable
-defaults: { rate: 1 }
+defaults: { rate: 1, duration: 5m }
 scenarios:
   - id: tail
     signal_type: metrics

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -125,6 +125,13 @@ pub enum NormalizeError {
     WhileWithoutDuration { source_id: String },
 
     #[error(
+        "entry '{source_id}': scenarios with `after:` must have `duration:` set \
+         (either on the entry or via `defaults.duration`).\n\
+         Bounds the scenario's lifetime so pending state has a terminal point."
+    )]
+    AfterWithoutDuration { source_id: String },
+
+    #[error(
         "entry '{source_id}': `delay:` requires `while:` on the same entry. \
          `delay:` debounces `while:` transitions and has no meaning without it."
     )]
@@ -417,6 +424,11 @@ fn normalize_entry(
     }
     if while_clause.is_some() && duration.is_none() {
         return Err(NormalizeError::WhileWithoutDuration {
+            source_id: diagnostic_label,
+        });
+    }
+    if entry.after.is_some() && duration.is_none() {
+        return Err(NormalizeError::AfterWithoutDuration {
             source_id: diagnostic_label,
         });
     }
@@ -1308,6 +1320,7 @@ version: 2
 kind: runnable
 defaults:
   rate: 1
+  duration: 5m
 scenarios:
   - id: src
     signal_type: metrics
@@ -1523,6 +1536,101 @@ scenarios:
         let file = normalize_yaml(yaml).expect("defaults.duration satisfies the gate");
         assert!(file.entries[1].while_clause.is_some());
         assert_eq!(file.entries[1].duration.as_deref(), Some("5m"));
+    }
+
+    #[test]
+    fn after_without_duration_is_rejected() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+scenarios:
+  - id: upstream
+    signal_type: metrics
+    name: upstream
+    duration: 5m
+    generator: { type: constant, value: 1 }
+  - id: downstream
+    signal_type: metrics
+    name: downstream
+    generator: { type: constant, value: 1 }
+    after: { ref: upstream, op: "<", value: 1 }
+"#;
+        let err = normalize_yaml(yaml).expect_err("missing duration must fail");
+        match err {
+            NormalizeError::AfterWithoutDuration { source_id } => {
+                assert_eq!(source_id, "downstream");
+            }
+            other => panic!("expected AfterWithoutDuration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn after_with_entry_duration_is_accepted() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+scenarios:
+  - id: upstream
+    signal_type: metrics
+    name: upstream
+    duration: 5m
+    generator: { type: constant, value: 1 }
+  - id: downstream
+    signal_type: metrics
+    name: downstream
+    duration: 5m
+    generator: { type: constant, value: 1 }
+    after: { ref: upstream, op: "<", value: 1 }
+"#;
+        let file = normalize_yaml(yaml).expect("entry duration satisfies the gate");
+        assert!(file.entries[1].after.is_some());
+        assert_eq!(file.entries[1].duration.as_deref(), Some("5m"));
+    }
+
+    #[test]
+    fn defaults_duration_satisfies_after_without_duration() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 5m
+scenarios:
+  - id: upstream
+    signal_type: metrics
+    name: upstream
+    generator: { type: constant, value: 1 }
+  - id: downstream
+    signal_type: metrics
+    name: downstream
+    generator: { type: constant, value: 1 }
+    after: { ref: upstream, op: "<", value: 1 }
+"#;
+        let file = normalize_yaml(yaml).expect("defaults.duration satisfies the gate");
+        assert!(file.entries[1].after.is_some());
+        assert_eq!(file.entries[1].duration.as_deref(), Some("5m"));
+    }
+
+    #[test]
+    fn non_after_entry_without_duration_is_accepted() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+scenarios:
+  - id: indefinite
+    signal_type: metrics
+    name: indefinite
+    generator: { type: constant, value: 1 }
+"#;
+        let file = normalize_yaml(yaml).expect("indefinite-run scenario is still valid");
+        assert!(file.entries[0].after.is_none());
+        assert!(file.entries[0].duration.is_none());
     }
 
     #[test]

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -19,6 +19,8 @@
 //! without a semver-major bump.
 
 pub mod analysis;
+#[cfg(feature = "config")]
+pub mod catalog;
 pub mod compiler;
 pub mod config;
 pub mod emit;

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-ambiguous-at-t0.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-ambiguous-at-t0.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: spiker

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-ambiguous-pack-ref.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-ambiguous-pack-ref.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   # node_exporter_cpu ships 8 `node_cpu_seconds_total` specs differentiated

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-conflicting-clock-group.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-conflicting-clock-group.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: alpha

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-cycle.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-cycle.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: a

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-non-metrics-target.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-non-metrics-target.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: log_src

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-out-of-range.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-out-of-range.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: util

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-self-reference.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-self-reference.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: loop_entry

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-unknown-ref.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-unknown-ref.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: link

--- a/sonda-core/tests/fixtures/v2-examples/invalid-compile-unsupported-sine.yaml
+++ b/sonda-core/tests/fixtures/v2-examples/invalid-compile-unsupported-sine.yaml
@@ -3,6 +3,7 @@ kind: runnable
 
 defaults:
   rate: 1
+  duration: 5m
 
 scenarios:
   - id: wave

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -11,7 +11,9 @@ use std::env;
 use std::io::Write;
 use std::net::SocketAddr;
 use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
 use std::process::{exit, Command};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -48,6 +50,13 @@ struct Args {
     /// Can also be set via the `SONDA_API_KEY` environment variable.
     #[arg(long, env = "SONDA_API_KEY")]
     api_key: Option<String>,
+
+    /// Directory of scenario and pack YAML files for resolving `pack: <name>`
+    /// references in posted scenario bodies.
+    ///
+    /// Can also be set via the `SONDA_CATALOG` environment variable.
+    #[arg(long, env = "SONDA_CATALOG")]
+    catalog: Option<PathBuf>,
 }
 
 impl std::fmt::Debug for Args {
@@ -56,6 +65,7 @@ impl std::fmt::Debug for Args {
             .field("port", &self.port)
             .field("bind", &self.bind)
             .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
+            .field("catalog", &self.catalog)
             .finish()
     }
 }
@@ -95,7 +105,18 @@ async fn main() -> anyhow::Result<()> {
         info!("API key authentication disabled — all endpoints are public");
     }
 
-    let state = AppState::with_api_key(api_key);
+    if let Some(dir) = &args.catalog {
+        if !dir.is_dir() {
+            anyhow::bail!(
+                "--catalog {}: does not exist or is not a directory",
+                dir.display()
+            );
+        }
+        info!(catalog = %dir.display(), "pack catalog enabled for POST /scenarios");
+    }
+
+    let mut state = AppState::with_api_key(api_key);
+    state.catalog_dir = args.catalog.map(Arc::new);
     let app = routes::router(state.clone());
 
     let listener = tokio::net::TcpListener::bind(bind_addr)

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -17,6 +17,7 @@
 //! All lifecycle logic is delegated to sonda-core. This module is pure HTTP
 //! plumbing: deserialize → compile → launch → store → respond.
 
+use std::path::Path as FsPath;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -26,7 +27,6 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Json, Response};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use sonda_core::compiler::expand::InMemoryPackResolver;
 use sonda_core::compiler::parse::detect_version;
 use sonda_core::encoder::prometheus::PrometheusText;
 use sonda_core::encoder::Encoder;
@@ -349,7 +349,11 @@ fn format_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
     out
 }
 
-fn parse_body(body: &[u8], headers: &HeaderMap) -> Result<ParsedBody, ParseFailure> {
+fn parse_body(
+    body: &[u8],
+    headers: &HeaderMap,
+    catalog_dir: Option<&FsPath>,
+) -> Result<ParsedBody, ParseFailure> {
     let text = yaml_body_text(body, headers).map_err(ParseFailure::Syntactic)?;
 
     let version = detect_version(&text);
@@ -359,7 +363,7 @@ fn parse_body(body: &[u8], headers: &HeaderMap) -> Result<ParsedBody, ParseFailu
         )));
     }
 
-    let resolver = InMemoryPackResolver::new();
+    let resolver = sonda_core::catalog::CatalogPackResolver::new(catalog_dir);
     let compiled = compile_scenario_file_compiled(&text, &resolver).map_err(|e| {
         let detail = format!(
             "v2 scenario body failed to compile: {}",
@@ -452,7 +456,8 @@ pub async fn post_scenario(
     headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> Result<Response, Response> {
-    let parsed = parse_body(&body, &headers).map_err(|fail| {
+    let catalog_dir = state.catalog_dir.as_deref().map(|p| p.as_path());
+    let parsed = parse_body(&body, &headers, catalog_dir).map_err(|fail| {
         warn!(error = %fail.message(), "POST /scenarios: invalid request body");
         match fail {
             ParseFailure::Syntactic(m) => bad_request(m),
@@ -2001,7 +2006,7 @@ scenarios:
     fn parse_body_accepts_v2_metrics_yaml() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/x-yaml".parse().unwrap());
-        let parsed = parse_body(VALID_METRICS_YAML.as_bytes(), &headers)
+        let parsed = parse_body(VALID_METRICS_YAML.as_bytes(), &headers, None)
             .expect("v2 metrics body must parse");
         let ParsedBody::Compiled(compiled) = parsed;
         assert_eq!(compiled.entries.len(), 1);
@@ -2014,8 +2019,8 @@ scenarios:
     fn parse_body_accepts_v2_logs_yaml() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/x-yaml".parse().unwrap());
-        let parsed =
-            parse_body(VALID_LOGS_YAML.as_bytes(), &headers).expect("v2 logs body must parse");
+        let parsed = parse_body(VALID_LOGS_YAML.as_bytes(), &headers, None)
+            .expect("v2 logs body must parse");
         let ParsedBody::Compiled(compiled) = parsed;
         assert_eq!(compiled.entries.len(), 1);
         assert_eq!(compiled.entries[0].signal_type, "logs");
@@ -2034,8 +2039,8 @@ generator:
   type: constant
   value: 1.0
 ";
-        let err =
-            parse_body(v1_yaml.as_bytes(), &headers).expect_err("v1 flat YAML must be rejected");
+        let err = parse_body(v1_yaml.as_bytes(), &headers, None)
+            .expect_err("v1 flat YAML must be rejected");
         let msg = err.message();
         assert!(
             msg.contains("v2"),
@@ -2061,7 +2066,7 @@ scenarios:
       type: constant
       value: 1.0
 ";
-        let err = parse_body(v1_multi.as_bytes(), &headers)
+        let err = parse_body(v1_multi.as_bytes(), &headers, None)
             .expect_err("v1 multi-scenario YAML must be rejected");
         let msg = err.message();
         assert!(
@@ -2075,7 +2080,7 @@ scenarios:
     fn parse_body_rejects_garbage_yaml() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/x-yaml".parse().unwrap());
-        let err = parse_body(b"not valid: [}{", &headers).expect_err("garbage must fail");
+        let err = parse_body(b"not valid: [}{", &headers, None).expect_err("garbage must fail");
         assert!(!err.message().is_empty(), "error message must not be empty");
     }
 
@@ -2102,8 +2107,8 @@ scenarios:
                 }
             ]
         });
-        let parsed =
-            parse_body(json.to_string().as_bytes(), &headers).expect("v2 JSON body must parse");
+        let parsed = parse_body(json.to_string().as_bytes(), &headers, None)
+            .expect("v2 JSON body must parse");
         let ParsedBody::Compiled(compiled) = parsed;
         assert_eq!(compiled.entries.len(), 1);
     }
@@ -2113,8 +2118,119 @@ scenarios:
     fn parse_body_rejects_invalid_json() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/json".parse().unwrap());
-        let err = parse_body(b"not json", &headers).expect_err("invalid JSON must fail");
+        let err = parse_body(b"not json", &headers, None).expect_err("invalid JSON must fail");
         assert!(!err.message().is_empty(), "error message must not be empty");
+    }
+
+    // ---- Test: pack catalog resolution -----------------------------------------
+
+    const PACK_YAML: &str = "\
+version: 2
+kind: composable
+name: tiny-pack
+description: A small test pack
+category: network
+metrics:
+  - name: pack_metric_a
+    generator:
+      type: constant
+      value: 1.0
+";
+
+    const PACK_REF_BODY: &str = "\
+version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 200ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - signal_type: metrics
+    pack: tiny-pack
+";
+
+    fn write_catalog_pack(dir: &std::path::Path) {
+        std::fs::write(dir.join("tiny-pack.yaml"), PACK_YAML).expect("write pack file");
+    }
+
+    #[test]
+    fn parse_body_resolves_pack_reference_from_catalog_dir() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        write_catalog_pack(tmp.path());
+
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/x-yaml".parse().unwrap());
+        let parsed = parse_body(PACK_REF_BODY.as_bytes(), &headers, Some(tmp.path()))
+            .expect("pack reference must resolve against the catalog dir");
+        let ParsedBody::Compiled(compiled) = parsed;
+        assert!(
+            compiled.entries.iter().any(|e| e.name == "pack_metric_a"),
+            "expanded pack metric must be present"
+        );
+    }
+
+    #[test]
+    fn parse_body_pack_reference_without_catalog_fails_cleanly() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/x-yaml".parse().unwrap());
+        let err = parse_body(PACK_REF_BODY.as_bytes(), &headers, None)
+            .expect_err("pack reference must fail without a catalog dir");
+        let msg = err.message();
+        assert!(msg.contains("tiny-pack"), "error must name the pack: {msg}");
+        assert!(
+            msg.contains("catalog") || msg.contains("--catalog"),
+            "error must explain the missing catalog: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_scenario_resolves_pack_reference_when_catalog_set() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        write_catalog_pack(tmp.path());
+
+        let mut state = AppState::new();
+        state.catalog_dir = Some(Arc::new(tmp.path().to_path_buf()));
+        let app = router(state.clone());
+
+        let resp = post_scenarios(app, "application/x-yaml", PACK_REF_BODY).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::CREATED,
+            "pack-referencing body must launch when catalog is configured"
+        );
+        cleanup_scenarios(&state);
+    }
+
+    #[tokio::test]
+    async fn post_scenario_pack_reference_without_catalog_returns_4xx() {
+        let (app, _state) = test_router();
+        let resp = post_scenarios(app, "application/x-yaml", PACK_REF_BODY).await;
+        assert!(
+            resp.status().is_client_error(),
+            "pack-referencing body must return 4xx without a catalog, got {}",
+            resp.status()
+        );
+    }
+
+    #[tokio::test]
+    async fn post_scenario_plain_body_works_with_catalog_set() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        write_catalog_pack(tmp.path());
+
+        let mut state = AppState::new();
+        state.catalog_dir = Some(Arc::new(tmp.path().to_path_buf()));
+        let app = router(state.clone());
+
+        let resp = post_scenarios(app, "application/x-yaml", VALID_METRICS_YAML).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::CREATED,
+            "ordinary body must still launch with a catalog configured"
+        );
+        cleanup_scenarios(&state);
     }
 
     /// is_yaml_content_type returns true for application/x-yaml.
@@ -4147,7 +4263,7 @@ scenarios:
     fn parse_body_returns_multi_entry_compiled_for_v2_scenarios_array() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/x-yaml".parse().unwrap());
-        let parsed = parse_body(VALID_MULTI_YAML.as_bytes(), &headers)
+        let parsed = parse_body(VALID_MULTI_YAML.as_bytes(), &headers, None)
             .expect("v2 multi YAML body must parse");
         let ParsedBody::Compiled(compiled) = parsed;
         assert_eq!(

--- a/sonda-server/src/state.rs
+++ b/sonda-server/src/state.rs
@@ -1,6 +1,7 @@
 //! Shared application state for the HTTP server.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use sonda_core::ScenarioHandle;
@@ -20,6 +21,8 @@ pub struct AppState {
     pub scenarios: Arc<RwLock<HashMap<String, ScenarioHandle>>>,
     /// Optional API key for bearer-token authentication on protected routes.
     pub api_key: Option<Arc<String>>,
+    /// Optional catalog directory for resolving `pack:` references in posted bodies.
+    pub catalog_dir: Option<Arc<PathBuf>>,
 }
 
 impl AppState {
@@ -28,6 +31,7 @@ impl AppState {
         Self {
             scenarios: Arc::new(RwLock::new(HashMap::new())),
             api_key: None,
+            catalog_dir: None,
         }
     }
 
@@ -36,6 +40,7 @@ impl AppState {
         Self {
             scenarios: Arc::new(RwLock::new(HashMap::new())),
             api_key: api_key.map(Arc::new),
+            catalog_dir: None,
         }
     }
 }
@@ -138,6 +143,32 @@ mod tests {
                 state2.api_key.as_ref().unwrap()
             ),
             "cloned AppState must share the same api_key Arc"
+        );
+    }
+
+    /// AppState::new and with_api_key default catalog_dir to None.
+    #[test]
+    fn constructors_default_catalog_dir_to_none() {
+        assert!(AppState::new().catalog_dir.is_none());
+        assert!(AppState::with_api_key(None).catalog_dir.is_none());
+        assert!(AppState::with_api_key(Some("k".to_string()))
+            .catalog_dir
+            .is_none());
+    }
+
+    /// A catalog dir set on AppState is carried and survives cloning.
+    #[test]
+    fn catalog_dir_is_carried_and_shared_on_clone() {
+        let mut state = AppState::new();
+        state.catalog_dir = Some(Arc::new(PathBuf::from("/scenarios")));
+        let clone = state.clone();
+        assert!(Arc::ptr_eq(
+            state.catalog_dir.as_ref().unwrap(),
+            clone.catalog_dir.as_ref().unwrap()
+        ));
+        assert_eq!(
+            clone.catalog_dir.as_ref().unwrap().as_path(),
+            std::path::Path::new("/scenarios")
         );
     }
 

--- a/sonda/src/config.rs
+++ b/sonda/src/config.rs
@@ -16,7 +16,7 @@ pub fn resolve_scenario_source(scenario_ref: &str, catalog_dir: Option<&Path>) -
     if let Some(name) = scenario_ref.strip_prefix('@') {
         let dir = catalog_dir
             .ok_or_else(|| anyhow!("--catalog <dir> is required to resolve @name references"))?;
-        let path = crate::catalog_dir::resolve(dir, name)?;
+        let path = sonda_core::catalog::resolve(dir, name)?;
         fs::read_to_string(&path)
             .map_err(|e| anyhow!("failed to read catalog entry {}: {e}", path.display()))
     } else {

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -1,6 +1,5 @@
 //! sonda CLI entrypoint.
 
-mod catalog_dir;
 mod cli;
 mod config;
 mod dry_run;
@@ -114,14 +113,14 @@ fn list_catalog(args: &cli::ListArgs, catalog: Option<&std::path::Path>) -> anyh
         catalog.ok_or_else(|| anyhow::anyhow!("--catalog <dir> is required for `sonda list`"))?;
     let kind_filter = match args.kind.as_deref() {
         None => None,
-        Some("runnable") => Some(catalog_dir::EntryKind::Runnable),
-        Some("composable") => Some(catalog_dir::EntryKind::Composable),
+        Some("runnable") => Some(sonda_core::catalog::EntryKind::Runnable),
+        Some("composable") => Some(sonda_core::catalog::EntryKind::Composable),
         Some(other) => {
             anyhow::bail!("unknown --kind {other:?}: expected 'runnable' or 'composable'")
         }
     };
 
-    let mut entries = catalog_dir::enumerate(dir)?;
+    let mut entries = sonda_core::catalog::enumerate(dir)?;
     if let Some(k) = kind_filter {
         entries.retain(|e| e.kind == k);
     }
@@ -165,7 +164,7 @@ fn show_entry(args: &cli::ShowArgs, catalog: Option<&std::path::Path>) -> anyhow
     let name = args.name.strip_prefix('@').unwrap_or(args.name.as_str());
     let dir =
         catalog.ok_or_else(|| anyhow::anyhow!("--catalog <dir> is required for `sonda show`"))?;
-    let entries = catalog_dir::enumerate(dir)?;
+    let entries = sonda_core::catalog::enumerate(dir)?;
     let entry = entries
         .iter()
         .find(|e| e.name == name)

--- a/sonda/src/scenario_loader.rs
+++ b/sonda/src/scenario_loader.rs
@@ -8,7 +8,7 @@ use sonda_core::compiler::compile_after::CompiledFile;
 use sonda_core::compiler::parse::detect_version;
 use sonda_core::{compile_scenario_file_compiled, CompileError};
 
-use crate::catalog_dir::CatalogPackResolver;
+use sonda_core::catalog::CatalogPackResolver;
 
 pub fn has_while_clause(file: &CompiledFile) -> bool {
     file.entries.iter().any(|e| e.while_clause.is_some())


### PR DESCRIPTION
## Summary

`POST /scenarios` on `sonda-server` could not resolve `pack: <name>` references — bodies compiled against an empty pack resolver, so operators had to expand packs into inline metric entries client-side before posting (the autocon5 workshop needed ~60 lines of Python to do this).

This PR gives the server the same pack-resolution the CLI has. It comes in two commits:

**1. `refactor(core)` — move the catalog subsystem into `sonda-core`.** Catalog discovery and pack resolution (`enumerate`, `resolve`, `CatalogPackResolver`) lived in `sonda/src/catalog_dir.rs` — the CLI binary crate, importable by nothing else. It is domain logic, so it moved to a new `sonda-core::catalog` module (`config`-feature-gated), with `anyhow` swapped for a `thiserror` `CatalogError`. Pure relocation, no behaviour change; the CLI re-imports from `sonda_core::catalog`.

**2. `feat(server)` — `--catalog` flag + pack resolution.** `sonda-server` takes a `--catalog <dir>` flag (or `SONDA_CATALOG`). When set, posted bodies resolve `pack: <name>` against the `kind: composable` YAML files in that directory. Without it, a pack-by-name body is rejected with a 4xx naming the unresolved pack; non-pack bodies are unaffected. A non-existent catalog path fails the server at startup. The Helm chart passes `--catalog /scenarios` automatically whenever `.Values.scenarios` is populated, so composable packs placed in the existing `scenarios:` ConfigMap resolve with no extra configuration.

Closes #362.

## Test plan

- [x] `cargo nextest run --workspace` — 2543 passed
- [x] `cargo nextest run --workspace --all-features` — 2717 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p sonda-core --no-default-features`
- [x] `helm lint` + `helm template` (with and without `scenarios`); flag and `/scenarios` mount render together under the same guard
- [x] k3d end-to-end: chart installed with a composable pack in the `scenarios` ConfigMap, server pod healthy, `POST /scenarios` with a `pack:` reference resolves in-cluster
- [x] CLI smoke: `list` / `show` / `run @name` / `run` with a `pack:` ref unchanged after the catalog move