### PR TITLE
fix(server): emit # HELP and # TYPE annotations on /metrics endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/docs/site/docs/configuration/generators.md
+++ b/docs/site/docs/configuration/generators.md
@@ -313,7 +313,15 @@ request_count{instance="web-01",job="app"} 4 1775192672943
 !!! tip "Simulating counter resets"
     Set `max` to a low value to see wrap-around behavior. For example, `start: 0`, `step_size: 1`,
     `max: 5` produces `0, 1, 2, 3, 4, 0, 1, 2, ...` -- useful for verifying that your `rate()`
-    queries handle counter resets correctly.
+    queries handle counter resets correctly. Prometheus treats the drop from `max-1` back to
+    `start` as a counter reset, so `rate()` and `increase()` stitch across the wrap transparently
+    — no data is lost or double-counted.
+
+!!! info "`step` defaults to `metric_type: counter`"
+    When scraped through [`sonda-server`](../deployment/sonda-server.md#aggregate-prometheus-scrape),
+    a `step` scenario surfaces as a `# TYPE <name> counter` metric by default. Every other metric
+    generator defaults to `gauge`. Override either default by setting [`metric_type:`](scenario-fields.md#prometheus-exposition-fields)
+    on the scenario.
 
 ### spike
 

--- a/docs/site/docs/configuration/scenario-fields.md
+++ b/docs/site/docs/configuration/scenario-fields.md
@@ -27,6 +27,9 @@ scenarios:
     signal_type: metrics
     name: cpu_usage
 
+    metric_type: gauge
+    help: "CPU usage percent on the device."
+
     generator:
       type: sine
       amplitude: 50.0
@@ -87,6 +90,54 @@ sonda run full-example.yaml
 | `jitter` | float | no | none | Noise amplitude. Adds uniform noise in `[-jitter, +jitter]` to every generated value. See [Generators - Jitter](generators.md#jitter). |
 | `jitter_seed` | integer | no | `0` | Seed for deterministic jitter noise. Different seeds produce different noise sequences. |
 | `on_sink_error` | string | no | `warn` | Behavior when the sink returns an error mid-run: `warn` (log + drop batch + keep running) or `fail` (propagate and exit the runner). Overrides `defaults.on_sink_error`. See [Sink-error policy](scenario-files.md#sink-error-policy). |
+| `metric_type` | string | no | derived | Prometheus exposition type: `gauge`, `counter`, `histogram`, `summary`, or `untyped`. Surfaces on the `sonda-server` [`/metrics` endpoints](../deployment/sonda-server.md#aggregate-prometheus-scrape) as the `# TYPE` line. See [Prometheus exposition fields](#prometheus-exposition-fields). |
+| `help` | string | no | none | Free-text description emitted as the `# HELP` line on the `sonda-server` [`/metrics` endpoints](../deployment/sonda-server.md#aggregate-prometheus-scrape). Omitted when unset. See [Prometheus exposition fields](#prometheus-exposition-fields). |
+
+### Prometheus exposition fields
+
+`metric_type` and `help` annotate a scenario's metric so the `sonda-server` `/metrics` endpoints emit Prometheus `# TYPE` and `# HELP` lines. Both fields apply to `metrics`, `histogram`, and `summary` entries. Log entries ignore them. They are also a no-op for the per-event sinks that the `sonda run` CLI uses (`stdout`, `file`, `tcp`, etc.) — these annotations exist for scrape-based delivery via [`sonda-server`](../deployment/sonda-server.md).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `metric_type` | string | no | derived (see below) | One of `gauge`, `counter`, `histogram`, `summary`, `untyped`. |
+| `help` | string | no | none | Free-text description. When omitted, no `# HELP` line is emitted. |
+
+**Defaults**, applied when `metric_type` is omitted:
+
+| Signal | Generator | Default `metric_type` |
+|--------|-----------|----------------------|
+| `metrics` | `step` | `counter` |
+| `metrics` | any other generator | `gauge` |
+| `histogram` | -- | `histogram` |
+| `summary` | -- | `summary` |
+
+```yaml title="Metrics entry with explicit exposition"
+scenarios:
+  - id: memory_utilization
+    signal_type: metrics
+    name: memory_utilization
+    metric_type: gauge
+    help: "Memory usage percent on the device."
+    generator:
+      type: constant
+      value: 41.5
+    labels:
+      device: srl1
+```
+
+Scrape the server and the response carries both annotations:
+
+```text title="GET /metrics"
+# HELP memory_utilization Memory usage percent on the device.
+# TYPE memory_utilization gauge
+memory_utilization{device="srl1"} 41.5 1779645380851
+```
+
+!!! info "Why declare `metric_type`?"
+    Prometheus-text consumers (Prometheus, VictoriaMetrics, Telegraf, vmagent) treat unannotated metrics as `untyped`. Downstream tooling can rename or special-case untyped samples — for example, an untyped metric named `bgp_oper_state` may surface as `bgp_oper_state_value` after a hop through a Telegraf-style relay. Declaring `metric_type:` keeps the metric name stable across every scraping consumer in the chain.
+
+!!! warning "Mixed-type collisions become `untyped`"
+    Prometheus permits only one `# TYPE` line per metric name. When two scenarios share a `name:` but declare different `metric_type` values (one `gauge`, one `counter`), the aggregate [`GET /metrics`](../deployment/sonda-server.md#aggregate-prometheus-scrape) emits a single `# TYPE <name> untyped` block containing samples from both, and logs a server-side warning. Pick a consistent `metric_type` per metric name to avoid the demotion.
 
 ### Gap window
 

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -722,23 +722,73 @@ The four sink-failure fields are the runtime telemetry surface for the [`on_sink
 
 To a scraper, `sonda-server` presents itself the same way a Prometheus exporter on a real device does — one URL (`GET /metrics`), idempotent within a scrape window, with label selectors to slice the view. `GET /metrics` returns a snapshot of every running scenario's recent metric events fused into a single Prometheus text-format response, and `?label=k:v` filters that view by the labels the user attached when starting each scenario.
 
+It is a **typed** exporter: each metric is fronted by `# TYPE` and (when configured) `# HELP` lines, so Prometheus, VictoriaMetrics, vmagent, and Telegraf consumers see the same exposition shape they would see scraping any real device. Set [`metric_type:` and `help:`](../configuration/scenario-fields.md#prometheus-exposition-fields) on a scenario to declare the type and description explicitly; omit them and the server picks a sensible default (`gauge` for most metric generators, `counter` for [`step`](../configuration/generators.md#step), `histogram` / `summary` for those signal types).
+
 Why labels are the durable identity at scrape time: scenarios, multi-scenarios, and metric packs are three ways to *configure* Sonda, but only individual scenarios exist at runtime — packs and multi-scenarios fan out into independent scenarios at compile time. The labels you set on each scenario (`device: srl1`, `interface: eth0`, `region: us-east`) are the only cross-scenario grouping that survives, so `?label=k:v` is how you ask "give me one device's metrics" regardless of how the underlying scenarios got launched.
 
 ### Happy path
+
+Post a scenario that declares `metric_type:` and `help:`, then scrape:
+
+```yaml title="memory-utilization.yaml"
+version: 2
+kind: runnable
+defaults:
+  rate: 2
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: mem_srl1
+    signal_type: metrics
+    name: memory_utilization
+    metric_type: gauge
+    help: "Memory usage percent on the device."
+    generator:
+      type: constant
+      value: 41.528
+    labels:
+      device: srl1
+  - id: mem_srl2
+    signal_type: metrics
+    name: memory_utilization
+    generator:
+      type: constant
+      value: 67.812
+    labels:
+      device: srl2
+```
 
 ```bash
 curl http://localhost:8080/metrics
 ```
 
 ```text title="Response (text/plain; version=0.0.4; charset=utf-8)"
-if_in_octets{device="srl1",interface="eth0"} 12345 1779622362660
-if_in_octets{device="srl1",interface="eth0"} 12345 1779622362870
-if_in_octets{device="srl1",interface="eth0"} 12345 1779622363070
-if_out_octets{device="srl2",interface="eth0"} 678 1779622363271
-if_out_octets{device="srl2",interface="eth0"} 681 1779622363470
+# HELP memory_utilization Memory usage percent on the device.
+# TYPE memory_utilization gauge
+memory_utilization{device="srl1"} 41.528 1779645380851
+memory_utilization{device="srl2"} 67.812 1779645380851
 ```
 
-Each line is `metric_name{labels} value timestamp_ms`. Timestamps are per-sample wall-clock milliseconds, so Prometheus and VictoriaMetrics dedupe naturally on `(name, labels, timestamp_ms, value)` across overlapping scrape windows. With no scenarios running, the response is `200 OK` with an empty body — exactly what Prometheus, vmagent, and Telegraf scrapers expect on a quiet target.
+Each sample line is `metric_name{labels} value timestamp_ms`. Per-sample wall-clock millisecond timestamps let Prometheus and VictoriaMetrics dedupe naturally on `(name, labels, timestamp_ms, value)` across overlapping scrape windows. The `# TYPE` line appears once per metric name, and `# HELP` appears when any contributing scenario set one. With no scenarios running, the response is `200 OK` with an empty body — exactly what Prometheus, vmagent, and Telegraf scrapers expect on a quiet target.
+
+Histogram and summary scenarios surface the same way — one `# TYPE` block per base name covering every `_bucket{le="..."}`, `_sum`, `_count`, and quantile line:
+
+```text title="Response (histogram entry)"
+# HELP http_request_duration_seconds Request latency in seconds.
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{le="0.005",method="GET"} 3 1779645380851
+http_request_duration_seconds_bucket{le="0.01",method="GET"} 11 1779645380851
+http_request_duration_seconds_bucket{le="+Inf",method="GET"} 100 1779645380851
+http_request_duration_seconds_sum{method="GET"} 9.505 1779645380851
+http_request_duration_seconds_count{method="GET"} 100 1779645380851
+```
+
+This is the exposition shape `histogram_quantile()` expects, so PromQL percentile queries work end-to-end against the server.
+
+!!! warning "Mixed-type collisions become `untyped`"
+    Two scenarios that share a `name:` but declare different `metric_type` values (one `gauge`, one `counter`) collapse to a single `# TYPE <name> untyped` block in the aggregate response — Prometheus permits only one TYPE per metric name. The server logs a warning identifying both contributors. See [Prometheus exposition fields](../configuration/scenario-fields.md#prometheus-exposition-fields) for the full rule.
 
 ### Filter by label
 
@@ -806,6 +856,16 @@ scrape_configs:
 ## Per-scenario scrape
 
 The `GET /scenarios/{id}/metrics` endpoint returns recent metric events for one scenario in Prometheus text exposition format. Each scrape **drains** the buffer — events appear once per cycle. Use it when you want a one-to-one consumer pulling from a single scenario; reach for [`GET /metrics`](#aggregate-prometheus-scrape) when more than one scraper needs the data or when you want a single job that covers every running scenario.
+
+The response carries the same `# TYPE` and `# HELP` annotations as the aggregate endpoint, scoped to the single scenario:
+
+```text title="GET /scenarios/<SCENARIO_ID>/metrics"
+# HELP memory_utilization Memory usage percent on the device.
+# TYPE memory_utilization gauge
+memory_utilization{device="srl1"} 41.528 1779645380851
+```
+
+See [Prometheus exposition fields](../configuration/scenario-fields.md#prometheus-exposition-fields) for how `metric_type:` and `help:` control these lines and how defaults are derived.
 
 ```yaml title="prometheus.yml"
 scrape_configs:

--- a/sonda-core/benches/while_steady_state.rs
+++ b/sonda-core/benches/while_steady_state.rs
@@ -41,6 +41,8 @@ fn metrics_entry(name: &str, rate: f64, duration_ms: u64) -> ScenarioEntry {
         },
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
     })
 }
 

--- a/sonda-core/src/compiler/compile_after.rs
+++ b/sonda-core/src/compiler/compile_after.rs
@@ -497,6 +497,10 @@ pub struct CompiledEntry {
     /// a different upstream.
     #[cfg_attr(feature = "config", serde(skip_serializing_if = "Option::is_none"))]
     pub after_ref: Option<String>,
+    #[cfg_attr(feature = "config", serde(skip_serializing_if = "Option::is_none"))]
+    pub metric_type: Option<crate::config::PromMetricType>,
+    #[cfg_attr(feature = "config", serde(skip_serializing_if = "Option::is_none"))]
+    pub help: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -713,6 +717,8 @@ pub fn compile_after(file: ExpandedFile) -> Result<CompiledFile, CompileAfterErr
             while_clause: entry.while_clause,
             delay_clause: entry.delay_clause,
             after_ref,
+            metric_type: entry.metric_type,
+            help: entry.help,
         });
     }
 
@@ -2387,6 +2393,8 @@ scenarios:
             mean_shift_per_sec: None,
             seed: None,
             on_sink_error: crate::OnSinkError::Warn,
+            metric_type: None,
+            help: None,
         };
         let edges: Vec<_> = outgoing_edges(&e).collect();
         assert_eq!(

--- a/sonda-core/src/compiler/expand.rs
+++ b/sonda-core/src/compiler/expand.rs
@@ -483,6 +483,11 @@ pub struct ExpandedEntry {
     pub seed: Option<u64>,
     /// Resolved sink-error policy.
     pub on_sink_error: OnSinkError,
+
+    #[cfg_attr(feature = "config", serde(skip_serializing_if = "Option::is_none"))]
+    pub metric_type: Option<crate::config::PromMetricType>,
+    #[cfg_attr(feature = "config", serde(skip_serializing_if = "Option::is_none"))]
+    pub help: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -611,6 +616,8 @@ fn expand_inline_entry(entry: NormalizedEntry) -> ExpandedEntry {
         mean_shift_per_sec: entry.mean_shift_per_sec,
         on_sink_error: entry.on_sink_error,
         seed: entry.seed,
+        metric_type: entry.metric_type,
+        help: entry.help,
     }
 }
 
@@ -755,6 +762,8 @@ fn expand_pack_entry<R: PackResolver>(
             mean_shift_per_sec: None,
             seed: None,
             on_sink_error: entry.on_sink_error,
+            metric_type: entry.metric_type,
+            help: entry.help.clone(),
         });
     }
 

--- a/sonda-core/src/compiler/mod.rs
+++ b/sonda-core/src/compiler/mod.rs
@@ -46,7 +46,7 @@ use std::collections::BTreeMap;
 
 use crate::config::{
     BurstConfig, CardinalitySpikeConfig, DistributionConfig, DynamicLabelConfig, GapConfig,
-    OnSinkError,
+    OnSinkError, PromMetricType,
 };
 use crate::encoder::EncoderConfig;
 use crate::generator::{GeneratorConfig, LogGeneratorConfig};
@@ -294,6 +294,17 @@ pub struct Entry {
     /// Per-entry sink-error policy (overrides defaults).
     #[cfg_attr(feature = "config", serde(default))]
     pub on_sink_error: Option<OnSinkError>,
+
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub metric_type: Option<PromMetricType>,
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub help: Option<String>,
 }
 
 /// Comparison operator for an [`AfterClause`] threshold check.

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -320,6 +320,9 @@ pub struct NormalizedEntry {
     pub seed: Option<u64>,
     /// Resolved sink-error policy.
     pub on_sink_error: OnSinkError,
+
+    pub metric_type: Option<crate::config::PromMetricType>,
+    pub help: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -500,6 +503,8 @@ fn normalize_entry(
         mean_shift_per_sec: entry.mean_shift_per_sec,
         seed: entry.seed,
         on_sink_error,
+        metric_type: entry.metric_type,
+        help: entry.help,
     })
 }
 

--- a/sonda-core/src/compiler/parse.rs
+++ b/sonda-core/src/compiler/parse.rs
@@ -236,6 +236,11 @@ struct FlatFile {
     seed: Option<u64>,
     #[serde(default)]
     on_sink_error: Option<crate::config::OnSinkError>,
+
+    #[serde(default)]
+    metric_type: Option<crate::config::PromMetricType>,
+    #[serde(default)]
+    help: Option<String>,
 }
 
 impl FlatFile {
@@ -287,6 +292,8 @@ impl FlatFile {
             mean_shift_per_sec: self.mean_shift_per_sec,
             seed: self.seed,
             on_sink_error: self.on_sink_error,
+            metric_type: self.metric_type,
+            help: self.help,
         };
 
         // Flat-form files deliberately do NOT expose the top-level metadata

--- a/sonda-core/src/compiler/prepare.rs
+++ b/sonda-core/src/compiler/prepare.rs
@@ -260,17 +260,19 @@ fn metrics_entry(mut entry: CompiledEntry) -> Result<ScenarioConfig, PrepareErro
         .ok_or_else(|| PrepareError::MissingGenerator {
             entry_label: describe(&entry),
         })?;
-    // `encoder` is non-`Option` on CompiledEntry (Phase 2 normalize filled it
-    // in), so a mem::replace with a cheap placeholder is sufficient.
     let encoder = std::mem::replace(
         &mut entry.encoder,
         crate::encoder::EncoderConfig::PrometheusText { precision: None },
     );
+    let metric_type = entry.metric_type.take();
+    let help = entry.help.take();
     let base = build_base(&mut entry);
     Ok(ScenarioConfig {
         base,
         generator,
         encoder,
+        metric_type,
+        help,
     })
 }
 
@@ -313,6 +315,8 @@ fn histogram_entry(mut entry: CompiledEntry) -> Result<HistogramScenarioConfig, 
         &mut entry.encoder,
         crate::encoder::EncoderConfig::PrometheusText { precision: None },
     );
+    let metric_type = entry.metric_type.take();
+    let help = entry.help.take();
     let base = build_base(&mut entry);
     Ok(HistogramScenarioConfig {
         base,
@@ -322,6 +326,8 @@ fn histogram_entry(mut entry: CompiledEntry) -> Result<HistogramScenarioConfig, 
         mean_shift_per_sec,
         seed,
         encoder,
+        metric_type,
+        help,
     })
 }
 
@@ -343,6 +349,8 @@ fn summary_entry(mut entry: CompiledEntry) -> Result<SummaryScenarioConfig, Prep
         &mut entry.encoder,
         crate::encoder::EncoderConfig::PrometheusText { precision: None },
     );
+    let metric_type = entry.metric_type.take();
+    let help = entry.help.take();
     let base = build_base(&mut entry);
     Ok(SummaryScenarioConfig {
         base,
@@ -352,6 +360,8 @@ fn summary_entry(mut entry: CompiledEntry) -> Result<SummaryScenarioConfig, Prep
         mean_shift_per_sec,
         seed,
         encoder,
+        metric_type,
+        help,
     })
 }
 
@@ -407,6 +417,8 @@ mod tests {
             while_clause: None,
             delay_clause: None,
             after_ref: None,
+            metric_type: None,
+            help: None,
         }
     }
 
@@ -887,5 +899,130 @@ mod tests {
             matches!(err, PrepareError::UnsupportedVersion { version: 0 }),
             "expected UnsupportedVersion {{ version: 0 }}, got {err:?}"
         );
+    }
+
+    // -- metric_type / help propagation through the compiler chain ----------
+
+    fn compile_yaml(yaml: &str) -> Vec<ScenarioEntry> {
+        use crate::compiler::expand::InMemoryPackResolver;
+        let resolver = InMemoryPackResolver::new();
+        crate::compile_scenario_file(yaml, &resolver).expect("yaml must compile")
+    }
+
+    #[test]
+    fn entry_with_metric_type_and_help_propagates_through_compiler() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 500ms
+scenarios:
+  - id: mem
+    signal_type: metrics
+    name: memory_utilization
+    metric_type: counter
+    help: "Memory usage percent on the device."
+    generator:
+      type: constant
+      value: 42
+"#;
+        let entries = compile_yaml(yaml);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            ScenarioEntry::Metrics(c) => {
+                assert_eq!(c.metric_type, Some(crate::config::PromMetricType::Counter));
+                assert_eq!(
+                    c.help.as_deref(),
+                    Some("Memory usage percent on the device.")
+                );
+            }
+            other => panic!("expected Metrics, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn entry_without_metric_type_and_help_propagates_as_none() {
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 500ms
+scenarios:
+  - id: mem
+    signal_type: metrics
+    name: memory_utilization
+    generator:
+      type: constant
+      value: 42
+"#;
+        let entries = compile_yaml(yaml);
+        match &entries[0] {
+            ScenarioEntry::Metrics(c) => {
+                assert!(c.metric_type.is_none());
+                assert!(c.help.is_none());
+            }
+            other => panic!("expected Metrics, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pack_expansion_propagates_entry_level_metric_type_to_all_expanded_metrics() {
+        use crate::compiler::expand::InMemoryPackResolver;
+        use crate::generator::GeneratorConfig;
+        use crate::packs::{MetricPackDef, MetricSpec};
+
+        let pack = MetricPackDef {
+            name: "test_pack".to_string(),
+            description: "test".to_string(),
+            category: "test".to_string(),
+            shared_labels: None,
+            metrics: vec![
+                MetricSpec {
+                    name: "m1".to_string(),
+                    labels: None,
+                    generator: Some(GeneratorConfig::Constant { value: 1.0 }),
+                },
+                MetricSpec {
+                    name: "m2".to_string(),
+                    labels: None,
+                    generator: Some(GeneratorConfig::Constant { value: 2.0 }),
+                },
+                MetricSpec {
+                    name: "m3".to_string(),
+                    labels: None,
+                    generator: Some(GeneratorConfig::Constant { value: 3.0 }),
+                },
+            ],
+        };
+        let mut resolver = InMemoryPackResolver::new();
+        resolver.insert("test_pack", pack);
+
+        let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 500ms
+scenarios:
+  - id: bundle
+    signal_type: metrics
+    pack: test_pack
+    metric_type: gauge
+    help: "Pack-level help"
+"#;
+        let entries =
+            crate::compile_scenario_file(yaml, &resolver).expect("pack yaml must compile");
+        assert_eq!(entries.len(), 3);
+        for entry in &entries {
+            match entry {
+                ScenarioEntry::Metrics(c) => {
+                    assert_eq!(c.metric_type, Some(crate::config::PromMetricType::Gauge));
+                    assert_eq!(c.help.as_deref(), Some("Pack-level help"));
+                }
+                other => panic!("expected Metrics, got {other:?}"),
+            }
+        }
     }
 }

--- a/sonda-core/src/config/mod.rs
+++ b/sonda-core/src/config/mod.rs
@@ -184,6 +184,46 @@ pub struct BurstConfig {
     pub multiplier: f64,
 }
 
+/// Prometheus exposition metric kind for `# TYPE` annotations.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "config", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "config", serde(rename_all = "lowercase"))]
+pub enum PromMetricType {
+    Gauge,
+    Counter,
+    Histogram,
+    Summary,
+    Untyped,
+}
+
+impl PromMetricType {
+    /// Canonical lowercase string used on the Prometheus `# TYPE` line.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PromMetricType::Gauge => "gauge",
+            PromMetricType::Counter => "counter",
+            PromMetricType::Histogram => "histogram",
+            PromMetricType::Summary => "summary",
+            PromMetricType::Untyped => "untyped",
+        }
+    }
+}
+
+/// Prometheus metadata attached to a launched scenario handle.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromMeta {
+    pub metric_type: PromMetricType,
+    pub help: Option<String>,
+}
+
+impl PromMeta {
+    pub fn new(metric_type: PromMetricType, help: Option<String>) -> Self {
+        Self { metric_type, help }
+    }
+}
+
 #[cfg(feature = "config")]
 fn default_encoder() -> EncoderConfig {
     EncoderConfig::PrometheusText { precision: None }
@@ -354,6 +394,16 @@ pub struct ScenarioConfig {
     /// Output encoder. Defaults to `prometheus_text`.
     #[cfg_attr(feature = "config", serde(default = "default_encoder"))]
     pub encoder: EncoderConfig,
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub metric_type: Option<PromMetricType>,
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub help: Option<String>,
 }
 
 impl std::ops::Deref for ScenarioConfig {
@@ -463,6 +513,16 @@ pub struct HistogramScenarioConfig {
     /// Output encoder. Defaults to `prometheus_text`.
     #[cfg_attr(feature = "config", serde(default = "default_encoder"))]
     pub encoder: EncoderConfig,
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub metric_type: Option<PromMetricType>,
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub help: Option<String>,
 }
 
 impl std::ops::Deref for HistogramScenarioConfig {
@@ -524,6 +584,16 @@ pub struct SummaryScenarioConfig {
     /// Output encoder. Defaults to `prometheus_text`.
     #[cfg_attr(feature = "config", serde(default = "default_encoder"))]
     pub encoder: EncoderConfig,
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub metric_type: Option<PromMetricType>,
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub help: Option<String>,
 }
 
 impl std::ops::Deref for SummaryScenarioConfig {
@@ -1592,6 +1662,8 @@ clock_group: compound-alert
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         assert_eq!(entry.phase_offset(), Some("5s"));
     }
@@ -1620,6 +1692,8 @@ clock_group: compound-alert
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         assert_eq!(entry.phase_offset(), None);
     }
@@ -1687,6 +1761,8 @@ clock_group: compound-alert
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         assert_eq!(entry.clock_group(), Some("my-group"));
     }
@@ -1715,6 +1791,8 @@ clock_group: compound-alert
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         assert_eq!(entry.clock_group(), None);
     }
@@ -1747,6 +1825,8 @@ clock_group: compound-alert
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         assert_eq!(entry.base().name, "base_test");
         assert_eq!(entry.base().rate, 42.0);
@@ -1998,6 +2078,8 @@ gaps:
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         };
         // All these access via Deref — no explicit `.base.` needed.
         assert_eq!(config.name, "deref_test");
@@ -2073,6 +2155,8 @@ gaps:
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         };
         config.name = "mutated".to_string();
         config.rate = 999.0;
@@ -2555,6 +2639,8 @@ mod expand_tests {
                 default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         }
     }
 
@@ -2657,6 +2743,8 @@ mod expand_tests {
             },
             generator: GeneratorConfig::Constant { value: 42.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         };
         let result = expand_scenario(config).expect("must succeed");
         assert_eq!(result.len(), 1);
@@ -3179,6 +3267,8 @@ mod expand_tests {
                 default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         };
         let result = expand_scenario(config).expect("must succeed");
 
@@ -3257,6 +3347,8 @@ mod expand_tests {
                 default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         };
         let result = expand_scenario(config).expect("must succeed");
 
@@ -3323,6 +3415,8 @@ mod expand_tests {
                 default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         };
         let err = expand_scenario(config).expect_err("must fail");
         let msg = err.to_string();
@@ -3374,6 +3468,8 @@ mod expand_tests {
                 default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         };
         let err = expand_scenario(config).expect_err("must fail");
         let msg = err.to_string();
@@ -3416,6 +3512,8 @@ mod expand_tests {
                 default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         };
         let err = expand_scenario(config).expect_err("must fail");
         assert!(
@@ -3462,6 +3560,8 @@ mod expand_tests {
                 default_metric_name: None,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         };
         let err = expand_scenario(config).expect_err("must fail");
         let msg = err.to_string();
@@ -3718,6 +3818,8 @@ distribution:
             mean_shift_per_sec: None,
             seed: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         let result = expand_entry(entry).expect("must succeed");
         assert_eq!(result.len(), 1);
@@ -3755,6 +3857,8 @@ distribution:
             mean_shift_per_sec: None,
             seed: None,
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         let result = expand_entry(entry).expect("must succeed");
         assert_eq!(result.len(), 1);
@@ -3810,6 +3914,8 @@ distribution:
                 default_metric_name,
             },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         }
     }
 

--- a/sonda-core/src/config/validate.rs
+++ b/sonda-core/src/config/validate.rs
@@ -2013,6 +2013,8 @@ generator:
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         }
     }
 
@@ -2847,6 +2849,8 @@ generator:
             mean_shift_per_sec: None,
             seed: Some(42),
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         }
     }
 
