### PR TITLE
docs: add newcomer on-ramps to the deployment pages

### DIFF
--- a/docs/site/docs/deployment/docker.md
+++ b/docs/site/docs/deployment/docker.md
@@ -1,29 +1,29 @@
 # Docker
 
-Sonda ships as a minimal Docker image built from scratch with statically linked musl binaries.
-The image contains both the `sonda` CLI and the `sonda-server` HTTP API.
+Reach for the Docker image when you want Sonda without a local Rust toolchain — on a CI runner, on a colleague's laptop, or alongside the bundled observability stacks (Prometheus, VictoriaMetrics, Grafana) that this page sets up further down. The image is a single artifact that carries both the `sonda` CLI and the `sonda-server` HTTP API, so the same `docker run` works whether you want a one-shot scenario or a long-running server.
 
-## Building the Image
+## Run a scenario in three commands
 
-The multi-stage Dockerfile compiles static musl binaries and copies them into a `scratch` base.
-The final image is typically under 20 MB.
+Pre-built multi-arch images are published to GitHub Container Registry on each release. Pull the image, point it at a scenario file on your machine, and watch the output:
 
 ```bash
-docker build -t sonda .
-```
-
-For multi-arch builds (linux/amd64 and linux/arm64) using Docker Buildx:
-
-```bash
-docker buildx build --platform linux/amd64,linux/arm64 -t sonda .
-```
-
-Pre-built multi-arch images are published to GitHub Container Registry on each release.
-Docker automatically pulls the correct architecture for your host.
-
-```bash
+# 1. Pull the published image (Docker picks the right architecture for your host)
 docker pull ghcr.io/davidban77/sonda:latest
+
+# 2. Scaffold a starter scenario into the current directory
+docker run --rm -v "$PWD":/work -w /work \
+  ghcr.io/davidban77/sonda:latest \
+  new --template -o hello.yaml
+
+# 3. Run it — synthetic metrics stream to your terminal
+docker run --rm -v "$PWD":/work -w /work \
+  ghcr.io/davidban77/sonda:latest \
+  run hello.yaml --duration 5s
 ```
