### PR TITLE
fix(ci): pin release workflow to dtolnay/rust-toolchain@1.95.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         # rustup name) which does not have the target std — surfacing as
         # `error[E0463]: can't find crate for core`. Bumping rust-toolchain.toml
         # requires bumping this version too.
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }}
 


### PR DESCRIPTION
## Summary

The v1.12.2 release silently failed. All three native build matrix jobs (`x86_64-linux-musl`, `aarch64-linux-musl`, `x86_64-apple-darwin`) exited in <10 seconds at the `Install Rust toolchain` step:

```
error: could not download nonexistent rust version `1.100.0-x86_64-unknown-linux-gnu`:
http request returned an unsuccessful status code: 404
```

Cause: PR #302 (a Dependabot Action bump) moved `dtolnay/rust-toolchain` from `@1.95.0` to `@1.100.0`. The action's tag is the Rust version it installs via `rustup toolchain install`, and Rust 1.100.0 doesn't exist. Dependabot likely picked up a pre-published or invalid tag in the action's repo.

This PR restores the pin to `@1.95.0` to match `rust-toolchain.toml`. The existing explanatory comment in the workflow already references 1.95.0 — it's accurate again.

The Docker multi-arch build succeeded (it doesn't use the toolchain action), so docker images for 1.12.2 are up; the GitHub release tarballs and `crates.io` publishing weren't produced.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, re-trigger the failed v1.12.2 release run; native build jobs install Rust 1.95.0 and produce tarballs