### PR TITLE
feat(server): aggregate /metrics endpoint with label filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.9.1"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.9.1"
+version = "1.11.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.9.1"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -152,18 +152,19 @@ instructions.
 
 ### ServiceMonitor
 
-Sonda emits Prometheus metrics **per scenario** at `GET /scenarios/<scenario-id>/metrics`, not at a fixed top-level `/metrics` endpoint. A ServiceMonitor endpoint scrapes a single path, so you must point `serviceMonitor.path` at the specific scenario you want scraped — typically a long-running synthetic monitoring scenario whose ID is known ahead of time (for example, one loaded from the `scenarios` ConfigMap and reachable at a stable route).
+A ServiceMonitor endpoint scrapes a single `path`. Two paths work for Sonda:
 
-`serviceMonitor.path` has no default. If you set `serviceMonitor.enabled: true` without also setting `serviceMonitor.path`, `helm install` and `helm upgrade` fail with a clear error telling you to set the path to a Prometheus-text endpoint such as `/scenarios/<scenario-id>/metrics`. This avoids silently producing a ServiceMonitor that scrapes a non-metrics route.
+- `/metrics` — aggregate scrape across every running scenario, with optional `?label=k:v` filtering. This is the right choice for most installs: one ServiceMonitor covers every scenario the server runs, regardless of how they were launched.
+- `/scenarios/<scenario-id>/metrics` — per-scenario drain. Use it when each scenario is its own logical target and you know its ID ahead of time (for example, one loaded from the `scenarios` ConfigMap at a stable route).
 
