### PR TITLE
feat(core): cross-POST while: foundation (1 of 3) — types, trait, parse-time validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-link",
 ]
 
@@ -2188,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2207,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2235,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [features]
 default = ["config"]
-config = ["dep:serde_yaml_ng", "dep:chrono"]
+config = ["dep:serde_yaml_ng", "dep:chrono", "chrono/serde"]
 http = ["dep:ureq"]
 kafka = ["dep:rskafka", "dep:tokio", "dep:chrono", "chrono/clock", "dep:rustls", "dep:rustls-pki-types", "dep:webpki-roots"]
 remote-write = ["dep:prost", "dep:snap", "dep:ureq"]

--- a/sonda-core/src/compiler/compile_after.rs
+++ b/sonda-core/src/compiler/compile_after.rs
@@ -2384,6 +2384,8 @@ scenarios:
                 ref_id: "w_target".to_string(),
                 op: WhileOp::LessThan,
                 value: 0.0,
+                scenario_name: None,
+                if_unresolved: None,
             }),
             delay_clause: None,
             distribution: None,

--- a/sonda-core/src/compiler/mod.rs
+++ b/sonda-core/src/compiler/mod.rs
@@ -392,6 +392,22 @@ impl<'de> serde::Deserialize<'de> for WhileOp {
     }
 }
 
+/// Policy applied when a cross-POST `while:` reference cannot be resolved at
+/// scenario start. Only meaningful when [`WhileClause::scenario_name`] is set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "config", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "config", serde(rename_all = "lowercase"))]
+#[non_exhaustive]
+pub enum UnresolvedBehavior {
+    /// Treat the gate as open until the upstream registers.
+    Open,
+    /// Treat the gate as closed until the upstream registers.
+    Closed,
+    /// Hold the scenario in `unresolved` state until the upstream registers.
+    #[default]
+    Pending,
+}
+
 /// Continuous lifecycle gate on another signal's value.
 ///
 /// ```yaml
@@ -411,6 +427,16 @@ pub struct WhileClause {
     pub ref_id: String,
     pub op: WhileOp,
     pub value: f64,
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub scenario_name: Option<String>,
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub if_unresolved: Option<UnresolvedBehavior>,
 }
 
 /// Open / close debounce windows applied to a [`WhileClause`] transition.

--- a/sonda-core/src/compiler/parse.rs
+++ b/sonda-core/src/compiler/parse.rs
@@ -117,6 +117,40 @@ pub enum ParseError {
     /// A `kind: composable` file failed to deserialize as a pack definition.
     #[error("kind: composable body is not a valid pack definition")]
     ComposablePackInvalid(#[source] serde_yaml_ng::Error),
+
+    /// A `while:` clause sets `if_unresolved:` without `scenario_name:`.
+    #[error(
+        "entry {index}: `while.if_unresolved` requires `while.scenario_name` to be set; \
+         `if_unresolved` only applies to cross-POST `while:` references"
+    )]
+    WhileUnresolvedWithoutScenarioName {
+        /// Zero-based index of the offending entry.
+        index: usize,
+    },
+
+    /// A `while:` clause carries `scenario_name:` but the file does not declare
+    /// a top-level `scenario_name:` of its own.
+    #[error(
+        "entry {index}: cross-POST `while:` refs require body-level `scenario_name` on the \
+         scenario file; add a top-level `scenario_name:` declaring this body's identity"
+    )]
+    CrossPostWhileMissingBodyScenarioName {
+        /// Zero-based index of the offending entry.
+        index: usize,
+    },
+
+    /// A cross-POST `while.ref` uses pack sub-signal `.` syntax, which is not
+    /// supported in v1 of the cross-POST surface.
+    #[error(
+        "entry {index}: cross-POST `while.ref` '{ref_id}' targets a pack sub-signal; \
+         cross-POST refs cannot target pack sub-signals in v1, use the top-level entry id"
+    )]
+    CrossPostWhileRefHasDot {
+        /// Zero-based index of the offending entry.
+        index: usize,
+        /// The offending `ref` value as written.
+        ref_id: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -368,8 +402,21 @@ pub fn parse(yaml: &str) -> Result<ScenarioFile, ParseError> {
         });
     }
     validate_entries(&file.scenarios)?;
