### PR TITLE
docs: introduce concepts page and drop v2 framing from scenario docs

### DIFF
--- a/docs/site/docs/configuration/cli-reference.md
+++ b/docs/site/docs/configuration/cli-reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-The `sonda` binary has four verbs: `run`, `list`, `show`, and `new`. `run` executes a [v2 scenario YAML file](v2-scenarios.md), `list` and `show` browse a catalog directory of scenarios and composable packs, and `new` scaffolds a starter file. Anything that used to live behind a per-signal subcommand (`metrics`, `logs`, `histogram`, `summary`) is now a v2 scenario YAML — pick a generator in the file, point `sonda run` at it.
+The `sonda` binary has four verbs: `run`, `list`, `show`, and `new`. `run` executes a [scenario YAML file](scenario-files.md), `list` and `show` browse a catalog directory of scenarios and composable packs, and `new` scaffolds a starter file. Anything that used to live behind a per-signal subcommand (`metrics`, `logs`, `histogram`, `summary`) is now a scenario YAML — pick a generator in the file, point `sonda run` at it.
 
 ## Global options
 
@@ -37,7 +37,7 @@ sonda [--catalog <DIR>] [--dry-run] [--format text|json] run <SCENARIO> [OVERRID
 
 | Argument / Flag | Description |
 |------|-------------|
-| `<SCENARIO>` | Filesystem path to a v2 YAML file (`./my.yaml`, `examples/cpu.yaml`) **or** `@name` for a catalog entry (requires `--catalog`). |
+| `<SCENARIO>` | Filesystem path to a scenario YAML file (`./my.yaml`, `examples/cpu.yaml`) **or** `@name` for a catalog entry (requires `--catalog`). |
 | `--catalog <DIR>` | Required when `<SCENARIO>` starts with `@`. Also used to resolve `pack: <name>` references inside the file. |
 | `--dry-run` | Compile and validate the scenario, print the resolved config, exit. |
 | `--format text\|json` | Dry-run output format. Default `text`. |
@@ -192,7 +192,7 @@ sonda --dry-run run /tmp/snap.yaml
 
 ## `sonda new`
 
-Scaffold a new v2 scenario YAML. Three modes — pick the one that matches how much you already know about the scenario you want.
+Scaffold a new scenario YAML. Three modes — pick the one that matches how much you already know about the scenario you want.
 
 ```
 sonda new [--template] [--from <CSV>] [-o <PATH>]

--- a/docs/site/docs/configuration/concepts.md
+++ b/docs/site/docs/configuration/concepts.md
@@ -1,0 +1,291 @@
+# Concepts
+
+Sonda generates synthetic telemetry — metrics, logs, histograms, summaries — from YAML you author. Four nouns carry the model: a **scenario** is a runnable YAML file, an **entry** is one signal inside that file, a **pack** is a reusable bundle of metric names, and a **catalog** is the directory of files Sonda discovers them from. The rest of this page defines each, shows what one looks like, and points at the detailed reference.
+
+## The four pieces
+
+The pieces nest. A catalog directory contains scenario files. Each scenario file contains one or more entries. Each entry chooses a generator, an encoder, and a sink — or references a pack instead of declaring those by hand.
+
+```
+my-catalog/                <-- catalog (a directory you point sonda at)
+├── cpu-spike.yaml         <-- scenario file (kind: runnable)
+│   └── scenarios:
+│       └── - id: cpu      <-- entry (one signal you emit)
+│           generator: ...   one of these per entry
+│           encoder:   ...
+│           sink:      ...
+│
+└── snmp-pack.yaml         <-- scenario file (kind: composable, i.e. a "pack")
+    └── metrics:
+        - name: ifHCInOctets    one bundle of related metric names,
+        - name: ifHCOutOctets   reusable across scenarios
+```
+
+You can keep the catalog flat or nest subdirectories — Sonda walks the tree. What matters is what's inside each file.
+
+## Scenario
+
+A **scenario file** is a single YAML you can hand to `sonda run`. Every scenario file declares two top-level fields:
+
+- `version: 2` — the format version.
+- `kind: runnable` — a file you can execute. `kind: composable` marks a file as a pack instead (see [Pack](#pack) below).
+
+The other top-level fields are `defaults:` (shared settings) and `scenarios:` (the list of entries). The minimal runnable file:
+
+```yaml title="hello.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: demo_cpu
+    generator:
+      type: constant
+      value: 42
+```
+
+```bash
+sonda run hello.yaml
+```
+
+That file emits one Prometheus-formatted metric named `demo_cpu` to stdout at 1 sample/sec for 30 seconds. The `kind:` distinction is the rule of thumb: `kind: runnable` makes the file executable; `kind: composable` makes it a pack you reference from other files. For the full top-level field reference — catalog metadata, environment-variable interpolation, sink-error policy — see [Scenario Files](scenario-files.md).
+
+## Entry
+
+An **entry** is one item under the `scenarios:` list. Each entry emits exactly one signal — one metric series, one log stream, one histogram, one summary. An entry needs at minimum a `signal_type:`, a `name:` (or a `pack:` reference), and the generator block that matches its signal type: `generator:` for metrics, `log_generator:` for logs, `distribution:` for histograms and summaries. Everything else — `rate`, `duration`, `encoder`, `sink`, `labels` — inherits from `defaults:` unless the entry overrides it.
+
+Why a scenario file has multiple entries: production systems emit many signals at once. A single Prometheus scrape returns dozens of metrics from one process. To model that realistically, the scenario file declares one entry per metric and they all run together on shared defaults. A four-entry node-exporter-shaped file:
+
+```yaml title="node-exporter-shape.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+  labels:
+    instance: web-01
+    job: node
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: sine
+      amplitude: 30
+      offset: 60
+      period_secs: 60
+
+  - id: mem
+    signal_type: metrics
+    name: memory_used_bytes
+    generator:
+      type: leak
+      baseline: 2000000000
+      ceiling: 6000000000
+      time_to_ceiling: 5m
+
+  - id: disk
+    signal_type: metrics
+    name: disk_io_bytes
+    generator:
+      type: sawtooth
+      min: 1000000
+      max: 50000000
+      period_secs: 30
+
+  - id: net
+    signal_type: metrics
+    name: network_throughput_bytes
+    generator:
+      type: spike
+      baseline: 100000
+      magnitude: 5000000
+      duration_secs: 5
+      interval_secs: 45
+```
+
+Four metrics, four generators, one shared encoder + sink + labels block — all four series scrape together as if they came from a single exporter. For the per-entry field reference (generators, schedules, labels, encoders, sinks, `after:` / `while:`) see [Scenario Fields](scenario-fields.md).
+
+## Pack
+
+A **pack** is a reusable bundle of metric names, label schemas, and sensible default generators per metric. You express a pack as a file with `kind: composable` and store it in the same catalog as your runnable scenarios. A runnable entry references a pack with `pack: <name>` and the compiler expands it at parse time into one entry per metric in the pack.
+
+The point: when you model an SNMP interface, you do not want to type out `ifHCInOctets`, `ifHCOutOctets`, `ifInErrors`, `ifOutErrors`, `ifOperStatus` and their label keys by hand. Author the pack once; reference it from every scenario that touches an interface.
+
+Side-by-side — writing five entries by hand versus referencing one pack:
+
+=== "By hand"
+
+    ```yaml title="snmp-by-hand.yaml"
+    version: 2
+    kind: runnable
+    defaults:
+      rate: 1
+      duration: 60s
+      encoder:
+        type: prometheus_text
+      sink:
+        type: stdout
+    scenarios:
+      - id: in_octets
+        signal_type: metrics
+        name: ifHCInOctets
+        generator: { type: sawtooth, min: 0, max: 1000000000, period_secs: 60 }
+        labels: { device: rtr-edge-01, ifName: Gi0/0/0 }
+      - id: out_octets
+        signal_type: metrics
+        name: ifHCOutOctets
+        generator: { type: sawtooth, min: 0, max: 1000000000, period_secs: 60 }
+        labels: { device: rtr-edge-01, ifName: Gi0/0/0 }
+      - id: in_errors
+        signal_type: metrics
+        name: ifInErrors
+        generator: { type: constant, value: 0 }
+        labels: { device: rtr-edge-01, ifName: Gi0/0/0 }
+      - id: out_errors
+        signal_type: metrics
+        name: ifOutErrors
+        generator: { type: constant, value: 0 }
+        labels: { device: rtr-edge-01, ifName: Gi0/0/0 }
+      - id: oper_status
+        signal_type: metrics
+        name: ifOperStatus
+        generator: { type: constant, value: 1 }
+        labels: { device: rtr-edge-01, ifName: Gi0/0/0 }
+    ```
+
+=== "With a pack"
+
+    ```yaml title="snmp-with-pack.yaml"
+    version: 2
+    kind: runnable
+    defaults:
+      rate: 1
+      duration: 60s
+      encoder:
+        type: prometheus_text
+      sink:
+        type: stdout
+    scenarios:
+      - id: edge_router_snmp
+        signal_type: metrics
+        pack: telegraf_snmp_interface
+        labels:
+          device: rtr-edge-01
+          ifName: Gi0/0/0
+    ```
+
+The pack version sits in the same catalog as the runnable file. The compiler reads `pack: telegraf_snmp_interface`, looks it up, and produces one prepared entry per metric — same names, same shared labels, ready to scrape. To author your own pack and read the full field reference, see [Metric Packs](../guides/metric-packs.md).
+
+## Catalog
+
+A **catalog** is a directory of scenario files you point `sonda` at with `--catalog <dir>`. Sonda walks the directory, indexes each file by its `name:` (or by filename if `name:` is omitted), and lets you run anything in it with `sonda run @name`. Runnable files and packs live side by side — the `kind:` field tells Sonda which is which.
+
+```
+~/sonda-catalog/
+├── cpu-spike.yaml          # kind: runnable,    name: cpu-spike
+├── memory-leak.yaml        # kind: runnable,    name: memory-leak
+└── snmp-interface.yaml     # kind: composable,  name: telegraf_snmp_interface
+```
+
+```bash
+sonda --catalog ~/sonda-catalog list
+sonda --catalog ~/sonda-catalog run @cpu-spike
+```
+
+Packs live in the catalog but you do not run them directly — they are only meaningful when a runnable entry references them by name. The catalog is yours: keep it in the same git repo as your alert rules and dashboards, so the scenarios that exercise those rules ship alongside them. For the discovery rules, `sonda list` / `sonda show` output, and the full directory contract, see [Catalogs](../guides/scenarios.md).
+
+## Defaults & overrides
+
+The `defaults:` block factors out fields that would otherwise repeat on every entry — `rate`, `duration`, `encoder`, `sink`, `labels`, `on_sink_error`. Each `scenarios:` entry only declares what differs.
+
+```yaml title="defaults-and-overrides.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+  labels:
+    job: sonda
+scenarios:
+  - id: noisy
+    signal_type: metrics
+    name: noisy_metric
+    generator: { type: sine, amplitude: 50, offset: 50, period_secs: 30 }
+
+  - id: chatty
+    signal_type: metrics
+    name: chatty_metric
+    generator: { type: constant, value: 1 }
+
+  - id: slow
+    signal_type: metrics
+    name: slow_metric
+    rate: 1                       # overrides the defaults: rate: 10
+    generator: { type: constant, value: 1 }
+```
+
+Two entries inherit `rate: 10`; the third overrides to `rate: 1`. Every entry shares the same encoder, sink, and `job` label. This is the everyday ergonomic win once a scenario file has more than one entry.
+
+## Multi-scenario runs
+
+When a scenario file has multiple entries, every entry runs on its own thread, concurrently, each on its own clock. They share `defaults:` by default but can override anything per entry. A common pattern: every entry pushes to the same Prometheus remote-write sink, so one `sonda run` populates a backend with a realistic mix of metrics + logs + histograms from one process.
+
+```yaml title="mixed-signals.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 60s
+  sink:
+    type: remote_write
+    url: http://localhost:9090/api/v1/write
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    encoder: { type: remote_write }
+    generator: { type: sine, amplitude: 30, offset: 60, period_secs: 60 }
+
+  - id: latency
+    signal_type: histogram
+    name: http_request_duration_seconds
+    encoder: { type: remote_write }
+    distribution: { type: exponential, rate: 10.0 }
+    observations_per_tick: 100
+
+  - id: app_logs
+    signal_type: logs
+    name: app_logs
+    encoder: { type: json_lines }
+    sink: { type: loki, url: http://localhost:3100 }
+    log_generator:
+      type: template
+      templates:
+        - message: "request handled"
+```
+
+Three signal types, three threads, two sinks — metrics + histogram go to Prometheus, logs go to Loki. For entries that depend on each other in time (one starts only after another crosses a threshold; one emits only while another is in a given state), see `after:` and `while:` on the [Scenario Files](scenario-files.md#temporal-chains-with-after) page. For a hands-on walkthrough, see the [Multi-Scenario Runs](../guides/tutorial-multi-scenario.md) tutorial.
+
+## What next
+
+- [**Scenario Files**](scenario-files.md) — the full file-format reference: every top-level field, `defaults:`, `after:` / `while:` temporal chains, environment variable interpolation, sink-error policy.
+- [**Scenario Fields**](scenario-fields.md) — per-entry field reference: generators, schedules, labels, encoders, sinks.
+- [**Catalogs**](../guides/scenarios.md) — directory layout, `sonda list`, `sonda show`.
+- [**Metric Packs**](../guides/metric-packs.md) — authoring composable packs.
+- [**Multi-Scenario Runs**](../guides/tutorial-multi-scenario.md) — walkthrough of a file with several signals running concurrently.

--- a/docs/site/docs/configuration/generators.md
+++ b/docs/site/docs/configuration/generators.md
@@ -706,11 +706,7 @@ Think of it this way: a counter tells you *how many* requests happened. A histog
     distribution, updates cumulative bucket counters, and emits the result in Prometheus format.
     The output is indistinguishable from a real instrumented service.
 
-Histograms and summaries are v2 scenario entries with `signal_type: histogram` or
-`signal_type: summary` and a `distribution:` block in place of the metric `generator:` block.
-Run them with `sonda run` just like any other scenario. For a hands-on walkthrough of testing
-latency alerts, see the
-[Histograms, Summaries, and Latency Alerts](../guides/histogram-alerts.md) guide.
+Histograms and summaries are scenario entries with `signal_type: histogram` or `signal_type: summary` and a `distribution:` block in place of the metric `generator:` block. Run them with `sonda run` just like any other scenario. For a hands-on walkthrough of testing latency alerts, see the [Histograms, Summaries, and Latency Alerts](../guides/histogram-alerts.md) guide.
 
 ### histogram
 
@@ -948,8 +944,7 @@ real metrics rarely distribute evenly.
 
 ## Log generators
 
-Log generators produce structured log events instead of numeric values. They live on a v2
-`signal_type: logs` entry under the `log_generator:` key (not `generator:`).
+Log generators produce structured log events instead of numeric values. They live on a `signal_type: logs` entry under the `log_generator:` key (not `generator:`).
 
 ### template
 

--- a/docs/site/docs/configuration/index.md
+++ b/docs/site/docs/configuration/index.md
@@ -15,14 +15,19 @@ this field do" and "what are the valid values."
 
 !!! tip "Read this first"
     If you only open one page in this section, make it
-    [**v2 Scenario Files**](v2-scenarios.md). Every other reference here -- generators,
+    [**Scenario Files**](scenario-files.md). Every other reference here -- generators,
     encoders, sinks -- plugs into that shape.
 
 ## Scenario file shape
 
 <div class="grid cards" markdown>
 
--   :material-file-document-outline: __[v2 Scenario Files](v2-scenarios.md)__
+-   :material-lightbulb-outline: __[Concepts](concepts.md)__
+
+    The vocabulary: scenario, entry, pack, catalog, defaults inheritance, and
+    multi-scenario runs. Start here if you are new.
+
+-   :material-file-document-outline: __[Scenario Files](scenario-files.md)__
 
     The canonical file format: `version: 2`, `defaults:`, `scenarios:`, packs, and
     `after:` temporal chains.

--- a/docs/site/docs/configuration/scenario-fields.md
+++ b/docs/site/docs/configuration/scenario-fields.md
@@ -1,18 +1,13 @@
 # Scenario Fields
 
-This page is the per-entry field reference. It describes every field you can set on a
-`scenarios:` entry inside a [v2 scenario file](v2-scenarios.md) -- generators, schedules,
-labels, encoders, sinks, and multi-scenario timing controls.
+This page is the per-entry field reference. It describes every field you can set on a `scenarios:` entry inside a [scenario file](scenario-files.md) -- generators, schedules, labels, encoders, sinks, and multi-scenario timing controls.
 
-!!! info "Start with the v2 guide"
-    For the file shape (`version: 2`, `defaults:`, `scenarios:`), catalog metadata,
-    pack-backed entries, and `after:` temporal chains, see
-    [**v2 Scenario Files**](v2-scenarios.md). Every field below sits inside a v2
-    `scenarios:` entry -- Sonda only accepts `version: 2` YAML.
+!!! info "Start with the file guide"
+    For the file shape (`version: 2`, `defaults:`, `scenarios:`), catalog metadata, pack-backed entries, and `after:` temporal chains, see [**Scenario Files**](scenario-files.md). Every field below sits inside a `scenarios:` entry.
 
 ## Complete example
 
-A single v2 entry touching every available field:
+A single entry touching every available field:
 
 ```yaml title="full-example.yaml"
 version: 2
@@ -91,7 +86,7 @@ sonda run full-example.yaml
 | `labels` | map | no | none | Static key-value labels attached to every event. |
 | `jitter` | float | no | none | Noise amplitude. Adds uniform noise in `[-jitter, +jitter]` to every generated value. See [Generators - Jitter](generators.md#jitter). |
 | `jitter_seed` | integer | no | `0` | Seed for deterministic jitter noise. Different seeds produce different noise sequences. |
-| `on_sink_error` | string | no | `warn` | Behavior when the sink returns an error mid-run: `warn` (log + drop batch + keep running) or `fail` (propagate and exit the runner). Overrides `defaults.on_sink_error`. See [Sink-error policy](v2-scenarios.md#sink-error-policy). |
+| `on_sink_error` | string | no | `warn` | Behavior when the sink returns an error mid-run: `warn` (log + drop batch + keep running) or `fail` (propagate and exit the runner). Overrides `defaults.on_sink_error`. See [Sink-error policy](scenario-files.md#sink-error-policy). |
 
 ### Gap window
 
@@ -284,15 +279,14 @@ request_count{hostname="web-0",region="eu-west-1",...} 3
 
 ### Temporal fields
 
-These fields control when and how entries coordinate inside a multi-entry v2 file (including
-bodies POSTed to [`POST /scenarios`](../deployment/sonda-server.md#start-a-scenario)).
+These fields control when and how entries coordinate inside a multi-entry scenario file (including bodies POSTed to [`POST /scenarios`](../deployment/sonda-server.md#start-a-scenario)).
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `id` | string | no | auto | Entry identifier. `after:` and explicit `clock_group:` references target other entries by `id`. Defaults to the entry's `name` when omitted. |
 | `phase_offset` | string | no | none | Explicit delay before starting this scenario. Supports `ms`, `s`, `m`, `h`. Mutually exclusive with `after:` (the compiler computes `phase_offset` from `after:`). |
 | `clock_group` | string | no | none | Entries with the same clock group share a start-time reference. Auto-assigned when you use `after:`. |
-| `after` | object | no | none | Start this entry when another entry's generator crosses a threshold. See [Temporal chains](v2-scenarios.md#temporal-chains-with-after). |
+| `after` | object | no | none | Start this entry when another entry's generator crosses a threshold. See [Temporal chains](scenario-files.md#temporal-chains-with-after). |
 
 See [Multi-signal files](#multi-signal-files) below for a working example.
 
@@ -398,8 +392,7 @@ JSON Lines output and become Loki stream labels when the sink is `loki`.
 
 ## Multi-signal files
 
-Each entry in a v2 `scenarios:` list declares its own `signal_type`. The compiler routes the
-entry to the matching generator family at compile time.
+Each entry in a `scenarios:` list declares its own `signal_type`. The compiler routes the entry to the matching generator family at compile time.
 
 | `signal_type` | Description | Body shape |
 |---------------|-------------|------------|
@@ -451,10 +444,7 @@ scenarios:
 sonda run multi-scenario.yaml
 ```
 
-The `phase_offset` on `memory_usage` delays it by 3 seconds, so CPU spikes first and memory
-follows. Both entries share the `alert-test` clock group for synchronized timing. For
-declarative chains, use [`after:`](v2-scenarios.md#temporal-chains-with-after) instead of
-hand-tuned offsets.
+The `phase_offset` on `memory_usage` delays it by 3 seconds, so CPU spikes first and memory follows. Both entries share the `alert-test` clock group for synchronized timing. For declarative chains, use [`after:`](scenario-files.md#temporal-chains-with-after) instead of hand-tuned offsets.
 
 ### Mixing all four signal types
 
@@ -580,9 +570,6 @@ see [CLI Reference: sonda run](cli-reference.md#sonda-run) for the full override
 
 ## What next
 
-- [**v2 Scenario Files**](v2-scenarios.md) -- file shape, `defaults:`, `after:` chains, catalog
-  metadata, and migration notes.
-- [**CLI Reference -- sonda run**](cli-reference.md#sonda-run) -- the unified entry point for
-  v2 scenario files.
-- [**Metric Packs**](../guides/metric-packs.md) -- reusable metric name + label schemas you can
-  reference via `pack:`.
+- [**Scenario Files**](scenario-files.md) -- file shape, `defaults:`, `after:` chains, and catalog metadata.
+- [**CLI Reference -- sonda run**](cli-reference.md#sonda-run) -- the unified entry point for scenario files.
+- [**Metric Packs**](../guides/metric-packs.md) -- reusable metric name + label schemas you can reference via `pack:`.

--- a/docs/site/docs/configuration/scenario-files.md
+++ b/docs/site/docs/configuration/scenario-files.md
@@ -1,6 +1,6 @@
-# v2 Scenario Files
+# Scenario Files
 
-The v2 scenario format is Sonda's way to describe one or many signals in a single YAML file. One top-level block declares shared defaults; another lists the scenarios. Packs, `after:` temporal dependencies, and clock groups all compose inside the same file.
+The scenario file format is Sonda's way to describe one or many signals in a single YAML file. One top-level block declares shared defaults; another lists the scenarios. Packs, `after:` temporal dependencies, and clock groups all compose inside the same file.
 
 Every scenario file declares two top-level fields:
 
@@ -9,17 +9,9 @@ Every scenario file declares two top-level fields:
 
 Everything else you already know about scenarios — generators, encoders, sinks, labels — still applies.
 
-!!! warning "v1 YAML is no longer accepted"
-    Sonda only accepts v2 scenario YAML. Both `sonda run` and the HTTP server
-    (`POST /scenarios`) refuse files or bodies without `version: 2` at the top and print a
-    migration hint pointing at this page.
-
-    If you are upgrading from a Sonda release before this change, jump straight to
-    [Migrating from v1](#migrating-from-v1).
-
 ## Minimal example
 
-```yaml title="hello-v2.yaml"
+```yaml title="hello.yaml"
 version: 2
 kind: runnable
 
@@ -43,7 +35,7 @@ scenarios:
 Run it like any other scenario file:
 
 ```bash
-sonda run hello-v2.yaml
+sonda run hello.yaml
 ```
 
 ```text title="Output"
@@ -55,7 +47,7 @@ demo_cpu 42 1776090152619
 ━━ run complete  scenarios: 1 | events: 30 | bytes: 680 B | errors: 0 | elapsed: 30.1s
 ```
 
-## What v2 buys you
+## What this format gives you
 
 - **Shared defaults** -- put `rate`, `duration`, `encoder`, `sink`, and `labels` in one place.
 - **Temporal chains** -- link scenarios with `after:` clauses (`this starts when that crosses a threshold`).
@@ -66,7 +58,7 @@ demo_cpu 42 1776090152619
 
 ## Catalog metadata
 
-v2 files can carry optional top-level metadata that powers the catalog views --
+A scenario file can carry optional top-level metadata that powers the catalog views --
 `sonda list` and `sonda show` against a `--catalog <dir>`. The fields sit at the root,
 alongside `version:`, `kind:`, and `defaults:`:
 
@@ -96,7 +88,7 @@ scenarios:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `kind` | yes | `runnable` for runnable scenarios; `composable` for packs. Required at the top level of every v2 file. |
+| `kind` | yes | `runnable` for runnable scenarios; `composable` for packs. Required at the top level of every scenario file. |
 | `name` | no | Catalog identifier (kebab-case). Defaults to the filename (without `.yaml`, hyphens preserved) if omitted. Used by `@name` shorthand and `sonda run @name`. When posted to a running `sonda-server`, this field also acts as a uniqueness key — POSTing two cascades that share an active `name` returns [`409 Conflict`](../deployment/sonda-server.md#duplicate-scenario_name-returns-409). |
 | `tags` | no | List of strings shown in the catalog table and filterable via `sonda list --tag <t>`. |
 | `description` | no | One-line summary shown in the catalog table and JSON output. Keep it under ~60 characters so it fits the table column. |
@@ -104,7 +96,7 @@ scenarios:
 The compiler ignores `tags:` and `description:` — they only feed the catalog. `deny_unknown_fields`
 stays in force, so typos like `tag:` (singular) or `desc:` are rejected at parse time.
 
-Drop a v2 file into your catalog directory and it shows up immediately:
+Drop a scenario file into your catalog directory and it shows up immediately:
 
 ```bash
 sonda --catalog ./my-catalog list --tag infrastructure
@@ -692,7 +684,7 @@ The `delay.close: 5s` debounces flap transitions: a brief recovery on the primar
 Reference a [metric pack](../guides/metric-packs.md) directly from a scenarios entry. Sonda
 expands the pack at compile time -- you get one prepared scenario per metric in the pack.
 
-```yaml title="snmp-interface.v2.yaml"
+```yaml title="snmp-interface.yaml"
 version: 2
 kind: runnable
 
@@ -739,9 +731,9 @@ The start banner and the grouped run summary both show the `clock_group`. See
 [CLI Reference -- Status output](cli-reference.md#status-output) for what the banners look
 like at runtime.
 
-## Scaffolding v2 files with `sonda new`
+## Scaffolding new files with `sonda new`
 
-`sonda new` emits v2 YAML. The fastest path is `--template`, which prints a minimal runnable
+`sonda new` emits a scenario YAML file. The fastest path is `--template`, which prints a minimal runnable
 file and exits with no prompts:
 
 ```bash
@@ -772,327 +764,10 @@ Drop the `--template` flag to walk the interactive flow (signal type → generat
 duration → sink type → output path), or use `--from <csv>` to seed the scaffold from
 existing CSV data. See [`sonda new`](cli-reference.md#sonda-new) for the full flag reference.
 
-## Migrating from v1
-
-Every legacy v1 shape maps cleanly to v2. Pick the tab that matches the file you have.
-
-### How Sonda rejects v1
-
-When Sonda encounters a file or request body without `version: 2`, it stops before running
-anything and prints the error alongside a pointer to this guide.
-
-=== "CLI (`sonda run`)"
-
-    ```text title="stderr"
-    error: scenario file /path/to/legacy.yaml is not a v2 scenario. Sonda only accepts v2 YAML (`version: 2` at the top level). Migrate this file to v2 — see docs/configuration/v2-scenarios.md for the migration guide.
-    ```
-
-    Exit code: `1`.
-
-=== "Server (`POST /scenarios`)"
-
-    ```http
-    HTTP/1.1 400 Bad Request
-    Content-Type: application/json
-
-    {
-      "error": "bad_request",
-      "detail": "body is not a v2 scenario. Sonda only accepts v2 scenario bodies (`version: 2` at the top level). Migrate this body to v2 — see docs/configuration/v2-scenarios.md for the migration guide."
-    }
-    ```
-
-    The server returns `400 Bad Request` (not `422`) because a non-v2 body is ill-formed by
-    contract, not a semantic validation failure. See
-    [Server API -- Start a Scenario](../deployment/sonda-server.md#start-a-scenario).
-
-### Shape-by-shape migration
-
-=== "Flat single-signal"
-
-    The legacy "flat" layout put `name:`, `rate:`, `generator:`, `encoder:`, and `sink:` at the
-    top level with no `scenarios:` wrapper. Wrap them in a single-entry v2 file:
-
-    ```yaml title="Before (v1, flat single-signal)"
-    name: cpu_usage
-    rate: 100
-    duration: 30s
-    generator:
-      type: sine
-      amplitude: 50.0
-      period_secs: 60
-      offset: 50.0
-    labels:
-      zone: us-east-1
-    encoder:
-      type: prometheus_text
-    sink:
-      type: stdout
-    ```
-
-    ```yaml title="After (v2)"
-    version: 2
-    kind: runnable
-
-    defaults:
-      rate: 100
-      duration: 30s
-      encoder:
-        type: prometheus_text
-      sink:
-        type: stdout
-
-    scenarios:
-      - id: cpu_usage
-        signal_type: metrics
-        name: cpu_usage
-        generator:
-          type: sine
-          amplitude: 50.0
-          period_secs: 60
-          offset: 50.0
-        labels:
-          zone: us-east-1
-    ```
-
-    Two things changed:
-
-    - `version: 2` at the top, with shared `rate` / `duration` / `encoder` / `sink` moved into
-      `defaults:`.
-    - One entry under `scenarios:` with an explicit `signal_type: metrics`. The `id:` is
-      free-form; it's what `after:` clauses and `clock_group:` references use.
-
-=== "Top-level `scenarios:` list"
-
-    The legacy multi-scenario layout already had a `scenarios:` list, but each entry repeated
-    `encoder:`, `sink:`, `rate:`, and `duration:`. Add `version: 2`, move the shared fields
-    into `defaults:`, and drop the repetition:
-
-    ```yaml title="Before (v1, multi-scenario)"
-    scenarios:
-      - signal_type: metrics
-        name: cpu
-        rate: 10
-        duration: 60s
-        generator: { type: constant, value: 1 }
-        encoder: { type: prometheus_text }
-        sink: { type: stdout }
-      - signal_type: metrics
-        name: mem
-        rate: 10
-        duration: 60s
-        generator: { type: constant, value: 2 }
-        encoder: { type: prometheus_text }
-        sink: { type: stdout }
-    ```
-
-    ```yaml title="After (v2)"
-    version: 2
-    kind: runnable
-
-    defaults:
-      rate: 10
-      duration: 60s
-      encoder: { type: prometheus_text }
-      sink: { type: stdout }
-
-    scenarios:
-      - id: cpu
-        signal_type: metrics
-        name: cpu
-        generator: { type: constant, value: 1 }
-      - id: mem
-        signal_type: metrics
-        name: mem
-        generator: { type: constant, value: 2 }
-    ```
-
-    Any per-entry field (`rate`, `labels`, `gaps`, `encoder`, ...) still wins over `defaults:`.
-
-=== "Logs"
-
-    Log entries move into a `scenarios:` entry with `signal_type: logs` and `log_generator:`
-    (note the `log_` prefix -- v2 log entries use `log_generator:` to keep the discriminated
-    union unambiguous):
-
-    ```yaml title="Before (v1, flat logs)"
-    name: app_logs
-    rate: 10
-    duration: 60s
-    generator:
-      type: template
-      templates:
-        - message: "Request from {ip} to {endpoint}"
-          field_pools:
-            ip: ["10.0.0.1", "10.0.0.2"]
-            endpoint: ["/api", "/health"]
-      severity_weights:
-        info: 0.7
-        warn: 0.2
-        error: 0.1
-      seed: 42
-    labels:
-      job: sonda
-      env: dev
-    encoder:
-      type: json_lines
-    sink:
-      type: stdout
-    ```
-
-    ```yaml title="After (v2)"
-    version: 2
-    kind: runnable
-
-    defaults:
-      rate: 10
-      duration: 60s
-      encoder:
-        type: json_lines
-      sink:
-        type: stdout
-      labels:
-        job: sonda
-        env: dev
-
-    scenarios:
-      - id: app_logs
-        signal_type: logs
-        name: app_logs
-        log_generator:
-          type: template
-          templates:
-            - message: "Request from {ip} to {endpoint}"
-              field_pools:
-                ip: ["10.0.0.1", "10.0.0.2"]
-                endpoint: ["/api", "/health"]
-          severity_weights:
-            info: 0.7
-            warn: 0.2
-            error: 0.1
-          seed: 42
-    ```
-
-=== "Histogram / Summary"
-
-    Histogram and summary entries do not use `generator:` at all -- they use
-    `distribution:`, `observations_per_tick:`, and (optionally) `buckets:` or `quantiles:`.
-    Wrap them in a v2 entry with `signal_type: histogram` or `signal_type: summary`:
-
-    ```yaml title="Before (v1, flat histogram)"
-    name: http_request_duration_seconds
-    rate: 1
-    duration: 60s
-    distribution:
-      type: exponential
-      rate: 10.0
-    observations_per_tick: 100
-    seed: 42
-    labels:
-      job: api
-    encoder:
-      type: prometheus_text
-    sink:
-      type: stdout
-    ```
-
-    ```yaml title="After (v2)"
-    version: 2
-    kind: runnable
-
-    defaults:
-      rate: 1
-      duration: 60s
-      encoder:
-        type: prometheus_text
-      sink:
-        type: stdout
-
-    scenarios:
-      - id: http_request_duration_seconds
-        signal_type: histogram
-        name: http_request_duration_seconds
-        distribution:
-          type: exponential
-          rate: 10.0
-        observations_per_tick: 100
-        seed: 42
-        labels:
-          job: api
-    ```
-
-    The `distribution`, `observations_per_tick`, `buckets`, and `quantiles` fields stay on the
-    entry. See [Generators -- histogram and summary](generators.md#histogram-and-summary-generators)
-    for the full field reference.
-
-=== "`pack:` shorthand"
-
-    The legacy `pack: <name>` shorthand file (a top-level `pack:` with `rate:` / `duration:` /
-    `labels:`) becomes a single v2 entry whose body is `pack: <name>`:
-
-    ```yaml title="Before (v1, pack shorthand)"
-    pack: telegraf_snmp_interface
-    rate: 1
-    duration: 60s
-    labels:
-      device: rtr-edge-01
-      ifName: GigabitEthernet0/0/0
-      ifIndex: "1"
-    encoder:
-      type: prometheus_text
-    sink:
-      type: stdout
-    ```
-
-    ```yaml title="After (v2)"
-    version: 2
-    kind: runnable
-
-    defaults:
-      rate: 1
-      duration: 60s
-      encoder:
-        type: prometheus_text
-      sink:
-        type: stdout
-
-    scenarios:
-      - id: edge_router_snmp
-        signal_type: metrics
-        pack: telegraf_snmp_interface
-        labels:
-          device: rtr-edge-01
-          ifName: GigabitEthernet0/0/0
-          ifIndex: "1"
-    ```
-
-    See [Pack-backed entries](#pack-backed-entries) above for how the compiler expands
-    `pack:` into one entry per metric.
-
-=== "Hand-tuned `phase_offset`"
-
-    If a legacy file chained signals with hand-tuned `phase_offset` values, v2 expresses the
-    same temporal relationships declaratively with `after:` clauses. Each entry says *when it
-    starts relative to another entry's shape* and the compiler resolves the offsets at parse
-    time. See the [`after:` section](#temporal-chains-with-after) above.
-
-### Common gotchas
-
-- **`signal_type` is per-entry in v2.** Legacy files let you put `signal_type:` at the top
-  level; v2 reads it from the first entry (`metrics`, `logs`, `histogram`, `summary`). Every
-  entry in a multi-signal file carries its own `signal_type:`.
-- **Log entries use `log_generator:`, not `generator:`.** Metrics use `generator:`;
-  histograms and summaries use `distribution:`; logs use `log_generator:`. Mismatched keys
-  trigger a v2 compile error.
-- **`deny_unknown_fields` is strict.** Typos like `scenarioName:` or `desc:` at the top of a
-  v2 file are rejected at parse time with the offending field name in the error. Fix the
-  typo and re-run.
-- **`sonda new --from <csv>` emits v2.** Regenerate any older scaffolded scenarios with
-  [`sonda new --from <csv>`](cli-reference.md#sonda-new) if you kept older output around.
-
 ## What next
 
-- [**CLI Reference -- sonda run**](cli-reference.md#sonda-run) -- flag reference for running v2 files
-- [**CLI Reference -- dry run**](cli-reference.md#dry-run) -- validate and preview a v2 file before running
+- [**CLI Reference -- sonda run**](cli-reference.md#sonda-run) -- flag reference for running scenario files
+- [**CLI Reference -- dry run**](cli-reference.md#dry-run) -- validate and preview a scenario file before running
 - [**Scenario Fields**](scenario-fields.md) -- per-entry field reference (generators, labels, schedules)
-- [**Server API**](../deployment/sonda-server.md) -- `POST /scenarios` accepts v2 YAML or JSON
-- [**Metric Packs**](../guides/metric-packs.md) -- the pack catalog you can reference from v2 entries
+- [**Server API**](../deployment/sonda-server.md) -- `POST /scenarios` accepts a scenario file as YAML or JSON
+- [**Metric Packs**](../guides/metric-packs.md) -- the pack catalog you can reference from scenario entries

--- a/docs/site/docs/deployment/docker.md
+++ b/docs/site/docs/deployment/docker.md
@@ -69,7 +69,7 @@ docker run --rm \
       --catalog /catalog list
     ```
 
-The image ships no built-in catalog. Mount a directory of your own scenario and pack YAML files (typically `kind: runnable` and `kind: composable` v2 files) at any path inside the container and pass `--catalog <path>` to point `sonda` at it. See [Catalogs](../guides/scenarios.md) for the directory layout.
+The image ships no built-in catalog. Mount a directory of your own scenario and pack YAML files (typically `kind: runnable` and `kind: composable` files) at any path inside the container and pass `--catalog <path>` to point `sonda` at it. See [Catalogs](../guides/scenarios.md) for the directory layout.
 
 !!! warning "Pre-1.9 env vars are gone"
     Earlier releases let the image discover scenarios from `SONDA_PACK_PATH=/packs` and `SONDA_SCENARIO_PATH=/scenarios` env vars (with companion `/packs` and `/scenarios` directories baked into the image). Both were dropped in 1.9. Discovery is explicit via `--catalog <dir>` — no env-var fallback, no implicit search path. Old recipes built around `docker run … run @scenario` (expecting `SONDA_PACK_PATH` to do the lookup) will fail with "catalog dir does not exist or is not a directory" or a `@name` resolution error — add `--catalog /catalog` and mount your catalog volume there.

--- a/docs/site/docs/deployment/endpoints.md
+++ b/docs/site/docs/deployment/endpoints.md
@@ -84,7 +84,7 @@ sink:
 The bundled `examples/docker-compose-victoriametrics.yml` exports the in-network
 overrides on the `sonda-server` container, so every scenario under `examples/`
 already works untouched in both places. See the
-[full reference](../configuration/v2-scenarios.md#environment-variable-interpolation)
+[full reference](../configuration/scenario-files.md#environment-variable-interpolation)
 for syntax and the seven built-in variable names every example honours.
 
 ## Rewriting URLs before POSTing

--- a/docs/site/docs/deployment/events.md
+++ b/docs/site/docs/deployment/events.md
@@ -2,7 +2,7 @@
 
 `POST /events` emits **one** log or metric event synchronously. The request blocks until the sink ACKs delivery, then returns the latency it took. Use it when you want a single signal to land *now* and you want to know it landed before continuing.
 
-The flat JSON body is the easy alternative to the v2 scenario shape — paste the encoder and sink inline, no `defaults:`, no `version: 2`, no scenario IDs to track.
+The flat JSON body is the easy alternative to the scenario file shape — paste the encoder and sink inline, no `defaults:`, no `version: 2`, no scenario IDs to track.
 
 ## When to use `/events` vs `/scenarios`
 
@@ -17,7 +17,7 @@ Both share the same encoders, sinks, auth, and loopback-warning behavior. They d
 - **`/scenarios`** is asynchronous. The server returns a scenario ID immediately and the scenario runs in the background until its `duration` expires or you call `DELETE /scenarios/{id}`.
 
 !!! tip "Two real-world drivers"
-    - **Workshop CLI** — fire teaching events without learning the v2 YAML shape.
+    - **Teaching and demos** — fire individual events without authoring a full scenario YAML.
     - **Live demos** — a single `curl` on stage produces a Loki log line that Grafana picks up as a panel annotation within ~5–15 ms.
 
 ## Request body

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -104,17 +104,10 @@ curl http://localhost:8080/health
 
 ## Start a Scenario
 
-Post a [v2 scenario](../configuration/v2-scenarios.md) YAML or JSON body to
-`POST /scenarios`. The server accepts both `text/yaml` (or `application/x-yaml`) and
-`application/json` content types.
+Post a [scenario](../configuration/scenario-files.md) YAML or JSON body to `POST /scenarios`. The server accepts both `text/yaml` (or `application/x-yaml`) and `application/json` content types.
 
 !!! tip "Need just one event?"
     `POST /scenarios` is for sustained emission over time. To fire a single log or metric synchronously and block until the sink ACKs, use the [Single-Event API (`POST /events`)](events.md) instead.
-
-!!! warning "v2 scenarios only"
-    The server only accepts v2 bodies (`version: 2` at the top level). Legacy v1 bodies are
-    rejected with `400 Bad Request` and a migration hint. See
-    [Migrating v1 bodies](#migrating-v1-bodies) below.
 
 !!! warning "Sink URLs resolve inside the server's network"
     POSTed scenarios compile and run inside the `sonda-server` process. A sink with
@@ -148,7 +141,7 @@ Post a [v2 scenario](../configuration/v2-scenarios.md) YAML or JSON body to
     clients that do not know about the field continue to parse the response unchanged.
 
     See [Endpoints & networking](endpoints.md) for the full reference,
-    [`${VAR:-default}` interpolation](../configuration/v2-scenarios.md#environment-variable-interpolation)
+    [`${VAR:-default}` interpolation](../configuration/scenario-files.md#environment-variable-interpolation)
     so one file works from both paths, and a `sed` one-liner for the rewrite-before-POST fallback.
 
 ### Single-scenario body
@@ -211,15 +204,13 @@ Post a [v2 scenario](../configuration/v2-scenarios.md) YAML or JSON body to
     EOF
     ```
 
-    The JSON body is transcoded to YAML server-side and compiled through the same v2 pipeline
-    as the YAML path. Any valid v2 scenario file can be posted as JSON by converting the YAML
-    to its JSON equivalent.
+    The JSON body is transcoded to YAML server-side and compiled through the same pipeline as the YAML path. Any valid scenario file can be posted as JSON by converting the YAML to its JSON equivalent.
 
 The response shape depends on how many entries the compiler produces, not on the request format. A single-entry result returns the flat `{"id", "name", "state"}` body; anything that compiles to two or more entries (for example, a pack-backed entry that fans out) returns `{"scenarios": [...]}`. The `state` field reports the live lifecycle state at response time and takes one of `"pending"`, `"running"`, `"paused"`, or `"finished"` (see [`/scenarios/{id}/stats`](#scenariosidstats) for the full enum and the `pending -> paused` transition note).
 
 ### Multi-scenario body
 
-Post a v2 file with two or more `scenarios:` entries to launch them atomically:
+Post a scenario file with two or more `scenarios:` entries to launch them atomically:
 
 === "YAML"
 
@@ -319,7 +310,7 @@ validation, the entire request is rejected and nothing is launched:
 
 | Condition | Status | Behavior |
 |-----------|--------|----------|
-| Body is not v2 (`version: 2` missing) | **400** | Rejected with migration hint |
+| Body is missing `version: 2` at the top level | **400** | Rejected with a pointer to the scenario file reference |
 | Body parses but compile fails (unknown field, unresolved pack, etc.) | **400** | Rejected with compiler error detail |
 | Empty `scenarios: []` | **400** | At least one scenario required |
 | Any entry fails runtime validation | **422** | Nothing launched, detail identifies the failing entry |
@@ -375,23 +366,11 @@ validation, the entire request is rejected and nothing is launched:
     The `memory_usage` scenario starts 3 seconds after `cpu_usage`, simulating a cascading
     failure for compound alert testing.
 
-### Migrating v1 bodies
+### Bodies missing `version: 2`
 
-When you POST a pre-v2 body, the server responds with `400 Bad Request` and a migration
-hint in the detail field:
+A body that does not declare `version: 2` at the top level is rejected with `400 Bad Request`. The `detail` field carries the parser's message and points at [Scenario Files](../configuration/scenario-files.md) for the file shape.
 
-```json title="Response (400)"
-{
-  "error": "bad_request",
-  "detail": "body is not a v2 scenario. Sonda only accepts v2 scenario bodies (`version: 2` at the top level). Migrate this body to v2 — see docs/configuration/v2-scenarios.md for the migration guide."
-}
-```
-
-The same hint appears for bodies that do declare `version: 2` but fail to compile (unknown
-fields, unresolved pack references, malformed `after:` clauses). In that case the `detail`
-carries the compiler's error message instead. See
-[Migrating from v1](../configuration/v2-scenarios.md#migrating-from-v1) for side-by-side
-shape conversions.
+Bodies that do declare `version: 2` but fail to compile (unknown fields, unresolved pack references, malformed `after:` clauses) are also rejected with `400`; in that case the `detail` carries the compiler's error message instead.
 
 ### Pack references over HTTP
 
@@ -414,7 +393,7 @@ Without `--catalog`, a body that references a pack by name is rejected with `400
 
 ### Duplicate scenario_name returns 409
 
-When a posted v2 body sets a top-level `scenario_name`, the server scans the active scenario map for any handle that already carries the same `scenario_name` and is in `pending`, `running`, or `paused` state. If at least one match is found the POST is rejected with `409 Conflict`; nothing is launched. The contract is explicit: the operator must `DELETE` the conflicting scenarios first, then re-post. There is no `?force=true` override -- the explicit DELETE is the only way to free the name.
+When a posted body sets a top-level `scenario_name`, the server scans the active scenario map for any handle that already carries the same `scenario_name` and is in `pending`, `running`, or `paused` state. If at least one match is found the POST is rejected with `409 Conflict`; nothing is launched. The contract is explicit: the operator must `DELETE` the conflicting scenarios first, then re-post. There is no `?force=true` override -- the explicit DELETE is the only way to free the name.
 
 Anonymous bodies (no top-level `scenario_name`) bypass this check entirely — two consecutive POSTs of the same anonymous body both return 201. Finished handles are considered stale and never block a new POST — once every prior cascade with the same name reaches `finished` state, a new cascade with the same name returns 201.
 
@@ -673,7 +652,7 @@ curl -s http://localhost:8080/scenarios/$ID/stats | jq .
 
 Five sinks — `loki`, `http_push`, `remote_write`, `otlp_grpc`, `kafka` — pile events into an in-memory buffer and only deliver them in bursts ("flushes"). The other sinks (`stdout`, `file`, `tcp`, `udp`) deliver every event immediately. For the batching group, `total_events` climbs on every *buffered* write, but the delivery-health fields (`last_successful_write_at`, `consecutive_failures`, `total_sink_failures`) only move when a real flush succeeds or fails. That mismatch is the whole reason `/stats` exists: it tells you what's actually landing, not what's queued.
 
-Picture a scenario writing to a Loki backend that has gone unreachable, running under the default [`on_sink_error: warn`](../configuration/v2-scenarios.md#sink-error-policy) policy. Six writes in:
+Picture a scenario writing to a Loki backend that has gone unreachable, running under the default [`on_sink_error: warn`](../configuration/scenario-files.md#sink-error-policy) policy. Six writes in:
 
 ```text
  write #1   buffer       Ok  →  /stats untouched (only buffered)
@@ -709,7 +688,7 @@ This is the shape to look for: rising `total_events`, `last_successful_write_at`
 | `bytes_emitted` | integer | Total bytes written to the sink. |
 | `errors` | integer | Encode or sink-write errors observed. |
 | `uptime_secs` | float | Seconds since the scenario was launched. |
-| `state` | string | One of `pending`, `running`, `paused`, `finished`. See the [`while:` lifecycle diagram](../configuration/v2-scenarios.md#lifecycle-states). |
+| `state` | string | One of `pending`, `running`, `paused`, `finished`. See the [`while:` lifecycle diagram](../configuration/scenario-files.md#lifecycle-states). |
 | `in_gap` | bool | `true` while a [gap window](../configuration/scenario-fields.md#gap-window) is suppressing output. |
 | `in_burst` | bool | `true` while a [burst window](../configuration/scenario-fields.md#burst-window) is elevating the rate. |
 | `consecutive_failures` | integer | Sink errors observed since the most recent successful *delivery*. Resets to `0` on the next delivery. |
@@ -721,7 +700,7 @@ This is the shape to look for: rising `total_events`, `last_successful_write_at`
 !!! info "Delivery-accurate, not buffer-accurate, for batching sinks"
     The batching sinks — `loki`, `http_push`, `remote_write`, `otlp_grpc`, `kafka` — buffer events and flush them to the backend in batches. `last_successful_write_at` and `consecutive_failures` track actual *delivery* to the destination, not buffering: `last_successful_write_at` advances only when a write triggers a successful flush, and a write that merely buffers neither advances it nor resets `consecutive_failures`. So a batching sink that is buffering but failing to reach its backend shows a *stale* `last_successful_write_at` and a *non-zero* `consecutive_failures` — the honest signal that nothing is landing. Non-batching sinks (`stdout`, `file`, `tcp`, `udp`) deliver synchronously on every write, so the two readings always reflect the latest write.
 
-The four sink-failure fields are the runtime telemetry surface for the [`on_sink_error` policy](../configuration/v2-scenarios.md#sink-error-policy). When `on_sink_error: warn` (the default) is in effect, the runner stays alive on transient sink errors and these counters tell you what's happening; when `on_sink_error: fail` is set, the thread exits on the first error and `state` flips to `finished`.
+The four sink-failure fields are the runtime telemetry surface for the [`on_sink_error` policy](../configuration/scenario-files.md#sink-error-policy). When `on_sink_error: warn` (the default) is in effect, the runner stays alive on transient sink errors and these counters tell you what's happening; when `on_sink_error: fail` is set, the thread exits on the first error and `state` flips to `finished`.
 
 !!! note "`pending -> paused` is a reachable direct transition"
     A scenario carrying both `after:` and `while:` whose `after:` fires while the gate is closed enters `paused` directly, skipping `running`. Clients building a state-machine assertion should not assume `pending` always precedes `running` -- watch for `paused` from the `pending` state too.

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -152,7 +152,7 @@ The wave oscillates between 0 and 100 with a 10-second period. The
 
 ## A larger scenario
 
-The same v2 shape lets you share defaults across many entries and add scheduling like
+The same shape lets you share defaults across many entries and add scheduling like
 gaps and bursts:
 
 ```yaml title="basic-metrics.yaml"
@@ -265,7 +265,7 @@ sonda show @cpu-spike --catalog ./my-catalog
 sonda run @cpu-spike --catalog ./my-catalog
 ```
 
-The catalog is just a directory of v2 YAML files with `kind: runnable` (scenarios you
+The catalog is just a directory of scenario YAML files with `kind: runnable` (scenarios you
 can run) or `kind: composable` (packs you reference from other scenarios with
 `pack: <name>`). See [Author your own catalog](guides/scenarios.md) for the layout.
 
@@ -285,7 +285,7 @@ advanced feature step by step. Skip the YAML grind:
 
 Reference pages:
 
-- [**v2 Scenario Files**](configuration/v2-scenarios.md) -- file shape, defaults, `after:` chains
+- [**Scenario Files**](configuration/scenario-files.md) -- file shape, defaults, `after:` chains
 - [**Scenario Fields**](configuration/scenario-fields.md) -- per-entry field reference
 - [**CLI Reference**](configuration/cli-reference.md) -- every flag for `run`, `list`, `show`, `new`
 - [**Docker**](deployment/docker.md) -- containers and Compose

--- a/docs/site/docs/guides/alert-testing-resolution.md
+++ b/docs/site/docs/guides/alert-testing-resolution.md
@@ -55,7 +55,7 @@ you want to validate against.
     "flapping service" pattern -- useful for testing that your alert hysteresis or
     `keep_firing_for` clause actually suppresses the noise.
 
-Gaps drive recovery passively — Prometheus resolves the alert on its own once the metric goes silent for the lookback-delta window. For active recovery, where Sonda emits a stale marker or an explicit recovery value the moment a `while:`-gated entry pauses, see [Recovering Prometheus alerts on gate close](../configuration/v2-scenarios.md#recovering-prometheus-alerts-on-gate-close). Gate close clears alerts on the next scrape rather than waiting for the lookback window, at the cost of being `remote_write`-specific unless you pair it with `snap_to:`.
+Gaps drive recovery passively — Prometheus resolves the alert on its own once the metric goes silent for the lookback-delta window. For active recovery, where Sonda emits a stale marker or an explicit recovery value the moment a `while:`-gated entry pauses, see [Recovering Prometheus alerts on gate close](../configuration/scenario-files.md#recovering-prometheus-alerts-on-gate-close). Gate close clears alerts on the next scrape rather than waiting for the lookback window, at the cost of being `remote_write`-specific unless you pair it with `snap_to:`.
 
 ## Next
 

--- a/docs/site/docs/guides/csv-import.md
+++ b/docs/site/docs/guides/csv-import.md
@@ -9,7 +9,7 @@ What you actually want is the *shape* of that incident as a reusable scenario:
 "a CPU spike like the one from the May 14 outage" parameterized on rate and duration,
 checked into the repo next to the alert rules. `sonda new --from <csv>` does that
 conversion in one step. It scans each column, classifies the pattern (steady, spike,
-leak, sawtooth, flap, step), and emits a v2 scenario YAML wired to a generator with
+leak, sawtooth, flap, step), and emits a scenario YAML wired to a generator with
 the right knobs.
 
 ---
@@ -35,7 +35,7 @@ need the *shape* of the data as a reusable scenario that does not depend on the 
 
 ## The workflow
 
-`sonda new --from <csv>` writes a v2 scenario YAML to stdout (or to a file with `-o`). Run the
+`sonda new --from <csv>` writes a scenario YAML to stdout (or to a file with `-o`). Run the
 result with `sonda run` once you are happy with it:
 
 ```text
@@ -53,7 +53,7 @@ sonda new --from examples/sample-multi-column.csv -o scenario.yaml
 wrote scenario to scenario.yaml
 ```
 
-The generated file is a valid [v2 scenario YAML](../configuration/v2-scenarios.md), ready for
+The generated file is a valid [scenario YAML](../configuration/scenario-files.md), ready for
 `sonda run`:
 
 ```yaml title="scenario.yaml"
@@ -94,10 +94,8 @@ Each numeric column in the CSV gets its own `scenarios:` entry. The generator al
 by pattern detection, so you can edit the output and tune the parameters rather than starting
 from a blank file.
 
-!!! info "Output is always v2"
-    `sonda new --from <csv>` emits v2 YAML regardless of column count. Single-column CSVs
-    produce a one-entry `scenarios:` list; multi-column CSVs produce one entry per column.
-    Shared `rate`, `duration`, `encoder`, and `sink` live in `defaults:`.
+!!! info "One column, one entry"
+    `sonda new --from <csv>` emits a scenario YAML regardless of column count. Single-column CSVs produce a one-entry `scenarios:` list; multi-column CSVs produce one entry per column. Shared `rate`, `duration`, `encoder`, and `sink` live in `defaults:`.
 
 ### Preview to stdout
 

--- a/docs/site/docs/guides/e2e-testing.md
+++ b/docs/site/docs/guides/e2e-testing.md
@@ -143,7 +143,7 @@ silently fails.
 Two ways to make one scenario file work from both paths:
 
 - Use `${VAR:-default}` in the URL — the bundled examples already do this. See
-  [Environment variable interpolation](../configuration/v2-scenarios.md#environment-variable-interpolation).
+  [Environment variable interpolation](../configuration/scenario-files.md#environment-variable-interpolation).
 - Rewrite the URL with `sed` before POSTing — see
   [Endpoints & networking](../deployment/endpoints.md#rewriting-urls-before-posting).
 

--- a/docs/site/docs/guides/examples.md
+++ b/docs/site/docs/guides/examples.md
@@ -67,7 +67,7 @@ See [Sinks](../configuration/sinks.md) for configuration details on each sink ty
 | `histogram.yaml` | histogram | prometheus_text | stdout | Exponential distribution, 100 observations/tick (latency-style histogram) |
 | `summary.yaml` | summary | prometheus_text | stdout | Normal distribution (mean 0.1, stddev 0.02), 100 observations/tick |
 
-Run them with `sonda run` — histograms and summaries are just `signal_type:` variants in the v2 YAML:
+Run them with `sonda run` — histograms and summaries are just `signal_type:` variants in the scenario YAML:
 
 ```bash
 sonda run examples/histogram.yaml
@@ -122,7 +122,7 @@ See the [Capacity Planning](capacity-planning.md) guide for measurement methodol
 | `loki-json-lines.yaml` | template | json_lines | loki | Push log events to a Loki instance |
 | `kafka-json-logs.yaml` | template | json_lines | kafka | Send log events to a Kafka topic |
 
-Run log scenarios with `sonda run` — log entries are just `signal_type: logs` in the v2 YAML:
+Run log scenarios with `sonda run` — log entries are just `signal_type: logs` in the scenario YAML:
 
 ```bash
 sonda run examples/log-template.yaml

--- a/docs/site/docs/guides/metric-packs.md
+++ b/docs/site/docs/guides/metric-packs.md
@@ -1,9 +1,6 @@
 # Metric Packs
 
-A metric pack is a reusable bundle of metric names and label schemas, expressed as a
-`kind: composable` v2 YAML file in your [catalog](scenarios.md). Reference a pack from any
-runnable scenario with `pack: <name>` and Sonda expands it into one entry per metric —
-exact names, correct shared labels, and sensible default generators per metric.
+A metric pack is a reusable bundle of metric names and label schemas, expressed as a `kind: composable` YAML file in your [catalog](scenarios.md). Reference a pack from any runnable scenario with `pack: <name>` and Sonda expands it into one entry per metric — exact names, correct shared labels, and sensible default generators per metric.
 
 Sonda no longer ships any built-in packs; you author your own and check them into a catalog
 directory alongside your scenarios.
@@ -175,7 +172,7 @@ Labels are merged in this order, with later sources winning on key conflicts:
 
 ## Author a pack
 
-A pack is a v2 YAML file with `kind: composable`. The pack identity (`name`, `description`, `category`) and the metric set (`shared_labels`, `metrics`) sit flat at the top level of the file:
+A pack is a YAML file with `kind: composable`. The pack identity (`name`, `description`, `category`) and the metric set (`shared_labels`, `metrics`) sit flat at the top level of the file:
 
 ```yaml title="~/sonda-catalog/my-app-pack.yaml"
 version: 2
@@ -276,6 +273,5 @@ This means every feature that works with multi-scenario runs — `--dry-run`, `-
   SNMP-shaped metrics for dashboard testing.
 - [**CLI Reference**](../configuration/cli-reference.md) -- full flag reference for `sonda list`,
   `sonda show`, `sonda run`.
-- [**v2 Scenario Files -- Pack-backed entries**](../configuration/v2-scenarios.md#pack-backed-entries)
-  -- reference a pack inline from a v2 `scenarios:` entry.
+- [**Scenario Files -- Pack-backed entries**](../configuration/scenario-files.md#pack-backed-entries) -- reference a pack inline from a `scenarios:` entry.
 - [**Generators**](../configuration/generators.md) -- all generator types and operational aliases.

--- a/docs/site/docs/guides/network-device-telemetry.md
+++ b/docs/site/docs/guides/network-device-telemetry.md
@@ -151,7 +151,7 @@ matches how you want to reason about time:
 | Scenario | Mechanic | Best for |
 |----------|----------|----------|
 | `examples/network-link-failure.yaml` | `sequence` generator + `repeat: true`, aligned tick-by-tick across multiple entries | Tight, repeating cycles where every tick's value matters and failures recur on a fixed drumbeat |
-| `scenarios/link-failover.yaml` | v2 `after:` chains -- each signal declares what it waits for, the compiler resolves phase offsets | Once-through causal chains where you care about ordering (primary drops -> backup saturates -> latency climbs) but not the exact tick |
+| `scenarios/link-failover.yaml` | `after:` chains -- each signal declares what it waits for, the compiler resolves phase offsets | Once-through causal chains where you care about ordering (primary drops -> backup saturates -> latency climbs) but not the exact tick |
 
 Use `sequence + repeat` when you need hand-authored values at specific ticks and the same
 pattern should loop indefinitely -- useful for soak testing and for dashboards that expect a
@@ -178,10 +178,7 @@ depends on crosses a threshold:
 | `backup_link_utilization` | `saturation` -- ramps 20% -> 85% over 2m | primary drops below 1 (first flap) |
 | `latency_ms` | `degradation` -- climbs 5ms -> 150ms over 3m | backup utilization exceeds 70% |
 
-Sonda resolves the chain at parse time: the v2 compiler computes a concrete `phase_offset` for
-each linked signal, so the signals still emit independently but start in the right order.
-See the [v2 `after:` chain reference](../configuration/v2-scenarios.md#temporal-chains-with-after)
-for the underlying mechanics.
+Sonda resolves the chain at parse time: the compiler computes a concrete `phase_offset` for each linked signal, so the signals still emit independently but start in the right order. See the [`after:` chain reference](../configuration/scenario-files.md#temporal-chains-with-after) for the underlying mechanics.
 
 ```yaml title="link-failover.yaml"
 version: 2
@@ -279,11 +276,7 @@ degrading ~152 seconds in (when the backup ramp crosses 70%). All three signals 
 auto-assigned `clock_group`, so their timers start from the same reference.
 
 !!! info "Why `after:` instead of aligned sequences?"
-    You can express a link failure with the `sequence` generator by hand-aligning values across
-    scenarios -- which is exactly what `examples/network-link-failure.yaml` does. `after:` is the
-    v2 equivalent: instead of counting ticks, you declare the causal relationship once and let
-    the compiler do the timing math. The [v2 scenarios guide](../configuration/v2-scenarios.md)
-    covers the full surface.
+    You can express a link failure with the `sequence` generator by hand-aligning values across scenarios -- which is exactly what `examples/network-link-failure.yaml` does. `after:` is the declarative alternative: instead of counting ticks, you declare the causal relationship once and let the compiler do the timing math. The [Scenario Files](../configuration/scenario-files.md) reference covers the full surface.
 
 ---
 
@@ -428,9 +421,7 @@ or Prometheus, change the sink in each scenario entry.
     ```
 
 !!! tip "Change the sink in one place"
-    In a v2 scenario file, the `defaults:` block holds the shared `sink` (and `encoder`,
-    `rate`, `duration`, `labels`). Swap the sink there once and every entry in
-    `scenarios:` picks it up. Per-entry overrides still win if you need a mixed setup.
+    In a scenario file, the `defaults:` block holds the shared `sink` (and `encoder`, `rate`, `duration`, `labels`). Swap the sink there once and every entry in `scenarios:` picks it up. Per-entry overrides still win if you need a mixed setup.
 
 ---
 

--- a/docs/site/docs/guides/scenarios.md
+++ b/docs/site/docs/guides/scenarios.md
@@ -1,6 +1,6 @@
 # Catalogs
 
-A **catalog** is a directory of v2 YAML files that Sonda discovers via `--catalog <dir>`. Each file declares a `kind:` — `runnable` for scenarios you can run, `composable` for [metric packs](metric-packs.md) other scenarios reference. Sonda doesn't ship a built-in catalog: yours lives in your own repo, versioned next to your alert rules, dashboards, and CI workflows. Scenarios become first-class artifacts of the system they model instead of being pinned to a Sonda release.
+A **catalog** is a directory of scenario YAML files that Sonda discovers via `--catalog <dir>`. Each file declares a `kind:` — `runnable` for scenarios you can run, `composable` for [metric packs](metric-packs.md) other scenarios reference. Sonda doesn't ship a built-in catalog: yours lives in your own repo, versioned next to your alert rules, dashboards, and CI workflows. Scenarios become first-class artifacts of the system they model instead of being pinned to a Sonda release.
 
 ## The minimum
 
@@ -132,7 +132,7 @@ sonda run my-cpu-spike.yaml
 
 ## Author your own entries
 
-A catalog entry is a v2 scenario YAML with a top-level `kind:` field. For runnable entries:
+A catalog entry is a scenario YAML with a top-level `kind:` field. For runnable entries:
 
 ```yaml title="~/sonda-catalog/my-scenario.yaml"
 version: 2
@@ -187,5 +187,4 @@ sonda --catalog ~/sonda-catalog list --tag application
   `sonda list`, `sonda show`, and `sonda new`.
 - [**Scenario Fields**](../configuration/scenario-fields.md) -- YAML reference for writing your
   own scenarios from scratch.
-- [**v2 Scenario Files**](../configuration/v2-scenarios.md) -- the canonical file format with
-  defaults, `after:`, and inline packs.
+- [**Scenario Files**](../configuration/scenario-files.md) -- the canonical file format with defaults, `after:`, and inline packs.

--- a/docs/site/docs/guides/troubleshooting.md
+++ b/docs/site/docs/guides/troubleshooting.md
@@ -49,7 +49,7 @@ sonda --verbose run my-scenario.yaml \
 
 ### A scenario stopped emitting silently
 
-A scenario looks alive (the process is running, no error in the foreground) but no data is reaching the backend. This typically means the sink is failing on every write. Sonda's default [`on_sink_error: warn`](../configuration/v2-scenarios.md#sink-error-policy) policy keeps the runner alive through transient sink errors, so the symptom is degradation rather than a crash. Confirm the diagnosis from three places:
+A scenario looks alive (the process is running, no error in the foreground) but no data is reaching the backend. This typically means the sink is failing on every write. Sonda's default [`on_sink_error: warn`](../configuration/scenario-files.md#sink-error-policy) policy keeps the runner alive through transient sink errors, so the symptom is degradation rather than a crash. Confirm the diagnosis from three places:
 
 - **Stderr `[progress]` banner** -- when a runner exits, the progress reporter prints a one-shot `STOPPED` line that includes the last sink error:
 
@@ -78,7 +78,7 @@ A scenario looks alive (the process is running, no error in the foreground) but 
 
     A non-empty result means at least one scenario has stopped delivering. The same expression works as a Kubernetes readiness probe or a Prometheus alert input. If you need a different staleness window than 30 seconds, you can still threshold the raw fields from the per-scenario `/stats` endpoint -- combine `total_sink_failures > 0` with your own staleness check on `last_successful_write_at`.
 
-The recovery is the default behavior: under `on_sink_error: warn`, the runner keeps ticking while you fix the sink (restart Loki, repair DNS, restore the network path). Once the sink accepts a write, `consecutive_failures` resets to `0` and `last_successful_write_at` advances, so any threshold you set clears automatically. If you want a sink failure to hard-fail the run instead, set `on_sink_error: fail` -- see [Sink-error policy](../configuration/v2-scenarios.md#sink-error-policy).
+The recovery is the default behavior: under `on_sink_error: warn`, the runner keeps ticking while you fix the sink (restart Loki, repair DNS, restore the network path). Once the sink accepts a write, `consecutive_failures` resets to `0` and `last_successful_write_at` advances, so any threshold you set clears automatically. If you want a sink failure to hard-fail the run instead, set `on_sink_error: fail` -- see [Sink-error policy](../configuration/scenario-files.md#sink-error-policy).
 
 ---
 
@@ -110,7 +110,7 @@ Sonda runs without errors but you don't see data in your backend.
 | No data in Prometheus | Prometheus needs remote write receiver enabled | Start Prometheus with `--web.enable-remote-write-receiver` |
 | Encoder/sink mismatch | Using `prometheus_text` encoder with `remote_write` sink (or vice versa) | Match encoder to sink: `remote_write` encoder with `remote_write` sink, `otlp` encoder with `otlp_grpc` sink |
 | HTTP 400 Bad Request | Wrong `content_type` for the endpoint | Use `text/plain` for VictoriaMetrics import endpoint |
-| POST to `sonda-server` succeeds but no data in backend | Sink `url: http://localhost:<port>` resolves inside the server container | Use the in-network address (Compose service name `http://victoriametrics:8428`, or Kubernetes Service DNS), or write the URL with [`${VAR:-default}`](../configuration/v2-scenarios.md#environment-variable-interpolation) so one file works from both paths. See [Endpoints & networking](../deployment/endpoints.md) |
+| POST to `sonda-server` succeeds but no data in backend | Sink `url: http://localhost:<port>` resolves inside the server container | Use the in-network address (Compose service name `http://victoriametrics:8428`, or Kubernetes Service DNS), or write the URL with [`${VAR:-default}`](../configuration/scenario-files.md#environment-variable-interpolation) so one file works from both paths. See [Endpoints & networking](../deployment/endpoints.md) |
 
 ### Batching delays
 
@@ -197,7 +197,7 @@ Data arrives in chunks or only appears when the scenario ends.
 
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
-| `v2 scenario file requires a top-level 'kind:' field` | The file is missing the `kind:` declaration | Add `kind: runnable` (for files you run) or `kind: composable` (for [metric packs](metric-packs.md)) at the top of the file, alongside `version: 2`. See [v2 Scenario Files](../configuration/v2-scenarios.md). |
+| `v2 scenario file requires a top-level 'kind:' field` | The file is missing the `kind:` declaration | Add `kind: runnable` (for files you run) or `kind: composable` (for [metric packs](metric-packs.md)) at the top of the file, alongside `version: 2`. See [Scenario Files](../configuration/scenario-files.md). |
 | `unknown kind '<value>': must be 'runnable' or 'composable'` | `kind:` is set to a typo or unsupported value | Use exactly `runnable` or `composable`. |
 | `invalid type` error on a numeric field | Value is quoted as a string in YAML (e.g., `rate: "10"`) | Remove quotes from numeric fields: `rate: 10` |
 | `unknown field` error | Typo in a field name, or field placed at the wrong nesting level | Check indentation. `labels` goes at the scenario level, not inside `sink` |

--- a/docs/site/docs/guides/tutorial-multi-scenario.md
+++ b/docs/site/docs/guides/tutorial-multi-scenario.md
@@ -53,9 +53,7 @@ Each scenario runs on its own thread. Use different sinks per scenario to keep o
 separate -- here, metrics go to stdout while logs land in `/tmp/sonda-logs.json`.
 
 !!! tip "Shared defaults shrink the file"
-    Common fields belong under `defaults:` so each scenario only declares what differs.
-    See [v2 Scenario Files](../configuration/v2-scenarios.md) for the full inheritance
-    rules.
+    Common fields belong under `defaults:` so each scenario only declares what differs. See [Scenario Files](../configuration/scenario-files.md) for the full inheritance rules.
 
 ## Correlated metrics with phase_offset
 

--- a/docs/site/docs/guides/tutorial-server.md
+++ b/docs/site/docs/guides/tutorial-server.md
@@ -1,8 +1,6 @@
 # The Server API
 
-For long-running or programmatic use, Sonda includes an HTTP API that lets you submit,
-monitor, and stop scenarios without touching the CLI. The API speaks the same v2 YAML
-format you have been using throughout the tour.
+For long-running or programmatic use, Sonda includes an HTTP API that lets you submit, monitor, and stop scenarios without touching the CLI. The API speaks the same scenario YAML format you have been using throughout the tour.
 
 ## Start the server
 
@@ -26,7 +24,7 @@ curl http://localhost:8080/health
 
 ## Submit a scenario
 
-POST a v2 YAML body to `/scenarios`:
+POST a scenario YAML body to `/scenarios`:
 
 ```bash
 curl -X POST \
@@ -52,8 +50,7 @@ curl -X POST \
 
 ## Submit a multi-scenario batch
 
-POST a v2 file with two or more `scenarios:` entries and the server launches them
-atomically -- either every entry compiles and starts, or nothing does:
+POST a scenario file with two or more `scenarios:` entries and the server launches them atomically -- either every entry compiles and starts, or nothing does:
 
 ```bash
 curl -X POST \
@@ -77,7 +74,7 @@ error handling, `phase_offset`, and `after:` chains.
 !!! tip "One file, host CLI and container"
     A sink URL like `${VICTORIAMETRICS_URL:-http://localhost:8428/...}` runs from your
     host CLI on the default and from a containerized `sonda-server` on the override. See
-    [Environment variable interpolation](../configuration/v2-scenarios.md#environment-variable-interpolation).
+    [Environment variable interpolation](../configuration/scenario-files.md#environment-variable-interpolation).
 
 ## Monitor a running scenario
 

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -127,7 +127,7 @@ Same file runs from your laptop, from CI, or [posted to `sonda-server`](deployme
     discover them with `sonda list --catalog <dir>` and run with
     `sonda run @name`.
 
--   :material-file-document-outline: __[v2 scenario files](configuration/v2-scenarios.md)__
+-   :material-file-document-outline: __[Scenario files](configuration/scenario-files.md)__
 
     The canonical file shape: `version: 2`, `kind: runnable`, shared `defaults:`,
     inline packs, `after:` temporal chains, and env-var interpolation.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -91,6 +91,12 @@ markdown_extensions:
       permalink: true
       toc_depth: 3
 
+plugins:
+  - search
+  - redirects:
+      redirect_maps:
+        'configuration/v2-scenarios.md': 'configuration/scenario-files.md'
+
 extra:
   social:
     - icon: fontawesome/brands/github
@@ -109,8 +115,9 @@ nav:
   - Getting Started: getting-started.md
   - Configuration:
     - configuration/index.md
+    - Concepts: configuration/concepts.md
     - Scenario Fields: configuration/scenario-fields.md
-    - v2 Scenario Files: configuration/v2-scenarios.md
+    - Scenario Files: configuration/scenario-files.md
     - Generators: configuration/generators.md
     - Encoders: configuration/encoders.md
     - Sinks: configuration/sinks.md

--- a/docs/site/requirements.txt
+++ b/docs/site/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs-material>=9.5
+mkdocs-redirects>=1.2


### PR DESCRIPTION
## Summary

The configuration docs had no single page that taught newcomers the vocabulary — what a scenario, entry, pack, or catalog is — before landing them on a 1,100-line reference. The page they did land on was titled "v2 Scenario Files", which left readers wondering whether a v1 path mattered to them. It doesn't: the binary rejects v1.

## What's addressed

- New `configuration/concepts.md` as the first Configuration nav entry. Defines **scenario**, **entry**, **pack**, **catalog**, **defaults**, **multi-scenario runs** with concrete YAML for each. Answers "why does the AutoCon5 workshop emit multiple scenarios per scrape?" in the Entry section (one entry per metric so the resulting endpoint matches a real exporter).
- Rename `configuration/v2-scenarios.md` → `scenario-files.md`. Title becomes `Scenario Files`. The `v2` framing is scrubbed from prose across ~20 doc pages; `version: 2` inside YAML stays.
- `mkdocs-redirects` added so the old `/configuration/v2-scenarios/` URL keeps resolving (workshop and external links won't 404).
- The `## Migrating from v1` section (≈300 lines, including the five migration tabs and "Common gotchas") and the v1-rejection warning admonition are removed from the Scenario Files page. v1 is no longer accepted; the migration walkthrough lives in git history.
- Configuration nav reordered: **Concepts** → **Scenario Fields** → **Scenario Files** → Generators → Encoders → Sinks → …

## Test plan

- [x] `task site:build` passes with `mkdocs --strict`
- [x] `/configuration/v2-scenarios/` redirects to `/configuration/scenario-files/`
- [x] Concepts page renders with all four core concepts defined, examples valid against the generators reference
- [x] No `## Migrating from v1` content in any rendered page
- [x] No prose `v2` references outside YAML code fences, Alertmanager `/api/v2/` URLs, and Docker `Compose v2` plugin mentions