@@ -2915,6 +2919,8 @@ generator:
             mean_shift_per_sec: None,
             seed: Some(42),
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         }
     }
 

--- a/sonda-core/src/encoder/mod.rs
+++ b/sonda-core/src/encoder/mod.rs
@@ -12,6 +12,7 @@ pub mod prometheus;
 pub mod remote_write;
 pub mod syslog;
 
+use crate::config::PromMetricType;
 use crate::model::log::LogEvent;
 use crate::model::metric::MetricEvent;
 
@@ -35,6 +36,17 @@ pub trait Encoder: Send + Sync {
         Err(crate::SondaError::Encoder(
             crate::EncoderError::NotSupported("log encoding not supported by this encoder".into()),
         ))
+    }
+
+    /// Emit Prometheus exposition `# HELP` and `# TYPE` lines for a metric name.
+    fn encode_metadata(
+        &self,
+        _name: &str,
+        _metric_type: PromMetricType,
+        _help: Option<&str>,
+        _buf: &mut Vec<u8>,
+    ) -> Result<(), crate::SondaError> {
+        Ok(())
     }
 }
 

--- a/sonda-core/src/encoder/prometheus.rs
+++ b/sonda-core/src/encoder/prometheus.rs
@@ -6,6 +6,7 @@
 use std::io::Write as _;
 use std::time::UNIX_EPOCH;
 
+use crate::config::PromMetricType;
 use crate::model::metric::MetricEvent;
 use crate::{EncoderError, SondaError};
 
@@ -64,6 +65,16 @@ fn escape_label_value(value: &str, buf: &mut Vec<u8>) {
     }
 }
 
+fn escape_help_text(value: &str, buf: &mut Vec<u8>) {
+    for byte in value.bytes() {
+        match byte {
+            b'\\' => buf.extend_from_slice(b"\\\\"),
+            b'\n' => buf.extend_from_slice(b"\\n"),
+            other => buf.push(other),
+        }
+    }
+}
+
 impl Encoder for PrometheusText {
     /// Encode a metric event into Prometheus text exposition format.
     ///
@@ -109,6 +120,28 @@ impl Encoder for PrometheusText {
 
         buf.push(b'\n');
 
+        Ok(())
+    }
+
+    fn encode_metadata(
+        &self,
+        name: &str,
+        metric_type: PromMetricType,
+        help: Option<&str>,
+        buf: &mut Vec<u8>,
+    ) -> Result<(), SondaError> {
+        if let Some(h) = help {
+            buf.extend_from_slice(b"# HELP ");
+            buf.extend_from_slice(name.as_bytes());
+            buf.push(b' ');
+            escape_help_text(h, buf);
+            buf.push(b'\n');
+        }
+        buf.extend_from_slice(b"# TYPE ");
+        buf.extend_from_slice(name.as_bytes());
+        buf.push(b' ');
+        buf.extend_from_slice(metric_type.as_str().as_bytes());
+        buf.push(b'\n');
         Ok(())
     }
 }
@@ -480,5 +513,68 @@ mod tests {
         enc.encode_metric(&event, &mut buf).unwrap();
         let output = String::from_utf8(buf).unwrap();
         assert_eq!(output, "up 1.00 0\n");
+    }
+
+    // ---- encode_metadata: TYPE and HELP line emission ----------------------
+
+    #[test]
+    fn encode_metadata_emits_type_line_only_when_help_is_none() {
+        let enc = PrometheusText::new(None);
+        let mut buf = Vec::new();
+        enc.encode_metadata("foo", PromMetricType::Gauge, None, &mut buf)
+            .unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(out, "# TYPE foo gauge\n");
+    }
+
+    #[test]
+    fn encode_metadata_emits_help_before_type() {
+        let enc = PrometheusText::new(None);
+        let mut buf = Vec::new();
+        enc.encode_metadata("foo", PromMetricType::Gauge, Some("desc"), &mut buf)
+            .unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(out, "# HELP foo desc\n# TYPE foo gauge\n");
+    }
+
+    #[test]
+    fn encode_metadata_help_text_escapes_backslash_and_newline() {
+        let enc = PrometheusText::new(None);
+        let mut buf = Vec::new();
+        enc.encode_metadata(
+            "foo",
+            PromMetricType::Gauge,
+            Some("line1\nline2 \\"),
+            &mut buf,
+        )
+        .unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(out, "# HELP foo line1\\nline2 \\\\\n# TYPE foo gauge\n");
+    }
+
+    #[test]
+    fn encode_metadata_all_metric_types_render_canonical_string() {
+        let enc = PrometheusText::new(None);
+        for (mt, expected) in [
+            (PromMetricType::Gauge, "gauge"),
+            (PromMetricType::Counter, "counter"),
+            (PromMetricType::Histogram, "histogram"),
+            (PromMetricType::Summary, "summary"),
+            (PromMetricType::Untyped, "untyped"),
+        ] {
+            let mut buf = Vec::new();
+            enc.encode_metadata("m", mt, None, &mut buf).unwrap();
+            let out = String::from_utf8(buf).unwrap();
+            assert_eq!(out, format!("# TYPE m {expected}\n"));
+        }
+    }
+
+    #[test]
+    fn prom_metric_type_as_str_returns_lowercase() {
+        assert_eq!(PromMetricType::Gauge.as_str(), "gauge");
+        assert_eq!(PromMetricType::Counter.as_str(), "counter");
+        assert_eq!(PromMetricType::Histogram.as_str(), "histogram");
+        assert_eq!(PromMetricType::Summary.as_str(), "summary");
+        assert_eq!(PromMetricType::Untyped.as_str(), "untyped");
     }
 }

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -44,6 +44,8 @@ pub use config::DynamicLabelStrategy;
 pub use config::HistogramScenarioConfig;
 pub use config::LogScenarioConfig;
 pub use config::OnSinkError;
