### PR TITLE
fix(server): isolate scenario shutdown flag so DELETE does not cascade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -41,10 +41,7 @@ pub struct ScenarioHandle {
     /// File-level `scenario_name` from the source YAML, when set. Read-only
     /// after launch; every handle from the same POST shares this value.
     pub scenario_name: Option<String>,
-    /// Per-handle shutdown flag, owned exclusively by this handle. `stop()`
-    /// flips it. Each scenario launched by `launch_multi_compiled` gets a
-    /// fresh, independent flag — `stop()` on one handle never affects any
-    /// other.
+    /// Per-handle shutdown flag. `stop()` on one handle never affects another.
     pub shutdown: Arc<AtomicBool>,
     /// The OS thread running the scenario. `None` after [`ScenarioHandle::join`] consumes it.
     pub thread: Option<JoinHandle<Result<(), SondaError>>>,
@@ -99,12 +96,7 @@ impl ScenarioHandle {
         }
     }
 
-    /// Signal this scenario to stop.
-    ///
-    /// Affects only this scenario; calling `stop()` on one handle never
-    /// affects another handle returned from the same `launch_multi_compiled`
-    /// call. The runner thread observes the per-handle shutdown flag on its
-    /// next tick and exits cleanly.
+    /// Signal this scenario to stop. Affects only this scenario.
     pub fn stop(&self) {
         self.shutdown.store(false, Ordering::SeqCst);
     }

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -41,7 +41,10 @@ pub struct ScenarioHandle {
     /// File-level `scenario_name` from the source YAML, when set. Read-only
     /// after launch; every handle from the same POST shares this value.
     pub scenario_name: Option<String>,
-    /// Shared shutdown flag. Setting this to `false` signals the runner to exit.
+    /// Per-handle shutdown flag, owned exclusively by this handle. `stop()`
+    /// flips it. Each scenario launched by `launch_multi_compiled` gets a
+    /// fresh, independent flag — `stop()` on one handle never affects any
+    /// other.
     pub shutdown: Arc<AtomicBool>,
     /// The OS thread running the scenario. `None` after [`ScenarioHandle::join`] consumes it.
     pub thread: Option<JoinHandle<Result<(), SondaError>>>,
@@ -96,10 +99,12 @@ impl ScenarioHandle {
         }
     }
 
-    /// Signal the scenario to stop.
+    /// Signal this scenario to stop.
     ///
-    /// Sets the shutdown flag to `false` with `SeqCst` ordering. The runner
-    /// thread will observe this on its next tick and exit cleanly.
+    /// Affects only this scenario; calling `stop()` on one handle never
+    /// affects another handle returned from the same `launch_multi_compiled`
+    /// call. The runner thread observes the per-handle shutdown flag on its
+    /// next tick and exits cleanly.
     pub fn stop(&self) {
         self.shutdown.store(false, Ordering::SeqCst);
     }

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -1,10 +1,8 @@
 //! Multi-scenario runner: runs multiple scenarios concurrently on separate threads.
 //!
-//! Each scenario runs on its own OS thread via [`launch_scenario`]. Every
-//! scenario owns its own shutdown flag — `handle.stop()` affects only that
-//! scenario, never its siblings. Callers that want a "stop them all" master
-//! trigger (CLI Ctrl+C, batch [`run_multi`]) pass a master `shutdown` flag
-//! and a watchdog thread fans it out into each handle's per-scenario flag.
+//! Each scenario owns its own shutdown flag. [`run_multi`] and
+//! [`run_multi_compiled`] accept a master `shutdown` flag and use a watchdog
+//! thread to fan a transition out into each handle's per-scenario flag.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -31,34 +29,7 @@ use crate::schedule::launch::{launch_scenario_with_gates, validate_entry};
 use std::collections::HashMap;
 
 /// Run all scenarios in `entries` concurrently, one OS thread per scenario.
