### PR TITLE
feat: cross-POST while: ref resolution across scenario sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-link",
 ]
 
@@ -2188,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2207,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2235,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/docs/site/docs/configuration/concepts.md
+++ b/docs/site/docs/configuration/concepts.md
@@ -290,7 +290,7 @@ scenarios:
         - message: "request handled"
 ```
 
-Three signal types, three threads, two sinks — metrics + histogram go to Prometheus, logs go to Loki. For entries that depend on each other in time (one starts only after another crosses a threshold; one emits only while another is in a given state), see `after:` and `while:` on the [Scenario Files](scenario-files.md#temporal-chains-with-after) page. For a hands-on walkthrough, see the [Multi-Scenario Runs](../guides/tutorial-multi-scenario.md) tutorial.
+Three signal types, three threads, two sinks — metrics + histogram go to Prometheus, logs go to Loki. For entries that depend on each other in time (one starts only after another crosses a threshold; one emits only while another is in a given state), see `after:` and `while:` on the [Scenario Files](scenario-files.md#temporal-chains-with-after) page. When the upstream signal is itself driven by a separate POST to a running [`sonda-server`](../deployment/sonda-server.md), the `while:` clause supports cross-POST refs — see [Cross-POST `while:` refs](scenario-files.md#cross-post-while-refs). For a hands-on walkthrough, see the [Multi-Scenario Runs](../guides/tutorial-multi-scenario.md) tutorial.
 
 ## What next
 

--- a/docs/site/docs/configuration/scenario-files.md
+++ b/docs/site/docs/configuration/scenario-files.md
@@ -415,7 +415,7 @@ For continuous gating that pauses and resumes a downstream as the upstream's val
 
 ## Continuous coupling with `while:`
 
-`after:` is a one-shot trigger -- it fires once and the dependent scenario runs to completion. `while:` is the continuous-coupling counterpart: the gated scenario emits only while the upstream's latest value satisfies the predicate, pauses when the predicate fails, and resumes when the predicate becomes true again. A `while:`-gated entry must declare a `duration:` -- on the entry itself or via `defaults.duration` -- and is rejected at compile time without one, because the `paused` state needs a terminal point to bound the scenario's lifetime. Use `while:` when an event stream should track an upstream signal's lifecycle, not just its first crossing. When a `while:`-gated scenario pauses, downstream alerts on its metrics keep firing for ~5 minutes by default — see [Recovering Prometheus alerts on gate close](#recovering-prometheus-alerts-on-gate-close) for the stale-marker default that resolves them immediately.
+`after:` is a one-shot trigger -- it fires once and the dependent scenario runs to completion. `while:` is the continuous-coupling counterpart: the gated scenario emits only while the upstream's latest value satisfies the predicate, pauses when the predicate fails, and resumes when the predicate becomes true again. A `while:`-gated entry must declare a `duration:` -- on the entry itself or via `defaults.duration` -- and is rejected at compile time without one, because the `paused` state needs a terminal point to bound the scenario's lifetime. Use `while:` when an event stream should track an upstream signal's lifecycle, not just its first crossing. When a `while:`-gated scenario pauses, downstream alerts on its metrics keep firing for ~5 minutes by default — see [Recovering Prometheus alerts on gate close](#recovering-prometheus-alerts-on-gate-close) for the stale-marker default that resolves them immediately. The upstream signal lives in the same scenario file by default; for [`sonda-server`](../deployment/sonda-server.md) deployments where the upstream arrives in a separate POST body, see [Cross-POST `while:` refs](#cross-post-while-refs).
 
 ```yaml title="link-traffic.yaml"
 version: 2