+    validate_cross_post_while(&file)?;
 
     Ok(file)
+}
+
+fn validate_cross_post_while(file: &ScenarioFile) -> Result<(), ParseError> {
+    for (index, entry) in file.scenarios.iter().enumerate() {
+        let Some(clause) = entry.while_clause.as_ref() else {
+            continue;
+        };
+        if clause.scenario_name.is_some() && file.scenario_name.is_none() {
+            return Err(ParseError::CrossPostWhileMissingBodyScenarioName { index });
+        }
+    }
+    Ok(())
 }
 
 fn parse_composable(yaml: &str) -> Result<ScenarioFile, ParseError> {
@@ -553,8 +600,26 @@ fn validate_entries(entries: &[Entry]) -> Result<(), ParseError> {
         if !has_pack && entry.name.is_none() {
             return Err(ParseError::MissingName { index });
         }
+
+        validate_while_clause(entry, index)?;
     }
 
+    Ok(())
+}
+
+fn validate_while_clause(entry: &Entry, index: usize) -> Result<(), ParseError> {
+    let Some(clause) = entry.while_clause.as_ref() else {
+        return Ok(());
+    };
+    if clause.if_unresolved.is_some() && clause.scenario_name.is_none() {
+        return Err(ParseError::WhileUnresolvedWithoutScenarioName { index });
+    }
+    if clause.scenario_name.is_some() && clause.ref_id.contains('.') {
+        return Err(ParseError::CrossPostWhileRefHasDot {
+            index,
+            ref_id: clause.ref_id.clone(),
+        });
+    }
     Ok(())
 }
 
@@ -2178,5 +2243,208 @@ scenarios:
 
         let file = parse(yaml).expect("file with empty tags must parse");
         assert!(file.tags.is_empty());