-///
-/// Each scenario thread runs until either:
-/// - The scenario's own duration expires, or
-/// - The master `shutdown` flag is set to `false` (a watchdog fans the
-///   transition out into every scenario's per-handle shutdown).
-///
-/// The main thread blocks until all scenario threads have finished. If any
-/// thread returns an error, those errors are collected and returned as a
-/// combined [`SondaError::Runtime`] with the
-/// [`RuntimeError::ScenariosFailed`] variant. Errors from all threads are
-/// reported, not just the first one.
-///
-/// # Parameters
-///
-/// * `entries` — the scenario entries to run concurrently, typically sourced
-///   from [`compile_scenario_file`][crate::compile_scenario_file].
-/// * `shutdown` — master shutdown flag. Set to `false` to stop all running
-///   scenarios; an internal watchdog mirrors the transition into each
-///   scenario's per-handle shutdown.
-///
-/// # Errors
-///
-/// Returns [`SondaError::Config`] for synchronous validation failures
-/// (invalid config fields, bad phase_offset). Returns
-/// [`SondaError::Runtime`] if any scenario thread encounters an error during
-/// setup (sink creation) or during the event loop (encoding, I/O). All
-/// thread errors are collected and formatted into a single
-/// [`RuntimeError::ScenariosFailed`] error.
+/// Set `shutdown` to `false` to stop all running scenarios.
 pub fn run_multi(entries: Vec<ScenarioEntry>, shutdown: Arc<AtomicBool>) -> Result<(), SondaError> {
     // Expand, validate, and resolve phase offsets for all entries atomically.
     let prepared = prepare_entries(entries)?;
@@ -136,13 +107,9 @@ pub fn signal_shutdown(shutdown: &AtomicBool) {
 }
 
 /// Launch a compiled scenario file with `while:` / `after:` gating wired in,
-/// returning the live handles without joining them.
-///
-/// Each returned handle owns an independent shutdown flag — calling
-/// `handle.stop()` on one handle never affects any other handle from this
-/// call. Callers that need a master "stop them all" trigger iterate the
-/// handles and call `.stop()` on each, or use [`run_multi_compiled`] which
-/// wires a watchdog for that purpose.
+/// returning the live handles without joining them. Each handle owns an
+/// independent shutdown flag; for a master "stop all" trigger, use
+/// [`run_multi_compiled`].
 #[cfg(feature = "config")]
 pub fn launch_multi_compiled(
     file: CompiledFile,

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -1,9 +1,10 @@
 //! Multi-scenario runner: runs multiple scenarios concurrently on separate threads.
 //!
-//! Each scenario runs on its own OS thread via [`launch_scenario`]. All threads
-//! share a single shutdown flag so that Ctrl+C (or any external signal) stops
-//! all scenarios cleanly. Thread errors are collected and returned after all
-//! threads have finished.
+//! Each scenario runs on its own OS thread via [`launch_scenario`]. Every
+//! scenario owns its own shutdown flag — `handle.stop()` affects only that
+//! scenario, never its siblings. Callers that want a "stop them all" master
+//! trigger (CLI Ctrl+C, batch [`run_multi`]) pass a master `shutdown` flag
+//! and a watchdog thread fans it out into each handle's per-scenario flag.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -33,7 +34,8 @@ use std::collections::HashMap;
 ///
 /// Each scenario thread runs until either:
 /// - The scenario's own duration expires, or
-/// - The shared `shutdown` flag is set to `false`.
+/// - The master `shutdown` flag is set to `false` (a watchdog fans the
+///   transition out into every scenario's per-handle shutdown).
 ///
 /// The main thread blocks until all scenario threads have finished. If any
 /// thread returns an error, those errors are collected and returned as a
@@ -45,8 +47,9 @@ use std::collections::HashMap;
 ///
 /// * `entries` — the scenario entries to run concurrently, typically sourced
 ///   from [`compile_scenario_file`][crate::compile_scenario_file].
-/// * `shutdown` — shared shutdown flag. Set to `false` to stop all running scenarios.
-///   Each scenario thread polls this flag on every tick.
+/// * `shutdown` — master shutdown flag. Set to `false` to stop all running
+///   scenarios; an internal watchdog mirrors the transition into each
+///   scenario's per-handle shutdown.
 ///
 /// # Errors
 ///
@@ -61,18 +64,23 @@ pub fn run_multi(entries: Vec<ScenarioEntry>, shutdown: Arc<AtomicBool>) -> Resu
     let prepared = prepare_entries(entries)?;
 
     let mut handles = Vec::with_capacity(prepared.len());
+    let mut per_handle_shutdowns: Vec<Arc<AtomicBool>> = Vec::with_capacity(prepared.len());
     for (i, prepared_entry) in prepared.into_iter().enumerate() {
         let id = format!("multi-{i}");
+        let scenario_shutdown = Arc::new(AtomicBool::new(true));
         let handle = launch_scenario(
             id,
             prepared_entry.entry,
-            Arc::clone(&shutdown),
+            Arc::clone(&scenario_shutdown),
             prepared_entry.start_delay,
         )?;
+        per_handle_shutdowns.push(scenario_shutdown);
         handles.push(handle);
     }
 
-    // Collect results from all threads.
+    let done = Arc::new(AtomicBool::new(false));
+    let watchdog = spawn_shutdown_watchdog(shutdown, per_handle_shutdowns, Arc::clone(&done));
+
     let mut errors: Vec<String> = Vec::new();
     for mut handle in handles {
         match handle.join(None) {
@@ -81,6 +89,9 @@ pub fn run_multi(entries: Vec<ScenarioEntry>, shutdown: Arc<AtomicBool>) -> Resu
         }
     }
 
+    done.store(true, Ordering::SeqCst);
+    let _ = watchdog.join();
+
     if errors.is_empty() {
         Ok(())
     } else {
@@ -88,6 +99,32 @@ pub fn run_multi(entries: Vec<ScenarioEntry>, shutdown: Arc<AtomicBool>) -> Resu
             errors.join("; "),
         )))
     }
