### PR TITLE
fix(server): add /metrics?include_state= allowlist filter

### DIFF
--- a/docs/site/docs/configuration/scenario-files.md
+++ b/docs/site/docs/configuration/scenario-files.md
@@ -851,6 +851,21 @@ The aggregate [`GET /metrics`](../deployment/sonda-server.md#get-metrics-vs-get-
 
 The practical consequence for cross-POST wiring: two scenarios that target the same `(metric_name, labels)` with mutually-exclusive gates both contribute samples to `/metrics`. The aggregate concatenates their points; it does not pick "the live one." If you want only one scenario to contribute a given series at a time, DELETE the inactive one rather than relying on the gate to silence it. This is load-bearing for the cascade-replaces-baseline pattern below.
 
+Scrapers can opt into a state-aware view of the aggregate by passing `?include_state=<allowlist>` on the request. Series from scenarios whose state is outside the allowlist are skipped; with the parameter absent the response is unchanged (every scenario still contributes its last-known sample). The allowlist is comma-separated and accepts the five scenario states — `pending`, `running`, `paused`, `unresolved`, `finished` — in any combination:
+
+```bash
+# Only running scenarios — paused and unresolved ghosts are filtered out
+curl 'http://localhost:8080/metrics?include_state=running'
+
+# Multiple states at once; whitespace after the comma is tolerated
+curl 'http://localhost:8080/metrics?include_state=running,paused'
+
+# Combine with the label filter; both are applied as intersection
+curl 'http://localhost:8080/metrics?include_state=running&label=device:srl1'
+```
+
+An unknown state name or an empty value (`?include_state=`) returns `400 Bad Request` with a message listing the five valid options. This filter is pull-only — push sinks such as `remote_write`, `kafka`, and `otlp` already honor scenario state by construction, because the runner skips encoding and writing while the gate is closed.
+
 #### Example: cascade replaces baseline emission
 
 The `if_unresolved: open` pattern shown earlier pauses the baseline whenever the cascade gates it shut, but the baseline's last value keeps appearing in the aggregate `/metrics` scrape (see the ghost-sample note just above). When the goal is to **replace** the baseline's emission with the cascade's (a constant healthy value swapped out for a flapping outage value on the same series), gate-pause is not enough — orchestrate with DELETE + POST.
@@ -911,6 +926,8 @@ The orchestration sequence:
 3. **End the outage.** DELETE the outage cascade, then POST `baseline.yaml` again. Series returns to a steady `1`.
 
 The inverse shape — keeping the baseline alive and adding a `while:` clause to pause it whenever the outage cascade fires — does NOT achieve the same effect on the aggregate scrape. The baseline's last `1` would still appear in `/metrics` alongside the outage's `0`, because gate-pause does not clear the handle's `current_values`. For replacement-of-emission, DELETE the baseline first.
+
+If your scrapers can pass `?include_state=running`, the DELETE-and-replace dance collapses to a POST-and-leave-running flow: POST the baseline and the outage cascade with inverse `while:` clauses on the same upstream signal, so that exactly one of them is `running` at any moment. Scrapers request `GET /metrics?include_state=running` and see whichever scenario currently holds the gate open; the paused side is filtered out, so the target series never carries two simultaneous samples and no DELETE is needed. Keep the DELETE-and-replace flow above for scrapers that cannot set the query parameter — push-only sinks already see the right thing because the runner does not emit while a `while:` gate is closed.
 
 For the HTTP surface — the strict-validation flag, the `pending_ref` field, the duplicate-name 409, and the new `/stats` fields — see [Server API](../deployment/sonda-server.md#cross-post-while-refs).
 

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -939,6 +939,52 @@ fn parse_label_filters(raw: Option<&str>) -> Result<Vec<(String, String)>, Strin
     Ok(filters)
 }
 
+/// Parse `include_state=a,b,...` into a deduped allowlist of [`ScenarioState`].
+/// Returns `Ok(None)` when the param is absent, `Err` for empty / unknown tokens.
+fn parse_include_state(raw_query: Option<&str>) -> Result<Option<Vec<ScenarioState>>, String> {
+    let Some(raw) = raw_query else {
+        return Ok(None);
+    };
+    // Last occurrence wins, matching axum's `Query<T>` convention.
+    let mut last_value: Option<String> = None;
+    for pair in raw.split('&').filter(|s| !s.is_empty()) {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        if key == "include_state" {
+            last_value = Some(percent_decode(value));
+        }
+    }
+    let Some(decoded) = last_value else {
+        return Ok(None);
+    };
+    if decoded.is_empty() {
+        return Err("include_state requires at least one state name".to_string());
+    }
+    let mut out: Vec<ScenarioState> = Vec::new();
+    for token in decoded.split(',') {
+        let trimmed = token.trim();
+        if trimmed.is_empty() {
+            return Err("include_state requires at least one state name".to_string());
+        }
+        let state = match trimmed {
+            "pending" => ScenarioState::Pending,
+            "running" => ScenarioState::Running,
+            "paused" => ScenarioState::Paused,
+            "unresolved" => ScenarioState::Unresolved,
+            "finished" => ScenarioState::Finished,
+            other => {
+                return Err(format!(
+                    "unknown state name '{other}' in include_state — expected one of: \
+                     pending, running, paused, unresolved, finished"
+                ));
+            }
+        };
+        if !out.contains(&state) {
+            out.push(state);
+        }
+    }
+    Ok(Some(out))
+}
+
 fn percent_decode(input: &str) -> String {
     let bytes = input.as_bytes();
     let mut out = Vec::with_capacity(bytes.len());
@@ -977,6 +1023,7 @@ pub async fn get_aggregate_metrics(
     RawQuery(raw_query): RawQuery,
 ) -> Result<Response, Response> {
     let filters = parse_label_filters(raw_query.as_deref()).map_err(bad_request)?;
+    let state_filter = parse_include_state(raw_query.as_deref()).map_err(bad_request)?;
 
     let scenarios = state
         .scenarios
@@ -1002,6 +1049,11 @@ pub async fn get_aggregate_metrics(
                 .unwrap_or(false)
         }) {
             continue;
+        }
+        if let Some(allow) = &state_filter {
+            if !allow.contains(&handle.stats_snapshot().state) {
+                continue;
+            }
         }
         let events = handle.recent_metrics_snapshot();
         if events.is_empty() && handle.prometheus_meta.is_none() {
@@ -4129,6 +4181,114 @@ scenarios:
         assert!(filters.is_empty());
         let filters2 = parse_label_filters(Some("")).expect("must parse");
         assert!(filters2.is_empty());
+    }
+
+    #[test]
+    fn parse_include_state_absent_returns_none() {
+        assert!(parse_include_state(None).unwrap().is_none());
+        assert!(parse_include_state(Some("")).unwrap().is_none());
+        assert!(parse_include_state(Some("label=device:srl1"))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn parse_include_state_single_value() {
+        let states = parse_include_state(Some("include_state=running"))
+            .unwrap()
+            .expect("filter must be present");
+        assert_eq!(states, vec![ScenarioState::Running]);
+    }
+
+    #[test]
+    fn parse_include_state_comma_separated() {
+        let states = parse_include_state(Some("include_state=running,paused"))
+            .unwrap()
+            .expect("filter must be present");
+        assert_eq!(states, vec![ScenarioState::Running, ScenarioState::Paused]);
+    }
+
+    #[test]
+    fn parse_include_state_trims_whitespace_per_token() {
+        let states = parse_include_state(Some("include_state=running,%20paused"))
+            .unwrap()
+            .expect("filter must be present");
+        assert_eq!(states, vec![ScenarioState::Running, ScenarioState::Paused]);
+    }
+
+    #[test]
+    fn parse_include_state_dedups_duplicates() {
+        let states = parse_include_state(Some("include_state=running,running,paused"))
+            .unwrap()
+            .expect("filter must be present");
+        assert_eq!(states, vec![ScenarioState::Running, ScenarioState::Paused]);
+    }
+
+    #[test]
+    fn parse_include_state_accepts_all_known_variants() {
+        let states = parse_include_state(Some(
+            "include_state=pending,running,paused,unresolved,finished",
+        ))
+        .unwrap()
+        .expect("filter must be present");
+        assert_eq!(
+            states,
+            vec![
+                ScenarioState::Pending,
+                ScenarioState::Running,
+                ScenarioState::Paused,
+                ScenarioState::Unresolved,
+                ScenarioState::Finished,
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_include_state_empty_value_is_error() {
+        let err = parse_include_state(Some("include_state=")).unwrap_err();
+        assert!(
+            err.contains("at least one state name"),
+            "error must explain the empty value: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_include_state_unknown_token_is_error() {
+        let err = parse_include_state(Some("include_state=running,foo")).unwrap_err();
+        assert!(
+            err.contains("'foo'"),
+            "error must quote the bad token: {err}"
+        );
+        assert!(
+            err.contains("pending, running, paused, unresolved, finished"),
+            "error must list valid options: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_include_state_rejects_unknown_sentinel() {
+        let err = parse_include_state(Some("include_state=unknown")).unwrap_err();
+        assert!(
+            err.contains("'unknown'"),
+            "the catch-all `unknown` sentinel must be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_include_state_repeated_param_takes_last() {
+        let states = parse_include_state(Some("include_state=running&include_state=paused"))
+            .unwrap()
+            .expect("filter must be present");
+        assert_eq!(states, vec![ScenarioState::Paused]);
+    }
+
+    #[test]
+    fn parse_include_state_composes_with_other_query_keys() {
+        let states =
+            parse_include_state(Some("label=env:prod&include_state=running&validate=strict"))
+                .unwrap()
+                .expect("filter must be present");
+        assert_eq!(states, vec![ScenarioState::Running]);
     }
 
     // ---- PROMETHEUS_CONTENT_TYPE constant ------------------------------------

--- a/sonda-server/tests/scenarios.rs
+++ b/sonda-server/tests/scenarios.rs
@@ -2322,3 +2322,503 @@ fn while_local_downstream_finishes_when_upstream_finishes() {
         "local-POST downstream must reach finished after upstream's duration expires, got {state:?}"
     );
 }
+
+// ---- GET /metrics?include_state=... allowlist filter ------------------------
+
+const ISFILTER_BASELINE_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: isfilter_baseline_up
+    signal_type: metrics
+    name: isfilter_baseline_up
+    labels:
+      env: prod
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+const ISFILTER_BASELINE_DEV_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: isfilter_baseline_dev_up
+    signal_type: metrics
+    name: isfilter_baseline_dev_up
+    labels:
+      env: dev
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+const ISFILTER_PAUSED_UPSTREAM_YAML: &str = r#"
+version: 2
+kind: runnable
+scenario_name: isfilter_paused_upstream
+defaults:
+  rate: 10
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: isfilter_upstream_signal
+    signal_type: metrics
+    name: isfilter_upstream_signal
+    generator:
+      type: sequence
+      values: [1.0, 1.0, 1.0, 1.0, 0.0]
+      repeat: false
+"#;
+
+const ISFILTER_PAUSED_DOWNSTREAM_YAML: &str = r#"
+version: 2
+kind: runnable
+scenario_name: isfilter_paused_downstream
+defaults:
+  rate: 50
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: isfilter_downstream_metric
+    signal_type: metrics
+    name: isfilter_downstream_metric
+    generator:
+      type: constant
+      value: 7.0
+    while:
+      ref: isfilter_upstream_signal
+      op: ">"
+      value: 0
+      scenario_name: isfilter_paused_upstream
+"#;
+
+const ISFILTER_UNRESOLVED_DOWNSTREAM_YAML: &str = r#"
+version: 2
+kind: runnable
+scenario_name: isfilter_unresolved_downstream
+defaults:
+  rate: 50
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: isfilter_unresolved_metric
+    signal_type: metrics
+    name: isfilter_unresolved_metric
+    generator:
+      type: constant
+      value: 3.0
+    while:
+      ref: nope
+      op: ">"
+      value: 0
+      scenario_name: isfilter_missing_upstream
+"#;
+
+fn isfilter_wait_for_state(
+    client: &reqwest::blocking::Client,
+    base: &str,
+    id: &str,
+    expected: &str,
+    timeout: std::time::Duration,
+) -> serde_json::Value {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut last = serde_json::Value::Null;
+    while std::time::Instant::now() < deadline {
+        let resp = client
+            .get(format!("{base}/scenarios/{id}"))
+            .send()
+            .expect("GET scenario detail");
+        let body: serde_json::Value = resp.json().expect("detail must be JSON");
+        if body["state"] == expected {
+            return body;
+        }
+        last = body;
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    panic!("timed out waiting for state {expected:?} on {id}; last detail = {last}");
+}
+
+fn isfilter_post(client: &reqwest::blocking::Client, base: &str, yaml: &str) -> serde_json::Value {
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(yaml.to_string())
+        .send()
+        .expect("POST must succeed");
+    let status = resp.status().as_u16();
+    let body_text = resp.text().expect("body must be UTF-8");
+    assert_eq!(status, 201, "POST must return 201; body={body_text}");
+    serde_json::from_str(&body_text).expect("response must be JSON")
+}
+
+fn isfilter_scrape(client: &reqwest::blocking::Client, base: &str, query: &str) -> String {
+    let url = if query.is_empty() {
+        format!("{base}/metrics")
+    } else {
+        format!("{base}/metrics?{query}")
+    };
+    let resp = client.get(url).send().expect("GET /metrics must succeed");
+    assert_eq!(resp.status().as_u16(), 200, "GET /metrics must return 200");
+    resp.text().expect("body must be UTF-8")
+}
+
+#[test]
+fn include_state_absent_returns_running_and_paused() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let baseline = isfilter_post(&client, &base, ISFILTER_BASELINE_YAML);
+    let baseline_id = baseline["id"].as_str().unwrap().to_string();
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &baseline_id,
+        "running",
+        std::time::Duration::from_secs(2),
+    );
+
+    let upstream = isfilter_post(&client, &base, ISFILTER_PAUSED_UPSTREAM_YAML);
+    let upstream_id = upstream["id"].as_str().unwrap().to_string();
+    let downstream = isfilter_post(&client, &base, ISFILTER_PAUSED_DOWNSTREAM_YAML);
+    let downstream_id = downstream["id"].as_str().unwrap().to_string();
+
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &downstream_id,
+        "running",
+        std::time::Duration::from_secs(3),
+    );
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &downstream_id,
+        "paused",
+        std::time::Duration::from_secs(3),
+    );
+
+    let body = isfilter_scrape(&client, &base, "");
+    assert!(
+        body.contains("isfilter_baseline_up"),
+        "default scrape must include running scenario; body=\n{body}"
+    );
+    assert!(
+        body.contains("isfilter_downstream_metric"),
+        "default scrape must include paused scenario's last-known sample (ghost); body=\n{body}"
+    );
+
+    let _ = client
+        .delete(format!("{base}/scenarios/{downstream_id}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{upstream_id}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{baseline_id}"))
+        .send();
+}
+
+#[test]
+fn include_state_running_excludes_paused() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let baseline = isfilter_post(&client, &base, ISFILTER_BASELINE_YAML);
+    let baseline_id = baseline["id"].as_str().unwrap().to_string();
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &baseline_id,
+        "running",
+        std::time::Duration::from_secs(2),
+    );
+
+    let upstream = isfilter_post(&client, &base, ISFILTER_PAUSED_UPSTREAM_YAML);
+    let upstream_id = upstream["id"].as_str().unwrap().to_string();
+    let downstream = isfilter_post(&client, &base, ISFILTER_PAUSED_DOWNSTREAM_YAML);
+    let downstream_id = downstream["id"].as_str().unwrap().to_string();
+
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &downstream_id,
+        "running",
+        std::time::Duration::from_secs(3),
+    );
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &downstream_id,
+        "paused",
+        std::time::Duration::from_secs(3),
+    );
+
+    let body = isfilter_scrape(&client, &base, "include_state=running");
+    assert!(
+        body.contains("isfilter_baseline_up"),
+        "running filter must include the running scenario; body=\n{body}"
+    );
+    assert!(
+        !body.contains("isfilter_downstream_metric"),
+        "running filter must exclude the paused scenario's ghost; body=\n{body}"
+    );
+
+    let _ = client
+        .delete(format!("{base}/scenarios/{downstream_id}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{upstream_id}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{baseline_id}"))
+        .send();
+}
+
+#[test]
+fn include_state_multi_value_running_unresolved_excludes_paused() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let baseline = isfilter_post(&client, &base, ISFILTER_BASELINE_YAML);
+    let baseline_id = baseline["id"].as_str().unwrap().to_string();
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &baseline_id,
+        "running",
+        std::time::Duration::from_secs(2),
+    );
+
+    let unresolved = isfilter_post(&client, &base, ISFILTER_UNRESOLVED_DOWNSTREAM_YAML);
+    let unresolved_id = unresolved["id"].as_str().unwrap().to_string();
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &unresolved_id,
+        "unresolved",
+        std::time::Duration::from_secs(2),
+    );
+
+    let upstream = isfilter_post(&client, &base, ISFILTER_PAUSED_UPSTREAM_YAML);
+    let upstream_id = upstream["id"].as_str().unwrap().to_string();
+    let downstream = isfilter_post(&client, &base, ISFILTER_PAUSED_DOWNSTREAM_YAML);
+    let downstream_id = downstream["id"].as_str().unwrap().to_string();
+
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &downstream_id,
+        "running",
+        std::time::Duration::from_secs(3),
+    );
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &downstream_id,
+        "paused",
+        std::time::Duration::from_secs(3),
+    );
+
+    let body = isfilter_scrape(&client, &base, "include_state=running,unresolved");
+    assert!(
+        body.contains("isfilter_baseline_up"),
+        "multi-state filter must include the running scenario; body=\n{body}"
+    );
+    // Unresolved downstream never ticks, so it contributes no samples even though it matches.
+    assert!(
+        !body.contains("isfilter_downstream_metric"),
+        "multi-state filter must exclude the paused scenario's ghost; body=\n{body}"
+    );
+
+    let _ = client
+        .delete(format!("{base}/scenarios/{downstream_id}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{upstream_id}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{unresolved_id}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{baseline_id}"))
+        .send();
+}
+
+#[test]
+fn include_state_unknown_value_returns_400() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let resp = client
+        .get(format!("{base}/metrics?include_state=foo"))
+        .send()
+        .expect("GET /metrics must succeed");
+    assert_eq!(resp.status().as_u16(), 400);
+    let body: serde_json::Value = resp.json().expect("error body must be JSON");
+    let detail = body["detail"].as_str().unwrap_or("");
+    assert!(
+        detail.contains("'foo'"),
+        "error detail must quote the bad token: {detail}"
+    );
+    assert!(
+        detail.contains("pending, running, paused, unresolved, finished"),
+        "error detail must list valid options: {detail}"
+    );
+}
+
+#[test]
+fn include_state_empty_value_returns_400() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let resp = client
+        .get(format!("{base}/metrics?include_state="))
+        .send()
+        .expect("GET /metrics must succeed");
+    assert_eq!(resp.status().as_u16(), 400);
+    let body: serde_json::Value = resp.json().expect("error body must be JSON");
+    let detail = body["detail"].as_str().unwrap_or("");
+    assert!(
+        detail.contains("at least one state name"),
+        "error detail must explain the empty value: {detail}"
+    );
+}
+
+#[test]
+fn include_state_combined_with_label_filter_intersects() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let prod = isfilter_post(&client, &base, ISFILTER_BASELINE_YAML);
+    let prod_id = prod["id"].as_str().unwrap().to_string();
+    let dev = isfilter_post(&client, &base, ISFILTER_BASELINE_DEV_YAML);
+    let dev_id = dev["id"].as_str().unwrap().to_string();
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &prod_id,
+        "running",
+        std::time::Duration::from_secs(2),
+    );
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &dev_id,
+        "running",
+        std::time::Duration::from_secs(2),
+    );
+
+    let upstream = isfilter_post(&client, &base, ISFILTER_PAUSED_UPSTREAM_YAML);
+    let upstream_id = upstream["id"].as_str().unwrap().to_string();
+    let downstream = isfilter_post(&client, &base, ISFILTER_PAUSED_DOWNSTREAM_YAML);
+    let downstream_id = downstream["id"].as_str().unwrap().to_string();
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &downstream_id,
+        "paused",
+        std::time::Duration::from_secs(5),
+    );
+
+    let body = isfilter_scrape(&client, &base, "include_state=running&label=env:prod");
+    assert!(
+        body.contains("isfilter_baseline_up"),
+        "intersection must include the prod-labelled running scenario; body=\n{body}"
+    );
+    assert!(
+        !body.contains("isfilter_baseline_dev_up"),
+        "intersection must exclude the dev-labelled scenario via label filter; body=\n{body}"
+    );
+    assert!(
+        !body.contains("isfilter_downstream_metric"),
+        "intersection must exclude the paused scenario via state filter; body=\n{body}"
+    );
+
+    let _ = client
+        .delete(format!("{base}/scenarios/{downstream_id}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{upstream_id}"))
+        .send();
+    let _ = client.delete(format!("{base}/scenarios/{dev_id}")).send();
+    let _ = client.delete(format!("{base}/scenarios/{prod_id}")).send();
+}
+
+#[test]
+fn include_state_whitespace_after_comma_parses_two_states() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let baseline = isfilter_post(&client, &base, ISFILTER_BASELINE_YAML);
+    let baseline_id = baseline["id"].as_str().unwrap().to_string();
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &baseline_id,
+        "running",
+        std::time::Duration::from_secs(2),
+    );
+
+    let upstream = isfilter_post(&client, &base, ISFILTER_PAUSED_UPSTREAM_YAML);
+    let upstream_id = upstream["id"].as_str().unwrap().to_string();
+    let downstream = isfilter_post(&client, &base, ISFILTER_PAUSED_DOWNSTREAM_YAML);
+    let downstream_id = downstream["id"].as_str().unwrap().to_string();
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &downstream_id,
+        "paused",
+        std::time::Duration::from_secs(5),
+    );
+
+    let body = isfilter_scrape(&client, &base, "include_state=running,%20paused");
+    assert!(
+        body.contains("isfilter_baseline_up"),
+        "whitespace-tolerant filter must include the running scenario; body=\n{body}"
+    );
+    assert!(
+        body.contains("isfilter_downstream_metric"),
+        "whitespace-tolerant filter must include the paused scenario; body=\n{body}"
+    );
+
+    let _ = client
+        .delete(format!("{base}/scenarios/{downstream_id}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{upstream_id}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{baseline_id}"))
+        .send();
+}