+    }
+
+    // ======================================================================
+    // Cross-POST while: schema
+    // ======================================================================
+
+    #[test]
+    fn cross_post_while_clause_round_trips() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenario_name: downstream
+scenarios:
+  - id: tail
+    signal_type: metrics
+    name: tail_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: head
+      op: ">"
+      value: 0
+      scenario_name: upstream
+      if_unresolved: open
+"#;
+        let file = parse(yaml).expect("must parse cross-POST while clause");
+        let clause = file.scenarios[0]
+            .while_clause
+            .as_ref()
+            .expect("while present");
+        assert_eq!(clause.scenario_name.as_deref(), Some("upstream"));
+        assert_eq!(
+            clause.if_unresolved,
+            Some(super::super::UnresolvedBehavior::Open)
+        );
+
+        let serialized = serde_yaml_ng::to_string(&file).expect("must serialize");
+        let round_tripped: ScenarioFile =
+            serde_yaml_ng::from_str(&serialized).expect("must round-trip");
+        let round_clause = round_tripped.scenarios[0]
+            .while_clause
+            .as_ref()
+            .expect("while present after round-trip");
+        assert_eq!(round_clause.scenario_name.as_deref(), Some("upstream"));
+        assert_eq!(
+            round_clause.if_unresolved,
+            Some(super::super::UnresolvedBehavior::Open)
+        );
+    }
+
+    #[test]
+    fn if_unresolved_without_scenario_name_is_rejected() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenarios:
+  - id: tail
+    signal_type: metrics
+    name: tail_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: head
+      op: ">"
+      value: 0
+      if_unresolved: open
+"#;
+        let err = parse(yaml).expect_err("if_unresolved alone must fail");
+        assert!(
+            matches!(
+                err,
+                ParseError::WhileUnresolvedWithoutScenarioName { index: 0 }
+            ),
+            "got: {err}"
+        );
+        assert!(
+            err.to_string().contains("requires"),
+            "message must mention requires, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("scenario_name"),
+            "message must mention scenario_name, got: {err}"
+        );
+    }
+
+    #[test]
+    fn cross_post_while_without_body_scenario_name_is_rejected() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenarios:
+  - id: tail
+    signal_type: metrics
+    name: tail_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: head
+      op: ">"
+      value: 0
+      scenario_name: upstream
+"#;
+        let err = parse(yaml).expect_err("missing body scenario_name must fail");
+        assert!(
+            matches!(
+                err,
+                ParseError::CrossPostWhileMissingBodyScenarioName { index: 0 }
+            ),
+            "got: {err}"
+        );
+        assert!(
+            err.to_string().contains("body-level"),
+            "message must mention body-level, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("scenario_name"),
+            "message must mention scenario_name, got: {err}"
+        );
+    }
+
+    #[test]
+    fn cross_post_while_ref_with_dot_is_rejected() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenario_name: downstream
+scenarios:
+  - id: tail
+    signal_type: metrics
+    name: tail_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: head.metric
+      op: ">"
+      value: 0
+      scenario_name: upstream
+"#;
+        let err = parse(yaml).expect_err("dot in cross-POST ref must fail");
+        assert!(
+            matches!(
+                err,
+                ParseError::CrossPostWhileRefHasDot {
+                    index: 0,
+                    ref_id: ref s,
+                } if s == "head.metric"
+            ),
+            "got: {err}"
+        );
+        assert!(
+            err.to_string().contains("entry id"),
+            "message must mention entry id, got: {err}"
+        );
+    }
+
+    #[test]
+    fn local_only_while_clause_continues_to_parse() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenarios:
+  - id: head
+    signal_type: metrics
+    name: head_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: sine
+      amplitude: 1.0
+      period_secs: 60
+      offset: 0
+  - id: tail
+    signal_type: metrics
+    name: tail_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: head
+      op: ">"
+      value: 0
+"#;
+        let file = parse(yaml).expect("local-only while: must still parse");
+        let clause = file.scenarios[1]
+            .while_clause
+            .as_ref()
+            .expect("while present");
+        assert!(clause.scenario_name.is_none());
+        assert!(clause.if_unresolved.is_none());
     }
 }

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -11,9 +11,10 @@
 //! [`RuntimeError`]), the config enums ([`GeneratorConfig`](generator::GeneratorConfig),
 //! [`EncoderConfig`](encoder::EncoderConfig), [`SinkConfig`](sink::SinkConfig),
 //! [`DistributionConfig`], [`ScenarioEntry`]), the compile-phase error enums
-//! under [`compiler`], [`ScenarioStats`], and [`ScenarioHandle`] — are
-//! marked `#[non_exhaustive]`. Downstream consumers that `match` on these
-//! types must include a wildcard `_ =>` arm, [`ScenarioStats`] must be
+//! under [`compiler`], [`ScenarioStats`], [`ScenarioHandle`], and
+//! [`GateEdge`](schedule::gate_bus::GateEdge) — are marked
+//! `#[non_exhaustive]`. Downstream consumers that `match` on these types
+//! must include a wildcard `_ =>` arm, [`ScenarioStats`] must be
 //! constructed via `Default::default()` plus field updates rather than a
 //! struct literal, and [`ScenarioHandle`] must be constructed via
 //! [`ScenarioHandle::new`] rather than a struct literal. This lets
@@ -34,6 +35,7 @@ pub mod schedule;
 pub mod sink;
 pub(crate) mod util;
 
+pub use compiler::UnresolvedBehavior;
 pub use config::aliases::{desugar_entry, desugar_scenario_config};
 pub use config::BaseScheduleConfig;
 pub use config::BurstConfig;
@@ -55,6 +57,9 @@ pub use model::log::Severity;
 pub use model::metric::Labels;
 pub use model::metric::MetricEvent;
 pub use model::metric::ValidatedMetricName;