+pub use config::PromMeta;
+pub use config::PromMetricType;
 pub use config::ScenarioEntry;
 pub use config::SpikeStrategy;
 pub use config::SummaryScenarioConfig;
@@ -587,6 +589,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         };
     }
 

--- a/sonda-core/src/packs/mod.rs
+++ b/sonda-core/src/packs/mod.rs
@@ -325,6 +325,8 @@ pub fn expand_pack(
             },
             generator,
             encoder: config.encoder.clone(),
+            metric_type: None,
+            help: None,
         };
 
         entries.push(ScenarioEntry::Metrics(scenario));

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -69,10 +69,12 @@ impl SinkErrorRateLimiter {
 pub(crate) struct TickResult {
     /// Number of bytes written to the sink on this tick.
     pub bytes_written: u64,
-    /// An optional metric event to push into the stats recent-metrics buffer.
+    /// Metric events emitted during this tick.
     ///
-    /// Only the metrics runner provides this; the log runner returns `None`.
-    pub metric_event: Option<MetricEvent>,
+    /// All events are pushed into the stats recent-metrics buffer under a
+    /// single lock acquisition so a scrape snapshot never interleaves with
+    /// a partial tick. Logs return an empty vec.
+    pub metric_events: Vec<MetricEvent>,
     /// Whether this tick's write() delivered to the destination, or only
     /// buffered it (batching sinks). Drives delivery-health stat updates.
     pub delivered: bool,
@@ -349,7 +351,7 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
                                 .map(|d| d.as_nanos() as u64)
                                 .ok();
                         }
-                        if let Some(event) = result.metric_event {
+                        for event in result.metric_events {
                             st.push_metric(event);
                         }
                     }
@@ -1092,7 +1094,7 @@ mod tests {
                 event_count += 1;
                 Ok(TickResult {
                     bytes_written: 6,
-                    metric_event: None,
+                    metric_events: Vec::new(),
                     delivered: true,
                 })
             };
@@ -1140,7 +1142,7 @@ mod tests {
                 event_count += 1;
                 Ok(TickResult {
                     bytes_written: 0,
-                    metric_event: None,
+                    metric_events: Vec::new(),
                     delivered: true,
                 })
             };
@@ -1188,7 +1190,7 @@ mod tests {
                 event_count += 1;
                 Ok(TickResult {
                     bytes_written: 0,
-                    metric_event: None,
+                    metric_events: Vec::new(),
                     delivered: true,
                 })
             };
@@ -1229,7 +1231,7 @@ mod tests {
                 event_count += 1;
                 Ok(TickResult {
                     bytes_written: 0,
-                    metric_event: None,
+                    metric_events: Vec::new(),
                     delivered: true,
                 })
             };
@@ -1256,7 +1258,7 @@ mod tests {
             |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
                 Ok(TickResult {
                     bytes_written: 42,
-                    metric_event: None,
+                    metric_events: Vec::new(),
                     delivered: true,
                 })
             };
@@ -1300,7 +1302,7 @@ mod tests {
                     .expect("valid metric name");
                 Ok(TickResult {
                     bytes_written: 10,
-                    metric_event: Some(event),
+                    metric_events: vec![event],
                     delivered: true,
                 })
             };
@@ -1357,7 +1359,7 @@ mod tests {
                 }
                 Ok(TickResult {
                     bytes_written: 0,
-                    metric_event: None,
+                    metric_events: Vec::new(),
                     delivered: true,
                 })
             };
@@ -1532,7 +1534,7 @@ mod tests {
                 if counter.is_multiple_of(2) {
                     Ok(TickResult {
                         bytes_written: 8,
-                        metric_event: None,
+                        metric_events: Vec::new(),
                         delivered: true,
                     })
                 } else {
@@ -1570,7 +1572,7 @@ mod tests {
             |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
                 Ok(TickResult {
                     bytes_written: 12,
-                    metric_event: None,
+                    metric_events: Vec::new(),
                     delivered: false,
                 })
             };
@@ -1613,7 +1615,7 @@ mod tests {
             |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
                 Ok(TickResult {
                     bytes_written: 12,
-                    metric_event: None,
+                    metric_events: Vec::new(),
                     delivered: true,
                 })
             };
@@ -1776,7 +1778,7 @@ mod tests {
                 }
                 Ok(TickResult {
                     bytes_written: 0,
-                    metric_event: None,
+                    metric_events: Vec::new(),
                     delivered: true,
                 })
             };
@@ -1810,7 +1812,7 @@ mod tests {
             |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
                 Ok(TickResult {
                     bytes_written: 0,
-                    metric_event: None,
+                    metric_events: Vec::new(),
                     delivered: true,
                 })
             };
@@ -1835,7 +1837,6 @@ mod tests {
         );
     }
 
