### PR TITLE
docs: correct the metric-pack file shape to flat top-level fields

### DIFF
--- a/docs/site/docs/guides/metric-packs.md
+++ b/docs/site/docs/guides/metric-packs.md
@@ -175,40 +175,40 @@ Labels are merged in this order, with later sources winning on key conflicts:
 
 ## Author a pack
 
-A pack is a v2 YAML file with `kind: composable` and a top-level `pack:` block describing the
-metric set:
+A pack is a v2 YAML file with `kind: composable`. The pack identity (`name`, `description`,
+`category`) and the metric set (`shared_labels`, `metrics`) sit flat at the top level of the file:
 
 ```yaml title="~/sonda-catalog/my-app-pack.yaml"
 version: 2
 kind: composable
 
 name: my_app_metrics
-tags: [application]
 description: "Core application metrics"
+category: application
+tags: [application]
 
-pack:
-  shared_labels:
-    service: ""
-    env: ""
+shared_labels:
+  service: ""
+  env: ""
 
-  metrics:
-    - name: http_requests_total
-      generator:
-        type: step
-        start: 0.0
-        step_size: 10.0
+metrics:
+  - name: http_requests_total
+    generator:
+      type: step
+      start: 0.0
+      step_size: 10.0
 
-    - name: http_request_duration_seconds
-      generator:
-        type: sine
-        amplitude: 0.05
-        period_secs: 60
-        offset: 0.1
+  - name: http_request_duration_seconds
+    generator:
+      type: sine
+      amplitude: 0.05
+      period_secs: 60
+      offset: 0.1
 
-    - name: http_errors_total
-      generator:
-        type: constant
-        value: 0.0
+  - name: http_errors_total
+    generator:
+      type: constant
+      value: 0.0
 ```
 
 Drop the file in your catalog directory and it shows up immediately:
@@ -245,10 +245,13 @@ sonda --catalog ~/sonda-catalog run run-my-pack.yaml
 
 ### Pack definition fields
 
-The fields under `pack:`:
+All pack fields are top-level keys in the file:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
+| `name` | string | yes | Snake_case identifier for the pack. This is the name a runnable scenario references with `pack: <name>`. |
+| `description` | string | yes | One-line human-readable description, shown in `sonda list`. |
+| `category` | string | yes | Broad grouping for the pack (e.g. `network`, `infrastructure`, `application`). |
 | `shared_labels` | map | no | Labels applied to every metric in the pack. Empty values are placeholders for the user to fill. |
 | `metrics` | list | yes | One or more metric specifications. |
 | `metrics[].name` | string | yes | The metric name. |

--- a/docs/site/docs/guides/metric-packs.md
+++ b/docs/site/docs/guides/metric-packs.md
@@ -175,8 +175,7 @@ Labels are merged in this order, with later sources winning on key conflicts:
 
 ## Author a pack
 
-A pack is a v2 YAML file with `kind: composable`. The pack identity (`name`, `description`,
-`category`) and the metric set (`shared_labels`, `metrics`) sit flat at the top level of the file:
+A pack is a v2 YAML file with `kind: composable`. The pack identity (`name`, `description`, `category`) and the metric set (`shared_labels`, `metrics`) sit flat at the top level of the file:
 
 ```yaml title="~/sonda-catalog/my-app-pack.yaml"
 version: 2


### PR DESCRIPTION
## Summary

The "Author a pack" section of `metric-packs.md` showed a metric-pack definition file with `shared_labels` and `metrics` wrapped under a top-level `pack:` block, and with no `category:` field. A pack definition deserializes into `MetricPackDef`, whose fields — `name`, `description`, `category`, `shared_labels`, `metrics` — sit flat at the top level, and `category` is required. A file authored from the old example failed at pack resolution (`cannot parse pack definition: missing field metrics` / `missing field category`).

- Rewrote the "Author a pack" YAML example to the flat shape, with `category:` present.
- Fixed the surrounding prose (it described "a top-level `pack:` block") and the pack-definition field table (added `name` / `description` / `category` rows; corrected the "fields under `pack:`" wording).
- `metric-packs.md` was the only page with a wrong pack-*definition* example — `pack: <name>` *reference* examples inside runnable scenarios are correct and untouched.

Surfaced during the autocon5 workshop migration to 1.11.0.

## Test plan

- [x] `mkdocs build --strict` — clean
- [x] The corrected example, placed in a catalog and referenced by a runnable scenario, resolves via `sonda --catalog <dir> --dry-run run` — the pack expands into its three metrics, exit 0
- [x] Confirmed the old `pack:`-wrapped shape fails pack resolution with a missing-field error
- [x] Real run against the corrected pack emits all three metrics