+pub use schedule::gate_bus::{
+    GateBusResolver, GateEdgeSender, PendingRef, PendingResolution, RegistryError,
+};
 pub use schedule::handle::ScenarioHandle;
 pub use schedule::launch::{launch_scenario, prepare_entries, validate_entry, PreparedEntry};
 pub use schedule::stats::{ScenarioState, ScenarioStats};

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -643,6 +643,12 @@ fn gated_loop_body(
                         Some(GateEdge::WhileClose) => {
                             while_open = false;
                         }
+                        Some(GateEdge::UpstreamGone) => {
+                            unreachable!(
+                                "UpstreamGone has no sender in this build; \
+                                 cross-POST runtime is wired in a later slice"
+                            );
+                        }
                         None => {
                             continue;
                         }
@@ -732,6 +738,12 @@ fn gated_loop_body(
                     Some(GateEdge::AfterFired) => {
                         after_satisfied = true;
                     }
+                    Some(GateEdge::UpstreamGone) => {
+                        unreachable!(
+                            "UpstreamGone has no sender in this build; \
+                             cross-POST runtime is wired in a later slice"
+                        );
+                    }
                     None => {}
                 }
 
@@ -745,8 +757,15 @@ fn gated_loop_body(
                         }
                         GateEdge::WhileClose => {}
                         GateEdge::AfterFired => {}
+                        GateEdge::UpstreamGone => {}
                     }
                 }
+            }
+            ScenarioState::Unresolved => {
+                unreachable!(
+                    "Unresolved has no entry path in this build; \
+                     cross-POST runtime is wired in a later slice"
+                );
             }
             ScenarioState::Finished => {
                 // Structurally dead; kept so `match state` stays exhaustive.
@@ -871,6 +890,12 @@ fn debounce_close_to_paused(
             Some(GateEdge::WhileOpen) => return false,
             Some(GateEdge::WhileClose) => {}
             Some(GateEdge::AfterFired) => {}
+            Some(GateEdge::UpstreamGone) => {
+                unreachable!(
+                    "UpstreamGone has no sender in this build; \
+                     cross-POST runtime is wired in a later slice"
+                );
+            }
             None => {}
         }
     }
@@ -935,6 +960,12 @@ fn run_running_segment(
                     }
                     GateEdge::AfterFired => {
                         // Already past the after gate.
+                    }
+                    GateEdge::UpstreamGone => {
+                        unreachable!(
+                            "UpstreamGone has no sender in this build; \
+                             cross-POST runtime is wired in a later slice"
+                        );
                     }
                 }
             }
@@ -1013,6 +1044,7 @@ impl DebounceState {
                 }
             }
             GateEdge::AfterFired => {}
+            GateEdge::UpstreamGone => {}
         }
     }
 

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -8,10 +8,14 @@
 //! latest, keeping memory flat regardless of upstream chatter.
 
 use std::sync::mpsc::{self, Receiver, SyncSender};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::{Duration, Instant};
 
-use crate::compiler::WhileOp;
+use crate::compiler::{UnresolvedBehavior, WhileOp};
+use crate::schedule::stats::ScenarioStats;
+
+/// Sender end of a per-subscriber gate-edge channel.
+pub type GateEdgeSender = SyncSender<GateEdge>;
 
 /// Direction of a strict comparison used by an `after:` clause.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -22,10 +26,13 @@ pub enum AfterOpDir {
 
 /// Edge fired into a [`GateReceiver`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum GateEdge {
     AfterFired,
     WhileOpen,
     WhileClose,
+    /// Upstream scenario has been removed; downstream must terminate.
+    UpstreamGone,
 }
 
 /// A subscriber's request for `after:` edges.
@@ -309,6 +316,73 @@ fn replace_send(tx: &SyncSender<GateEdge>, edge: GateEdge) {
     let _ = tx.try_send(edge);
 }
 
