### PR TITLE
refactor(core): seal GateContext with #[non_exhaustive] + builder

### DIFF
--- a/sonda-core/benches/while_steady_state.rs
+++ b/sonda-core/benches/while_steady_state.rs
@@ -88,16 +88,7 @@ fn bench_gated_open(c: &mut Criterion) {
                 shutdown,
                 None,
                 Some(Arc::clone(&bus)),
-                Some(GateContext {
-                    gate_rx: rx,
-                    initial: init,
-                    delay: None,
-                    has_after: false,
-                    has_while: true,
-                    close_emit: None,
-                    if_unresolved: None,
-                    start_unresolved: false,
-                }),
+                Some(GateContext::new(rx, init).with_has_while(true)),
                 None,
             )
             .unwrap();

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -505,6 +505,7 @@ fn invoke_close_emit(
 const PAUSED_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Gate-side context attached to a `gated_loop` run.
+#[non_exhaustive]
 pub struct GateContext {
     /// Receiver for `after:` and/or `while:` edges from the upstream bus.
     pub gate_rx: GateReceiver,
@@ -522,6 +523,52 @@ pub struct GateContext {
     pub close_emit: Option<CloseEmitFn>,
     pub if_unresolved: Option<UnresolvedBehavior>,
     pub start_unresolved: bool,
+}
+
+impl GateContext {
+    /// Construct a `GateContext` with required pieces; optional fields default to `None` / `false`.
+    pub fn new(gate_rx: GateReceiver, initial: InitialState) -> Self {
+        Self {
+            gate_rx,
+            initial,
+            delay: None,
+            has_after: false,
+            has_while: false,
+            close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
+        }
+    }
+
+    pub fn with_delay(mut self, delay: Option<DelayClause>) -> Self {
+        self.delay = delay;
+        self
+    }
+
+    pub fn with_has_after(mut self, has_after: bool) -> Self {
+        self.has_after = has_after;
+        self
+    }
+
+    pub fn with_has_while(mut self, has_while: bool) -> Self {
+        self.has_while = has_while;
+        self
+    }
+
+    pub fn with_close_emit(mut self, close_emit: Option<CloseEmitFn>) -> Self {
+        self.close_emit = close_emit;
+        self
+    }
+
+    pub fn with_if_unresolved(mut self, mode: Option<UnresolvedBehavior>) -> Self {
+        self.if_unresolved = mode;
+        self
+    }
+
+    pub fn with_start_unresolved(mut self, start_unresolved: bool) -> Self {
+        self.start_unresolved = start_unresolved;
+        self
+    }
 }
 
 /// Run a signal scenario through the four-state lifecycle gate.

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -227,16 +227,13 @@ pub fn launch_multi_compiled(
                         )
                     }
                 };
