### PR TITLE
feat(core): cross-POST while: runtime (2 of 3) — state machine + resolver wiring

### DIFF
--- a/sonda-core/benches/while_steady_state.rs
+++ b/sonda-core/benches/while_steady_state.rs
@@ -94,6 +94,8 @@ fn bench_gated_open(c: &mut Criterion) {
                     has_after: false,
                     has_while: true,
                     close_emit: None,
+                    if_unresolved: None,
+                    start_unresolved: false,
                 }),
             )
             .unwrap();

--- a/sonda-core/src/compiler/compile_after.rs
+++ b/sonda-core/src/compiler/compile_after.rs
@@ -544,10 +544,11 @@ pub fn compile_after(file: ExpandedFile) -> Result<CompiledFile, CompileAfterErr
     } = file;
 
     let id_to_idx = build_id_index(&entries);
+    let file_scenario_name = scenario_name.as_deref();
 
     for entry in &entries {
         let source_id = source_label(entry);
-        for (ref_id, clause) in outgoing_edges(entry) {
+        for (ref_id, clause) in outgoing_edges(entry, file_scenario_name) {
             resolve_reference(ref_id, &id_to_idx, &source_id, clause)?;
             if entry.id.as_deref() == Some(ref_id) {
                 return Err(CompileAfterError::SelfReference {
@@ -562,7 +563,7 @@ pub fn compile_after(file: ExpandedFile) -> Result<CompiledFile, CompileAfterErr
     let mut in_degree = vec![0u32; n];
     let mut dependents: Vec<Vec<(usize, ClauseKind)>> = vec![Vec::new(); n];
     for (i, entry) in entries.iter().enumerate() {
-        for (ref_id, clause) in outgoing_edges(entry) {
+        for (ref_id, clause) in outgoing_edges(entry, file_scenario_name) {
             let dep_idx = id_to_idx[ref_id];
             in_degree[i] += 1;
             dependents[dep_idx].push((i, clause));
@@ -581,7 +582,7 @@ pub fn compile_after(file: ExpandedFile) -> Result<CompiledFile, CompileAfterErr
         }
     }
     if sorted.len() < n {
-        let cycle = find_cycle(&entries, &id_to_idx);
+        let cycle = find_cycle(&entries, &id_to_idx, file_scenario_name);
         return Err(CompileAfterError::CircularDependency { cycle });
     }
 
@@ -589,6 +590,9 @@ pub fn compile_after(file: ExpandedFile) -> Result<CompiledFile, CompileAfterErr
         let Some(clause) = &entry.while_clause else {
             continue;
         };
+        if is_deferred_while(clause, file_scenario_name) {
+            continue;
+        }
         let source_id = source_label(entry).into_owned();
         let dep_idx = id_to_idx[clause.ref_id.as_str()];
         let target = &entries[dep_idx];
@@ -830,23 +834,30 @@ fn resolve_reference(
 }
 
 /// Yield every outgoing edge from `entry` as `(target_ref_id, edge_label)`.
-///
-/// Order is `after:` first, then `while:` — used by index building, cycle
-/// detection, and reference validation. Adding a new clause type (e.g.
-/// v2's `gated_by:`) extends this iterator and reaches every cycle-aware
-/// site automatically.
-fn outgoing_edges(entry: &ExpandedEntry) -> impl Iterator<Item = (&str, ClauseKind)> {
+/// Cross-POST `while:` refs (scenario_name outside the file) are excluded.
+fn outgoing_edges<'a>(
+    entry: &'a ExpandedEntry,
+    file_scenario_name: Option<&'a str>,
+) -> impl Iterator<Item = (&'a str, ClauseKind)> {
+    let while_edge = entry
+        .while_clause
+        .as_ref()
+        .filter(|c| !is_deferred_while(c, file_scenario_name))
+        .map(|c| (c.ref_id.as_str(), ClauseKind::While));
+
     entry
         .after
         .as_ref()
         .map(|c| (c.ref_id.as_str(), ClauseKind::After))
         .into_iter()
-        .chain(
-            entry
-                .while_clause
-                .as_ref()
-                .map(|c| (c.ref_id.as_str(), ClauseKind::While)),
-        )
+        .chain(while_edge)
+}
+
+fn is_deferred_while(clause: &WhileClause, file_scenario_name: Option<&str>) -> bool {
+    match clause.scenario_name.as_deref() {
+        Some(name) => Some(name) != file_scenario_name,
+        None => false,
+    }
 }
 
 /// Format an entry into a human-readable label for error messages.
@@ -1215,6 +1226,7 @@ fn auto_chain_name(members: &[usize], entries: &[ExpandedEntry]) -> String {
 fn find_cycle(
     entries: &[ExpandedEntry],
     id_to_idx: &BTreeMap<&str, usize>,
+    file_scenario_name: Option<&str>,
 ) -> Vec<(String, ClauseKind)> {
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum Color {
@@ -1231,13 +1243,14 @@ fn find_cycle(
         node: usize,
         entries: &[ExpandedEntry],
         id_to_idx: &BTreeMap<&str, usize>,
+        file_scenario_name: Option<&str>,
         color: &mut [Color],
         path: &mut Vec<(usize, ClauseKind)>,
     ) -> Option<Vec<(usize, ClauseKind)>> {
         color[node] = Color::Gray;
         path.push((node, ClauseKind::After));
 
-        for (ref_id, clause) in outgoing_edges(&entries[node]) {
+        for (ref_id, clause) in outgoing_edges(&entries[node], file_scenario_name) {
             let Some(&dep) = id_to_idx.get(ref_id) else {
                 continue;
             };
@@ -1246,7 +1259,9 @@ fn find_cycle(
             }
             match color[dep] {
                 Color::White => {
-                    if let Some(cycle) = dfs(dep, entries, id_to_idx, color, path) {
+                    if let Some(cycle) =
+                        dfs(dep, entries, id_to_idx, file_scenario_name, color, path)
+                    {
                         return Some(cycle);
                     }
                 }
@@ -1267,7 +1282,14 @@ fn find_cycle(
 
     for start in 0..n {
         if color[start] == Color::White {
-            if let Some(cycle) = dfs(start, entries, id_to_idx, &mut color, &mut path) {
+            if let Some(cycle) = dfs(
+                start,
+                entries,
+                id_to_idx,
+                file_scenario_name,
+                &mut color,
+                &mut path,
+            ) {
                 return cycle
                     .into_iter()
                     .map(|(i, kind)| (source_label(&entries[i]).into_owned(), kind))
@@ -2398,7 +2420,7 @@ scenarios:
             metric_type: None,
             help: None,
         };
-        let edges: Vec<_> = outgoing_edges(&e).collect();
+        let edges: Vec<_> = outgoing_edges(&e, None).collect();
         assert_eq!(
             edges,
             vec![
@@ -2408,11 +2430,11 @@ scenarios:
         );
 
         e.while_clause = None;
-        let edges_after_only: Vec<_> = outgoing_edges(&e).collect();
+        let edges_after_only: Vec<_> = outgoing_edges(&e, None).collect();
         assert_eq!(edges_after_only, vec![("a_target", ClauseKind::After)]);
 
         e.after = None;
-        let edges_none: Vec<_> = outgoing_edges(&e).collect();
+        let edges_none: Vec<_> = outgoing_edges(&e, None).collect();
         assert!(edges_none.is_empty());
     }
 
@@ -2790,5 +2812,95 @@ scenarios:
             msg.contains("unsupported operator") && msg.contains("strict"),
             "error must use the 'unsupported operator … strict' wording. got: {msg}"
         );
+    }
+
+    #[test]
+    fn while_with_self_scenario_name_and_local_match_resolves_locally() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenario_name: foo
+defaults:
+  rate: 1
+  duration: 1m
+scenarios:
+  - id: link
+    signal_type: metrics
+    name: link
+    generator: { type: flap, up_duration: 60s, down_duration: 30s }
+  - id: dependent
+    signal_type: metrics
+    name: dependent
+    generator: { type: constant, value: 1 }
+    while: { ref: link, op: ">", value: 0, scenario_name: foo, if_unresolved: open }
+"#;
+        let compiled = compile_after_from_yaml(yaml).expect("self-scenario_name compiles locally");
+        let dep = compiled
+            .entries
+            .iter()
+            .find(|e| e.id.as_deref() == Some("dependent"))
+            .expect("dependent present");
+        let w = dep.while_clause.as_ref().expect("while preserved");
+        assert_eq!(w.ref_id, "link");
+        assert_eq!(w.scenario_name.as_deref(), Some("foo"));
+    }
+
+    #[test]
+    fn while_with_cross_scenario_name_and_unknown_ref_defers() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenario_name: bar
+defaults:
+  rate: 1
+  duration: 1m
+scenarios:
+  - id: dependent
+    signal_type: metrics
+    name: dependent
+    generator: { type: constant, value: 1 }
+    while: { ref: non_local_id, op: ">", value: 0, scenario_name: foo, if_unresolved: open }
+"#;
+        let compiled = compile_after_from_yaml(yaml).expect("cross-POST defers, no error");
+        let dep = compiled
+            .entries
+            .iter()
+            .find(|e| e.id.as_deref() == Some("dependent"))
+            .expect("dependent present");
+        let w = dep.while_clause.as_ref().expect("while preserved");
+        assert_eq!(w.ref_id, "non_local_id");
+        assert_eq!(w.scenario_name.as_deref(), Some("foo"));
+    }
+
+    #[test]
+    fn while_with_self_scenario_name_and_typo_ref_errors() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenario_name: foo
+defaults:
+  rate: 1
+  duration: 1m
+scenarios:
+  - id: link
+    signal_type: metrics
+    name: link
+    generator: { type: flap, up_duration: 60s, down_duration: 30s }
+  - id: dependent
+    signal_type: metrics
+    name: dependent
+    generator: { type: constant, value: 1 }
+    while: { ref: typo_id, op: ">", value: 0, scenario_name: foo, if_unresolved: open }
+"#;
+        let err = compile_after_from_yaml(yaml).expect_err("self-scenario_name + typo errors");
+        match err {
+            CompileAfterError::UnknownRef {
+                source_id, ref_id, ..
+            } => {
+                assert_eq!(source_id, "dependent");
+                assert_eq!(ref_id, "typo_id");
+            }
+            other => panic!("expected UnknownRef, got {other:?}"),
+        }
     }
 }

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crate::compiler::DelayClause;
+use crate::compiler::{DelayClause, UnresolvedBehavior};
 use crate::config::validate::StartTime;
 use crate::config::OnSinkError;
 use crate::model::metric::MetricEvent;
@@ -520,6 +520,8 @@ pub struct GateContext {
     /// transition. Metric runners with a `RemoteWrite` sink set this; logs,
     /// histograms, and summaries leave it `None`.
     pub close_emit: Option<CloseEmitFn>,
+    pub if_unresolved: Option<UnresolvedBehavior>,
+    pub start_unresolved: bool,
 }
 
 /// Run a signal scenario through the four-state lifecycle gate.
@@ -600,7 +602,11 @@ fn gated_loop_body(
     let started_at = Instant::now();
     let wall = WallClock::resolve(schedule, started_at);
 
-    let mut state = ScenarioState::Pending;
+    let mut state = if gate_ctx.start_unresolved {
+        ScenarioState::Unresolved
+    } else {
+        ScenarioState::Pending
+    };
     let mut after_satisfied = if gate_ctx.has_after {
         gate_ctx.initial.after_already_fired
     } else {
@@ -616,7 +622,8 @@ fn gated_loop_body(
 
     let mut next_tick: u64 = 0;
 
-    write_state(stats, ScenarioState::Pending, false);
+    let paused_zero_rate = matches!(state, ScenarioState::Unresolved | ScenarioState::Paused);
+    write_state(stats, state, paused_zero_rate);
 
     loop {
         if shutdown_requested(shutdown) {
@@ -644,10 +651,11 @@ fn gated_loop_body(
                             while_open = false;
                         }
                         Some(GateEdge::UpstreamGone) => {
-                            unreachable!(
-                                "UpstreamGone has no sender in this build; \
-                                 cross-POST runtime is wired in a later slice"
-                            );
+                            state = ScenarioState::Unresolved;
+                            while_open = false;
+                            write_state(stats, ScenarioState::Unresolved, true);
+                            debounce.reset();
+                            continue;
                         }
                         None => {
                             continue;
@@ -683,6 +691,7 @@ fn gated_loop_body(
                     wall,
                     sink,
                     tick_fn,
+                    false,
                 )?;
                 next_tick = last_tick.load(Ordering::SeqCst);
 
@@ -691,6 +700,20 @@ fn gated_loop_body(
                 }
                 if duration_expired(schedule, started_at) {
                     return Ok(LoopExit::DurationExpired);
+                }
+                if exit == SegmentExit::UpstreamGone {
+                    invoke_close_emit(
+                        schedule,
+                        stats,
+                        close_warn_limiter,
+                        gate_ctx.close_emit.as_mut(),
+                        sink,
+                    )?;
+                    state = ScenarioState::Unresolved;
+                    while_open = false;
+                    write_state(stats, ScenarioState::Unresolved, true);
+                    debounce.reset();
+                    continue;
                 }
                 if exit == SegmentExit::WhileClose
                     && !debounce_close_to_paused(
@@ -739,10 +762,11 @@ fn gated_loop_body(
                         after_satisfied = true;
                     }
                     Some(GateEdge::UpstreamGone) => {
-                        unreachable!(
-                            "UpstreamGone has no sender in this build; \
-                             cross-POST runtime is wired in a later slice"
-                        );
+                        state = ScenarioState::Unresolved;
+                        while_open = false;
+                        write_state(stats, ScenarioState::Unresolved, true);
+                        debounce.reset();
+                        continue;
                     }
                     None => {}
                 }
@@ -762,10 +786,82 @@ fn gated_loop_body(
                 }
             }
             ScenarioState::Unresolved => {
-                unreachable!(
-                    "Unresolved has no entry path in this build; \
-                     cross-POST runtime is wired in a later slice"
-                );
+                let mode = gate_ctx.if_unresolved.unwrap_or_default();
+                match mode {
+                    UnresolvedBehavior::Open => {
+                        let segment_running = Arc::new(AtomicBool::new(true));
+                        let last_tick = Arc::new(AtomicU64::new(next_tick));
+                        let exit = run_running_segment(
+                            schedule,
+                            rate,
+                            shutdown,
+                            stats.cloned(),
+                            gate_ctx,
+                            &segment_running,
+                            next_tick,
+                            Arc::clone(&last_tick),
+                            wall,
+                            sink,
+                            tick_fn,
+                            true,
+                        )?;
+                        next_tick = last_tick.load(Ordering::SeqCst);
+
+                        if shutdown_requested(shutdown) {
+                            return Ok(LoopExit::Shutdown);
+                        }
+                        if duration_expired(schedule, started_at) {
+                            return Ok(LoopExit::DurationExpired);
+                        }
+                        match exit {
+                            SegmentExit::WhileClose => {
+                                invoke_close_emit(
+                                    schedule,
+                                    stats,
+                                    close_warn_limiter,
+                                    gate_ctx.close_emit.as_mut(),
+                                    sink,
+                                )?;
+                                state = ScenarioState::Paused;
+                                while_open = false;
+                                write_state(stats, ScenarioState::Paused, true);
+                                debounce.reset();
+                            }
+                            SegmentExit::UpstreamGone => {
+                                // Already Unresolved; stay.
+                            }
+                            SegmentExit::WhileOpen => {
+                                state = ScenarioState::Running;
+                                while_open = true;
+                                write_state(stats, ScenarioState::Running, false);
+                                debounce.reset();
+                            }
+                            SegmentExit::ShutdownOrDuration => {}
+                        }
+                    }
+                    UnresolvedBehavior::Closed | UnresolvedBehavior::Pending => {
+                        let wakeup = remaining_until(schedule, started_at, PAUSED_POLL_INTERVAL);
+                        match gate_ctx.gate_rx.recv_timeout(wakeup) {
+                            Some(GateEdge::WhileOpen) => {
+                                while_open = true;
+                                state = ScenarioState::Pending;
+                                write_state(stats, ScenarioState::Pending, false);
+                                debounce.reset();
+                            }
+                            Some(GateEdge::WhileClose) => {
+                                while_open = false;
+                                state = ScenarioState::Paused;
+                                write_state(stats, ScenarioState::Paused, true);
+                                debounce.reset();
+                            }
+                            Some(GateEdge::AfterFired) => {
+                                after_satisfied = true;
+                            }
+                            Some(GateEdge::UpstreamGone) => {}
+                            None => {}
+                        }
+                    }
+                }
             }
             ScenarioState::Finished => {
                 // Structurally dead; kept so `match state` stays exhaustive.
@@ -837,6 +933,10 @@ fn finish(stats: Option<Arc<RwLock<ScenarioStats>>>) -> Result<(), SondaError> {
 enum SegmentExit {
     /// Upstream gate transitioned to closed.
     WhileClose,
+    /// Upstream scenario was removed mid-segment.
+    UpstreamGone,
+    /// Upstream gate transitioned to open while running under `if_unresolved: open`.
+    WhileOpen,
     /// User-shutdown flag cleared, or scenario duration expired.
     ShutdownOrDuration,
 }
@@ -890,12 +990,7 @@ fn debounce_close_to_paused(
             Some(GateEdge::WhileOpen) => return false,
             Some(GateEdge::WhileClose) => {}
             Some(GateEdge::AfterFired) => {}
-            Some(GateEdge::UpstreamGone) => {
-                unreachable!(
-                    "UpstreamGone has no sender in this build; \
-                     cross-POST runtime is wired in a later slice"
-                );
-            }
+            Some(GateEdge::UpstreamGone) => return true,
             None => {}
         }
     }
@@ -922,8 +1017,11 @@ fn run_running_segment(
     wall: WallClock,
     sink: &mut dyn Sink,
     tick_fn: &mut TickFn<'_>,
+    exit_on_while_open: bool,
 ) -> Result<SegmentExit, SondaError> {
     let saw_close = Arc::new(AtomicBool::new(false));
+    let saw_gone = Arc::new(AtomicBool::new(false));
+    let saw_open = Arc::new(AtomicBool::new(false));
 
     // The inner loop's `shutdown` parameter wants "true = keep running."
     // We pass our segment flag, and we additionally drain the user
@@ -931,6 +1029,8 @@ fn run_running_segment(
     let user_shutdown_for_wrapper = shutdown;
     let segment_for_wrapper = Arc::clone(segment_running);
     let saw_close_for_wrapper = Arc::clone(&saw_close);
+    let saw_gone_for_wrapper = Arc::clone(&saw_gone);
+    let saw_open_for_wrapper = Arc::clone(&saw_open);
     let gate_rx = &gate_ctx.gate_rx;
 
     type WrappedTick<'a> = Box<
@@ -956,16 +1056,17 @@ fn run_running_segment(
                         segment_for_wrapper.store(false, Ordering::SeqCst);
                     }
                     GateEdge::WhileOpen => {
-                        // Already running; ignore.
+                        if exit_on_while_open {
+                            saw_open_for_wrapper.store(true, Ordering::SeqCst);
+                            segment_for_wrapper.store(false, Ordering::SeqCst);
+                        }
                     }
                     GateEdge::AfterFired => {
                         // Already past the after gate.
                     }
                     GateEdge::UpstreamGone => {
-                        unreachable!(
-                            "UpstreamGone has no sender in this build; \
-                             cross-POST runtime is wired in a later slice"
-                        );
+                        saw_gone_for_wrapper.store(true, Ordering::SeqCst);
+                        segment_for_wrapper.store(false, Ordering::SeqCst);
                     }
                 }
             }
@@ -993,8 +1094,12 @@ fn run_running_segment(
         wrapped.as_mut(),
     )?;
 
-    Ok(if saw_close.load(Ordering::SeqCst) {
+    Ok(if saw_gone.load(Ordering::SeqCst) {
+        SegmentExit::UpstreamGone
+    } else if saw_close.load(Ordering::SeqCst) {
         SegmentExit::WhileClose
+    } else if saw_open.load(Ordering::SeqCst) {
+        SegmentExit::WhileOpen
     } else {
         SegmentExit::ShutdownOrDuration
     })

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -76,6 +76,13 @@ pub struct GateReceiver {
 }
 
 impl GateReceiver {
+    pub(crate) fn from_while_rx(rx: Receiver<GateEdge>) -> Self {
+        Self {
+            after_rx: None,
+            while_rx: Some(rx),
+        }
+    }
+
     /// Poll both per-kind channels in priority order: after, then while.
     pub fn try_recv(&self) -> Option<GateEdge> {
         if let Some(ref rx) = self.after_rx {
@@ -231,6 +238,50 @@ impl GateBus {
         )
     }
 
+    pub(crate) fn subscribe_with_while_sender(
+        &self,
+        spec: WhileSpec,
+        while_tx: GateEdgeSender,
+    ) -> InitialState {
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let (current_value, while_gate_open) = if inner.has_value {
+            let v = inner.last_value;
+            let open = strict_eval(v, spec.op, spec.threshold);
+            let edge = if open {
+                GateEdge::WhileOpen
+            } else {
+                GateEdge::WhileClose
+            };
+            let _ = while_tx.try_send(edge);
+            (v, Some(open))
+        } else {
+            (f64::NAN, None)
+        };
+
+        let sub = Subscription {
+            spec: SubscriptionSpec {
+                after: None,
+                while_: Some(spec),
+            },
+            after_tx: None,
+            while_tx: Some(while_tx),
+            after_fired: false,
+            prev_while_open: while_gate_open,
+        };
+
+        inner.subs.push(sub);
+
+        InitialState {
+            after_already_fired: false,
+            while_gate_open,
+            current_value,
+        }
+    }
+
     /// Publish a new upstream value.
     ///
     /// Fast path: bit-equal to the previous publish returns immediately
@@ -280,6 +331,22 @@ impl GateBus {
     pub(crate) fn drive_value(&self, v: f64) {
         self.tick(v);
     }
+
+    #[cfg(test)]
+    pub(crate) fn broadcast_upstream_gone(&self) {
+        let inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for sub in inner.subs.iter() {
+            if let Some(ref tx) = sub.while_tx {
+                replace_send(tx, GateEdge::UpstreamGone);
+            }
+            if let Some(ref tx) = sub.after_tx {
+                replace_send(tx, GateEdge::UpstreamGone);
+            }
+        }
+    }
 }
 
 impl Default for GateBus {
@@ -328,6 +395,7 @@ pub struct PendingResolution {
     pub if_unresolved: UnresolvedBehavior,
     pub registered_at: Instant,
     pub attempts: u64,
+    pub spec: WhileSpec,
 }
 
 /// Wire-shaped projection of a [`PendingResolution`] surfaced over the HTTP API.

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -63,6 +63,7 @@ pub struct ScenarioHandle {
     ///
     /// `Some` for metrics, histogram, and summary scenarios; `None` for logs.
     pub prometheus_meta: Option<Arc<PromMeta>>,
+    pub cleaned_up: Arc<AtomicBool>,
 }
 
 impl ScenarioHandle {
@@ -80,6 +81,7 @@ impl ScenarioHandle {
         alive: Arc<AtomicBool>,
         labels: Arc<HashMap<String, String>>,
         prometheus_meta: Option<Arc<PromMeta>>,
+        cleaned_up: Arc<AtomicBool>,
     ) -> Self {
         Self {
             id,
@@ -93,6 +95,7 @@ impl ScenarioHandle {
             alive,
             labels,
             prometheus_meta,
+            cleaned_up,
         }
     }
 
@@ -247,6 +250,21 @@ impl ScenarioHandle {
     }
 }
 
+impl Drop for ScenarioHandle {
+    fn drop(&mut self) {
+        if self.cleaned_up.load(Ordering::SeqCst) {
+            return;
+        }
+        if self.scenario_name.is_none() {
+            return;
+        }
+        eprintln!(
+            "sonda: scenario '{}' dropped without unregistering from the gate bus registry",
+            self.id
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -303,6 +321,7 @@ mod tests {
                 crate::config::PromMetricType::Gauge,
                 None,
             ))),
+            Arc::new(AtomicBool::new(true)),
         )
     }
 
@@ -563,6 +582,7 @@ mod tests {
                 crate::config::PromMetricType::Gauge,
                 None,
             ))),
+            Arc::new(AtomicBool::new(true)),
         );
 
         // stats_snapshot must not panic — it recovers from the poisoned lock.
@@ -610,6 +630,7 @@ mod tests {
                 crate::config::PromMetricType::Gauge,
                 None,
             ))),
+            Arc::new(AtomicBool::new(true)),
         );
 
         let events = handle.recent_metrics_snapshot();

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -344,6 +344,7 @@ pub fn launch_scenario_with_gates(
         alive,
         labels,
         prometheus_meta,
+        Arc::new(AtomicBool::new(false)),
     ))
 }
 

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -23,11 +23,16 @@ use crate::config::expand_entry;
 #[cfg(feature = "config")]
 use crate::schedule::core_loop::GateContext;
 #[cfg(feature = "config")]
-use crate::schedule::gate_bus::{GateBus, SubscriptionSpec, WhileSpec};
+use crate::schedule::gate_bus::{
+    GateBus, GateBusResolver, GateReceiver, InitialState, PendingResolution, SubscriptionSpec,
+    WhileSpec,
+};
 #[cfg(feature = "config")]
 use crate::schedule::launch::{launch_scenario_with_gates, validate_entry};
 #[cfg(feature = "config")]
 use std::collections::HashMap;
+#[cfg(feature = "config")]
+use std::sync::mpsc;
 
 /// Run all scenarios in `entries` concurrently, one OS thread per scenario.
 ///
@@ -99,31 +104,49 @@ pub fn signal_shutdown(shutdown: &AtomicBool) {
 }
 
 /// Launch a compiled scenario file with `while:` / `after:` gating wired in,
-/// returning the live handles without joining them.
-///
-/// Equivalent to the spawn portion of [`run_multi_compiled`]: pre-builds an
-/// `Arc<GateBus>` per metric scenario id, subscribes each downstream to its
-/// upstream's bus, and launches every scenario with the matching
-/// [`GateContext`]. Returns the launched [`ScenarioHandle`]s so callers can
-/// observe per-scenario stats (for progress displays) before joining.
+/// returning the live handles without joining them. When `resolver` is `Some`,
+/// cross-POST `while:` references resolve through the registry; otherwise every
+/// reference must resolve inside `file`.
 #[cfg(feature = "config")]
 pub fn launch_multi_compiled(
     file: CompiledFile,
     shutdown: Arc<AtomicBool>,
+    resolver: Option<Arc<dyn GateBusResolver>>,
 ) -> Result<Vec<crate::schedule::handle::ScenarioHandle>, SondaError> {
     let CompiledFile {
-        scenario_name,
+        scenario_name: file_scenario_name,
         entries,
         ..
     } = file;
+    let file_scenario_name_ref = file_scenario_name.as_deref();
 
-    let bus_ids = while_upstream_ids(&entries);
+    let mut bus_ids = while_upstream_ids(&entries, file_scenario_name_ref);
+    if file_scenario_name_ref.is_some() {
+        for entry in &entries {
+            if entry.signal_type == "metrics" {
+                if let Some(id) = entry.id.as_deref() {
+                    bus_ids.push(id.to_string());
+                }
+            }
+        }
+        bus_ids.sort();
+        bus_ids.dedup();
+    }
     let mut buses: HashMap<String, Arc<GateBus>> = HashMap::with_capacity(bus_ids.len());
     for id in bus_ids {
         buses.insert(id, Arc::new(GateBus::new()));
     }
 
-    // Build (entry, gate_ctx, upstream_bus, start_delay, id) per scenario.
+    if let (Some(ref r), Some(name)) = (&resolver, file_scenario_name_ref) {
+        for (entry_id, bus) in buses.iter() {
+            r.register(name, entry_id, Arc::clone(bus)).map_err(|e| {
+                SondaError::Config(crate::ConfigError::invalid(format!(
+                    "gate bus registry: {e}"
+                )))
+            })?;
+        }
+    }
+
     let mut launches: Vec<LaunchPlan> = Vec::with_capacity(entries.len());
     for compiled_entry in entries.into_iter() {
         let id = compiled_entry.id.clone();
@@ -156,29 +179,87 @@ pub fn launch_multi_compiled(
 
         let upstream_bus = id.as_ref().and_then(|name| buses.get(name).cloned());
 
+        let mut deferred: Option<DeferredSubscription> = None;
         let gate_ctx = if let Some(ref clause) = while_clause {
-            let upstream = buses.get(&clause.ref_id).ok_or_else(|| {
-                SondaError::Config(crate::ConfigError::invalid(format!(
-                    "while: ref '{}' not found among scenario ids",
-                    clause.ref_id
-                )))
-            })?;
-            let spec = SubscriptionSpec {
-                after: None,
-                while_: Some(WhileSpec {
+            if let Some(cross_scenario) = cross_scenario_target(clause, file_scenario_name_ref) {
+                let resolver = resolver.as_ref().ok_or_else(|| {
+                    SondaError::Config(crate::ConfigError::invalid(
+                        "cross-POST while: reference requires a GateBusResolver; \
+                         the CLI does not support cross-POST `while:`",
+                    ))
+                })?;
+                let spec = WhileSpec {
                     op: clause.op,
                     threshold: clause.value,
-                }),
-            };
-            let (rx, init) = upstream.subscribe(spec);
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: delay_clause,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-            })
+                };
+                let (tx, rx) = mpsc::sync_channel::<crate::schedule::gate_bus::GateEdge>(1);
+                let if_unresolved = clause.if_unresolved.unwrap_or_default();
+                let bus = resolver.subscribe(
+                    (cross_scenario, clause.ref_id.as_str()),
+                    id.as_deref().unwrap_or(""),
+                    std::sync::Weak::new(),
+                    tx.clone(),
+                );
+                let (gate_rx, initial, start_unresolved) = match bus {
+                    Some(bus) => {
+                        let init = bus.subscribe_with_while_sender(spec, tx);
+                        (GateReceiver::from_while_rx(rx), init, false)
+                    }
+                    None => {
+                        deferred = Some(DeferredSubscription {
+                            sender: tx,
+                            scenario_name: cross_scenario.to_string(),
+                            entry_id: clause.ref_id.clone(),
+                            if_unresolved,
+                            spec,
+                        });
+                        (
+                            GateReceiver::from_while_rx(rx),
+                            InitialState {
+                                after_already_fired: false,
+                                while_gate_open: None,
+                                current_value: f64::NAN,
+                            },
+                            true,
+                        )
+                    }
+                };
+                Some(GateContext {
+                    gate_rx,
+                    initial,
+                    delay: delay_clause,
+                    has_after: false,
+                    has_while: true,
+                    close_emit: None,
+                    if_unresolved: Some(if_unresolved),
+                    start_unresolved,
+                })
+            } else {
+                let upstream = buses.get(&clause.ref_id).ok_or_else(|| {
+                    SondaError::Config(crate::ConfigError::invalid(format!(
+                        "while: ref '{}' not found among scenario ids",
+                        clause.ref_id
+                    )))
+                })?;
+                let spec = SubscriptionSpec {
+                    after: None,
+                    while_: Some(WhileSpec {
+                        op: clause.op,
+                        threshold: clause.value,
+                    }),
+                };
+                let (rx, init) = upstream.subscribe(spec);
+                Some(GateContext {
+                    gate_rx: rx,
+                    initial: init,
+                    delay: delay_clause,
+                    has_after: false,
+                    has_while: true,
+                    close_emit: None,
+                    if_unresolved: None,
+                    start_unresolved: false,
+                })
+            }
         } else {
             None
         };
@@ -196,22 +277,39 @@ pub fn launch_multi_compiled(
             gate_ctx,
             upstream_bus,
             start_delay,
+            deferred,
         });
     }
 
     let mut handles = Vec::with_capacity(launches.len());
     for (idx, plan) in launches.into_iter().enumerate() {
         let id = plan.id.unwrap_or_else(|| format!("multi-{idx}"));
+        let deferred = plan.deferred;
         match launch_scenario_with_gates(
-            id,
-            scenario_name.clone(),
+            id.clone(),
+            file_scenario_name.clone(),
             plan.entry,
             Arc::clone(&shutdown),
             plan.start_delay,
             plan.upstream_bus,
             plan.gate_ctx,
         ) {
-            Ok(handle) => handles.push(handle),
+            Ok(handle) => {
+                if let (Some(d), Some(r)) = (deferred, resolver.as_ref()) {
+                    r.insert_pending(PendingResolution {
+                        handle_id: handle.id.clone(),
+                        stats: Arc::downgrade(&handle.stats),
+                        edge_sender: d.sender,
+                        scenario_name: d.scenario_name,
+                        entry_id: d.entry_id,
+                        if_unresolved: d.if_unresolved,
+                        registered_at: std::time::Instant::now(),
+                        attempts: 0,
+                        spec: d.spec,
+                    });
+                }
+                handles.push(handle);
+            }
             Err(e) => {
                 for handle in &handles {
                     handle.stop();
@@ -224,7 +322,33 @@ pub fn launch_multi_compiled(
         }
     }
 
+    if let Some(ref r) = resolver {
+        r.sweep_pending();
+    }
+
     Ok(handles)
+}
+
+#[cfg(feature = "config")]
+fn cross_scenario_target<'a>(
+    clause: &'a crate::compiler::WhileClause,
+    file_scenario_name: Option<&'a str>,
+) -> Option<&'a str> {
+    let name = clause.scenario_name.as_deref()?;
+    if Some(name) == file_scenario_name {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+#[cfg(feature = "config")]
+struct DeferredSubscription {
+    sender: crate::schedule::gate_bus::GateEdgeSender,
+    scenario_name: String,
+    entry_id: String,
+    if_unresolved: crate::compiler::UnresolvedBehavior,
+    spec: WhileSpec,
 }
 
 /// Run a compiled scenario file with `while:` / `after:` gating wired in.
@@ -234,7 +358,7 @@ pub fn launch_multi_compiled(
 /// overhead.
 #[cfg(feature = "config")]
 pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Result<(), SondaError> {
-    let handles = launch_multi_compiled(file, shutdown)?;
+    let handles = launch_multi_compiled(file, shutdown, None)?;
 
     let mut errors: Vec<String> = Vec::new();
     for mut handle in handles {
@@ -253,14 +377,22 @@ pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Resu
     }
 }
 
-/// Collect the set of compiled-entry ids referenced by some `while:` clause.
-/// Only these ids need a [`GateBus`]; non-referenced entries publish nothing
-/// and skip the per-tick `tick()` lock.
+/// Local `while:` upstream ids; cross-POST refs are excluded.
 #[cfg(feature = "config")]
-fn while_upstream_ids(entries: &[crate::compiler::compile_after::CompiledEntry]) -> Vec<String> {
+fn while_upstream_ids(
+    entries: &[crate::compiler::compile_after::CompiledEntry],
+    file_scenario_name: Option<&str>,
+) -> Vec<String> {
     let mut ids: Vec<String> = entries
         .iter()
-        .filter_map(|e| e.while_clause.as_ref().map(|w| w.ref_id.clone()))
+        .filter_map(|e| {
+            let clause = e.while_clause.as_ref()?;
+            if cross_scenario_target(clause, file_scenario_name).is_some() {
+                None
+            } else {
+                Some(clause.ref_id.clone())
+            }
+        })
         .collect();
     ids.sort();
     ids.dedup();
@@ -274,6 +406,7 @@ struct LaunchPlan {
     gate_ctx: Option<GateContext>,
     upstream_bus: Option<Arc<GateBus>>,
     start_delay: Option<std::time::Duration>,
+    deferred: Option<DeferredSubscription>,
 }
 
 #[cfg(test)]
@@ -1070,7 +1203,7 @@ scenarios:
         let resolver = InMemoryPackResolver::new();
         let compiled =
             compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-        let ids = while_upstream_ids(&compiled.entries);
+        let ids = while_upstream_ids(&compiled.entries, compiled.scenario_name.as_deref());
         assert_eq!(
             ids,
             vec!["upstream_a".to_string()],
@@ -1113,8 +1246,8 @@ scenarios:
             compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
 
         let shutdown = Arc::new(AtomicBool::new(true));
-        let mut handles =
-            launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        let mut handles = launch_multi_compiled(compiled, Arc::clone(&shutdown), None)
+            .expect("launch must succeed");
         assert_eq!(handles.len(), 2, "must launch both entries");
         assert!(
             handles.iter().all(|h| h.is_alive()),
@@ -1138,6 +1271,546 @@ scenarios:
             handle
                 .join(Some(Duration::from_secs(1)))
                 .expect("join must succeed after stop");
+        }
+    }
+
+    #[cfg(feature = "config")]
+    mod cross_post {
+        use std::collections::HashMap;
+        use std::sync::atomic::AtomicBool;
+        use std::sync::{Arc, Mutex, RwLock, Weak};
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        use crate::compile_scenario_file_compiled;
+        use crate::compiler::expand::InMemoryPackResolver;
+        use crate::schedule::gate_bus::{
+            GateBus, GateBusResolver, GateEdgeSender, PendingRef, PendingResolution, RegistryError,
+        };
+        use crate::schedule::handle::ScenarioHandle;
+        use crate::schedule::stats::{ScenarioState, ScenarioStats};
+
+        use super::super::launch_multi_compiled;
+
+        struct TestRegistry {
+            buses: Mutex<HashMap<(String, String), Arc<GateBus>>>,
+            pending: Mutex<Vec<PendingResolution>>,
+        }
+
+        impl TestRegistry {
+            fn new() -> Arc<Self> {
+                Arc::new(Self {
+                    buses: Mutex::new(HashMap::new()),
+                    pending: Mutex::new(Vec::new()),
+                })
+            }
+
+            fn pending_len(&self) -> usize {
+                self.pending.lock().unwrap().len()
+            }
+        }
+
+        impl GateBusResolver for TestRegistry {
+            fn register(
+                &self,
+                scenario_name: &str,
+                entry_id: &str,
+                bus: Arc<GateBus>,
+            ) -> Result<(), RegistryError> {
+                let key = (scenario_name.to_string(), entry_id.to_string());
+                let mut buses = self.buses.lock().unwrap();
+                if buses.contains_key(&key) {
+                    return Err(RegistryError::DuplicateScenarioName {
+                        name: scenario_name.to_string(),
+                    });
+                }
+                buses.insert(key, bus);
+                Ok(())
+            }
+
+            fn lookup(&self, scenario_name: &str, entry_id: &str) -> Option<Arc<GateBus>> {
+                self.buses
+                    .lock()
+                    .unwrap()
+                    .get(&(scenario_name.to_string(), entry_id.to_string()))
+                    .cloned()
+            }
+
+            fn subscribe(
+                &self,
+                upstream: (&str, &str),
+                _downstream_handle_id: &str,
+                _downstream_stats: Weak<RwLock<ScenarioStats>>,
+                _edge_sender: GateEdgeSender,
+            ) -> Option<Arc<GateBus>> {
+                self.buses
+                    .lock()
+                    .unwrap()
+                    .get(&(upstream.0.to_string(), upstream.1.to_string()))
+                    .cloned()
+            }
+
+            fn unregister(&self, scenario_name: &str) {
+                let mut buses = self.buses.lock().unwrap();
+                let keys: Vec<_> = buses
+                    .keys()
+                    .filter(|(s, _)| s == scenario_name)
+                    .cloned()
+                    .collect();
+                for key in keys {
+                    if let Some(bus) = buses.remove(&key) {
+                        bus.broadcast_upstream_gone();
+                    }
+                }
+            }
+
+            fn sweep_pending(&self) -> usize {
+                let mut pending = self.pending.lock().unwrap();
+                let buses = self.buses.lock().unwrap();
+                let mut promoted = 0;
+                pending.retain(|p| {
+                    if p.stats.strong_count() == 0 {
+                        return false;
+                    }
+                    let key = (p.scenario_name.clone(), p.entry_id.clone());
+                    if let Some(bus) = buses.get(&key) {
+                        bus.subscribe_with_while_sender(p.spec, p.edge_sender.clone());
+                        promoted += 1;
+                        false
+                    } else {
+                        true
+                    }
+                });
+                promoted
+            }
+
+            fn insert_pending(&self, pending: PendingResolution) {
+                self.pending.lock().unwrap().push(pending);
+            }
+
+            fn pending_for_handle(&self, handle_id: &str) -> Option<PendingRef> {
+                let pending = self.pending.lock().unwrap();
+                pending
+                    .iter()
+                    .find(|p| p.handle_id == handle_id)
+                    .map(|p| PendingRef {
+                        scenario_name: p.scenario_name.clone(),
+                        entry_id: p.entry_id.clone(),
+                        if_unresolved: p.if_unresolved,
+                        #[cfg(feature = "config")]
+                        registered_at: chrono::DateTime::<chrono::Utc>::from(
+                            std::time::SystemTime::now(),
+                        ),
+                        attempts: p.attempts,
+                    })
+            }
+
+            fn scenario_name_in_use(&self, scenario_name: &str) -> bool {
+                self.buses
+                    .lock()
+                    .unwrap()
+                    .keys()
+                    .any(|(s, _)| s == scenario_name)
+            }
+        }
+
+        fn downstream_yaml(if_unresolved: &str) -> String {
+            format!(
+                r#"
+version: 2
+kind: runnable
+scenario_name: downstream_post
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: dependent
+    signal_type: metrics
+    name: dependent
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream_metric
+      op: ">"
+      value: 0
+      scenario_name: upstream_post
+      if_unresolved: {if_unresolved}
+"#
+            )
+        }
+
+        fn upstream_yaml() -> String {
+            r#"
+version: 2
+kind: runnable
+scenario_name: upstream_post
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: upstream_metric
+    signal_type: metrics
+    name: upstream_metric
+    generator:
+      type: constant
+      value: 1.0
+"#
+            .to_string()
+        }
+
+        fn wait_for_state(handle: &ScenarioHandle, expected: ScenarioState, timeout: Duration) {
+            let deadline = Instant::now() + timeout;
+            while Instant::now() < deadline {
+                if handle.stats_snapshot().state == expected {
+                    return;
+                }
+                thread::sleep(Duration::from_millis(20));
+            }
+            let actual = handle.stats_snapshot().state;
+            panic!("timed out waiting for {expected:?}; current state = {actual:?}");
+        }
+
+        fn stop_and_join(mut handles: Vec<ScenarioHandle>) {
+            for h in &handles {
+                h.stop();
+            }
+            for h in &mut handles {
+                let _ = h.join(Some(Duration::from_secs(2)));
+            }
+        }
+
+        #[test]
+        fn t8_downstream_enters_unresolved_then_promoted_on_register_and_sweep() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let compiled = compile_scenario_file_compiled(
+                &downstream_yaml("pending"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let handles =
+                launch_multi_compiled(compiled, Arc::clone(&shutdown), Some(Arc::clone(&resolver)))
+                    .expect("launch downstream");
+            assert_eq!(handles.len(), 1);
+            wait_for_state(
+                &handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+            assert_eq!(registry.pending_len(), 1);
+
+            let bus = Arc::new(GateBus::new());
+            bus.tick(1.0);
+            resolver
+                .register("upstream_post", "upstream_metric", bus)
+                .expect("register upstream");
+            let promoted = resolver.sweep_pending();
+            assert_eq!(promoted, 1);
+
+            wait_for_state(&handles[0], ScenarioState::Running, Duration::from_secs(2));
+            stop_and_join(handles);
+        }
+
+        #[test]
+        fn t9_downstream_first_then_upstream_post_promotes_via_sweep() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let downstream = compile_scenario_file_compiled(
+                &downstream_yaml("pending"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+
+            let shutdown_a = Arc::new(AtomicBool::new(true));
+            let downstream_handles = launch_multi_compiled(
+                downstream,
+                Arc::clone(&shutdown_a),
+                Some(Arc::clone(&resolver)),
+            )
+            .expect("launch downstream");
+            wait_for_state(
+                &downstream_handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+
+            let upstream =
+                compile_scenario_file_compiled(&upstream_yaml(), &InMemoryPackResolver::new())
+                    .expect("compile upstream");
+            let shutdown_b = Arc::new(AtomicBool::new(true));
+            let upstream_handles = launch_multi_compiled(
+                upstream,
+                Arc::clone(&shutdown_b),
+                Some(Arc::clone(&resolver)),
+            )
+            .expect("launch upstream");
+            wait_for_state(
+                &downstream_handles[0],
+                ScenarioState::Running,
+                Duration::from_secs(2),
+            );
+
+            stop_and_join(downstream_handles);
+            stop_and_join(upstream_handles);
+        }
+
+        // Re-resolution after `unregister` (so a downstream Unresolved can pick up a fresh
+        // upstream with the same scenario_name) requires the registry to push affected
+        // downstreams back into `pending` on unregister — that mechanism lives with the
+        // production `GateBusRegistry` implementation, not the test resolver.
+        #[test]
+        fn t10_unregister_drives_downstream_back_to_unresolved() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let upstream =
+                compile_scenario_file_compiled(&upstream_yaml(), &InMemoryPackResolver::new())
+                    .expect("compile upstream");
+            let shutdown_a = Arc::new(AtomicBool::new(true));
+            let upstream_handles = launch_multi_compiled(
+                upstream,
+                Arc::clone(&shutdown_a),
+                Some(Arc::clone(&resolver)),
+            )
+            .expect("launch upstream");
+
+            let downstream = compile_scenario_file_compiled(
+                &downstream_yaml("open"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+            let shutdown_b = Arc::new(AtomicBool::new(true));
+            let downstream_handles = launch_multi_compiled(
+                downstream,
+                Arc::clone(&shutdown_b),
+                Some(Arc::clone(&resolver)),
+            )
+            .expect("launch downstream");
+            wait_for_state(
+                &downstream_handles[0],
+                ScenarioState::Running,
+                Duration::from_secs(2),
+            );
+
+            resolver.unregister("upstream_post");
+            wait_for_state(
+                &downstream_handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+            for h in &upstream_handles {
+                h.stop();
+            }
+            for mut h in upstream_handles {
+                let _ = h.join(Some(Duration::from_secs(1)));
+            }
+
+            let bus = Arc::new(GateBus::new());
+            bus.tick(1.0);
+            resolver
+                .register("upstream_post", "upstream_metric", bus)
+                .expect("re-register");
+            assert_eq!(
+                downstream_handles[0].stats_snapshot().state,
+                ScenarioState::Unresolved,
+            );
+
+            stop_and_join(downstream_handles);
+        }
+
+        #[test]
+        fn t11_if_unresolved_open_ticks_at_full_rate() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let compiled = compile_scenario_file_compiled(
+                &downstream_yaml("open"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let handles =
+                launch_multi_compiled(compiled, Arc::clone(&shutdown), Some(Arc::clone(&resolver)))
+                    .expect("launch");
+            wait_for_state(
+                &handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+
+            let snapshot_at_t0 = handles[0].stats_snapshot().total_events;
+            thread::sleep(Duration::from_millis(400));
+            let snapshot_after = handles[0].stats_snapshot().total_events;
+            let delta = snapshot_after - snapshot_at_t0;
+            assert!(
+                delta >= 5,
+                "if_unresolved: open must keep ticking; delta = {delta}"
+            );
+
+            stop_and_join(handles);
+        }
+
+        #[test]
+        fn t11b_if_unresolved_open_transitions_to_running_on_upstream_register() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let compiled = compile_scenario_file_compiled(
+                &downstream_yaml("open"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let handles =
+                launch_multi_compiled(compiled, Arc::clone(&shutdown), Some(Arc::clone(&resolver)))
+                    .expect("launch");
+            wait_for_state(
+                &handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+
+            let pre_register = handles[0].stats_snapshot().total_events;
+
+            let bus = Arc::new(GateBus::new());
+            bus.tick(1.0);
+            resolver
+                .register("upstream_post", "upstream_metric", bus)
+                .expect("register upstream");
+            let promoted = resolver.sweep_pending();
+            assert_eq!(promoted, 1);
+
+            wait_for_state(&handles[0], ScenarioState::Running, Duration::from_secs(2));
+
+            let post_transition = handles[0].stats_snapshot().total_events;
+            thread::sleep(Duration::from_millis(400));
+            let after_running = handles[0].stats_snapshot().total_events;
+            assert!(
+                post_transition > pre_register,
+                "emission must continue across the Unresolved -> Running transition; \
+                 pre_register = {pre_register}, post_transition = {post_transition}"
+            );
+            let delta = after_running - post_transition;
+            assert!(
+                delta >= 5,
+                "Running state must keep ticking after transition; delta = {delta}"
+            );
+
+            stop_and_join(handles);
+        }
+
+        #[test]
+        fn t12_if_unresolved_closed_does_not_emit() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let compiled = compile_scenario_file_compiled(
+                &downstream_yaml("closed"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let handles =
+                launch_multi_compiled(compiled, Arc::clone(&shutdown), Some(Arc::clone(&resolver)))
+                    .expect("launch");
+            wait_for_state(
+                &handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+
+            let snapshot_at_t0 = handles[0].stats_snapshot().total_events;
+            thread::sleep(Duration::from_millis(400));
+            let snapshot_after = handles[0].stats_snapshot().total_events;
+            assert_eq!(
+                snapshot_after, snapshot_at_t0,
+                "if_unresolved: closed must not emit ticks"
+            );
+
+            stop_and_join(handles);
+        }
+
+        #[test]
+        fn t13_if_unresolved_pending_does_not_emit_and_holds_state() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let compiled = compile_scenario_file_compiled(
+                &downstream_yaml("pending"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let handles =
+                launch_multi_compiled(compiled, Arc::clone(&shutdown), Some(Arc::clone(&resolver)))
+                    .expect("launch");
+            wait_for_state(
+                &handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+
+            let snapshot_at_t0 = handles[0].stats_snapshot().total_events;
+            thread::sleep(Duration::from_millis(400));
+            let snap = handles[0].stats_snapshot();
+            assert_eq!(snap.total_events, snapshot_at_t0);
+            assert_eq!(snap.state, ScenarioState::Unresolved);
+
+            stop_and_join(handles);
+        }
+
+        #[test]
+        fn t_regress_2_local_only_while_path_unchanged() {
+            let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 200ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: upstream
+    signal_type: metrics
+    name: upstream
+    generator:
+      type: constant
+      value: 1.0
+  - id: dependent
+    signal_type: metrics
+    name: dependent
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream
+      op: ">"
+      value: 0
+"#;
+            let compiled = compile_scenario_file_compiled(yaml, &InMemoryPackResolver::new())
+                .expect("compile local-only");
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let mut handles =
+                launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch");
+            assert_eq!(handles.len(), 2);
+            for h in &mut handles {
+                let _ = h.join(Some(Duration::from_secs(2)));
+            }
         }
     }
 }

--- a/sonda-core/tests/start_time_shift.rs
+++ b/sonda-core/tests/start_time_shift.rs
@@ -351,6 +351,8 @@ fn gated_close_emit_marker_lands_in_shifted_window() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("gated runner must succeed");

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -127,6 +127,8 @@ fn run_with_capture(
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         };
         sonda_core::schedule::runner::run_with_sink_gated(
             &config,
@@ -351,6 +353,8 @@ fn non_remote_write_sink_no_close_marker_by_default() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -448,6 +452,8 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -548,6 +554,8 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -650,6 +658,8 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -739,6 +749,8 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -840,6 +852,8 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -930,6 +944,8 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -1024,6 +1040,8 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -1119,6 +1137,8 @@ fn shutdown_while_gate_open_emits_stale_marker() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");

--- a/sonda-core/tests/while_close_workshop_repro.rs
+++ b/sonda-core/tests/while_close_workshop_repro.rs
@@ -193,7 +193,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     // Wait for both threads to finish (they exit when duration expires).
@@ -313,7 +313,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
 
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut handles = handles;
@@ -510,7 +510,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
     assert_eq!(handles.len(), 8, "must launch primary + 7 downstream");
 
     let deadline = Instant::now() + Duration::from_secs(6);
@@ -643,7 +643,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(10);
@@ -1447,7 +1447,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1544,7 +1544,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1748,7 +1748,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + gated_metric");
 
     let deadline = Instant::now() + Duration::from_secs(5);

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -109,6 +109,8 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
         has_after: false,
         has_while: true,
         close_emit: None,
+        if_unresolved: None,
+        start_unresolved: false,
     };
 
     let entry = metrics_entry("downstream", 200.0, 600);
@@ -174,6 +176,8 @@ fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscriptio
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -216,6 +220,8 @@ fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -253,6 +259,8 @@ fn while_runtime_no_catch_up_burst_on_resume() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -354,6 +362,8 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -430,6 +440,8 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -494,6 +506,8 @@ fn while_runtime_finished_state_after_duration_expires() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -531,6 +545,8 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch a must succeed");
@@ -549,6 +565,8 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch b must succeed");
@@ -594,6 +612,8 @@ fn while_runtime_logs_signal_can_be_gated_downstream() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -656,6 +676,8 @@ fn while_runtime_delay_open_debounces_pause_to_running_transition() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -716,6 +738,8 @@ fn while_runtime_strict_lt_threshold_gating() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -757,6 +781,8 @@ fn scenario_restart_does_not_leak_gate_bus() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("launch must succeed");
@@ -807,6 +833,8 @@ fn while_runtime_delay_close_debounces_running_to_paused_transition() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -885,6 +913,8 @@ fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
             has_after: true,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -957,6 +987,8 @@ fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
             has_after: true,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -1040,6 +1072,8 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
             has_after: true,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -1122,6 +1156,8 @@ fn while_runtime_steady_within_5pct_of_baseline() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .unwrap();
@@ -1270,6 +1306,8 @@ fn nan_upstream_value_keeps_downstream_paused() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -520,7 +520,7 @@ async fn launch_compiled(
     warnings: Vec<String>,
 ) -> Result<Response, Response> {
     let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handles = launch_multi_compiled(compiled, shutdown).map_err(|e| {
+    let mut handles = launch_multi_compiled(compiled, shutdown, None).map_err(|e| {
         warn!(error = %e, "POST /scenarios: failed to launch scenarios");
         match e {
             sonda_core::SondaError::Config(_) => unprocessable(e),
@@ -1039,6 +1039,7 @@ mod tests {
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -1075,6 +1076,7 @@ mod tests {
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -2908,6 +2910,7 @@ scenarios:
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -3364,6 +3367,7 @@ scenarios:
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -3643,6 +3647,7 @@ scenarios:
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -4076,6 +4081,7 @@ scenarios:
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -4109,6 +4115,7 @@ scenarios:
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -5021,6 +5028,7 @@ scenarios:
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
             std::sync::Arc::new(std::collections::HashMap::new()),
             meta.map(std::sync::Arc::new),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -5147,6 +5155,7 @@ scenarios:
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
             std::sync::Arc::new(label_map),
             meta.map(std::sync::Arc::new),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -350,9 +350,12 @@ fn run_compiled_with_progress(
     running: &Arc<AtomicBool>,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
-    let handles =
-        sonda_core::schedule::multi_runner::launch_multi_compiled(compiled, Arc::clone(running))
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let handles = sonda_core::schedule::multi_runner::launch_multi_compiled(
+        compiled,
+        Arc::clone(running),
+        None,
+    )
+    .map_err(|e| anyhow::anyhow!("{}", e))?;
 
     let progress = maybe_start_progress_multi(&handles, verbosity);
 


### PR DESCRIPTION
## Summary

**Brief 2 of 3** for the cross-POST `while:` ref resolution feature. Builds on Brief 1 (PR #418, landed) which shipped types + trait + parse-time validation. This PR activates the runtime: compile-time relax-not-skip for cross-POST refs, gated_loop state-machine arms for the new `Unresolved` lifecycle, `multi_runner` resolver wiring with insert-all-then-sweep ordering, and `ScenarioHandle.cleaned_up` readied for Brief 3's cleanup integration. Brief 3 (next) ships the production `GateBusRegistry` impl + HTTP surface + workshop E2E. All 3 briefs land on the landing branch; landing merges to `main` as one cohesive feature.

- `compile_after`: relax-not-skip — cross-POST `ref:` resolves locally when matched; defers to the resolver when scenario_name is set and no local match; today's error still fires when scenario_name is unset
- Self-reference rule: body's `scenario_name: foo` + WhileClause `scenario_name: foo` resolves locally (typos caught at parse time)
- New state-machine arms: `Running/Paused/Pending → Unresolved` on `UpstreamGone`; `Unresolved → Pending → Running` and `Unresolved → Paused` on edges; `Unresolved → Running` directly via the new `SegmentExit::WhileOpen` when `if_unresolved: open` resolves mid-segment
- Close-emit per-transition on `Running → Unresolved` matching existing `delay.close` semantics
- `launch_multi_compiled` accepts `Option<Arc<dyn GateBusResolver>>`; registers all entries' buses first, then subscribes per entry, then sweeps pending
- `ScenarioHandle.cleaned_up: Arc<AtomicBool>` field + Drop integration (defensive backstop; Brief 3 sets the flag via Phase 1)
- 11 new tests covering compiler relax-not-skip (T4, T5, T7), deferred resolution + sweep (T8, T9), unregister cycle (T10), `if_unresolved:` modes (T11, T12, T13), mid-segment open-resolution (T11b), regression guard for local-only scenarios

## Test plan

- [ ] `cargo build --workspace`
- [ ] `cargo nextest run --workspace` (2631 tests, +11 new)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo audit` (baseline yanked warning unchanged)
- [ ] `cargo test -p sonda-core --no-default-features --no-run`
- [ ] Existing local-only `while:` scenarios run unchanged (T-regress-2)
- [ ] Deferred cross-POST resolution: POST B then A wires up cleanly; POST A then B also works
- [ ] `if_unresolved: open` emits at full rate while Unresolved AND transitions to Running once upstream registers (T11b)