-For scraping more than one scenario, apply a custom ServiceMonitor with one `endpoints` entry per scenario ID — see [ServiceMonitor](#servicemonitor_1) below the values reference.
+`serviceMonitor.path` has no default. If you set `serviceMonitor.enabled: true` without also setting `serviceMonitor.path`, `helm install` and `helm upgrade` fail with a clear error telling you to set the path to a Prometheus-text endpoint such as `/metrics` or `/scenarios/<scenario-id>/metrics`. This avoids silently producing a ServiceMonitor that scrapes a non-metrics route.
 
 | Value | Default | Description |
 |-------|---------|-------------|
 | `serviceMonitor.enabled` | `false` | Enable Prometheus Operator ServiceMonitor |
 | `serviceMonitor.interval` | `30s` | Scrape interval |
 | `serviceMonitor.scrapeTimeout` | `10s` | Scrape timeout |
-| `serviceMonitor.path` | `""` (required when enabled) | Metrics endpoint path, e.g. `/scenarios/<scenario-id>/metrics` |
+| `serviceMonitor.path` | `""` (required when enabled) | Metrics endpoint path, e.g. `/metrics` or `/scenarios/<scenario-id>/metrics` |
 | `serviceMonitor.additionalLabels` | `{}` | Extra labels on the ServiceMonitor resource |
 
 ### Scenarios (ConfigMap)
@@ -276,14 +277,28 @@ For example, a Prometheus instance in the same namespace can scrape
 
 ## Prometheus scraping
 
-Each running scenario exposes metrics at `GET /scenarios/{id}/metrics` in Prometheus text
-exposition format. You can configure Prometheus (or vmagent) to scrape this endpoint.
+`sonda-server` exposes two scrape endpoints. `GET /metrics` is the aggregate view — every running scenario fused into one response, with `?label=k:v` to slice by the labels you attached to each scenario. `GET /scenarios/{id}/metrics` is the per-scenario drain — one consumer pulls from one scenario's buffer. For most Prometheus setups, the aggregate endpoint is the right call: one job covers every scenario, multiple scrapers can read it, and you do not need to know scenario IDs ahead of time. See [Aggregate Prometheus scrape](sonda-server.md#aggregate-prometheus-scrape) for the full reference, including the `?label=k:v` AND-filter syntax.
 
-### Static scrape config
+### Aggregate scrape config
 
 ```yaml title="prometheus-scrape.yaml"
 scrape_configs:
   - job_name: sonda
+    scrape_interval: 15s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["sonda.default.svc:8080"]
+```
+
+Add `params: {label: ["device:srl1"]}` to scope a job to one device's metrics; repeat the `label` value to AND-combine selectors.
+
+### Per-scenario scrape config
+
+When you want one scrape job per scenario, point `metrics_path` at the scenario ID. The endpoint drains its buffer on every scrape, so only one consumer should pull from a given ID at a time:
+
+```yaml title="prometheus-scrape.yaml"
+scrape_configs:
+  - job_name: sonda-id
     scrape_interval: 15s
     metrics_path: /scenarios/<SCENARIO_ID>/metrics
     static_configs:
@@ -331,15 +346,13 @@ kubectl apply -f sonda-servicemonitor.yaml
 The `port: http` field matches the named port on the Sonda Service.
 
 !!! warning "One path per endpoint"
-    Each ServiceMonitor endpoint scrapes a single `path`. If you run multiple scenarios, add
-    one `endpoints` entry per scenario ID. For dynamic discovery, consider a script that
-    queries `GET /scenarios` and regenerates the ServiceMonitor.
+    Each ServiceMonitor endpoint scrapes a single `path`. For per-scenario scrapes, add one `endpoints` entry per scenario ID. To cover every scenario in one entry, point the endpoint at `/metrics` instead and use `?label=k:v` to slice the view.
 
 ## API key authentication
 
-Sonda-server supports optional bearer token authentication on all `/scenarios/*` endpoints.
-When enabled, clients must include an `Authorization: Bearer <key>` header. The `/health`
-endpoint stays public so liveness and readiness probes work without credentials.
+Sonda-server supports optional bearer token authentication on `/scenarios/*`, `/metrics`, and
+`/events`. When enabled, clients must include an `Authorization: Bearer <key>` header. The
+`/health` endpoint stays public so liveness and readiness probes work without credentials.
 
 For the full authentication behavior (error responses, protected vs. public endpoints), see the
 [Server API Authentication](sonda-server.md#authentication) section.
@@ -392,12 +405,12 @@ The chart sets `SONDA_API_KEY` in the container environment from the Secret. On 
 will see:
 
 ```text
-INFO sonda_server: API key authentication enabled for /scenarios/* and /events endpoints
+INFO sonda_server: API key authentication enabled for /scenarios/*, /events, and /metrics endpoints
 ```
 
 ### Authenticated API calls
 
-Once auth is enabled, include the bearer token in all `/scenarios/*` requests:
+Once auth is enabled, include the bearer token in all `/scenarios/*`, `/metrics`, and `/events` requests:
 
 ```bash
 # Port-forward to reach the server
@@ -416,7 +429,7 @@ curl http://localhost:8080/health
 
 ### Prometheus scraping with auth
 
-When authentication is enabled, the `/scenarios/{id}/metrics` endpoint also requires a
+When authentication is enabled, both `/metrics` and `/scenarios/{id}/metrics` require a
 bearer token. Add the token to your Prometheus scrape config:
 
 === "Static scrape config"

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -86,7 +86,7 @@ RUST_LOG=debug sonda-server --port 8080
 |------|---------|---------|---------|
 | `--port <PORT>` | -- | `8080` | Port the server listens on |
 | `--bind <ADDR>` | -- | `0.0.0.0` | Bind address |
-| `--api-key <KEY>` | `SONDA_API_KEY` | (unset) | Bearer token for `/scenarios/*` and `/events`. See [Authentication](#authentication). |
+| `--api-key <KEY>` | `SONDA_API_KEY` | (unset) | Bearer token for `/scenarios/*`, `/metrics`, and `/events`. See [Authentication](#authentication). |
 | `--catalog <DIR>` | `SONDA_CATALOG` | (unset) | Directory of scenario and pack YAML files. Lets `POST /scenarios` resolve `pack: <name>` references. See [Pack references over HTTP](#pack-references-over-http). |
 
 When you pass `--catalog`, point it at a directory that holds your `kind: composable` pack YAML
@@ -423,12 +423,13 @@ Each `conflicting_scenarios` entry carries the scenario `id` (use it with `DELET
 | GET | `/scenarios/{id}` | Inspect a scenario: config, stats, elapsed |
 | DELETE | `/scenarios/{id}` | Stop and remove a running scenario |
 | GET | `/scenarios/{id}/stats` | Live stats: rate, events, gap/burst state, sink-failure counters. See [Self-observability via /stats](#self-observability-via-stats). |
-| GET | `/scenarios/{id}/metrics` | Latest metrics in Prometheus text format |
+| GET | `/scenarios/{id}/metrics` | Latest metrics in Prometheus text format. DRAIN semantics — one consumer. |
+| GET | `/metrics` | Aggregate Prometheus scrape across all running scenarios. SNAPSHOT semantics — multi-consumer. Supports `?label=k:v` filtering. See [Aggregate Prometheus scrape](#aggregate-prometheus-scrape). |
 | POST | `/events` | Emit one log or metric event synchronously. See [Single-Event API](events.md). |
 
 ## Authentication
 
-You can protect scenario endpoints with API key authentication. When enabled, all `/scenarios/*` requests and `POST /events` must include a bearer token. The `/health` endpoint is always public, so health probes and load balancer checks work without credentials.
+You can protect scenario endpoints with API key authentication. When enabled, all `/scenarios/*` requests, `GET /metrics`, and `POST /events` must include a bearer token. The `/health` endpoint is always public, so health probes and load balancer checks work without credentials.
 
 ### Enabling authentication
 
@@ -449,7 +450,7 @@ Pass an API key via the `--api-key` flag or the `SONDA_API_KEY` environment vari
 When the server starts with a key configured, you will see:
 
 ```text
-INFO sonda_server: API key authentication enabled for /scenarios/* and /events endpoints
+INFO sonda_server: API key authentication enabled for /scenarios/*, /events, and /metrics endpoints
 ```
 
 !!! info "No key = no auth"
@@ -498,13 +499,11 @@ JSON error body:
 | `DELETE /scenarios/{id}` | Yes |
 | `GET /scenarios/{id}/stats` | Yes |
 | `GET /scenarios/{id}/metrics` | Yes |
+| `GET /metrics` | Yes |
 | `POST /events` | Yes |
 
 !!! warning "Prometheus scraping with auth"
-    If you enable authentication, your Prometheus scrape config must include the bearer
-    token for `/scenarios/{id}/metrics`. Add a `bearer_token` or `bearer_token_file`
-    field to your `scrape_configs` entry. See [Scrape Integration](#scrape-integration)
-    below.
+    If you enable authentication, your Prometheus scrape config must include the bearer token for both `/metrics` and `/scenarios/{id}/metrics`. Add a `bearer_token` or `bearer_token_file` field to your `scrape_configs` entry. See [Aggregate Prometheus scrape](#aggregate-prometheus-scrape) for the scrape-config shape.
 
 ??? tip "Kubernetes Secrets"
     In Kubernetes deployments, store the API key in a Secret and reference it as an
@@ -719,11 +718,94 @@ The four sink-failure fields are the runtime telemetry surface for the [`on_sink
 
     Wire that into a Kubernetes readiness probe, a Prometheus alert query, or a Grafana panel. If you need a different staleness window than the built-in 30 seconds, threshold `total_sink_failures` and the staleness of `last_successful_write_at` from this endpoint yourself.
 
-## Scrape Integration
+## Aggregate Prometheus scrape
 
-The `GET /scenarios/{id}/metrics` endpoint returns recent metric events in Prometheus text
-exposition format. This enables pull-based integration: start a scenario via `POST /scenarios`,
-then configure Prometheus or vmagent to scrape the endpoint directly.
+To a scraper, `sonda-server` presents itself the same way a Prometheus exporter on a real device does — one URL (`GET /metrics`), idempotent within a scrape window, with label selectors to slice the view. `GET /metrics` returns a snapshot of every running scenario's recent metric events fused into a single Prometheus text-format response, and `?label=k:v` filters that view by the labels the user attached when starting each scenario.
+
+Why labels are the durable identity at scrape time: scenarios, multi-scenarios, and metric packs are three ways to *configure* Sonda, but only individual scenarios exist at runtime — packs and multi-scenarios fan out into independent scenarios at compile time. The labels you set on each scenario (`device: srl1`, `interface: eth0`, `region: us-east`) are the only cross-scenario grouping that survives, so `?label=k:v` is how you ask "give me one device's metrics" regardless of how the underlying scenarios got launched.
+
+### Happy path
+
+```bash
+curl http://localhost:8080/metrics
+```
+
+```text title="Response (text/plain; version=0.0.4; charset=utf-8)"
+if_in_octets{device="srl1",interface="eth0"} 12345 1779622362660
+if_in_octets{device="srl1",interface="eth0"} 12345 1779622362870
+if_in_octets{device="srl1",interface="eth0"} 12345 1779622363070
+if_out_octets{device="srl2",interface="eth0"} 678 1779622363271
+if_out_octets{device="srl2",interface="eth0"} 681 1779622363470
+```
+
+Each line is `metric_name{labels} value timestamp_ms`. Timestamps are per-sample wall-clock milliseconds, so Prometheus and VictoriaMetrics dedupe naturally on `(name, labels, timestamp_ms, value)` across overlapping scrape windows. With no scenarios running, the response is `200 OK` with an empty body — exactly what Prometheus, vmagent, and Telegraf scrapers expect on a quiet target.
+
+### Filter by label
+
+`?label=k:v` narrows the response to scenarios whose configured `labels` contain that exact `k: v` pair. Repeat the parameter to AND-combine selectors — a scenario is included only when every filter matches:
+
+```bash
+# One device, all interfaces
+curl 'http://localhost:8080/metrics?label=device:srl1'
+
+# One device AND one interface — both must match
+curl 'http://localhost:8080/metrics?label=device:srl1&label=interface:eth0'
+```
+
+A scenario started with no `labels:` block never matches any filter — there is nothing to match against. Drop the filter to see those events.
+
+A malformed filter (missing `:`, empty key, empty value) returns `400 Bad Request`:
+
+```json title="Response (400 Bad Request)"
+{
+  "error": "bad_request",
+  "detail": "label filter 'invalid' is malformed: expected 'key:value'"
+}
+```
+
+### `GET /metrics` vs `GET /scenarios/{id}/metrics`
+
+Both endpoints emit Prometheus text. They serve different scrape models:
+
+| Endpoint | Semantics | Use it for |
+|---|---|---|
+| `GET /metrics` | **Snapshot** — non-destructive. Two back-to-back calls return identical bytes. | Production scraping. Multiple scrapers can read it (Prometheus + vmagent + an ops dashboard) without stealing events from each other. |
+| `GET /scenarios/{id}/metrics` | **Drain** — each call empties the per-scenario buffer. | Debugging a single scenario. Drives the per-event consumer pattern (one consumer pulls, observes, discards). |
+
+Pick `GET /metrics` for any Prometheus / VictoriaMetrics / vmagent job — it is the endpoint that behaves like a normal exporter. Reach for the per-scenario drain when you are inspecting one scenario in isolation or wiring a one-off pull-based consumer.
+
+### Scrape config
+
+A Prometheus or vmagent scrape job targeting one device's metrics:
+
+```yaml title="prometheus.yml"
+scrape_configs:
+  - job_name: sonda-srl1
+    scrape_interval: 15s
+    metrics_path: /metrics
+    params:
+      label: ["device:srl1"]
+    static_configs:
+      - targets: ["localhost:8080"]
+```
+
+Use one job per slice you want to scrape — different devices, different regions, different tenants — and add a `label` param to each. With no `params`, the job scrapes everything the server is running.
+
+When [API key authentication](#authentication) is enabled, add the bearer token to the job:
+
+```yaml title="prometheus.yml (with auth)"
+scrape_configs:
+  - job_name: sonda
+    scrape_interval: 15s
+    metrics_path: /metrics
+    bearer_token: my-secret-key
+    static_configs:
+      - targets: ["localhost:8080"]
+```
+
+## Per-scenario scrape
+
+The `GET /scenarios/{id}/metrics` endpoint returns recent metric events for one scenario in Prometheus text exposition format. Each scrape **drains** the buffer — events appear once per cycle. Use it when you want a one-to-one consumer pulling from a single scenario; reach for [`GET /metrics`](#aggregate-prometheus-scrape) when more than one scraper needs the data or when you want a single job that covers every running scenario.
 
 ```yaml title="prometheus.yml"
 scrape_configs:
@@ -736,10 +818,7 @@ scrape_configs:
 
 Replace `<SCENARIO_ID>` with the ID returned by `POST /scenarios`.
 
-The endpoint accepts an optional `?limit=N` query parameter (default 100, max 1000)
-to control how many recent events are returned per scrape. Each scrape drains the buffer,
-so events appear once per cycle. If no metrics are available yet, you get `204 No Content`.
-Unknown scenario IDs return `404 Not Found`.
+The endpoint accepts an optional `?limit=N` query parameter (default 100, max 1000) to control how many recent events are returned per scrape. If no metrics are available yet, you get `204 No Content`. Unknown scenario IDs return `404 Not Found`.
 
 !!! note
     The server is also available as a [Docker image](docker.md) and

--- a/docs/site/docs/guides/synthetic-monitoring.md
+++ b/docs/site/docs/guides/synthetic-monitoring.md
@@ -239,25 +239,35 @@ For the full API reference, see [Server API](../deployment/sonda-server.md).
 
 ## Scrape metrics with Prometheus
 
-Each running scenario exposes its metrics at `GET /scenarios/{id}/metrics` in Prometheus text
-exposition format. You can point Prometheus (or any compatible scraper like vmagent) at this
-endpoint.
+`sonda-server` exposes two scrape endpoints. `GET /metrics` is the aggregate view — every running scenario fused into one Prometheus text response, with `?label=k:v` to slice by the labels you set on each scenario. `GET /scenarios/{id}/metrics` is the per-scenario drain — one consumer pulls from one scenario's buffer. For Prometheus / vmagent / VictoriaMetrics jobs, use the aggregate endpoint: it survives multiple scrapers, covers every scenario without knowing IDs ahead of time, and behaves like a normal exporter. See [Aggregate Prometheus scrape](../deployment/sonda-server.md#aggregate-prometheus-scrape) for the full reference.
 
-### Static scrape config
-
-If you know the scenario ID ahead of time, configure a static scrape job:
+### Aggregate scrape config
 
 ```yaml title="prometheus-scrape.yaml"
 scrape_configs:
   - job_name: sonda
+    scrape_interval: 15s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["sonda.default.svc:8080"]
+```
+
+The target address uses the Kubernetes Service DNS name (`sonda.<namespace>.svc`). Add `params: {label: ["device:srl1"]}` to scope a job to one device's metrics; repeat the `label` value to AND-combine selectors.
+
+### Per-scenario scrape config
+
+If you want one scrape job per scenario — typically when each scenario is its own logical target — point `metrics_path` at the scenario ID. The endpoint drains its buffer on every scrape, so only one consumer should pull from a given ID at a time:
+
+```yaml title="prometheus-scrape.yaml"
+scrape_configs:
+  - job_name: sonda-id
     scrape_interval: 15s
     metrics_path: /scenarios/<SCENARIO_ID>/metrics
     static_configs:
       - targets: ["sonda.default.svc:8080"]
 ```
 
-Replace `<SCENARIO_ID>` with the UUID returned by `POST /scenarios`. The target address uses
-the Kubernetes Service DNS name (`sonda.<namespace>.svc`).
+Replace `<SCENARIO_ID>` with the UUID returned by `POST /scenarios`.
 
 ### Prometheus ServiceMonitor
 

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -11,12 +11,14 @@
 //! [`RuntimeError`]), the config enums ([`GeneratorConfig`](generator::GeneratorConfig),
 //! [`EncoderConfig`](encoder::EncoderConfig), [`SinkConfig`](sink::SinkConfig),
 //! [`DistributionConfig`], [`ScenarioEntry`]), the compile-phase error enums
-//! under [`compiler`], and [`ScenarioStats`] — are marked
-//! `#[non_exhaustive]`. Downstream consumers that `match` on these types must
-//! include a wildcard `_ =>` arm, and [`ScenarioStats`] must be constructed
-//! via `Default::default()` plus field updates rather than a struct literal.
-//! This lets sonda-core add new variants and fields in a minor release
-//! without a semver-major bump.
+//! under [`compiler`], [`ScenarioStats`], and [`ScenarioHandle`] — are
+//! marked `#[non_exhaustive]`. Downstream consumers that `match` on these
+//! types must include a wildcard `_ =>` arm, [`ScenarioStats`] must be
+//! constructed via `Default::default()` plus field updates rather than a
+//! struct literal, and [`ScenarioHandle`] must be constructed via
+//! [`ScenarioHandle::new`] rather than a struct literal. This lets
+//! sonda-core add new variants and fields in a minor release without a
+//! semver-major bump.
 
 pub mod analysis;
 #[cfg(feature = "config")]

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -1,5 +1,6 @@
 //! Lifecycle handle for a running scenario.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread::JoinHandle;
@@ -54,6 +55,8 @@ pub struct ScenarioHandle {
     /// panic. External observers (e.g. the CLI progress display) read this
     /// without acquiring `JoinHandle::is_finished()`.
     pub alive: Arc<AtomicBool>,
+    /// Scenario-level labels captured at launch time from `entry.base().labels`.
+    pub labels: Arc<HashMap<String, String>>,
 }
 
 impl ScenarioHandle {
@@ -217,6 +220,18 @@ impl ScenarioHandle {
             Err(poisoned) => poisoned.into_inner().drain_recent_metrics(),
         }
     }
+
+    pub fn recent_metrics_snapshot(&self) -> Vec<crate::model::metric::MetricEvent> {
+        match self.stats.read() {
+            Ok(guard) => guard.recent_metrics.iter().cloned().collect(),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .recent_metrics
+                .iter()
+                .cloned()
+                .collect(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -270,6 +285,7 @@ mod tests {
             stats,
             target_rate: 100.0,
             alive: Arc::new(AtomicBool::new(true)),
+            labels: Arc::new(HashMap::new()),
         }
     }
 
@@ -547,6 +563,7 @@ mod tests {
             stats,
             target_rate: 10.0,
             alive: Arc::new(AtomicBool::new(true)),
+            labels: Arc::new(HashMap::new()),
         };
 
         // stats_snapshot must not panic — it recovers from the poisoned lock.
@@ -595,6 +612,7 @@ mod tests {
             stats,
             target_rate: 10.0,
             alive: Arc::new(AtomicBool::new(true)),
+            labels: Arc::new(HashMap::new()),
         };
 
         // recent_metrics must not panic — it recovers from the poisoned lock.

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -31,6 +31,7 @@ impl std::error::Error for JoinTimeout {}
 /// The handle is `Send`: the `JoinHandle` is behind an `Option` and the other
 /// fields are all `Send`, so the handle can be stored in server state and
 /// moved across await points.
+#[non_exhaustive]
 pub struct ScenarioHandle {
     /// Unique identifier for this scenario instance.
     pub id: String,
@@ -55,11 +56,39 @@ pub struct ScenarioHandle {
     /// panic. External observers (e.g. the CLI progress display) read this
     /// without acquiring `JoinHandle::is_finished()`.
     pub alive: Arc<AtomicBool>,
-    /// Scenario-level labels captured at launch time from `entry.base().labels`.
+    /// Scenario-level labels.
     pub labels: Arc<HashMap<String, String>>,
 }
 
 impl ScenarioHandle {
+    /// Construct a `ScenarioHandle` from its raw parts.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: String,
+        name: String,
+        scenario_name: Option<String>,
+        shutdown: Arc<AtomicBool>,
+        thread: Option<JoinHandle<Result<(), SondaError>>>,
+        started_at: Instant,
+        stats: Arc<RwLock<ScenarioStats>>,
+        target_rate: f64,
+        alive: Arc<AtomicBool>,
+        labels: Arc<HashMap<String, String>>,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            scenario_name,
+            shutdown,
+            thread,
+            started_at,
+            stats,
+            target_rate,
+            alive,
+            labels,
+        }
+    }
+
     /// Signal the scenario to stop.
     ///
     /// Sets the shutdown flag to `false` with `SeqCst` ordering. The runner
@@ -221,6 +250,7 @@ impl ScenarioHandle {
         }
     }
 
+    /// Clone the recent-metrics buffer without draining it.
     pub fn recent_metrics_snapshot(&self) -> Vec<crate::model::metric::MetricEvent> {
         match self.stats.read() {
             Ok(guard) => guard.recent_metrics.iter().cloned().collect(),
@@ -275,18 +305,18 @@ mod tests {
             })
             .expect("thread must spawn");
 
-        ScenarioHandle {
-            id: id.to_string(),
-            name: name.to_string(),
-            scenario_name: None,
+        ScenarioHandle::new(
+            id.to_string(),
+            name.to_string(),
+            None,
             shutdown,
-            thread: Some(thread),
-            started_at: Instant::now(),
+            Some(thread),
+            Instant::now(),
             stats,
-            target_rate: 100.0,
-            alive: Arc::new(AtomicBool::new(true)),
-            labels: Arc::new(HashMap::new()),
-        }
+            100.0,
+            Arc::new(AtomicBool::new(true)),
+            Arc::new(HashMap::new()),
+        )
     }
 
     // ---- is_running: true before stop, false after join ---------------------
@@ -553,18 +583,18 @@ mod tests {
             .spawn(|| -> Result<(), SondaError> { Ok(()) })
             .expect("thread must spawn");
 
-        let handle = ScenarioHandle {
-            id: "test-poisoned".to_string(),
-            name: "poisoned".to_string(),
-            scenario_name: None,
+        let handle = ScenarioHandle::new(
+            "test-poisoned".to_string(),
+            "poisoned".to_string(),
+            None,
             shutdown,
-            thread: Some(thread),
-            started_at: Instant::now(),
+            Some(thread),
+            Instant::now(),
             stats,
-            target_rate: 10.0,
-            alive: Arc::new(AtomicBool::new(true)),
-            labels: Arc::new(HashMap::new()),
-        };
+            10.0,
+            Arc::new(AtomicBool::new(true)),
+            Arc::new(HashMap::new()),
+        );
 
         // stats_snapshot must not panic — it recovers from the poisoned lock.
         let snap = handle.stats_snapshot();
@@ -602,18 +632,18 @@ mod tests {
             .spawn(|| -> Result<(), SondaError> { Ok(()) })
             .expect("thread must spawn");
 
-        let handle = ScenarioHandle {
-            id: "test-poisoned-m".to_string(),
-            name: "poisoned_metrics".to_string(),
-            scenario_name: None,
+        let handle = ScenarioHandle::new(
+            "test-poisoned-m".to_string(),
+            "poisoned_metrics".to_string(),
+            None,
             shutdown,
-            thread: Some(thread),
-            started_at: Instant::now(),
+            Some(thread),
+            Instant::now(),
             stats,
-            target_rate: 10.0,
-            alive: Arc::new(AtomicBool::new(true)),
-            labels: Arc::new(HashMap::new()),
-        };
+            10.0,
+            Arc::new(AtomicBool::new(true)),
+            Arc::new(HashMap::new()),
+        );
 
         // recent_metrics must not panic — it recovers from the poisoned lock.
         let events = handle.recent_metrics();

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -230,6 +230,7 @@ pub fn launch_scenario_with_gates(
         ScenarioEntry::Histogram(c) => (c.name.clone(), c.rate),
         ScenarioEntry::Summary(c) => (c.name.clone(), c.rate),
     };
+    let labels = Arc::new(entry.base().labels.clone().unwrap_or_default());
 
     let started_at = Instant::now();
 
@@ -339,6 +340,7 @@ pub fn launch_scenario_with_gates(
         stats,
         target_rate,
         alive,
+        labels,
     })
 }
 

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -330,18 +330,18 @@ pub fn launch_scenario_with_gates(
         })
         .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
 
-    Ok(ScenarioHandle {
+    Ok(ScenarioHandle::new(
         id,
         name,
         scenario_name,
         shutdown,
-        thread: Some(thread),
+        Some(thread),
         started_at,
         stats,
         target_rate,
         alive,
         labels,
-    })
+    ))
 }
 
 struct AliveGuard {

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -41,9 +41,9 @@ struct Args {
     #[arg(long, default_value = "0.0.0.0")]
     bind: String,
 
-    /// API key for bearer-token authentication on `/scenarios/*` endpoints.
+    /// API key for bearer-token authentication on `/scenarios/*`, `/events`, and `/metrics` endpoints.
     ///
-    /// When set, all requests to `/scenarios/*` must include an
+    /// When set, requests to these endpoints must include an
     /// `Authorization: Bearer <key>` header. The `/health` endpoint remains
     /// public regardless of this setting.
     ///
@@ -100,7 +100,7 @@ async fn main() -> anyhow::Result<()> {
     });
 
     if api_key.is_some() {
-        info!("API key authentication enabled for /scenarios/* and /events endpoints");
+        info!("API key authentication enabled for /scenarios/*, /events, and /metrics endpoints");
     } else {
         info!("API key authentication disabled — all endpoints are public");
     }

--- a/sonda-server/src/routes/mod.rs
+++ b/sonda-server/src/routes/mod.rs
@@ -48,6 +48,7 @@ pub fn router(state: AppState) -> Router {
             "/scenarios/{id}/metrics",
             get(scenarios::get_scenario_metrics),
         )
+        .route("/metrics", get(scenarios::get_aggregate_metrics))
         .route("/events", axum::routing::post(events::post_events))
         .route_layer(middleware::from_fn_with_state(
             state.clone(),

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -22,7 +22,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use axum::extract::{Path, Query, State};
+use axum::extract::{Path, Query, RawQuery, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Json, Response};
 use serde::{Deserialize, Serialize};
@@ -841,6 +841,111 @@ pub async fn get_scenario_metrics(
         .into_response())
 }
 
+// ---- Aggregate scrape endpoint ----------------------------------------------
+
+fn parse_label_filters(raw: Option<&str>) -> Result<Vec<(String, String)>, String> {
+    let Some(raw) = raw else {
+        return Ok(Vec::new());
+    };
+    let mut filters = Vec::new();
+    for pair in raw.split('&').filter(|s| !s.is_empty()) {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        if key != "label" {
+            continue;
+        }
+        let decoded = percent_decode(value);
+        let (k, v) = decoded.split_once(':').ok_or_else(|| {
+            format!("label filter '{decoded}' is malformed: expected 'key:value'")
+        })?;
+        if k.is_empty() {
+            return Err(format!("label filter '{decoded}' has an empty key"));
+        }
+        if v.is_empty() {
+            return Err(format!("label filter '{decoded}' has an empty value"));
+        }
+        filters.push((k.to_string(), v.to_string()));
+    }
+    Ok(filters)
+}
+
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hi = (bytes[i + 1] as char).to_digit(16);
+                let lo = (bytes[i + 2] as char).to_digit(16);
+                match (hi, lo) {
+                    (Some(h), Some(l)) => {
+                        out.push((h * 16 + l) as u8);
+                        i += 3;
+                    }
+                    _ => {
+                        out.push(bytes[i]);
+                        i += 1;
+                    }
+                }
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8(out).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+}
+
+pub async fn get_aggregate_metrics(
+    State(state): State<AppState>,
+    RawQuery(raw_query): RawQuery,
+) -> Result<Response, Response> {
+    let filters = parse_label_filters(raw_query.as_deref()).map_err(bad_request)?;
+
+    let scenarios = state
+        .scenarios
+        .read()
+        .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
+
+    let mut ids: Vec<&String> = scenarios.keys().collect();
+    ids.sort();
+
+    let encoder = PrometheusText::new(None);
+    let mut buf = Vec::new();
+    for id in ids {
+        let handle = match scenarios.get(id) {
+            Some(h) => h,
+            None => continue,
+        };
+        if !filters.iter().all(|(k, v)| {
+            handle
+                .labels
+                .get(k.as_str())
+                .map(|hv| hv == v)
+                .unwrap_or(false)
+        }) {
+            continue;
+        }
+        for event in handle.recent_metrics_snapshot() {
+            if let Err(e) = encoder.encode_metric(&event, &mut buf) {
+                warn!(id = %id, error = %e, "GET /metrics: failed to encode metric event");
+            }
+        }
+    }
+
+    Ok((
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, PROMETHEUS_CONTENT_TYPE)],
+        buf,
+    )
+        .into_response())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -895,6 +1000,7 @@ mod tests {
             stats,
             target_rate: 100.0,
             alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            labels: std::sync::Arc::new(std::collections::HashMap::new()),
         }
     }
 
@@ -926,6 +1032,7 @@ mod tests {
             stats,
             target_rate: 100.0,
             alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            labels: std::sync::Arc::new(std::collections::HashMap::new()),
         }
     }
 
@@ -2752,6 +2859,7 @@ scenarios:
             stats,
             target_rate,
             alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            labels: std::sync::Arc::new(std::collections::HashMap::new()),
         }
     }
 
@@ -3203,6 +3311,7 @@ scenarios:
             stats,
             target_rate: 10.0,
             alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            labels: std::sync::Arc::new(std::collections::HashMap::new()),
         }
     }
 
@@ -3501,6 +3610,402 @@ scenarios:
         );
     }
 
+    // ========================================================================
+    // GET /metrics aggregate scrape tests
+    // ========================================================================
+
+    fn make_handle_with_labels_and_metrics(
+        id: &str,
+        name: &str,
+        labels: Vec<(&str, &str)>,
+        events: Vec<sonda_core::model::metric::MetricEvent>,
+    ) -> ScenarioHandle {
+        let shutdown = Arc::new(AtomicBool::new(true));
+        let mut stats = ScenarioStats::default();
+        for event in events {
+            stats.push_metric(event);
+        }
+        let stats = Arc::new(RwLock::new(stats));
+        let shutdown_clone = Arc::clone(&shutdown);
+
+        let thread = thread::Builder::new()
+            .name(format!("test-agg-{name}"))
+            .spawn(move || -> Result<(), sonda_core::SondaError> {
+                while shutdown_clone.load(Ordering::SeqCst) {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Ok(())
+            })
+            .expect("thread must spawn");
+
+        let mut label_map = std::collections::HashMap::new();
+        for (k, v) in labels {
+            label_map.insert(k.to_string(), v.to_string());
+        }
+
+        ScenarioHandle {
+            id: id.to_string(),
+            name: name.to_string(),
+            scenario_name: None,
+            shutdown,
+            thread: Some(thread),
+            started_at: Instant::now(),
+            stats,
+            target_rate: 10.0,
+            alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            labels: std::sync::Arc::new(label_map),
+        }
+    }
+
+    async fn get_aggregate_req(
+        app: axum::Router,
+        query: &str,
+    ) -> hyper::Response<axum::body::Body> {
+        let uri = if query.is_empty() {
+            "/metrics".to_string()
+        } else {
+            format!("/metrics?{query}")
+        };
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        app.oneshot(req).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_empty_state_returns_200_empty_body() {
+        let app = router_with_handles(vec![]);
+        let resp = get_aggregate_req(app, "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .expect("Content-Type must be present")
+            .to_str()
+            .unwrap();
+        assert_eq!(ct, "text/plain; version=0.0.4; charset=utf-8");
+
+        let body = body_string(resp).await;
+        assert!(
+            body.trim().is_empty(),
+            "empty state must render as empty body, got: {body:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_single_scenario_no_filter_returns_events() {
+        let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
+        let h = make_handle_with_labels_and_metrics("agg-1", "single", vec![], events);
+        let app = router_with_handles(vec![h]);
+
+        let resp = get_aggregate_req(app, "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp).await;
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 2, "must encode 2 events, got: {body:?}");
+        for line in &lines {
+            assert!(
+                line.starts_with("up"),
+                "each line must start with metric name 'up', got: {line}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_snapshot_is_non_destructive() {
+        let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
+        let h = make_handle_with_labels_and_metrics("agg-snap", "snap", vec![], events);
+        let state = AppState::new();
+        {
+            let mut map = state.scenarios.write().unwrap();
+            map.insert(h.id.clone(), h);
+        }
+
+        let app1 = router(state.clone());
+        let body_1 = body_string(get_aggregate_req(app1, "").await).await;
+
+        let app2 = router(state.clone());
+        let body_2 = body_string(get_aggregate_req(app2, "").await).await;
+
+        assert_eq!(
+            body_1, body_2,
+            "two snapshot calls must return identical bodies"
+        );
+        assert!(
+            !body_1.trim().is_empty(),
+            "snapshot must include the pushed events"
+        );
+
+        cleanup_scenarios(&state);
+    }
+
+    #[tokio::test]
+    async fn per_scenario_metrics_still_drains_after_aggregate_snapshot() {
+        let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
+        let h = make_handle_with_labels_and_metrics("agg-drain", "drain", vec![], events);
+        let state = AppState::new();
+        {
+            let mut map = state.scenarios.write().unwrap();
+            map.insert(h.id.clone(), h);
+        }
+
+        let agg_app = router(state.clone());
+        let agg_body = body_string(get_aggregate_req(agg_app, "").await).await;
+        assert!(!agg_body.trim().is_empty(), "aggregate must see the events");
+
+        let per_app = router(state.clone());
+        let per_body = body_string(get_metrics_req(per_app, "agg-drain").await).await;
+        assert!(
+            !per_body.trim().is_empty(),
+            "per-scenario scrape must still drain the buffer"
+        );
+
+        let per_app_2 = router(state.clone());
+        let per_body_2 = body_string(get_metrics_req(per_app_2, "agg-drain").await).await;
+        assert!(
+            per_body_2.trim().is_empty(),
+            "second per-scenario scrape must return empty after drain"
+        );
+
+        cleanup_scenarios(&state);
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_filter_single_label_match_included() {
+        let h1 = make_handle_with_labels_and_metrics(
+            "agg-srl1",
+            "srl1",
+            vec![("device", "srl1")],
+            vec![make_metric_event("up", 1.0)],
+        );
+        let h2 = make_handle_with_labels_and_metrics(
+            "agg-srl2",
+            "srl2",
+            vec![("device", "srl2")],
+            vec![make_metric_event("up", 2.0)],
+        );
+        let app = router_with_handles(vec![h1, h2]);
+
+        let resp = get_aggregate_req(app, "label=device:srl1").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp).await;
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(
+            lines.len(),
+            1,
+            "filter must include only one event, got: {body:?}"
+        );
+        assert!(
+            lines[0].contains(" 1"),
+            "matching event must have value 1, got: {}",
+            lines[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_filter_single_label_no_match_excluded() {
+        let h1 = make_handle_with_labels_and_metrics(
+            "agg-nm-1",
+            "nm1",
+            vec![("device", "srl1")],
+            vec![make_metric_event("up", 1.0)],
+        );
+        let h2 = make_handle_with_labels_and_metrics(
+            "agg-nm-2",
+            "nm2",
+            vec![("device", "srl2")],
+            vec![make_metric_event("up", 2.0)],
+        );
+        let app = router_with_handles(vec![h1, h2]);
+
+        let resp = get_aggregate_req(app, "label=device:srl3").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp).await;
+        assert!(
+            body.trim().is_empty(),
+            "no-match filter must return empty body, got: {body:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_filter_multi_label_and_semantics() {
+        let h1 = make_handle_with_labels_and_metrics(
+            "agg-ml-1",
+            "ml1",
+            vec![("device", "srl1"), ("if", "eth0")],
+            vec![make_metric_event("up", 10.0)],
+        );
+        let h2 = make_handle_with_labels_and_metrics(
+            "agg-ml-2",
+            "ml2",
+            vec![("device", "srl1"), ("if", "eth1")],
+            vec![make_metric_event("up", 11.0)],
+        );
+        let h3 = make_handle_with_labels_and_metrics(
+            "agg-ml-3",
+            "ml3",
+            vec![("device", "srl2"), ("if", "eth0")],
+            vec![make_metric_event("up", 12.0)],
+        );
+        let app = router_with_handles(vec![h1, h2, h3]);
+
+        let resp = get_aggregate_req(app, "label=device:srl1&label=if:eth0").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp).await;
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(
+            lines.len(),
+            1,
+            "multi-label AND must match exactly one handle, got: {body:?}"
+        );
+        assert!(
+            lines[0].contains(" 10"),
+            "matching event must have value 10, got: {}",
+            lines[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_handle_with_no_labels_never_matches_filter() {
+        let h = make_handle_with_labels_and_metrics(
+            "agg-nolabels",
+            "nolabels",
+            vec![],
+            vec![make_metric_event("up", 42.0)],
+        );
+        let app = router_with_handles(vec![h]);
+
+        let resp = get_aggregate_req(app, "label=device:srl1").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp).await;
+        assert!(
+            body.trim().is_empty(),
+            "unlabelled handle must be excluded by any filter, got: {body:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_malformed_filter_returns_400() {
+        let h = make_handle_with_labels_and_metrics(
+            "agg-bad",
+            "bad",
+            vec![("device", "srl1")],
+            vec![make_metric_event("up", 1.0)],
+        );
+
+        let app = router_with_handles(vec![h]);
+        let resp = get_aggregate_req(app, "label=invalid").await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"].as_str().unwrap(), "bad_request");
+        assert!(
+            body["detail"].as_str().unwrap().contains("invalid"),
+            "detail must reference the bad input, got: {body:?}"
+        );
+
+        let h2 = make_handle_with_labels_and_metrics(
+            "agg-bad2",
+            "bad2",
+            vec![("device", "srl1")],
+            vec![],
+        );
+        let app2 = router_with_handles(vec![h2]);
+        let resp2 = get_aggregate_req(app2, "label=:value").await;
+        assert_eq!(resp2.status(), StatusCode::BAD_REQUEST);
+        let body2 = body_json(resp2).await;
+        assert_eq!(body2["error"].as_str().unwrap(), "bad_request");
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_auth_gate_enforced() {
+        let state = AppState::with_api_key(Some("the-key".to_string()));
+        let app = router(state);
+
+        let req = Request::builder()
+            .uri("/metrics")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "missing bearer must return 401"
+        );
+
+        let req_ok = Request::builder()
+            .uri("/metrics")
+            .header("authorization", "Bearer the-key")
+            .body(Body::empty())
+            .unwrap();
+        let resp_ok = app.oneshot(req_ok).await.unwrap();
+        assert_eq!(
+            resp_ok.status(),
+            StatusCode::OK,
+            "correct bearer must return 200"
+        );
+    }
+
+    #[test]
+    fn parse_label_filters_accepts_repeated_pairs() {
+        let filters =
+            parse_label_filters(Some("label=device:srl1&label=if:eth0")).expect("must parse");
+        assert_eq!(
+            filters,
+            vec![
+                ("device".to_string(), "srl1".to_string()),
+                ("if".to_string(), "eth0".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_label_filters_value_may_contain_colon() {
+        let filters = parse_label_filters(Some("label=addr:::1")).expect("must parse");
+        assert_eq!(filters, vec![("addr".to_string(), "::1".to_string())]);
+    }
+
+    #[test]
+    fn parse_label_filters_rejects_missing_colon() {
+        let err = parse_label_filters(Some("label=novalue")).unwrap_err();
+        assert!(err.contains("novalue"), "error must reference input: {err}");
+    }
+
+    #[test]
+    fn parse_label_filters_rejects_empty_key() {
+        let err = parse_label_filters(Some("label=:value")).unwrap_err();
+        assert!(
+            err.contains("empty key"),
+            "error must mention empty key: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_label_filters_rejects_empty_value() {
+        let err = parse_label_filters(Some("label=key:")).unwrap_err();
+        assert!(
+            err.contains("empty value"),
+            "error must mention empty value: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_label_filters_ignores_non_label_keys() {
+        let filters = parse_label_filters(Some("foo=bar&label=device:srl1")).expect("must parse");
+        assert_eq!(filters, vec![("device".to_string(), "srl1".to_string())]);
+    }
+
+    #[test]
+    fn parse_label_filters_empty_query_returns_empty() {
+        let filters = parse_label_filters(None).expect("must parse");
+        assert!(filters.is_empty());
+        let filters2 = parse_label_filters(Some("")).expect("must parse");
+        assert!(filters2.is_empty());
+    }
+
     // ---- MetricsQuery deserialization ----------------------------------------
 
     /// MetricsQuery with no fields deserializes with limit=None.
@@ -3563,6 +4068,7 @@ scenarios:
             stats,
             target_rate: 50.0,
             alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            labels: std::sync::Arc::new(std::collections::HashMap::new()),
         }
     }
 
@@ -3591,6 +4097,7 @@ scenarios:
             stats,
             target_rate: 10.0,
             alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            labels: std::sync::Arc::new(std::collections::HashMap::new()),
         }
     }
 

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -990,18 +990,18 @@ mod tests {
             })
             .expect("thread must spawn");
 
-        ScenarioHandle {
-            id: id.to_string(),
-            name: name.to_string(),
-            scenario_name: None,
+        ScenarioHandle::new(
+            id.to_string(),
+            name.to_string(),
+            None,
             shutdown,
-            thread: Some(thread),
-            started_at: Instant::now(),
+            Some(thread),
+            Instant::now(),
             stats,
-            target_rate: 100.0,
-            alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
-            labels: std::sync::Arc::new(std::collections::HashMap::new()),
-        }
+            100.0,
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            std::sync::Arc::new(std::collections::HashMap::new()),
+        )
     }
 
     /// Build a ScenarioHandle that has already finished (thread exits immediately).
@@ -1022,18 +1022,18 @@ mod tests {
         // Give thread time to finish.
         thread::sleep(Duration::from_millis(50));
 
-        ScenarioHandle {
-            id: id.to_string(),
-            name: name.to_string(),
-            scenario_name: None,
+        ScenarioHandle::new(
+            id.to_string(),
+            name.to_string(),
+            None,
             shutdown,
-            thread: Some(thread),
-            started_at: Instant::now(),
+            Some(thread),
+            Instant::now(),
             stats,
-            target_rate: 100.0,
-            alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
-            labels: std::sync::Arc::new(std::collections::HashMap::new()),
-        }
+            100.0,
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            std::sync::Arc::new(std::collections::HashMap::new()),
+        )
     }
 
     /// Build a router with the given handles pre-inserted.
@@ -2849,18 +2849,18 @@ scenarios:
             thread::sleep(Duration::from_millis(50));
         }
 
-        ScenarioHandle {
-            id: id.to_string(),
-            name: name.to_string(),
-            scenario_name: None,
+        ScenarioHandle::new(
+            id.to_string(),
+            name.to_string(),
+            None,
             shutdown,
-            thread: Some(thread),
-            started_at: Instant::now(),
+            Some(thread),
+            Instant::now(),
             stats,
             target_rate,
-            alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
-            labels: std::sync::Arc::new(std::collections::HashMap::new()),
-        }
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            std::sync::Arc::new(std::collections::HashMap::new()),
+        )
     }
 
     /// Helper: send a GET /scenarios/{id}/stats request.
@@ -3301,18 +3301,18 @@ scenarios:
             })
             .expect("thread must spawn");
 
-        ScenarioHandle {
-            id: id.to_string(),
-            name: name.to_string(),
-            scenario_name: None,
+        ScenarioHandle::new(
+            id.to_string(),
+            name.to_string(),
+            None,
             shutdown,
-            thread: Some(thread),
-            started_at: Instant::now(),
+            Some(thread),
+            Instant::now(),
             stats,
-            target_rate: 10.0,
-            alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
-            labels: std::sync::Arc::new(std::collections::HashMap::new()),
-        }
+            10.0,
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            std::sync::Arc::new(std::collections::HashMap::new()),
+        )
     }
 
     /// Helper: send a GET /scenarios/{id}/metrics request.
@@ -3643,18 +3643,18 @@ scenarios:
             label_map.insert(k.to_string(), v.to_string());
         }
 
-        ScenarioHandle {
-            id: id.to_string(),
-            name: name.to_string(),
-            scenario_name: None,
+        ScenarioHandle::new(
+            id.to_string(),
+            name.to_string(),
+            None,
             shutdown,
-            thread: Some(thread),
-            started_at: Instant::now(),
+            Some(thread),
+            Instant::now(),
             stats,
-            target_rate: 10.0,
-            alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
-            labels: std::sync::Arc::new(label_map),
-        }
+            10.0,
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            std::sync::Arc::new(label_map),
+        )
     }
 
     async fn get_aggregate_req(
@@ -4058,18 +4058,18 @@ scenarios:
             })
             .expect("thread must spawn");
 
-        ScenarioHandle {
-            id: id.to_string(),
-            name: name.to_string(),
-            scenario_name: None,
+        ScenarioHandle::new(
+            id.to_string(),
+            name.to_string(),
+            None,
             shutdown,
-            thread: Some(thread),
-            started_at: Instant::now(),
+            Some(thread),
+            Instant::now(),
             stats,
-            target_rate: 50.0,
-            alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
-            labels: std::sync::Arc::new(std::collections::HashMap::new()),
-        }
+            50.0,
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            std::sync::Arc::new(std::collections::HashMap::new()),
+        )
     }
 
     /// Build a ScenarioHandle whose thread panics immediately.
@@ -4087,18 +4087,18 @@ scenarios:
         // Give the thread time to panic.
         thread::sleep(Duration::from_millis(50));
 
-        ScenarioHandle {
-            id: id.to_string(),
-            name: name.to_string(),
-            scenario_name: None,
+        ScenarioHandle::new(
+            id.to_string(),
+            name.to_string(),
+            None,
             shutdown,
-            thread: Some(thread),
-            started_at: Instant::now(),
+            Some(thread),
+            Instant::now(),
             stats,
-            target_rate: 10.0,
-            alive: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
-            labels: std::sync::Arc::new(std::collections::HashMap::new()),
-        }
+            10.0,
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            std::sync::Arc::new(std::collections::HashMap::new()),
+        )
     }
 
     // ---- L1: DELETE on unjoinable thread returns force_stopped --------------

--- a/sonda-server/tests/metrics.rs
+++ b/sonda-server/tests/metrics.rs
@@ -1,0 +1,107 @@
+//! End-to-end integration tests for `GET /metrics` (aggregate scrape).
+
+mod common;
+
+use std::thread;
+use std::time::Duration;
+
+const SRL1_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: srl1_up
+    signal_type: metrics
+    name: srl1_up
+    labels:
+      device: srl1
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+const SRL2_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: srl2_up
+    signal_type: metrics
+    name: srl2_up
+    labels:
+      device: srl2
+    generator:
+      type: constant
+      value: 2.0
+"#;
+
+#[test]
+fn aggregate_metrics_end_to_end_with_label_filter() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("Content-Type", "text/yaml")
+        .body(SRL1_YAML)
+        .send()
+        .expect("POST srl1 must succeed");
+    assert_eq!(resp.status().as_u16(), 201, "POST srl1 must return 201");
+
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("Content-Type", "text/yaml")
+        .body(SRL2_YAML)
+        .send()
+        .expect("POST srl2 must succeed");
+    assert_eq!(resp.status().as_u16(), 201, "POST srl2 must return 201");
+
+    thread::sleep(Duration::from_millis(500));
+
+    let resp = client
+        .get(format!("{base}/metrics"))
+        .send()
+        .expect("GET /metrics must succeed");
+    assert_eq!(resp.status().as_u16(), 200);
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .expect("Content-Type must be present")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(ct, "text/plain; version=0.0.4; charset=utf-8");
+    let body_all = resp.text().expect("body must be UTF-8");
+    assert!(
+        body_all.contains("srl1_up") && body_all.contains("srl2_up"),
+        "aggregate body must include both scenarios, got: {body_all}"
+    );
+
+    let resp = client
+        .get(format!("{base}/metrics?label=device:srl1"))
+        .send()
+        .expect("GET /metrics?label=device:srl1 must succeed");
+    assert_eq!(resp.status().as_u16(), 200);
+    let body_filtered = resp.text().expect("body must be UTF-8");
+    assert!(
+        body_filtered.contains("srl1_up"),
+        "filtered body must include srl1, got: {body_filtered}"
+    );
+    assert!(
+        !body_filtered.contains("srl2_up"),
+        "filtered body must exclude srl2, got: {body_filtered}"
+    );
+}


### PR DESCRIPTION
## Summary

`GET /metrics` returns Prometheus text exposition across every running scenario in a single HTTP call. Repeated `?label=k:v` query parameters filter by handle labels with AND semantics. Snapshot semantics are non-destructive so concurrent scrapes are idempotent — per-sample timestamps in the exposition let Prometheus / VictoriaMetrics dedupe naturally. The existing `GET /scenarios/{id}/metrics` endpoint is unchanged and continues to drain.

The mental model: sonda-server presents itself to a scraper the same way a Prometheus exporter on a real device does — one URL, idempotent within a scrape window, labels as selectors. Of sonda's three configuration primitives (scenarios, multi-scenarios, packs), only scenarios exist at runtime; the labels you attach are the only cross-scenario grouping that survives compile-time expansion, so `?label=k:v` is how you query by your own grouping regardless of how the underlying scenarios were launched.

- Surface configured labels on `ScenarioHandle` at launch time
- Add `recent_metrics_snapshot()` as the non-destructive variant of `recent_metrics()`
- Register `GET /metrics` in the protected sub-router (same auth as `/scenarios/*`)
- Update `--help` and startup log to list `/metrics` among auth-gated endpoints
- Document the endpoint in the server reference, K8s deployment guide, and synthetic-monitoring guide

## Test plan

- [ ] `cargo build --workspace`
- [ ] `cargo nextest run --workspace`
- [ ] Start server, POST two scenarios labeled `device:srl1` and `device:srl2`; `curl /metrics` returns both
- [ ] `curl /metrics?label=device:srl1` narrows to one device
- [ ] `curl /metrics?label=device:srl1&label=interface:eth0` AND-combines correctly
- [ ] Two back-to-back `curl /metrics` calls return byte-identical bodies (snapshot is non-destructive)
- [ ] `curl /scenarios/{id}/metrics` twice — first returns events, second is empty (drain semantics preserved)
- [ ] Start server with `--api-key`; `/metrics` returns 401 without bearer, 200 with
- [ ] `task site:build` passes