+/// A downstream subscription waiting for the named upstream to register.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct PendingResolution {
+    pub handle_id: String,
+    pub stats: Weak<RwLock<ScenarioStats>>,
+    pub edge_sender: GateEdgeSender,
+    pub scenario_name: String,
+    pub entry_id: String,
+    pub if_unresolved: UnresolvedBehavior,
+    pub registered_at: Instant,
+    pub attempts: u64,
+}
+
+/// Wire-shaped projection of a [`PendingResolution`] surfaced over the HTTP API.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Serialize))]
+#[non_exhaustive]
+pub struct PendingRef {
+    pub scenario_name: String,
+    pub entry_id: String,
+    pub if_unresolved: UnresolvedBehavior,
+    #[cfg(feature = "config")]
+    pub registered_at: chrono::DateTime<chrono::Utc>,
+    pub attempts: u64,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RegistryError {
+    #[error("scenario_name '{name}' is already in use by a running scenario")]
+    DuplicateScenarioName { name: String },
+}
+
+/// Process-wide registry for cross-POST gate bus lookup.
+pub trait GateBusResolver: Send + Sync {
+    fn register(
+        &self,
+        scenario_name: &str,
+        entry_id: &str,
+        bus: Arc<GateBus>,
+    ) -> Result<(), RegistryError>;
+
+    fn lookup(&self, scenario_name: &str, entry_id: &str) -> Option<Arc<GateBus>>;
+
+    /// Returns the bus to subscribe against if the upstream is live; `None`
+    /// signals the caller must defer via [`insert_pending`](Self::insert_pending).
+    fn subscribe(
+        &self,
+        upstream: (&str, &str),
+        downstream_handle_id: &str,
+        downstream_stats: Weak<RwLock<ScenarioStats>>,
+        edge_sender: GateEdgeSender,
+    ) -> Option<Arc<GateBus>>;
+
+    fn unregister(&self, scenario_name: &str);
+
+    /// Discard pending entries whose downstream stats handle has been dropped.
+    fn sweep_pending(&self) -> usize;
+
+    fn insert_pending(&self, pending: PendingResolution);
+
+    fn pending_for_handle(&self, handle_id: &str) -> Option<PendingRef>;
+
+    fn scenario_name_in_use(&self, scenario_name: &str) -> bool;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -493,5 +567,68 @@ mod tests {
     fn gate_bus_is_send_and_sync() {
         fn check<T: Send + Sync>() {}
         check::<GateBus>();
+    }
+
+    // ---- GateBusResolver: trait object-safety + no-op impl --------------------
+
+    struct NoOpResolver;
+
+    impl GateBusResolver for NoOpResolver {
+        fn register(
+            &self,
+            _scenario_name: &str,
+            _entry_id: &str,
+            _bus: Arc<GateBus>,
+        ) -> Result<(), RegistryError> {
+            Ok(())
+        }
+
+        fn lookup(&self, _scenario_name: &str, _entry_id: &str) -> Option<Arc<GateBus>> {
+            None
+        }
+
+        fn subscribe(
+            &self,
+            _upstream: (&str, &str),
+            _downstream_handle_id: &str,
+            _downstream_stats: Weak<RwLock<ScenarioStats>>,
+            _edge_sender: GateEdgeSender,
+        ) -> Option<Arc<GateBus>> {
+            None
+        }
+
+        fn unregister(&self, _scenario_name: &str) {}
+
+        fn sweep_pending(&self) -> usize {
+            0
+        }
+
+        fn insert_pending(&self, _pending: PendingResolution) {}
+
+        fn pending_for_handle(&self, _handle_id: &str) -> Option<PendingRef> {
+            None
+        }
+
+        fn scenario_name_in_use(&self, _scenario_name: &str) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn gate_bus_resolver_is_object_safe() {
+        let resolver: Box<dyn GateBusResolver> = Box::new(NoOpResolver);
+        assert!(resolver.lookup("nothing", "here").is_none());
+    }
+
+    #[test]
+    fn gate_edge_upstream_gone_variant_exists() {
+        let edge = GateEdge::UpstreamGone;
+        let label = match edge {
+            GateEdge::AfterFired => "after",
+            GateEdge::WhileOpen => "open",
+            GateEdge::WhileClose => "close",
+            GateEdge::UpstreamGone => "gone",
+        };
+        assert_eq!(label, "gone");
     }
 }

--- a/sonda-core/src/schedule/stats.rs
+++ b/sonda-core/src/schedule/stats.rs
@@ -21,8 +21,10 @@ pub const DEGRADED_STALENESS_NANOS: u64 = 30 * 1_000_000_000;
 /// Lifecycle position of a scenario, surfaced for `while:`-gated runs.
 ///
 /// `Pending` covers the pre-`after:` window for chained scenarios; `Running`
-/// and `Paused` reflect the live `while:` gate state; `Finished` marks the
-/// scenario as having exited (duration expired or shutdown received).
+/// and `Paused` reflect the live `while:` gate state; `Unresolved` marks a
+/// cross-POST `while:` reference whose upstream has not yet registered;
+/// `Finished` marks the scenario as having exited (duration expired or
+/// shutdown received).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
@@ -31,6 +33,7 @@ pub enum ScenarioState {
     Pending,
     Running,
     Paused,
+    Unresolved,
     Finished,
 }
 

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -250,6 +250,7 @@ fn state_string(stats: &ScenarioStats) -> &'static str {
         ScenarioState::Pending => "pending",
         ScenarioState::Running => "running",
         ScenarioState::Paused => "paused",
+        ScenarioState::Unresolved => "unresolved",
         ScenarioState::Finished => "finished",
         _ => "unknown",
     }
@@ -270,7 +271,10 @@ fn collect_active_conflicts(state: &AppState, name: &str) -> Result<Vec<Conflict
         }
         let snap = handle.stats_snapshot();
         let blocks = match snap.state {
-            ScenarioState::Pending | ScenarioState::Running | ScenarioState::Paused => true,
+            ScenarioState::Pending
+            | ScenarioState::Running
+            | ScenarioState::Paused
+            | ScenarioState::Unresolved => true,
             ScenarioState::Finished => false,
             _ => false,
         };
@@ -1695,6 +1699,8 @@ scenarios:
         assert_eq!(state_string(&s), "running");
         s.state = ScenarioState::Paused;
         assert_eq!(state_string(&s), "paused");
+        s.state = ScenarioState::Unresolved;
+        assert_eq!(state_string(&s), "unresolved");
         s.state = ScenarioState::Finished;
         assert_eq!(state_string(&s), "finished");
     }