-                Some(GateContext {
-                    gate_rx,
-                    initial,
-                    delay: delay_clause,
-                    has_after: false,
-                    has_while: true,
-                    close_emit: None,
-                    if_unresolved: Some(if_unresolved),
-                    start_unresolved,
-                })
+                Some(
+                    GateContext::new(gate_rx, initial)
+                        .with_delay(delay_clause)
+                        .with_has_while(true)
+                        .with_if_unresolved(Some(if_unresolved))
+                        .with_start_unresolved(start_unresolved),
+                )
             } else {
                 let upstream = buses.get(&clause.ref_id).ok_or_else(|| {
                     SondaError::Config(crate::ConfigError::invalid(format!(
@@ -252,16 +249,11 @@ pub fn launch_multi_compiled(
                     }),
                 };
                 let (rx, init) = upstream.subscribe(spec);
-                Some(GateContext {
-                    gate_rx: rx,
-                    initial: init,
-                    delay: delay_clause,
-                    has_after: false,
-                    has_while: true,
-                    close_emit: None,
-                    if_unresolved: None,
-                    start_unresolved: false,
-                })
+                Some(
+                    GateContext::new(rx, init)
+                        .with_delay(delay_clause)
+                        .with_has_while(true),
+                )
             }
         } else {
             None

--- a/sonda-core/tests/start_time_shift.rs
+++ b/sonda-core/tests/start_time_shift.rs
@@ -344,16 +344,11 @@ fn gated_close_emit_marker_lands_in_shifted_window() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: Some(delay),
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(
+                GateContext::new(rx, init)
+                    .with_delay(Some(delay))
+                    .with_has_while(true),
+            ),
         )
         .expect("gated runner must succeed");
         sink

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -120,16 +120,9 @@ fn run_with_capture(
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let shutdown = Arc::new(AtomicBool::new(true));
-        let gate_ctx = GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        };
+        let gate_ctx = GateContext::new(rx, init)
+            .with_delay(delay)
+            .with_has_while(true);
         sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
@@ -346,16 +339,7 @@ fn non_remote_write_sink_no_close_marker_by_default() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: None,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(GateContext::new(rx, init).with_has_while(true)),
         )
         .expect("runner must succeed");
         sink
@@ -445,16 +429,11 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: Some(delay),
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(
+                GateContext::new(rx, init)
+                    .with_delay(Some(delay))
+                    .with_has_while(true),
+            ),
         )
         .expect("runner must succeed");
         sink
@@ -547,16 +526,11 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: Some(delay),
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(
+                GateContext::new(rx, init)
+                    .with_delay(Some(delay))
+                    .with_has_while(true),
+            ),
         )
         .expect("runner must succeed");
     });
@@ -651,16 +625,7 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: None,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(GateContext::new(rx, init).with_has_while(true)),
         )
         .expect("runner must succeed");
     });
@@ -742,16 +707,11 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: Some(delay),
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(
+                GateContext::new(rx, init)
+                    .with_delay(Some(delay))
+                    .with_has_while(true),
+            ),
         )
         .expect("runner must succeed");
         sink
@@ -840,21 +800,16 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: Some(DelayClause {
-                    open: Some(Duration::from_millis(0)),
-                    close: Some(Duration::from_millis(0)),
-                    close_stale_marker: None,
-                    close_snap_to: None,
-                }),
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(
+                GateContext::new(rx, init)
+                    .with_delay(Some(DelayClause {
+                        open: Some(Duration::from_millis(0)),
+                        close: Some(Duration::from_millis(0)),
+                        close_stale_marker: None,
+                        close_snap_to: None,
+                    }))
+                    .with_has_while(true),
+            ),
         )
         .expect("runner must succeed");
     });
@@ -937,16 +892,7 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: None,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(GateContext::new(rx, init).with_has_while(true)),
         )
         .expect("runner must succeed");
     });
@@ -1028,21 +974,16 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: Some(DelayClause {
-                    open: Some(Duration::from_millis(0)),
-                    close: Some(Duration::from_millis(0)),
-                    close_stale_marker: None,
-                    close_snap_to: None,
-                }),
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(
+                GateContext::new(rx, init)
+                    .with_delay(Some(DelayClause {
+                        open: Some(Duration::from_millis(0)),
+                        close: Some(Duration::from_millis(0)),
+                        close_stale_marker: None,
+                        close_snap_to: None,
+                    }))
+                    .with_has_while(true),
+            ),
         )
         .expect("runner must succeed");
     });
@@ -1130,16 +1071,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
             Some(shutdown_for_thread.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: None,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(GateContext::new(rx, init).with_has_while(true)),
         )
         .expect("runner must succeed");
     });

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -102,16 +102,7 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let shutdown = Arc::new(AtomicBool::new(true));
-    let gate_ctx = GateContext {
-        gate_rx: rx,
-        initial: init,
-        delay: None,
-        has_after: false,
-        has_while: true,
-        close_emit: None,
-        if_unresolved: None,
-        start_unresolved: false,
-    };
+    let gate_ctx = GateContext::new(rx, init).with_has_while(true);
 
     let entry = metrics_entry("downstream", 200.0, 600);
     let mut handle = launch_scenario_with_gates(
@@ -170,16 +161,7 @@ fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscriptio
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -215,16 +197,7 @@ fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -255,16 +228,7 @@ fn while_runtime_no_catch_up_burst_on_resume() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -359,16 +323,7 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -438,16 +393,7 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -505,16 +451,7 @@ fn while_runtime_finished_state_after_duration_expires() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -545,16 +482,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx_a,
-            initial: init_a,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx_a, init_a).with_has_while(true)),
         None,
     )
     .expect("launch a must succeed");