-    /// TickResult correctly carries bytes_written and metric_event.
     #[test]
     fn tick_result_carries_all_fields() {
         use crate::model::metric::{Labels, MetricEvent};
@@ -1844,11 +1845,11 @@ mod tests {
             MetricEvent::new("test".to_string(), 42.0, Labels::default()).expect("valid name");
         let result = TickResult {
             bytes_written: 100,
-            metric_event: Some(event),
+            metric_events: vec![event],
             delivered: true,
         };
 
         assert_eq!(result.bytes_written, 100);
-        assert!(result.metric_event.is_some());
+        assert_eq!(result.metric_events.len(), 1);
     }
 }

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -65,16 +65,13 @@ impl SinkErrorRateLimiter {
 /// The result returned by a per-tick callback.
 ///
 /// Carries the information the shared loop needs to update stats after
-/// the signal-specific work is done.
+/// the signal-specific work is done. Metric events for the tick are pushed
+/// into the `events_buf` parameter passed to the callback, not returned
+/// here — that buffer is reused across ticks to keep the hot path
+/// allocation-free.
 pub(crate) struct TickResult {
     /// Number of bytes written to the sink on this tick.
     pub bytes_written: u64,
-    /// Metric events emitted during this tick.
-    ///
-    /// All events are pushed into the stats recent-metrics buffer under a
-    /// single lock acquisition so a scrape snapshot never interleaves with
-    /// a partial tick. Logs return an empty vec.
-    pub metric_events: Vec<MetricEvent>,
     /// Whether this tick's write() delivered to the destination, or only
     /// buffered it (batching sinks). Drives delivery-health stat updates.
     pub delivered: bool,
@@ -112,9 +109,11 @@ pub(crate) struct TickContext<'a> {
 ///
 /// Called once per scheduled tick with the sink threaded as a parameter so
 /// that gated runs can additionally invoke a separate close-emit closure on
-/// the same sink without a borrow split.
-pub(crate) type TickFn<'a> =
-    dyn FnMut(&TickContext<'_>, &mut dyn Sink) -> Result<TickResult, SondaError> + 'a;
+/// the same sink without a borrow split. The `events_buf` is pre-cleared by
+/// the loop before each call; the callback pushes any emitted metric events
+/// into it so the loop can drain them into stats without per-tick allocation.
+pub(crate) type TickFn<'a> = dyn FnMut(&TickContext<'_>, &mut dyn Sink, &mut Vec<MetricEvent>) -> Result<TickResult, SondaError>
+    + 'a;
 
 /// Scenario-level wall-clock anchor: the resolved emission-time base plus the
 /// monotonic instant the scenario began.
@@ -239,6 +238,10 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
 
     let mut sink_warn_limiter = SinkErrorRateLimiter::new();
 
+    // Sized to cover typical histogram (10 buckets + 3) and summary
+    // (~6 quantiles + 2) without reallocating.
+    let mut events_buf: Vec<MetricEvent> = Vec::with_capacity(16);
+
     loop {
         // Check shutdown flag first — highest priority exit path.
         if let Some(flag) = shutdown {
@@ -315,7 +318,8 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
             elapsed,
             wall_clock: wall.wall_at(start, elapsed),
         };
-        let tick_outcome = tick_fn(&ctx, sink);
+        events_buf.clear();
+        let tick_outcome = tick_fn(&ctx, sink, &mut events_buf);
 
         // Determine spike state for stats (check all spike windows).
         let currently_in_spike = schedule
@@ -351,7 +355,7 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
                                 .map(|d| d.as_nanos() as u64)
                                 .ok();
                         }
-                        for event in result.metric_events {
+                        for event in events_buf.drain(..) {
                             st.push_metric(event);
                         }
                     }
@@ -904,11 +908,20 @@ fn run_running_segment(
     let saw_close_for_wrapper = Arc::clone(&saw_close);
     let gate_rx = &gate_ctx.gate_rx;
 
-    type WrappedTick<'a> =
-        Box<dyn FnMut(&TickContext<'_>, &mut dyn Sink) -> Result<TickResult, SondaError> + 'a>;
+    type WrappedTick<'a> = Box<
+        dyn FnMut(
+                &TickContext<'_>,
+                &mut dyn Sink,
+                &mut Vec<MetricEvent>,
+            ) -> Result<TickResult, SondaError>
+            + 'a,
+    >;
     let mut wrapped: WrappedTick<'_> = Box::new(
-        move |ctx: &TickContext<'_>, s: &mut dyn Sink| -> Result<TickResult, SondaError> {
-            let outcome = tick_fn(ctx, s);
+        move |ctx: &TickContext<'_>,
+              s: &mut dyn Sink,
+              events_buf: &mut Vec<MetricEvent>|
+              -> Result<TickResult, SondaError> {
+            let outcome = tick_fn(ctx, s, events_buf);
 
             // Poll for gate edges after the tick. On WhileClose, break out.
             while let Some(edge) = gate_rx.try_recv() {
@@ -1089,15 +1102,16 @@ mod tests {
         let schedule = minimal_schedule(Some(Duration::from_millis(500)));
 
         let mut event_count: u64 = 0;
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                event_count += 1;
-                Ok(TickResult {
-                    bytes_written: 6,
-                    metric_events: Vec::new(),
-                    delivered: true,
-                })
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            event_count += 1;
+            Ok(TickResult {
+                bytes_written: 6,
+                delivered: true,
+            })
+        };
 
         run_schedule_loop(
             &schedule,
@@ -1137,15 +1151,16 @@ mod tests {
             flag_clone.store(false, Ordering::SeqCst);
         });
 
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                event_count += 1;
-                Ok(TickResult {
-                    bytes_written: 0,
-                    metric_events: Vec::new(),
-                    delivered: true,
-                })
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            event_count += 1;
+            Ok(TickResult {
+                bytes_written: 0,
+                delivered: true,
+            })
+        };
 
         run_schedule_loop(
             &schedule,
@@ -1185,15 +1200,16 @@ mod tests {
         };
 
         let mut event_count: u64 = 0;
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                event_count += 1;
-                Ok(TickResult {
-                    bytes_written: 0,
-                    metric_events: Vec::new(),
-                    delivered: true,
-                })
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            event_count += 1;
+            Ok(TickResult {
+                bytes_written: 0,
+                delivered: true,
+            })
+        };
 
         run_schedule_loop(&schedule, 100.0, None, None, &mut NullSink, &mut tick_fn)
             .expect("loop must succeed");
@@ -1226,15 +1242,16 @@ mod tests {
         };
 
         let mut event_count: u64 = 0;
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                event_count += 1;
-                Ok(TickResult {
-                    bytes_written: 0,
-                    metric_events: Vec::new(),
-                    delivered: true,
-                })
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            event_count += 1;
+            Ok(TickResult {
+                bytes_written: 0,
+                delivered: true,
+            })
+        };
 
         run_schedule_loop(&schedule, 10.0, None, None, &mut NullSink, &mut tick_fn)
             .expect("loop must succeed");
@@ -1254,14 +1271,15 @@ mod tests {
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                Ok(TickResult {
-                    bytes_written: 42,
-                    metric_events: Vec::new(),
-                    delivered: true,
-                })
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            Ok(TickResult {
+                bytes_written: 42,
+                delivered: true,
+            })
+        };
 
         run_schedule_loop(
             &schedule,
@@ -1296,16 +1314,18 @@ mod tests {
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                let event = MetricEvent::new("test".to_string(), 1.0, Labels::default())
-                    .expect("valid metric name");
-                Ok(TickResult {
-                    bytes_written: 10,
-                    metric_events: vec![event],
-                    delivered: true,
-                })
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            let event = MetricEvent::new("test".to_string(), 1.0, Labels::default())
+                .expect("valid metric name");
+            events_buf.push(event);
+            Ok(TickResult {
+                bytes_written: 10,
+                delivered: true,
+            })
+        };
 
         run_schedule_loop(
             &schedule,
@@ -1352,17 +1372,18 @@ mod tests {
         };
 
         let mut saw_spike_windows = false;
-        let mut tick_fn =
-            |ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                if !ctx.spike_windows.is_empty() {
-                    saw_spike_windows = true;
-                }
-                Ok(TickResult {
-                    bytes_written: 0,
-                    metric_events: Vec::new(),
-                    delivered: true,
-                })
-            };
+        let mut tick_fn = |ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            if !ctx.spike_windows.is_empty() {
+                saw_spike_windows = true;
+            }
+            Ok(TickResult {
+                bytes_written: 0,
+                delivered: true,
+            })
+        };
 
         run_schedule_loop(&schedule, 100.0, None, None, &mut NullSink, &mut tick_fn)
             .expect("loop must succeed");
@@ -1379,12 +1400,14 @@ mod tests {
     fn loop_propagates_encoder_error_under_warn_policy() {
         let schedule = minimal_schedule(Some(Duration::from_secs(10)));
 
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                Err(SondaError::Encoder(crate::EncoderError::NotSupported(
-                    "synthetic encoder failure".to_string(),
-                )))
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            Err(SondaError::Encoder(crate::EncoderError::NotSupported(
+                "synthetic encoder failure".to_string(),
+            )))
+        };
 
         let result = run_schedule_loop(&schedule, 10.0, None, None, &mut NullSink, &mut tick_fn);
 
@@ -1399,10 +1422,12 @@ mod tests {
         let mut schedule = minimal_schedule(Some(Duration::from_secs(10)));
         schedule.on_sink_error = OnSinkError::Fail;
 
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                Err(SondaError::Sink(std::io::Error::other("test error")))
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            Err(SondaError::Sink(std::io::Error::other("test error")))
+        };
 
         let result = run_schedule_loop(&schedule, 10.0, None, None, &mut NullSink, &mut tick_fn);
 
@@ -1418,13 +1443,15 @@ mod tests {
         schedule.on_sink_error = OnSinkError::Fail;
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                Err(SondaError::Sink(std::io::Error::new(
-                    std::io::ErrorKind::ConnectionRefused,
-                    "fail-before-die",
-                )))
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            Err(SondaError::Sink(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                "fail-before-die",
+            )))
+        };
 
         let result = run_schedule_loop(
             &schedule,
@@ -1469,10 +1496,12 @@ mod tests {
         // must complete without propagating.
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
 
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                Err(SondaError::Sink(std::io::Error::other("transient")))
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            Err(SondaError::Sink(std::io::Error::other("transient")))
+        };
 
         let result = run_schedule_loop(&schedule, 50.0, None, None, &mut NullSink, &mut tick_fn);
 
@@ -1487,13 +1516,15 @@ mod tests {
         let schedule = minimal_schedule(Some(Duration::from_millis(150)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                Err(SondaError::Sink(std::io::Error::new(
-                    std::io::ErrorKind::ConnectionReset,
-                    "boom",
-                )))
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            Err(SondaError::Sink(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "boom",
+            )))
+        };
 
         run_schedule_loop(
             &schedule,
@@ -1528,19 +1559,20 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
         let mut counter: u64 = 0;
 
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                counter += 1;
-                if counter.is_multiple_of(2) {
-                    Ok(TickResult {
-                        bytes_written: 8,
-                        metric_events: Vec::new(),
-                        delivered: true,
-                    })
-                } else {
-                    Err(SondaError::Sink(std::io::Error::other("alt")))
-                }
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            counter += 1;
+            if counter.is_multiple_of(2) {
+                Ok(TickResult {
+                    bytes_written: 8,
+                    delivered: true,
+                })
+            } else {
+                Err(SondaError::Sink(std::io::Error::other("alt")))
+            }
+        };
 
         run_schedule_loop(
             &schedule,
@@ -1568,14 +1600,15 @@ mod tests {
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                Ok(TickResult {
-                    bytes_written: 12,
-                    metric_events: Vec::new(),
-                    delivered: false,
-                })
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            Ok(TickResult {
+                bytes_written: 12,
+                delivered: false,
+            })
+        };
 
         run_schedule_loop(
             &schedule,
@@ -1611,14 +1644,15 @@ mod tests {
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                Ok(TickResult {
-                    bytes_written: 12,
-                    metric_events: Vec::new(),
-                    delivered: true,
-                })
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            Ok(TickResult {
+                bytes_written: 12,
+                delivered: true,
+            })
+        };
 
         run_schedule_loop(
             &schedule,
@@ -1688,7 +1722,7 @@ mod tests {
         let mut schedule = minimal_schedule(Some(Duration::from_millis(150)));
         schedule.on_sink_error = policy;
 
-        let mut tick_fn = |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
+        let mut tick_fn = |_ctx: &TickContext<'_>, _sink: &mut dyn Sink, _events_buf: &mut Vec<MetricEvent>| -> Result<TickResult, SondaError> {
             match err_kind {
                 ErrKind::Sink => Err(SondaError::Sink(std::io::Error::other(
                     "matrix",
@@ -1770,18 +1804,19 @@ mod tests {
         let schedule = minimal_schedule(Some(Duration::from_millis(150)));
         let observed_first = std::sync::Mutex::new(None::<u64>);
 
-        let mut tick_fn =
-            |ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                let mut g = observed_first.lock().unwrap();
-                if g.is_none() {
-                    *g = Some(ctx.tick);
-                }
-                Ok(TickResult {
-                    bytes_written: 0,
-                    metric_events: Vec::new(),
-                    delivered: true,
-                })
-            };
+        let mut tick_fn = |ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            let mut g = observed_first.lock().unwrap();
+            if g.is_none() {
+                *g = Some(ctx.tick);
+            }
+            Ok(TickResult {
+                bytes_written: 0,
+                delivered: true,
+            })
+        };
 
         run_schedule_loop_with_initial_tick(
             &schedule,
@@ -1808,14 +1843,15 @@ mod tests {
         let schedule = minimal_schedule(Some(Duration::from_millis(150)));
         let last_tick = AtomicU64::new(0);
 
-        let mut tick_fn =
-            |_ctx: &TickContext<'_>, _sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-                Ok(TickResult {
-                    bytes_written: 0,
-                    metric_events: Vec::new(),
-                    delivered: true,
-                })
-            };
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           _events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            Ok(TickResult {
+                bytes_written: 0,
+                delivered: true,
+            })
+        };
 
         run_schedule_loop_with_initial_tick(
             &schedule,
@@ -1839,17 +1875,73 @@ mod tests {
 
     #[test]
     fn tick_result_carries_all_fields() {
-        use crate::model::metric::{Labels, MetricEvent};
-
-        let event =
-            MetricEvent::new("test".to_string(), 42.0, Labels::default()).expect("valid name");
         let result = TickResult {
             bytes_written: 100,
-            metric_events: vec![event],
             delivered: true,
         };
 
         assert_eq!(result.bytes_written, 100);
-        assert_eq!(result.metric_events.len(), 1);
+        assert!(result.delivered);
+    }
+
+    #[test]
+    fn events_buf_capacity_does_not_grow_under_metrics_workload() {
+        use crate::model::metric::{Labels, MetricEvent};
+        use std::cell::Cell;
+
+        let schedule = minimal_schedule(Some(Duration::from_millis(500)));
+        let stats = Arc::new(RwLock::new(ScenarioStats::default()));
+        let first_ptr: Cell<Option<usize>> = Cell::new(None);
+
+        let mut tick_fn = |_ctx: &TickContext<'_>,
+                           _sink: &mut dyn Sink,
+                           events_buf: &mut Vec<MetricEvent>|
+         -> Result<TickResult, SondaError> {
+            let event =
+                MetricEvent::new("test".to_string(), 1.0, Labels::default()).expect("valid name");
+            assert_eq!(
+                events_buf.len(),
+                0,
+                "events_buf must be cleared by the loop before each tick"
+            );
+            assert_eq!(
+                events_buf.capacity(),
+                16,
+                "events_buf capacity must stay at the pre-allocated 16 for a 1-event-per-tick workload"
+            );
+            let ptr = events_buf.as_ptr() as usize;
+            match first_ptr.get() {
+                None => first_ptr.set(Some(ptr)),
+                Some(p) => assert_eq!(
+                    ptr, p,
+                    "events_buf backing allocation must be reused across ticks"
+                ),
+            }
+            events_buf.push(event);
+            Ok(TickResult {
+                bytes_written: 10,
+                delivered: true,
+            })
+        };
+
+        run_schedule_loop(
+            &schedule,
+            50.0,
+            None,
+            Some(Arc::clone(&stats)),
+            &mut NullSink,
+            &mut tick_fn,
+        )
+        .expect("loop must succeed");
+
+        let st = stats.read().expect("lock");
+        assert!(
+            st.total_events > 1,
+            "loop must have executed multiple ticks to exercise the buffer reuse"
+        );
+        assert!(
+            first_ptr.get().is_some(),
+            "tick_fn must have observed at least one events_buf pointer"
+        );
     }
 }

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, RwLock};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
+use crate::config::PromMeta;
 use crate::schedule::stats::ScenarioStats;
 use crate::{RuntimeError, SondaError};
 
@@ -58,6 +59,10 @@ pub struct ScenarioHandle {
     pub alive: Arc<AtomicBool>,
     /// Scenario-level labels.
     pub labels: Arc<HashMap<String, String>>,
+    /// Prometheus `# TYPE` / `# HELP` metadata derived at launch.
+    ///
+    /// `Some` for metrics, histogram, and summary scenarios; `None` for logs.
+    pub prometheus_meta: Option<Arc<PromMeta>>,
 }
 
 impl ScenarioHandle {
@@ -74,6 +79,7 @@ impl ScenarioHandle {
         target_rate: f64,
         alive: Arc<AtomicBool>,
         labels: Arc<HashMap<String, String>>,
+        prometheus_meta: Option<Arc<PromMeta>>,
     ) -> Self {
         Self {
             id,
@@ -86,6 +92,7 @@ impl ScenarioHandle {
             target_rate,
             alive,
             labels,
+            prometheus_meta,
         }
     }
 
@@ -316,6 +323,10 @@ mod tests {
             100.0,
             Arc::new(AtomicBool::new(true)),
             Arc::new(HashMap::new()),
+            Some(Arc::new(PromMeta::new(
+                crate::config::PromMetricType::Gauge,
+                None,
+            ))),
         )
     }
 
@@ -594,6 +605,10 @@ mod tests {
             10.0,
             Arc::new(AtomicBool::new(true)),
             Arc::new(HashMap::new()),
+            Some(Arc::new(PromMeta::new(
+                crate::config::PromMetricType::Gauge,
+                None,
+            ))),
         );
 
         // stats_snapshot must not panic — it recovers from the poisoned lock.
@@ -643,6 +658,10 @@ mod tests {
             10.0,
             Arc::new(AtomicBool::new(true)),
             Arc::new(HashMap::new()),
+            Some(Arc::new(PromMeta::new(
+                crate::config::PromMetricType::Gauge,
+                None,
+            ))),
         );
 
         // recent_metrics must not panic — it recovers from the poisoned lock.

--- a/sonda-core/src/schedule/histogram_runner.rs
+++ b/sonda-core/src/schedule/histogram_runner.rs
@@ -148,80 +148,26 @@ pub fn run_with_sink_gated(
     // Pre-allocate encode buffer.
     let mut buf: Vec<u8> = Vec::with_capacity(1024);
 
-    let mut tick_fn =
-        |ctx: &TickContext<'_>, sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-            let wall_now = ctx.wall_clock;
+    let mut tick_fn = |ctx: &TickContext<'_>,
+                       sink: &mut dyn Sink,
+                       events_buf: &mut Vec<MetricEvent>|
+     -> Result<TickResult, SondaError> {
+        let wall_now = ctx.wall_clock;
 
-            let sample = histogram_gen.observe(ctx.tick);
+        let sample = histogram_gen.observe(ctx.tick);
 
-            let needs_dynamic = !ctx.dynamic_labels.is_empty();
-            let has_active_spike = ctx
-                .spike_windows
-                .iter()
-                .any(|sw| is_in_spike(ctx.elapsed, sw));
-            let needs_clone = needs_dynamic || has_active_spike;
+        let needs_dynamic = !ctx.dynamic_labels.is_empty();
+        let has_active_spike = ctx
+            .spike_windows
+            .iter()
+            .any(|sw| is_in_spike(ctx.elapsed, sw));
+        let needs_clone = needs_dynamic || has_active_spike;
 
-            let mut total_bytes: u64 = 0;
-            let mut events: Vec<MetricEvent> = Vec::with_capacity(sample.bucket_counts.len() + 3);
+        let mut total_bytes: u64 = 0;
 
-            for (i, &bucket_count) in sample.bucket_counts.iter().enumerate() {
-                let bucket_labels = if needs_clone {
-                    let mut bl = (*prebuilt_bucket_labels[i]).clone();
-                    for dl in ctx.dynamic_labels {
-                        bl.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
-                    }
-                    for sw in ctx.spike_windows {
-                        if is_in_spike(ctx.elapsed, sw) {
-                            bl.insert(sw.label.clone(), sw.label_value_for_tick(ctx.tick));
-                        }
-                    }
-                    Arc::new(bl)
-                } else {
-                    Arc::clone(&prebuilt_bucket_labels[i])
-                };
-                let event = MetricEvent::from_parts(
-                    bucket_name.clone(),
-                    bucket_count as f64,
-                    bucket_labels,
-                    wall_now,
-                );
-                buf.clear();
-                encoder.encode_metric(&event, &mut buf)?;
-                total_bytes += buf.len() as u64;
-                sink.write(&buf)?;
-                events.push(event);
-            }
-
-            {
-                let inf_labels = if needs_clone {
-                    let mut bl = (*prebuilt_inf_labels).clone();
-                    for dl in ctx.dynamic_labels {
-                        bl.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
-                    }
-                    for sw in ctx.spike_windows {
-                        if is_in_spike(ctx.elapsed, sw) {
-                            bl.insert(sw.label.clone(), sw.label_value_for_tick(ctx.tick));
-                        }
-                    }
-                    Arc::new(bl)
-                } else {
-                    Arc::clone(&prebuilt_inf_labels)
-                };
-                let event = MetricEvent::from_parts(
-                    bucket_name.clone(),
-                    sample.count as f64,
-                    inf_labels,
-                    wall_now,
-                );
-                buf.clear();
-                encoder.encode_metric(&event, &mut buf)?;
-                total_bytes += buf.len() as u64;
-                sink.write(&buf)?;
-                events.push(event);
-            }
-
-            let count_sum_labels = if needs_clone {
-                let mut bl = (*prebuilt_count_sum_labels).clone();
+        for (i, &bucket_count) in sample.bucket_counts.iter().enumerate() {
+            let bucket_labels = if needs_clone {
+                let mut bl = (*prebuilt_bucket_labels[i]).clone();
                 for dl in ctx.dynamic_labels {
                     bl.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
                 }
@@ -232,41 +178,95 @@ pub fn run_with_sink_gated(
                 }
                 Arc::new(bl)
             } else {
-                Arc::clone(&prebuilt_count_sum_labels)
+                Arc::clone(&prebuilt_bucket_labels[i])
             };
-
-            let sum_event = MetricEvent::from_parts(
-                sum_name.clone(),
-                sample.sum,
-                Arc::clone(&count_sum_labels),
+            let event = MetricEvent::from_parts(
+                bucket_name.clone(),
+                bucket_count as f64,
+                bucket_labels,
                 wall_now,
             );
             buf.clear();
-            encoder.encode_metric(&sum_event, &mut buf)?;
+            encoder.encode_metric(&event, &mut buf)?;
             total_bytes += buf.len() as u64;
             sink.write(&buf)?;
-            events.push(sum_event);
+            events_buf.push(event);
+        }
 
-            let count_event = MetricEvent::from_parts(
-                count_name.clone(),
+        {
+            let inf_labels = if needs_clone {
+                let mut bl = (*prebuilt_inf_labels).clone();
+                for dl in ctx.dynamic_labels {
+                    bl.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
+                }
+                for sw in ctx.spike_windows {
+                    if is_in_spike(ctx.elapsed, sw) {
+                        bl.insert(sw.label.clone(), sw.label_value_for_tick(ctx.tick));
+                    }
+                }
+                Arc::new(bl)
+            } else {
+                Arc::clone(&prebuilt_inf_labels)
+            };
+            let event = MetricEvent::from_parts(
+                bucket_name.clone(),
                 sample.count as f64,
-                count_sum_labels,
+                inf_labels,
                 wall_now,
             );
             buf.clear();
-            encoder.encode_metric(&count_event, &mut buf)?;
+            encoder.encode_metric(&event, &mut buf)?;
             total_bytes += buf.len() as u64;
             sink.write(&buf)?;
-            events.push(count_event);
+            events_buf.push(event);
+        }
 
-            let delivered = sink.last_write_delivered();
-
-            Ok(TickResult {
-                bytes_written: total_bytes,
-                metric_events: events,
-                delivered,
-            })
+        let count_sum_labels = if needs_clone {
+            let mut bl = (*prebuilt_count_sum_labels).clone();
+            for dl in ctx.dynamic_labels {
+                bl.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
+            }
+            for sw in ctx.spike_windows {
+                if is_in_spike(ctx.elapsed, sw) {
+                    bl.insert(sw.label.clone(), sw.label_value_for_tick(ctx.tick));
+                }
+            }
+            Arc::new(bl)
+        } else {
+            Arc::clone(&prebuilt_count_sum_labels)
         };
+
+        let sum_event = MetricEvent::from_parts(
+            sum_name.clone(),
+            sample.sum,
+            Arc::clone(&count_sum_labels),
+            wall_now,
+        );
+        buf.clear();
+        encoder.encode_metric(&sum_event, &mut buf)?;
+        total_bytes += buf.len() as u64;
+        sink.write(&buf)?;
+        events_buf.push(sum_event);
+
+        let count_event = MetricEvent::from_parts(
+            count_name.clone(),
+            sample.count as f64,
+            count_sum_labels,
+            wall_now,
+        );
+        buf.clear();
+        encoder.encode_metric(&count_event, &mut buf)?;
+        total_bytes += buf.len() as u64;
+        sink.write(&buf)?;
+        events_buf.push(count_event);
+
+        let delivered = sink.last_write_delivered();
+
+        Ok(TickResult {
+            bytes_written: total_bytes,
+            delivered,
+        })
+    };
 
     let stats_for_flush = stats.clone();
     let loop_result = match gate_ctx {

--- a/sonda-core/src/schedule/histogram_runner.rs
+++ b/sonda-core/src/schedule/histogram_runner.rs
@@ -152,10 +152,8 @@ pub fn run_with_sink_gated(
         |ctx: &TickContext<'_>, sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
             let wall_now = ctx.wall_clock;
 
-            // Advance the histogram generator.
             let sample = histogram_gen.observe(ctx.tick);
 
-            // Determine whether dynamic labels or spikes are active this tick.
             let needs_dynamic = !ctx.dynamic_labels.is_empty();
             let has_active_spike = ctx
                 .spike_windows
@@ -164,8 +162,8 @@ pub fn run_with_sink_gated(
             let needs_clone = needs_dynamic || has_active_spike;
 
             let mut total_bytes: u64 = 0;
+            let mut events: Vec<MetricEvent> = Vec::with_capacity(sample.bucket_counts.len() + 3);
 
-            // Emit one event per bucket boundary.
             for (i, &bucket_count) in sample.bucket_counts.iter().enumerate() {
                 let bucket_labels = if needs_clone {
                     let mut bl = (*prebuilt_bucket_labels[i]).clone();
@@ -191,9 +189,9 @@ pub fn run_with_sink_gated(
                 encoder.encode_metric(&event, &mut buf)?;
                 total_bytes += buf.len() as u64;
                 sink.write(&buf)?;
+                events.push(event);
             }
 
-            // Emit +Inf bucket (value = total count).
             {
                 let inf_labels = if needs_clone {
                     let mut bl = (*prebuilt_inf_labels).clone();
@@ -219,9 +217,9 @@ pub fn run_with_sink_gated(
                 encoder.encode_metric(&event, &mut buf)?;
                 total_bytes += buf.len() as u64;
                 sink.write(&buf)?;
+                events.push(event);
             }
 
-            // Build labels for _count and _sum (no `le` label).
             let count_sum_labels = if needs_clone {
                 let mut bl = (*prebuilt_count_sum_labels).clone();
                 for dl in ctx.dynamic_labels {
@@ -237,30 +235,35 @@ pub fn run_with_sink_gated(
                 Arc::clone(&prebuilt_count_sum_labels)
             };
 
-            // Emit _count event.
+            let sum_event = MetricEvent::from_parts(
+                sum_name.clone(),
+                sample.sum,
+                Arc::clone(&count_sum_labels),
+                wall_now,
+            );
+            buf.clear();
+            encoder.encode_metric(&sum_event, &mut buf)?;
+            total_bytes += buf.len() as u64;
+            sink.write(&buf)?;
+            events.push(sum_event);
+
             let count_event = MetricEvent::from_parts(
                 count_name.clone(),
                 sample.count as f64,
-                Arc::clone(&count_sum_labels),
+                count_sum_labels,
                 wall_now,
             );
             buf.clear();
             encoder.encode_metric(&count_event, &mut buf)?;
             total_bytes += buf.len() as u64;
             sink.write(&buf)?;
+            events.push(count_event);
 
-            // Emit _sum event.
-            let sum_event =
-                MetricEvent::from_parts(sum_name.clone(), sample.sum, count_sum_labels, wall_now);
-            buf.clear();
-            encoder.encode_metric(&sum_event, &mut buf)?;
-            total_bytes += buf.len() as u64;
-            sink.write(&buf)?;
             let delivered = sink.last_write_delivered();
 
             Ok(TickResult {
                 bytes_written: total_bytes,
-                metric_event: Some(count_event),
+                metric_events: events,
                 delivered,
             })
         };
@@ -344,6 +347,8 @@ mod tests {
             mean_shift_per_sec: None,
             seed: Some(42),
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         }
     }
 

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -13,7 +13,8 @@ use crate::config::aliases::desugar_entry;
 use crate::config::validate::{
     validate_config, validate_histogram_config, validate_log_config, validate_summary_config,
 };
-use crate::config::{expand_entry, ScenarioEntry};
+use crate::config::{expand_entry, PromMeta, PromMetricType, ScenarioEntry};
+use crate::generator::GeneratorConfig;
 use crate::schedule::core_loop::GateContext;
 use crate::schedule::gate_bus::GateBus;
 use crate::schedule::handle::ScenarioHandle;
@@ -231,6 +232,7 @@ pub fn launch_scenario_with_gates(
         ScenarioEntry::Summary(c) => (c.name.clone(), c.rate),
     };
     let labels = Arc::new(entry.base().labels.clone().unwrap_or_default());
+    let prometheus_meta = derive_prometheus_meta(&entry);
 
     let started_at = Instant::now();
 
@@ -341,7 +343,29 @@ pub fn launch_scenario_with_gates(
         target_rate,
         alive,
         labels,
+        prometheus_meta,
     ))
+}
+
+fn derive_prometheus_meta(entry: &ScenarioEntry) -> Option<Arc<PromMeta>> {
+    match entry {
+        ScenarioEntry::Metrics(c) => {
+            let metric_type = c.metric_type.unwrap_or(match c.generator {
+                GeneratorConfig::Step { .. } => PromMetricType::Counter,
+                _ => PromMetricType::Gauge,
+            });
+            Some(Arc::new(PromMeta::new(metric_type, c.help.clone())))
+        }
+        ScenarioEntry::Histogram(c) => Some(Arc::new(PromMeta::new(
+            c.metric_type.unwrap_or(PromMetricType::Histogram),
+            c.help.clone(),
+        ))),
+        ScenarioEntry::Summary(c) => Some(Arc::new(PromMeta::new(
+            c.metric_type.unwrap_or(PromMetricType::Summary),
+            c.help.clone(),
+        ))),
+        ScenarioEntry::Logs(_) => None,
+    }
 }
 
 struct AliveGuard {
@@ -407,6 +431,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         })
     }
 
@@ -466,6 +492,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         })
     }
 
@@ -550,6 +578,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         let result = validate_entry(&entry);
         assert!(
@@ -582,6 +612,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         let result = validate_entry(&entry);
         assert!(
@@ -653,6 +685,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         let result = validate_entry(&entry);
         assert!(
@@ -796,6 +830,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
 
         let mut handle =
@@ -949,6 +985,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
 
         let mut handle =
@@ -998,6 +1036,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
 
         let delay = Duration::from_millis(500);
@@ -1179,6 +1219,8 @@ mod tests {
             mean_shift_per_sec: None,
             seed: Some(42),
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         })
     }
 
@@ -1212,6 +1254,8 @@ mod tests {
             mean_shift_per_sec: None,
             seed: Some(42),
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         })
     }
 
@@ -1342,6 +1386,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
 
         let entries = vec![metrics_entry("good"), invalid];
@@ -1378,6 +1424,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
 
         let result = prepare_entries(vec![entry]);
@@ -1414,6 +1462,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
 
         let result = prepare_entries(vec![entry]);
@@ -1449,6 +1499,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
 
         let result = prepare_entries(vec![entry]);
@@ -1641,6 +1693,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
 
         // Entry 0 is valid, entry 1 is invalid. Even though entry 0 does not
@@ -1682,6 +1736,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
 
         let entries = vec![valid, bad_offset];
@@ -1696,5 +1752,157 @@ mod tests {
             err_msg.contains("phase_offset"),
             "error must mention phase_offset, got: {err_msg}"
         );
+    }
+
+    // ---- prometheus_meta derivation ----------------------------------------
+
+    fn entry_with_metric_type(metric_type: Option<PromMetricType>) -> ScenarioEntry {
+        let mut entry = metrics_entry("meta_metrics");
+        if let ScenarioEntry::Metrics(c) = &mut entry {
+            c.metric_type = metric_type;
+        }
+        entry
+    }
+
+    fn step_entry(name: &str) -> ScenarioEntry {
+        ScenarioEntry::Metrics(ScenarioConfig {
+            base: BaseScheduleConfig {
+                name: name.to_string(),
+                rate: 50.0,
+                duration: Some("200ms".to_string()),
+                gaps: None,
+                bursts: None,
+                cardinality_spikes: None,
+                dynamic_labels: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+                clock_group_is_auto: None,
+                start_time: None,
+                jitter: None,
+                jitter_seed: None,
+                on_sink_error: crate::OnSinkError::Warn,
+            },
+            generator: GeneratorConfig::Step {
+                start: None,
+                step_size: 1.0,
+                max: None,
+            },
+            encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
+        })
+    }
+
+    #[test]
+    fn launch_metrics_scenario_with_no_type_defaults_to_gauge() {
+        let entry = entry_with_metric_type(None);
+        let mut handle = launch_scenario(
+            "id-meta-gauge".to_string(),
+            entry,
+            Arc::new(AtomicBool::new(true)),
+            None,
+        )
+        .expect("launch must succeed");
+        let meta = handle
+            .prometheus_meta
+            .as_ref()
+            .expect("metrics entry must have prometheus_meta");
+        assert_eq!(meta.metric_type, PromMetricType::Gauge);
+        handle.stop();
+        handle.join(Some(Duration::from_secs(2))).ok();
+    }
+
+    #[test]
+    fn launch_metrics_scenario_with_step_generator_defaults_to_counter() {
+        let entry = step_entry("step_counter");
+        let mut handle = launch_scenario(
+            "id-meta-step".to_string(),
+            entry,
+            Arc::new(AtomicBool::new(true)),
+            None,
+        )
+        .expect("launch must succeed");
+        let meta = handle
+            .prometheus_meta
+            .as_ref()
+            .expect("metrics entry must have prometheus_meta");
+        assert_eq!(meta.metric_type, PromMetricType::Counter);
+        handle.stop();
+        handle.join(Some(Duration::from_secs(2))).ok();
+    }
+
+    #[test]
+    fn launch_histogram_scenario_defaults_to_histogram() {
+        let entry = histogram_entry("hist_default");
+        let mut handle = launch_scenario(
+            "id-meta-hist".to_string(),
+            entry,
+            Arc::new(AtomicBool::new(true)),
+            None,
+        )
+        .expect("launch must succeed");
+        let meta = handle
+            .prometheus_meta
+            .as_ref()
+            .expect("histogram entry must have prometheus_meta");
+        assert_eq!(meta.metric_type, PromMetricType::Histogram);
+        handle.join(Some(Duration::from_secs(2))).ok();
+    }
+
+    #[test]
+    fn launch_summary_scenario_defaults_to_summary() {
+        let entry = summary_entry("summary_default");
+        let mut handle = launch_scenario(
+            "id-meta-sum".to_string(),
+            entry,
+            Arc::new(AtomicBool::new(true)),
+            None,
+        )
+        .expect("launch must succeed");
+        let meta = handle
+            .prometheus_meta
+            .as_ref()
+            .expect("summary entry must have prometheus_meta");
+        assert_eq!(meta.metric_type, PromMetricType::Summary);
+        handle.join(Some(Duration::from_secs(2))).ok();
+    }
+
+    #[test]
+    fn launch_scenario_explicit_metric_type_overrides_default() {
+        let entry = entry_with_metric_type(Some(PromMetricType::Counter));
+        let mut handle = launch_scenario(
+            "id-meta-explicit".to_string(),
+            entry,
+            Arc::new(AtomicBool::new(true)),
+            None,
+        )
+        .expect("launch must succeed");
+        let meta = handle
+            .prometheus_meta
+            .as_ref()
+            .expect("metrics entry must have prometheus_meta");
+        assert_eq!(meta.metric_type, PromMetricType::Counter);
+        handle.stop();
+        handle.join(Some(Duration::from_secs(2))).ok();
+    }
+
+    #[test]
+    fn launch_log_scenario_has_no_prometheus_meta() {
+        let entry = logs_entry("log_no_meta");
+        let mut handle = launch_scenario(
+            "id-meta-logs".to_string(),
+            entry,
+            Arc::new(AtomicBool::new(true)),
+            None,
+        )
+        .expect("launch must succeed");
+        assert!(
+            handle.prometheus_meta.is_none(),
+            "log scenario must not have prometheus_meta"
+        );
+        handle.stop();
+        handle.join(Some(Duration::from_secs(2))).ok();
     }
 }

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -133,7 +133,7 @@ pub fn run_logs_with_sink_gated(
 
             Ok(TickResult {
                 bytes_written,
-                metric_event: None,
+                metric_events: Vec::new(),
                 delivered,
             })
         };

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, RwLock};
 use crate::config::LogScenarioConfig;
 use crate::encoder::create_encoder;
 use crate::generator::create_log_generator;
-use crate::model::metric::Labels;
+use crate::model::metric::{Labels, MetricEvent};
 use crate::schedule::core_loop::{self, GateContext, TickContext, TickResult};
 use crate::schedule::is_in_spike;
 use crate::schedule::stats::ScenarioStats;
@@ -104,39 +104,40 @@ pub fn run_logs_with_sink_gated(
 
     let mut buf: Vec<u8> = Vec::with_capacity(512);
 
-    let mut tick_fn =
-        |ctx: &TickContext<'_>, sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-            let mut event = generator.generate(ctx.tick);
-            event.timestamp = ctx.wall_clock;
+    let mut tick_fn = |ctx: &TickContext<'_>,
+                       sink: &mut dyn Sink,
+                       _events_buf: &mut Vec<MetricEvent>|
+     -> Result<TickResult, SondaError> {
+        let mut event = generator.generate(ctx.tick);
+        event.timestamp = ctx.wall_clock;
 
-            let needs_dynamic = !ctx.dynamic_labels.is_empty();
-            if ctx.spike_windows.is_empty() && !needs_dynamic {
-                event.labels = labels.clone();
-            } else {
-                let mut tl = labels.clone();
-                for dl in ctx.dynamic_labels {
-                    tl.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
-                }
-                for sw in ctx.spike_windows {
-                    if is_in_spike(ctx.elapsed, sw) {
-                        tl.insert(sw.label.clone(), sw.label_value_for_tick(ctx.tick));
-                    }
-                }
-                event.labels = tl;
+        let needs_dynamic = !ctx.dynamic_labels.is_empty();
+        if ctx.spike_windows.is_empty() && !needs_dynamic {
+            event.labels = labels.clone();
+        } else {
+            let mut tl = labels.clone();
+            for dl in ctx.dynamic_labels {
+                tl.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
             }
+            for sw in ctx.spike_windows {
+                if is_in_spike(ctx.elapsed, sw) {
+                    tl.insert(sw.label.clone(), sw.label_value_for_tick(ctx.tick));
+                }
+            }
+            event.labels = tl;
+        }
 
-            buf.clear();
-            encoder.encode_log(&event, &mut buf)?;
-            let bytes_written = buf.len() as u64;
-            sink.write_log_event(&event, &buf)?;
-            let delivered = sink.last_write_delivered();
+        buf.clear();
+        encoder.encode_log(&event, &mut buf)?;
+        let bytes_written = buf.len() as u64;
+        sink.write_log_event(&event, &buf)?;
+        let delivered = sink.last_write_delivered();
 
-            Ok(TickResult {
-                bytes_written,
-                metric_events: Vec::new(),
-                delivered,
-            })
-        };
+        Ok(TickResult {
+            bytes_written,
+            delivered,
+        })
+    };
 
     let stats_for_flush = stats.clone();
     let loop_result = match gate_ctx {

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -316,6 +316,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         })
     }
 
@@ -448,6 +450,8 @@ mod tests {
                 },
                 generator: GeneratorConfig::Constant { value: 1.0 },
                 encoder: EncoderConfig::PrometheusText { precision: None },
+                metric_type: None,
+                help: None,
             }),
             ScenarioEntry::Logs(LogScenarioConfig {
                 base: BaseScheduleConfig {
@@ -542,6 +546,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
         let result = run_multi(entries, shutdown);
@@ -583,6 +589,8 @@ mod tests {
                 },
                 generator: GeneratorConfig::Constant { value: 1.0 },
                 encoder: EncoderConfig::PrometheusText { precision: None },
+                metric_type: None,
+                help: None,
             }),
             ScenarioEntry::Metrics(ScenarioConfig {
                 base: BaseScheduleConfig {
@@ -607,6 +615,8 @@ mod tests {
                 },
                 generator: GeneratorConfig::Constant { value: 1.0 },
                 encoder: EncoderConfig::PrometheusText { precision: None },
+                metric_type: None,
+                help: None,
             }),
         ];
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -647,6 +657,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
         let result = run_multi(entries, shutdown);
@@ -689,6 +701,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
         let start = Instant::now();
@@ -728,6 +742,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
         let result = run_multi(entries, shutdown);
@@ -777,6 +793,8 @@ mod tests {
                 },
                 generator: GeneratorConfig::Constant { value: 1.0 },
                 encoder: EncoderConfig::PrometheusText { precision: None },
+                metric_type: None,
+                help: None,
             }),
             ScenarioEntry::Metrics(ScenarioConfig {
                 base: BaseScheduleConfig {
@@ -799,6 +817,8 @@ mod tests {
                 },
                 generator: GeneratorConfig::Constant { value: 2.0 },
                 encoder: EncoderConfig::PrometheusText { precision: None },
+                metric_type: None,
+                help: None,
             }),
         ];
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -842,6 +862,8 @@ mod tests {
                 },
                 generator: GeneratorConfig::Constant { value: 1.0 },
                 encoder: EncoderConfig::PrometheusText { precision: None },
+                metric_type: None,
+                help: None,
             }),
             // Second scenario has a long delay — we'll shut down before it starts.
             ScenarioEntry::Metrics(ScenarioConfig {
@@ -865,6 +887,8 @@ mod tests {
                 },
                 generator: GeneratorConfig::Constant { value: 2.0 },
                 encoder: EncoderConfig::PrometheusText { precision: None },
+                metric_type: None,
+                help: None,
             }),
         ];
 
@@ -917,6 +941,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
         let result = run_multi(entries, shutdown);
@@ -956,6 +982,8 @@ mod tests {
                 },
                 generator: GeneratorConfig::Constant { value: 1.0 },
                 encoder: EncoderConfig::PrometheusText { precision: None },
+                metric_type: None,
+                help: None,
             }),
             ScenarioEntry::Metrics(ScenarioConfig {
                 base: BaseScheduleConfig {
@@ -978,6 +1006,8 @@ mod tests {
                 },
                 generator: GeneratorConfig::Constant { value: 2.0 },
                 encoder: EncoderConfig::PrometheusText { precision: None },
+                metric_type: None,
+                help: None,
             }),
         ];
         let shutdown = Arc::new(AtomicBool::new(true));

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -116,52 +116,55 @@ pub fn run_with_sink_gated(
     let mut buf: Vec<u8> = Vec::with_capacity(256);
 
     let upstream_bus_for_tick = upstream_bus.clone();
-    let mut tick_fn =
-        |ctx: &TickContext<'_>, sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-            let wall_now = ctx.wall_clock;
+    let mut tick_fn = |ctx: &TickContext<'_>,
+                       sink: &mut dyn Sink,
+                       events_buf: &mut Vec<MetricEvent>|
+     -> Result<TickResult, SondaError> {
+        let wall_now = ctx.wall_clock;
 
-            let value = generator.value(ctx.tick);
-            if let Some(ref bus) = upstream_bus_for_tick {
-                bus.tick(value);
+        let value = generator.value(ctx.tick);
+        if let Some(ref bus) = upstream_bus_for_tick {
+            bus.tick(value);
+        }
+
+        let needs_dynamic = !ctx.dynamic_labels.is_empty();
+        let tick_labels: Arc<Labels> = if ctx.spike_windows.is_empty() && !needs_dynamic {
+            Arc::clone(&labels)
+        } else {
+            let mut mutated: Option<Labels> = None;
+            if needs_dynamic {
+                let tl = mutated.get_or_insert_with(|| (*labels).clone());
+                for dl in ctx.dynamic_labels {
+                    tl.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
+                }
             }
-
-            let needs_dynamic = !ctx.dynamic_labels.is_empty();
-            let tick_labels: Arc<Labels> = if ctx.spike_windows.is_empty() && !needs_dynamic {
-                Arc::clone(&labels)
-            } else {
-                let mut mutated: Option<Labels> = None;
-                if needs_dynamic {
+            for sw in ctx.spike_windows {
+                if is_in_spike(ctx.elapsed, sw) {
                     let tl = mutated.get_or_insert_with(|| (*labels).clone());
-                    for dl in ctx.dynamic_labels {
-                        tl.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
-                    }
+                    tl.insert(sw.label.clone(), sw.label_value_for_tick(ctx.tick));
                 }
-                for sw in ctx.spike_windows {
-                    if is_in_spike(ctx.elapsed, sw) {
-                        let tl = mutated.get_or_insert_with(|| (*labels).clone());
-                        tl.insert(sw.label.clone(), sw.label_value_for_tick(ctx.tick));
-                    }
-                }
-                match mutated {
-                    Some(tl) => Arc::new(tl),
-                    None => Arc::clone(&labels),
-                }
-            };
-
-            let event = MetricEvent::from_parts(name.clone(), value, tick_labels, wall_now);
-
-            buf.clear();
-            encoder.encode_metric(&event, &mut buf)?;
-            let bytes_written = buf.len() as u64;
-            sink.write(&buf)?;
-            let delivered = sink.last_write_delivered();
-
-            Ok(TickResult {
-                bytes_written,
-                metric_events: vec![event],
-                delivered,
-            })
+            }
+            match mutated {
+                Some(tl) => Arc::new(tl),
+                None => Arc::clone(&labels),
+            }
         };
+
+        let event = MetricEvent::from_parts(name.clone(), value, tick_labels, wall_now);
+
+        buf.clear();
+        encoder.encode_metric(&event, &mut buf)?;
+        let bytes_written = buf.len() as u64;
+        sink.write(&buf)?;
+        let delivered = sink.last_write_delivered();
+
+        events_buf.push(event);
+
+        Ok(TickResult {
+            bytes_written,
+            delivered,
+        })
+    };
 
     let stats_for_flush = stats.clone();
     let loop_result = match gate_ctx {

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -158,7 +158,7 @@ pub fn run_with_sink_gated(
 
             Ok(TickResult {
                 bytes_written,
-                metric_event: Some(event),
+                metric_events: vec![event],
                 delivered,
             })
         };
@@ -318,6 +318,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         }
     }
 
@@ -485,6 +487,8 @@ mod tests {
             },
             generator: crate::generator::GeneratorConfig::Constant { value: 1.0 },
             encoder: crate::encoder::EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         }
     }
 
@@ -839,6 +843,8 @@ mod tests {
             },
             generator: crate::generator::GeneratorConfig::Constant { value: 1.0 },
             encoder: crate::encoder::EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         }
     }
 
@@ -1045,6 +1051,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         };
         let mut sink = MemorySink::new();
         let result = super::run_with_sink(&config, &mut sink, None, None);
