### PR TITLE
chore: regenerate Cargo.lock for workspace 1.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.12.2"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.12.2"
+version = "1.13.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.12.2"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
release-please bumped the workspace crates to 1.13.0 in \`Cargo.toml\` via #417 but didn't regenerate \`Cargo.lock\`, leaving it stuck on 1.12.2. Every cargo command on a checkout re-syncs the lockfile silently, which surfaces as a noisy uncommitted change on every feature branch. This commit syncs it once on main so future branches stay clean.

Pure version sync — no dependency updates. \`cargo update --workspace\` reported "Locking 0 packages to latest compatible versions, Already up to date."

\`\`\`
-version = "1.12.2"
+version = "1.13.0"
\`\`\`

(× 3 — \`sonda\`, \`sonda-core\`, \`sonda-server\`)