+
+That last command prints five Prometheus-format metric lines and a completion banner — the same output you would get from a locally installed `sonda`. The `-v "$PWD":/work -w /work` flags mount your current directory into the container so `sonda` can read the YAML file and write the scaffold back out.
+
+From here you can run your own scenarios, start the HTTP server (see [Running with Docker](#running-with-docker) below), or bring up one of the bundled [Docker Compose stacks](#docker-compose-stack). Most readers consume the published image and never need to build it — the [build instructions](#building-the-image) are at the end of the page for when you do.
 
 ## Running with Docker
 
@@ -305,3 +305,25 @@ sonda run examples/alertmanager/alerting-scenario.yaml
 ```
 
 See the [Alerting Pipeline](../guides/alerting-pipeline.md) guide for the full walkthrough.
+
+## Building the Image
+
+Most readers use the published `ghcr.io/davidban77/sonda` image and never need this section. Build your own only when you want a local image from a working tree — for example, to test an unreleased change.
+
+The multi-stage Dockerfile compiles static musl binaries and copies them into a `scratch` base. The final image is typically under 20 MB.
+
+```bash
+docker build -t sonda .
+```
+
+For multi-arch builds (linux/amd64 and linux/arm64) using Docker Buildx:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t sonda .
+```
+
+The pre-built multi-arch images on GitHub Container Registry are produced by this same Dockerfile on each release, and Docker automatically pulls the correct architecture for your host:
+
+```bash
+docker pull ghcr.io/davidban77/sonda:latest
+```

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -1,8 +1,11 @@
 # Kubernetes
 
-Sonda includes a Helm chart for deploying `sonda-server` to any Kubernetes cluster. The chart
-creates a Deployment with health probes, a ClusterIP Service with a named `http` port, and
-optional scenario injection via ConfigMap.
+Run `sonda-server` in Kubernetes when you want an always-on synthetic-telemetry baseline living *inside* the cluster — a service that emits known metrics through your stack continuously, so a Grafana panel going flat means "the data stopped" and not "the scrape config broke." It is the difference between guessing whether a quiet dashboard is a real outage and knowing it at a glance.
+
+When you finish the install below, you have a `sonda-server` pod running in the cluster, reachable at a stable Service DNS name (`sonda.<namespace>.svc.cluster.local:8080`), ready to accept scenarios POSTed over HTTP and expose their metrics for Prometheus to scrape. Sonda ships a Helm chart that produces exactly that: a Deployment with health probes, a ClusterIP Service with a named `http` port, and optional scenario injection via ConfigMap.
+
+!!! tip "Looking for the full walkthrough?"
+    The [Synthetic Monitoring](../guides/synthetic-monitoring.md) guide is the end-to-end worked example for this use case — spin up a local cluster, deploy the chart, submit long-running scenarios, scrape them with Prometheus, and build Grafana dashboards. This page is the chart *reference*: every value, probe setting, and auth option the guide draws on.
 
 ## Prerequisites
 

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -1,24 +1,85 @@
 # Server API
 
-`sonda-server` exposes a REST API for starting, inspecting, and stopping scenarios over HTTP.
-Use it to integrate Sonda into CI pipelines, test harnesses, or dashboards without shell access.
+`sonda-server` is the HTTP control plane for Sonda: a long-running process you POST scenarios to, then inspect or stop them over a REST API. Reach for it when you want Sonda running as a service rather than a one-shot CLI command — integrating into CI pipelines, test harnesses, or dashboards, or keeping a synthetic-telemetry baseline alive for hours or days.
+
+The `sonda-server` binary ships alongside the `sonda` CLI: the [install script](../getting-started.md#installation) and release tarballs place both on your PATH, and the [Docker image](docker.md) runs `sonda-server` as its default entrypoint.
 
 ## Starting the Server
 
-```bash
-# Default port (8080)
-cargo run -p sonda-server
+Start the server with the installed `sonda-server` binary. It listens on port `8080` by default:
 
-# Custom port and bind address
-cargo run -p sonda-server -- --port 9090 --bind 127.0.0.1
+=== "Installed binary"
+
+    ```bash
+    # Default port (8080), bind 0.0.0.0
+    sonda-server
+
+    # Custom port and bind address
+    sonda-server --port 9090 --bind 127.0.0.1
+    ```
+
+=== "Docker"
+
+    ```bash
+    # The image's default entrypoint is sonda-server
+    docker run -p 8080:8080 ghcr.io/davidban77/sonda:latest
+    ```
+
+=== "From source"
+
+    ```bash
+    # For contributors working from a checkout of the repo
+    cargo run -p sonda-server
+    ```
+
+## Your first request loop
+
+With the server running, you can drive its full lifecycle from `curl` in three steps — start it, POST a scenario, and confirm it is running:
+
+```bash
+# 1. Confirm the server is up
+curl http://localhost:8080/health
+# {"status":"ok"}
+
+# 2. POST a scenario — the server compiles it and starts emitting
+curl -X POST -H "Content-Type: text/yaml" \
+  --data-binary @- http://localhost:8080/scenarios <<'EOF'
+version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: up
+    signal_type: metrics
+    name: up
+    generator:
+      type: constant
+      value: 1.0
+EOF
+# {"id":"a1b2c3d4-...","name":"up","state":"running"}
+
+# 3. List running scenarios — your scenario appears with its live state
+curl http://localhost:8080/scenarios
 ```
+
+The scenario runs in a background thread inside the server until its `duration` expires, or until you stop it with `DELETE /scenarios/{id}`. Everything else on this page is the detail underneath that loop: the full flag table, every endpoint, batch submission, authentication, and the stats surface.
+
+!!! tip "Two ways into the server"
+    `POST /scenarios` runs a *sustained stream* of events over time — the loop above. To fire a **single** log or metric and block until the sink confirms delivery, use the [Single-Event API (`POST /events`)](events.md) instead. The [tutorial Server API page](../guides/tutorial-server.md) walks the same start-submit-stop loop step by step with more scenario shapes.
+
+### Server flags
 
 `sonda-server` accepts `--port <PORT>` (default `8080`), `--bind <ADDR>` (default `0.0.0.0`),
 `--api-key <KEY>` (or `SONDA_API_KEY` env var), and `--catalog <DIR>` (or `SONDA_CATALOG` env
 var). Control log verbosity with the `RUST_LOG` environment variable (default `info`):
 
 ```bash
-RUST_LOG=debug cargo run -p sonda-server -- --port 8080
+RUST_LOG=debug sonda-server --port 8080
 ```
 
 | Flag | Env var | Default | Purpose |

--- a/docs/site/docs/guides/tutorial-server.md
+++ b/docs/site/docs/guides/tutorial-server.md
@@ -9,7 +9,7 @@ format you have been using throughout the tour.
 === "Docker (recommended)"
 
     ```bash
-    docker run -p 8080:8080 ghcr.io/davidban77/sonda-server:latest
+    docker run -p 8080:8080 ghcr.io/davidban77/sonda:latest
     ```
 
 === "From source"


### PR DESCRIPTION
## Summary

A newcomer-friendliness changes:

- `deployment/docker.md` — leads with a three-command "pull → scaffold → run" example; the multi-stage image build moves below it.
- `deployment/kubernetes.md` — leads with why/when to run `sonda-server` in-cluster and the concrete end state; the Helm-chart values reference follows.
- `deployment/sonda-server.md` — leads with the installed `sonda-server` binary and a health-check → `POST /scenarios` → `GET /scenarios` request loop; `cargo run -p sonda-server` is demoted from the headline to a "from source" option.
- `guides/tutorial-server.md` — corrects the Docker image reference to `ghcr.io/davidban77/sonda` (the project publishes a single combined image; `ghcr.io/davidban77/sonda-server` does not exist and would fail for anyone who copy-pasted it).

## Test plan

- [x] `mkdocs build --strict` — clean, all cross-links/anchors resolve
- [x] Every worked-example command run end-to-end: `docker pull`/`run` against the published image, `sonda-server` start + `curl` health/POST/list loop, `helm lint`/`template`
- [x] Confirmed `ghcr.io/davidban77/sonda-server:latest` does not resolve — the `tutorial-server.md` fix was needed
- [x] Reference content retained on all three deployment pages