--- a/sonda/src/scenario_loader.rs
+++ b/sonda/src/scenario_loader.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 use anyhow::{bail, Context, Result};
 
 use sonda_core::compiler::compile_after::CompiledFile;
-use sonda_core::compiler::parse::detect_version;
+use sonda_core::compiler::env_interpolate::interpolate;
+use sonda_core::compiler::parse::{detect_version, parse};
 use sonda_core::{compile_scenario_file_compiled, CompileError};
 
 use sonda_core::catalog::CatalogPackResolver;
@@ -22,8 +23,12 @@ pub fn load_scenario_compiled(
     let yaml = crate::config::resolve_scenario_source(scenario_ref, catalog_dir)?;
     let version = detect_version(&yaml);
     match version {
-        Some(2) => compile_v2_yaml_compiled(&yaml, catalog_dir)
-            .with_context(|| format!("failed to compile v2 scenario {scenario_ref}")),
+        Some(2) => {
+            reject_cross_post_while_from_yaml(&yaml)
+                .with_context(|| format!("failed to parse v2 scenario {scenario_ref}"))?;
+            compile_v2_yaml_compiled(&yaml, catalog_dir)
+                .with_context(|| format!("failed to compile v2 scenario {scenario_ref}"))
+        }
         _ => bail!(
             "scenario {scenario_ref} is not a v2 scenario. \
              Sonda only accepts v2 YAML (`version: 2` at the top level). \
@@ -31,6 +36,23 @@ pub fn load_scenario_compiled(
              for the migration guide."
         ),
     }
+}
+
+fn reject_cross_post_while_from_yaml(yaml: &str) -> Result<()> {
+    let interpolated = interpolate(yaml).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let parsed = parse(&interpolated).map_err(|e| anyhow::anyhow!("{e}"))?;
+    for entry in &parsed.scenarios {
+        if let Some(clause) = entry.while_clause.as_ref() {
+            if clause.scenario_name.is_some() {
+                bail!(
+                    "`while.scenario_name` requires a running sonda-server (POST /scenarios); \
+                     the CLI runs in single-process mode with no cross-POST registry. \
+                     See https://davidban77.github.io/sonda/configuration/scenario-files.md#cross-post-while-refs"
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 pub fn compile_v2_yaml_compiled(

--- a/sonda/tests/cli_run.rs
+++ b/sonda/tests/cli_run.rs
@@ -131,3 +131,49 @@ fn run_at_name_with_overrides_applies_them() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+const CROSS_POST_WHILE_YAML: &str = "version: 2
+kind: runnable
+scenario_name: downstream
+defaults:
+  duration: 200ms
+scenarios:
+  - id: tail
+    signal_type: metrics
+    name: tail_metric
+    rate: 5
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream_metric
+      op: \">\"
+      value: 0
+      scenario_name: upstream
+";
+
+#[test]
+fn run_rejects_cross_post_while_scenario_name() {
+    let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+    f.write_all(CROSS_POST_WHILE_YAML.as_bytes())
+        .expect("write");
+    f.flush().expect("flush");
+    let output = Command::new(sonda_bin())
+        .args(["--quiet", "run"])
+        .arg(f.path())
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        !output.status.success(),
+        "cross-POST while: in CLI must fail"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("requires a running sonda-server"),
+        "error must point at sonda-server, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("cross-post-while-refs"),
+        "error must include docs link, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

**Brief 1 of 3** for the cross-POST `while:` ref resolution feature. Lands the type and trait surface that lets a future `while:` clause in one POST body reference a signal in a separately-POSTed body. This PR ships the public API shape and parse-time validation; runtime activation (Brief 2) and the `GateBusRegistry` impl + HTTP surface (Brief 3) land in subsequent PRs against the same landing branch (`feat/cross-post-while-refs-landing`). The landing branch merges to `main` as one cohesive feature when all 3 sub-PRs are in.

- `WhileClause` gains `scenario_name: Option<String>` and `if_unresolved: UnresolvedBehavior` (default `Pending`)
- New `ScenarioState::Unresolved` lifecycle variant for entries waiting on a cross-POST upstream
- New `GateEdge::UpstreamGone` variant; `GateEdge` is now `#[non_exhaustive]`
- New `GateBusResolver` trait + `PendingResolution`, `PendingRef`, `RegistryError`, `GateEdgeSender` types. Trait is object-safe (verified by `Box<dyn>` test)
- Three parse-time hard errors: `if_unresolved` without `scenario_name`; `WhileClause.scenario_name` without body-level `scenario_name`; cross-POST `ref:` containing `.`
- CLI rejects `scenario_name:` at parse time with a clear error pointing at sonda-server
- `collect_active_conflicts` blocks `Unresolved` from same-name reuse (defensive — prevents Brief 2's runtime from silently breaking the cross-POST link)
- `gated_loop`'s `UpstreamGone` arms are `unreachable!()` until Brief 2 wires the runtime

## Test plan

- [ ] `cargo build --workspace`
- [ ] `cargo nextest run --workspace` (2620 tests, +8 new)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo audit` (baseline yanked warning unchanged)
- [ ] `cargo test -p sonda-core --no-default-features --no-run`
- [ ] Parse a YAML with cross-POST `while: { scenario_name: foo, ... }` — `WhileClause` populates both new fields
- [ ] Parse YAML with `if_unresolved:` but no `scenario_name:` → hard error
- [ ] Parse YAML with `WhileClause.scenario_name:` but no body-level `scenario_name:` → hard error
- [ ] Parse YAML with `ref: foo.bar` and `scenario_name:` set → hard error
- [ ] CLI `sonda run` with `scenario_name:` → exits non-zero with sonda-server pointer
- [ ] Existing local-only `while:` clauses parse and run unchanged