--- a/sonda-server/tests/scenarios.rs
+++ b/sonda-server/tests/scenarios.rs
@@ -2438,6 +2438,25 @@ scenarios:
       scenario_name: isfilter_missing_upstream
 "#;
 
+const ISFILTER_FINISHED_SCENARIO_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 1s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: isfilter_finished_metric
+    signal_type: metrics
+    name: isfilter_finished_metric
+    generator:
+      type: constant
+      value: 5.0
+"#;
+
 fn isfilter_wait_for_state(
     client: &reqwest::blocking::Client,
     base: &str,
@@ -2601,7 +2620,7 @@ fn include_state_running_excludes_paused() {
 }
 
 #[test]
-fn include_state_multi_value_running_unresolved_excludes_paused() {
+fn include_state_multi_value_admits_running_and_finished_excludes_paused() {
     let (port, _guard) = common::start_server();
     let base = format!("http://127.0.0.1:{port}");
     let client = common::http_client();
@@ -2646,17 +2665,33 @@ fn include_state_multi_value_running_unresolved_excludes_paused() {
         std::time::Duration::from_secs(3),
     );
 
-    let body = isfilter_scrape(&client, &base, "include_state=running,unresolved");
+    let finished = isfilter_post(&client, &base, ISFILTER_FINISHED_SCENARIO_YAML);
+    let finished_id = finished["id"].as_str().unwrap().to_string();
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &finished_id,
+        "finished",
+        std::time::Duration::from_secs(3),
+    );
+
+    let body = isfilter_scrape(&client, &base, "include_state=running,unresolved,finished");
     assert!(
         body.contains("isfilter_baseline_up"),
         "multi-state filter must include the running scenario; body=\n{body}"
     );
-    // Unresolved downstream never ticks, so it contributes no samples even though it matches.
+    assert!(
+        body.contains("isfilter_finished_metric"),
+        "multi-state filter must include the finished scenario's last sample; body=\n{body}"
+    );
     assert!(
         !body.contains("isfilter_downstream_metric"),
         "multi-state filter must exclude the paused scenario's ghost; body=\n{body}"
     );
 
+    let _ = client
+        .delete(format!("{base}/scenarios/{finished_id}"))
+        .send();
     let _ = client
         .delete(format!("{base}/scenarios/{downstream_id}"))
         .send();


### PR DESCRIPTION
## Summary

Adds an opt-in \`?include_state=\` query parameter on \`GET /metrics\` that restricts which scenarios contribute samples by lifecycle state. Resolves the cascade-replaces-baseline pattern without DELETE-and-replace orchestration. Closes #429.

## What changed

\`\`\`
GET /metrics?include_state=running
GET /metrics?include_state=running,paused   # comma-separated multi-value
\`\`\`

- Accepted values: \`pending\`, \`running\`, \`paused\`, \`unresolved\`, \`finished\`.
- Default behavior unchanged — when the param is absent, every scenario contributes its last sample regardless of state.
- Unknown state name → HTTP 400 with the offending token quoted and valid options listed.
- Empty value → HTTP 400.
- Whitespace-tolerant: \`?include_state=running,%20paused\`.
- Composes with the existing \`?label=k:v\` filter as intersection.
- \`GET /scenarios/{id}/metrics\` (per-scenario) is intentionally not filtered.
- Push sinks (remote_write, kafka, otlp, …) are not affected — the runner already skips encode + sink.write while the gate is closed.

## Test plan

- [x] \`cargo nextest run --workspace --all-features\` — 2850/2850 pass (baseline 2832; +18 tests: 11 parser unit + 7 E2E)
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo test --workspace --doc\` — clean
- [x] \`cargo test -p sonda-core --no-default-features --no-run\` — clean
- [x] \`cargo audit\` — clean (pre-existing yanked \`core2\` advisory, unchanged)
- [x] \`task site:build --strict\` — clean
- [x] Each of the 7 acceptance criteria from #429 covered by a named E2E test in \`sonda-server/tests/scenarios.rs\`

Closes #429.