### PR TITLE
fix(core): finish local-POST while-gated downstreams on upstream exit

### DIFF
--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -631,6 +631,16 @@ pub(crate) fn gated_loop(
             )?;
             finish(stats)
         }
+        Ok(LoopExit::UpstreamFinished) => {
+            invoke_close_emit(
+                schedule,
+                stats.as_ref(),
+                &mut close_warn_limiter,
+                gate_ctx.close_emit.as_mut(),
+                sink,
+            )?;
+            finish(stats)
+        }
         Err(e) => Err(e),
     }
 }
@@ -698,6 +708,9 @@ fn gated_loop_body(
                             while_open = false;
                         }
                         Some(GateEdge::UpstreamGone) => {
+                            if gate_ctx.if_unresolved.is_none() {
+                                return Ok(LoopExit::UpstreamFinished);
+                            }
                             state = ScenarioState::Unresolved;
                             while_open = false;
                             write_state(stats, ScenarioState::Unresolved, true);
@@ -749,6 +762,9 @@ fn gated_loop_body(
                     return Ok(LoopExit::DurationExpired);
                 }
                 if exit == SegmentExit::UpstreamGone {
+                    if gate_ctx.if_unresolved.is_none() {
+                        return Ok(LoopExit::UpstreamFinished);
+                    }
                     invoke_close_emit(
                         schedule,
                         stats,
@@ -809,6 +825,9 @@ fn gated_loop_body(
                         after_satisfied = true;
                     }
                     Some(GateEdge::UpstreamGone) => {
+                        if gate_ctx.if_unresolved.is_none() {
+                            return Ok(LoopExit::UpstreamFinished);
+                        }
                         state = ScenarioState::Unresolved;
                         while_open = false;
                         write_state(stats, ScenarioState::Unresolved, true);
@@ -1007,6 +1026,7 @@ enum SegmentExit {
 enum LoopExit {
     Shutdown,
     DurationExpired,
+    UpstreamFinished,
 }
 
 /// Wait `delay.close` for either a fresh `WhileOpen` (cancel) or the
@@ -1262,10 +1282,12 @@ mod tests {
             match le {
                 LoopExit::Shutdown => {}
                 LoopExit::DurationExpired => {}
+                LoopExit::UpstreamFinished => {}
             }
         }
         assert_clean_exit_match(LoopExit::Shutdown);
         assert_clean_exit_match(LoopExit::DurationExpired);
+        assert_clean_exit_match(LoopExit::UpstreamFinished);
     }
 
     /// Build a minimal ParsedSchedule for testing.

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -253,6 +253,15 @@ pub fn launch_scenario_with_gates(
     let resolver_for_thread = resolver.clone();
     let scenario_name_for_thread = scenario_name.clone();
 
+    // Cross-POST scenarios broadcast via resolver.unregister; broadcasting
+    // here too races the registry's subscriber migration.
+    let bus_for_finish_guard =
+        if scenario_name_for_thread.is_some() && resolver_for_thread.is_some() {
+            None
+        } else {
+            upstream_bus.as_ref().map(Arc::clone)
+        };
+
     let thread = std::thread::Builder::new()
         .name(format!("sonda-{}", name))
         .spawn(move || -> Result<(), SondaError> {
@@ -269,6 +278,12 @@ pub fn launch_scenario_with_gates(
                 resolver: resolver_for_thread,
                 scenario_name: scenario_name_for_thread,
                 cleaned_up: cleaned_up_for_thread,
+            };
+
+            // Drops before _state_guard so downstreams see UpstreamGone
+            // before the scenario flips to Finished.
+            let _bus_finish_guard = BusFinishGuard {
+                bus: bus_for_finish_guard,
             };
 
             // Sleep through the start_delay before entering the event loop.
@@ -411,6 +426,18 @@ impl Drop for StateGuard {
             (self.scenario_name.as_deref(), self.resolver.as_ref())
         {
             resolver.unregister(name);
+        }
+    }
+}
+
+struct BusFinishGuard {
+    bus: Option<Arc<GateBus>>,
+}
+
+impl Drop for BusFinishGuard {
+    fn drop(&mut self) {
+        if let Some(bus) = self.bus.take() {
+            bus.broadcast_upstream_gone();
         }
     }
 }

--- a/sonda-core/tests/while_local_upstream_finishes.rs
+++ b/sonda-core/tests/while_local_upstream_finishes.rs
@@ -1,0 +1,287 @@
+//! Local-POST `while:` downstream finishes when its upstream exits.
+//!
+//! `while: { ref: <id> }` without `scenario_name:` resolves to a sibling
+//! in the same `CompiledFile`. When that sibling's runner exits, the
+//! downstream transitions to `Finished` (not `Unresolved`).
+
+#![cfg(feature = "config")]
+
+mod common;
+
+use std::thread;
+use std::time::{Duration, Instant};
+
+use sonda_core::compile_scenario_file_compiled;
+use sonda_core::compiler::expand::InMemoryPackResolver;
+use sonda_core::schedule::handle::ScenarioHandle;
+use sonda_core::schedule::multi_runner::launch_multi_compiled;
+use sonda_core::schedule::stats::ScenarioState;
+
+fn find_by_id<'a>(handles: &'a [ScenarioHandle], id: &str) -> &'a ScenarioHandle {
+    handles
+        .iter()
+        .find(|h| h.id == id)
+        .unwrap_or_else(|| panic!("no scenario handle for id {id}"))
+}
+
+fn wait_for_state(handle: &ScenarioHandle, expected: ScenarioState, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if handle.stats_snapshot().state == expected {
+            return;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    panic!(
+        "scenario {} did not reach state {:?} within {:?} (last state = {:?})",
+        handle.id,
+        expected,
+        timeout,
+        handle.stats_snapshot().state
+    );
+}
+
+fn wait_for_not_alive(handle: &ScenarioHandle, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if !handle.is_alive() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    panic!(
+        "scenario {} runner thread still alive after {:?}",
+        handle.id, timeout
+    );
+}
+
+#[test]
+fn local_downstream_finishes_when_upstream_duration_expires() {
+    let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: upstream_a
+    signal_type: metrics
+    name: upstream_a
+    duration: 200ms
+    generator:
+      type: constant
+      value: 100.0
+  - id: downstream_b
+    signal_type: metrics
+    name: downstream_b
+    duration: 5s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream_a
+      op: ">"
+      value: 50.0
+"#;
+
+    let resolver = InMemoryPackResolver::new();
+    let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
+    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    assert_eq!(handles.len(), 2);
+
+    {
+        let upstream = find_by_id(&handles, "upstream_a");
+        let downstream = find_by_id(&handles, "downstream_b");
+        wait_for_state(upstream, ScenarioState::Finished, Duration::from_secs(2));
+        wait_for_state(downstream, ScenarioState::Finished, Duration::from_secs(2));
+        wait_for_not_alive(upstream, Duration::from_secs(1));
+        wait_for_not_alive(downstream, Duration::from_secs(1));
+    }
+
+    for handle in &mut handles {
+        handle
+            .join(Some(Duration::from_secs(2)))
+            .expect("thread join");
+    }
+}
+
+#[test]
+fn local_cascade_a_b_c_all_finish_when_a_finishes() {
+    let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: a
+    signal_type: metrics
+    name: a
+    duration: 200ms
+    generator:
+      type: constant
+      value: 100.0
+  - id: b
+    signal_type: metrics
+    name: b
+    duration: 5s
+    generator:
+      type: constant
+      value: 10.0
+    while:
+      ref: a
+      op: ">"
+      value: 50.0
+  - id: c
+    signal_type: metrics
+    name: c
+    duration: 5s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: b
+      op: ">"
+      value: 0.0
+"#;
+
+    let resolver = InMemoryPackResolver::new();
+    let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
+    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    assert_eq!(handles.len(), 3);
+
+    for id in ["a", "b", "c"] {
+        let h = find_by_id(&handles, id);
+        wait_for_state(h, ScenarioState::Finished, Duration::from_secs(3));
+        wait_for_not_alive(h, Duration::from_secs(1));
+    }
+
+    for handle in &mut handles {
+        handle
+            .join(Some(Duration::from_secs(2)))
+            .expect("thread join");
+    }
+}
+
+#[test]
+fn local_downstream_paused_finishes_when_upstream_finishes() {
+    // Sawtooth dips below threshold so the downstream is Paused when
+    // the upstream's duration expires.
+    let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 100
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: upstream
+    signal_type: metrics
+    name: upstream
+    duration: 300ms
+    generator:
+      type: sawtooth
+      min: 0.0
+      max: 100.0
+      period_secs: 0.2
+  - id: downstream
+    signal_type: metrics
+    name: downstream
+    duration: 5s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream
+      op: ">"
+      value: 90.0
+"#;
+
+    let resolver = InMemoryPackResolver::new();
+    let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
+    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    assert_eq!(handles.len(), 2);
+
+    {
+        let upstream = find_by_id(&handles, "upstream");
+        let downstream = find_by_id(&handles, "downstream");
+        wait_for_state(upstream, ScenarioState::Finished, Duration::from_secs(2));
+        wait_for_state(downstream, ScenarioState::Finished, Duration::from_secs(2));
+        wait_for_not_alive(upstream, Duration::from_secs(1));
+        wait_for_not_alive(downstream, Duration::from_secs(1));
+    }
+
+    for handle in &mut handles {
+        handle
+            .join(Some(Duration::from_secs(2)))
+            .expect("thread join");
+    }
+}
+
+#[test]
+fn local_downstream_running_finishes_when_upstream_finishes() {
+    // Constant value > threshold keeps the downstream Running until the
+    // upstream's duration expires.
+    let yaml = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 100
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: upstream
+    signal_type: metrics
+    name: upstream
+    duration: 200ms
+    generator:
+      type: constant
+      value: 100.0
+  - id: downstream
+    signal_type: metrics
+    name: downstream
+    duration: 5s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream
+      op: ">"
+      value: 10.0
+"#;
+
+    let resolver = InMemoryPackResolver::new();
+    let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
+    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    assert_eq!(handles.len(), 2);
+
+    {
+        let upstream = find_by_id(&handles, "upstream");
+        let downstream = find_by_id(&handles, "downstream");
+        wait_for_state(upstream, ScenarioState::Finished, Duration::from_secs(2));
+        wait_for_state(downstream, ScenarioState::Finished, Duration::from_secs(2));
+        wait_for_not_alive(upstream, Duration::from_secs(1));
+        wait_for_not_alive(downstream, Duration::from_secs(1));
+        // Must have produced events while Running.
+        assert!(
+            downstream.stats_snapshot().total_events > 0,
+            "downstream should have emitted events while gate was open"
+        );
+    }
+
+    for handle in &mut handles {
+        handle
+            .join(Some(Duration::from_secs(2)))
+            .expect("thread join");
+    }
+}

--- a/sonda-core/tests/while_local_upstream_finishes.rs
+++ b/sonda-core/tests/while_local_upstream_finishes.rs
@@ -171,13 +171,16 @@ scenarios:
 
 #[test]
 fn local_downstream_paused_finishes_when_upstream_finishes() {
-    // Sawtooth dips below threshold so the downstream is Paused when
-    // the upstream's duration expires.
+    // A non-repeating sequence drops below threshold on tick 1 and stays
+    // there for the rest of the upstream's life. The downstream is
+    // therefore reliably Paused (not Running) at the moment the upstream
+    // exits, anchoring the Paused-arm `UpstreamGone → UpstreamFinished`
+    // branch in core_loop.rs.
     let yaml = r#"
 version: 2
 kind: runnable
 defaults:
-  rate: 100
+  rate: 50
   encoder:
     type: prometheus_text
   sink:
@@ -186,12 +189,11 @@ scenarios:
   - id: upstream
     signal_type: metrics
     name: upstream
-    duration: 300ms
+    duration: 400ms
     generator:
-      type: sawtooth
-      min: 0.0
-      max: 100.0
-      period_secs: 0.2
+      type: sequence
+      values: [100.0, 0.0]
+      repeat: false
   - id: downstream
     signal_type: metrics
     name: downstream
@@ -202,7 +204,7 @@ scenarios:
     while:
       ref: upstream
       op: ">"
-      value: 90.0
+      value: 50.0
 "#;
 
     let resolver = InMemoryPackResolver::new();
@@ -213,6 +215,7 @@ scenarios:
     {
         let upstream = find_by_id(&handles, "upstream");
         let downstream = find_by_id(&handles, "downstream");
+        wait_for_state(downstream, ScenarioState::Paused, Duration::from_secs(2));
         wait_for_state(upstream, ScenarioState::Finished, Duration::from_secs(2));
         wait_for_state(downstream, ScenarioState::Finished, Duration::from_secs(2));
         wait_for_not_alive(upstream, Duration::from_secs(1));

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -999,6 +999,81 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
 }
 
 #[test]
+fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
+    // Subscribe with after.op=">" threshold=100 at value=5: after has not
+    // fired, gate is irrelevant (after gates Pending entry). Broadcast
+    // UpstreamGone while still Pending. With if_unresolved=None, the
+    // Pending arm must return LoopExit::UpstreamFinished and the scenario
+    // must transition to Finished.
+    let bus = Arc::new(GateBus::new());
+    bus.tick(5.0);
+
+    let (rx, init) = bus.subscribe(SubscriptionSpec {
+        after: Some(AfterSpec {
+            op: AfterOpDir::GreaterThan,
+            threshold: 100.0,
+        }),
+        while_: Some(WhileSpec {
+            op: WhileOp::GreaterThan,
+            threshold: 0.0,
+        }),
+    });
+    assert!(!init.after_already_fired);
+    assert_eq!(init.while_gate_open, Some(true));
+
+    let shutdown = Arc::new(AtomicBool::new(true));
+    let entry = metrics_entry("pending_upstream_gone", 100.0, 5000);
+    let mut handle = launch_scenario_with_gates(
+        "pending_upstream_gone".to_string(),
+        None,
+        entry,
+        Arc::clone(&shutdown),
+        None,
+        None,
+        Some(
+            GateContext::new(rx, init)
+                .with_has_after(true)
+                .with_has_while(true),
+        ),
+        None,
+    )
+    .expect("launch must succeed");
+
+    thread::sleep(Duration::from_millis(80));
+    let snap = handle.stats_snapshot();
+    assert_eq!(
+        snap.state,
+        ScenarioState::Pending,
+        "expected Pending before UpstreamGone, got {:?}",
+        snap.state
+    );
+    assert_eq!(snap.total_events, 0);
+
+    bus.broadcast_upstream_gone();
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        if handle.stats_snapshot().state == ScenarioState::Finished {
+            break;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    let snap = handle.stats_snapshot();
+    assert_eq!(
+        snap.state,
+        ScenarioState::Finished,
+        "UpstreamGone in Pending arm must transition to Finished, got {:?}",
+        snap.state
+    );
+    assert_eq!(
+        snap.total_events, 0,
+        "Pending scenario must emit zero events before UpstreamGone"
+    );
+
+    handle.join(Some(Duration::from_secs(2))).ok();
+}
+
+#[test]
 fn while_runtime_steady_within_5pct_of_baseline() {
     // Perf-regression gate (A10): a scenario with `while:` open the entire
     // run must produce within 5% of the event count of the same scenario

--- a/sonda-server/tests/scenarios.rs
+++ b/sonda-server/tests/scenarios.rs
@@ -2251,3 +2251,74 @@ fn delete_one_scenario_does_not_cascade_finish_siblings() {
         );
     }
 }
+
+const LOCAL_WHILE_UPSTREAM_FINISHES_YAML: &str = "\
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: local_upstream
+    signal_type: metrics
+    name: local_upstream
+    duration: 1s
+    generator:
+      type: constant
+      value: 1.0
+  - id: local_downstream
+    signal_type: metrics
+    name: local_downstream
+    duration: 30s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: local_upstream
+      op: \">\"
+      value: 0.0
+";
+
+/// Local-POST downstream (`while:` ref to a sibling, no `scenario_name:`)
+/// must finish when its upstream's duration expires.
+#[test]
+fn while_local_downstream_finishes_when_upstream_finishes() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(LOCAL_WHILE_UPSTREAM_FINISHES_YAML)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(resp.status().as_u16(), 201);
+
+    let body: serde_json::Value = resp.json().expect("response must be JSON");
+    let scenarios = body["scenarios"]
+        .as_array()
+        .expect("multi response must have a 'scenarios' array");
+    let downstream_id = scenarios
+        .iter()
+        .find(|s| s["name"].as_str() == Some("local_downstream"))
+        .and_then(|s| s["id"].as_str())
+        .expect("downstream must be in response")
+        .to_string();
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    let detail = client
+        .get(format!("http://127.0.0.1:{port}/scenarios/{downstream_id}"))
+        .send()
+        .expect("GET downstream detail must succeed");
+    assert_eq!(detail.status().as_u16(), 200);
+    let body: serde_json::Value = detail.json().expect("detail body is JSON");
+    let state = body["state"].as_str().unwrap_or("");
+    assert_eq!(
+        state, "finished",
+        "local-POST downstream must reach finished after upstream's duration expires, got {state:?}"
+    );
+}


### PR DESCRIPTION
A scenario with a local-POST `while:` clause stayed running indefinitely after its upstream's `duration:` expired. The per-CompiledFile `GateBus` was never told the upstream had gone, and the existing `UpstreamGone` arms always transitioned to `Unresolved` — a state designed for cross-POST re-resolution, which has no path for a local-POST bus. This PR adds the missing exit-time broadcast and a local-vs-cross-POST branch so local-POST gated downstreams transition to `finished` (terminal) while cross-POST behaviour from #426 is preserved.

- `BusFinishGuard` Drop in `launch_scenario_with_gates` broadcasts `UpstreamGone` on every exit path of the upstream's runner thread, including early `?` returns from sink/encoder/generator construction.
- Guard is skipped for cross-POST scenarios (`scenario_name.is_some() && resolver.is_some()`) — the cross-POST flow already broadcasts via `resolver.unregister()`; a second broadcast would mask the new upstream's `WhileOpen` on re-resolution.
- New private `LoopExit::UpstreamFinished` variant; outer `gated_loop` runs the same `invoke_close_emit + finish(stats)` tail as `DurationExpired`.
- The three `UpstreamGone` arms (Pending, Running, Paused) branch on `gate_ctx.if_unresolved.is_none()` to return `UpstreamFinished` for local-POST.
- Integration tests cover Pending/Running/Paused single-downstream cases and the A→B→C cascade; server-side test verifies via real HTTP.

Refs: #420 (cascade-delete fix that established the per-handle lifecycle ownership), #426 (cross-POST `while:` ref resolution that introduced `Unresolved` and `UpstreamGone`).