+}
+
+/// Mirror `master`'s false transition into each per-handle shutdown; exit when `master` flips or `done` flips.
+fn spawn_shutdown_watchdog(
+    master: Arc<AtomicBool>,
+    per_handle: Vec<Arc<AtomicBool>>,
+    done: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::Builder::new()
+        .name("sonda-shutdown-watchdog".to_string())
+        .spawn(move || {
+            let poll = std::time::Duration::from_millis(100);
+            loop {
+                if done.load(Ordering::SeqCst) {
+                    return;
+                }
+                if !master.load(Ordering::SeqCst) {
+                    for flag in &per_handle {
+                        flag.store(false, Ordering::SeqCst);
+                    }
+                    return;
+                }
+                std::thread::sleep(poll);
+            }
+        })
+        .expect("watchdog thread must spawn")
 }
 
 /// Set the shutdown flag, signalling all running scenarios to stop.
@@ -101,15 +138,14 @@ pub fn signal_shutdown(shutdown: &AtomicBool) {
 /// Launch a compiled scenario file with `while:` / `after:` gating wired in,
 /// returning the live handles without joining them.
 ///
-/// Equivalent to the spawn portion of [`run_multi_compiled`]: pre-builds an
-/// `Arc<GateBus>` per metric scenario id, subscribes each downstream to its
-/// upstream's bus, and launches every scenario with the matching
-/// [`GateContext`]. Returns the launched [`ScenarioHandle`]s so callers can
-/// observe per-scenario stats (for progress displays) before joining.
+/// Each returned handle owns an independent shutdown flag — calling
+/// `handle.stop()` on one handle never affects any other handle from this
+/// call. Callers that need a master "stop them all" trigger iterate the
+/// handles and call `.stop()` on each, or use [`run_multi_compiled`] which
+/// wires a watchdog for that purpose.
 #[cfg(feature = "config")]
 pub fn launch_multi_compiled(
     file: CompiledFile,
-    shutdown: Arc<AtomicBool>,
 ) -> Result<Vec<crate::schedule::handle::ScenarioHandle>, SondaError> {
     let CompiledFile {
         scenario_name,
@@ -202,11 +238,12 @@ pub fn launch_multi_compiled(
     let mut handles = Vec::with_capacity(launches.len());
     for (idx, plan) in launches.into_iter().enumerate() {
         let id = plan.id.unwrap_or_else(|| format!("multi-{idx}"));
+        let scenario_shutdown = Arc::new(AtomicBool::new(true));
         match launch_scenario_with_gates(
             id,
             scenario_name.clone(),
             plan.entry,
-            Arc::clone(&shutdown),
+            scenario_shutdown,
             plan.start_delay,
             plan.upstream_bus,
             plan.gate_ctx,
@@ -234,7 +271,12 @@ pub fn launch_multi_compiled(
 /// overhead.
 #[cfg(feature = "config")]
 pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Result<(), SondaError> {
-    let handles = launch_multi_compiled(file, shutdown)?;
+    let handles = launch_multi_compiled(file)?;
+    let per_handle_shutdowns: Vec<Arc<AtomicBool>> =
+        handles.iter().map(|h| Arc::clone(&h.shutdown)).collect();
+
+    let done = Arc::new(AtomicBool::new(false));
+    let watchdog = spawn_shutdown_watchdog(shutdown, per_handle_shutdowns, Arc::clone(&done));
 
     let mut errors: Vec<String> = Vec::new();
     for mut handle in handles {
@@ -243,6 +285,9 @@ pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Resu
             Err(e) => errors.push(e.to_string()),
         }
     }
+
+    done.store(true, Ordering::SeqCst);
+    let _ = watchdog.join();
 
     if errors.is_empty() {
         Ok(())
@@ -1112,9 +1157,7 @@ scenarios:
         let compiled =
             compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
 
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let mut handles =
-            launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        let mut handles = launch_multi_compiled(compiled).expect("launch must succeed");
         assert_eq!(handles.len(), 2, "must launch both entries");
         assert!(
             handles.iter().all(|h| h.is_alive()),
@@ -1138,6 +1181,83 @@ scenarios:
             handle
                 .join(Some(Duration::from_secs(1)))
                 .expect("join must succeed after stop");
+        }
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn launch_multi_compiled_gives_each_handle_an_independent_shutdown_flag() {
+        use crate::compile_scenario_file_compiled;
+        use crate::compiler::expand::InMemoryPackResolver;
+
+        let yaml = "\
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 10s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: iso_a
+    signal_type: metrics
+    name: iso_a
+    generator:
+      type: constant
+      value: 1.0
+  - id: iso_b
+    signal_type: metrics
+    name: iso_b
+    generator:
+      type: constant
+      value: 2.0
+  - id: iso_c
+    signal_type: metrics
+    name: iso_c
+    generator:
+      type: constant
+      value: 3.0
+";
+        let resolver = InMemoryPackResolver::new();
+        let compiled =
+            compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
+
+        let mut handles = launch_multi_compiled(compiled).expect("launch must succeed");
+        assert_eq!(handles.len(), 3, "must launch all three entries");
+
+        for i in 0..handles.len() {
+            for j in (i + 1)..handles.len() {
+                assert!(
+                    !Arc::ptr_eq(&handles[i].shutdown, &handles[j].shutdown),
+                    "handles {i} and {j} must own independent shutdown Arcs"
+                );
+            }
+        }
+
+        handles[0].stop();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline && handles[0].is_alive() {
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(!handles[0].is_alive(), "stopped handle must exit");
+        assert!(
+            handles[1].is_alive() && handles[2].is_alive(),
+            "siblings must remain alive — stop() on one handle must not cascade"
+        );
+
+        for handle in &handles {
+            handle.stop();
+        }
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline && handles.iter().any(|h| h.is_alive()) {
+            thread::sleep(Duration::from_millis(20));
+        }
+        for handle in &mut handles {
+            handle
+                .join(Some(Duration::from_secs(1)))
+                .expect("join must succeed");
         }
     }
 }

--- a/sonda-core/tests/while_close_workshop_repro.rs
+++ b/sonda-core/tests/while_close_workshop_repro.rs
@@ -191,9 +191,7 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     // Wait for both threads to finish (they exit when duration expires).
@@ -311,9 +309,7 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled).expect("launch must succeed");
 
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut handles = handles;
@@ -508,9 +504,7 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled).expect("launch must succeed");
     assert_eq!(handles.len(), 8, "must launch primary + 7 downstream");
 
     let deadline = Instant::now() + Duration::from_secs(6);
@@ -641,9 +635,7 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(10);
@@ -1445,9 +1437,7 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1542,9 +1532,7 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1746,9 +1734,7 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + gated_metric");
 
     let deadline = Instant::now() + Duration::from_secs(5);

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -18,8 +18,6 @@
 //! plumbing: deserialize → compile → launch → store → respond.
 
 use std::path::Path as FsPath;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::extract::{Path, RawQuery, State};
@@ -515,8 +513,7 @@ async fn launch_compiled(
     compiled: CompiledFile,
     warnings: Vec<String>,
 ) -> Result<Response, Response> {
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handles = launch_multi_compiled(compiled, shutdown).map_err(|e| {
+    let mut handles = launch_multi_compiled(compiled).map_err(|e| {
         warn!(error = %e, "POST /scenarios: failed to launch scenarios");
         match e {
             sonda_core::SondaError::Config(_) => unprocessable(e),

--- a/sonda-server/tests/scenarios.rs
+++ b/sonda-server/tests/scenarios.rs
@@ -2131,3 +2131,123 @@ fn post_named_scenario_with_finished_existing_returns_201() {
         "finished handles are stale; new POST with the same scenario_name must return 201"
     );
 }
+
+const THREE_SCENARIO_NO_DURATION_YAML: &str = "\
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: cascade_a
+    signal_type: metrics
+    name: cascade_a
+    generator:
+      type: constant
+      value: 1.0
+  - id: cascade_b
+    signal_type: metrics
+    name: cascade_b
+    generator:
+      type: constant
+      value: 2.0
+  - id: cascade_c
+    signal_type: metrics
+    name: cascade_c
+    generator:
+      type: constant
+      value: 3.0
+";
+
+/// Regression: DELETE on one scenario from a multi-scenario POST must not
+/// cascade-finish its siblings (sonda 1.12.2 bug — shared shutdown flag).
+#[test]
+fn delete_one_scenario_does_not_cascade_finish_siblings() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(THREE_SCENARIO_NO_DURATION_YAML)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(resp.status().as_u16(), 201);
+
+    let body: serde_json::Value = resp.json().expect("response must be JSON");
+    let ids: Vec<String> = body["scenarios"]
+        .as_array()
+        .expect("multi response must have a 'scenarios' array")
+        .iter()
+        .map(|s| s["id"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(ids.len(), 3, "POST must launch all three scenarios");
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let pre_delete_events: Vec<u64> = ids[1..]
+        .iter()
+        .map(|id| {
+            let stats = client
+                .get(format!("http://127.0.0.1:{port}/scenarios/{id}/stats"))
+                .send()
+                .expect("GET /stats must succeed");
+            assert_eq!(stats.status().as_u16(), 200);
+            let body: serde_json::Value = stats.json().expect("stats body is JSON");
+            body["total_events"].as_u64().unwrap_or(0)
+        })
+        .collect();
+
+    let first = &ids[0];
+    let del = client
+        .delete(format!("http://127.0.0.1:{port}/scenarios/{first}"))
+        .send()
+        .expect("DELETE must succeed");
+    assert_eq!(
+        del.status().as_u16(),
+        200,
+        "DELETE on the first scenario must return 200"
+    );
+    let del_body: serde_json::Value = del.json().expect("DELETE body is JSON");
+    assert_eq!(
+        del_body["status"].as_str(),
+        Some("stopped"),
+        "DELETE response status must be 'stopped'"
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    for (i, id) in ids[1..].iter().enumerate() {
+        let resp = client
+            .get(format!("http://127.0.0.1:{port}/scenarios/{id}"))
+            .send()
+            .expect("GET /scenarios/{id} must succeed");
+        assert_eq!(
+            resp.status().as_u16(),
+            200,
+            "sibling {id} must still be addressable after DELETE on a peer"
+        );
+        let body: serde_json::Value = resp.json().expect("GET body is JSON");
+        let state = body["state"].as_str().unwrap_or("");
+        assert_eq!(
+            state, "running",
+            "sibling {id} must remain running after DELETE on a peer, got state={state:?}"
+        );
+
+        let stats = client
+            .get(format!("http://127.0.0.1:{port}/scenarios/{id}/stats"))
+            .send()
+            .expect("GET /stats must succeed");
+        let stats_body: serde_json::Value = stats.json().expect("stats body is JSON");
+        let total = stats_body["total_events"].as_u64().unwrap_or(0);
+        assert!(
+            total > pre_delete_events[i],
+            "sibling {id} must keep emitting after DELETE on a peer: pre={} post={}",
+            pre_delete_events[i],
+            total
+        );
+    }
+}

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -350,9 +350,14 @@ fn run_compiled_with_progress(
     running: &Arc<AtomicBool>,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
-    let handles =
-        sonda_core::schedule::multi_runner::launch_multi_compiled(compiled, Arc::clone(running))
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let handles = sonda_core::schedule::multi_runner::launch_multi_compiled(compiled)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let per_handle_shutdowns: Vec<Arc<AtomicBool>> =
+        handles.iter().map(|h| Arc::clone(&h.shutdown)).collect();
+    let done = Arc::new(AtomicBool::new(false));
+    let watchdog =
+        spawn_ctrlc_watchdog(Arc::clone(running), per_handle_shutdowns, Arc::clone(&done));
 
     let progress = maybe_start_progress_multi(&handles, verbosity);
 
@@ -363,6 +368,9 @@ fn run_compiled_with_progress(
         }
     }
 
+    done.store(true, Ordering::SeqCst);
+    let _ = watchdog.join();
+
     if let Some(p) = progress {
         p.stop();
     }
@@ -371,6 +379,31 @@ fn run_compiled_with_progress(
         return Err(anyhow::anyhow!("{}", errors.join("; ")));
     }
     Ok(())
+}
+
+fn spawn_ctrlc_watchdog(
+    master: Arc<AtomicBool>,
+    per_handle: Vec<Arc<AtomicBool>>,
+    done: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::Builder::new()
+        .name("sonda-cli-shutdown-watchdog".to_string())
+        .spawn(move || {
+            let poll = std::time::Duration::from_millis(100);
+            loop {
+                if done.load(Ordering::SeqCst) {
+                    return;
+                }
+                if !master.load(Ordering::SeqCst) {
+                    for flag in &per_handle {
+                        flag.store(false, Ordering::SeqCst);
+                    }
+                    return;
+                }
+                std::thread::sleep(poll);
+            }
+        })
+        .expect("watchdog thread must spawn")
 }
 
 fn stop_infos_for_groups(


### PR DESCRIPTION
`POST /scenarios` with a multi-scenario body previously shared one `Arc<AtomicBool>` shutdown flag across every spawned scenario thread, so `DELETE /scenarios/<id>` cascade-finished every sibling on its next tick. Each `ScenarioHandle` now owns an independent shutdown flag; `stop()` affects only that scenario. Server SIGINT and CLI Ctrl+C continue to stop everything via a small watchdog that fans a master signal into per-handle stops.

- `launch_multi_compiled(file)` drops the shared `shutdown` parameter; creates a per-scenario flag internally.
- `run_multi` / `run_multi_compiled` keep the master `shutdown` parameter and use a watchdog to translate it into per-handle stops.
- CLI `run_compiled_with_progress` wires the same watchdog for Ctrl+C.
- Server's `launch_compiled` drops the per-POST `Arc<AtomicBool>` plumbing entirely.
- Doc comments on `ScenarioHandle::shutdown` and `stop()` state the per-handle invariant.
- Regression test posts three scenarios, deletes one, asserts the others stay running and keep emitting.

A separate `while:`-gated-scenario lifecycle issue (downstream stays `state=running` after its ref finishes) will follow as its own PR.