### PR TITLE
fix(server): emit one Prometheus sample per series with no timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/docs/site/docs/configuration/scenario-fields.md
+++ b/docs/site/docs/configuration/scenario-fields.md
@@ -130,7 +130,7 @@ Scrape the server and the response carries both annotations:
 ```text title="GET /metrics"
 # HELP memory_utilization Memory usage percent on the device.
 # TYPE memory_utilization gauge
-memory_utilization{device="srl1"} 41.5 1779645380851
+memory_utilization{device="srl1"} 41.5
 ```
 
 !!! info "Why declare `metric_type`?"

--- a/docs/site/docs/deployment/kubernetes.md
+++ b/docs/site/docs/deployment/kubernetes.md
@@ -155,7 +155,7 @@ instructions.
 A ServiceMonitor endpoint scrapes a single `path`. Two paths work for Sonda:
 
 - `/metrics` — aggregate scrape across every running scenario, with optional `?label=k:v` filtering. This is the right choice for most installs: one ServiceMonitor covers every scenario the server runs, regardless of how they were launched.
-- `/scenarios/<scenario-id>/metrics` — per-scenario drain. Use it when each scenario is its own logical target and you know its ID ahead of time (for example, one loaded from the `scenarios` ConfigMap at a stable route).
+- `/scenarios/<scenario-id>/metrics` — single-scenario snapshot. Use it when each scenario is its own logical target and you know its ID ahead of time (for example, one loaded from the `scenarios` ConfigMap at a stable route).
 
 `serviceMonitor.path` has no default. If you set `serviceMonitor.enabled: true` without also setting `serviceMonitor.path`, `helm install` and `helm upgrade` fail with a clear error telling you to set the path to a Prometheus-text endpoint such as `/metrics` or `/scenarios/<scenario-id>/metrics`. This avoids silently producing a ServiceMonitor that scrapes a non-metrics route.
 
@@ -277,7 +277,7 @@ For example, a Prometheus instance in the same namespace can scrape
 
 ## Prometheus scraping
 