@@ -678,6 +678,107 @@ scenarios:
 ```
 
 The `delay.close: 5s` debounces flap transitions: a brief recovery on the primary does not immediately tear down `backup_util`, but a sustained recovery longer than 5s does.
+
+### Cross-POST `while:` refs
+
+The `while:` clause shown above gates a scenario on another signal *in the same file*. When you drive Sonda via [`sonda-server`](../deployment/sonda-server.md), you can also gate on a signal from a **separately POSTed body** by qualifying the `ref:` with the upstream's `scenario_name:`. This lets one process drive multiple independent POSTs whose lifecycles are loosely coupled — a baseline counter you launch at boot, paused or resumed by a cascade body you POST on demand later — without restarting either side or rewriting the YAML when a new upstream arrives.
+
+Cross-POST refs are a `sonda-server` feature. The CLI runs every scenario in a single process and has no cross-POST registry, so `sonda run` rejects a file with `while.scenario_name` at parse time and points here.
+
+#### Schema
+
+A cross-POST `while:` clause is the same shape as the local form plus two fields:
+
+```yaml
+while:
+  scenario_name: <upstream-body-name>     # which POST body owns the upstream signal
+  ref: <entry-id>                         # entry id INSIDE that body
+  op: ">"                                 # same operators as local while: (< or >)
+  value: 1                                # threshold
+  if_unresolved: open                     # behavior when the upstream is not running yet
+```
+
+Both POST bodies — the gated one and the gate source — MUST declare a top-level `scenario_name:` field. The upstream body's `scenario_name:` is the identifier the downstream's `while.scenario_name` references. A body without a top-level `scenario_name:` is anonymous and cannot be addressed by another body's `while:` clause; the compiler rejects a cross-POST `while:` on a body that does not name itself.
+
+`ref:` must be the top-level entry `id:` of an entry in the upstream body. Pack sub-signal syntax (`ref: my_entry.metric_name`) is rejected at parse time on cross-POST refs — use the top-level entry id.
+
+#### `if_unresolved:` modes
+
+`if_unresolved:` controls what the downstream does when its named upstream has not yet POSTed. Three values:
+
+| Value | Behavior |
+|---|---|
+| `open` | Emit at full rate as if the gate were true. Events flow at the configured rate; the scenario sits in `unresolved` (the resolution-status state) until the upstream POSTs and the resolver wires the subscription. Use this when the downstream is a baseline counter you want running unless the cascade gates it. |
+| `closed` | Pause emission as if the gate were false. The scenario sits in `unresolved`, no events are emitted. |
+| `pending` (default) | Neither emit nor advance state. The scenario sits in `unresolved` until the upstream POSTs. This is the conservative default — no traffic until the dependency is satisfied. |
+
+Once the upstream IS running, the downstream behaves like a local `while:` clause: open when the predicate is true, paused (with `delay:` debounce, recovery markers, etc. — see [Continuous coupling with `while:`](#continuous-coupling-with-while)) when the predicate is false.
+
+#### Lifecycle
+
+A cross-POST-gated scenario adds one state to the `while:` lifecycle: **`unresolved`**, used while waiting for the named upstream to register. The scenario moves through the lifecycle like this:
+
+- **Initial POST**: the downstream lands in `unresolved`. Its [`pending_ref` field on `GET /scenarios/{id}`](../deployment/sonda-server.md#pending_ref-field-on-get-scenariosid) shows the upstream it is waiting on.
+- **Upstream POSTs**: the downstream resolves automatically — the server's resolver wires the subscription and the downstream transitions to `running` (or to `paused` if the predicate is already false). No client orchestration needed.
+- **Upstream is DELETEd, or finishes its duration**: the downstream transitions back to `unresolved` and applies the `if_unresolved:` mode again — `open` keeps it emitting, `closed` pauses, `pending` halts.
+- **A new POST arrives with the same `scenario_name:`**: the downstream re-resolves to the new upstream automatically. The downstream keeps its accumulated state across the gap — counters preserve their value through pause/resume cycles.
+
+#### Example: baseline counter gated by a cascade
+
+A baseline counter that you want running at full rate by default, but paused whenever an on-demand cascade declares a "link state" of 0:
+
+```yaml title="baseline.yaml — POST first, runs immediately under if_unresolved: open"
+version: 2
+kind: runnable
+scenario_name: baseline_post
+defaults:
+  rate: 100
+  duration: 1h
+  encoder:
+    type: prometheus_text
+  sink:
+    type: remote_write
+    url: ${VICTORIAMETRICS_REMOTE_WRITE_URL:-http://localhost:8428/api/v1/write}
+scenarios:
+  - id: requests_total
+    signal_type: metrics
+    name: requests_total
+    generator:
+      type: step
+      start: 0
+      step_size: 1
+    while:
+      scenario_name: cascade_post
+      ref: link_state
+      op: ">"
+      value: 0
+      if_unresolved: open
+```
+
+```yaml title="cascade.yaml — POST later to gate the baseline"
+version: 2
+kind: runnable
+scenario_name: cascade_post
+defaults:
+  rate: 1
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: link_state
+    signal_type: metrics
+    name: link_state
+    generator:
+      type: flap
+      up_duration: 10s
+      down_duration: 5s
+```
+
+POST `baseline.yaml` first. Because the cascade has not arrived, `if_unresolved: open` keeps the counter emitting at the full 100/s rate. Later, POST `cascade.yaml` — the baseline resolves to the cascade automatically. The counter now emits only while `link_state > 0` and pauses while it is `0`. When the cascade finishes (30s) or you DELETE it, the baseline returns to `if_unresolved: open` and resumes the unpaused 100/s rate. POST the cascade again and the baseline re-resolves; the counter picks up from where it froze, so its values stay monotonic across pause/resume cycles.
+
+For the HTTP surface — the strict-validation flag, the `pending_ref` field, the duplicate-name 409, and the new `/stats` fields — see [Server API](../deployment/sonda-server.md#cross-post-while-refs).
 
 ## Pack-backed entries
 

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -206,7 +206,7 @@ Post a [scenario](../configuration/scenario-files.md) YAML or JSON body to `POST
 
     The JSON body is transcoded to YAML server-side and compiled through the same pipeline as the YAML path. Any valid scenario file can be posted as JSON by converting the YAML to its JSON equivalent.
 
-The response shape depends on how many entries the compiler produces, not on the request format. A single-entry result returns the flat `{"id", "name", "state"}` body; anything that compiles to two or more entries (for example, a pack-backed entry that fans out) returns `{"scenarios": [...]}`. The `state` field reports the live lifecycle state at response time and takes one of `"pending"`, `"running"`, `"paused"`, or `"finished"` (see [`/scenarios/{id}/stats`](#scenariosidstats) for the full enum and the `pending -> paused` transition note).
+The response shape depends on how many entries the compiler produces, not on the request format. A single-entry result returns the flat `{"id", "name", "state"}` body; anything that compiles to two or more entries (for example, a pack-backed entry that fans out) returns `{"scenarios": [...]}`. The `state` field reports the live lifecycle state at response time and takes one of `"pending"`, `"running"`, `"paused"`, `"unresolved"`, or `"finished"` (see [`/scenarios/{id}/stats`](#scenariosidstats) for the full enum, the `pending -> paused` transition note, and the [cross-POST `unresolved` state](#unresolved-lifecycle-state)).
 
 ### Multi-scenario body
 
@@ -388,7 +388,7 @@ Without `--catalog`, a body that references a pack by name is rejected with `400
 |--------|-----------|--------------|
 | **400 Bad Request** | Body is not UTF-8, not valid JSON/YAML, missing `version: 2`, or fails compilation. | Parser or compiler error; v1 bodies include the migration hint. |
 | **409 Conflict** | The posted body sets a top-level `scenario_name` that matches an active scenario already in the map. | Identifies the duplicate name and lists the conflicting scenarios. See [Duplicate scenario_name returns 409](#duplicate-scenario_name-returns-409). |
-| **422 Unprocessable Entity** | Body compiles but fails runtime validation (`rate: 0`, zero `duration`, etc.). | Validation error identifying the failing entry. |
+| **422 Unprocessable Entity** | Body compiles but fails runtime validation (`rate: 0`, zero `duration`, etc.), or — with `?validate=strict` — at least one cross-POST `while:` reference does not resolve at compile time. | Validation error identifying the failing entry, or `{error: "unresolved_refs", unresolved_refs: [...]}`. See [Cross-POST `while:` refs](#cross-post-while-refs). |
 | **500 Internal Server Error** | Scenario thread could not be spawned, or internal state error. | Short internal error; check server logs. |
 
 ### Duplicate scenario_name returns 409
@@ -411,7 +411,98 @@ The 409 body lists every active scenario contributing to the conflict so the ope
 }
 ```
 
-Each `conflicting_scenarios` entry carries the scenario `id` (use it with `DELETE /scenarios/{id}`), the per-entry `name` (the runtime-launched scenario name, not the file-level `scenario_name`), and the live `state` (one of `pending`, `running`, `paused`). When the body produced multiple entries (multi-entry POST or pack expansion), each launched handle inherits the same file-level `scenario_name` and contributes one item to the array.
+Each `conflicting_scenarios` entry carries the scenario `id` (use it with `DELETE /scenarios/{id}`), the per-entry `name` (the runtime-launched scenario name, not the file-level `scenario_name`), and the live `state` (one of `pending`, `running`, `paused`, `unresolved`). When the body produced multiple entries (multi-entry POST or pack expansion), each launched handle inherits the same file-level `scenario_name` and contributes one item to the array.
+
+## Cross-POST `while:` refs
+
+A POSTed scenario can `while:`-gate itself on a signal in a **separate** POST body by qualifying the `ref:` with the upstream's `scenario_name:`. The HTTP surface adds four things on top of the [YAML schema](../configuration/scenario-files.md#cross-post-while-refs): a `?validate=strict` flag on `POST /scenarios`, a `pending_ref` field on `GET /scenarios/{id}`, an `unresolved` lifecycle state, and two new fields on `GET /scenarios/{id}/stats`.
+
+### Deferred vs strict validation
+
+By default `POST /scenarios` accepts a body whose cross-POST refs have not been registered yet. The scenario lands in the `unresolved` state and resolves automatically once a matching upstream POSTs — this is the loose-coupling shape that lets you launch a baseline body without coordinating with whatever drives it later.
+
+Pass `?validate=strict` to flip that behavior: the server rejects the whole body with `422 Unprocessable Entity` if any cross-POST `while:` reference does not resolve at compile time. Nothing is launched. Use it when the dependency order is part of your contract and a missing upstream should fail loudly.
+
+```bash
+curl -X POST -H "Content-Type: text/yaml" \
+  --data-binary @baseline.yaml \
+  'http://localhost:8080/scenarios?validate=strict'
+```
+
+```json title="Response (422 Unprocessable Entity) — strict rejection"
+{
+  "error": "unresolved_refs",
+  "unresolved_refs": [
+    {
+      "scenario_name": "cascade_post",
+      "entry_id": "link_state",
+      "referenced_by": "requests_total"
+    }
+  ]
+}
+```
+
+Each `unresolved_refs` entry identifies the missing upstream by `scenario_name` (the upstream POST body's name), `entry_id` (the entry inside that body the `while:` clause references), and `referenced_by` (the id of the downstream entry whose `while:` clause could not be wired).
+
+### `unresolved` lifecycle state
+
+A scenario whose cross-POST `while:` clause has no registered upstream — and whose `if_unresolved:` mode is `pending` (the default) — sits in the `unresolved` state. The wire string is `"state": "unresolved"`. The lifecycle states a scenario can report on `GET /scenarios/{id}` and `GET /scenarios/{id}/stats` are therefore:
+
+| State | When |
+|---|---|
+| `pending` | Waiting for `after:` to fire, or the first eligible tick of a local `while:` gate. |
+| `running` | Emitting events. |
+| `paused` | Local `while:` gate is closed, or a cross-POST gate's `if_unresolved: closed` is in effect. |
+| `unresolved` | Cross-POST `while.scenario_name:` has not been POSTed yet (with `if_unresolved: pending`), or its upstream was DELETEd. |
+| `finished` | `duration:` elapsed or shutdown signalled. Terminal. |
+
+A scenario can transition `unresolved → pending → running` once the upstream registers, and back to `unresolved` when the upstream is DELETEd or finishes its own duration. Re-POSTing the same `scenario_name:` re-resolves the downstream automatically — no client orchestration. See [Cross-POST `while:` refs](../configuration/scenario-files.md#cross-post-while-refs) for the YAML schema and the `if_unresolved:` mode reference.
+
+!!! warning "Add `unresolved` to your dashboards"
+    If you maintain Prometheus recording rules or Grafana dashboards that enumerate `state=~"pending|running|paused|finished"`, add `unresolved` to the alternation (`state=~"pending|running|paused|unresolved|finished"`) or rewrite the matcher as a negation (`state!="finished"`). Cross-POST scenarios in `unresolved` are silently dropped by exhaustive enumerations.
+
+### `pending_ref` field on `GET /scenarios/{id}`
+
+When a scenario is in the `unresolved` state, `GET /scenarios/{id}` includes a `pending_ref` object identifying the upstream it is waiting on. The field is omitted from the response for any other state.
+
+```bash
+curl -s http://localhost:8080/scenarios/$ID | jq .
+```
+
+```json title="Response (state == unresolved)"
+{
+  "id": "a1b2c3d4-...",
+  "name": "requests_total",
+  "state": "unresolved",
+  "elapsed_secs": 2.4,
+  "degraded": false,
+  "stats": { "total_events": 0, "current_rate": 0.0, "bytes_emitted": 0, "...": "..." },
+  "pending_ref": {
+    "scenario_name": "cascade_post",
+    "entry_id": "link_state",
+    "if_unresolved": "pending",
+    "registered_at": "2026-05-26T14:32:08Z",
+    "attempts": 3
+  }
+}
+```
+
+`scenario_name` and `entry_id` are the upstream the downstream is waiting for. `if_unresolved` is the mode that applies until the upstream resolves (`open`, `closed`, or `pending`). `registered_at` is the ISO-8601 wall-clock time the downstream entered the resolver queue. `attempts` counts how many times the resolver has tried to wire this subscription — it advances on every promotion attempt and persists across `unresolved → running → unresolved` cycles so you can detect a downstream that has bounced repeatedly between states.
+
+### New stats fields
+
+`GET /scenarios/{id}/stats` adds two fields to the existing [stats payload](#scenariosidstats):
+
+| Field | Type | Meaning |
+|---|---|---|
+| `current_state_secs` | float | Seconds since the most recent state transition. Resets to `0.0` every time `state` changes (including the `unresolved → running` resolution edge). Use this to alert on a scenario that has been stuck in one state too long — e.g., `current_state_secs > 60 and state == "unresolved"` flags a cross-POST dependency that has not arrived. |
+| `cumulative_resolution_attempts` | integer | Lifetime count of how many times the cross-POST resolver has tried to wire this scenario's subscription. Increments on each promotion attempt; persists across `unresolved → running → unresolved` cycles. Only `DELETE /scenarios/{id}` resets it. Use it to spot a downstream that is bouncing between states because its upstream keeps coming and going. |
+
+Both fields are present on every response, not just `unresolved` scenarios — `cumulative_resolution_attempts` is `0` for any scenario whose `while:` clause does not carry `scenario_name:`, and `current_state_secs` measures time since the last lifecycle edge for every state.
+
+### Duplicate name across POSTs
+
+The [`409 Conflict` rule](#duplicate-scenario_name-returns-409) extends to cross-POST scenarios: a body whose top-level `scenario_name:` collides with one already registered in the resolver — whether that earlier scenario is `pending`, `running`, `paused`, or `unresolved` — is rejected. The `conflicting_scenarios` array on the 409 response identifies which IDs to DELETE before re-POSTing. This applies both to the upstream (the body that publishes the gate signal) and to any downstream POST whose top-level `scenario_name:` is already in use.
 
 ## API Endpoints
 
@@ -585,7 +676,7 @@ curl -s http://localhost:8080/scenarios | jq .
 }
 ```
 
-Each entry carries `id`, `name`, `state`, `elapsed_secs`, and `degraded`. The `state` field takes one of `pending`, `running`, `paused`, or `finished` (see the [`state` field reference](#scenariosidstats) below for what each value means and the transition note for `pending -> paused`).
+Each entry carries `id`, `name`, `state`, `elapsed_secs`, and `degraded`. The `state` field takes one of `pending`, `running`, `paused`, `unresolved`, or `finished` (see the [`state` field reference](#scenariosidstats) below for what each value means, the transition note for `pending -> paused`, and the [cross-POST `unresolved` state](#unresolved-lifecycle-state)).
 
 #### The `degraded` field
 
@@ -643,7 +734,9 @@ curl -s http://localhost:8080/scenarios/$ID/stats | jq .
   "total_sink_failures": 12,
   "last_sink_error": "HTTP 500 from 'http://loki:3100/loki/api/v1/push'",
   "last_successful_write_at": 1714694400000000000,
-  "degraded": true
+  "degraded": true,
+  "current_state_secs": 12.7,
+  "cumulative_resolution_attempts": 0
 }
 ```
 
@@ -687,7 +780,9 @@ This is the shape to look for: rising `total_events`, `last_successful_write_at`
 | `bytes_emitted` | integer | Total bytes written to the sink. |
 | `errors` | integer | Encode or sink-write errors observed. |
 | `uptime_secs` | float | Seconds since the scenario was launched. |
-| `state` | string | One of `pending`, `running`, `paused`, `finished`. See the [`while:` lifecycle diagram](../configuration/scenario-files.md#lifecycle-states). |
+| `state` | string | One of `pending`, `running`, `paused`, `unresolved`, `finished`. See the [`while:` lifecycle diagram](../configuration/scenario-files.md#lifecycle-states) and the [cross-POST `unresolved` state](#unresolved-lifecycle-state). |
+| `current_state_secs` | float | Seconds since the most recent state transition. See [Cross-POST `while:` refs](#cross-post-while-refs). |
+| `cumulative_resolution_attempts` | integer | Lifetime count of cross-POST resolver attempts for this scenario. `0` for local-only scenarios. See [Cross-POST `while:` refs](#cross-post-while-refs). |
 | `in_gap` | bool | `true` while a [gap window](../configuration/scenario-fields.md#gap-window) is suppressing output. |
 | `in_burst` | bool | `true` while a [burst window](../configuration/scenario-fields.md#burst-window) is elevating the rate. |
 | `consecutive_failures` | integer | Sink errors observed since the most recent successful *delivery*. Resets to `0` on the next delivery. |

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [features]
 default = ["config"]
-config = ["dep:serde_yaml_ng", "dep:chrono"]
+config = ["dep:serde_yaml_ng", "dep:chrono", "chrono/serde"]
 http = ["dep:ureq"]
 kafka = ["dep:rskafka", "dep:tokio", "dep:chrono", "chrono/clock", "dep:rustls", "dep:rustls-pki-types", "dep:webpki-roots"]
 remote-write = ["dep:prost", "dep:snap", "dep:ureq"]

--- a/sonda-core/benches/while_steady_state.rs
+++ b/sonda-core/benches/while_steady_state.rs
@@ -94,6 +94,8 @@ fn bench_gated_open(c: &mut Criterion) {
                     has_after: false,
                     has_while: true,
                     close_emit: None,
+                    if_unresolved: None,
+                    start_unresolved: false,
                 }),
             )
             .unwrap();

--- a/sonda-core/benches/while_steady_state.rs
+++ b/sonda-core/benches/while_steady_state.rs
@@ -88,16 +88,7 @@ fn bench_gated_open(c: &mut Criterion) {
                 shutdown,
                 None,
                 Some(Arc::clone(&bus)),
-                Some(GateContext {
-                    gate_rx: rx,
-                    initial: init,
-                    delay: None,
-                    has_after: false,
-                    has_while: true,
-                    close_emit: None,
-                    if_unresolved: None,
-                    start_unresolved: false,
-                }),
+                Some(GateContext::new(rx, init).with_has_while(true)),
                 None,
             )
             .unwrap();

--- a/sonda-core/benches/while_steady_state.rs
+++ b/sonda-core/benches/while_steady_state.rs
@@ -59,6 +59,7 @@ fn bench_baseline_ungated(c: &mut Criterion) {
                 None,
                 None,
                 None,
+                None,
             )
             .unwrap();
             handle.join(Some(Duration::from_secs(2))).unwrap();
@@ -97,6 +98,7 @@ fn bench_gated_open(c: &mut Criterion) {
                     if_unresolved: None,
                     start_unresolved: false,
                 }),
+                None,
             )
             .unwrap();
             handle.join(Some(Duration::from_secs(2))).unwrap();

--- a/sonda-core/src/compiler/compile_after.rs
+++ b/sonda-core/src/compiler/compile_after.rs
@@ -544,10 +544,11 @@ pub fn compile_after(file: ExpandedFile) -> Result<CompiledFile, CompileAfterErr
     } = file;
 
     let id_to_idx = build_id_index(&entries);
+    let file_scenario_name = scenario_name.as_deref();
 
     for entry in &entries {
         let source_id = source_label(entry);
-        for (ref_id, clause) in outgoing_edges(entry) {
+        for (ref_id, clause) in outgoing_edges(entry, file_scenario_name) {
             resolve_reference(ref_id, &id_to_idx, &source_id, clause)?;
             if entry.id.as_deref() == Some(ref_id) {
                 return Err(CompileAfterError::SelfReference {
@@ -562,7 +563,7 @@ pub fn compile_after(file: ExpandedFile) -> Result<CompiledFile, CompileAfterErr
     let mut in_degree = vec![0u32; n];
     let mut dependents: Vec<Vec<(usize, ClauseKind)>> = vec![Vec::new(); n];
     for (i, entry) in entries.iter().enumerate() {
-        for (ref_id, clause) in outgoing_edges(entry) {
+        for (ref_id, clause) in outgoing_edges(entry, file_scenario_name) {
             let dep_idx = id_to_idx[ref_id];
             in_degree[i] += 1;
             dependents[dep_idx].push((i, clause));
@@ -581,7 +582,7 @@ pub fn compile_after(file: ExpandedFile) -> Result<CompiledFile, CompileAfterErr
         }
     }
     if sorted.len() < n {
-        let cycle = find_cycle(&entries, &id_to_idx);
+        let cycle = find_cycle(&entries, &id_to_idx, file_scenario_name);
         return Err(CompileAfterError::CircularDependency { cycle });
     }
 
@@ -589,6 +590,9 @@ pub fn compile_after(file: ExpandedFile) -> Result<CompiledFile, CompileAfterErr
         let Some(clause) = &entry.while_clause else {
             continue;
         };
+        if is_deferred_while(clause, file_scenario_name) {
+            continue;
+        }
         let source_id = source_label(entry).into_owned();
         let dep_idx = id_to_idx[clause.ref_id.as_str()];
         let target = &entries[dep_idx];
@@ -830,23 +834,30 @@ fn resolve_reference(
 }
 
 /// Yield every outgoing edge from `entry` as `(target_ref_id, edge_label)`.
-///
-/// Order is `after:` first, then `while:` — used by index building, cycle
-/// detection, and reference validation. Adding a new clause type (e.g.
-/// v2's `gated_by:`) extends this iterator and reaches every cycle-aware
-/// site automatically.
-fn outgoing_edges(entry: &ExpandedEntry) -> impl Iterator<Item = (&str, ClauseKind)> {
+/// Cross-POST `while:` refs (scenario_name outside the file) are excluded.
+fn outgoing_edges<'a>(
+    entry: &'a ExpandedEntry,
+    file_scenario_name: Option<&'a str>,
+) -> impl Iterator<Item = (&'a str, ClauseKind)> {
+    let while_edge = entry
+        .while_clause
+        .as_ref()
+        .filter(|c| !is_deferred_while(c, file_scenario_name))
+        .map(|c| (c.ref_id.as_str(), ClauseKind::While));
+
     entry
         .after
         .as_ref()
         .map(|c| (c.ref_id.as_str(), ClauseKind::After))
         .into_iter()
-        .chain(
-            entry
-                .while_clause
-                .as_ref()
-                .map(|c| (c.ref_id.as_str(), ClauseKind::While)),
-        )
+        .chain(while_edge)
+}
+
+fn is_deferred_while(clause: &WhileClause, file_scenario_name: Option<&str>) -> bool {
+    match clause.scenario_name.as_deref() {
+        Some(name) => Some(name) != file_scenario_name,
+        None => false,
+    }
 }
 
 /// Format an entry into a human-readable label for error messages.
@@ -1215,6 +1226,7 @@ fn auto_chain_name(members: &[usize], entries: &[ExpandedEntry]) -> String {
 fn find_cycle(
     entries: &[ExpandedEntry],
     id_to_idx: &BTreeMap<&str, usize>,
+    file_scenario_name: Option<&str>,
 ) -> Vec<(String, ClauseKind)> {
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum Color {
@@ -1231,13 +1243,14 @@ fn find_cycle(
         node: usize,
         entries: &[ExpandedEntry],
         id_to_idx: &BTreeMap<&str, usize>,
+        file_scenario_name: Option<&str>,
         color: &mut [Color],
         path: &mut Vec<(usize, ClauseKind)>,
     ) -> Option<Vec<(usize, ClauseKind)>> {
         color[node] = Color::Gray;
         path.push((node, ClauseKind::After));
 
-        for (ref_id, clause) in outgoing_edges(&entries[node]) {
+        for (ref_id, clause) in outgoing_edges(&entries[node], file_scenario_name) {
             let Some(&dep) = id_to_idx.get(ref_id) else {
                 continue;
             };
@@ -1246,7 +1259,9 @@ fn find_cycle(
             }
             match color[dep] {
                 Color::White => {
-                    if let Some(cycle) = dfs(dep, entries, id_to_idx, color, path) {
+                    if let Some(cycle) =
+                        dfs(dep, entries, id_to_idx, file_scenario_name, color, path)
+                    {
                         return Some(cycle);
                     }
                 }
@@ -1267,7 +1282,14 @@ fn find_cycle(
 
     for start in 0..n {
         if color[start] == Color::White {
-            if let Some(cycle) = dfs(start, entries, id_to_idx, &mut color, &mut path) {
+            if let Some(cycle) = dfs(
+                start,
+                entries,
+                id_to_idx,
+                file_scenario_name,
+                &mut color,
+                &mut path,
+            ) {
                 return cycle
                     .into_iter()
                     .map(|(i, kind)| (source_label(&entries[i]).into_owned(), kind))
@@ -2398,7 +2420,7 @@ scenarios:
             metric_type: None,
             help: None,
         };
-        let edges: Vec<_> = outgoing_edges(&e).collect();
+        let edges: Vec<_> = outgoing_edges(&e, None).collect();
         assert_eq!(
             edges,
             vec![
@@ -2408,11 +2430,11 @@ scenarios:
         );
 
         e.while_clause = None;
-        let edges_after_only: Vec<_> = outgoing_edges(&e).collect();
+        let edges_after_only: Vec<_> = outgoing_edges(&e, None).collect();
         assert_eq!(edges_after_only, vec![("a_target", ClauseKind::After)]);
 
         e.after = None;
-        let edges_none: Vec<_> = outgoing_edges(&e).collect();
+        let edges_none: Vec<_> = outgoing_edges(&e, None).collect();
         assert!(edges_none.is_empty());
     }
 
@@ -2790,5 +2812,95 @@ scenarios:
             msg.contains("unsupported operator") && msg.contains("strict"),
             "error must use the 'unsupported operator … strict' wording. got: {msg}"
         );
+    }
+
+    #[test]
+    fn while_with_self_scenario_name_and_local_match_resolves_locally() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenario_name: foo
+defaults:
+  rate: 1
+  duration: 1m
+scenarios:
+  - id: link
+    signal_type: metrics
+    name: link
+    generator: { type: flap, up_duration: 60s, down_duration: 30s }
+  - id: dependent
+    signal_type: metrics
+    name: dependent
+    generator: { type: constant, value: 1 }
+    while: { ref: link, op: ">", value: 0, scenario_name: foo, if_unresolved: open }
+"#;
+        let compiled = compile_after_from_yaml(yaml).expect("self-scenario_name compiles locally");
+        let dep = compiled
+            .entries
+            .iter()
+            .find(|e| e.id.as_deref() == Some("dependent"))
+            .expect("dependent present");
+        let w = dep.while_clause.as_ref().expect("while preserved");
+        assert_eq!(w.ref_id, "link");
+        assert_eq!(w.scenario_name.as_deref(), Some("foo"));
+    }
+
+    #[test]
+    fn while_with_cross_scenario_name_and_unknown_ref_defers() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenario_name: bar
+defaults:
+  rate: 1
+  duration: 1m
+scenarios:
+  - id: dependent
+    signal_type: metrics
+    name: dependent
+    generator: { type: constant, value: 1 }
+    while: { ref: non_local_id, op: ">", value: 0, scenario_name: foo, if_unresolved: open }
+"#;
+        let compiled = compile_after_from_yaml(yaml).expect("cross-POST defers, no error");
+        let dep = compiled
+            .entries
+            .iter()
+            .find(|e| e.id.as_deref() == Some("dependent"))
+            .expect("dependent present");
+        let w = dep.while_clause.as_ref().expect("while preserved");
+        assert_eq!(w.ref_id, "non_local_id");
+        assert_eq!(w.scenario_name.as_deref(), Some("foo"));
+    }
+
+    #[test]
+    fn while_with_self_scenario_name_and_typo_ref_errors() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenario_name: foo
+defaults:
+  rate: 1
+  duration: 1m
+scenarios:
+  - id: link
+    signal_type: metrics
+    name: link
+    generator: { type: flap, up_duration: 60s, down_duration: 30s }
+  - id: dependent
+    signal_type: metrics
+    name: dependent
+    generator: { type: constant, value: 1 }
+    while: { ref: typo_id, op: ">", value: 0, scenario_name: foo, if_unresolved: open }
+"#;
+        let err = compile_after_from_yaml(yaml).expect_err("self-scenario_name + typo errors");
+        match err {
+            CompileAfterError::UnknownRef {
+                source_id, ref_id, ..
+            } => {
+                assert_eq!(source_id, "dependent");
+                assert_eq!(ref_id, "typo_id");
+            }
+            other => panic!("expected UnknownRef, got {other:?}"),
+        }
     }
 }

--- a/sonda-core/src/compiler/compile_after.rs
+++ b/sonda-core/src/compiler/compile_after.rs
@@ -2384,6 +2384,8 @@ scenarios:
                 ref_id: "w_target".to_string(),
                 op: WhileOp::LessThan,
                 value: 0.0,
+                scenario_name: None,
+                if_unresolved: None,
             }),
             delay_clause: None,
             distribution: None,

--- a/sonda-core/src/compiler/mod.rs
+++ b/sonda-core/src/compiler/mod.rs
@@ -392,6 +392,22 @@ impl<'de> serde::Deserialize<'de> for WhileOp {
     }
 }
 
+/// Policy applied when a cross-POST `while:` reference cannot be resolved at
+/// scenario start. Only meaningful when [`WhileClause::scenario_name`] is set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "config", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "config", serde(rename_all = "lowercase"))]
+#[non_exhaustive]
+pub enum UnresolvedBehavior {
+    /// Treat the gate as open until the upstream registers.
+    Open,
+    /// Treat the gate as closed until the upstream registers.
+    Closed,
+    /// Hold the scenario in `unresolved` state until the upstream registers.
+    #[default]
+    Pending,
+}
+
 /// Continuous lifecycle gate on another signal's value.
 ///
 /// ```yaml
@@ -411,6 +427,16 @@ pub struct WhileClause {
     pub ref_id: String,
     pub op: WhileOp,
     pub value: f64,
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub scenario_name: Option<String>,
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub if_unresolved: Option<UnresolvedBehavior>,
 }
 
 /// Open / close debounce windows applied to a [`WhileClause`] transition.

--- a/sonda-core/src/compiler/parse.rs
+++ b/sonda-core/src/compiler/parse.rs
@@ -117,6 +117,40 @@ pub enum ParseError {
     /// A `kind: composable` file failed to deserialize as a pack definition.
     #[error("kind: composable body is not a valid pack definition")]
     ComposablePackInvalid(#[source] serde_yaml_ng::Error),
+
+    /// A `while:` clause sets `if_unresolved:` without `scenario_name:`.
+    #[error(
+        "entry {index}: `while.if_unresolved` requires `while.scenario_name` to be set; \
+         `if_unresolved` only applies to cross-POST `while:` references"
+    )]
+    WhileUnresolvedWithoutScenarioName {
+        /// Zero-based index of the offending entry.
+        index: usize,
+    },
+
+    /// A `while:` clause carries `scenario_name:` but the file does not declare
+    /// a top-level `scenario_name:` of its own.
+    #[error(
+        "entry {index}: cross-POST `while:` refs require body-level `scenario_name` on the \
+         scenario file; add a top-level `scenario_name:` declaring this body's identity"
+    )]
+    CrossPostWhileMissingBodyScenarioName {
+        /// Zero-based index of the offending entry.
+        index: usize,
+    },
+
+    /// A cross-POST `while.ref` uses pack sub-signal `.` syntax, which is not
+    /// supported in v1 of the cross-POST surface.
+    #[error(
+        "entry {index}: cross-POST `while.ref` '{ref_id}' targets a pack sub-signal; \
+         cross-POST refs cannot target pack sub-signals in v1, use the top-level entry id"
+    )]
+    CrossPostWhileRefHasDot {
+        /// Zero-based index of the offending entry.
+        index: usize,
+        /// The offending `ref` value as written.
+        ref_id: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -368,8 +402,21 @@ pub fn parse(yaml: &str) -> Result<ScenarioFile, ParseError> {
         });
     }
     validate_entries(&file.scenarios)?;
+    validate_cross_post_while(&file)?;
 
     Ok(file)
+}
+
+fn validate_cross_post_while(file: &ScenarioFile) -> Result<(), ParseError> {
+    for (index, entry) in file.scenarios.iter().enumerate() {
+        let Some(clause) = entry.while_clause.as_ref() else {
+            continue;
+        };
+        if clause.scenario_name.is_some() && file.scenario_name.is_none() {
+            return Err(ParseError::CrossPostWhileMissingBodyScenarioName { index });
+        }
+    }
+    Ok(())
 }
 
 fn parse_composable(yaml: &str) -> Result<ScenarioFile, ParseError> {
@@ -553,8 +600,26 @@ fn validate_entries(entries: &[Entry]) -> Result<(), ParseError> {
         if !has_pack && entry.name.is_none() {
             return Err(ParseError::MissingName { index });
         }
+
+        validate_while_clause(entry, index)?;
     }
 
+    Ok(())
+}
+
+fn validate_while_clause(entry: &Entry, index: usize) -> Result<(), ParseError> {
+    let Some(clause) = entry.while_clause.as_ref() else {
+        return Ok(());
+    };
+    if clause.if_unresolved.is_some() && clause.scenario_name.is_none() {
+        return Err(ParseError::WhileUnresolvedWithoutScenarioName { index });
+    }
+    if clause.scenario_name.is_some() && clause.ref_id.contains('.') {
+        return Err(ParseError::CrossPostWhileRefHasDot {
+            index,
+            ref_id: clause.ref_id.clone(),
+        });
+    }
     Ok(())
 }
 
@@ -2178,5 +2243,208 @@ scenarios:
 
         let file = parse(yaml).expect("file with empty tags must parse");
         assert!(file.tags.is_empty());
+    }
+
+    // ======================================================================
+    // Cross-POST while: schema
+    // ======================================================================
+
+    #[test]
+    fn cross_post_while_clause_round_trips() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenario_name: downstream
+scenarios:
+  - id: tail
+    signal_type: metrics
+    name: tail_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: head
+      op: ">"
+      value: 0
+      scenario_name: upstream
+      if_unresolved: open
+"#;
+        let file = parse(yaml).expect("must parse cross-POST while clause");
+        let clause = file.scenarios[0]
+            .while_clause
+            .as_ref()
+            .expect("while present");
+        assert_eq!(clause.scenario_name.as_deref(), Some("upstream"));
+        assert_eq!(
+            clause.if_unresolved,
+            Some(super::super::UnresolvedBehavior::Open)
+        );
+
+        let serialized = serde_yaml_ng::to_string(&file).expect("must serialize");
+        let round_tripped: ScenarioFile =
+            serde_yaml_ng::from_str(&serialized).expect("must round-trip");
+        let round_clause = round_tripped.scenarios[0]
+            .while_clause
+            .as_ref()
+            .expect("while present after round-trip");
+        assert_eq!(round_clause.scenario_name.as_deref(), Some("upstream"));
+        assert_eq!(
+            round_clause.if_unresolved,
+            Some(super::super::UnresolvedBehavior::Open)
+        );
+    }
+
+    #[test]
+    fn if_unresolved_without_scenario_name_is_rejected() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenarios:
+  - id: tail
+    signal_type: metrics
+    name: tail_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: head
+      op: ">"
+      value: 0
+      if_unresolved: open
+"#;
+        let err = parse(yaml).expect_err("if_unresolved alone must fail");
+        assert!(
+            matches!(
+                err,
+                ParseError::WhileUnresolvedWithoutScenarioName { index: 0 }
+            ),
+            "got: {err}"
+        );
+        assert!(
+            err.to_string().contains("requires"),
+            "message must mention requires, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("scenario_name"),
+            "message must mention scenario_name, got: {err}"
+        );
+    }
+
+    #[test]
+    fn cross_post_while_without_body_scenario_name_is_rejected() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenarios:
+  - id: tail
+    signal_type: metrics
+    name: tail_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: head
+      op: ">"
+      value: 0
+      scenario_name: upstream
+"#;
+        let err = parse(yaml).expect_err("missing body scenario_name must fail");
+        assert!(
+            matches!(
+                err,
+                ParseError::CrossPostWhileMissingBodyScenarioName { index: 0 }
+            ),
+            "got: {err}"
+        );
+        assert!(
+            err.to_string().contains("body-level"),
+            "message must mention body-level, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("scenario_name"),
+            "message must mention scenario_name, got: {err}"
+        );
+    }
+
+    #[test]
+    fn cross_post_while_ref_with_dot_is_rejected() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenario_name: downstream
+scenarios:
+  - id: tail
+    signal_type: metrics
+    name: tail_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: head.metric
+      op: ">"
+      value: 0
+      scenario_name: upstream
+"#;
+        let err = parse(yaml).expect_err("dot in cross-POST ref must fail");
+        assert!(
+            matches!(
+                err,
+                ParseError::CrossPostWhileRefHasDot {
+                    index: 0,
+                    ref_id: ref s,
+                } if s == "head.metric"
+            ),
+            "got: {err}"
+        );
+        assert!(
+            err.to_string().contains("entry id"),
+            "message must mention entry id, got: {err}"
+        );
+    }
+
+    #[test]
+    fn local_only_while_clause_continues_to_parse() {
+        let yaml = r#"
+version: 2
+kind: runnable
+scenarios:
+  - id: head
+    signal_type: metrics
+    name: head_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: sine
+      amplitude: 1.0
+      period_secs: 60
+      offset: 0
+  - id: tail
+    signal_type: metrics
+    name: tail_metric
+    rate: 1
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: head
+      op: ">"
+      value: 0
+"#;
+        let file = parse(yaml).expect("local-only while: must still parse");
+        let clause = file.scenarios[1]
+            .while_clause
+            .as_ref()
+            .expect("while present");
+        assert!(clause.scenario_name.is_none());
+        assert!(clause.if_unresolved.is_none());
     }
 }

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -11,9 +11,10 @@
 //! [`RuntimeError`]), the config enums ([`GeneratorConfig`](generator::GeneratorConfig),
 //! [`EncoderConfig`](encoder::EncoderConfig), [`SinkConfig`](sink::SinkConfig),
 //! [`DistributionConfig`], [`ScenarioEntry`]), the compile-phase error enums
-//! under [`compiler`], [`ScenarioStats`], and [`ScenarioHandle`] — are
-//! marked `#[non_exhaustive]`. Downstream consumers that `match` on these
-//! types must include a wildcard `_ =>` arm, [`ScenarioStats`] must be
+//! under [`compiler`], [`ScenarioStats`], [`ScenarioHandle`], and
+//! [`GateEdge`](schedule::gate_bus::GateEdge) — are marked
+//! `#[non_exhaustive]`. Downstream consumers that `match` on these types
+//! must include a wildcard `_ =>` arm, [`ScenarioStats`] must be
 //! constructed via `Default::default()` plus field updates rather than a
 //! struct literal, and [`ScenarioHandle`] must be constructed via
 //! [`ScenarioHandle::new`] rather than a struct literal. This lets
@@ -34,6 +35,7 @@ pub mod schedule;
 pub mod sink;
 pub(crate) mod util;
 
+pub use compiler::UnresolvedBehavior;
 pub use config::aliases::{desugar_entry, desugar_scenario_config};
 pub use config::BaseScheduleConfig;
 pub use config::BurstConfig;
@@ -55,6 +57,9 @@ pub use model::log::Severity;
 pub use model::metric::Labels;
 pub use model::metric::MetricEvent;
 pub use model::metric::ValidatedMetricName;
+pub use schedule::gate_bus::{
+    GateBusResolver, GateEdgeSender, PendingRef, PendingResolution, RegistryError,
+};
 pub use schedule::handle::ScenarioHandle;
 pub use schedule::launch::{launch_scenario, prepare_entries, validate_entry, PreparedEntry};
 pub use schedule::stats::{ScenarioState, ScenarioStats};

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -907,7 +907,9 @@ fn write_state(
 ) {
     if let Some(s) = stats {
         if let Ok(mut st) = s.write() {
-            st.state = state;
+            if st.state != state {
+                st.transition_state(state);
+            }
             if paused_zero_rate {
                 st.current_rate = 0.0;
             }
@@ -922,7 +924,9 @@ fn write_state(
 fn finish(stats: Option<Arc<RwLock<ScenarioStats>>>) -> Result<(), SondaError> {
     if let Some(s) = stats {
         if let Ok(mut st) = s.write() {
-            st.state = ScenarioState::Finished;
+            if st.state != ScenarioState::Finished {
+                st.transition_state(ScenarioState::Finished);
+            }
         }
     }
     Ok(())

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crate::compiler::DelayClause;
+use crate::compiler::{DelayClause, UnresolvedBehavior};
 use crate::config::validate::StartTime;
 use crate::config::OnSinkError;
 use crate::model::metric::MetricEvent;
@@ -520,6 +520,8 @@ pub struct GateContext {
     /// transition. Metric runners with a `RemoteWrite` sink set this; logs,
     /// histograms, and summaries leave it `None`.
     pub close_emit: Option<CloseEmitFn>,
+    pub if_unresolved: Option<UnresolvedBehavior>,
+    pub start_unresolved: bool,
 }
 
 /// Run a signal scenario through the four-state lifecycle gate.
@@ -600,7 +602,11 @@ fn gated_loop_body(
     let started_at = Instant::now();
     let wall = WallClock::resolve(schedule, started_at);
 
-    let mut state = ScenarioState::Pending;
+    let mut state = if gate_ctx.start_unresolved {
+        ScenarioState::Unresolved
+    } else {
+        ScenarioState::Pending
+    };
     let mut after_satisfied = if gate_ctx.has_after {
         gate_ctx.initial.after_already_fired
     } else {
@@ -616,7 +622,8 @@ fn gated_loop_body(
 
     let mut next_tick: u64 = 0;
 
-    write_state(stats, ScenarioState::Pending, false);
+    let paused_zero_rate = matches!(state, ScenarioState::Unresolved | ScenarioState::Paused);
+    write_state(stats, state, paused_zero_rate);
 
     loop {
         if shutdown_requested(shutdown) {
@@ -644,10 +651,11 @@ fn gated_loop_body(
                             while_open = false;
                         }
                         Some(GateEdge::UpstreamGone) => {
-                            unreachable!(
-                                "UpstreamGone has no sender in this build; \
-                                 cross-POST runtime is wired in a later slice"
-                            );
+                            state = ScenarioState::Unresolved;
+                            while_open = false;
+                            write_state(stats, ScenarioState::Unresolved, true);
+                            debounce.reset();
+                            continue;
                         }
                         None => {
                             continue;
@@ -683,6 +691,7 @@ fn gated_loop_body(
                     wall,
                     sink,
                     tick_fn,
+                    false,
                 )?;
                 next_tick = last_tick.load(Ordering::SeqCst);
 
@@ -691,6 +700,20 @@ fn gated_loop_body(
                 }
                 if duration_expired(schedule, started_at) {
                     return Ok(LoopExit::DurationExpired);
+                }
+                if exit == SegmentExit::UpstreamGone {
+                    invoke_close_emit(
+                        schedule,
+                        stats,
+                        close_warn_limiter,
+                        gate_ctx.close_emit.as_mut(),
+                        sink,
+                    )?;
+                    state = ScenarioState::Unresolved;
+                    while_open = false;
+                    write_state(stats, ScenarioState::Unresolved, true);
+                    debounce.reset();
+                    continue;
                 }
                 if exit == SegmentExit::WhileClose
                     && !debounce_close_to_paused(
@@ -739,10 +762,11 @@ fn gated_loop_body(
                         after_satisfied = true;
                     }
                     Some(GateEdge::UpstreamGone) => {
-                        unreachable!(
-                            "UpstreamGone has no sender in this build; \
-                             cross-POST runtime is wired in a later slice"
-                        );
+                        state = ScenarioState::Unresolved;
+                        while_open = false;
+                        write_state(stats, ScenarioState::Unresolved, true);
+                        debounce.reset();
+                        continue;
                     }
                     None => {}
                 }
@@ -762,10 +786,82 @@ fn gated_loop_body(
                 }
             }
             ScenarioState::Unresolved => {
-                unreachable!(
-                    "Unresolved has no entry path in this build; \
-                     cross-POST runtime is wired in a later slice"
-                );
+                let mode = gate_ctx.if_unresolved.unwrap_or_default();
+                match mode {
+                    UnresolvedBehavior::Open => {
+                        let segment_running = Arc::new(AtomicBool::new(true));
+                        let last_tick = Arc::new(AtomicU64::new(next_tick));
+                        let exit = run_running_segment(
+                            schedule,
+                            rate,
+                            shutdown,
+                            stats.cloned(),
+                            gate_ctx,
+                            &segment_running,
+                            next_tick,
+                            Arc::clone(&last_tick),
+                            wall,
+                            sink,
+                            tick_fn,
+                            true,
+                        )?;
+                        next_tick = last_tick.load(Ordering::SeqCst);
+
+                        if shutdown_requested(shutdown) {
+                            return Ok(LoopExit::Shutdown);
+                        }
+                        if duration_expired(schedule, started_at) {
+                            return Ok(LoopExit::DurationExpired);
+                        }
+                        match exit {
+                            SegmentExit::WhileClose => {
+                                invoke_close_emit(
+                                    schedule,
+                                    stats,
+                                    close_warn_limiter,
+                                    gate_ctx.close_emit.as_mut(),
+                                    sink,
+                                )?;
+                                state = ScenarioState::Paused;
+                                while_open = false;
+                                write_state(stats, ScenarioState::Paused, true);
+                                debounce.reset();
+                            }
+                            SegmentExit::UpstreamGone => {
+                                // Already Unresolved; stay.
+                            }
+                            SegmentExit::WhileOpen => {
+                                state = ScenarioState::Running;
+                                while_open = true;
+                                write_state(stats, ScenarioState::Running, false);
+                                debounce.reset();
+                            }
+                            SegmentExit::ShutdownOrDuration => {}
+                        }
+                    }
+                    UnresolvedBehavior::Closed | UnresolvedBehavior::Pending => {
+                        let wakeup = remaining_until(schedule, started_at, PAUSED_POLL_INTERVAL);
+                        match gate_ctx.gate_rx.recv_timeout(wakeup) {
+                            Some(GateEdge::WhileOpen) => {
+                                while_open = true;
+                                state = ScenarioState::Pending;
+                                write_state(stats, ScenarioState::Pending, false);
+                                debounce.reset();
+                            }
+                            Some(GateEdge::WhileClose) => {
+                                while_open = false;
+                                state = ScenarioState::Paused;
+                                write_state(stats, ScenarioState::Paused, true);
+                                debounce.reset();
+                            }
+                            Some(GateEdge::AfterFired) => {
+                                after_satisfied = true;
+                            }
+                            Some(GateEdge::UpstreamGone) => {}
+                            None => {}
+                        }
+                    }
+                }
             }
             ScenarioState::Finished => {
                 // Structurally dead; kept so `match state` stays exhaustive.
@@ -837,6 +933,10 @@ fn finish(stats: Option<Arc<RwLock<ScenarioStats>>>) -> Result<(), SondaError> {
 enum SegmentExit {
     /// Upstream gate transitioned to closed.
     WhileClose,
+    /// Upstream scenario was removed mid-segment.
+    UpstreamGone,
+    /// Upstream gate transitioned to open while running under `if_unresolved: open`.
+    WhileOpen,
     /// User-shutdown flag cleared, or scenario duration expired.
     ShutdownOrDuration,
 }
@@ -890,12 +990,7 @@ fn debounce_close_to_paused(
             Some(GateEdge::WhileOpen) => return false,
             Some(GateEdge::WhileClose) => {}
             Some(GateEdge::AfterFired) => {}
-            Some(GateEdge::UpstreamGone) => {
-                unreachable!(
-                    "UpstreamGone has no sender in this build; \
-                     cross-POST runtime is wired in a later slice"
-                );
-            }
+            Some(GateEdge::UpstreamGone) => return true,
             None => {}
         }
     }
@@ -922,8 +1017,11 @@ fn run_running_segment(
     wall: WallClock,
     sink: &mut dyn Sink,
     tick_fn: &mut TickFn<'_>,
+    exit_on_while_open: bool,
 ) -> Result<SegmentExit, SondaError> {
     let saw_close = Arc::new(AtomicBool::new(false));
+    let saw_gone = Arc::new(AtomicBool::new(false));
+    let saw_open = Arc::new(AtomicBool::new(false));
 
     // The inner loop's `shutdown` parameter wants "true = keep running."
     // We pass our segment flag, and we additionally drain the user
@@ -931,6 +1029,8 @@ fn run_running_segment(
     let user_shutdown_for_wrapper = shutdown;
     let segment_for_wrapper = Arc::clone(segment_running);
     let saw_close_for_wrapper = Arc::clone(&saw_close);
+    let saw_gone_for_wrapper = Arc::clone(&saw_gone);
+    let saw_open_for_wrapper = Arc::clone(&saw_open);
     let gate_rx = &gate_ctx.gate_rx;
 
     type WrappedTick<'a> = Box<
@@ -956,16 +1056,17 @@ fn run_running_segment(
                         segment_for_wrapper.store(false, Ordering::SeqCst);
                     }
                     GateEdge::WhileOpen => {
-                        // Already running; ignore.
+                        if exit_on_while_open {
+                            saw_open_for_wrapper.store(true, Ordering::SeqCst);
+                            segment_for_wrapper.store(false, Ordering::SeqCst);
+                        }
                     }
                     GateEdge::AfterFired => {
                         // Already past the after gate.
                     }
                     GateEdge::UpstreamGone => {
-                        unreachable!(
-                            "UpstreamGone has no sender in this build; \
-                             cross-POST runtime is wired in a later slice"
-                        );
+                        saw_gone_for_wrapper.store(true, Ordering::SeqCst);
+                        segment_for_wrapper.store(false, Ordering::SeqCst);
                     }
                 }
             }
@@ -993,8 +1094,12 @@ fn run_running_segment(
         wrapped.as_mut(),
     )?;
 
-    Ok(if saw_close.load(Ordering::SeqCst) {
+    Ok(if saw_gone.load(Ordering::SeqCst) {
+        SegmentExit::UpstreamGone
+    } else if saw_close.load(Ordering::SeqCst) {
         SegmentExit::WhileClose
+    } else if saw_open.load(Ordering::SeqCst) {
+        SegmentExit::WhileOpen
     } else {
         SegmentExit::ShutdownOrDuration
     })

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -643,6 +643,12 @@ fn gated_loop_body(
                         Some(GateEdge::WhileClose) => {
                             while_open = false;
                         }
+                        Some(GateEdge::UpstreamGone) => {
+                            unreachable!(
+                                "UpstreamGone has no sender in this build; \
+                                 cross-POST runtime is wired in a later slice"
+                            );
+                        }
                         None => {
                             continue;
                         }
@@ -732,6 +738,12 @@ fn gated_loop_body(
                     Some(GateEdge::AfterFired) => {
                         after_satisfied = true;
                     }
+                    Some(GateEdge::UpstreamGone) => {
+                        unreachable!(
+                            "UpstreamGone has no sender in this build; \
+                             cross-POST runtime is wired in a later slice"
+                        );
+                    }
                     None => {}
                 }
 
@@ -745,8 +757,15 @@ fn gated_loop_body(
                         }
                         GateEdge::WhileClose => {}
                         GateEdge::AfterFired => {}
+                        GateEdge::UpstreamGone => {}
                     }
                 }
+            }
+            ScenarioState::Unresolved => {
+                unreachable!(
+                    "Unresolved has no entry path in this build; \
+                     cross-POST runtime is wired in a later slice"
+                );
             }
             ScenarioState::Finished => {
                 // Structurally dead; kept so `match state` stays exhaustive.
@@ -871,6 +890,12 @@ fn debounce_close_to_paused(
             Some(GateEdge::WhileOpen) => return false,
             Some(GateEdge::WhileClose) => {}
             Some(GateEdge::AfterFired) => {}
+            Some(GateEdge::UpstreamGone) => {
+                unreachable!(
+                    "UpstreamGone has no sender in this build; \
+                     cross-POST runtime is wired in a later slice"
+                );
+            }
             None => {}
         }
     }
@@ -935,6 +960,12 @@ fn run_running_segment(
                     }
                     GateEdge::AfterFired => {
                         // Already past the after gate.
+                    }
+                    GateEdge::UpstreamGone => {
+                        unreachable!(
+                            "UpstreamGone has no sender in this build; \
+                             cross-POST runtime is wired in a later slice"
+                        );
                     }
                 }
             }
@@ -1013,6 +1044,7 @@ impl DebounceState {
                 }
             }
             GateEdge::AfterFired => {}
+            GateEdge::UpstreamGone => {}
         }
     }
 

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -505,6 +505,7 @@ fn invoke_close_emit(
 const PAUSED_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Gate-side context attached to a `gated_loop` run.
+#[non_exhaustive]
 pub struct GateContext {
     /// Receiver for `after:` and/or `while:` edges from the upstream bus.
     pub gate_rx: GateReceiver,
@@ -522,6 +523,52 @@ pub struct GateContext {
     pub close_emit: Option<CloseEmitFn>,
     pub if_unresolved: Option<UnresolvedBehavior>,
     pub start_unresolved: bool,
+}
+
+impl GateContext {
+    /// Construct a `GateContext` with required pieces; optional fields default to `None` / `false`.
+    pub fn new(gate_rx: GateReceiver, initial: InitialState) -> Self {
+        Self {
+            gate_rx,
+            initial,
+            delay: None,
+            has_after: false,
+            has_while: false,
+            close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
+        }
+    }
+
+    pub fn with_delay(mut self, delay: Option<DelayClause>) -> Self {
+        self.delay = delay;
+        self
+    }
+
+    pub fn with_has_after(mut self, has_after: bool) -> Self {
+        self.has_after = has_after;
+        self
+    }
+
+    pub fn with_has_while(mut self, has_while: bool) -> Self {
+        self.has_while = has_while;
+        self
+    }
+
+    pub fn with_close_emit(mut self, close_emit: Option<CloseEmitFn>) -> Self {
+        self.close_emit = close_emit;
+        self
+    }
+
+    pub fn with_if_unresolved(mut self, mode: Option<UnresolvedBehavior>) -> Self {
+        self.if_unresolved = mode;
+        self
+    }
+
+    pub fn with_start_unresolved(mut self, start_unresolved: bool) -> Self {
+        self.start_unresolved = start_unresolved;
+        self
+    }
 }
 
 /// Run a signal scenario through the four-state lifecycle gate.

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -76,6 +76,7 @@ pub struct GateReceiver {
 }
 
 impl GateReceiver {
+    #[cfg(feature = "config")]
     pub(crate) fn from_while_rx(rx: Receiver<GateEdge>) -> Self {
         Self {
             after_rx: None,
@@ -238,7 +239,8 @@ impl GateBus {
         )
     }
 
-    pub(crate) fn subscribe_with_while_sender(
+    /// Subscribe an existing [`GateEdgeSender`] to the bus's `while:` events.
+    pub fn subscribe_with_while_sender(
         &self,
         spec: WhileSpec,
         while_tx: GateEdgeSender,
@@ -332,8 +334,7 @@ impl GateBus {
         self.tick(v);
     }
 
-    #[cfg(test)]
-    pub(crate) fn broadcast_upstream_gone(&self) {
+    pub fn broadcast_upstream_gone(&self) {
         let inner = self
             .inner
             .lock()
@@ -398,6 +399,33 @@ pub struct PendingResolution {
     pub spec: WhileSpec,
 }
 
+impl PendingResolution {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        handle_id: String,
+        stats: Weak<RwLock<ScenarioStats>>,
+        edge_sender: GateEdgeSender,
+        scenario_name: String,
+        entry_id: String,
+        if_unresolved: UnresolvedBehavior,
+        registered_at: Instant,
+        attempts: u64,
+        spec: WhileSpec,
+    ) -> Self {
+        Self {
+            handle_id,
+            stats,
+            edge_sender,
+            scenario_name,
+            entry_id,
+            if_unresolved,
+            registered_at,
+            attempts,
+            spec,
+        }
+    }
+}
+
 /// Wire-shaped projection of a [`PendingResolution`] surfaced over the HTTP API.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "config", derive(serde::Serialize))]
@@ -409,6 +437,26 @@ pub struct PendingRef {
     #[cfg(feature = "config")]
     pub registered_at: chrono::DateTime<chrono::Utc>,
     pub attempts: u64,
+}
+
+impl PendingRef {
+    /// Snapshot a [`PendingRef`] from a registry's [`PendingResolution`].
+    pub fn from_pending(pending: &PendingResolution, now: std::time::SystemTime) -> Self {
+        #[cfg(not(feature = "config"))]
+        let _ = now;
+        Self {
+            scenario_name: pending.scenario_name.clone(),
+            entry_id: pending.entry_id.clone(),
+            if_unresolved: pending.if_unresolved,
+            #[cfg(feature = "config")]
+            registered_at: {
+                let elapsed = pending.registered_at.elapsed();
+                let wall = now.checked_sub(elapsed).unwrap_or(std::time::UNIX_EPOCH);
+                chrono::DateTime::<chrono::Utc>::from(wall)
+            },
+            attempts: pending.attempts,
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -449,6 +497,11 @@ pub trait GateBusResolver: Send + Sync {
     fn pending_for_handle(&self, handle_id: &str) -> Option<PendingRef>;
 
     fn scenario_name_in_use(&self, scenario_name: &str) -> bool;
+
+    /// Record an active subscriber so [`unregister`](Self::unregister) can
+    /// re-pend it for cross-POST re-resolution. Default impl is a no-op for
+    /// resolvers that do not implement re-resolution tracking.
+    fn track_subscriber(&self, _pending: PendingResolution) {}
 }
 
 #[cfg(test)]

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -8,10 +8,14 @@
 //! latest, keeping memory flat regardless of upstream chatter.
 
 use std::sync::mpsc::{self, Receiver, SyncSender};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::{Duration, Instant};
 
-use crate::compiler::WhileOp;
+use crate::compiler::{UnresolvedBehavior, WhileOp};
+use crate::schedule::stats::ScenarioStats;
+
+/// Sender end of a per-subscriber gate-edge channel.
+pub type GateEdgeSender = SyncSender<GateEdge>;
 
 /// Direction of a strict comparison used by an `after:` clause.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -22,10 +26,13 @@ pub enum AfterOpDir {
 
 /// Edge fired into a [`GateReceiver`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum GateEdge {
     AfterFired,
     WhileOpen,
     WhileClose,
+    /// Upstream scenario has been removed; downstream must terminate.
+    UpstreamGone,
 }
 
 /// A subscriber's request for `after:` edges.
@@ -309,6 +316,73 @@ fn replace_send(tx: &SyncSender<GateEdge>, edge: GateEdge) {
     let _ = tx.try_send(edge);
 }
 
+/// A downstream subscription waiting for the named upstream to register.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct PendingResolution {
+    pub handle_id: String,
+    pub stats: Weak<RwLock<ScenarioStats>>,
+    pub edge_sender: GateEdgeSender,
+    pub scenario_name: String,
+    pub entry_id: String,
+    pub if_unresolved: UnresolvedBehavior,
+    pub registered_at: Instant,
+    pub attempts: u64,
+}
+
+/// Wire-shaped projection of a [`PendingResolution`] surfaced over the HTTP API.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Serialize))]
+#[non_exhaustive]
+pub struct PendingRef {
+    pub scenario_name: String,
+    pub entry_id: String,
+    pub if_unresolved: UnresolvedBehavior,
+    #[cfg(feature = "config")]
+    pub registered_at: chrono::DateTime<chrono::Utc>,
+    pub attempts: u64,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RegistryError {
+    #[error("scenario_name '{name}' is already in use by a running scenario")]
+    DuplicateScenarioName { name: String },
+}
+
+/// Process-wide registry for cross-POST gate bus lookup.
+pub trait GateBusResolver: Send + Sync {
+    fn register(
+        &self,
+        scenario_name: &str,
+        entry_id: &str,
+        bus: Arc<GateBus>,
+    ) -> Result<(), RegistryError>;
+
+    fn lookup(&self, scenario_name: &str, entry_id: &str) -> Option<Arc<GateBus>>;
+
+    /// Returns the bus to subscribe against if the upstream is live; `None`
+    /// signals the caller must defer via [`insert_pending`](Self::insert_pending).
+    fn subscribe(
+        &self,
+        upstream: (&str, &str),
+        downstream_handle_id: &str,
+        downstream_stats: Weak<RwLock<ScenarioStats>>,
+        edge_sender: GateEdgeSender,
+    ) -> Option<Arc<GateBus>>;
+
+    fn unregister(&self, scenario_name: &str);
+
+    /// Discard pending entries whose downstream stats handle has been dropped.
+    fn sweep_pending(&self) -> usize;
+
+    fn insert_pending(&self, pending: PendingResolution);
+
+    fn pending_for_handle(&self, handle_id: &str) -> Option<PendingRef>;
+
+    fn scenario_name_in_use(&self, scenario_name: &str) -> bool;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -493,5 +567,68 @@ mod tests {
     fn gate_bus_is_send_and_sync() {
         fn check<T: Send + Sync>() {}
         check::<GateBus>();
+    }
+
+    // ---- GateBusResolver: trait object-safety + no-op impl --------------------
+
+    struct NoOpResolver;
+
+    impl GateBusResolver for NoOpResolver {
+        fn register(
+            &self,
+            _scenario_name: &str,
+            _entry_id: &str,
+            _bus: Arc<GateBus>,
+        ) -> Result<(), RegistryError> {
+            Ok(())
+        }
+
+        fn lookup(&self, _scenario_name: &str, _entry_id: &str) -> Option<Arc<GateBus>> {
+            None
+        }
+
+        fn subscribe(
+            &self,
+            _upstream: (&str, &str),
+            _downstream_handle_id: &str,
+            _downstream_stats: Weak<RwLock<ScenarioStats>>,
+            _edge_sender: GateEdgeSender,
+        ) -> Option<Arc<GateBus>> {
+            None
+        }
+
+        fn unregister(&self, _scenario_name: &str) {}
+
+        fn sweep_pending(&self) -> usize {
+            0
+        }
+
+        fn insert_pending(&self, _pending: PendingResolution) {}
+
+        fn pending_for_handle(&self, _handle_id: &str) -> Option<PendingRef> {
+            None
+        }
+
+        fn scenario_name_in_use(&self, _scenario_name: &str) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn gate_bus_resolver_is_object_safe() {
+        let resolver: Box<dyn GateBusResolver> = Box::new(NoOpResolver);
+        assert!(resolver.lookup("nothing", "here").is_none());
+    }
+
+    #[test]
+    fn gate_edge_upstream_gone_variant_exists() {
+        let edge = GateEdge::UpstreamGone;
+        let label = match edge {
+            GateEdge::AfterFired => "after",
+            GateEdge::WhileOpen => "open",
+            GateEdge::WhileClose => "close",
+            GateEdge::UpstreamGone => "gone",
+        };
+        assert_eq!(label, "gone");
     }
 }

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -76,6 +76,13 @@ pub struct GateReceiver {
 }
 
 impl GateReceiver {
+    pub(crate) fn from_while_rx(rx: Receiver<GateEdge>) -> Self {
+        Self {
+            after_rx: None,
+            while_rx: Some(rx),
+        }
+    }
+
     /// Poll both per-kind channels in priority order: after, then while.
     pub fn try_recv(&self) -> Option<GateEdge> {
         if let Some(ref rx) = self.after_rx {
@@ -231,6 +238,50 @@ impl GateBus {
         )
     }
 
+    pub(crate) fn subscribe_with_while_sender(
+        &self,
+        spec: WhileSpec,
+        while_tx: GateEdgeSender,
+    ) -> InitialState {
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let (current_value, while_gate_open) = if inner.has_value {
+            let v = inner.last_value;
+            let open = strict_eval(v, spec.op, spec.threshold);
+            let edge = if open {
+                GateEdge::WhileOpen
+            } else {
+                GateEdge::WhileClose
+            };
+            let _ = while_tx.try_send(edge);
+            (v, Some(open))
+        } else {
+            (f64::NAN, None)
+        };
+
+        let sub = Subscription {
+            spec: SubscriptionSpec {
+                after: None,
+                while_: Some(spec),
+            },
+            after_tx: None,
+            while_tx: Some(while_tx),
+            after_fired: false,
+            prev_while_open: while_gate_open,
+        };
+
+        inner.subs.push(sub);
+
+        InitialState {
+            after_already_fired: false,
+            while_gate_open,
+            current_value,
+        }
+    }
+
     /// Publish a new upstream value.
     ///
     /// Fast path: bit-equal to the previous publish returns immediately
@@ -280,6 +331,22 @@ impl GateBus {
     pub(crate) fn drive_value(&self, v: f64) {
         self.tick(v);
     }
+
+    #[cfg(test)]
+    pub(crate) fn broadcast_upstream_gone(&self) {
+        let inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for sub in inner.subs.iter() {
+            if let Some(ref tx) = sub.while_tx {
+                replace_send(tx, GateEdge::UpstreamGone);
+            }
+            if let Some(ref tx) = sub.after_tx {
+                replace_send(tx, GateEdge::UpstreamGone);
+            }
+        }
+    }
 }
 
 impl Default for GateBus {
@@ -328,6 +395,7 @@ pub struct PendingResolution {
     pub if_unresolved: UnresolvedBehavior,
     pub registered_at: Instant,
     pub attempts: u64,
+    pub spec: WhileSpec,
 }
 
 /// Wire-shaped projection of a [`PendingResolution`] surfaced over the HTTP API.

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -63,6 +63,7 @@ pub struct ScenarioHandle {
     ///
     /// `Some` for metrics, histogram, and summary scenarios; `None` for logs.
     pub prometheus_meta: Option<Arc<PromMeta>>,
+    pub cleaned_up: Arc<AtomicBool>,
 }
 
 impl ScenarioHandle {
@@ -80,6 +81,7 @@ impl ScenarioHandle {
         alive: Arc<AtomicBool>,
         labels: Arc<HashMap<String, String>>,
         prometheus_meta: Option<Arc<PromMeta>>,
+        cleaned_up: Arc<AtomicBool>,
     ) -> Self {
         Self {
             id,
@@ -93,6 +95,7 @@ impl ScenarioHandle {
             alive,
             labels,
             prometheus_meta,
+            cleaned_up,
         }
     }
 
@@ -247,6 +250,21 @@ impl ScenarioHandle {
     }
 }
 
+impl Drop for ScenarioHandle {
+    fn drop(&mut self) {
+        if self.cleaned_up.load(Ordering::SeqCst) {
+            return;
+        }
+        if self.scenario_name.is_none() {
+            return;
+        }
+        eprintln!(
+            "sonda: scenario '{}' dropped without unregistering from the gate bus registry",
+            self.id
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -303,6 +321,7 @@ mod tests {
                 crate::config::PromMetricType::Gauge,
                 None,
             ))),
+            Arc::new(AtomicBool::new(true)),
         )
     }
 
@@ -563,6 +582,7 @@ mod tests {
                 crate::config::PromMetricType::Gauge,
                 None,
             ))),
+            Arc::new(AtomicBool::new(true)),
         );
 
         // stats_snapshot must not panic — it recovers from the poisoned lock.
@@ -610,6 +630,7 @@ mod tests {
                 crate::config::PromMetricType::Gauge,
                 None,
             ))),
+            Arc::new(AtomicBool::new(true)),
         );
 
         let events = handle.recent_metrics_snapshot();

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -344,6 +344,7 @@ pub fn launch_scenario_with_gates(
         alive,
         labels,
         prometheus_meta,
+        Arc::new(AtomicBool::new(false)),
     ))
 }
 

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -16,7 +16,7 @@ use crate::config::validate::{
 use crate::config::{expand_entry, PromMeta, PromMetricType, ScenarioEntry};
 use crate::generator::GeneratorConfig;
 use crate::schedule::core_loop::GateContext;
-use crate::schedule::gate_bus::GateBus;
+use crate::schedule::gate_bus::{GateBus, GateBusResolver};
 use crate::schedule::handle::ScenarioHandle;
 use crate::schedule::histogram_runner::run_with_sink_gated as run_histogram_with_sink_gated;
 use crate::schedule::log_runner::run_logs_with_sink_gated;
@@ -200,7 +200,7 @@ pub fn launch_scenario(
     shutdown: Arc<AtomicBool>,
     start_delay: Option<Duration>,
 ) -> Result<ScenarioHandle, SondaError> {
-    launch_scenario_with_gates(id, None, entry, shutdown, start_delay, None, None)
+    launch_scenario_with_gates(id, None, entry, shutdown, start_delay, None, None, None)
 }
 
 /// Launch a scenario with optional `while:` / `after:` gating wired in.
@@ -208,7 +208,9 @@ pub fn launch_scenario(
 /// `scenario_name` surfaces on [`ScenarioHandle::scenario_name`]; pass `None`
 /// for anonymous bodies. `upstream_bus` is the bus this scenario PUBLISHES
 /// into (for downstream gates to read). `gate_ctx` is what THIS scenario
-/// consumes from an upstream bus.
+/// consumes from an upstream bus. When `resolver` is `Some` AND `scenario_name`
+/// is `Some`, natural-exit cleanup unregisters the upstream bus on thread exit.
+#[allow(clippy::too_many_arguments)]
 pub fn launch_scenario_with_gates(
     id: String,
     scenario_name: Option<String>,
@@ -217,6 +219,7 @@ pub fn launch_scenario_with_gates(
     start_delay: Option<Duration>,
     upstream_bus: Option<Arc<GateBus>>,
     gate_ctx: Option<GateContext>,
+    resolver: Option<Arc<dyn GateBusResolver>>,
 ) -> Result<ScenarioHandle, SondaError> {
     let stats = Arc::new(RwLock::new(ScenarioStats::default()));
     let stats_for_thread = Arc::clone(&stats);
@@ -245,6 +248,10 @@ pub fn launch_scenario_with_gates(
 
     let stats_for_state = Arc::clone(&stats);
     let is_gated = gate_ctx.is_some();
+    let cleaned_up = Arc::new(AtomicBool::new(false));
+    let cleaned_up_for_thread = Arc::clone(&cleaned_up);
+    let resolver_for_thread = resolver.clone();
+    let scenario_name_for_thread = scenario_name.clone();
 
     let thread = std::thread::Builder::new()
         .name(format!("sonda-{}", name))
@@ -256,9 +263,12 @@ pub fn launch_scenario_with_gates(
                 flag: alive_for_thread,
             };
 
-            // Drop guard writes ScenarioState::Finished on every exit path.
+            // Marks Finished on drop; unregisters when a resolver is wired.
             let _state_guard = StateGuard {
                 stats: Arc::clone(&stats_for_state),
+                resolver: resolver_for_thread,
+                scenario_name: scenario_name_for_thread,
+                cleaned_up: cleaned_up_for_thread,
             };
 
             // Sleep through the start_delay before entering the event loop.
@@ -282,7 +292,7 @@ pub fn launch_scenario_with_gates(
             // need someone to mark Running once the start_delay has elapsed.
             if !is_gated {
                 if let Ok(mut st) = stats_for_state.write() {
-                    st.state = ScenarioState::Running;
+                    st.transition_state(ScenarioState::Running);
                 }
             }
 
@@ -344,7 +354,7 @@ pub fn launch_scenario_with_gates(
         alive,
         labels,
         prometheus_meta,
-        Arc::new(AtomicBool::new(false)),
+        cleaned_up,
     ))
 }
 
@@ -381,12 +391,26 @@ impl Drop for AliveGuard {
 
 struct StateGuard {
     stats: Arc<RwLock<ScenarioStats>>,
+    resolver: Option<Arc<dyn GateBusResolver>>,
+    scenario_name: Option<String>,
+    cleaned_up: Arc<AtomicBool>,
 }
 
 impl Drop for StateGuard {
     fn drop(&mut self) {
         if let Ok(mut st) = self.stats.write() {
-            st.state = ScenarioState::Finished;
+            if st.state != ScenarioState::Finished {
+                st.transition_state(ScenarioState::Finished);
+            }
+        }
+        // Skip when Phase 1 (delete_scenario) already ran; ensure exactly once.
+        if self.cleaned_up.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        if let (Some(name), Some(resolver)) =
+            (self.scenario_name.as_deref(), self.resolver.as_ref())
+        {
+            resolver.unregister(name);
         }
     }
 }
@@ -1558,6 +1582,9 @@ mod tests {
         {
             let _g = StateGuard {
                 stats: Arc::clone(&stats),
+                resolver: None,
+                scenario_name: None,
+                cleaned_up: Arc::new(AtomicBool::new(false)),
             };
         }
         assert_eq!(stats.read().unwrap().state, ScenarioState::Finished);
@@ -1573,6 +1600,9 @@ mod tests {
             .spawn(move || {
                 let _g = StateGuard {
                     stats: stats_for_thread,
+                    resolver: None,
+                    scenario_name: None,
+                    cleaned_up: Arc::new(AtomicBool::new(false)),
                 };
                 panic!("intentional panic for StateGuard test");
             })

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -227,16 +227,13 @@ pub fn launch_multi_compiled(
                         )
                     }
                 };
-                Some(GateContext {
-                    gate_rx,
-                    initial,
-                    delay: delay_clause,
-                    has_after: false,
-                    has_while: true,
-                    close_emit: None,
-                    if_unresolved: Some(if_unresolved),
-                    start_unresolved,
-                })
+                Some(
+                    GateContext::new(gate_rx, initial)
+                        .with_delay(delay_clause)
+                        .with_has_while(true)
+                        .with_if_unresolved(Some(if_unresolved))
+                        .with_start_unresolved(start_unresolved),
+                )
             } else {
                 let upstream = buses.get(&clause.ref_id).ok_or_else(|| {
                     SondaError::Config(crate::ConfigError::invalid(format!(
@@ -252,16 +249,11 @@ pub fn launch_multi_compiled(
                     }),
                 };
                 let (rx, init) = upstream.subscribe(spec);
-                Some(GateContext {
-                    gate_rx: rx,
-                    initial: init,
-                    delay: delay_clause,
-                    has_after: false,
-                    has_while: true,
-                    close_emit: None,
-                    if_unresolved: None,
-                    start_unresolved: false,
-                })
+                Some(
+                    GateContext::new(rx, init)
+                        .with_delay(delay_clause)
+                        .with_has_while(true),
+                )
             }
         } else {
             None

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -23,11 +23,16 @@ use crate::config::expand_entry;
 #[cfg(feature = "config")]
 use crate::schedule::core_loop::GateContext;
 #[cfg(feature = "config")]
-use crate::schedule::gate_bus::{GateBus, SubscriptionSpec, WhileSpec};
+use crate::schedule::gate_bus::{
+    GateBus, GateBusResolver, GateReceiver, InitialState, PendingResolution, SubscriptionSpec,
+    WhileSpec,
+};
 #[cfg(feature = "config")]
 use crate::schedule::launch::{launch_scenario_with_gates, validate_entry};
 #[cfg(feature = "config")]
 use std::collections::HashMap;
+#[cfg(feature = "config")]
+use std::sync::mpsc;
 
 /// Run all scenarios in `entries` concurrently, one OS thread per scenario.
 ///
@@ -99,31 +104,49 @@ pub fn signal_shutdown(shutdown: &AtomicBool) {
 }
 
 /// Launch a compiled scenario file with `while:` / `after:` gating wired in,
-/// returning the live handles without joining them.
-///
-/// Equivalent to the spawn portion of [`run_multi_compiled`]: pre-builds an
-/// `Arc<GateBus>` per metric scenario id, subscribes each downstream to its
-/// upstream's bus, and launches every scenario with the matching
-/// [`GateContext`]. Returns the launched [`ScenarioHandle`]s so callers can
-/// observe per-scenario stats (for progress displays) before joining.
+/// returning the live handles without joining them. When `resolver` is `Some`,
+/// cross-POST `while:` references resolve through the registry; otherwise every
+/// reference must resolve inside `file`.
 #[cfg(feature = "config")]
 pub fn launch_multi_compiled(
     file: CompiledFile,
     shutdown: Arc<AtomicBool>,
+    resolver: Option<Arc<dyn GateBusResolver>>,
 ) -> Result<Vec<crate::schedule::handle::ScenarioHandle>, SondaError> {
     let CompiledFile {
-        scenario_name,
+        scenario_name: file_scenario_name,
         entries,
         ..
     } = file;
+    let file_scenario_name_ref = file_scenario_name.as_deref();
 
-    let bus_ids = while_upstream_ids(&entries);
+    let mut bus_ids = while_upstream_ids(&entries, file_scenario_name_ref);
+    if file_scenario_name_ref.is_some() {
+        for entry in &entries {
+            if entry.signal_type == "metrics" {
+                if let Some(id) = entry.id.as_deref() {
+                    bus_ids.push(id.to_string());
+                }
+            }
+        }
+        bus_ids.sort();
+        bus_ids.dedup();
+    }
     let mut buses: HashMap<String, Arc<GateBus>> = HashMap::with_capacity(bus_ids.len());
     for id in bus_ids {
         buses.insert(id, Arc::new(GateBus::new()));
     }
 
-    // Build (entry, gate_ctx, upstream_bus, start_delay, id) per scenario.
+    if let (Some(ref r), Some(name)) = (&resolver, file_scenario_name_ref) {
+        for (entry_id, bus) in buses.iter() {
+            r.register(name, entry_id, Arc::clone(bus)).map_err(|e| {
+                SondaError::Config(crate::ConfigError::invalid(format!(
+                    "gate bus registry: {e}"
+                )))
+            })?;
+        }
+    }
+
     let mut launches: Vec<LaunchPlan> = Vec::with_capacity(entries.len());
     for compiled_entry in entries.into_iter() {
         let id = compiled_entry.id.clone();
@@ -156,29 +179,87 @@ pub fn launch_multi_compiled(
 
         let upstream_bus = id.as_ref().and_then(|name| buses.get(name).cloned());
 
+        let mut deferred: Option<DeferredSubscription> = None;
         let gate_ctx = if let Some(ref clause) = while_clause {
-            let upstream = buses.get(&clause.ref_id).ok_or_else(|| {
-                SondaError::Config(crate::ConfigError::invalid(format!(
-                    "while: ref '{}' not found among scenario ids",
-                    clause.ref_id
-                )))
-            })?;
-            let spec = SubscriptionSpec {
-                after: None,
-                while_: Some(WhileSpec {
+            if let Some(cross_scenario) = cross_scenario_target(clause, file_scenario_name_ref) {
+                let resolver = resolver.as_ref().ok_or_else(|| {
+                    SondaError::Config(crate::ConfigError::invalid(
+                        "cross-POST while: reference requires a GateBusResolver; \
+                         the CLI does not support cross-POST `while:`",
+                    ))
+                })?;
+                let spec = WhileSpec {
                     op: clause.op,
                     threshold: clause.value,
-                }),
-            };
-            let (rx, init) = upstream.subscribe(spec);
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: delay_clause,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-            })
+                };
+                let (tx, rx) = mpsc::sync_channel::<crate::schedule::gate_bus::GateEdge>(1);
+                let if_unresolved = clause.if_unresolved.unwrap_or_default();
+                let bus = resolver.subscribe(
+                    (cross_scenario, clause.ref_id.as_str()),
+                    id.as_deref().unwrap_or(""),
+                    std::sync::Weak::new(),
+                    tx.clone(),
+                );
+                let (gate_rx, initial, start_unresolved) = match bus {
+                    Some(bus) => {
+                        let init = bus.subscribe_with_while_sender(spec, tx);
+                        (GateReceiver::from_while_rx(rx), init, false)
+                    }
+                    None => {
+                        deferred = Some(DeferredSubscription {
+                            sender: tx,
+                            scenario_name: cross_scenario.to_string(),
+                            entry_id: clause.ref_id.clone(),
+                            if_unresolved,
+                            spec,
+                        });
+                        (
+                            GateReceiver::from_while_rx(rx),
+                            InitialState {
+                                after_already_fired: false,
+                                while_gate_open: None,
+                                current_value: f64::NAN,
+                            },
+                            true,
+                        )
+                    }
+                };
+                Some(GateContext {
+                    gate_rx,
+                    initial,
+                    delay: delay_clause,
+                    has_after: false,
+                    has_while: true,
+                    close_emit: None,
+                    if_unresolved: Some(if_unresolved),
+                    start_unresolved,
+                })
+            } else {
+                let upstream = buses.get(&clause.ref_id).ok_or_else(|| {
+                    SondaError::Config(crate::ConfigError::invalid(format!(
+                        "while: ref '{}' not found among scenario ids",
+                        clause.ref_id
+                    )))
+                })?;
+                let spec = SubscriptionSpec {
+                    after: None,
+                    while_: Some(WhileSpec {
+                        op: clause.op,
+                        threshold: clause.value,
+                    }),
+                };
+                let (rx, init) = upstream.subscribe(spec);
+                Some(GateContext {
+                    gate_rx: rx,
+                    initial: init,
+                    delay: delay_clause,
+                    has_after: false,
+                    has_while: true,
+                    close_emit: None,
+                    if_unresolved: None,
+                    start_unresolved: false,
+                })
+            }
         } else {
             None
         };
@@ -196,22 +277,39 @@ pub fn launch_multi_compiled(
             gate_ctx,
             upstream_bus,
             start_delay,
+            deferred,
         });
     }
 
     let mut handles = Vec::with_capacity(launches.len());
     for (idx, plan) in launches.into_iter().enumerate() {
         let id = plan.id.unwrap_or_else(|| format!("multi-{idx}"));
+        let deferred = plan.deferred;
         match launch_scenario_with_gates(
-            id,
-            scenario_name.clone(),
+            id.clone(),
+            file_scenario_name.clone(),
             plan.entry,
             Arc::clone(&shutdown),
             plan.start_delay,
             plan.upstream_bus,
             plan.gate_ctx,
         ) {
-            Ok(handle) => handles.push(handle),
+            Ok(handle) => {
+                if let (Some(d), Some(r)) = (deferred, resolver.as_ref()) {
+                    r.insert_pending(PendingResolution {
+                        handle_id: handle.id.clone(),
+                        stats: Arc::downgrade(&handle.stats),
+                        edge_sender: d.sender,
+                        scenario_name: d.scenario_name,
+                        entry_id: d.entry_id,
+                        if_unresolved: d.if_unresolved,
+                        registered_at: std::time::Instant::now(),
+                        attempts: 0,
+                        spec: d.spec,
+                    });
+                }
+                handles.push(handle);
+            }
             Err(e) => {
                 for handle in &handles {
                     handle.stop();
@@ -224,7 +322,33 @@ pub fn launch_multi_compiled(
         }
     }
 
+    if let Some(ref r) = resolver {
+        r.sweep_pending();
+    }
+
     Ok(handles)
+}
+
+#[cfg(feature = "config")]
+fn cross_scenario_target<'a>(
+    clause: &'a crate::compiler::WhileClause,
+    file_scenario_name: Option<&'a str>,
+) -> Option<&'a str> {
+    let name = clause.scenario_name.as_deref()?;
+    if Some(name) == file_scenario_name {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+#[cfg(feature = "config")]
+struct DeferredSubscription {
+    sender: crate::schedule::gate_bus::GateEdgeSender,
+    scenario_name: String,
+    entry_id: String,
+    if_unresolved: crate::compiler::UnresolvedBehavior,
+    spec: WhileSpec,
 }
 
 /// Run a compiled scenario file with `while:` / `after:` gating wired in.
@@ -234,7 +358,7 @@ pub fn launch_multi_compiled(
 /// overhead.
 #[cfg(feature = "config")]
 pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Result<(), SondaError> {
-    let handles = launch_multi_compiled(file, shutdown)?;
+    let handles = launch_multi_compiled(file, shutdown, None)?;
 
     let mut errors: Vec<String> = Vec::new();
     for mut handle in handles {
@@ -253,14 +377,22 @@ pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Resu
     }
 }
 
-/// Collect the set of compiled-entry ids referenced by some `while:` clause.
-/// Only these ids need a [`GateBus`]; non-referenced entries publish nothing
-/// and skip the per-tick `tick()` lock.
+/// Local `while:` upstream ids; cross-POST refs are excluded.
 #[cfg(feature = "config")]
-fn while_upstream_ids(entries: &[crate::compiler::compile_after::CompiledEntry]) -> Vec<String> {
+fn while_upstream_ids(
+    entries: &[crate::compiler::compile_after::CompiledEntry],
+    file_scenario_name: Option<&str>,
+) -> Vec<String> {
     let mut ids: Vec<String> = entries
         .iter()
-        .filter_map(|e| e.while_clause.as_ref().map(|w| w.ref_id.clone()))
+        .filter_map(|e| {
+            let clause = e.while_clause.as_ref()?;
+            if cross_scenario_target(clause, file_scenario_name).is_some() {
+                None
+            } else {
+                Some(clause.ref_id.clone())
+            }
+        })
         .collect();
     ids.sort();
     ids.dedup();
@@ -274,6 +406,7 @@ struct LaunchPlan {
     gate_ctx: Option<GateContext>,
     upstream_bus: Option<Arc<GateBus>>,
     start_delay: Option<std::time::Duration>,
+    deferred: Option<DeferredSubscription>,
 }
 
 #[cfg(test)]
@@ -1070,7 +1203,7 @@ scenarios:
         let resolver = InMemoryPackResolver::new();
         let compiled =
             compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-        let ids = while_upstream_ids(&compiled.entries);
+        let ids = while_upstream_ids(&compiled.entries, compiled.scenario_name.as_deref());
         assert_eq!(
             ids,
             vec!["upstream_a".to_string()],
@@ -1113,8 +1246,8 @@ scenarios:
             compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
 
         let shutdown = Arc::new(AtomicBool::new(true));
-        let mut handles =
-            launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        let mut handles = launch_multi_compiled(compiled, Arc::clone(&shutdown), None)
+            .expect("launch must succeed");
         assert_eq!(handles.len(), 2, "must launch both entries");
         assert!(
             handles.iter().all(|h| h.is_alive()),
@@ -1138,6 +1271,546 @@ scenarios:
             handle
                 .join(Some(Duration::from_secs(1)))
                 .expect("join must succeed after stop");
+        }
+    }
+
+    #[cfg(feature = "config")]
+    mod cross_post {
+        use std::collections::HashMap;
+        use std::sync::atomic::AtomicBool;
+        use std::sync::{Arc, Mutex, RwLock, Weak};
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        use crate::compile_scenario_file_compiled;
+        use crate::compiler::expand::InMemoryPackResolver;
+        use crate::schedule::gate_bus::{
+            GateBus, GateBusResolver, GateEdgeSender, PendingRef, PendingResolution, RegistryError,
+        };
+        use crate::schedule::handle::ScenarioHandle;
+        use crate::schedule::stats::{ScenarioState, ScenarioStats};
+
+        use super::super::launch_multi_compiled;
+
+        struct TestRegistry {
+            buses: Mutex<HashMap<(String, String), Arc<GateBus>>>,
+            pending: Mutex<Vec<PendingResolution>>,
+        }
+
+        impl TestRegistry {
+            fn new() -> Arc<Self> {
+                Arc::new(Self {
+                    buses: Mutex::new(HashMap::new()),
+                    pending: Mutex::new(Vec::new()),
+                })
+            }
+
+            fn pending_len(&self) -> usize {
+                self.pending.lock().unwrap().len()
+            }
+        }
+
+        impl GateBusResolver for TestRegistry {
+            fn register(
+                &self,
+                scenario_name: &str,
+                entry_id: &str,
+                bus: Arc<GateBus>,
+            ) -> Result<(), RegistryError> {
+                let key = (scenario_name.to_string(), entry_id.to_string());
+                let mut buses = self.buses.lock().unwrap();
+                if buses.contains_key(&key) {
+                    return Err(RegistryError::DuplicateScenarioName {
+                        name: scenario_name.to_string(),
+                    });
+                }
+                buses.insert(key, bus);
+                Ok(())
+            }
+
+            fn lookup(&self, scenario_name: &str, entry_id: &str) -> Option<Arc<GateBus>> {
+                self.buses
+                    .lock()
+                    .unwrap()
+                    .get(&(scenario_name.to_string(), entry_id.to_string()))
+                    .cloned()
+            }
+
+            fn subscribe(
+                &self,
+                upstream: (&str, &str),
+                _downstream_handle_id: &str,
+                _downstream_stats: Weak<RwLock<ScenarioStats>>,
+                _edge_sender: GateEdgeSender,
+            ) -> Option<Arc<GateBus>> {
+                self.buses
+                    .lock()
+                    .unwrap()
+                    .get(&(upstream.0.to_string(), upstream.1.to_string()))
+                    .cloned()
+            }
+
+            fn unregister(&self, scenario_name: &str) {
+                let mut buses = self.buses.lock().unwrap();
+                let keys: Vec<_> = buses
+                    .keys()
+                    .filter(|(s, _)| s == scenario_name)
+                    .cloned()
+                    .collect();
+                for key in keys {
+                    if let Some(bus) = buses.remove(&key) {
+                        bus.broadcast_upstream_gone();
+                    }
+                }
+            }
+
+            fn sweep_pending(&self) -> usize {
+                let mut pending = self.pending.lock().unwrap();
+                let buses = self.buses.lock().unwrap();
+                let mut promoted = 0;
+                pending.retain(|p| {
+                    if p.stats.strong_count() == 0 {
+                        return false;
+                    }
+                    let key = (p.scenario_name.clone(), p.entry_id.clone());
+                    if let Some(bus) = buses.get(&key) {
+                        bus.subscribe_with_while_sender(p.spec, p.edge_sender.clone());
+                        promoted += 1;
+                        false
+                    } else {
+                        true
+                    }
+                });
+                promoted
+            }
+
+            fn insert_pending(&self, pending: PendingResolution) {
+                self.pending.lock().unwrap().push(pending);
+            }
+
+            fn pending_for_handle(&self, handle_id: &str) -> Option<PendingRef> {
+                let pending = self.pending.lock().unwrap();
+                pending
+                    .iter()
+                    .find(|p| p.handle_id == handle_id)
+                    .map(|p| PendingRef {
+                        scenario_name: p.scenario_name.clone(),
+                        entry_id: p.entry_id.clone(),
+                        if_unresolved: p.if_unresolved,
+                        #[cfg(feature = "config")]
+                        registered_at: chrono::DateTime::<chrono::Utc>::from(
+                            std::time::SystemTime::now(),
+                        ),
+                        attempts: p.attempts,
+                    })
+            }
+
+            fn scenario_name_in_use(&self, scenario_name: &str) -> bool {
+                self.buses
+                    .lock()
+                    .unwrap()
+                    .keys()
+                    .any(|(s, _)| s == scenario_name)
+            }
+        }
+
+        fn downstream_yaml(if_unresolved: &str) -> String {
+            format!(
+                r#"
+version: 2
+kind: runnable
+scenario_name: downstream_post
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: dependent
+    signal_type: metrics
+    name: dependent
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream_metric
+      op: ">"
+      value: 0
+      scenario_name: upstream_post
+      if_unresolved: {if_unresolved}
+"#
+            )
+        }
+
+        fn upstream_yaml() -> String {
+            r#"
+version: 2
+kind: runnable
+scenario_name: upstream_post
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: upstream_metric
+    signal_type: metrics
+    name: upstream_metric
+    generator:
+      type: constant
+      value: 1.0
+"#
+            .to_string()
+        }
+
+        fn wait_for_state(handle: &ScenarioHandle, expected: ScenarioState, timeout: Duration) {
+            let deadline = Instant::now() + timeout;
+            while Instant::now() < deadline {
+                if handle.stats_snapshot().state == expected {
+                    return;
+                }
+                thread::sleep(Duration::from_millis(20));
+            }
+            let actual = handle.stats_snapshot().state;
+            panic!("timed out waiting for {expected:?}; current state = {actual:?}");
+        }
+
+        fn stop_and_join(mut handles: Vec<ScenarioHandle>) {
+            for h in &handles {
+                h.stop();
+            }
+            for h in &mut handles {
+                let _ = h.join(Some(Duration::from_secs(2)));
+            }
+        }
+
+        #[test]
+        fn t8_downstream_enters_unresolved_then_promoted_on_register_and_sweep() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let compiled = compile_scenario_file_compiled(
+                &downstream_yaml("pending"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let handles =
+                launch_multi_compiled(compiled, Arc::clone(&shutdown), Some(Arc::clone(&resolver)))
+                    .expect("launch downstream");
+            assert_eq!(handles.len(), 1);
+            wait_for_state(
+                &handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+            assert_eq!(registry.pending_len(), 1);
+
+            let bus = Arc::new(GateBus::new());
+            bus.tick(1.0);
+            resolver
+                .register("upstream_post", "upstream_metric", bus)
+                .expect("register upstream");
+            let promoted = resolver.sweep_pending();
+            assert_eq!(promoted, 1);
+
+            wait_for_state(&handles[0], ScenarioState::Running, Duration::from_secs(2));
+            stop_and_join(handles);
+        }
+
+        #[test]
+        fn t9_downstream_first_then_upstream_post_promotes_via_sweep() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let downstream = compile_scenario_file_compiled(
+                &downstream_yaml("pending"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+
+            let shutdown_a = Arc::new(AtomicBool::new(true));
+            let downstream_handles = launch_multi_compiled(
+                downstream,
+                Arc::clone(&shutdown_a),
+                Some(Arc::clone(&resolver)),
+            )
+            .expect("launch downstream");
+            wait_for_state(
+                &downstream_handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+
+            let upstream =
+                compile_scenario_file_compiled(&upstream_yaml(), &InMemoryPackResolver::new())
+                    .expect("compile upstream");
+            let shutdown_b = Arc::new(AtomicBool::new(true));
+            let upstream_handles = launch_multi_compiled(
+                upstream,
+                Arc::clone(&shutdown_b),
+                Some(Arc::clone(&resolver)),
+            )
+            .expect("launch upstream");
+            wait_for_state(
+                &downstream_handles[0],
+                ScenarioState::Running,
+                Duration::from_secs(2),
+            );
+
+            stop_and_join(downstream_handles);
+            stop_and_join(upstream_handles);
+        }
+
+        // Re-resolution after `unregister` (so a downstream Unresolved can pick up a fresh
+        // upstream with the same scenario_name) requires the registry to push affected
+        // downstreams back into `pending` on unregister — that mechanism lives with the
+        // production `GateBusRegistry` implementation, not the test resolver.
+        #[test]
+        fn t10_unregister_drives_downstream_back_to_unresolved() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let upstream =
+                compile_scenario_file_compiled(&upstream_yaml(), &InMemoryPackResolver::new())
+                    .expect("compile upstream");
+            let shutdown_a = Arc::new(AtomicBool::new(true));
+            let upstream_handles = launch_multi_compiled(
+                upstream,
+                Arc::clone(&shutdown_a),
+                Some(Arc::clone(&resolver)),
+            )
+            .expect("launch upstream");
+
+            let downstream = compile_scenario_file_compiled(
+                &downstream_yaml("open"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+            let shutdown_b = Arc::new(AtomicBool::new(true));
+            let downstream_handles = launch_multi_compiled(
+                downstream,
+                Arc::clone(&shutdown_b),
+                Some(Arc::clone(&resolver)),
+            )
+            .expect("launch downstream");
+            wait_for_state(
+                &downstream_handles[0],
+                ScenarioState::Running,
+                Duration::from_secs(2),
+            );
+
+            resolver.unregister("upstream_post");
+            wait_for_state(
+                &downstream_handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+            for h in &upstream_handles {
+                h.stop();
+            }
+            for mut h in upstream_handles {
+                let _ = h.join(Some(Duration::from_secs(1)));
+            }
+
+            let bus = Arc::new(GateBus::new());
+            bus.tick(1.0);
+            resolver
+                .register("upstream_post", "upstream_metric", bus)
+                .expect("re-register");
+            assert_eq!(
+                downstream_handles[0].stats_snapshot().state,
+                ScenarioState::Unresolved,
+            );
+
+            stop_and_join(downstream_handles);
+        }
+
+        #[test]
+        fn t11_if_unresolved_open_ticks_at_full_rate() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let compiled = compile_scenario_file_compiled(
+                &downstream_yaml("open"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let handles =
+                launch_multi_compiled(compiled, Arc::clone(&shutdown), Some(Arc::clone(&resolver)))
+                    .expect("launch");
+            wait_for_state(
+                &handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+
+            let snapshot_at_t0 = handles[0].stats_snapshot().total_events;
+            thread::sleep(Duration::from_millis(400));
+            let snapshot_after = handles[0].stats_snapshot().total_events;
+            let delta = snapshot_after - snapshot_at_t0;
+            assert!(
+                delta >= 5,
+                "if_unresolved: open must keep ticking; delta = {delta}"
+            );
+
+            stop_and_join(handles);
+        }
+
+        #[test]
+        fn t11b_if_unresolved_open_transitions_to_running_on_upstream_register() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let compiled = compile_scenario_file_compiled(
+                &downstream_yaml("open"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let handles =
+                launch_multi_compiled(compiled, Arc::clone(&shutdown), Some(Arc::clone(&resolver)))
+                    .expect("launch");
+            wait_for_state(
+                &handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+
+            let pre_register = handles[0].stats_snapshot().total_events;
+
+            let bus = Arc::new(GateBus::new());
+            bus.tick(1.0);
+            resolver
+                .register("upstream_post", "upstream_metric", bus)
+                .expect("register upstream");
+            let promoted = resolver.sweep_pending();
+            assert_eq!(promoted, 1);
+
+            wait_for_state(&handles[0], ScenarioState::Running, Duration::from_secs(2));
+
+            let post_transition = handles[0].stats_snapshot().total_events;
+            thread::sleep(Duration::from_millis(400));
+            let after_running = handles[0].stats_snapshot().total_events;
+            assert!(
+                post_transition > pre_register,
+                "emission must continue across the Unresolved -> Running transition; \
+                 pre_register = {pre_register}, post_transition = {post_transition}"
+            );
+            let delta = after_running - post_transition;
+            assert!(
+                delta >= 5,
+                "Running state must keep ticking after transition; delta = {delta}"
+            );
+
+            stop_and_join(handles);
+        }
+
+        #[test]
+        fn t12_if_unresolved_closed_does_not_emit() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let compiled = compile_scenario_file_compiled(
+                &downstream_yaml("closed"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let handles =
+                launch_multi_compiled(compiled, Arc::clone(&shutdown), Some(Arc::clone(&resolver)))
+                    .expect("launch");
+            wait_for_state(
+                &handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+
+            let snapshot_at_t0 = handles[0].stats_snapshot().total_events;
+            thread::sleep(Duration::from_millis(400));
+            let snapshot_after = handles[0].stats_snapshot().total_events;
+            assert_eq!(
+                snapshot_after, snapshot_at_t0,
+                "if_unresolved: closed must not emit ticks"
+            );
+
+            stop_and_join(handles);
+        }
+
+        #[test]
+        fn t13_if_unresolved_pending_does_not_emit_and_holds_state() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+
+            let compiled = compile_scenario_file_compiled(
+                &downstream_yaml("pending"),
+                &InMemoryPackResolver::new(),
+            )
+            .expect("compile downstream");
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let handles =
+                launch_multi_compiled(compiled, Arc::clone(&shutdown), Some(Arc::clone(&resolver)))
+                    .expect("launch");
+            wait_for_state(
+                &handles[0],
+                ScenarioState::Unresolved,
+                Duration::from_secs(2),
+            );
+
+            let snapshot_at_t0 = handles[0].stats_snapshot().total_events;
+            thread::sleep(Duration::from_millis(400));
+            let snap = handles[0].stats_snapshot();
+            assert_eq!(snap.total_events, snapshot_at_t0);
+            assert_eq!(snap.state, ScenarioState::Unresolved);
+
+            stop_and_join(handles);
+        }
+
+        #[test]
+        fn t_regress_2_local_only_while_path_unchanged() {
+            let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 200ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: upstream
+    signal_type: metrics
+    name: upstream
+    generator:
+      type: constant
+      value: 1.0
+  - id: dependent
+    signal_type: metrics
+    name: dependent
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream
+      op: ">"
+      value: 0
+"#;
+            let compiled = compile_scenario_file_compiled(yaml, &InMemoryPackResolver::new())
+                .expect("compile local-only");
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let mut handles =
+                launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch");
+            assert_eq!(handles.len(), 2);
+            for h in &mut handles {
+                let _ = h.join(Some(Duration::from_secs(2)));
+            }
         }
     }
 }

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -180,6 +180,7 @@ pub fn launch_multi_compiled(
         let upstream_bus = id.as_ref().and_then(|name| buses.get(name).cloned());
 
         let mut deferred: Option<DeferredSubscription> = None;
+        let mut active: Option<ActiveSubscription> = None;
         let gate_ctx = if let Some(ref clause) = while_clause {
             if let Some(cross_scenario) = cross_scenario_target(clause, file_scenario_name_ref) {
                 let resolver = resolver.as_ref().ok_or_else(|| {
@@ -194,15 +195,17 @@ pub fn launch_multi_compiled(
                 };
                 let (tx, rx) = mpsc::sync_channel::<crate::schedule::gate_bus::GateEdge>(1);
                 let if_unresolved = clause.if_unresolved.unwrap_or_default();
-                let bus = resolver.subscribe(
-                    (cross_scenario, clause.ref_id.as_str()),
-                    id.as_deref().unwrap_or(""),
-                    std::sync::Weak::new(),
-                    tx.clone(),
-                );
+                let bus = resolver.lookup(cross_scenario, clause.ref_id.as_str());
                 let (gate_rx, initial, start_unresolved) = match bus {
                     Some(bus) => {
-                        let init = bus.subscribe_with_while_sender(spec, tx);
+                        let init = bus.subscribe_with_while_sender(spec, tx.clone());
+                        active = Some(ActiveSubscription {
+                            sender: tx,
+                            scenario_name: cross_scenario.to_string(),
+                            entry_id: clause.ref_id.clone(),
+                            if_unresolved,
+                            spec,
+                        });
                         (GateReceiver::from_while_rx(rx), init, false)
                     }
                     None => {
@@ -278,6 +281,7 @@ pub fn launch_multi_compiled(
             upstream_bus,
             start_delay,
             deferred,
+            active,
         });
     }
 
@@ -285,6 +289,7 @@ pub fn launch_multi_compiled(
     for (idx, plan) in launches.into_iter().enumerate() {
         let id = plan.id.unwrap_or_else(|| format!("multi-{idx}"));
         let deferred = plan.deferred;
+        let active = plan.active;
         match launch_scenario_with_gates(
             id.clone(),
             file_scenario_name.clone(),
@@ -293,6 +298,7 @@ pub fn launch_multi_compiled(
             plan.start_delay,
             plan.upstream_bus,
             plan.gate_ctx,
+            resolver.clone(),
         ) {
             Ok(handle) => {
                 if let (Some(d), Some(r)) = (deferred, resolver.as_ref()) {
@@ -306,6 +312,19 @@ pub fn launch_multi_compiled(
                         registered_at: std::time::Instant::now(),
                         attempts: 0,
                         spec: d.spec,
+                    });
+                }
+                if let (Some(a), Some(r)) = (active, resolver.as_ref()) {
+                    r.track_subscriber(PendingResolution {
+                        handle_id: handle.id.clone(),
+                        stats: Arc::downgrade(&handle.stats),
+                        edge_sender: a.sender,
+                        scenario_name: a.scenario_name,
+                        entry_id: a.entry_id,
+                        if_unresolved: a.if_unresolved,
+                        registered_at: std::time::Instant::now(),
+                        attempts: 0,
+                        spec: a.spec,
                     });
                 }
                 handles.push(handle);
@@ -344,6 +363,15 @@ fn cross_scenario_target<'a>(
 
 #[cfg(feature = "config")]
 struct DeferredSubscription {
+    sender: crate::schedule::gate_bus::GateEdgeSender,
+    scenario_name: String,
+    entry_id: String,
+    if_unresolved: crate::compiler::UnresolvedBehavior,
+    spec: WhileSpec,
+}
+
+#[cfg(feature = "config")]
+struct ActiveSubscription {
     sender: crate::schedule::gate_bus::GateEdgeSender,
     scenario_name: String,
     entry_id: String,
@@ -407,6 +435,7 @@ struct LaunchPlan {
     upstream_bus: Option<Arc<GateBus>>,
     start_delay: Option<std::time::Duration>,
     deferred: Option<DeferredSubscription>,
+    active: Option<ActiveSubscription>,
 }
 
 #[cfg(test)]

--- a/sonda-core/src/schedule/stats.rs
+++ b/sonda-core/src/schedule/stats.rs
@@ -21,8 +21,10 @@ pub const DEGRADED_STALENESS_NANOS: u64 = 30 * 1_000_000_000;
 /// Lifecycle position of a scenario, surfaced for `while:`-gated runs.
 ///
 /// `Pending` covers the pre-`after:` window for chained scenarios; `Running`
-/// and `Paused` reflect the live `while:` gate state; `Finished` marks the
-/// scenario as having exited (duration expired or shutdown received).
+/// and `Paused` reflect the live `while:` gate state; `Unresolved` marks a
+/// cross-POST `while:` reference whose upstream has not yet registered;
+/// `Finished` marks the scenario as having exited (duration expired or
+/// shutdown received).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
@@ -31,6 +33,7 @@ pub enum ScenarioState {
     Pending,
     Running,
     Paused,
+    Unresolved,
     Finished,
 }
 

--- a/sonda-core/src/schedule/stats.rs
+++ b/sonda-core/src/schedule/stats.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{Instant, SystemTime};
 
 use serde::Serialize;
 
@@ -96,6 +96,11 @@ pub struct ScenarioStats {
     /// Whether the push path should track distinct series for close-emit.
     #[serde(skip)]
     pub track_close_series: bool,
+    /// Instant of the most recent [`ScenarioState`] change; resets on every transition.
+    #[serde(skip)]
+    pub last_state_transition_at: Option<Instant>,
+    /// Lifetime count of resolver subscription attempts; persists across state transitions.
+    pub cumulative_resolution_attempts: u64,
 }
 
 impl ScenarioStats {
@@ -119,6 +124,19 @@ impl ScenarioStats {
     /// built for the scenario.
     pub fn enable_close_series_tracking(&mut self) {
         self.track_close_series = true;
+    }
+
+    /// Move into `new_state` and reset the current-state watermark.
+    pub fn transition_state(&mut self, new_state: ScenarioState) {
+        self.state = new_state;
+        self.last_state_transition_at = Some(Instant::now());
+    }
+
+    /// Seconds spent in the current state. Zero if no transition has been recorded.
+    pub fn current_state_secs(&self) -> f64 {
+        self.last_state_transition_at
+            .map(|t| t.elapsed().as_secs_f64())
+            .unwrap_or(0.0)
     }
 
     /// Drain the close-emit series set and reset the emit-timestamp watermark.

--- a/sonda-core/tests/start_time_shift.rs
+++ b/sonda-core/tests/start_time_shift.rs
@@ -351,6 +351,8 @@ fn gated_close_emit_marker_lands_in_shifted_window() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("gated runner must succeed");

--- a/sonda-core/tests/start_time_shift.rs
+++ b/sonda-core/tests/start_time_shift.rs
@@ -344,16 +344,11 @@ fn gated_close_emit_marker_lands_in_shifted_window() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: Some(delay),
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(
+                GateContext::new(rx, init)
+                    .with_delay(Some(delay))
+                    .with_has_while(true),
+            ),
         )
         .expect("gated runner must succeed");
         sink

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -127,6 +127,8 @@ fn run_with_capture(
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         };
         sonda_core::schedule::runner::run_with_sink_gated(
             &config,
@@ -351,6 +353,8 @@ fn non_remote_write_sink_no_close_marker_by_default() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -448,6 +452,8 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -548,6 +554,8 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -650,6 +658,8 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -739,6 +749,8 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -840,6 +852,8 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -930,6 +944,8 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -1024,6 +1040,8 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");
@@ -1119,6 +1137,8 @@ fn shutdown_while_gate_open_emits_stale_marker() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("runner must succeed");

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -120,16 +120,9 @@ fn run_with_capture(
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let shutdown = Arc::new(AtomicBool::new(true));
-        let gate_ctx = GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        };
+        let gate_ctx = GateContext::new(rx, init)
+            .with_delay(delay)
+            .with_has_while(true);
         sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
@@ -346,16 +339,7 @@ fn non_remote_write_sink_no_close_marker_by_default() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: None,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(GateContext::new(rx, init).with_has_while(true)),
         )
         .expect("runner must succeed");
         sink
@@ -445,16 +429,11 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: Some(delay),
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(
+                GateContext::new(rx, init)
+                    .with_delay(Some(delay))
+                    .with_has_while(true),
+            ),
         )
         .expect("runner must succeed");
         sink
@@ -547,16 +526,11 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: Some(delay),
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(
+                GateContext::new(rx, init)
+                    .with_delay(Some(delay))
+                    .with_has_while(true),
+            ),
         )
         .expect("runner must succeed");
     });
@@ -651,16 +625,7 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: None,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(GateContext::new(rx, init).with_has_while(true)),
         )
         .expect("runner must succeed");
     });
@@ -742,16 +707,11 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: Some(delay),
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(
+                GateContext::new(rx, init)
+                    .with_delay(Some(delay))
+                    .with_has_while(true),
+            ),
         )
         .expect("runner must succeed");
         sink
@@ -840,21 +800,16 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: Some(DelayClause {
-                    open: Some(Duration::from_millis(0)),
-                    close: Some(Duration::from_millis(0)),
-                    close_stale_marker: None,
-                    close_snap_to: None,
-                }),
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(
+                GateContext::new(rx, init)
+                    .with_delay(Some(DelayClause {
+                        open: Some(Duration::from_millis(0)),
+                        close: Some(Duration::from_millis(0)),
+                        close_stale_marker: None,
+                        close_snap_to: None,
+                    }))
+                    .with_has_while(true),
+            ),
         )
         .expect("runner must succeed");
     });
@@ -937,16 +892,7 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: None,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(GateContext::new(rx, init).with_has_while(true)),
         )
         .expect("runner must succeed");
     });
@@ -1028,21 +974,16 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: Some(DelayClause {
-                    open: Some(Duration::from_millis(0)),
-                    close: Some(Duration::from_millis(0)),
-                    close_stale_marker: None,
-                    close_snap_to: None,
-                }),
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(
+                GateContext::new(rx, init)
+                    .with_delay(Some(DelayClause {
+                        open: Some(Duration::from_millis(0)),
+                        close: Some(Duration::from_millis(0)),
+                        close_stale_marker: None,
+                        close_snap_to: None,
+                    }))
+                    .with_has_while(true),
+            ),
         )
         .expect("runner must succeed");
     });
@@ -1130,16 +1071,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
             Some(shutdown_for_thread.as_ref()),
             Some(stats_for_thread),
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: None,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(GateContext::new(rx, init).with_has_while(true)),
         )
         .expect("runner must succeed");
     });

--- a/sonda-core/tests/while_close_workshop_repro.rs
+++ b/sonda-core/tests/while_close_workshop_repro.rs
@@ -193,7 +193,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     // Wait for both threads to finish (they exit when duration expires).
@@ -313,7 +313,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
 
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut handles = handles;
@@ -510,7 +510,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
     assert_eq!(handles.len(), 8, "must launch primary + 7 downstream");
 
     let deadline = Instant::now() + Duration::from_secs(6);
@@ -643,7 +643,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(10);
@@ -1447,7 +1447,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1544,7 +1544,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1748,7 +1748,7 @@ scenarios:
 
     let shutdown = Arc::new(AtomicBool::new(true));
     let handles =
-        launch_multi_compiled(compiled, Arc::clone(&shutdown)).expect("launch must succeed");
+        launch_multi_compiled(compiled, Arc::clone(&shutdown), None).expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + gated_metric");
 
     let deadline = Instant::now() + Duration::from_secs(5);

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -102,16 +102,7 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let shutdown = Arc::new(AtomicBool::new(true));
-    let gate_ctx = GateContext {
-        gate_rx: rx,
-        initial: init,
-        delay: None,
-        has_after: false,
-        has_while: true,
-        close_emit: None,
-        if_unresolved: None,
-        start_unresolved: false,
-    };
+    let gate_ctx = GateContext::new(rx, init).with_has_while(true);
 
     let entry = metrics_entry("downstream", 200.0, 600);
     let mut handle = launch_scenario_with_gates(
@@ -170,16 +161,7 @@ fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscriptio
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -215,16 +197,7 @@ fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -255,16 +228,7 @@ fn while_runtime_no_catch_up_burst_on_resume() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -359,16 +323,7 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -438,16 +393,7 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -505,16 +451,7 @@ fn while_runtime_finished_state_after_duration_expires() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -545,16 +482,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx_a,
-            initial: init_a,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx_a, init_a).with_has_while(true)),
         None,
     )
     .expect("launch a must succeed");
@@ -566,16 +494,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx_b,
-            initial: init_b,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx_b, init_b).with_has_while(true)),
         None,
     )
     .expect("launch b must succeed");
@@ -614,16 +533,7 @@ fn while_runtime_logs_signal_can_be_gated_downstream() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -679,16 +589,11 @@ fn while_runtime_delay_open_debounces_pause_to_running_transition() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: Some(delay),
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(
+            GateContext::new(rx, init)
+                .with_delay(Some(delay))
+                .with_has_while(true),
+        ),
         None,
     )
     .expect("launch must succeed");
@@ -742,16 +647,7 @@ fn while_runtime_strict_lt_threshold_gating() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");
@@ -786,16 +682,7 @@ fn scenario_restart_does_not_leak_gate_bus() {
             shutdown,
             None,
             None,
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: None,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(GateContext::new(rx, init).with_has_while(true)),
             None,
         )
         .expect("launch must succeed");
@@ -839,16 +726,11 @@ fn while_runtime_delay_close_debounces_running_to_paused_transition() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: Some(delay),
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(
+            GateContext::new(rx, init)
+                .with_delay(Some(delay))
+                .with_has_while(true),
+        ),
         None,
     )
     .expect("launch must succeed");
@@ -920,16 +802,11 @@ fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: true,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(
+            GateContext::new(rx, init)
+                .with_has_after(true)
+                .with_has_while(true),
+        ),
         None,
     )
     .expect("launch must succeed");
@@ -995,16 +872,11 @@ fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: true,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(
+            GateContext::new(rx, init)
+                .with_has_after(true)
+                .with_has_while(true),
+        ),
         None,
     )
     .expect("launch must succeed");
@@ -1081,16 +953,11 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: true,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(
+            GateContext::new(rx, init)
+                .with_has_after(true)
+                .with_has_while(true),
+        ),
         None,
     )
     .expect("launch must succeed");
@@ -1167,16 +1034,7 @@ fn while_runtime_steady_within_5pct_of_baseline() {
             shutdown,
             None,
             Some(Arc::clone(&bus)),
-            Some(GateContext {
-                gate_rx: rx,
-                initial: init,
-                delay: None,
-                has_after: false,
-                has_while: true,
-                close_emit: None,
-                if_unresolved: None,
-                start_unresolved: false,
-            }),
+            Some(GateContext::new(rx, init).with_has_while(true)),
             None,
         )
         .unwrap();
@@ -1318,16 +1176,7 @@ fn nan_upstream_value_keeps_downstream_paused() {
         Arc::clone(&shutdown),
         None,
         None,
-        Some(GateContext {
-            gate_rx: rx,
-            initial: init,
-            delay: None,
-            has_after: false,
-            has_while: true,
-            close_emit: None,
-            if_unresolved: None,
-            start_unresolved: false,
-        }),
+        Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
     .expect("launch must succeed");

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -109,6 +109,8 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
         has_after: false,
         has_while: true,
         close_emit: None,
+        if_unresolved: None,
+        start_unresolved: false,
     };
 
     let entry = metrics_entry("downstream", 200.0, 600);
@@ -174,6 +176,8 @@ fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscriptio
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -216,6 +220,8 @@ fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -253,6 +259,8 @@ fn while_runtime_no_catch_up_burst_on_resume() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -354,6 +362,8 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -430,6 +440,8 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -494,6 +506,8 @@ fn while_runtime_finished_state_after_duration_expires() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -531,6 +545,8 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch a must succeed");
@@ -549,6 +565,8 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch b must succeed");
@@ -594,6 +612,8 @@ fn while_runtime_logs_signal_can_be_gated_downstream() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -656,6 +676,8 @@ fn while_runtime_delay_open_debounces_pause_to_running_transition() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -716,6 +738,8 @@ fn while_runtime_strict_lt_threshold_gating() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -757,6 +781,8 @@ fn scenario_restart_does_not_leak_gate_bus() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .expect("launch must succeed");
@@ -807,6 +833,8 @@ fn while_runtime_delay_close_debounces_running_to_paused_transition() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -885,6 +913,8 @@ fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
             has_after: true,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -957,6 +987,8 @@ fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
             has_after: true,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -1040,6 +1072,8 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
             has_after: true,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");
@@ -1122,6 +1156,8 @@ fn while_runtime_steady_within_5pct_of_baseline() {
                 has_after: false,
                 has_while: true,
                 close_emit: None,
+                if_unresolved: None,
+                start_unresolved: false,
             }),
         )
         .unwrap();
@@ -1270,6 +1306,8 @@ fn nan_upstream_value_keeps_downstream_paused() {
             has_after: false,
             has_while: true,
             close_emit: None,
+            if_unresolved: None,
+            start_unresolved: false,
         }),
     )
     .expect("launch must succeed");

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -122,6 +122,7 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
         None,
         None,
         Some(gate_ctx),
+        None,
     )
     .expect("launch must succeed");
 
@@ -179,6 +180,7 @@ fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscriptio
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -223,6 +225,7 @@ fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -262,6 +265,7 @@ fn while_runtime_no_catch_up_burst_on_resume() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -365,6 +369,7 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -443,6 +448,7 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -509,6 +515,7 @@ fn while_runtime_finished_state_after_duration_expires() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -548,6 +555,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch a must succeed");
 
@@ -568,6 +576,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch b must succeed");
 
@@ -615,6 +624,7 @@ fn while_runtime_logs_signal_can_be_gated_downstream() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -679,6 +689,7 @@ fn while_runtime_delay_open_debounces_pause_to_running_transition() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -741,6 +752,7 @@ fn while_runtime_strict_lt_threshold_gating() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -784,6 +796,7 @@ fn scenario_restart_does_not_leak_gate_bus() {
                 if_unresolved: None,
                 start_unresolved: false,
             }),
+            None,
         )
         .expect("launch must succeed");
         handle
@@ -836,6 +849,7 @@ fn while_runtime_delay_close_debounces_running_to_paused_transition() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -916,6 +930,7 @@ fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -990,6 +1005,7 @@ fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -1075,6 +1091,7 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 
@@ -1130,6 +1147,7 @@ fn while_runtime_steady_within_5pct_of_baseline() {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
         handle.join(Some(Duration::from_secs(2))).unwrap();
@@ -1159,6 +1177,7 @@ fn while_runtime_steady_within_5pct_of_baseline() {
                 if_unresolved: None,
                 start_unresolved: false,
             }),
+            None,
         )
         .unwrap();
         handle.join(Some(Duration::from_secs(2))).unwrap();
@@ -1309,6 +1328,7 @@ fn nan_upstream_value_keeps_downstream_paused() {
             if_unresolved: None,
             start_unresolved: false,
         }),
+        None,
     )
     .expect("launch must succeed");
 

--- a/sonda-server/src/gate_registry.rs
+++ b/sonda-server/src/gate_registry.rs
@@ -1,0 +1,463 @@
+//! Production [`GateBusResolver`] backing the HTTP server's cross-POST `while:` refs.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock, Weak};
+use std::time::Instant;
+
+use sonda_core::schedule::gate_bus::{
+    GateBus, GateBusResolver, GateEdge, GateEdgeSender, PendingRef, PendingResolution,
+    RegistryError, WhileSpec,
+};
+use sonda_core::schedule::stats::ScenarioStats;
+use sonda_core::UnresolvedBehavior;
+
+type BusKey = (String, String);
+
+struct SubscriberRef {
+    handle_id: String,
+    stats: Weak<RwLock<ScenarioStats>>,
+    sender: GateEdgeSender,
+    spec: WhileSpec,
+    if_unresolved: UnresolvedBehavior,
+    registered_at: Instant,
+    attempts: u64,
+}
+
+impl SubscriberRef {
+    fn from_pending(p: PendingResolution) -> (BusKey, Self) {
+        let key = (p.scenario_name, p.entry_id);
+        let sub = SubscriberRef {
+            handle_id: p.handle_id,
+            stats: p.stats,
+            sender: p.edge_sender,
+            spec: p.spec,
+            if_unresolved: p.if_unresolved,
+            registered_at: p.registered_at,
+            attempts: p.attempts,
+        };
+        (key, sub)
+    }
+
+    fn into_pending(self, scenario_name: String, entry_id: String) -> PendingResolution {
+        PendingResolution::new(
+            self.handle_id,
+            self.stats,
+            self.sender,
+            scenario_name,
+            entry_id,
+            self.if_unresolved,
+            self.registered_at,
+            self.attempts,
+            self.spec,
+        )
+    }
+}
+
+#[derive(Default)]
+pub struct GateBusRegistry {
+    buses: RwLock<HashMap<BusKey, Arc<GateBus>>>,
+    subscribers: RwLock<HashMap<BusKey, Vec<SubscriberRef>>>,
+    pending: RwLock<HashMap<String, PendingResolution>>,
+}
+
+impl GateBusRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Rewrite tracking keys when the caller assigns a new external handle id
+    /// after a scenario has already been launched and recorded.
+    pub fn rename_handle(&self, old_id: &str, new_id: &str) {
+        if old_id == new_id {
+            return;
+        }
+        let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
+        if let Some(mut entry) = pending.remove(old_id) {
+            entry.handle_id = new_id.to_string();
+            pending.insert(new_id.to_string(), entry);
+        }
+        drop(pending);
+        let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
+        for refs in subs.values_mut() {
+            for sub in refs.iter_mut() {
+                if sub.handle_id == old_id {
+                    sub.handle_id = new_id.to_string();
+                }
+            }
+        }
+    }
+}
+
+impl GateBusResolver for GateBusRegistry {
+    fn register(
+        &self,
+        scenario_name: &str,
+        entry_id: &str,
+        bus: Arc<GateBus>,
+    ) -> Result<(), RegistryError> {
+        let mut buses = self.buses.write().unwrap_or_else(|p| p.into_inner());
+        let key = (scenario_name.to_string(), entry_id.to_string());
+        if buses.contains_key(&key) {
+            return Err(RegistryError::DuplicateScenarioName {
+                name: scenario_name.to_string(),
+            });
+        }
+        buses.insert(key, bus);
+        Ok(())
+    }
+
+    fn lookup(&self, scenario_name: &str, entry_id: &str) -> Option<Arc<GateBus>> {
+        self.buses
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .get(&(scenario_name.to_string(), entry_id.to_string()))
+            .cloned()
+    }
+
+    fn subscribe(
+        &self,
+        upstream: (&str, &str),
+        _downstream_handle_id: &str,
+        _downstream_stats: Weak<RwLock<ScenarioStats>>,
+        _edge_sender: GateEdgeSender,
+    ) -> Option<Arc<GateBus>> {
+        // Tracking happens via `track_subscriber`, which carries the spec.
+        self.lookup(upstream.0, upstream.1)
+    }
+
+    fn unregister(&self, scenario_name: &str) {
+        let mut buses = self.buses.write().unwrap_or_else(|p| p.into_inner());
+        let removed_keys: Vec<BusKey> = buses
+            .keys()
+            .filter(|(name, _)| name == scenario_name)
+            .cloned()
+            .collect();
+        let mut removed_buses: Vec<(BusKey, Arc<GateBus>)> = Vec::with_capacity(removed_keys.len());
+        for key in &removed_keys {
+            if let Some(bus) = buses.remove(key) {
+                removed_buses.push((key.clone(), bus));
+            }
+        }
+        drop(buses);
+
+        // Broadcast on the bus first so in-flight subscribers (those that called
+        // subscribe_with_while_sender but whose track_subscriber has not yet landed
+        // in the registry) still receive UpstreamGone.
+        for (_, bus) in &removed_buses {
+            bus.broadcast_upstream_gone();
+        }
+
+        let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
+        let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
+
+        for key in removed_keys {
+            let Some(refs) = subs.remove(&key) else {
+                continue;
+            };
+            for sub in refs {
+                if sub.stats.strong_count() == 0 {
+                    continue;
+                }
+                let _ = sub.sender.try_send(GateEdge::UpstreamGone);
+                let handle_id = sub.handle_id.clone();
+                let pending_entry = sub.into_pending(key.0.clone(), key.1.clone());
+                pending.insert(handle_id, pending_entry);
+            }
+        }
+    }
+
+    fn sweep_pending(&self) -> usize {
+        let buses = self.buses.read().unwrap_or_else(|p| p.into_inner());
+        let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
+        let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
+
+        let mut promoted = 0usize;
+        let keys: Vec<String> = pending.keys().cloned().collect();
+        for handle_id in keys {
+            let entry = pending
+                .get(&handle_id)
+                .expect("key from snapshot must exist");
+            if entry.stats.strong_count() == 0 {
+                pending.remove(&handle_id);
+                continue;
+            }
+            let bus_key = (entry.scenario_name.clone(), entry.entry_id.clone());
+            let Some(bus) = buses.get(&bus_key) else {
+                continue;
+            };
+            let mut entry = pending.remove(&handle_id).expect("just looked up");
+            entry.attempts = entry.attempts.saturating_add(1);
+            if let Some(stats_arc) = entry.stats.upgrade() {
+                if let Ok(mut s) = stats_arc.write() {
+                    s.cumulative_resolution_attempts =
+                        s.cumulative_resolution_attempts.saturating_add(1);
+                }
+            }
+            bus.subscribe_with_while_sender(entry.spec, entry.edge_sender.clone());
+            let (key, sub) = SubscriberRef::from_pending(entry);
+            subs.entry(key).or_default().push(sub);
+            promoted += 1;
+        }
+        promoted
+    }
+
+    fn insert_pending(&self, pending: PendingResolution) {
+        let mut map = self.pending.write().unwrap_or_else(|p| p.into_inner());
+        map.insert(pending.handle_id.clone(), pending);
+    }
+
+    fn pending_for_handle(&self, handle_id: &str) -> Option<PendingRef> {
+        let map = self.pending.read().unwrap_or_else(|p| p.into_inner());
+        let entry = map.get(handle_id)?;
+        Some(PendingRef::from_pending(
+            entry,
+            std::time::SystemTime::now(),
+        ))
+    }
+
+    fn scenario_name_in_use(&self, scenario_name: &str) -> bool {
+        let buses = self.buses.read().unwrap_or_else(|p| p.into_inner());
+        buses.keys().any(|(name, _)| name == scenario_name)
+    }
+
+    fn track_subscriber(&self, pending: PendingResolution) {
+        let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
+        let (key, sub) = SubscriberRef::from_pending(pending);
+        subs.entry(key).or_default().push(sub);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sonda_core::compiler::WhileOp;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    fn while_spec() -> WhileSpec {
+        WhileSpec {
+            op: WhileOp::GreaterThan,
+            threshold: 0.0,
+        }
+    }
+
+    fn live_stats() -> (Arc<RwLock<ScenarioStats>>, Weak<RwLock<ScenarioStats>>) {
+        let arc = Arc::new(RwLock::new(ScenarioStats::default()));
+        let weak = Arc::downgrade(&arc);
+        (arc, weak)
+    }
+
+    fn make_pending(
+        handle_id: &str,
+        scenario_name: &str,
+        entry_id: &str,
+        stats: Weak<RwLock<ScenarioStats>>,
+        sender: GateEdgeSender,
+    ) -> PendingResolution {
+        PendingResolution::new(
+            handle_id.to_string(),
+            stats,
+            sender,
+            scenario_name.to_string(),
+            entry_id.to_string(),
+            UnresolvedBehavior::default(),
+            Instant::now(),
+            0,
+            while_spec(),
+        )
+    }
+
+    #[test]
+    fn t_reg_1_register_then_lookup_roundtrip() {
+        let reg = GateBusRegistry::new();
+        let bus = Arc::new(GateBus::new());
+        reg.register("post-a", "metric1", Arc::clone(&bus))
+            .expect("register");
+        let looked = reg.lookup("post-a", "metric1").expect("lookup hit");
+        assert!(Arc::ptr_eq(&bus, &looked));
+        assert!(reg.lookup("post-a", "other").is_none());
+        assert!(reg.lookup("post-b", "metric1").is_none());
+    }
+
+    #[test]
+    fn t_reg_2_subscribe_with_live_upstream_returns_bus_and_track_records_subscriber() {
+        let reg = GateBusRegistry::new();
+        let bus = Arc::new(GateBus::new());
+        reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
+        let (tx, _rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (_alive, weak) = live_stats();
+        let got = reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone());
+        assert!(got.is_some());
+        reg.track_subscriber(make_pending("h1", "post-a", "m", weak, tx));
+        let subs = reg.subscribers.read().unwrap();
+        let row = subs
+            .get(&("post-a".to_string(), "m".to_string()))
+            .expect("subscribers row exists");
+        assert_eq!(row.len(), 1);
+        assert_eq!(row[0].handle_id, "h1");
+    }
+
+    #[test]
+    fn t_reg_3_subscribe_with_no_upstream_returns_none_then_insert_pending() {
+        let reg = GateBusRegistry::new();
+        let (tx, _rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (_alive, weak) = live_stats();
+        let got = reg.subscribe(("missing", "m"), "h2", weak.clone(), tx.clone());
+        assert!(got.is_none());
+        reg.insert_pending(make_pending("h2", "missing", "m", weak, tx));
+        let pending_ref = reg.pending_for_handle("h2").expect("pending present");
+        assert_eq!(pending_ref.scenario_name, "missing");
+        assert_eq!(pending_ref.entry_id, "m");
+    }
+
+    #[test]
+    fn t_reg_4_sweep_pending_resolves_after_register() {
+        let reg = GateBusRegistry::new();
+        let (alive, weak) = live_stats();
+        let (tx, _rx) = mpsc::sync_channel::<GateEdge>(1);
+        reg.insert_pending(make_pending("h1", "upstream", "m", weak, tx));
+
+        let bus = Arc::new(GateBus::new());
+        bus.tick(1.0);
+        reg.register("upstream", "m", bus).expect("register");
+        let promoted = reg.sweep_pending();
+        assert_eq!(promoted, 1);
+        assert!(reg.pending_for_handle("h1").is_none());
+        let subs = reg.subscribers.read().unwrap();
+        assert!(subs
+            .get(&("upstream".to_string(), "m".to_string()))
+            .is_some());
+        drop(alive);
+    }
+
+    #[test]
+    fn t_reg_5_unregister_moves_subscribers_to_pending_and_signals_gone() {
+        let reg = GateBusRegistry::new();
+        let bus = Arc::new(GateBus::new());
+        reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
+        let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (alive, weak) = live_stats();
+        reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone())
+            .expect("sub");
+        reg.track_subscriber(make_pending("h1", "post-a", "m", weak, tx));
+
+        reg.unregister("post-a");
+        let edge = rx
+            .recv_timeout(Duration::from_millis(200))
+            .expect("UpstreamGone within 200ms");
+        assert_eq!(edge, GateEdge::UpstreamGone);
+        assert!(reg.lookup("post-a", "m").is_none());
+        assert!(
+            reg.pending_for_handle("h1").is_some(),
+            "subscriber must move to pending for re-resolution",
+        );
+        drop(alive);
+    }
+
+    #[test]
+    fn t_reg_6_re_register_after_unregister_re_wires_existing_sender() {
+        let reg = GateBusRegistry::new();
+        let bus_a = Arc::new(GateBus::new());
+        bus_a.tick(1.0);
+        reg.register("post-a", "m", Arc::clone(&bus_a))
+            .expect("reg-a");
+        let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (alive, weak) = live_stats();
+        reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone())
+            .expect("sub");
+        reg.track_subscriber(make_pending("h1", "post-a", "m", weak, tx));
+
+        reg.unregister("post-a");
+        let _ = rx.recv_timeout(Duration::from_millis(200));
+
+        let bus_b = Arc::new(GateBus::new());
+        bus_b.tick(1.0);
+        reg.register("post-a", "m", Arc::clone(&bus_b))
+            .expect("re-reg");
+        let promoted = reg.sweep_pending();
+        assert_eq!(promoted, 1, "sweep must re-resolve the pending subscriber");
+
+        let edge = rx
+            .recv_timeout(Duration::from_millis(200))
+            .expect("WhileOpen within 200ms");
+        assert_eq!(edge, GateEdge::WhileOpen);
+        drop(alive);
+    }
+
+    #[test]
+    fn t_reg_7_scenario_name_in_use_reports_correctly() {
+        let reg = GateBusRegistry::new();
+        let bus = Arc::new(GateBus::new());
+        assert!(!reg.scenario_name_in_use("post-a"));
+        reg.register("post-a", "m", bus).expect("reg");
+        assert!(reg.scenario_name_in_use("post-a"));
+        assert!(!reg.scenario_name_in_use("post-b"));
+    }
+
+    #[test]
+    fn t_reg_8_dead_weak_is_silently_skipped_on_unregister_and_sweep() {
+        let reg = GateBusRegistry::new();
+        let bus = Arc::new(GateBus::new());
+        reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
+        let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
+        {
+            let (alive_local, weak) = live_stats();
+            reg.subscribe(("post-a", "m"), "h-dead", weak.clone(), tx.clone())
+                .expect("sub");
+            reg.track_subscriber(make_pending("h-dead", "post-a", "m", weak, tx));
+            drop(alive_local);
+        }
+        reg.unregister("post-a");
+        let edge = rx.recv_timeout(Duration::from_millis(100));
+        assert!(
+            edge.is_err(),
+            "no edge should be delivered for a dead-weak subscriber"
+        );
+        assert!(reg.pending_for_handle("h-dead").is_none());
+    }
+
+    #[test]
+    fn t_reg_duplicate_register_returns_err() {
+        // Same (scenario_name, entry_id) pair → reject.
+        // Same scenario_name with different entry_id → allowed (multi-entry POST).
+        let reg = GateBusRegistry::new();
+        let bus = Arc::new(GateBus::new());
+        reg.register("post-a", "m1", Arc::clone(&bus)).expect("reg");
+        reg.register("post-a", "m2", Arc::clone(&bus))
+            .expect("multi-entry under same scenario_name must succeed");
+        let err = reg
+            .register("post-a", "m1", bus)
+            .expect_err("duplicate (scenario_name, entry_id) pair must reject");
+        assert!(matches!(err, RegistryError::DuplicateScenarioName { .. }));
+    }
+
+    #[test]
+    fn t22_concurrent_subscribe_does_not_deadlock() {
+        let reg = Arc::new(GateBusRegistry::new());
+        let bus = Arc::new(GateBus::new());
+        reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
+
+        let mut threads = Vec::new();
+        let mut kept: Vec<Arc<RwLock<ScenarioStats>>> = Vec::new();
+        for i in 0..8 {
+            let r = Arc::clone(&reg);
+            let stats = Arc::new(RwLock::new(ScenarioStats::default()));
+            let weak = Arc::downgrade(&stats);
+            kept.push(stats);
+            let handle_id = format!("h{i}");
+            let h = thread::spawn(move || {
+                let (tx, _rx) = mpsc::sync_channel::<GateEdge>(1);
+                let _ = r.subscribe(("post-a", "m"), &handle_id, weak.clone(), tx.clone());
+                r.track_subscriber(make_pending(&handle_id, "post-a", "m", weak, tx));
+            });
+            threads.push(h);
+        }
+        for t in threads {
+            t.join().expect("join");
+        }
+        let subs = reg.subscribers.read().unwrap();
+        assert_eq!(subs.values().map(|v| v.len()).sum::<usize>(), 8);
+        drop(kept);
+    }
+}

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -4,6 +4,7 @@
 //! stopped over HTTP. All scenario lifecycle logic is delegated to sonda-core.
 
 mod auth;
+mod gate_registry;
 mod routes;
 mod state;
 

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -250,6 +250,7 @@ fn state_string(stats: &ScenarioStats) -> &'static str {
         ScenarioState::Pending => "pending",
         ScenarioState::Running => "running",
         ScenarioState::Paused => "paused",
+        ScenarioState::Unresolved => "unresolved",
         ScenarioState::Finished => "finished",
         _ => "unknown",
     }
@@ -270,7 +271,10 @@ fn collect_active_conflicts(state: &AppState, name: &str) -> Result<Vec<Conflict
         }
         let snap = handle.stats_snapshot();
         let blocks = match snap.state {
-            ScenarioState::Pending | ScenarioState::Running | ScenarioState::Paused => true,
+            ScenarioState::Pending
+            | ScenarioState::Running
+            | ScenarioState::Paused
+            | ScenarioState::Unresolved => true,
             ScenarioState::Finished => false,
             _ => false,
         };
@@ -1695,6 +1699,8 @@ scenarios:
         assert_eq!(state_string(&s), "running");
         s.state = ScenarioState::Paused;
         assert_eq!(state_string(&s), "paused");
+        s.state = ScenarioState::Unresolved;
+        assert_eq!(state_string(&s), "unresolved");
         s.state = ScenarioState::Finished;
         assert_eq!(state_string(&s), "finished");
     }

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -520,7 +520,7 @@ async fn launch_compiled(
     warnings: Vec<String>,
 ) -> Result<Response, Response> {
     let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handles = launch_multi_compiled(compiled, shutdown).map_err(|e| {
+    let mut handles = launch_multi_compiled(compiled, shutdown, None).map_err(|e| {
         warn!(error = %e, "POST /scenarios: failed to launch scenarios");
         match e {
             sonda_core::SondaError::Config(_) => unprocessable(e),
@@ -1039,6 +1039,7 @@ mod tests {
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -1075,6 +1076,7 @@ mod tests {
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -2908,6 +2910,7 @@ scenarios:
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -3364,6 +3367,7 @@ scenarios:
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -3643,6 +3647,7 @@ scenarios:
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -4076,6 +4081,7 @@ scenarios:
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -4109,6 +4115,7 @@ scenarios:
                 sonda_core::PromMetricType::Gauge,
                 None,
             ))),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -5021,6 +5028,7 @@ scenarios:
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
             std::sync::Arc::new(std::collections::HashMap::new()),
             meta.map(std::sync::Arc::new),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 
@@ -5147,6 +5155,7 @@ scenarios:
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
             std::sync::Arc::new(label_map),
             meta.map(std::sync::Arc::new),
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
 

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -30,7 +30,7 @@ use serde_json::json;
 use sonda_core::compiler::parse::detect_version;
 use sonda_core::encoder::prometheus::PrometheusText;
 use sonda_core::encoder::Encoder;
-use sonda_core::{ScenarioState, ScenarioStats};
+use sonda_core::{GateBusResolver, ScenarioState, ScenarioStats};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -100,6 +100,9 @@ pub struct ScenarioDetail {
     /// Whether the scenario has sink failures and no recent successful delivery.
     pub degraded: bool,
     pub stats: StatsResponse,
+    /// Cross-POST `while:` reference snapshot when state is `unresolved`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_ref: Option<sonda_core::PendingRef>,
 }
 
 /// Response body for a successfully deleted (stopped) scenario.
@@ -200,6 +203,10 @@ pub struct DetailedStatsResponse {
     pub last_successful_write_at: Option<u64>,
     /// Whether the scenario has sink failures and no recent successful delivery.
     pub degraded: bool,
+    /// Seconds elapsed since the most recent state transition.
+    pub current_state_secs: f64,
+    /// Lifetime count of resolver subscription attempts for this scenario.
+    pub cumulative_resolution_attempts: u64,
 }
 
 // ---- Error helpers ----------------------------------------------------------
@@ -436,6 +443,48 @@ fn yaml_body_text(body: &[u8], headers: &HeaderMap) -> Result<String, String> {
 
 // ---- Handlers ---------------------------------------------------------------
 
+fn parse_validate_strict(raw_query: Option<&str>) -> bool {
+    let Some(raw) = raw_query else {
+        return false;
+    };
+    raw.split('&').any(|pair| pair == "validate=strict")
+}
+
+#[derive(Debug, Serialize)]
+struct UnresolvedRefEntry {
+    scenario_name: String,
+    entry_id: String,
+    referenced_by: String,
+}
+
+fn collect_unresolved_refs(state: &AppState, compiled: &CompiledFile) -> Vec<UnresolvedRefEntry> {
+    let mut out = Vec::new();
+    let own_name = compiled.scenario_name.as_deref();
+    for entry in &compiled.entries {
+        let Some(clause) = entry.while_clause.as_ref() else {
+            continue;
+        };
+        let Some(scenario_name) = clause.scenario_name.as_deref() else {
+            continue;
+        };
+        if Some(scenario_name) == own_name {
+            continue;
+        }
+        if state
+            .gate_bus_registry
+            .lookup(scenario_name, &clause.ref_id)
+            .is_none()
+        {
+            out.push(UnresolvedRefEntry {
+                scenario_name: scenario_name.to_string(),
+                entry_id: clause.ref_id.clone(),
+                referenced_by: entry.id.clone().unwrap_or_default(),
+            });
+        }
+    }
+    out
+}
+
 /// `POST /scenarios` — start scenarios from a v2 YAML or JSON body.
 ///
 /// The body is compiled via [`compile_scenario_file_compiled`] and launched
@@ -458,8 +507,10 @@ fn yaml_body_text(body: &[u8], headers: &HeaderMap) -> Result<String, String> {
 pub async fn post_scenario(
     State(state): State<AppState>,
     headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
     body: axum::body::Bytes,
 ) -> Result<Response, Response> {
+    let strict = parse_validate_strict(raw_query.as_deref());
     let catalog_dir = state.catalog_dir.as_deref().map(|p| p.as_path());
     let parsed = parse_body(&body, &headers, catalog_dir).map_err(|fail| {
         warn!(error = %fail.message(), "POST /scenarios: invalid request body");
@@ -471,11 +522,36 @@ pub async fn post_scenario(
 
     let ParsedBody::Compiled(compiled) = parsed;
 
+    if strict {
+        let unresolved = collect_unresolved_refs(&state, &compiled);
+        if !unresolved.is_empty() {
+            warn!(
+                count = unresolved.len(),
+                "POST /scenarios?validate=strict: rejecting body with unresolved refs"
+            );
+            return Err((
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(json!({
+                    "error": "unresolved_refs",
+                    "unresolved_refs": unresolved,
+                })),
+            )
+                .into_response());
+        }
+    }
+
     if let Some(name) = compiled.scenario_name.as_deref() {
-        let conflicts = collect_active_conflicts(&state, name).map_err(|()| {
+        let mut conflicts = collect_active_conflicts(&state, name).map_err(|()| {
             warn!("POST /scenarios: scenarios lock is poisoned");
             internal_error("internal state lock is poisoned")
         })?;
+        if conflicts.is_empty() && state.gate_bus_registry.scenario_name_in_use(name) {
+            conflicts.push(ConflictingScenario {
+                id: String::new(),
+                name: name.to_string(),
+                state: "running".to_string(),
+            });
+        }
         if !conflicts.is_empty() {
             warn!(
                 scenario_name = %name,
@@ -520,7 +596,8 @@ async fn launch_compiled(
     warnings: Vec<String>,
 ) -> Result<Response, Response> {
     let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handles = launch_multi_compiled(compiled, shutdown, None).map_err(|e| {
+    let resolver: Arc<dyn sonda_core::GateBusResolver> = state.gate_bus_registry.clone();
+    let mut handles = launch_multi_compiled(compiled, shutdown, Some(resolver)).map_err(|e| {
         warn!(error = %e, "POST /scenarios: failed to launch scenarios");
         match e {
             sonda_core::SondaError::Config(_) => unprocessable(e),
@@ -538,7 +615,8 @@ async fn launch_compiled(
     let mut created: Vec<CreatedScenario> = Vec::with_capacity(handles.len());
     for handle in handles.iter_mut() {
         let new_id = Uuid::new_v4().to_string();
-        handle.id = new_id.clone();
+        let old_id = std::mem::replace(&mut handle.id, new_id.clone());
+        state.gate_bus_registry.rename_handle(&old_id, &new_id);
         let name = handle.name.clone();
         let state_str = state_string(&handle.stats_snapshot()).to_string();
         info!(id = %new_id, name = %name, state = %state_str, "scenario launched");
@@ -638,16 +716,22 @@ pub async fn get_scenario(
 
     let snap = handle.stats_snapshot();
     let degraded = snap.is_degraded(now_unix_nanos);
-    let state = state_string(&snap).to_string();
+    let state_str = state_string(&snap).to_string();
+    let pending_ref = if snap.state == ScenarioState::Unresolved {
+        state.gate_bus_registry.pending_for_handle(&handle.id)
+    } else {
+        None
+    };
     let mut stats: StatsResponse = snap.into();
     stats.degraded = degraded;
     let detail = ScenarioDetail {
         id: id.clone(),
         name: handle.name.clone(),
-        state,
+        state: state_str,
         elapsed_secs: handle.elapsed().as_secs_f64(),
         degraded,
         stats,
+        pending_ref,
     };
 
     Ok(Json(detail))
@@ -675,6 +759,12 @@ pub async fn delete_scenario(
         .get_mut(&id)
         .ok_or_else(|| not_found(format!("scenario not found: {id}")))?;
 
+    // Pre-mark so the StateGuard skips its own unregister; Phase 1 owns it.
+    handle
+        .cleaned_up
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let scenario_name_to_unregister = handle.scenario_name.clone();
+
     // Signal the scenario to stop (idempotent — safe to call on already-stopped).
     handle.stop();
 
@@ -700,8 +790,12 @@ pub async fn delete_scenario(
 
     // Remove the handle from the map to free resources (fixes memory leak).
     scenarios.remove(&id);
-    // Release the write lock before logging and building the response.
+    // Lock order: scenarios then registry.
     drop(scenarios);
+
+    if let Some(name) = scenario_name_to_unregister {
+        state.gate_bus_registry.unregister(&name);
+    }
 
     info!(id = %id, status = %status, total_events = final_stats.total_events, "scenario deleted");
 
@@ -742,8 +836,9 @@ pub async fn get_scenario_stats(
         .unwrap_or(0);
 
     let snap = handle.stats_snapshot();
-    let state = state_string(&snap).to_string();
+    let state_str = state_string(&snap).to_string();
     let degraded = snap.is_degraded(now_unix_nanos);
+    let current_state_secs = snap.current_state_secs();
     let response = DetailedStatsResponse {
         total_events: snap.total_events,
         current_rate: snap.current_rate,
@@ -751,7 +846,7 @@ pub async fn get_scenario_stats(
         bytes_emitted: snap.bytes_emitted,
         errors: snap.errors,
         uptime_secs: handle.elapsed().as_secs_f64(),
-        state,
+        state: state_str,
         in_gap: snap.in_gap,
         in_burst: snap.in_burst,
         consecutive_failures: snap.consecutive_failures,
@@ -759,6 +854,8 @@ pub async fn get_scenario_stats(
         last_sink_error: snap.last_sink_error,
         last_successful_write_at: snap.last_successful_write_at,
         degraded,
+        current_state_secs,
+        cumulative_resolution_attempts: snap.cumulative_resolution_attempts,
     };
 
     Ok(Json(response))
@@ -1736,6 +1833,7 @@ scenarios:
             state: "stopped".to_string(),
             elapsed_secs: 42.0,
             degraded: false,
+            pending_ref: None,
             stats: StatsResponse {
                 total_events: 100,
                 current_rate: 5.0,
@@ -3271,6 +3369,8 @@ scenarios:
             last_sink_error: None,
             last_successful_write_at: None,
             degraded: false,
+            current_state_secs: 0.0,
+            cumulative_resolution_attempts: 0,
         };
         let json = serde_json::to_value(&resp).expect("must serialize");
         assert_eq!(json["total_events"], 42);
@@ -4935,6 +5035,8 @@ scenarios:
             last_sink_error: Some("connection refused".to_string()),
             last_successful_write_at: Some(1_700_000_000_000_000_000),
             degraded: true,
+            current_state_secs: 5.25,
+            cumulative_resolution_attempts: 2,
         };
         snapshot_settings().bind(|| {
             insta::assert_json_snapshot!("detailed_stats_response", resp);
@@ -4974,6 +5076,8 @@ scenarios:
             last_sink_error: None,
             last_successful_write_at: None,
             degraded: false,
+            current_state_secs: 0.0,
+            cumulative_resolution_attempts: 0,
         };
         assert_eq!(resp.state, wire);
         snapshot_settings().bind(|| {
@@ -5399,5 +5503,305 @@ scenarios:
             body.contains("rpc_duration_count"),
             "expected _count series, got:\n{body}"
         );
+    }
+
+    // ========================================================================
+    // Brief 3 — cross-POST while: HTTP surface
+    // ========================================================================
+
+    const DOWNSTREAM_YAML: &str = "\
+version: 2
+kind: runnable
+scenario_name: downstream_post
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: dependent
+    signal_type: metrics
+    name: dependent
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream_metric
+      op: \">\"
+      value: 0
+      scenario_name: upstream_post
+      if_unresolved: pending
+";
+
+    const UPSTREAM_YAML: &str = "\
+version: 2
+kind: runnable
+scenario_name: upstream_post
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: upstream_metric
+    signal_type: metrics
+    name: upstream_metric
+    generator:
+      type: constant
+      value: 1.0
+";
+
+    async fn post_with_query(
+        app: axum::Router,
+        content_type: &str,
+        body: &str,
+        query: &str,
+    ) -> hyper::Response<axum::body::Body> {
+        let uri = if query.is_empty() {
+            "/scenarios".to_string()
+        } else {
+            format!("/scenarios?{query}")
+        };
+        let req = Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", content_type)
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        app.oneshot(req).await.unwrap()
+    }
+
+    async fn get_body(app: axum::Router, uri: &str) -> serde_json::Value {
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        body_json(resp).await
+    }
+
+    #[tokio::test]
+    async fn t14_validate_strict_with_typo_returns_422_and_unresolved_refs() {
+        let (_, state) = test_router();
+        let bad = DOWNSTREAM_YAML.replace("upstream_post", "totally_wrong");
+        let resp = post_with_query(
+            router(state.clone()),
+            "application/x-yaml",
+            &bad,
+            "validate=strict",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"], "unresolved_refs");
+        let unresolved = body["unresolved_refs"]
+            .as_array()
+            .expect("unresolved_refs must be array");
+        assert_eq!(unresolved.len(), 1);
+        assert_eq!(unresolved[0]["scenario_name"], "totally_wrong");
+        cleanup_scenarios(&state);
+    }
+
+    #[tokio::test]
+    async fn t15_validate_strict_with_mixed_refs_rejects_whole_body() {
+        let (_, state) = test_router();
+        let mixed = "\
+version: 2
+kind: runnable
+scenario_name: mixed_post
+defaults:
+  rate: 50
+  duration: 5s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: resolvable_dep
+    signal_type: metrics
+    name: resolvable_dep
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream_metric
+      op: \">\"
+      value: 0
+      scenario_name: upstream_post
+      if_unresolved: pending
+  - id: unresolvable_dep
+    signal_type: metrics
+    name: unresolvable_dep
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: missing_ref
+      op: \">\"
+      value: 0
+      scenario_name: missing_post
+      if_unresolved: pending
+";
+        // Post upstream so one ref resolves.
+        let upstream_resp = post_with_query(
+            router(state.clone()),
+            "application/x-yaml",
+            UPSTREAM_YAML,
+            "",
+        )
+        .await;
+        assert_eq!(upstream_resp.status(), StatusCode::CREATED);
+
+        let resp = post_with_query(
+            router(state.clone()),
+            "application/x-yaml",
+            mixed,
+            "validate=strict",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = body_json(resp).await;
+        let unresolved = body["unresolved_refs"].as_array().unwrap();
+        assert_eq!(unresolved.len(), 1, "only one entry must be flagged");
+        assert_eq!(unresolved[0]["scenario_name"], "missing_post");
+        cleanup_scenarios(&state);
+    }
+
+    #[tokio::test]
+    async fn t16_validate_strict_with_all_resolvable_returns_201() {
+        let (_, state) = test_router();
+        let up_resp = post_with_query(router(state.clone()), "text/yaml", UPSTREAM_YAML, "").await;
+        assert_eq!(up_resp.status(), StatusCode::CREATED);
+
+        let resp = post_with_query(
+            router(state.clone()),
+            "text/yaml",
+            DOWNSTREAM_YAML,
+            "validate=strict",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        cleanup_scenarios(&state);
+    }
+
+    #[tokio::test]
+    async fn t18_get_scenario_for_unresolved_returns_pending_ref() {
+        let (_, state) = test_router();
+        let resp = post_with_query(
+            router(state.clone()),
+            "application/x-yaml",
+            DOWNSTREAM_YAML,
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let created = body_json(resp).await;
+        let id = created["id"].as_str().unwrap().to_string();
+
+        // Give the scenario a moment to reach Unresolved.
+        std::thread::sleep(Duration::from_millis(200));
+
+        let detail = get_body(router(state.clone()), &format!("/scenarios/{id}")).await;
+        assert_eq!(detail["state"], "unresolved");
+        assert!(
+            detail["pending_ref"].is_object(),
+            "pending_ref must be populated for Unresolved, got: {detail}",
+        );
+        assert_eq!(detail["pending_ref"]["scenario_name"], "upstream_post");
+        assert_eq!(detail["pending_ref"]["entry_id"], "upstream_metric");
+
+        // Now post upstream and verify pending_ref clears once Running.
+        let up = post_with_query(router(state.clone()), "text/yaml", UPSTREAM_YAML, "").await;
+        assert_eq!(up.status(), StatusCode::CREATED);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut saw_running = false;
+        while Instant::now() < deadline {
+            let detail = get_body(router(state.clone()), &format!("/scenarios/{id}")).await;
+            if detail["state"] == "running" {
+                saw_running = true;
+                assert!(
+                    detail["pending_ref"].is_null() || detail.get("pending_ref").is_none(),
+                    "pending_ref must be null/absent for non-Unresolved",
+                );
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            saw_running,
+            "downstream must reach Running after upstream POST"
+        );
+        cleanup_scenarios(&state);
+    }
+
+    #[tokio::test]
+    async fn t19_stats_endpoint_has_current_state_secs_and_cumulative_attempts() {
+        let (_, state) = test_router();
+        let resp = post_with_query(
+            router(state.clone()),
+            "application/x-yaml",
+            DOWNSTREAM_YAML,
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let created = body_json(resp).await;
+        let id = created["id"].as_str().unwrap().to_string();
+
+        std::thread::sleep(Duration::from_millis(300));
+        let stats = get_body(router(state.clone()), &format!("/scenarios/{id}/stats")).await;
+        assert!(stats["current_state_secs"].is_f64());
+        let secs_unresolved = stats["current_state_secs"].as_f64().unwrap();
+        assert!(secs_unresolved > 0.0);
+        let attempts_before = stats["cumulative_resolution_attempts"].as_u64().unwrap();
+
+        // Trigger a state transition by resolving the upstream.
+        let up = post_with_query(router(state.clone()), "text/yaml", UPSTREAM_YAML, "").await;
+        assert_eq!(up.status(), StatusCode::CREATED);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut saw_running = false;
+        let mut attempts_after = 0u64;
+        while Instant::now() < deadline {
+            let s = get_body(router(state.clone()), &format!("/scenarios/{id}/stats")).await;
+            if s["state"] == "running" {
+                // current_state_secs reset on transition.
+                let s2 = s["current_state_secs"].as_f64().unwrap();
+                assert!(
+                    s2 < secs_unresolved,
+                    "current_state_secs must reset on transition; was {secs_unresolved}, now {s2}",
+                );
+                attempts_after = s["cumulative_resolution_attempts"].as_u64().unwrap();
+                saw_running = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            saw_running,
+            "downstream must reach Running after upstream POST"
+        );
+        assert!(
+            attempts_after > attempts_before,
+            "cumulative_resolution_attempts must strictly increase across unresolved→running; was {attempts_before}, now {attempts_after}",
+        );
+        assert!(
+            attempts_after >= 1,
+            "the resolving sweep counts as at least one attempt, got {attempts_after}",
+        );
+        cleanup_scenarios(&state);
+    }
+
+    #[tokio::test]
+    async fn t20_duplicate_scenario_name_returns_409_via_registry() {
+        let (_, state) = test_router();
+        let first = post_with_query(router(state.clone()), "text/yaml", UPSTREAM_YAML, "").await;
+        assert_eq!(first.status(), StatusCode::CREATED);
+
+        let second = post_with_query(router(state.clone()), "text/yaml", UPSTREAM_YAML, "").await;
+        assert_eq!(second.status(), StatusCode::CONFLICT);
+        let body = body_json(second).await;
+        assert!(body["conflicting_scenarios"].is_array());
+        cleanup_scenarios(&state);
     }
 }

--- a/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response.snap
+++ b/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response.snap
@@ -16,5 +16,7 @@ expression: resp
   "total_sink_failures": 7,
   "last_sink_error": "connection refused",
   "last_successful_write_at": 1700000000000000000,
-  "degraded": true
+  "degraded": true,
+  "current_state_secs": 5.25,
+  "cumulative_resolution_attempts": 2
 }

--- a/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_finished.snap
+++ b/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_finished.snap
@@ -1,6 +1,5 @@
 ---
 source: sonda-server/src/routes/scenarios.rs
-assertion_line: 4189
 expression: resp
 ---
 {
@@ -15,5 +14,7 @@ expression: resp
   "in_burst": false,
   "consecutive_failures": 0,
   "total_sink_failures": 0,
-  "degraded": false
+  "degraded": false,
+  "current_state_secs": 0.0,
+  "cumulative_resolution_attempts": 0
 }

--- a/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_paused.snap
+++ b/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_paused.snap
@@ -1,6 +1,5 @@
 ---
 source: sonda-server/src/routes/scenarios.rs
-assertion_line: 4189
 expression: resp
 ---
 {
@@ -15,5 +14,7 @@ expression: resp
   "in_burst": false,
   "consecutive_failures": 0,
   "total_sink_failures": 0,
-  "degraded": false
+  "degraded": false,
+  "current_state_secs": 0.0,
+  "cumulative_resolution_attempts": 0
 }

--- a/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_pending.snap
+++ b/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_pending.snap
@@ -1,6 +1,5 @@
 ---
 source: sonda-server/src/routes/scenarios.rs
-assertion_line: 4189
 expression: resp
 ---
 {
@@ -15,5 +14,7 @@ expression: resp
   "in_burst": false,
   "consecutive_failures": 0,
   "total_sink_failures": 0,
-  "degraded": false
+  "degraded": false,
+  "current_state_secs": 0.0,
+  "cumulative_resolution_attempts": 0
 }

--- a/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_running.snap
+++ b/sonda-server/src/routes/snapshots/sonda_server__routes__scenarios__tests__detailed_stats_response_state_running.snap
@@ -1,6 +1,5 @@
 ---
 source: sonda-server/src/routes/scenarios.rs
-assertion_line: 4189
 expression: resp
 ---
 {
@@ -15,5 +14,7 @@ expression: resp
   "in_burst": false,
   "consecutive_failures": 0,
   "total_sink_failures": 0,
-  "degraded": false
+  "degraded": false,
+  "current_state_secs": 0.0,
+  "cumulative_resolution_attempts": 0
 }

--- a/sonda-server/src/state.rs
+++ b/sonda-server/src/state.rs
@@ -6,12 +6,15 @@ use std::sync::{Arc, RwLock};
 
 use sonda_core::ScenarioHandle;
 
+use crate::gate_registry::GateBusRegistry;
+
 /// Shared application state for the HTTP server.
 ///
-/// Holds a map of running [`ScenarioHandle`]s keyed by scenario ID and an
-/// optional API key for bearer-token authentication. No scenario lifecycle
-/// logic lives here — this is only the container. All launch and stop
-/// operations are delegated to sonda-core.
+/// Holds a map of running [`ScenarioHandle`]s keyed by scenario ID, the
+/// process-wide [`GateBusRegistry`] backing cross-POST `while:` refs, and
+/// an optional API key for bearer-token authentication. No scenario lifecycle
+/// logic lives here — all launch and stop operations are delegated to
+/// sonda-core.
 ///
 /// The state is wrapped in an [`Arc`] by axum and cloned into each handler
 /// automatically via the `State` extractor.
@@ -23,6 +26,8 @@ pub struct AppState {
     pub api_key: Option<Arc<String>>,
     /// Optional catalog directory for resolving `pack:` references in posted bodies.
     pub catalog_dir: Option<Arc<PathBuf>>,
+    /// Registry of cross-POST `while:` upstream buses.
+    pub gate_bus_registry: Arc<GateBusRegistry>,
 }
 
 impl AppState {
@@ -32,6 +37,7 @@ impl AppState {
             scenarios: Arc::new(RwLock::new(HashMap::new())),
             api_key: None,
             catalog_dir: None,
+            gate_bus_registry: Arc::new(GateBusRegistry::new()),
         }
     }
 
@@ -41,6 +47,7 @@ impl AppState {
             scenarios: Arc::new(RwLock::new(HashMap::new())),
             api_key: api_key.map(Arc::new),
             catalog_dir: None,
+            gate_bus_registry: Arc::new(GateBusRegistry::new()),
         }
     }
 }

--- a/sonda-server/tests/cross_post_e2e.rs
+++ b/sonda-server/tests/cross_post_e2e.rs
@@ -1,0 +1,197 @@
+//! Workshop-shape end-to-end coverage for cross-POST `while:` refs.
+
+mod common;
+
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+const BASELINE_YAML: &str = r#"
+version: 2
+kind: runnable
+scenario_name: baseline_post
+defaults:
+  rate: 100
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: baseline_traffic
+    signal_type: metrics
+    name: baseline_traffic
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: cascade_signal
+      op: ">"
+      value: 0
+      scenario_name: cascade_post
+      if_unresolved: pending
+"#;
+
+const CASCADE_YAML: &str = r#"
+version: 2
+kind: runnable
+scenario_name: cascade_post
+defaults:
+  rate: 50
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: cascade_signal
+    signal_type: metrics
+    name: cascade_signal
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+fn wait_for_state(
+    client: &reqwest::blocking::Client,
+    base: &str,
+    id: &str,
+    expected: &str,
+    timeout: Duration,
+) -> Value {
+    let deadline = Instant::now() + timeout;
+    let mut last: Value = Value::Null;
+    while Instant::now() < deadline {
+        let resp = client
+            .get(format!("{base}/scenarios/{id}"))
+            .send()
+            .expect("GET scenario detail");
+        let body: Value = resp.json().expect("detail must be JSON");
+        if body["state"] == expected {
+            return body;
+        }
+        last = body;
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("timed out waiting for state {expected:?}; last detail = {last}");
+}
+
+#[test]
+fn t23_workshop_cross_post_lifecycle_with_re_resolution() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    // POST baseline — depends on cascade_post which is not yet running.
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("Content-Type", "text/yaml")
+        .body(BASELINE_YAML)
+        .send()
+        .expect("POST baseline must succeed");
+    assert_eq!(resp.status().as_u16(), 201);
+    let baseline_body: Value = resp.json().unwrap();
+    let baseline_id = baseline_body["id"].as_str().unwrap().to_string();
+
+    // Baseline starts in Unresolved because cascade_post is missing.
+    let detail = wait_for_state(
+        &client,
+        &base,
+        &baseline_id,
+        "unresolved",
+        Duration::from_secs(2),
+    );
+    assert!(detail["pending_ref"].is_object());
+    assert_eq!(detail["pending_ref"]["scenario_name"], "cascade_post");
+
+    // POST cascade — sets scenario_name = cascade_post, registering bus.
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("Content-Type", "text/yaml")
+        .body(CASCADE_YAML)
+        .send()
+        .expect("POST cascade must succeed");
+    assert_eq!(resp.status().as_u16(), 201);
+    let cascade_body: Value = resp.json().unwrap();
+    let cascade_id = cascade_body["id"].as_str().unwrap().to_string();
+
+    // Baseline must transition Unresolved -> Pending -> Running.
+    wait_for_state(
+        &client,
+        &base,
+        &baseline_id,
+        "running",
+        Duration::from_secs(3),
+    );
+
+    // Let baseline accumulate events while running.
+    thread::sleep(Duration::from_millis(500));
+    let snap_before_delete: Value = client
+        .get(format!("{base}/scenarios/{baseline_id}/stats"))
+        .send()
+        .expect("GET stats")
+        .json()
+        .unwrap();
+    let bytes_before = snap_before_delete["bytes_emitted"].as_u64().unwrap();
+    assert!(
+        bytes_before > 0,
+        "baseline must emit while running, got bytes={bytes_before}",
+    );
+
+    // DELETE cascade — baseline must drop back to Unresolved.
+    let resp = client
+        .delete(format!("{base}/scenarios/{cascade_id}"))
+        .send()
+        .expect("DELETE cascade");
+    assert_eq!(resp.status().as_u16(), 200);
+
+    wait_for_state(
+        &client,
+        &base,
+        &baseline_id,
+        "unresolved",
+        Duration::from_secs(2),
+    );
+
+    // POST cascade AGAIN — re-resolution must wire the existing baseline subscriber.
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("Content-Type", "text/yaml")
+        .body(CASCADE_YAML)
+        .send()
+        .expect("POST cascade again");
+    assert_eq!(resp.status().as_u16(), 201);
+    let cascade_body_2: Value = resp.json().unwrap();
+    let cascade_id_2 = cascade_body_2["id"].as_str().unwrap().to_string();
+
+    wait_for_state(
+        &client,
+        &base,
+        &baseline_id,
+        "running",
+        Duration::from_secs(3),
+    );
+
+    // After re-resolution, baseline keeps emitting.
+    thread::sleep(Duration::from_millis(500));
+    let snap_after_re_resolve: Value = client
+        .get(format!("{base}/scenarios/{baseline_id}/stats"))
+        .send()
+        .expect("GET stats")
+        .json()
+        .unwrap();
+    let bytes_after = snap_after_re_resolve["bytes_emitted"].as_u64().unwrap();
+    assert!(
+        bytes_after >= bytes_before,
+        "bytes_emitted must be monotonic across re-resolution; before={bytes_before}, after={bytes_after}",
+    );
+
+    // Clean up both scenarios.
+    let _ = client
+        .delete(format!("{base}/scenarios/{cascade_id_2}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{baseline_id}"))
+        .send();
+}

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -350,9 +350,12 @@ fn run_compiled_with_progress(
     running: &Arc<AtomicBool>,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
-    let handles =
-        sonda_core::schedule::multi_runner::launch_multi_compiled(compiled, Arc::clone(running))
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let handles = sonda_core::schedule::multi_runner::launch_multi_compiled(
+        compiled,
+        Arc::clone(running),
+        None,
+    )
+    .map_err(|e| anyhow::anyhow!("{}", e))?;
 
     let progress = maybe_start_progress_multi(&handles, verbosity);
 

--- a/sonda/src/scenario_loader.rs
+++ b/sonda/src/scenario_loader.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 use anyhow::{bail, Context, Result};
 
 use sonda_core::compiler::compile_after::CompiledFile;
-use sonda_core::compiler::parse::detect_version;
+use sonda_core::compiler::env_interpolate::interpolate;
+use sonda_core::compiler::parse::{detect_version, parse};
 use sonda_core::{compile_scenario_file_compiled, CompileError};
 
 use sonda_core::catalog::CatalogPackResolver;
@@ -22,8 +23,12 @@ pub fn load_scenario_compiled(
     let yaml = crate::config::resolve_scenario_source(scenario_ref, catalog_dir)?;
     let version = detect_version(&yaml);
     match version {
-        Some(2) => compile_v2_yaml_compiled(&yaml, catalog_dir)
-            .with_context(|| format!("failed to compile v2 scenario {scenario_ref}")),
+        Some(2) => {
+            reject_cross_post_while_from_yaml(&yaml)
+                .with_context(|| format!("failed to parse v2 scenario {scenario_ref}"))?;
+            compile_v2_yaml_compiled(&yaml, catalog_dir)
+                .with_context(|| format!("failed to compile v2 scenario {scenario_ref}"))
+        }
         _ => bail!(
             "scenario {scenario_ref} is not a v2 scenario. \
              Sonda only accepts v2 YAML (`version: 2` at the top level). \
@@ -31,6 +36,23 @@ pub fn load_scenario_compiled(
              for the migration guide."
         ),
     }
+}
+
+fn reject_cross_post_while_from_yaml(yaml: &str) -> Result<()> {
+    let interpolated = interpolate(yaml).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let parsed = parse(&interpolated).map_err(|e| anyhow::anyhow!("{e}"))?;
+    for entry in &parsed.scenarios {
+        if let Some(clause) = entry.while_clause.as_ref() {
+            if clause.scenario_name.is_some() {
+                bail!(
+                    "`while.scenario_name` requires a running sonda-server (POST /scenarios); \
+                     the CLI runs in single-process mode with no cross-POST registry. \
+                     See https://davidban77.github.io/sonda/configuration/scenario-files.md#cross-post-while-refs"
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 pub fn compile_v2_yaml_compiled(

--- a/sonda/tests/cli_run.rs
+++ b/sonda/tests/cli_run.rs
@@ -131,3 +131,49 @@ fn run_at_name_with_overrides_applies_them() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+const CROSS_POST_WHILE_YAML: &str = "version: 2
+kind: runnable
+scenario_name: downstream
+defaults:
+  duration: 200ms
+scenarios:
+  - id: tail
+    signal_type: metrics
+    name: tail_metric
+    rate: 5
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream_metric
+      op: \">\"
+      value: 0
+      scenario_name: upstream
+";
+
+#[test]
+fn run_rejects_cross_post_while_scenario_name() {
+    let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+    f.write_all(CROSS_POST_WHILE_YAML.as_bytes())
+        .expect("write");
+    f.flush().expect("flush");
+    let output = Command::new(sonda_bin())
+        .args(["--quiet", "run"])
+        .arg(f.path())
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        !output.status.success(),
+        "cross-POST while: in CLI must fail"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("requires a running sonda-server"),
+        "error must point at sonda-server, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("cross-post-while-refs"),
+        "error must include docs link, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds cross-POST \`while:\` ref resolution to sonda: a \`while:\` clause in one scenario can now reference a scenario delivered by a different POST request. The resolver, registry, and HTTP surface coordinate so subscribers register against scenarios that exist now and re-wire automatically when the referenced scenario shows up later.

This shipment is the union of four reviewed sub-PRs (#418, #419, #421, #422) merged onto a landing branch and brought to main as one cohesive feature. \`+3230 / -392\` across 33 files.

## What ships

- **Types + trait** — \`GateBusResolver\` trait, \`PendingResolution\`, \`UnresolvedBehavior\`, \`InitialState\` and the parse-time schema validation that surfaces unresolvable refs before runtime.
- **Runtime state machine** — scenarios with a \`while:\` upstream enter \`Unresolved\` until the resolver wires them; \`if_unresolved: open\` lets them produce while waiting; the resolver re-wires on every \`sweep_pending\` pass.
- **Production registry** — \`GateBusRegistry\` in \`sonda-server\` keyed by \`(scenario_name, entry_id)\`, with insert-all-then-sweep ordering, atomic \`?validate=strict\` reject semantics, 409 on duplicate \`scenario_name\`, and \`cumulative_resolution_attempts\` accounting.
- **HTTP surface** — POST handler resolves refs across in-flight and previously-POSTed scenarios; T23 workshop-shape E2E test exercises the full cross-POST flow against the real server.
- **Forward-compat sealing** — \`GateContext\` is \`#[non_exhaustive]\` with a consuming-builder constructor (\`new(...) + with_*()\`), so future field additions don't break external consumers.

## Follow-ups (not blocking)

- #423 — pre-assign UUIDs through \`launch_multi_compiled\` to drop the \`rename_handle\` shim
- #424 — fold \`track_subscriber\` back into \`subscribe()\` once the trait surface stabilizes
- #425 — \`#[must_use]\` audit on consuming-builders + \`clippy::must_use_candidate\` decision

## Test plan

- [x] \`cargo nextest run --workspace --all-features\` (2822/2822 pass on landing tip)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --workspace --doc\`
- [x] \`cargo test -p sonda-core --no-default-features\`
- [x] \`cargo audit\`
- [x] Workshop-shape E2E (\`cross_post_e2e.rs\`)

Closes the cross-POST \`while:\` feature track.