@@ -1083,6 +1091,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         }
     }
 

--- a/sonda-core/src/schedule/summary_runner.rs
+++ b/sonda-core/src/schedule/summary_runner.rs
@@ -147,10 +147,8 @@ pub fn run_with_sink_gated(
         |ctx: &TickContext<'_>, sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
             let wall_now = ctx.wall_clock;
 
-            // Advance the summary generator.
             let sample = summary_gen.observe(ctx.tick);
 
-            // Determine whether dynamic labels or spikes are active this tick.
             let needs_dynamic = !ctx.dynamic_labels.is_empty();
             let has_active_spike = ctx
                 .spike_windows
@@ -159,8 +157,8 @@ pub fn run_with_sink_gated(
             let needs_clone = needs_dynamic || has_active_spike;
 
             let mut total_bytes: u64 = 0;
+            let mut events: Vec<MetricEvent> = Vec::with_capacity(sample.quantiles.len() + 2);
 
-            // Emit one event per quantile.
             for (i, &(_q_target, q_value)) in sample.quantiles.iter().enumerate() {
                 let quantile_labels = if needs_clone {
                     let mut ql = (*prebuilt_quantile_labels[i]).clone();
@@ -182,9 +180,9 @@ pub fn run_with_sink_gated(
                 encoder.encode_metric(&event, &mut buf)?;
                 total_bytes += buf.len() as u64;
                 sink.write(&buf)?;
+                events.push(event);
             }
 
-            // Build labels for _count and _sum (no `quantile` label).
             let count_sum_labels = if needs_clone {
                 let mut bl = (*prebuilt_count_sum_labels).clone();
                 for dl in ctx.dynamic_labels {
@@ -200,30 +198,35 @@ pub fn run_with_sink_gated(
                 Arc::clone(&prebuilt_count_sum_labels)
             };
 
-            // Emit _count event.
+            let sum_event = MetricEvent::from_parts(
+                sum_name.clone(),
+                sample.sum,
+                Arc::clone(&count_sum_labels),
+                wall_now,
+            );
+            buf.clear();
+            encoder.encode_metric(&sum_event, &mut buf)?;
+            total_bytes += buf.len() as u64;
+            sink.write(&buf)?;
+            events.push(sum_event);
+
             let count_event = MetricEvent::from_parts(
                 count_name.clone(),
                 sample.count as f64,
-                Arc::clone(&count_sum_labels),
+                count_sum_labels,
                 wall_now,
             );
             buf.clear();
             encoder.encode_metric(&count_event, &mut buf)?;
             total_bytes += buf.len() as u64;
             sink.write(&buf)?;
+            events.push(count_event);
 
-            // Emit _sum event.
-            let sum_event =
-                MetricEvent::from_parts(sum_name.clone(), sample.sum, count_sum_labels, wall_now);
-            buf.clear();
-            encoder.encode_metric(&sum_event, &mut buf)?;
-            total_bytes += buf.len() as u64;
-            sink.write(&buf)?;
             let delivered = sink.last_write_delivered();
 
             Ok(TickResult {
                 bytes_written: total_bytes,
-                metric_event: Some(count_event),
+                metric_events: events,
                 delivered,
             })
         };
@@ -297,6 +300,8 @@ mod tests {
             mean_shift_per_sec: None,
             seed: Some(42),
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         }
     }
 

--- a/sonda-core/src/schedule/summary_runner.rs
+++ b/sonda-core/src/schedule/summary_runner.rs
@@ -143,93 +143,93 @@ pub fn run_with_sink_gated(
     // Pre-allocate encode buffer.
     let mut buf: Vec<u8> = Vec::with_capacity(1024);
 
-    let mut tick_fn =
-        |ctx: &TickContext<'_>, sink: &mut dyn Sink| -> Result<TickResult, SondaError> {
-            let wall_now = ctx.wall_clock;
+    let mut tick_fn = |ctx: &TickContext<'_>,
+                       sink: &mut dyn Sink,
+                       events_buf: &mut Vec<MetricEvent>|
+     -> Result<TickResult, SondaError> {
+        let wall_now = ctx.wall_clock;
 
-            let sample = summary_gen.observe(ctx.tick);
+        let sample = summary_gen.observe(ctx.tick);
 
-            let needs_dynamic = !ctx.dynamic_labels.is_empty();
-            let has_active_spike = ctx
-                .spike_windows
-                .iter()
-                .any(|sw| is_in_spike(ctx.elapsed, sw));
-            let needs_clone = needs_dynamic || has_active_spike;
+        let needs_dynamic = !ctx.dynamic_labels.is_empty();
+        let has_active_spike = ctx
+            .spike_windows
+            .iter()
+            .any(|sw| is_in_spike(ctx.elapsed, sw));
+        let needs_clone = needs_dynamic || has_active_spike;
 
-            let mut total_bytes: u64 = 0;
-            let mut events: Vec<MetricEvent> = Vec::with_capacity(sample.quantiles.len() + 2);
+        let mut total_bytes: u64 = 0;
 
-            for (i, &(_q_target, q_value)) in sample.quantiles.iter().enumerate() {
-                let quantile_labels = if needs_clone {
-                    let mut ql = (*prebuilt_quantile_labels[i]).clone();
-                    for dl in ctx.dynamic_labels {
-                        ql.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
-                    }
-                    for sw in ctx.spike_windows {
-                        if is_in_spike(ctx.elapsed, sw) {
-                            ql.insert(sw.label.clone(), sw.label_value_for_tick(ctx.tick));
-                        }
-                    }
-                    Arc::new(ql)
-                } else {
-                    Arc::clone(&prebuilt_quantile_labels[i])
-                };
-                let event =
-                    MetricEvent::from_parts(base_name.clone(), q_value, quantile_labels, wall_now);
-                buf.clear();
-                encoder.encode_metric(&event, &mut buf)?;
-                total_bytes += buf.len() as u64;
-                sink.write(&buf)?;
-                events.push(event);
-            }
-
-            let count_sum_labels = if needs_clone {
-                let mut bl = (*prebuilt_count_sum_labels).clone();
+        for (i, &(_q_target, q_value)) in sample.quantiles.iter().enumerate() {
+            let quantile_labels = if needs_clone {
+                let mut ql = (*prebuilt_quantile_labels[i]).clone();
                 for dl in ctx.dynamic_labels {
-                    bl.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
+                    ql.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
                 }
                 for sw in ctx.spike_windows {
                     if is_in_spike(ctx.elapsed, sw) {
-                        bl.insert(sw.label.clone(), sw.label_value_for_tick(ctx.tick));
+                        ql.insert(sw.label.clone(), sw.label_value_for_tick(ctx.tick));
                     }
                 }
-                Arc::new(bl)
+                Arc::new(ql)
             } else {
-                Arc::clone(&prebuilt_count_sum_labels)
+                Arc::clone(&prebuilt_quantile_labels[i])
             };
-
-            let sum_event = MetricEvent::from_parts(
-                sum_name.clone(),
-                sample.sum,
-                Arc::clone(&count_sum_labels),
-                wall_now,
-            );
+            let event =
+                MetricEvent::from_parts(base_name.clone(), q_value, quantile_labels, wall_now);
             buf.clear();
-            encoder.encode_metric(&sum_event, &mut buf)?;
+            encoder.encode_metric(&event, &mut buf)?;
             total_bytes += buf.len() as u64;
             sink.write(&buf)?;
-            events.push(sum_event);
+            events_buf.push(event);
+        }
 
-            let count_event = MetricEvent::from_parts(
-                count_name.clone(),
-                sample.count as f64,
-                count_sum_labels,
-                wall_now,
-            );
-            buf.clear();
-            encoder.encode_metric(&count_event, &mut buf)?;
-            total_bytes += buf.len() as u64;
-            sink.write(&buf)?;
-            events.push(count_event);
-
-            let delivered = sink.last_write_delivered();
-
-            Ok(TickResult {
-                bytes_written: total_bytes,
-                metric_events: events,
-                delivered,
-            })
+        let count_sum_labels = if needs_clone {
+            let mut bl = (*prebuilt_count_sum_labels).clone();
+            for dl in ctx.dynamic_labels {
+                bl.insert(dl.key.clone(), dl.label_value_for_tick(ctx.tick));
+            }
+            for sw in ctx.spike_windows {
+                if is_in_spike(ctx.elapsed, sw) {
+                    bl.insert(sw.label.clone(), sw.label_value_for_tick(ctx.tick));
+                }
+            }
+            Arc::new(bl)
+        } else {
+            Arc::clone(&prebuilt_count_sum_labels)
         };
+
+        let sum_event = MetricEvent::from_parts(
+            sum_name.clone(),
+            sample.sum,
+            Arc::clone(&count_sum_labels),
+            wall_now,
+        );
+        buf.clear();
+        encoder.encode_metric(&sum_event, &mut buf)?;
+        total_bytes += buf.len() as u64;
+        sink.write(&buf)?;
+        events_buf.push(sum_event);
+
+        let count_event = MetricEvent::from_parts(
+            count_name.clone(),
+            sample.count as f64,
+            count_sum_labels,
+            wall_now,
+        );
+        buf.clear();
+        encoder.encode_metric(&count_event, &mut buf)?;
+        total_bytes += buf.len() as u64;
+        sink.write(&buf)?;
+        events_buf.push(count_event);
+
+        let delivered = sink.last_write_delivered();
+
+        Ok(TickResult {
+            bytes_written: total_bytes,
+            delivered,
+        })
+    };
 
     let stats_for_flush = stats.clone();
     let loop_result = match gate_ctx {

--- a/sonda-core/tests/csv_replay_roundtrip.rs
+++ b/sonda-core/tests/csv_replay_roundtrip.rs
@@ -60,6 +60,8 @@ fn build_scenario(file: String, timescale: Option<f64>) -> ScenarioConfig {
             default_metric_name: None,
         },
         encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
     }
 }
 

--- a/sonda-core/tests/start_time_shift.rs
+++ b/sonda-core/tests/start_time_shift.rs
@@ -53,6 +53,8 @@ fn metric_config(
         base: base(name, rate, duration, start_time),
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
     }
 }
 
@@ -275,6 +277,8 @@ fn histogram_signal_honours_absolute_past_shift() {
         mean_shift_per_sec: None,
         seed: Some(42),
         encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
     };
 
     let mut sink = MemorySink::new();
@@ -295,6 +299,8 @@ fn summary_signal_honours_absolute_past_shift() {
         mean_shift_per_sec: None,
         seed: Some(42),
         encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
     };
 
     let mut sink = MemorySink::new();

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -92,6 +92,8 @@ fn run_with_capture(
         },
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder,
+        metric_type: None,
+        help: None,
     };
     let _ = config.base.name.clone();
 
@@ -322,6 +324,8 @@ fn non_remote_write_sink_no_close_marker_by_default() {
         },
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
     };
 
     let mut sink = MemorySink::new();
@@ -417,6 +421,8 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
         },
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
     };
 
     let mut sink = MemorySink::new();