-`sonda-server` exposes two scrape endpoints. `GET /metrics` is the aggregate view — every running scenario fused into one response, with `?label=k:v` to slice by the labels you attached to each scenario. `GET /scenarios/{id}/metrics` is the per-scenario drain — one consumer pulls from one scenario's buffer. For most Prometheus setups, the aggregate endpoint is the right call: one job covers every scenario, multiple scrapers can read it, and you do not need to know scenario IDs ahead of time. See [Aggregate Prometheus scrape](sonda-server.md#aggregate-prometheus-scrape) for the full reference, including the `?label=k:v` AND-filter syntax.
+`sonda-server` exposes two scrape endpoints. `GET /metrics` is the aggregate view — every running scenario fused into one response, with `?label=k:v` to slice by the labels you attached to each scenario. `GET /scenarios/{id}/metrics` is the per-scenario view — the current value of every series for one scenario. Both endpoints are idempotent snapshots: one sample per `(name, labels)` series with no timestamp, exactly like a `node_exporter` scrape. For most Prometheus setups, the aggregate endpoint is the right call — one job covers every scenario and you do not need to know scenario IDs ahead of time. See [Aggregate Prometheus scrape](sonda-server.md#aggregate-prometheus-scrape) for the full reference, including the `?label=k:v` AND-filter syntax.
 
 ### Aggregate scrape config
 
@@ -294,7 +294,7 @@ Add `params: {label: ["device:srl1"]}` to scope a job to one device's metrics; r
 
 ### Per-scenario scrape config
 
-When you want one scrape job per scenario, point `metrics_path` at the scenario ID. The endpoint drains its buffer on every scrape, so only one consumer should pull from a given ID at a time:
+When you want one scrape job per scenario, point `metrics_path` at the scenario ID:
 
 ```yaml title="prometheus-scrape.yaml"
 scrape_configs:

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -423,8 +423,8 @@ Each `conflicting_scenarios` entry carries the scenario `id` (use it with `DELET
 | GET | `/scenarios/{id}` | Inspect a scenario: config, stats, elapsed |
 | DELETE | `/scenarios/{id}` | Stop and remove a running scenario |
 | GET | `/scenarios/{id}/stats` | Live stats: rate, events, gap/burst state, sink-failure counters. See [Self-observability via /stats](#self-observability-via-stats). |
-| GET | `/scenarios/{id}/metrics` | Latest metrics in Prometheus text format. DRAIN semantics — one consumer. |
-| GET | `/metrics` | Aggregate Prometheus scrape across all running scenarios. SNAPSHOT semantics — multi-consumer. Supports `?label=k:v` filtering. See [Aggregate Prometheus scrape](#aggregate-prometheus-scrape). |
+| GET | `/scenarios/{id}/metrics` | Current per-series values for one scenario in Prometheus text format. Idempotent snapshot. |
+| GET | `/metrics` | Aggregate Prometheus scrape across all running scenarios. Idempotent snapshot, multi-consumer safe. Supports `?label=k:v` filtering. See [Aggregate Prometheus scrape](#aggregate-prometheus-scrape). |
 | POST | `/events` | Emit one log or metric event synchronously. See [Single-Event API](events.md). |
 
 ## Authentication
@@ -720,7 +720,7 @@ The four sink-failure fields are the runtime telemetry surface for the [`on_sink
 
 ## Aggregate Prometheus scrape
 
-To a scraper, `sonda-server` presents itself the same way a Prometheus exporter on a real device does — one URL (`GET /metrics`), idempotent within a scrape window, with label selectors to slice the view. `GET /metrics` returns a snapshot of every running scenario's recent metric events fused into a single Prometheus text-format response, and `?label=k:v` filters that view by the labels the user attached when starting each scenario.
+To a scraper, `sonda-server` presents itself the same way a Prometheus exporter on a real device does — one URL (`GET /metrics`), idempotent within a scrape window, with label selectors to slice the view. `GET /metrics` returns the current value of every series across every running scenario, one sample per `(name, labels)` series with no per-sample timestamp, fused into a single Prometheus text-format response. `?label=k:v` filters that view by the labels the user attached when starting each scenario.
 
 It is a **typed** exporter: each metric is fronted by `# TYPE` and (when configured) `# HELP` lines, so Prometheus, VictoriaMetrics, vmagent, and Telegraf consumers see the same exposition shape they would see scraping any real device. Set [`metric_type:` and `help:`](../configuration/scenario-fields.md#prometheus-exposition-fields) on a scenario to declare the type and description explicitly; omit them and the server picks a sensible default (`gauge` for most metric generators, `counter` for [`step`](../configuration/generators.md#step), `histogram` / `summary` for those signal types).
 
@@ -767,22 +767,25 @@ curl http://localhost:8080/metrics
 ```text title="Response (text/plain; version=0.0.4; charset=utf-8)"
 # HELP memory_utilization Memory usage percent on the device.
 # TYPE memory_utilization gauge
-memory_utilization{device="srl1"} 41.528 1779645380851
-memory_utilization{device="srl2"} 67.812 1779645380851
+memory_utilization{device="srl1"} 41.528
+memory_utilization{device="srl2"} 67.812
 ```
 
-Each sample line is `metric_name{labels} value timestamp_ms`. Per-sample wall-clock millisecond timestamps let Prometheus and VictoriaMetrics dedupe naturally on `(name, labels, timestamp_ms, value)` across overlapping scrape windows. The `# TYPE` line appears once per metric name, and `# HELP` appears when any contributing scenario set one. With no scenarios running, the response is `200 OK` with an empty body — exactly what Prometheus, vmagent, and Telegraf scrapers expect on a quiet target.
+One line per `(name, labels)` series, carrying the current value with no per-sample timestamp — the same shape `node_exporter` and Prometheus self-scrape produce. The scraper stamps every sample with its own scrape wall-clock at ingest time, so the server emitting its own timestamps would conflict with that. The `# TYPE` line appears once per metric name, and `# HELP` appears when any contributing scenario set one. With no scenarios running, the response is `200 OK` with an empty body — exactly what Prometheus, vmagent, and Telegraf scrapers expect on a quiet target.
+
+!!! info "Idempotent within a scrape window"
+    `GET /metrics` is non-destructive and stable: two scrapes back-to-back return byte-identical bodies. A Prometheus job and a vmagent job (and an ops dashboard) can scrape the same server without stealing events from each other. The CLI streaming sinks (`stdout`, `file`, `tcp`, `udp`) still emit a timestamp per event — they encode a stream over time, so the timestamp is what gives each line its identity. The HTTP scrape and the CLI stream serve different consumer models, so the encoder is configured differently for each path.
 
 Histogram and summary scenarios surface the same way — one `# TYPE` block per base name covering every `_bucket{le="..."}`, `_sum`, `_count`, and quantile line:
 
 ```text title="Response (histogram entry)"
 # HELP http_request_duration_seconds Request latency in seconds.
 # TYPE http_request_duration_seconds histogram
-http_request_duration_seconds_bucket{le="0.005",method="GET"} 3 1779645380851
-http_request_duration_seconds_bucket{le="0.01",method="GET"} 11 1779645380851
-http_request_duration_seconds_bucket{le="+Inf",method="GET"} 100 1779645380851
-http_request_duration_seconds_sum{method="GET"} 9.505 1779645380851
-http_request_duration_seconds_count{method="GET"} 100 1779645380851
+http_request_duration_seconds_bucket{le="0.005",method="GET"} 3
+http_request_duration_seconds_bucket{le="0.01",method="GET"} 11
+http_request_duration_seconds_bucket{le="+Inf",method="GET"} 100
+http_request_duration_seconds_sum{method="GET"} 9.505
+http_request_duration_seconds_count{method="GET"} 100
 ```
 
 This is the exposition shape `histogram_quantile()` expects, so PromQL percentile queries work end-to-end against the server.
@@ -815,14 +818,14 @@ A malformed filter (missing `:`, empty key, empty value) returns `400 Bad Reques
 
 ### `GET /metrics` vs `GET /scenarios/{id}/metrics`
 
-Both endpoints emit Prometheus text. They serve different scrape models:
+Both endpoints emit Prometheus text and both are idempotent snapshots — two back-to-back calls return byte-identical bodies. They differ only in scope:
 
-| Endpoint | Semantics | Use it for |
+| Endpoint | Scope | Use it for |
 |---|---|---|
-| `GET /metrics` | **Snapshot** — non-destructive. Two back-to-back calls return identical bytes. | Production scraping. Multiple scrapers can read it (Prometheus + vmagent + an ops dashboard) without stealing events from each other. |
-| `GET /scenarios/{id}/metrics` | **Drain** — each call empties the per-scenario buffer. | Debugging a single scenario. Drives the per-event consumer pattern (one consumer pulls, observes, discards). |
+| `GET /metrics` | Every running scenario fused into one response. Supports `?label=k:v` to slice the view. | Production scraping. One job covers every scenario, with no need to know IDs ahead of time. |
+| `GET /scenarios/{id}/metrics` | One scenario. | Debugging or wiring a per-scenario route when each scenario is its own logical target. |
 
-Pick `GET /metrics` for any Prometheus / VictoriaMetrics / vmagent job — it is the endpoint that behaves like a normal exporter. Reach for the per-scenario drain when you are inspecting one scenario in isolation or wiring a one-off pull-based consumer.
+Pick `GET /metrics` for any Prometheus / VictoriaMetrics / vmagent job — it is the endpoint that behaves like a normal exporter. Reach for the per-scenario endpoint when you are inspecting one scenario in isolation or want a stable URL per scenario.
 
 ### Scrape config
 
@@ -855,14 +858,14 @@ scrape_configs:
 
 ## Per-scenario scrape
 
-The `GET /scenarios/{id}/metrics` endpoint returns recent metric events for one scenario in Prometheus text exposition format. Each scrape **drains** the buffer — events appear once per cycle. Use it when you want a one-to-one consumer pulling from a single scenario; reach for [`GET /metrics`](#aggregate-prometheus-scrape) when more than one scraper needs the data or when you want a single job that covers every running scenario.
+The `GET /scenarios/{id}/metrics` endpoint returns the current value of every series one scenario is emitting, in Prometheus text exposition format. It is the per-scenario counterpart to [`GET /metrics`](#aggregate-prometheus-scrape): same one-sample-per-series shape, same idempotent snapshot semantics, scoped to a single scenario. Reach for it when each scenario is its own logical target and you have a stable ID to point at.
 
 The response carries the same `# TYPE` and `# HELP` annotations as the aggregate endpoint, scoped to the single scenario:
 
 ```text title="GET /scenarios/<SCENARIO_ID>/metrics"
 # HELP memory_utilization Memory usage percent on the device.
 # TYPE memory_utilization gauge
-memory_utilization{device="srl1"} 41.528 1779645380851
+memory_utilization{device="srl1"} 41.528
 ```
 
 See [Prometheus exposition fields](../configuration/scenario-fields.md#prometheus-exposition-fields) for how `metric_type:` and `help:` control these lines and how defaults are derived.
@@ -876,9 +879,7 @@ scrape_configs:
       - targets: ["localhost:8080"]
 ```
 
-Replace `<SCENARIO_ID>` with the ID returned by `POST /scenarios`.
-
-The endpoint accepts an optional `?limit=N` query parameter (default 100, max 1000) to control how many recent events are returned per scrape. If no metrics are available yet, you get `204 No Content`. Unknown scenario IDs return `404 Not Found`.
+Replace `<SCENARIO_ID>` with the ID returned by `POST /scenarios`. Unknown scenario IDs return `404 Not Found`.
 
 !!! note
     The server is also available as a [Docker image](docker.md) and

--- a/docs/site/docs/guides/synthetic-monitoring.md
+++ b/docs/site/docs/guides/synthetic-monitoring.md
@@ -239,7 +239,7 @@ For the full API reference, see [Server API](../deployment/sonda-server.md).
 
 ## Scrape metrics with Prometheus
 
-`sonda-server` exposes two scrape endpoints. `GET /metrics` is the aggregate view — every running scenario fused into one Prometheus text response, with `?label=k:v` to slice by the labels you set on each scenario. `GET /scenarios/{id}/metrics` is the per-scenario drain — one consumer pulls from one scenario's buffer. For Prometheus / vmagent / VictoriaMetrics jobs, use the aggregate endpoint: it survives multiple scrapers, covers every scenario without knowing IDs ahead of time, and behaves like a normal exporter. See [Aggregate Prometheus scrape](../deployment/sonda-server.md#aggregate-prometheus-scrape) for the full reference.
+`sonda-server` exposes two scrape endpoints. `GET /metrics` is the aggregate view — every running scenario fused into one Prometheus text response, with `?label=k:v` to slice by the labels you set on each scenario. `GET /scenarios/{id}/metrics` is the per-scenario view — the current value of every series for one scenario. Both endpoints are idempotent snapshots: one sample per `(name, labels)` series with no timestamp, exactly like a `node_exporter` scrape. For Prometheus / vmagent / VictoriaMetrics jobs, the aggregate endpoint is the right call: one job covers every scenario without knowing IDs ahead of time, and it behaves like a normal exporter. See [Aggregate Prometheus scrape](../deployment/sonda-server.md#aggregate-prometheus-scrape) for the full reference.
 
 ### Aggregate scrape config
 
@@ -256,7 +256,7 @@ The target address uses the Kubernetes Service DNS name (`sonda.<namespace>.svc`
 
 ### Per-scenario scrape config
 
-If you want one scrape job per scenario — typically when each scenario is its own logical target — point `metrics_path` at the scenario ID. The endpoint drains its buffer on every scrape, so only one consumer should pull from a given ID at a time:
+If you want one scrape job per scenario — typically when each scenario is its own logical target — point `metrics_path` at the scenario ID:
 
 ```yaml title="prometheus-scrape.yaml"
 scrape_configs:

--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -54,7 +54,7 @@ src/
 │   ├── core_loop.rs    ← pub(crate) shared schedule loop (run_schedule_loop, TickFn, TickContext,
 │   │                      TickResult). Owns all rate control, gap/burst/spike window handling,
 │   │                      stats tracking, and shutdown. Signal runners provide a TickFn closure.
-│   ├── stats.rs        ← ScenarioStats (live telemetry + recent_metrics buffer for scrape endpoints)
+│   ├── stats.rs        ← ScenarioStats (live telemetry + current_values map: one entry per series for scrape endpoints)
 │   ├── handle.rs       ← ScenarioHandle (lifecycle: stop, join, elapsed, stats_snapshot;
 │   │                      recovers from poisoned stats lock instead of panicking)
 │   ├── launch.rs       ← validate_entry + prepare_entries + launch_scenario (unified launch API,

--- a/sonda-core/src/encoder/prometheus.rs
+++ b/sonda-core/src/encoder/prometheus.rs
@@ -24,15 +24,18 @@ use super::Encoder;
 /// metric_name value timestamp_ms\n
 /// ```
 ///
-/// The timestamp is in milliseconds since the Unix epoch (integer).
+/// The timestamp is in milliseconds since the Unix epoch (integer) and is
+/// emitted by default. HTTP scrape endpoints opt out via
+/// [`PrometheusText::with_emit_timestamp`]`(false)` so the rendered exposition
+/// matches what `node_exporter` and Prometheus self-scrape produce.
 ///
 /// Label values are escaped: `\` → `\\`, `"` → `\"`, newline → `\n`.
 ///
 /// When `precision` is set, metric values are formatted to the specified number
 /// of decimal places (e.g., precision=2 formats `99.60573` as `99.61`).
 pub struct PrometheusText {
-    /// Optional decimal precision for metric values.
     precision: Option<u8>,
+    emit_timestamp: bool,
 }
 
 impl PrometheusText {
@@ -41,7 +44,17 @@ impl PrometheusText {
     /// `precision` optionally limits the number of decimal places in metric values.
     /// `None` preserves full `f64` precision (default behavior).
     pub fn new(precision: Option<u8>) -> Self {
-        Self { precision }
+        Self {
+            precision,
+            emit_timestamp: true,
+        }
+    }
+
+    /// Toggle per-sample timestamp emission. Default is `true` (CLI stream
+    /// behavior); HTTP scrape handlers set `false` for spec-correct output.
+    pub fn with_emit_timestamp(mut self, emit_timestamp: bool) -> Self {
+        self.emit_timestamp = emit_timestamp;
+        self
     }
 }
 
@@ -108,15 +121,15 @@ impl Encoder for PrometheusText {
         // Value: write f64, optionally with fixed decimal precision
         super::write_value(buf, event.value, self.precision);
 
-        // Timestamp in milliseconds since epoch
-        let timestamp_ms = event
-            .timestamp
-            .duration_since(UNIX_EPOCH)
-            .map_err(|e| SondaError::Encoder(EncoderError::TimestampBeforeEpoch(e)))?
-            .as_millis();
-
-        buf.push(b' ');
-        write!(buf, "{timestamp_ms}").expect("write to Vec<u8> is infallible");
+        if self.emit_timestamp {
+            let timestamp_ms = event
+                .timestamp
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e| SondaError::Encoder(EncoderError::TimestampBeforeEpoch(e)))?
+                .as_millis();
+            buf.push(b' ');
+            write!(buf, "{timestamp_ms}").expect("write to Vec<u8> is infallible");
+        }
 
         buf.push(b'\n');
 
@@ -576,5 +589,70 @@ mod tests {
         assert_eq!(PromMetricType::Histogram.as_str(), "histogram");
         assert_eq!(PromMetricType::Summary.as_str(), "summary");
         assert_eq!(PromMetricType::Untyped.as_str(), "untyped");
+    }
+
+    #[test]
+    fn prometheus_text_default_constructor_emits_timestamp() {
+        let labels = Labels::from_pairs(&[("host", "srl1")]).unwrap();
+        let event = make_event("up", 1.0, labels, 1_700_000_000_000);
+        let enc = PrometheusText::new(None);
+        let mut buf = Vec::new();
+        enc.encode_metric(&event, &mut buf).unwrap();
+        assert_eq!(buf, b"up{host=\"srl1\"} 1 1700000000000\n");
+    }
+
+    #[test]
+    fn prometheus_text_with_emit_timestamp_false_omits_timestamp() {
+        let labels = Labels::from_pairs(&[("host", "srl1")]).unwrap();
+        let event = make_event("up", 1.0, labels, 1_700_000_000_000);
+        let enc = PrometheusText::new(None).with_emit_timestamp(false);
+        let mut buf = Vec::new();
+        enc.encode_metric(&event, &mut buf).unwrap();
+        assert_eq!(buf, b"up{host=\"srl1\"} 1\n");
+    }
+
+    #[test]
+    fn prometheus_text_with_emit_timestamp_false_no_labels_omits_timestamp() {
+        let labels = Labels::from_pairs(&[]).unwrap();
+        let event = make_event("up", 42.5, labels, 1_700_000_000_000);
+        let enc = PrometheusText::new(None).with_emit_timestamp(false);
+        let mut buf = Vec::new();
+        enc.encode_metric(&event, &mut buf).unwrap();
+        assert_eq!(buf, b"up 42.5\n");
+    }
+
+    #[test]
+    fn prometheus_text_with_emit_timestamp_true_then_false_round_trips() {
+        let labels = Labels::from_pairs(&[]).unwrap();
+        let event = make_event("up", 1.0, labels, 1_700_000_000_000);
+        let enc = PrometheusText::new(None)
+            .with_emit_timestamp(false)
+            .with_emit_timestamp(true);
+        let mut buf = Vec::new();
+        enc.encode_metric(&event, &mut buf).unwrap();
+        assert_eq!(buf, b"up 1 1700000000000\n");
+    }
+
+    #[test]
+    fn prometheus_text_with_emit_timestamp_false_still_emits_help_and_type_lines() {
+        let enc = PrometheusText::new(None).with_emit_timestamp(false);
+        let mut buf = Vec::new();
+        enc.encode_metadata("foo", PromMetricType::Gauge, Some("desc"), &mut buf)
+            .unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(out, "# HELP foo desc\n# TYPE foo gauge\n");
+    }
+
+    #[test]
+    fn prometheus_text_with_emit_timestamp_false_pre_epoch_does_not_error() {
+        let before_epoch = UNIX_EPOCH - Duration::from_secs(1);
+        let labels = Labels::from_pairs(&[]).unwrap();
+        let event =
+            MetricEvent::with_timestamp("up".to_string(), 1.0, labels, before_epoch).unwrap();
+        let enc = PrometheusText::new(None).with_emit_timestamp(false);
+        let mut buf = Vec::new();
+        enc.encode_metric(&event, &mut buf)
+            .expect("timestamp is not consulted when emission is disabled");
+        assert_eq!(buf, b"up 1\n");
     }
 }

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -1339,8 +1339,8 @@ mod tests {
 
         let st = stats.read().expect("lock must not be poisoned");
         assert!(
-            !st.recent_metrics.is_empty(),
-            "stats buffer must contain metric events"
+            !st.current_values.is_empty(),
+            "stats current_values must contain at least one series"
         );
     }
 

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -237,36 +237,12 @@ impl ScenarioHandle {
         }
     }
 
-    /// Drain and return recent metric events from the stats buffer.
-    ///
-    /// Acquires the write lock briefly, drains the buffered events, and
-    /// returns them ordered oldest-first. After this call the buffer is
-    /// empty. Subsequent calls return an empty vec until new events arrive.
-    ///
-    /// This is used by the scrape endpoint (`GET /scenarios/{id}/metrics`)
-    /// to retrieve the latest metric events for Prometheus text encoding.
-    ///
-    /// If the stats lock is poisoned (because a writer panicked), this method
-    /// recovers the data from the poisoned guard rather than propagating the
-    /// panic. The returned events may be incomplete but will not cause the
-    /// caller to panic.
-    pub fn recent_metrics(&self) -> Vec<crate::model::metric::MetricEvent> {
-        match self.stats.write() {
-            Ok(mut guard) => guard.drain_recent_metrics(),
-            Err(poisoned) => poisoned.into_inner().drain_recent_metrics(),
-        }
-    }
-
-    /// Clone the recent-metrics buffer without draining it.
+    /// Snapshot the current value of each series the scenario is emitting,
+    /// sorted by `(name, labels)` for deterministic output.
     pub fn recent_metrics_snapshot(&self) -> Vec<crate::model::metric::MetricEvent> {
         match self.stats.read() {
-            Ok(guard) => guard.recent_metrics.iter().cloned().collect(),
-            Err(poisoned) => poisoned
-                .into_inner()
-                .recent_metrics
-                .iter()
-                .cloned()
-                .collect(),
+            Ok(guard) => guard.current_values_snapshot(),
+            Err(poisoned) => poisoned.into_inner().current_values_snapshot(),
         }
     }
 }
@@ -498,9 +474,6 @@ mod tests {
         handle.join(None).ok();
     }
 
-    // ---- recent_metrics: drains from stats buffer ----------------------------
-
-    /// Helper to build a MetricEvent for testing.
     fn make_metric_event(name: &str, value: f64) -> crate::model::metric::MetricEvent {
         crate::model::metric::MetricEvent::new(
             name.to_string(),
@@ -510,57 +483,38 @@ mod tests {
         .expect("test metric name must be valid")
     }
 
-    /// recent_metrics on a fresh handle returns an empty Vec.
     #[test]
-    fn recent_metrics_on_fresh_handle_returns_empty() {
+    fn recent_metrics_snapshot_on_fresh_handle_returns_empty() {
         let handle = make_handle("test-rm-1", "fresh", 0, Duration::ZERO);
-        let events = handle.recent_metrics();
-        assert!(
-            events.is_empty(),
-            "recent_metrics must return empty Vec on a fresh handle"
-        );
+        assert!(handle.recent_metrics_snapshot().is_empty());
     }
 
-    /// recent_metrics drains events that were pushed to the stats buffer.
     #[test]
-    fn recent_metrics_drains_pushed_events() {
-        let handle = make_handle("test-rm-2", "drain", 0, Duration::ZERO);
-
-        // Push events directly into the stats buffer.
+    fn recent_metrics_snapshot_returns_current_values_not_history() {
+        let handle = make_handle("test-rm-2", "current", 0, Duration::ZERO);
         {
             let mut stats = handle.stats.write().expect("lock must not be poisoned");
             stats.push_metric(make_metric_event("up", 1.0));
             stats.push_metric(make_metric_event("up", 2.0));
+            stats.push_metric(make_metric_event("up", 3.0));
         }
-
-        let events = handle.recent_metrics();
-        assert_eq!(
-            events.len(),
-            2,
-            "recent_metrics must return all pushed events"
-        );
-        assert_eq!(events[0].value, 1.0, "first event must be value=1.0");
-        assert_eq!(events[1].value, 2.0, "second event must be value=2.0");
+        let events = handle.recent_metrics_snapshot();
+        assert_eq!(events.len(), 1, "same series must collapse to one entry");
+        assert_eq!(events[0].value, 3.0, "latest value must win");
     }
 
-    /// After calling recent_metrics, the buffer is empty (second call returns empty).
     #[test]
-    fn recent_metrics_clears_buffer_after_drain() {
-        let handle = make_handle("test-rm-3", "clear", 0, Duration::ZERO);
-
+    fn recent_metrics_snapshot_is_idempotent() {
+        let handle = make_handle("test-rm-3", "idempotent", 0, Duration::ZERO);
         {
             let mut stats = handle.stats.write().expect("lock must not be poisoned");
             stats.push_metric(make_metric_event("up", 42.0));
         }
-
-        let first = handle.recent_metrics();
+        let first = handle.recent_metrics_snapshot();
+        let second = handle.recent_metrics_snapshot();
         assert_eq!(first.len(), 1);
-
-        let second = handle.recent_metrics();
-        assert!(
-            second.is_empty(),
-            "second call to recent_metrics must return empty Vec after drain"
-        );
+        assert_eq!(second.len(), 1);
+        assert_eq!(first[0].value, second[0].value);
     }
 
     // ---- stats_snapshot: recovers from poisoned lock -------------------------
@@ -619,22 +573,16 @@ mod tests {
         );
     }
 
-    // ---- recent_metrics: recovers from poisoned lock --------------------------
-
-    /// If the stats lock is poisoned, recent_metrics recovers the data instead
-    /// of panicking.
     #[test]
-    fn recent_metrics_recovers_from_poisoned_lock() {
+    fn recent_metrics_snapshot_recovers_from_poisoned_lock() {
         let shutdown = Arc::new(AtomicBool::new(false));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        // Push a metric event before poisoning.
         {
             let mut guard = stats.write().expect("lock must not be poisoned");
             guard.push_metric(make_metric_event("up", 99.0));
         }
 
-        // Poison the lock.
         let stats_clone = Arc::clone(&stats);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _guard = stats_clone.write().expect("lock must not be poisoned");
@@ -664,17 +612,9 @@ mod tests {
             ))),
         );
 
-        // recent_metrics must not panic — it recovers from the poisoned lock.
-        let events = handle.recent_metrics();
-        assert_eq!(
-            events.len(),
-            1,
-            "must recover buffered events from poisoned lock"
-        );
-        assert_eq!(
-            events[0].value, 99.0,
-            "recovered event must have correct value"
-        );
+        let events = handle.recent_metrics_snapshot();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].value, 99.0);
     }
 
     // ---- Contract: ScenarioHandle is Send -----------------------------------

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -709,10 +709,8 @@ mod tests {
 
     // ---- Integration: stats buffer receives metric events ---------------------
 
-    /// When a stats arc is provided, the runner pushes metric events into the
-    /// recent_metrics buffer.
     #[test]
-    fn runner_pushes_metric_events_to_stats_buffer() {
+    fn runner_pushes_metric_events_to_stats_current_values() {
         use std::sync::{Arc, RwLock};
 
         let config = make_config(50.0, "200ms", None);
@@ -724,17 +722,8 @@ mod tests {
 
         let st = stats.read().expect("lock must not be poisoned");
         assert!(
-            !st.recent_metrics.is_empty(),
-            "runner must push events into the stats recent_metrics buffer, got {} events",
-            st.recent_metrics.len()
-        );
-        // The buffer is capped at MAX_RECENT_METRICS, so verify the count
-        // does not exceed that limit.
-        assert!(
-            st.recent_metrics.len() <= crate::schedule::stats::MAX_RECENT_METRICS,
-            "recent_metrics buffer must not exceed MAX_RECENT_METRICS ({}), got {}",
-            crate::schedule::stats::MAX_RECENT_METRICS,
-            st.recent_metrics.len()
+            !st.current_values.is_empty(),
+            "runner must push events into stats.current_values"
         );
     }
 
@@ -755,9 +744,8 @@ mod tests {
         );
     }
 
-    /// Stats buffer events have the correct metric name matching the config.
     #[test]
-    fn runner_stats_buffer_events_have_correct_metric_name() {
+    fn runner_stats_current_values_have_correct_metric_name() {
         use std::sync::{Arc, RwLock};
 
         let config = make_config(50.0, "100ms", None);
@@ -768,11 +756,8 @@ mod tests {
             .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
-        for event in st.recent_metrics.iter() {
-            assert_eq!(
-                &*event.name, "up",
-                "all buffered events must have the metric name from config"
-            );
+        for event in st.current_values.values() {
+            assert_eq!(&*event.name, "up");
         }
     }
 
@@ -967,10 +952,8 @@ mod tests {
     // ---- Arc sharing: name and labels are reference-counted, not deep-cloned ---
 
     /// All metric events buffered in stats must share the same Arc<str> name
-    /// allocation, proving that the runner uses Arc::clone (refcount bump)
-    /// instead of deep-cloning the name string on every tick.
     #[test]
-    fn buffered_events_share_name_arc_allocation() {
+    fn current_values_holds_one_entry_for_single_series_scenario() {
         use std::sync::{Arc, RwLock};
 
         let config = make_config(200.0, "100ms", None);
@@ -981,53 +964,17 @@ mod tests {
             .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
-        let events: Vec<_> = st.recent_metrics.iter().collect();
-        assert!(
-            events.len() >= 2,
-            "need at least 2 events to verify sharing, got {}",
-            events.len()
+        assert_eq!(
+            st.current_values.len(),
+            1,
+            "a single-series scenario must collapse to one current value"
         );
-
-        // All events should share the same Arc<str> allocation for the name.
-        let first_name = events[0].name.arc();
-        for (i, event) in events.iter().enumerate().skip(1) {
-            assert!(
-                Arc::ptr_eq(first_name, event.name.arc()),
-                "event[{i}].name should share Arc allocation with event[0].name"
-            );
-        }
-    }
-
-    /// When no cardinality spikes are configured, all buffered events must share
-    /// the same Arc<Labels> allocation, proving that the runner avoids
-    /// deep-cloning the BTreeMap on every tick.
-    #[test]
-    fn buffered_events_share_labels_arc_when_no_spikes() {
-        use std::sync::{Arc, RwLock};
-
-        let config = make_config(200.0, "100ms", None);
-        let mut sink = MemorySink::new();
-        let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
-
-        super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
-            .expect("run must succeed");
-
-        let st = stats.read().expect("lock must not be poisoned");
-        let events: Vec<_> = st.recent_metrics.iter().collect();
-        assert!(
-            events.len() >= 2,
-            "need at least 2 events to verify sharing, got {}",
-            events.len()
-        );
-
-        // All events should share the same Arc<Labels> allocation.
-        let first_labels = &events[0].labels;
-        for (i, event) in events.iter().enumerate().skip(1) {
-            assert!(
-                Arc::ptr_eq(first_labels, &event.labels),
-                "event[{i}].labels should share Arc allocation with event[0].labels"
-            );
-        }
+        let persisted = st
+            .current_values
+            .values()
+            .next()
+            .expect("runner must push at least one event");
+        assert_eq!(&*persisted.name, "up");
     }
 
     /// Invalid metric name in config is caught before the hot loop, not during.
@@ -1388,16 +1335,16 @@ mod tests {
     }
 
     #[test]
-    fn close_emit_emits_every_series_above_recent_metrics_cap() {
+    fn close_emit_emits_every_distinct_series_regardless_of_count() {
         use crate::encoder::create_encoder;
         use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
         use crate::schedule::core_loop::CloseSignal;
-        use crate::schedule::stats::{ScenarioStats, MAX_RECENT_METRICS};
+        use crate::schedule::stats::ScenarioStats;
         use crate::sink::memory::MemorySink;
         use std::sync::{Arc, RwLock};
         use std::time::SystemTime;
 
-        let series_count = MAX_RECENT_METRICS * 3;
+        let series_count: usize = 300;
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
         {
             let mut st = stats.write().unwrap();
@@ -1424,14 +1371,7 @@ mod tests {
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines = output.lines().filter(|l| !l.is_empty()).count();
-        assert_eq!(
-            lines, series_count,
-            "every distinct series must get a marker, even past the {MAX_RECENT_METRICS}-event scrape cap"
-        );
-        assert!(
-            lines > MAX_RECENT_METRICS,
-            "regression guard: marker count {lines} must exceed the scrape buffer cap"
-        );
+        assert_eq!(lines, series_count);
     }
 
     #[test]

--- a/sonda-core/src/schedule/stats.rs
+++ b/sonda-core/src/schedule/stats.rs
@@ -1,6 +1,6 @@
 //! Live statistics for a running scenario.
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -11,11 +11,8 @@ use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
 /// Dedup key for the close-emit series set: a distinct `(name, labels)` pair.
 pub type CloseEmitKey = (ValidatedMetricName, Arc<Labels>);
 
-/// Maximum number of recent metric events buffered for scrape endpoints.
-///
-/// This bounds memory usage to at most 100 `MetricEvent` clones per scenario.
-/// The buffer is a circular deque: when full, the oldest event is evicted.
-pub const MAX_RECENT_METRICS: usize = 100;
+/// Series identity for the [`ScenarioStats::current_values`] map.
+pub type MetricKey = (ValidatedMetricName, Arc<Labels>);
 
 /// How long since the last successful delivery before a failing scenario is
 /// considered degraded, in nanoseconds (30 seconds).
@@ -44,9 +41,9 @@ pub enum ScenarioState {
 /// [`std::sync::RwLock`]. The write lock is held only for the brief counter
 /// update, not during encode/write operations.
 ///
-/// The `recent_metrics` buffer holds the most recent metric events for
-/// scrape-based integration (e.g., Prometheus pulling from
-/// `GET /scenarios/{id}/metrics`). It is bounded by [`MAX_RECENT_METRICS`].
+/// The `current_values` map holds the current value of each distinct
+/// `(name, labels)` series the scenario has emitted. Scrape endpoints render
+/// one sample per series from this map.
 #[derive(Debug, Clone, Default, Serialize)]
 #[non_exhaustive]
 pub struct ScenarioStats {
@@ -72,14 +69,14 @@ pub struct ScenarioStats {
     pub last_sink_error: Option<String>,
     /// Wall-clock time of the most recent successful write, as Unix nanoseconds.
     pub last_successful_write_at: Option<u64>,
-    /// Circular buffer of recent metric events for scrape endpoints.
-    ///
-    /// Bounded by [`MAX_RECENT_METRICS`]. When full, the oldest event is
-    /// evicted on the next push. This field is not serialized because
-    /// [`MetricEvent`] does not implement `Serialize` and the buffer is
-    /// consumed via a dedicated drain method, not via JSON stats responses.
+    /// Current value of each distinct `(name, labels)` series the runner has
+    /// emitted since the scenario started. Overwritten in place on every new
+    /// emission for that series; bounded by series cardinality, not by sample
+    /// count. A cardinality-spike scenario that emits thousands of distinct
+    /// series will grow the map accordingly — that is the spec-correct
+    /// behavior for a Prometheus-style exporter.
     #[serde(skip)]
-    pub recent_metrics: VecDeque<MetricEvent>,
+    pub current_values: HashMap<MetricKey, MetricEvent>,
     /// Lifecycle state of the scenario.
     pub state: ScenarioState,
     /// Distinct `(name, labels)` series active since the last gate-close.
@@ -99,12 +96,10 @@ pub struct ScenarioStats {
 }
 
 impl ScenarioStats {
-    /// Push a metric event into the recent-metrics buffer.
-    ///
-    /// If the buffer is at capacity ([`MAX_RECENT_METRICS`]), the oldest
-    /// event is evicted before the new one is inserted. When
-    /// `track_close_series` is set, the event's `(name, labels)` series is
-    /// also recorded for close-emit.
+    /// Record a metric event as the current value of its `(name, labels)`
+    /// series. Overwrites any prior value for that series. When
+    /// `track_close_series` is set, the event's series is also recorded for
+    /// close-emit.
     pub fn push_metric(&mut self, event: MetricEvent) {
         // Only gated scenarios drain the series set on close; populating it
         // unconditionally would let a non-gated scenario's set grow unbounded.
@@ -113,10 +108,8 @@ impl ScenarioStats {
                 .insert((event.name.clone(), Arc::clone(&event.labels)));
             self.last_emit_ts = Some(event.timestamp);
         }
-        if self.recent_metrics.len() >= MAX_RECENT_METRICS {
-            self.recent_metrics.pop_front();
-        }
-        self.recent_metrics.push_back(event);
+        let key = (event.name.clone(), Arc::clone(&event.labels));
+        self.current_values.insert(key, event);
     }
 
     /// Enable close-emit series tracking. Called once when a close-emitter is
@@ -135,12 +128,16 @@ impl ScenarioStats {
         (series, ts)
     }
 
-    /// Drain and return all buffered metric events.
-    ///
-    /// After this call the buffer is empty. The returned events are ordered
-    /// oldest-first.
-    pub fn drain_recent_metrics(&mut self) -> Vec<MetricEvent> {
-        self.recent_metrics.drain(..).collect()
+    /// Snapshot the current value of each series, sorted by name then label
+    /// pairs so successive calls produce byte-identical output.
+    pub fn current_values_snapshot(&self) -> Vec<MetricEvent> {
+        let mut events: Vec<MetricEvent> = self.current_values.values().cloned().collect();
+        events.sort_by(|a, b| {
+            (*a.name)
+                .cmp(&b.name)
+                .then_with(|| a.labels.iter().cmp(b.labels.iter()))
+        });
+        events
     }
 
     /// Whether the scenario looks unhealthy. Returns `true` only when the
@@ -295,21 +292,12 @@ mod tests {
         assert_send_sync::<ScenarioStats>();
     }
 
-    // ---- recent_metrics buffer: default is empty ----------------------------
-
-    /// Default-constructed stats must have an empty recent_metrics buffer.
     #[test]
-    fn default_stats_has_empty_recent_metrics_buffer() {
+    fn default_stats_has_empty_current_values_map() {
         let s = ScenarioStats::default();
-        assert!(
-            s.recent_metrics.is_empty(),
-            "recent_metrics buffer must be empty on default construction"
-        );
+        assert!(s.current_values.is_empty());
     }
 
-    // ---- Helper: build a MetricEvent for testing ----------------------------
-
-    /// Build a MetricEvent with the given name and value for testing.
     fn make_metric_event(name: &str, value: f64) -> crate::model::metric::MetricEvent {
         crate::model::metric::MetricEvent::new(
             name.to_string(),
@@ -319,224 +307,110 @@ mod tests {
         .expect("test metric name must be valid")
     }
 
-    // ---- push_metric: adds events to the deque ------------------------------
-
-    /// push_metric adds a single event to the buffer.
-    #[test]
-    fn push_metric_adds_event_to_buffer() {
-        let mut s = ScenarioStats::default();
-        let event = make_metric_event("up", 1.0);
-        s.push_metric(event);
-        assert_eq!(
-            s.recent_metrics.len(),
-            1,
-            "buffer must contain exactly 1 event after one push"
-        );
+    fn make_labeled_event(
+        name: &str,
+        value: f64,
+        pairs: &[(&str, &str)],
+    ) -> crate::model::metric::MetricEvent {
+        let labels = crate::model::metric::Labels::from_pairs(pairs).expect("labels must build");
+        crate::model::metric::MetricEvent::new(name.to_string(), value, labels)
+            .expect("test metric name must be valid")
     }
 
-    /// push_metric preserves insertion order (oldest first).
     #[test]
-    fn push_metric_preserves_insertion_order() {
+    fn push_metric_inserts_new_series_into_current_values() {
         let mut s = ScenarioStats::default();
-        s.push_metric(make_metric_event("up", 10.0));
-        s.push_metric(make_metric_event("up", 20.0));
-        s.push_metric(make_metric_event("up", 30.0));
-
-        assert_eq!(s.recent_metrics.len(), 3);
-        assert_eq!(
-            s.recent_metrics[0].value, 10.0,
-            "first event must be the oldest (value=10.0)"
-        );
-        assert_eq!(
-            s.recent_metrics[1].value, 20.0,
-            "second event must be value=20.0"
-        );
-        assert_eq!(
-            s.recent_metrics[2].value, 30.0,
-            "third event must be the newest (value=30.0)"
-        );
+        s.push_metric(make_metric_event("up", 1.0));
+        assert_eq!(s.current_values.len(), 1);
     }
 
-    /// push_metric can fill the buffer up to MAX_RECENT_METRICS.
     #[test]
-    fn push_metric_fills_buffer_to_max_capacity() {
-        let mut s = ScenarioStats::default();
-        for i in 0..MAX_RECENT_METRICS {
-            s.push_metric(make_metric_event("up", i as f64));
-        }
-        assert_eq!(
-            s.recent_metrics.len(),
-            MAX_RECENT_METRICS,
-            "buffer must hold exactly MAX_RECENT_METRICS events"
-        );
-    }
-
-    // ---- push_metric: eviction when full ------------------------------------
-
-    /// When the buffer is full, push_metric evicts the oldest event.
-    #[test]
-    fn push_metric_evicts_oldest_when_full() {
-        let mut s = ScenarioStats::default();
-        // Fill to capacity with values 0..MAX_RECENT_METRICS.
-        for i in 0..MAX_RECENT_METRICS {
-            s.push_metric(make_metric_event("up", i as f64));
-        }
-        assert_eq!(s.recent_metrics.len(), MAX_RECENT_METRICS);
-
-        // The oldest event has value 0.0.
-        assert_eq!(
-            s.recent_metrics.front().unwrap().value,
-            0.0,
-            "oldest event before eviction must be value=0.0"
-        );
-
-        // Push one more event.
-        s.push_metric(make_metric_event("up", 999.0));
-
-        // Buffer size must not exceed MAX_RECENT_METRICS.
-        assert_eq!(
-            s.recent_metrics.len(),
-            MAX_RECENT_METRICS,
-            "buffer must not grow beyond MAX_RECENT_METRICS after eviction"
-        );
-
-        // The oldest event (value=0.0) was evicted; now value=1.0 is oldest.
-        assert_eq!(
-            s.recent_metrics.front().unwrap().value,
-            1.0,
-            "oldest event after eviction must be value=1.0"
-        );
-
-        // The newest event is value=999.0.
-        assert_eq!(
-            s.recent_metrics.back().unwrap().value,
-            999.0,
-            "newest event after eviction must be value=999.0"
-        );
-    }
-
-    /// Multiple evictions work correctly: push MAX + 5 events, oldest 5 are gone.
-    #[test]
-    fn push_metric_multiple_evictions_discard_oldest() {
-        let mut s = ScenarioStats::default();
-        let total = MAX_RECENT_METRICS + 5;
-        for i in 0..total {
-            s.push_metric(make_metric_event("up", i as f64));
-        }
-
-        assert_eq!(s.recent_metrics.len(), MAX_RECENT_METRICS);
-
-        // Oldest should be value 5.0 (0..4 evicted).
-        assert_eq!(
-            s.recent_metrics.front().unwrap().value,
-            5.0,
-            "after MAX+5 pushes, oldest event must be value=5.0"
-        );
-
-        // Newest should be value (total-1) = MAX_RECENT_METRICS + 4.
-        assert_eq!(
-            s.recent_metrics.back().unwrap().value,
-            (total - 1) as f64,
-            "newest event must be the last pushed value"
-        );
-    }
-
-    // ---- drain_recent_metrics: returns all and empties ----------------------
-
-    /// drain_recent_metrics returns all buffered events and empties the deque.
-    #[test]
-    fn drain_recent_metrics_returns_all_events_and_empties_buffer() {
+    fn push_metric_overwrites_existing_series_with_latest_value() {
         let mut s = ScenarioStats::default();
         s.push_metric(make_metric_event("up", 1.0));
         s.push_metric(make_metric_event("up", 2.0));
-        s.push_metric(make_metric_event("up", 3.0));
-
-        let drained = s.drain_recent_metrics();
-        assert_eq!(drained.len(), 3, "drain must return all 3 buffered events");
-        assert!(
-            s.recent_metrics.is_empty(),
-            "buffer must be empty after drain"
-        );
+        assert_eq!(s.current_values.len(), 1);
+        let snap = s.current_values_snapshot();
+        assert_eq!(snap[0].value, 2.0);
     }
 
-    /// drain_recent_metrics returns events ordered oldest-first.
     #[test]
-    fn drain_recent_metrics_returns_oldest_first_order() {
+    fn push_metric_distinguishes_different_label_sets() {
         let mut s = ScenarioStats::default();
-        s.push_metric(make_metric_event("up", 100.0));
-        s.push_metric(make_metric_event("up", 200.0));
-        s.push_metric(make_metric_event("up", 300.0));
-
-        let drained = s.drain_recent_metrics();
-        assert_eq!(drained[0].value, 100.0, "first drained must be oldest");
-        assert_eq!(drained[1].value, 200.0, "second drained must be middle");
-        assert_eq!(drained[2].value, 300.0, "third drained must be newest");
+        s.push_metric(make_labeled_event("up", 1.0, &[("host", "a")]));
+        s.push_metric(make_labeled_event("up", 2.0, &[("host", "b")]));
+        assert_eq!(s.current_values.len(), 2);
     }
 
-    /// drain_recent_metrics on an empty buffer returns an empty Vec.
     #[test]
-    fn drain_recent_metrics_on_empty_buffer_returns_empty_vec() {
+    fn current_values_snapshot_returns_one_event_per_series() {
         let mut s = ScenarioStats::default();
-        let drained = s.drain_recent_metrics();
-        assert!(
-            drained.is_empty(),
-            "draining an empty buffer must return an empty Vec"
-        );
+        for i in 0..100 {
+            s.push_metric(make_metric_event("up", i as f64));
+        }
+        let snap = s.current_values_snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].value, 99.0);
     }
 
-    /// After draining, pushing new events starts fresh.
     #[test]
-    fn drain_then_push_starts_fresh_buffer() {
+    fn current_values_snapshot_is_deterministic_across_calls() {
+        let mut s = ScenarioStats::default();
+        s.push_metric(make_labeled_event("up", 1.0, &[("host", "c")]));
+        s.push_metric(make_labeled_event("up", 2.0, &[("host", "a")]));
+        s.push_metric(make_labeled_event("up", 3.0, &[("host", "b")]));
+        s.push_metric(make_labeled_event("down", 9.0, &[]));
+
+        let first = s.current_values_snapshot();
+        let second = s.current_values_snapshot();
+        assert_eq!(first.len(), second.len());
+        for (a, b) in first.iter().zip(second.iter()) {
+            assert_eq!(&*a.name, &*b.name);
+            assert!(a.labels.iter().eq(b.labels.iter()));
+            assert_eq!(a.value, b.value);
+        }
+
+        let names: Vec<&str> = first.iter().map(|e| &*e.name).collect();
+        assert_eq!(names, vec!["down", "up", "up", "up"]);
+        let up_hosts: Vec<&str> = first
+            .iter()
+            .filter(|e| &*e.name == "up")
+            .map(|e| {
+                e.labels
+                    .iter()
+                    .next()
+                    .map(|(_, v)| v)
+                    .expect("label must exist")
+            })
+            .collect();
+        assert_eq!(up_hosts, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn current_values_grows_with_distinct_series_no_cap() {
+        let mut s = ScenarioStats::default();
+        for i in 0..200 {
+            s.push_metric(make_labeled_event(
+                "up",
+                i as f64,
+                &[("host", &format!("h{i}"))],
+            ));
+        }
+        assert_eq!(s.current_values.len(), 200);
+    }
+
+    #[test]
+    fn current_values_snapshot_on_empty_stats_returns_empty_vec() {
+        let s = ScenarioStats::default();
+        assert!(s.current_values_snapshot().is_empty());
+    }
+
+    #[test]
+    fn current_values_is_not_serialized_to_json() {
         let mut s = ScenarioStats::default();
         s.push_metric(make_metric_event("up", 1.0));
-        s.push_metric(make_metric_event("up", 2.0));
-
-        let first_drain = s.drain_recent_metrics();
-        assert_eq!(first_drain.len(), 2);
-        assert!(s.recent_metrics.is_empty());
-
-        // Push new events after drain.
-        s.push_metric(make_metric_event("up", 10.0));
-        assert_eq!(s.recent_metrics.len(), 1);
-
-        let second_drain = s.drain_recent_metrics();
-        assert_eq!(second_drain.len(), 1);
-        assert_eq!(
-            second_drain[0].value, 10.0,
-            "new event after drain must be retrievable"
-        );
-    }
-
-    /// Calling drain twice without intermediate pushes returns empty on second call.
-    #[test]
-    fn drain_twice_returns_empty_on_second_call() {
-        let mut s = ScenarioStats::default();
-        s.push_metric(make_metric_event("up", 42.0));
-
-        let first = s.drain_recent_metrics();
-        assert_eq!(first.len(), 1);
-
-        let second = s.drain_recent_metrics();
-        assert!(
-            second.is_empty(),
-            "second drain must return empty Vec after first drain consumed all events"
-        );
-    }
-
-    // ---- recent_metrics is not serialized (serde skip) ----------------------
-
-    /// The recent_metrics field is skipped during JSON serialization.
-    #[test]
-    fn recent_metrics_buffer_is_not_serialized_to_json() {
-        let mut s = ScenarioStats::default();
-        s.push_metric(make_metric_event("up", 1.0));
-        s.push_metric(make_metric_event("up", 2.0));
-
         let json = serde_json::to_string(&s).expect("must serialize");
-        assert!(
-            !json.contains("recent_metrics"),
-            "recent_metrics must not appear in JSON output (serde skip): {json}"
-        );
+        assert!(!json.contains("current_values"));
     }
 
     // ---- is_degraded --------------------------------------------------------
@@ -563,7 +437,11 @@ mod tests {
             "non-gated scenario must not accumulate the series set"
         );
         assert!(s.last_emit_ts.is_none(), "watermark must stay unset");
-        assert_eq!(s.recent_metrics.len(), 10, "scrape buffer must still fill");
+        assert_eq!(
+            s.current_values.len(),
+            10,
+            "scrape map must hold one entry per distinct series"
+        );
     }
 
     #[test]
@@ -595,23 +473,15 @@ mod tests {
     }
 
     #[test]
-    fn series_set_is_uncapped_past_recent_metrics_cap() {
+    fn series_set_grows_with_distinct_series_uncapped() {
         let mut s = ScenarioStats::default();
         s.enable_close_series_tracking();
-        let count = MAX_RECENT_METRICS * 4;
+        let count = 400;
         for i in 0..count {
             s.push_metric(make_series_event("up", &format!("h{i}")));
         }
-        assert_eq!(
-            s.close_emit_series.len(),
-            count,
-            "series set must hold every distinct series, ignoring the scrape cap"
-        );
-        assert_eq!(
-            s.recent_metrics.len(),
-            MAX_RECENT_METRICS,
-            "scrape buffer stays capped"
-        );
+        assert_eq!(s.close_emit_series.len(), count);
+        assert_eq!(s.current_values.len(), count);
     }
 
     #[test]

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -7,8 +7,8 @@
 //! sample. `delay.close.stale_marker: false` disables the marker entirely.
 //! Non-`remote_write` sinks default to no close-emit; `snap_to` opts in.
 //!
-//! The recent-metrics buffer is capped at `MAX_RECENT_METRICS = 100`, so
-//! high-cardinality scenarios under-emit on close.
+//! The close-emit series set is uncapped, so high-cardinality scenarios
+//! still emit one stale marker per distinct series on close.
 
 #![cfg(feature = "config")]
 #![cfg(feature = "remote-write")]
@@ -140,8 +140,8 @@ fn run_with_capture(
         let _ = bus_for_thread;
     });
 
-    // Open then close after a short delay so the runner accumulates labels
-    // in stats.recent_metrics before the close commits.
+    // Open then close after a short delay so the runner accumulates the
+    // active series set before the close commits.
     if !open_at_start {
         thread::sleep(Duration::from_millis(50));
         bus.tick(1.0);
@@ -553,7 +553,7 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
         .expect("runner must succeed");
     });
 
-    // Let the scenario run for ~150ms so recent_metrics fills.
+    // Let the scenario run for ~150ms so the close-emit series set fills.
     thread::sleep(Duration::from_millis(150));
     let buf_before = capture.buf.lock().unwrap().clone();
 

--- a/sonda-core/tests/while_close_workshop_repro.rs
+++ b/sonda-core/tests/while_close_workshop_repro.rs
@@ -138,7 +138,7 @@ fn workshop_paused_finished_cascade_emits_stale_marker_via_multi_runner() {
     // Timeline (ms):
     //   0..200    primary UP   (value=1.0). Gate `>1` => CLOSED. downstream Pending->Paused.
     //   200..600  primary DOWN (value=2.0). Gate OPEN. delay.open=50ms debounce.
-    //   ~250      open commits. downstream Paused->Running. accumulates recent_metrics.
+    //   ~250      open commits. downstream Paused->Running. accumulates active series.
     //   600..800  primary UP. Gate CLOSE edge. delay.close=0 => commit immediately,
     //             close-emit fires (stale marker) and downstream goes Paused.
     //   800..1200 primary DOWN. Gate OPEN. open-commit at ~850. Running again.
@@ -362,9 +362,9 @@ scenarios:
 /// Mirrors the workshop's actual cascade: 1 primary + 7 downstream gated metrics
 /// (the 6 BGP counters from the workshop YAML + the operational status) all
 /// gated on the same `primary_flap` upstream. Each entry has its own GateBus
-/// subscriber, its own debounce, its own close-emit closure, its own
-/// recent_metrics buffer. If there's a multi-subscriber race in the GateBus
-/// broadcast or a per-entry stats-buffer issue, this exposes it.
+/// subscriber, its own debounce, its own close-emit closure, its own stats.
+/// If there's a multi-subscriber race in the GateBus broadcast or a per-entry
+/// stats issue, this exposes it.
 ///
 /// Expectation: every gated metric has >=1 stale-NaN sample reach the wire.
 #[test]
@@ -589,7 +589,7 @@ scenarios:
 /// Workshop: 2m duration, 90s flap cycle, 10s open debounce, 0s close debounce.
 /// Compressed-time tests run in microseconds — the workshop runs in seconds.
 /// Maybe at real-millisecond magnitudes something different happens around
-/// debounce reset, gate-edge ordering, or recent_metrics dedup.
+/// debounce reset, gate-edge ordering, or close-emit series dedup.
 ///
 /// Compressed here: 5s duration, 600ms up / 1200ms down (cycle 1.8s), 200ms
 /// open / 0s close. ~2.7 cycles → at least 2 running→paused transitions.

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -358,18 +358,16 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
     )
     .expect("launch must succeed");
 
-    // Phase 1: emit ~3 events (150ms at 20/s).
+    // Phase 1: emit ~3 events (150ms at 20/s). Single series → one entry.
     thread::sleep(Duration::from_millis(150));
-    let phase1 = handle.recent_metrics();
-    let phase1_count = phase1.len();
-    assert!(
-        (2..=4).contains(&phase1_count),
-        "phase 1 expected ~3 events, got {phase1_count}"
+    let phase1 = handle.recent_metrics_snapshot();
+    assert_eq!(
+        phase1.len(),
+        1,
+        "single series must collapse to one current value, got {}",
+        phase1.len()
     );
-    let last_phase1_value = phase1
-        .last()
-        .map(|e| e.value)
-        .expect("phase 1 must have at least one value");
+    let last_phase1_value = phase1[0].value;
 
     // Phase 2: close gate.
     bus.tick(0.0);
@@ -378,7 +376,7 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
     // Phase 3: reopen and let several more ticks fire.
     bus.tick(1.0);
     thread::sleep(Duration::from_millis(200));
-    let phase3 = handle.recent_metrics();
+    let phase3 = handle.recent_metrics_snapshot();
 
     handle.stop();
     handle.join(Some(Duration::from_secs(2))).ok();
@@ -436,9 +434,9 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
     )
     .expect("launch must succeed");
 
-    // Phase 1: ~10 ticks emitted (200ms at 50/s).
+    // Phase 1: ~10 ticks emitted (200ms at 50/s). Single series → one entry.
     thread::sleep(Duration::from_millis(200));
-    let phase1 = handle.recent_metrics();
+    let phase1 = handle.recent_metrics_snapshot();
     let last_pre_pause = phase1
         .last()
         .map(|e| e.value)
@@ -455,7 +453,7 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
     // Phase 3: resume.
     bus.tick(1.0);
     thread::sleep(Duration::from_millis(150));
-    let phase3 = handle.recent_metrics();
+    let phase3 = handle.recent_metrics_snapshot();
 
     handle.stop();
     handle.join(Some(Duration::from_secs(2))).ok();

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -11,7 +11,7 @@
 //! - `GET /scenarios` — list all scenarios with summary information.
 //! - `GET /scenarios/{id}` — inspect a single scenario with full detail and stats.
 //! - `GET /scenarios/{id}/stats` — return detailed live stats for a scenario.
-//! - `GET /scenarios/{id}/metrics` — return recent metrics in Prometheus text format (scrapeable).
+//! - `GET /scenarios/{id}/metrics` — return one Prometheus sample per series, no timestamps.
 //! - `DELETE /scenarios/{id}` — stop a running scenario and return final stats.
 //!
 //! All lifecycle logic is delegated to sonda-core. This module is pure HTTP
@@ -22,10 +22,10 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use axum::extract::{Path, Query, RawQuery, State};
+use axum::extract::{Path, RawQuery, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Json, Response};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::json;
 use sonda_core::compiler::parse::detect_version;
 use sonda_core::encoder::prometheus::PrometheusText;
@@ -762,44 +762,18 @@ pub async fn get_scenario_stats(
 
 // ---- Scrape endpoint --------------------------------------------------------
 
-/// Query parameters for `GET /scenarios/{id}/metrics`.
-#[derive(Debug, Deserialize)]
-pub struct MetricsQuery {
-    /// Maximum number of recent metric events to return. Defaults to 100,
-    /// capped at 1000.
-    pub limit: Option<usize>,
-}
-
 /// Prometheus text exposition format content type.
 const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
 
-/// `GET /scenarios/{id}/metrics` — return recent metrics in Prometheus text format.
+/// `GET /scenarios/{id}/metrics` — emit one Prometheus sample per series.
 ///
-/// Drains the recent metric event buffer from the scenario handle, encodes
-/// each event using the Prometheus text encoder, and returns the result with
-/// `Content-Type: text/plain; version=0.0.4; charset=utf-8`.
-///
-/// This endpoint is designed to be scraped by Prometheus or vmagent. Each
-/// call drains the buffer, so repeated scrapes within the same tick interval
-/// may return fewer events.
-///
-/// # Query parameters
-///
-/// * `limit` — maximum number of events to return (default 100, max 1000).
-///
-/// # Responses
-///
-/// * `200 OK` — Prometheus text exposition (possibly empty when no events
-///   are buffered between scrapes).
-/// * `404 Not Found` — scenario ID not found.
+/// Returns the current value of every series the scenario has emitted so far,
+/// encoded in Prometheus text exposition format with no per-sample timestamp,
+/// matching the shape that `node_exporter` and Prometheus self-scrape produce.
 pub async fn get_scenario_metrics(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    Query(query): Query<MetricsQuery>,
 ) -> Result<Response, Response> {
-    let limit = query.limit.unwrap_or(100).min(1000);
-
-    // Look up the scenario by ID.
     let scenarios = state
         .scenarios
         .read()
@@ -809,25 +783,11 @@ pub async fn get_scenario_metrics(
         .get(&id)
         .ok_or_else(|| not_found(format!("scenario not found: {id}")))?;
 
-    // Drain recent metric events from the handle's stats buffer.
-    let events = handle.recent_metrics();
+    let events = handle.recent_metrics_snapshot();
 
-    // Empty buffer renders as `200 OK` with an empty Prometheus exposition,
-    // matching the contract Prometheus / vmagent / Telegraf scrapers expect.
-    // Returning 204 here breaks scrapers that use `curl --fail` or treat
-    // anything but 200 as an exposition error.
-    let events_to_encode: &[_] = if events.is_empty() {
-        &[]
-    } else if events.len() > limit {
-        &events[events.len() - limit..]
-    } else {
-        &events
-    };
-
-    // Encode each event into Prometheus text format.
-    let encoder = PrometheusText::new(None);
-    let mut buf = Vec::with_capacity(events_to_encode.len() * 128 + 256);
-    if !events_to_encode.is_empty() {
+    let encoder = PrometheusText::new(None).with_emit_timestamp(false);
+    let mut buf = Vec::with_capacity(events.len() * 128 + 256);
+    if !events.is_empty() {
         if let Some(meta) = handle.prometheus_meta.as_ref() {
             if let Err(e) = encoder.encode_metadata(
                 &handle.name,
@@ -839,7 +799,7 @@ pub async fn get_scenario_metrics(
             }
         }
     }
-    for event in events_to_encode {
+    for event in &events {
         if let Err(e) = encoder.encode_metric(event, &mut buf) {
             warn!(id = %id, error = %e, "GET /scenarios/{id}/metrics: failed to encode metric event");
         }
@@ -927,7 +887,7 @@ pub async fn get_aggregate_metrics(
     let mut ids: Vec<&String> = scenarios.keys().collect();
     ids.sort();
 
-    let encoder = PrometheusText::new(None);
+    let encoder = PrometheusText::new(None).with_emit_timestamp(false);
     let mut buf = Vec::new();
     let mut groups: Vec<AggregateGroup> = Vec::new();
     for id in ids {
@@ -3410,19 +3370,6 @@ scenarios:
         app.oneshot(req).await.unwrap()
     }
 
-    /// Helper: send a GET /scenarios/{id}/metrics?limit=N request.
-    async fn get_metrics_with_limit(
-        app: axum::Router,
-        id: &str,
-        limit: usize,
-    ) -> hyper::Response<axum::body::Body> {
-        let req = Request::builder()
-            .uri(format!("/scenarios/{id}/metrics?limit={limit}"))
-            .body(Body::empty())
-            .unwrap();
-        app.oneshot(req).await.unwrap()
-    }
-
     /// Helper: extract the body as a String from a response.
     async fn body_string(response: axum::response::Response) -> String {
         let bytes = response.into_body().collect().await.unwrap().to_bytes();
@@ -3472,7 +3419,6 @@ scenarios:
 
     // ---- Metrics scrape: returns Prometheus text format ----------------------
 
-    /// GET /scenarios/{id}/metrics returns Prometheus text exposition format.
     #[tokio::test]
     async fn metrics_endpoint_returns_prometheus_text_format() {
         let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
@@ -3483,22 +3429,79 @@ scenarios:
         assert_eq!(resp.status(), StatusCode::OK);
 
         let body = body_string(resp).await;
-
-        // Each event should produce a line starting with "up". TYPE/HELP lines (starting with '#')
-        // appear once per metric name and are filtered out here.
         let sample_lines: Vec<&str> = body.lines().filter(|line| !line.starts_with('#')).collect();
-        assert!(
-            sample_lines.len() >= 2,
-            "must have at least 2 sample lines of Prometheus text, got {}",
-            sample_lines.len()
+        assert_eq!(
+            sample_lines.len(),
+            1,
+            "same series must collapse to one sample, got {sample_lines:?}"
         );
+        assert!(
+            sample_lines[0].starts_with("up"),
+            "sample must start with metric name 'up', got: {}",
+            sample_lines[0]
+        );
+    }
 
-        for line in &sample_lines {
-            assert!(
-                line.starts_with("up"),
-                "each sample line must start with the metric name 'up', got: {line}"
-            );
+    #[tokio::test]
+    async fn per_scenario_metrics_emits_one_sample_per_series_no_timestamp() {
+        let events = vec![make_metric_event("up", 42.0)];
+        let h = make_handle_with_metrics("id-no-ts", "no_ts", events);
+        let app = router_with_handles(vec![h]);
+
+        let resp = get_metrics_req(app, "id-no-ts").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp).await;
+        let sample_lines: Vec<&str> = body.lines().filter(|l| !l.starts_with('#')).collect();
+        assert_eq!(sample_lines.len(), 1);
+        assert_eq!(
+            sample_lines[0], "up 42",
+            "sample must omit trailing timestamp, got: {}",
+            sample_lines[0]
+        );
+        assert!(
+            body.ends_with("up 42\n"),
+            "body must end with value+newline, no timestamp: {body:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn per_scenario_metrics_distinct_series_emit_distinct_samples() {
+        let events = vec![
+            labeled_metric_event("up", 1.0, &[("host", "a")]),
+            labeled_metric_event("up", 2.0, &[("host", "b")]),
+        ];
+        let h = make_handle_with_metrics("id-distinct", "distinct", events);
+        let app = router_with_handles(vec![h]);
+
+        let resp = get_metrics_req(app, "id-distinct").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        let sample_lines: Vec<&str> = body.lines().filter(|l| !l.starts_with('#')).collect();
+        assert_eq!(sample_lines.len(), 2, "got: {body:?}");
+    }
+
+    #[tokio::test]
+    async fn per_scenario_metrics_idempotent_across_scrapes() {
+        let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
+        let h = make_handle_with_metrics("id-idem", "idem", events);
+        let state = AppState::new();
+        {
+            let mut map = state.scenarios.write().unwrap();
+            map.insert(h.id.clone(), h);
         }
+
+        let app1 = router(state.clone());
+        let body_1 = body_string(get_metrics_req(app1, "id-idem").await).await;
+        let app2 = router(state.clone());
+        let body_2 = body_string(get_metrics_req(app2, "id-idem").await).await;
+        assert_eq!(
+            body_1, body_2,
+            "two scrapes must return byte-identical bodies"
+        );
+        assert!(!body_1.is_empty(), "first scrape must not be empty");
+
+        cleanup_scenarios(&state);
     }
 
     // ---- Metrics scrape: correct Content-Type header ------------------------
@@ -3525,94 +3528,6 @@ scenarios:
         );
     }
 
-    // ---- Metrics scrape: ?limit=N returns at most N events ------------------
-
-    /// GET /scenarios/{id}/metrics?limit=2 returns at most 2 events from a buffer of 5.
-    #[tokio::test]
-    async fn metrics_endpoint_limit_parameter_caps_event_count() {
-        let events: Vec<_> = (0..5).map(|i| make_metric_event("up", i as f64)).collect();
-        let h = make_handle_with_metrics("id-metrics-limit", "limit_test", events);
-        let app = router_with_handles(vec![h]);
-
-        let resp = get_metrics_with_limit(app, "id-metrics-limit", 2).await;
-        assert_eq!(resp.status(), StatusCode::OK);
-
-        let body = body_string(resp).await;
-        let sample_lines: Vec<&str> = body.lines().filter(|line| !line.starts_with('#')).collect();
-        assert_eq!(
-            sample_lines.len(),
-            2,
-            "limit=2 must produce exactly 2 sample lines of output, got {}",
-            sample_lines.len()
-        );
-    }
-
-    /// GET /scenarios/{id}/metrics?limit=N returns the most recent N events.
-    #[tokio::test]
-    async fn metrics_endpoint_limit_returns_most_recent_events() {
-        // Push 5 events with values 0.0, 1.0, 2.0, 3.0, 4.0.
-        let events: Vec<_> = (0..5).map(|i| make_metric_event("val", i as f64)).collect();
-        let h = make_handle_with_metrics("id-metrics-recent", "recent_test", events);
-        let app = router_with_handles(vec![h]);
-
-        // Request only the most recent 2.
-        let resp = get_metrics_with_limit(app, "id-metrics-recent", 2).await;
-        assert_eq!(resp.status(), StatusCode::OK);
-
-        let body = body_string(resp).await;
-        // The last 2 events have values 3.0 and 4.0.
-        assert!(
-            body.contains("3"),
-            "limited output must contain the second-to-last event value (3.0)"
-        );
-        assert!(
-            body.contains("4"),
-            "limited output must contain the last event value (4.0)"
-        );
-    }
-
-    /// `limit=0` drains the buffer but encodes zero events; returns 200 with empty body.
-    #[tokio::test]
-    async fn metrics_endpoint_limit_zero_returns_200_empty_body() {
-        let events = vec![make_metric_event("up", 1.0)];
-        let h = make_handle_with_metrics("id-metrics-lim0", "lim0_test", events);
-        let app = router_with_handles(vec![h]);
-
-        let resp = get_metrics_with_limit(app, "id-metrics-lim0", 0).await;
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    // ---- Metrics scrape: drain clears buffer --------------------------------
-
-    /// After scraping, a second request returns 200 with an empty body because
-    /// the buffer was drained. Prometheus contract: 200 with empty exposition,
-    /// not 204.
-    #[tokio::test]
-    async fn metrics_endpoint_drain_clears_buffer_second_request_returns_200_empty() {
-        let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
-        let h = make_handle_with_metrics("id-metrics-drain", "drain_test", events);
-        let state = AppState::new();
-        {
-            let mut map = state.scenarios.write().unwrap();
-            map.insert(h.id.clone(), h);
-        }
-
-        let app1 = router(state.clone());
-        let resp1 = get_metrics_req(app1, "id-metrics-drain").await;
-        assert_eq!(resp1.status(), StatusCode::OK);
-        assert!(!body_string(resp1).await.is_empty());
-
-        let app2 = router(state.clone());
-        let resp2 = get_metrics_req(app2, "id-metrics-drain").await;
-        assert_eq!(resp2.status(), StatusCode::OK);
-        assert!(
-            body_string(resp2).await.is_empty(),
-            "drained buffer must render as empty Prometheus exposition"
-        );
-
-        cleanup_scenarios(&state);
-    }
-
     // ---- Metrics scrape: 404 returns JSON Content-Type ----------------------
 
     /// GET /scenarios/{id}/metrics 404 has Content-Type application/json.
@@ -3635,17 +3550,15 @@ scenarios:
         );
     }
 
-    // ---- Metrics scrape: limit defaults to 100 (implicit) -------------------
-
-    /// Without a limit parameter, all buffered events (up to 100 default) are returned.
     #[tokio::test]
-    async fn metrics_endpoint_default_limit_returns_all_buffered_events() {
-        // Push 5 events, no limit parameter.
-        let events: Vec<_> = (0..5).map(|i| make_metric_event("up", i as f64)).collect();
-        let h = make_handle_with_metrics("id-metrics-nomax", "nomax_test", events);
+    async fn metrics_endpoint_emits_one_sample_per_distinct_series() {
+        let events: Vec<_> = (0..5)
+            .map(|i| labeled_metric_event("up", i as f64, &[("host", &format!("h{i}"))]))
+            .collect();
+        let h = make_handle_with_metrics("id-metrics-five", "five_series", events);
         let app = router_with_handles(vec![h]);
 
-        let resp = get_metrics_req(app, "id-metrics-nomax").await;
+        let resp = get_metrics_req(app, "id-metrics-five").await;
         assert_eq!(resp.status(), StatusCode::OK);
 
         let body = body_string(resp).await;
@@ -3653,28 +3566,7 @@ scenarios:
         assert_eq!(
             sample_lines.len(),
             5,
-            "all 5 buffered events must be returned when no limit is specified"
-        );
-    }
-
-    // ---- Metrics scrape: limit larger than buffer returns all events ---------
-
-    /// When limit > buffer size, all buffered events are returned.
-    #[tokio::test]
-    async fn metrics_endpoint_limit_larger_than_buffer_returns_all() {
-        let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
-        let h = make_handle_with_metrics("id-metrics-biglim", "biglim_test", events);
-        let app = router_with_handles(vec![h]);
-
-        let resp = get_metrics_with_limit(app, "id-metrics-biglim", 500).await;
-        assert_eq!(resp.status(), StatusCode::OK);
-
-        let body = body_string(resp).await;
-        let sample_lines: Vec<&str> = body.lines().filter(|line| !line.starts_with('#')).collect();
-        assert_eq!(
-            sample_lines.len(),
-            2,
-            "when limit > buffer size, all buffered events must be returned"
+            "five distinct series must produce five samples, got {sample_lines:?}"
         );
     }
 
@@ -3784,7 +3676,10 @@ scenarios:
 
     #[tokio::test]
     async fn aggregate_metrics_single_scenario_no_filter_returns_events() {
-        let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
+        let events = vec![
+            labeled_metric_event("up", 1.0, &[("host", "a")]),
+            labeled_metric_event("up", 2.0, &[("host", "b")]),
+        ];
         let h = make_handle_with_labels_and_metrics("agg-1", "single", vec![], events);
         let app = router_with_handles(vec![h]);
 
@@ -3793,19 +3688,56 @@ scenarios:
 
         let body = body_string(resp).await;
         let sample_lines: Vec<&str> = body.lines().filter(|line| !line.starts_with('#')).collect();
-        assert_eq!(sample_lines.len(), 2, "must encode 2 events, got: {body:?}");
+        assert_eq!(sample_lines.len(), 2, "must encode 2 series, got: {body:?}");
         for line in &sample_lines {
             assert!(
                 line.starts_with("up"),
                 "each sample line must start with metric name 'up', got: {line}"
             );
+            assert!(
+                !line.chars().last().unwrap().is_ascii_digit() || !line.contains(" 17"),
+                "no trailing timestamp expected on aggregate scrape, got: {line}"
+            );
         }
     }
 
     #[tokio::test]
-    async fn aggregate_metrics_snapshot_is_non_destructive() {
-        let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
-        let h = make_handle_with_labels_and_metrics("agg-snap", "snap", vec![], events);
+    async fn aggregate_metrics_emits_one_sample_per_series_no_timestamp() {
+        let h1 = make_handle_with_labels_and_metrics(
+            "agg-no-ts-1",
+            "scrape",
+            vec![("device", "srl1")],
+            vec![make_metric_event("up", 1.0)],
+        );
+        let h2 = make_handle_with_labels_and_metrics(
+            "agg-no-ts-2",
+            "scrape",
+            vec![("device", "srl2")],
+            vec![make_metric_event("up", 2.0)],
+        );
+        let app = router_with_handles(vec![h1, h2]);
+
+        let resp = get_aggregate_req(app, "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        let sample_lines: Vec<&str> = body.lines().filter(|l| !l.starts_with('#')).collect();
+        assert_eq!(sample_lines.len(), 2);
+        for line in &sample_lines {
+            assert!(
+                line == &"up 1" || line == &"up 2",
+                "each sample must be exactly metric+value with no timestamp, got: {line}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn aggregate_metrics_idempotent_across_scrapes() {
+        let h = make_handle_with_labels_and_metrics(
+            "agg-idem",
+            "idem",
+            vec![],
+            vec![make_metric_event("up", 7.0)],
+        );
         let state = AppState::new();
         {
             let mut map = state.scenarios.write().unwrap();
@@ -3814,26 +3746,22 @@ scenarios:
 
         let app1 = router(state.clone());
         let body_1 = body_string(get_aggregate_req(app1, "").await).await;
-
         let app2 = router(state.clone());
         let body_2 = body_string(get_aggregate_req(app2, "").await).await;
-
-        assert_eq!(
-            body_1, body_2,
-            "two snapshot calls must return identical bodies"
-        );
-        assert!(
-            !body_1.trim().is_empty(),
-            "snapshot must include the pushed events"
-        );
+        assert_eq!(body_1, body_2);
+        assert!(!body_1.trim().is_empty());
 
         cleanup_scenarios(&state);
     }
 
     #[tokio::test]
-    async fn per_scenario_metrics_still_drains_after_aggregate_snapshot() {
-        let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
-        let h = make_handle_with_labels_and_metrics("agg-drain", "drain", vec![], events);
+    async fn aggregate_and_per_scenario_scrapes_are_both_idempotent() {
+        let h = make_handle_with_labels_and_metrics(
+            "agg-both",
+            "both",
+            vec![],
+            vec![make_metric_event("up", 1.0)],
+        );
         let state = AppState::new();
         {
             let mut map = state.scenarios.write().unwrap();
@@ -3842,20 +3770,17 @@ scenarios:
 
         let agg_app = router(state.clone());
         let agg_body = body_string(get_aggregate_req(agg_app, "").await).await;
-        assert!(!agg_body.trim().is_empty(), "aggregate must see the events");
+        assert!(!agg_body.trim().is_empty());
 
         let per_app = router(state.clone());
-        let per_body = body_string(get_metrics_req(per_app, "agg-drain").await).await;
-        assert!(
-            !per_body.trim().is_empty(),
-            "per-scenario scrape must still drain the buffer"
-        );
+        let per_body = body_string(get_metrics_req(per_app, "agg-both").await).await;
+        assert!(!per_body.trim().is_empty());
 
         let per_app_2 = router(state.clone());
-        let per_body_2 = body_string(get_metrics_req(per_app_2, "agg-drain").await).await;
-        assert!(
-            per_body_2.trim().is_empty(),
-            "second per-scenario scrape must return empty after drain"
+        let per_body_2 = body_string(get_metrics_req(per_app_2, "agg-both").await).await;
+        assert_eq!(
+            per_body, per_body_2,
+            "per-scenario scrape must be idempotent"
         );
 
         cleanup_scenarios(&state);
@@ -4095,25 +4020,6 @@ scenarios:
         assert!(filters.is_empty());
         let filters2 = parse_label_filters(Some("")).expect("must parse");
         assert!(filters2.is_empty());
-    }
-
-    // ---- MetricsQuery deserialization ----------------------------------------
-
-    /// MetricsQuery with no fields deserializes with limit=None.
-    #[test]
-    fn metrics_query_default_limit_is_none() {
-        let q: MetricsQuery = serde_json::from_str("{}").expect("must deserialize");
-        assert!(
-            q.limit.is_none(),
-            "limit must default to None when not specified"
-        );
-    }
-
-    /// MetricsQuery with limit=50 deserializes correctly.
-    #[test]
-    fn metrics_query_with_limit_deserializes() {
-        let q: MetricsQuery = serde_json::from_str(r#"{"limit": 50}"#).expect("must deserialize");
-        assert_eq!(q.limit, Some(50));
     }
 
     // ---- PROMETHEUS_CONTENT_TYPE constant ------------------------------------

--- a/sonda-server/tests/metrics.rs
+++ b/sonda-server/tests/metrics.rs
@@ -264,6 +264,80 @@ scenarios:
       value: 42
 "#;
 
+const AUTOCON5_REPRO_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: autocon5_up
+    signal_type: metrics
+    name: autocon5_up
+    labels:
+      device: srl1
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+#[test]
+fn autocon5_repro_one_line_per_series_at_rate_10() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("Content-Type", "text/yaml")
+        .body(AUTOCON5_REPRO_YAML)
+        .send()
+        .expect("POST autocon5_up must succeed");
+    assert_eq!(resp.status().as_u16(), 201);
+
+    // Wait long enough that the broken ring-buffer would have ~20 samples.
+    thread::sleep(Duration::from_secs(2));
+
+    let body_first = scrape_sample_lines(&client, &base);
+    assert_eq!(
+        body_first.len(),
+        1,
+        "autocon5 repro: exactly one sample per series, got: {body_first:?}"
+    );
+    let line = &body_first[0];
+    assert!(
+        line.starts_with("autocon5_up{") && line.ends_with(" 1"),
+        "sample must be `<name>{{labels}} <value>` with no trailing timestamp, got: {line}"
+    );
+
+    // Repeat scrapes — idempotent. The exact body bytes must match because
+    // there's no per-sample timestamp to drift.
+    let body_again = scrape_sample_lines(&client, &base);
+    assert_eq!(body_first, body_again, "scrape must be idempotent");
+
+    thread::sleep(Duration::from_secs(1));
+    let body_later = scrape_sample_lines(&client, &base);
+    assert_eq!(body_later.len(), 1, "still one sample 1s later");
+}
+
+fn scrape_sample_lines(client: &reqwest::blocking::Client, base: &str) -> Vec<String> {
+    let resp = client
+        .get(format!("{base}/metrics"))
+        .send()
+        .expect("GET /metrics must succeed");
+    assert_eq!(resp.status().as_u16(), 200);
+    resp.text()
+        .expect("body must be UTF-8")
+        .lines()
+        .filter(|l| !l.starts_with('#') && !l.is_empty())
+        .map(|l| l.to_string())
+        .collect()
+}
+
 #[test]
 fn e2e_yaml_metric_type_field_reaches_scrape_output() {
     let (port, _guard) = common::start_server();


### PR DESCRIPTION
## Summary

Both `/metrics` endpoints (aggregate and per-scenario) now match the Prometheus exposition spec: one sample per `(name, labels)` series with the current value, no per-sample timestamp. Previously they emitted up to 100 sample lines per series with millisecond timestamps. That violated the spec — "a given metric SHOULD only be reported once per scrape" — and made `curl /metrics` look broken to anyone inspecting it.

Side-by-side at `rate: 10` against one scenario, scraping at 15s wall time:

| Endpoint | Lines per series | Trailing timestamp |
|---|---|---|
| node_exporter | 1 | no |
| Prometheus self-scrape | 1 | no |
| sonda 1.12.1 `/metrics` (before this PR) | up to 100 | yes (ms) |
| sonda after this PR | 1 | no |

Body size for a single gauge scenario goes from ~10KB to ~60 bytes.

- Replace the `recent_metrics: VecDeque<MetricEvent>` ring buffer with a `current_values: HashMap<(name, labels), MetricEvent>` map; `push_metric` becomes insert-or-overwrite per series
- Add `emit_timestamp` flag on `PrometheusText` (default `true` for CLI streams); HTTP scrape handlers opt out
- Remove the drain variant of `ScenarioHandle::recent_metrics()`; both endpoints now use snapshot semantics and are byte-identical across consecutive scrapes
- Drop `?limit=` query param on `/scenarios/{id}/metrics` (meaningless under one-per-series)
- CLI streaming sinks (`stdout`, `file`, `tcp`, ...) unchanged — they still emit timestamps per event for stream identity over time
- Update user-facing docs across `sonda-server.md`, `kubernetes.md`, `synthetic-monitoring.md`, `scenario-fields.md`

## Test plan

- [ ] `cargo build --workspace`
- [ ] `cargo nextest run --workspace` (includes `autocon5_repro_one_line_per_series_at_rate_10` regression guard)
- [ ] POST a scenario at `rate: 10`; `curl /metrics` at 1s, 5s, 15s, 30s — body always contains exactly 1 line for the series, no trailing timestamp
- [ ] `curl /metrics` twice back-to-back — bodies are byte-identical (idempotent)
- [ ] Histogram scenario → one `# TYPE <name> histogram` block, one bucket line per `le`, one `_sum`, one `_count`, no timestamps
- [ ] `?label=k:v` filter still works correctly
- [ ] CLI: `sonda run` to `stdout` sink still emits timestamps per line (stream identity preserved)
- [ ] `task site:build` passes