@@ -566,16 +494,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx_b,
-            initial: init_b,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx_b, init_b).with_has_while(true)),
         None,
     )
     .expect("launch b must succeed");
@@ -614,16 +533,7 @@ fn while_runtime_logs_signal_can_be_gated_downstream() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -679,16 +589,11 @@ fn while_runtime_delay_open_debounces_pause_to_running_transition() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: Some(delay),
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(
+            GateContext::new(rx, init)
+                .with_delay(Some(delay))
+                .with_has_while(true),
+        ),
         None,
     )
     .expect("launch must succeed");
@@ -742,16 +647,7 @@ fn while_runtime_strict_lt_threshold_gating() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -786,16 +682,7 @@ fn scenario_restart_does_not_leak_gate_bus() {
             shutdown,
             None,
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: None,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(GateContext::new(rx, init).with_has_while(true)),
             None,
         )
         .expect("launch must succeed");
@@ -839,16 +726,11 @@ fn while_runtime_delay_close_debounces_running_to_paused_transition() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: Some(delay),
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(
+            GateContext::new(rx, init)
+                .with_delay(Some(delay))
+                .with_has_while(true),
+        ),
         None,
     )
     .expect("launch must succeed");
@@ -920,16 +802,11 @@ fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: true,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(
+            GateContext::new(rx, init)
+                .with_has_after(true)
+                .with_has_while(true),
+        ),
         None,
     )
     .expect("launch must succeed");
@@ -995,16 +872,11 @@ fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: true,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(
+            GateContext::new(rx, init)
+                .with_has_after(true)
+                .with_has_while(true),
+        ),
         None,
     )
     .expect("launch must succeed");
@@ -1081,16 +953,11 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: true,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(
+            GateContext::new(rx, init)
+                .with_has_after(true)
+                .with_has_while(true),
+        ),
         None,
     )
     .expect("launch must succeed");
@@ -1167,16 +1034,7 @@ fn while_runtime_steady_within_5pct_of_baseline() {
             shutdown,
             None,
             Some(Arc::clone(&bus)),
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: None,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(GateContext::new(rx, init).with_has_while(true)),
             None,
         )
         .unwrap();
@@ -1318,16 +1176,7 @@ fn nan_upstream_value_keeps_downstream_paused() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");


### PR DESCRIPTION
## Summary

Closes the Brief 3 carryover: `GateContext` was the only public re-exported `sonda-core` type left without `#[non_exhaustive]` after the cross-POST `while:` work added two new fields. This PR introduces a consuming-builder constructor, rewrites every literal construction site through it, then layers `#[non_exhaustive]` on the struct so future field additions are backwards-compatible for external consumers.

## What changed

- `impl GateContext { new(gate_rx, initial) }` + 6 `with_*` setters (consuming-builder pattern, matches `PrometheusText` precedent)
- `#[non_exhaustive]` on the struct
- 33 in-tree literal construction sites rewritten through the builder (2 production, 30 tests + 1 bench)
- Fields stay `pub` for reads; only inline struct construction outside the defining crate is now forbidden
- Net `+146 / −340` — per-site 9-field literals collapse to `new() + 1–4 setters`

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace --all-features` (2822/2822 pass, 3 skipped)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --doc`
- [x] `cargo test -p sonda-core --no-default-features`
- [x] `cargo audit`

Refs: cross-POST \`while:\` ref resolution feature (landing branch).