@@ -520,6 +526,8 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
         },
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder: EncoderConfig::RemoteWrite,
+        metric_type: None,
+        help: None,
     };
 
     let stats_for_thread = Arc::clone(&stats);
@@ -620,6 +628,8 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
         },
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder: EncoderConfig::RemoteWrite,
+        metric_type: None,
+        help: None,
     };
 
     let stats_for_thread = Arc::clone(&stats);
@@ -702,6 +712,8 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
         },
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
     };
 
     let mut sink = MemorySink::new();
@@ -801,6 +813,8 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
         },
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder: EncoderConfig::RemoteWrite,
+        metric_type: None,
+        help: None,
     };
 
     let stats_for_thread = Arc::clone(&stats);
@@ -894,6 +908,8 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
         },
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder: EncoderConfig::RemoteWrite,
+        metric_type: None,
+        help: None,
     };
 
     let stats_for_thread = Arc::clone(&stats);
@@ -981,6 +997,8 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
         },
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder: EncoderConfig::RemoteWrite,
+        metric_type: None,
+        help: None,
     };
 
     let stats_for_thread = Arc::clone(&stats);
@@ -1079,6 +1097,8 @@ fn shutdown_while_gate_open_emits_stale_marker() {
         },
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder: EncoderConfig::RemoteWrite,
+        metric_type: None,
+        help: None,
     };
 
     let stats_for_thread = Arc::clone(&stats);

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -45,6 +45,8 @@ fn metrics_entry(name: &str, rate: f64, duration_ms: u64) -> ScenarioEntry {
         },
         generator: GeneratorConfig::Constant { value: 1.0 },
         encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
     })
 }
 
@@ -316,6 +318,8 @@ fn metrics_entry_with_generator(
         },
         generator,
         encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
     })
 }
 

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -826,7 +826,19 @@ pub async fn get_scenario_metrics(
 
     // Encode each event into Prometheus text format.
     let encoder = PrometheusText::new(None);
-    let mut buf = Vec::with_capacity(events_to_encode.len() * 128);
+    let mut buf = Vec::with_capacity(events_to_encode.len() * 128 + 256);
+    if !events_to_encode.is_empty() {
+        if let Some(meta) = handle.prometheus_meta.as_ref() {
+            if let Err(e) = encoder.encode_metadata(
+                &handle.name,
+                meta.metric_type,
+                meta.help.as_deref(),
+                &mut buf,
+            ) {
+                warn!(id = %id, error = %e, "GET /scenarios/{id}/metrics: failed to encode metadata");
+            }
+        }
+    }
     for event in events_to_encode {
         if let Err(e) = encoder.encode_metric(event, &mut buf) {
             warn!(id = %id, error = %e, "GET /scenarios/{id}/metrics: failed to encode metric event");
@@ -917,6 +929,7 @@ pub async fn get_aggregate_metrics(
 
     let encoder = PrometheusText::new(None);
     let mut buf = Vec::new();
+    let mut groups: Vec<AggregateGroup> = Vec::new();
     for id in ids {
         let handle = match scenarios.get(id) {
             Some(h) => h,
@@ -931,9 +944,60 @@ pub async fn get_aggregate_metrics(
         }) {
             continue;
         }
-        for event in handle.recent_metrics_snapshot() {
-            if let Err(e) = encoder.encode_metric(&event, &mut buf) {
-                warn!(id = %id, error = %e, "GET /metrics: failed to encode metric event");
+        let events = handle.recent_metrics_snapshot();
+        if events.is_empty() && handle.prometheus_meta.is_none() {
+            continue;
+        }
+        let name = handle.name.clone();
+        let meta = handle.prometheus_meta.as_ref().map(|m| m.as_ref().clone());
+        match groups.iter_mut().find(|g| g.name == name) {
+            Some(group) => {
+                if let Some(incoming) = meta {
+                    match group.meta.as_mut() {
+                        Some(existing) => {
+                            if existing.metric_type != incoming.metric_type
+                                && existing.metric_type != sonda_core::PromMetricType::Untyped
+                            {
+                                let declared = [existing.metric_type, incoming.metric_type];
+                                warn!(
+                                    metric_name = %name,
+                                    declared_types = ?declared,
+                                    "GET /metrics: mixed metric_type declarations for same name; \
+                                     emitting as untyped",
+                                );
+                                existing.metric_type = sonda_core::PromMetricType::Untyped;
+                            }
+                            if existing.help.is_none() && incoming.help.is_some() {
+                                existing.help = incoming.help;
+                            }
+                        }
+                        None => {
+                            group.meta = Some(incoming);
+                        }
+                    }
+                }
+                group.events.extend(events);
+            }
+            None => {
+                groups.push(AggregateGroup { name, meta, events });
+            }
+        }
+    }
+
+    for group in &groups {
+        if let Some(meta) = group.meta.as_ref() {
+            if let Err(e) = encoder.encode_metadata(
+                &group.name,
+                meta.metric_type,
+                meta.help.as_deref(),
+                &mut buf,
+            ) {
+                warn!(name = %group.name, error = %e, "GET /metrics: failed to encode metadata");
+            }
+        }
+        for event in &group.events {
+            if let Err(e) = encoder.encode_metric(event, &mut buf) {
+                warn!(name = %group.name, error = %e, "GET /metrics: failed to encode metric event");
             }
         }
     }
@@ -944,6 +1008,12 @@ pub async fn get_aggregate_metrics(
         buf,
     )
         .into_response())
+}
+
+struct AggregateGroup {
+    name: String,
+    meta: Option<sonda_core::PromMeta>,
+    events: Vec<sonda_core::model::metric::MetricEvent>,
 }
 
 #[cfg(test)]
@@ -1001,6 +1071,10 @@ mod tests {
             100.0,
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
             std::sync::Arc::new(std::collections::HashMap::new()),
+            Some(std::sync::Arc::new(sonda_core::PromMeta::new(
+                sonda_core::PromMetricType::Gauge,
+                None,
+            ))),
         )
     }
 
@@ -1033,6 +1107,10 @@ mod tests {
             100.0,
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
             std::sync::Arc::new(std::collections::HashMap::new()),
+            Some(std::sync::Arc::new(sonda_core::PromMeta::new(
+                sonda_core::PromMetricType::Gauge,
+                None,
+            ))),
         )
     }
 
@@ -2860,6 +2938,10 @@ scenarios:
             target_rate,
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
             std::sync::Arc::new(std::collections::HashMap::new()),
+            Some(std::sync::Arc::new(sonda_core::PromMeta::new(
+                sonda_core::PromMetricType::Gauge,
+                None,
+            ))),
         )
     }
 
@@ -3312,6 +3394,10 @@ scenarios:
             10.0,
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
             std::sync::Arc::new(std::collections::HashMap::new()),
+            Some(std::sync::Arc::new(sonda_core::PromMeta::new(
+                sonda_core::PromMetricType::Gauge,
+                None,
+            ))),
         )
     }
 
@@ -3398,18 +3484,19 @@ scenarios:
 
         let body = body_string(resp).await;
 
-        // Each event should produce a line starting with "up".
-        let lines: Vec<&str> = body.lines().collect();
+        // Each event should produce a line starting with "up". TYPE/HELP lines (starting with '#')
+        // appear once per metric name and are filtered out here.
+        let sample_lines: Vec<&str> = body.lines().filter(|line| !line.starts_with('#')).collect();
         assert!(
-            lines.len() >= 2,
-            "must have at least 2 lines of Prometheus text, got {}",
-            lines.len()
+            sample_lines.len() >= 2,
+            "must have at least 2 sample lines of Prometheus text, got {}",
+            sample_lines.len()
         );
 
-        for line in &lines {
+        for line in &sample_lines {
             assert!(
                 line.starts_with("up"),
-                "each Prometheus line must start with the metric name 'up', got: {line}"
+                "each sample line must start with the metric name 'up', got: {line}"
             );
         }
     }
@@ -3451,12 +3538,12 @@ scenarios:
         assert_eq!(resp.status(), StatusCode::OK);
 
         let body = body_string(resp).await;
-        let lines: Vec<&str> = body.lines().collect();
+        let sample_lines: Vec<&str> = body.lines().filter(|line| !line.starts_with('#')).collect();
         assert_eq!(
-            lines.len(),
+            sample_lines.len(),
             2,
-            "limit=2 must produce exactly 2 lines of output, got {}",
-            lines.len()
+            "limit=2 must produce exactly 2 sample lines of output, got {}",
+            sample_lines.len()
         );
     }
 
@@ -3562,9 +3649,9 @@ scenarios:
         assert_eq!(resp.status(), StatusCode::OK);
 
         let body = body_string(resp).await;
-        let lines: Vec<&str> = body.lines().collect();
+        let sample_lines: Vec<&str> = body.lines().filter(|line| !line.starts_with('#')).collect();
         assert_eq!(
-            lines.len(),
+            sample_lines.len(),
             5,
             "all 5 buffered events must be returned when no limit is specified"
         );
@@ -3583,9 +3670,9 @@ scenarios:
         assert_eq!(resp.status(), StatusCode::OK);
 
         let body = body_string(resp).await;
-        let lines: Vec<&str> = body.lines().collect();
+        let sample_lines: Vec<&str> = body.lines().filter(|line| !line.starts_with('#')).collect();
         assert_eq!(
-            lines.len(),
+            sample_lines.len(),
             2,
             "when limit > buffer size, all buffered events must be returned"
         );
@@ -3654,6 +3741,10 @@ scenarios:
             10.0,
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
             std::sync::Arc::new(label_map),
+            Some(std::sync::Arc::new(sonda_core::PromMeta::new(
+                sonda_core::PromMetricType::Gauge,
+                None,
+            ))),
         )
     }
 
@@ -3701,12 +3792,12 @@ scenarios:
         assert_eq!(resp.status(), StatusCode::OK);
 
         let body = body_string(resp).await;
-        let lines: Vec<&str> = body.lines().collect();
-        assert_eq!(lines.len(), 2, "must encode 2 events, got: {body:?}");
-        for line in &lines {
+        let sample_lines: Vec<&str> = body.lines().filter(|line| !line.starts_with('#')).collect();
+        assert_eq!(sample_lines.len(), 2, "must encode 2 events, got: {body:?}");
+        for line in &sample_lines {
             assert!(
                 line.starts_with("up"),
-                "each line must start with metric name 'up', got: {line}"
+                "each sample line must start with metric name 'up', got: {line}"
             );
         }
     }
@@ -3790,16 +3881,16 @@ scenarios:
         assert_eq!(resp.status(), StatusCode::OK);
 
         let body = body_string(resp).await;
-        let lines: Vec<&str> = body.lines().collect();
+        let sample_lines: Vec<&str> = body.lines().filter(|line| !line.starts_with('#')).collect();
         assert_eq!(
-            lines.len(),
+            sample_lines.len(),
             1,
             "filter must include only one event, got: {body:?}"
         );
         assert!(
-            lines[0].contains(" 1"),
+            sample_lines[0].contains(" 1"),
             "matching event must have value 1, got: {}",
-            lines[0]
+            sample_lines[0]
         );
     }
 
@@ -3855,16 +3946,16 @@ scenarios:
         assert_eq!(resp.status(), StatusCode::OK);
 
         let body = body_string(resp).await;
-        let lines: Vec<&str> = body.lines().collect();
+        let sample_lines: Vec<&str> = body.lines().filter(|line| !line.starts_with('#')).collect();
         assert_eq!(
-            lines.len(),
+            sample_lines.len(),
             1,
             "multi-label AND must match exactly one handle, got: {body:?}"
         );
         assert!(
-            lines[0].contains(" 10"),
+            sample_lines[0].contains(" 10"),
             "matching event must have value 10, got: {}",
-            lines[0]
+            sample_lines[0]
         );
     }
 
@@ -4069,6 +4160,10 @@ scenarios:
             50.0,
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
             std::sync::Arc::new(std::collections::HashMap::new()),
+            Some(std::sync::Arc::new(sonda_core::PromMeta::new(
+                sonda_core::PromMetricType::Gauge,
+                None,
+            ))),
         )
     }
 
@@ -4098,6 +4193,10 @@ scenarios:
             10.0,
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
             std::sync::Arc::new(std::collections::HashMap::new()),
+            Some(std::sync::Arc::new(sonda_core::PromMeta::new(
+                sonda_core::PromMetricType::Gauge,
+                None,
+            ))),
         )
     }
 
@@ -4971,4 +5070,413 @@ scenarios:
 
     // Sink loopback pre-flight tests (helpers + cases) live in the
     // sibling `sink_warnings` module.
+
+    // =====================================================================
+    // TYPE / HELP exposition tests (per-scenario and aggregate handlers)
+    // =====================================================================
+
+    fn handle_with_meta(
+        id: &str,
+        name: &str,
+        meta: Option<sonda_core::PromMeta>,
+        events: Vec<sonda_core::model::metric::MetricEvent>,
+    ) -> ScenarioHandle {
+        let shutdown = Arc::new(AtomicBool::new(true));
+        let mut stats = ScenarioStats::default();
+        for event in events {
+            stats.push_metric(event);
+        }
+        let stats = Arc::new(RwLock::new(stats));
+        let shutdown_clone = Arc::clone(&shutdown);
+        let thread = thread::Builder::new()
+            .name(format!("test-meta-{name}"))
+            .spawn(move || -> Result<(), sonda_core::SondaError> {
+                while shutdown_clone.load(Ordering::SeqCst) {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Ok(())
+            })
+            .expect("thread must spawn");
+        ScenarioHandle::new(
+            id.to_string(),
+            name.to_string(),
+            None,
+            shutdown,
+            Some(thread),
+            Instant::now(),
+            stats,
+            10.0,
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            std::sync::Arc::new(std::collections::HashMap::new()),
+            meta.map(std::sync::Arc::new),
+        )
+    }
+
+    fn metric_event(name: &str, value: f64) -> sonda_core::model::metric::MetricEvent {
+        sonda_core::model::metric::MetricEvent::new(
+            name.to_string(),
+            value,
+            sonda_core::model::metric::Labels::default(),
+        )
+        .expect("metric name must be valid")
+    }
+
+    #[tokio::test]
+    async fn per_scenario_metrics_emits_type_line() {
+        let meta = sonda_core::PromMeta::new(sonda_core::PromMetricType::Gauge, None);
+        let h = handle_with_meta(
+            "id-type",
+            "memory_utilization",
+            Some(meta),
+            vec![metric_event("memory_utilization", 41.5)],
+        );
+        let app = router_with_handles(vec![h]);
+        let resp = get_metrics_req(app, "id-type").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            body.starts_with("# TYPE memory_utilization gauge\n"),
+            "body must begin with TYPE line, got:\n{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn per_scenario_metrics_emits_help_line_when_set() {
+        let meta = sonda_core::PromMeta::new(
+            sonda_core::PromMetricType::Gauge,
+            Some("memory util".to_string()),
+        );
+        let h = handle_with_meta(
+            "id-help",
+            "memory_utilization",
+            Some(meta),
+            vec![metric_event("memory_utilization", 41.5)],
+        );
+        let app = router_with_handles(vec![h]);
+        let resp = get_metrics_req(app, "id-help").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            body.starts_with(
+                "# HELP memory_utilization memory util\n# TYPE memory_utilization gauge\n"
+            ),
+            "body must begin with HELP and TYPE lines in order, got:\n{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn per_scenario_metrics_omits_help_when_unset() {
+        let meta = sonda_core::PromMeta::new(sonda_core::PromMetricType::Gauge, None);
+        let h = handle_with_meta(
+            "id-no-help",
+            "memory_utilization",
+            Some(meta),
+            vec![metric_event("memory_utilization", 1.0)],
+        );
+        let app = router_with_handles(vec![h]);
+        let resp = get_metrics_req(app, "id-no-help").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            !body.contains("# HELP"),
+            "body must not contain a HELP line, got:\n{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn per_scenario_metrics_log_scenario_returns_empty() {
+        let h = handle_with_meta("id-log", "log_scenario", None, vec![]);
+        let app = router_with_handles(vec![h]);
+        let resp = get_metrics_req(app, "id-log").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            body.is_empty(),
+            "log scenario (no prometheus_meta) must return empty body, got:\n{body}"
+        );
+    }
+
+    fn handle_with_meta_and_labels(
+        id: &str,
+        name: &str,
+        meta: Option<sonda_core::PromMeta>,
+        labels: Vec<(&str, &str)>,
+        events: Vec<sonda_core::model::metric::MetricEvent>,
+    ) -> ScenarioHandle {
+        let shutdown = Arc::new(AtomicBool::new(true));
+        let mut stats = ScenarioStats::default();
+        for event in events {
+            stats.push_metric(event);
+        }
+        let stats = Arc::new(RwLock::new(stats));
+        let shutdown_clone = Arc::clone(&shutdown);
+        let thread = thread::Builder::new()
+            .name(format!("test-agg-meta-{name}"))
+            .spawn(move || -> Result<(), sonda_core::SondaError> {
+                while shutdown_clone.load(Ordering::SeqCst) {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Ok(())
+            })
+            .expect("thread must spawn");
+        let mut label_map = std::collections::HashMap::new();
+        for (k, v) in labels {
+            label_map.insert(k.to_string(), v.to_string());
+        }
+        ScenarioHandle::new(
+            id.to_string(),
+            name.to_string(),
+            None,
+            shutdown,
+            Some(thread),
+            Instant::now(),
+            stats,
+            10.0,
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            std::sync::Arc::new(label_map),
+            meta.map(std::sync::Arc::new),
+        )
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_emits_one_type_block_per_name() {
+        let meta = sonda_core::PromMeta::new(sonda_core::PromMetricType::Gauge, None);
+        let h1 = handle_with_meta_and_labels(
+            "a-1",
+            "shared_metric",
+            Some(meta.clone()),
+            vec![("device", "srl1")],
+            vec![metric_event("shared_metric", 1.0)],
+        );
+        let h2 = handle_with_meta_and_labels(
+            "a-2",
+            "shared_metric",
+            Some(meta),
+            vec![("device", "srl2")],
+            vec![metric_event("shared_metric", 2.0)],
+        );
+        let app = router_with_handles(vec![h1, h2]);
+        let resp = get_aggregate_req(app, "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        let type_lines: Vec<&str> = body
+            .lines()
+            .filter(|l| l.starts_with("# TYPE shared_metric"))
+            .collect();
+        assert_eq!(
+            type_lines.len(),
+            1,
+            "aggregate body must have exactly one TYPE line for shared_metric, got:\n{body}"
+        );
+        let sample_lines: Vec<&str> = body.lines().filter(|l| !l.starts_with('#')).collect();
+        assert_eq!(
+            sample_lines.len(),
+            2,
+            "aggregate body must contain both samples, got:\n{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_groups_samples_by_name() {
+        let meta = sonda_core::PromMeta::new(sonda_core::PromMetricType::Gauge, None);
+        let h1 = handle_with_meta_and_labels(
+            "g-1",
+            "m1",
+            Some(meta.clone()),
+            vec![],
+            vec![metric_event("m1", 1.0)],
+        );
+        let h2 = handle_with_meta_and_labels(
+            "g-2",
+            "m1",
+            Some(meta.clone()),
+            vec![],
+            vec![metric_event("m1", 2.0)],
+        );
+        let h3 = handle_with_meta_and_labels(
+            "g-3",
+            "m2",
+            Some(meta),
+            vec![],
+            vec![metric_event("m2", 3.0)],
+        );
+        let app = router_with_handles(vec![h1, h2, h3]);
+        let resp = get_aggregate_req(app, "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        let m1_type_pos = body
+            .find("# TYPE m1 gauge")
+            .expect("TYPE m1 line must be present");
+        let m2_type_pos = body
+            .find("# TYPE m2 gauge")
+            .expect("TYPE m2 line must be present");
+        assert!(
+            m1_type_pos < m2_type_pos,
+            "m1 group must precede m2 group, got:\n{body}"
+        );
+        let between = &body[m1_type_pos..m2_type_pos];
+        assert!(
+            between.contains("m1 1") && between.contains("m1 2"),
+            "samples for m1 must appear between m1 and m2 TYPE lines, got:\n{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_mixed_type_collision_emits_untyped_and_warns() {
+        let h1 = handle_with_meta_and_labels(
+            "mix-1",
+            "collision",
+            Some(sonda_core::PromMeta::new(
+                sonda_core::PromMetricType::Gauge,
+                None,
+            )),
+            vec![],
+            vec![metric_event("collision", 1.0)],
+        );
+        let h2 = handle_with_meta_and_labels(
+            "mix-2",
+            "collision",
+            Some(sonda_core::PromMeta::new(
+                sonda_core::PromMetricType::Counter,
+                None,
+            )),
+            vec![],
+            vec![metric_event("collision", 2.0)],
+        );
+        let app = router_with_handles(vec![h1, h2]);
+        let resp = get_aggregate_req(app, "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            body.contains("# TYPE collision untyped"),
+            "mixed-type collision must emit untyped, got:\n{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_label_filter_still_works_with_type_lines() {
+        let meta = sonda_core::PromMeta::new(sonda_core::PromMetricType::Gauge, None);
+        let h1 = handle_with_meta_and_labels(
+            "lf-1",
+            "srl_metric",
+            Some(meta.clone()),
+            vec![("device", "srl1")],
+            vec![metric_event("srl_metric", 1.0)],
+        );
+        let h2 = handle_with_meta_and_labels(
+            "lf-2",
+            "srl_metric",
+            Some(meta),
+            vec![("device", "srl2")],
+            vec![metric_event("srl_metric", 2.0)],
+        );
+        let app = router_with_handles(vec![h1, h2]);
+        let resp = get_aggregate_req(app, "label=device:srl1").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            body.contains("# TYPE srl_metric gauge"),
+            "filter result must still emit TYPE line, got:\n{body}"
+        );
+        let sample_lines: Vec<&str> = body.lines().filter(|l| !l.starts_with('#')).collect();
+        assert_eq!(
+            sample_lines.len(),
+            1,
+            "filter must include only one sample, got:\n{body}"
+        );
+        assert!(
+            sample_lines[0].contains(" 1"),
+            "matching sample must have value 1, got: {}",
+            sample_lines[0]
+        );
+    }
+
+    fn labeled_metric_event(
+        name: &str,
+        value: f64,
+        pairs: &[(&str, &str)],
+    ) -> sonda_core::model::metric::MetricEvent {
+        let labels =
+            sonda_core::model::metric::Labels::from_pairs(pairs).expect("labels must build");
+        sonda_core::model::metric::MetricEvent::new(name.to_string(), value, labels)
+            .expect("metric name must be valid")
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_histogram_scenario_exposes_buckets_sum_and_count() {
+        let events = vec![
+            labeled_metric_event("req_latency_bucket", 12.0, &[("le", "0.1")]),
+            labeled_metric_event("req_latency_bucket", 24.0, &[("le", "1")]),
+            labeled_metric_event("req_latency_bucket", 50.0, &[("le", "+Inf")]),
+            labeled_metric_event("req_latency_sum", 7.5, &[]),
+            labeled_metric_event("req_latency_count", 50.0, &[]),
+        ];
+
+        let meta = sonda_core::PromMeta::new(sonda_core::PromMetricType::Histogram, None);
+        let h = handle_with_meta("hist", "req_latency", Some(meta), events);
+        let app = router_with_handles(vec![h]);
+        let resp = get_aggregate_req(app, "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            body.contains("# TYPE req_latency histogram"),
+            "expected single histogram TYPE on base name, got:\n{body}"
+        );
+        assert_eq!(
+            body.matches("# TYPE req_latency ").count(),
+            1,
+            "expected exactly one TYPE line for the base name, got:\n{body}"
+        );
+        assert!(
+            body.contains("req_latency_bucket{le=\"0.1\"}") && body.contains("le=\"+Inf\""),
+            "expected bucket samples including +Inf, got:\n{body}"
+        );
+        assert!(
+            body.contains("req_latency_sum"),
+            "expected _sum series, got:\n{body}"
+        );
+        assert!(
+            body.contains("req_latency_count"),
+            "expected _count series, got:\n{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_summary_scenario_exposes_quantiles_sum_and_count() {
+        let events = vec![
+            labeled_metric_event("rpc_duration", 0.05, &[("quantile", "0.5")]),
+            labeled_metric_event("rpc_duration", 0.09, &[("quantile", "0.9")]),
+            labeled_metric_event("rpc_duration", 0.18, &[("quantile", "0.99")]),
+            labeled_metric_event("rpc_duration_sum", 6.0, &[]),
+            labeled_metric_event("rpc_duration_count", 50.0, &[]),
+        ];
+
+        let meta = sonda_core::PromMeta::new(sonda_core::PromMetricType::Summary, None);
+        let h = handle_with_meta("summ", "rpc_duration", Some(meta), events);
+        let app = router_with_handles(vec![h]);
+        let resp = get_aggregate_req(app, "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            body.contains("# TYPE rpc_duration summary"),
+            "expected single summary TYPE on base name, got:\n{body}"
+        );
+        assert_eq!(
+            body.matches("# TYPE rpc_duration ").count(),
+            1,
+            "expected exactly one TYPE line for the base name, got:\n{body}"
+        );
+        assert!(
+            body.contains("quantile=\"0.5\"") && body.contains("quantile=\"0.99\""),
+            "expected quantile samples, got:\n{body}"
+        );
+        assert!(
+            body.contains("rpc_duration_sum"),
+            "expected _sum series, got:\n{body}"
+        );
+        assert!(
+            body.contains("rpc_duration_count"),
+            "expected _count series, got:\n{body}"
+        );
+    }
 }

--- a/sonda-server/tests/metrics.rs
+++ b/sonda-server/tests/metrics.rs
@@ -105,3 +105,198 @@ fn aggregate_metrics_end_to_end_with_label_filter() {
         "filtered body must exclude srl2, got: {body_filtered}"
     );
 }
+
+const METRICS_TYPE_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: cpu_usage
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+const HISTOGRAM_TYPE_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 5
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: req_latency
+    signal_type: histogram
+    name: req_latency
+    distribution:
+      type: exponential
+      rate: 10.0
+    observations_per_tick: 50
+    seed: 1
+"#;
+
+const SUMMARY_TYPE_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 5
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: rpc_duration
+    signal_type: summary
+    name: rpc_duration
+    distribution:
+      type: normal
+      mean: 0.1
+      stddev: 0.02
+    observations_per_tick: 50
+    seed: 1
+"#;
+
+#[test]
+fn aggregate_metrics_e2e_includes_type_lines_per_signal_type() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    for yaml in [METRICS_TYPE_YAML, HISTOGRAM_TYPE_YAML, SUMMARY_TYPE_YAML] {
+        let resp = client
+            .post(format!("{base}/scenarios"))
+            .header("Content-Type", "text/yaml")
+            .body(yaml)
+            .send()
+            .expect("POST must succeed");
+        assert_eq!(resp.status().as_u16(), 201, "POST must return 201");
+    }
+
+    thread::sleep(Duration::from_millis(800));
+
+    let resp = client
+        .get(format!("{base}/metrics"))
+        .send()
+        .expect("GET /metrics must succeed");
+    assert_eq!(resp.status().as_u16(), 200);
+    let body = resp.text().expect("body must be UTF-8");
+
+    assert!(
+        body.contains("# TYPE cpu_usage gauge"),
+        "body must contain '# TYPE cpu_usage gauge', got:\n{body}"
+    );
+    assert!(
+        body.contains("# TYPE req_latency histogram"),
+        "body must contain '# TYPE req_latency histogram', got:\n{body}"
+    );
+    assert!(
+        body.contains("# TYPE rpc_duration summary"),
+        "body must contain '# TYPE rpc_duration summary', got:\n{body}"
+    );
+
+    assert!(
+        body.contains("req_latency_bucket{") && body.contains("le=\"+Inf\""),
+        "body must contain histogram bucket samples including +Inf, got:\n{body}"
+    );
+    assert!(
+        body.contains("req_latency_sum"),
+        "body must contain histogram _sum samples, got:\n{body}"
+    );
+    assert!(
+        body.contains("req_latency_count"),
+        "body must contain histogram _count samples, got:\n{body}"
+    );
+    assert!(
+        body.contains("rpc_duration{") && body.contains("quantile=\""),
+        "body must contain summary quantile samples, got:\n{body}"
+    );
+    assert!(
+        body.contains("rpc_duration_sum"),
+        "body must contain summary _sum samples, got:\n{body}"
+    );
+    assert!(
+        body.contains("rpc_duration_count"),
+        "body must contain summary _count samples, got:\n{body}"
+    );
+
+    let type_lines: Vec<&str> = body.lines().filter(|l| l.starts_with("# TYPE ")).collect();
+    let mut seen = std::collections::HashSet::new();
+    for line in &type_lines {
+        assert!(
+            seen.insert(*line),
+            "duplicate TYPE line found: {line}\nfull body:\n{body}"
+        );
+    }
+}
+
+const YAML_METRIC_TYPE_FROM_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: memory_utilization
+    signal_type: metrics
+    name: memory_utilization
+    metric_type: counter
+    help: "Memory usage percent on the device."
+    labels:
+      device: srl1
+    generator:
+      type: constant
+      value: 42
+"#;
+
+#[test]
+fn e2e_yaml_metric_type_field_reaches_scrape_output() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("Content-Type", "text/yaml")
+        .body(YAML_METRIC_TYPE_FROM_YAML)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(resp.status().as_u16(), 201, "POST must return 201");
+
+    thread::sleep(Duration::from_millis(500));
+
+    let resp = client
+        .get(format!("{base}/metrics"))
+        .send()
+        .expect("GET /metrics must succeed");
+    assert_eq!(resp.status().as_u16(), 200);
+    let body = resp.text().expect("body must be UTF-8");
+
+    assert!(
+        body.contains("# TYPE memory_utilization counter"),
+        "YAML metric_type:counter must reach scrape output, got:\n{body}"
+    );
+    assert!(
+        !body.contains("# TYPE memory_utilization gauge"),
+        "scrape must not fall back to gauge default, got:\n{body}"
+    );
+    assert!(
+        body.contains("# HELP memory_utilization Memory usage percent on the device."),
+        "YAML help: field must reach scrape output, got:\n{body}"
+    );
+}

--- a/sonda/src/status.rs
+++ b/sonda/src/status.rs
@@ -1340,6 +1340,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         })
     }
 
@@ -1437,6 +1439,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 0.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         print_start(&entry, Verbosity::Normal, None);
     }
@@ -1599,6 +1603,8 @@ mod tests {
                 offset: 50.0,
             },
             encoder: EncoderConfig::PrometheusText { precision: Some(2) },
+            metric_type: None,
+            help: None,
         });
         print_config(&entry, 1, 1);
     }
@@ -1794,6 +1800,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         print_config(&entry, 1, 1);
     }
@@ -1953,6 +1961,8 @@ mod tests {
             },
             generator: GeneratorConfig::Constant { value: 1.0 },
             encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
         });
         print_config(&entry, 1, 1);
     }


### PR DESCRIPTION
## Summary

Both `/metrics` endpoints (aggregate and per-scenario) now emit Prometheus exposition `# TYPE` lines per metric name plus an optional `# HELP` line when configured. Prometheus-text scrape consumers — Prometheus, VictoriaMetrics, vmagent, Telegraf — see typed metrics. This keeps the metric name stable across every consumer in the chain (some consumers rename or special-case untyped samples, so an untyped `bgp_oper_state` may surface downstream as `bgp_oper_state_value`; declaring a type avoids that).

- Optional `metric_type: gauge | counter | histogram | summary | untyped` and `help: "<text>"` on Metrics / Histogram / Summary scenario YAML
- Defaults per signal type: `gauge` for Metrics, `counter` for Metrics with the `step` generator, `histogram` for Histogram, `summary` for Summary
- Histogram and summary scrape endpoints now expose the full series (buckets, sum, count, quantiles) — `histogram_quantile()` works end-to-end
- Mixed-type collision on a shared metric name emits one `# TYPE <name> untyped` block plus a warn log
- New `encode_metadata` method on the `Encoder` trait with a no-op default; only `PrometheusText` overrides
- Docs updated across scenario-fields, generators, and sonda-server reference pages

## Test plan

- [ ] `cargo build --workspace`
- [ ] `cargo nextest run --workspace`
- [ ] POST a YAML scenario with `metric_type: counter` + `help: "..."`, scrape `/metrics`, verify both lines appear before samples
- [ ] POST a histogram scenario, scrape `/metrics`, verify buckets / `_sum` / `_count` all appear under one `# TYPE <name> histogram` block
- [ ] POST a summary scenario, scrape `/metrics`, verify quantiles / `_sum` / `_count` all appear under one `# TYPE <name> summary` block
- [ ] POST two scenarios sharing a metric name with conflicting `metric_type`, scrape, verify a single `# TYPE <name> untyped` line and a warning in the server log
- [ ] Backward compat: existing YAML without `metric_type` / `help` still parses and runs; defaults apply
- [ ] `task site:build` passes