### PR TITLE
feat(server): add ScenarioState::Held + ?include_state=held filter token

### DIFF
--- a/docs/site/docs/configuration/scenario-files.md
+++ b/docs/site/docs/configuration/scenario-files.md
@@ -477,6 +477,8 @@ A scenario carrying a `while:` clause walks through four lifecycle states. The r
 
 `pending` covers the wait for the upstream's first eligible tick. The downstream enters `running` when the gate first opens, oscillates between `running` and `paused` for the rest of the run, and ends in `finished` when its `duration:` elapses or shutdown is signaled. A scenario with both `after:` and `while:` whose `after:` fires while the gate is closed enters `paused` directly -- `pending` need not always precede `running`.
 
+A fifth state, `held`, replaces `paused` after a gate close when the scenario opts into the snap-to recovery shape via [`delay.close.snap_to`](#recovering-prometheus-alerts-on-gate-close) AND has emitted at least one sample. `held` differs from `paused` only on the pull-path: scrapers passing [`?include_state=...,held`](#aggregate-metrics-sees-paused-and-unresolved-scenarios) keep seeing the frozen value, while `paused` ghosts stay filtered out under that same allowlist. Push sinks behave identically in both states (the runner stops emitting). `held` applies to metric scenarios. See [Pattern C — Counter freeze-and-hold during outage](#pattern-c-counter-freeze-and-hold-during-outage) for the orchestration.
+
 ### Debouncing transitions with `delay:`
 
 Pair `while:` with `delay:` to debounce noisy upstream signals.
@@ -693,8 +695,9 @@ Cross-POST `while:` is most often used to coordinate a long-running **baseline**
 |---|---|---|
 | [**Pattern A — Cascade signals to pause a baseline**](#pattern-a-cascade-signals-to-pause-a-baseline) | Baseline and cascade emit **different series**. You want the baseline silent (no emissions, no scrape ghosts) only while the cascade is firing. | Baseline carries a cross-POST `while:` gated on a cascade signal, plus `if_unresolved: open` so it runs at the default rate when the cascade is absent. Push sinks honor the gate naturally; pull scrapers need `?include_state=running,unresolved` (see the callout under `?include_state=`). |
 | [**Pattern B — Cascade overrides baseline emission**](#pattern-b-cascade-overrides-baseline-emission) | Baseline and cascade emit the **same series**. You want the cascade's values to replace the baseline's in the scrape during the outage window. | DELETE the baseline, POST the cascade for the outage window, DELETE the cascade, POST the baseline again. Or — for scrapers that can pass `?include_state=running` — keep both alive with inverse `while:` clauses so only one is `running` at a time. |
+| [**Pattern C — Counter freeze-and-hold during outage**](#pattern-c-counter-freeze-and-hold-during-outage) | Single metric series (no separate baseline POST) whose value should freeze at the last sample during the outage window, then resume from the frozen value when the gate reopens. | A single scenario with `delay.close.snap_to: <value>` and a `while:` clause. Gate close transitions the scenario to `held`, the pull-path retains the frozen sample, and scrapers opt in with `?include_state=running,unresolved,held`. No DELETE-and-replace orchestration. |
 
-Both worked examples are below. Read both before picking — the same-series vs different-series distinction governs which one is correct for your pipeline, and getting it wrong shows up as either duplicate samples in `/metrics` or an empty scrape body at steady state.
+All three worked examples are below. Read them before picking — the same-series vs different-series distinction governs A vs B, and the freeze-vs-replace distinction governs C. Picking the wrong one shows up as either duplicate samples in `/metrics`, an empty scrape body at steady state, or a counter that goes to zero during the outage when you wanted it held at its last value.
 
 #### Schema
 
@@ -862,20 +865,25 @@ The aggregate [`GET /metrics`](../deployment/sonda-server.md#get-metrics-vs-get-
 
 The practical consequence for cross-POST wiring: two scenarios that target the same `(metric_name, labels)` with mutually-exclusive gates both contribute samples to `/metrics`. The aggregate concatenates their points; it does not pick "the live one." If you want only one scenario to contribute a given series at a time, DELETE the inactive one rather than relying on the gate to silence it. This is load-bearing for the cascade-replaces-baseline pattern below.
 
-Scrapers can opt into a state-aware view of the aggregate by passing `?include_state=<allowlist>` on the request. Series from scenarios whose state is outside the allowlist are skipped; with the parameter absent the response is unchanged (every scenario still contributes its last-known sample). The allowlist is comma-separated and accepts the five scenario states — `pending`, `running`, `paused`, `unresolved`, `finished` — in any combination:
+Scrapers can opt into a state-aware view of the aggregate by passing `?include_state=<allowlist>` on the request. Series from scenarios whose state is outside the allowlist are skipped; with the parameter absent the response is unchanged (every scenario still contributes its last-known sample). The allowlist is comma-separated and accepts the six scenario states — `pending`, `running`, `paused`, `held`, `unresolved`, `finished` — in any combination:
 
 ```bash
-# Only running scenarios — paused and unresolved ghosts are filtered out
+# Only running scenarios — paused, held, and unresolved ghosts are filtered out
 curl 'http://localhost:8080/metrics?include_state=running'
 
 # Multiple states at once; whitespace after the comma is tolerated
 curl 'http://localhost:8080/metrics?include_state=running,paused'
 
+# Include held scenarios in the scrape (counter freeze-and-hold pattern)
+curl 'http://localhost:8080/metrics?include_state=running,unresolved,held'
+
 # Combine with the label filter; both are applied as intersection
 curl 'http://localhost:8080/metrics?include_state=running&label=device:srl1'
 ```
 
-An unknown state name or an empty value (`?include_state=`) returns `400 Bad Request` with a message listing the five valid options. This filter is pull-only — push sinks such as `remote_write`, `kafka`, and `otlp` already honor scenario state by construction, because the runner skips encoding and writing while the gate is closed.
+An unknown state name or an empty value (`?include_state=`) returns `400 Bad Request` with a message listing the six valid options. This filter is pull-only — push sinks such as `remote_write`, `kafka`, and `otlp` already honor scenario state by construction, because the runner skips encoding and writing while the gate is closed.
+
+A metric scenario configured with `delay.close.snap_to` reports `state: "held"` after gate close instead of `state: "paused"`, provided at least one sample emitted before the close. A scraper that matches on `?include_state=paused` to surface snap-to scenarios should switch to `?include_state=held` (or include both).
 
 !!! warning "`?include_state=running` filters out `if_unresolved: open` baselines"
 
@@ -952,6 +960,60 @@ The orchestration sequence:
 The inverse shape — keeping the baseline alive and adding a `while:` clause to pause it whenever the outage cascade fires — does NOT achieve the same effect on the aggregate scrape. The baseline's last `1` would still appear in `/metrics` alongside the outage's `0`, because gate-pause does not clear the handle's `current_values`. For replacement-of-emission, DELETE the baseline first.
 
 If your scrapers can pass `?include_state=running`, the DELETE-and-replace dance collapses to a POST-and-leave-running flow: POST the baseline and the outage cascade with inverse `while:` clauses on the same upstream signal, so that exactly one of them is `running` at any moment. Scrapers request `GET /metrics?include_state=running` and see whichever scenario currently holds the gate open; the paused side is filtered out, so the target series never carries two simultaneous samples and no DELETE is needed. Keep the DELETE-and-replace flow above for scrapers that cannot set the query parameter — push-only sinks already see the right thing because the runner does not emit while a `while:` gate is closed.
+
+#### Pattern C — Counter freeze-and-hold during outage
+
+Some operational signals should freeze at their last value during an outage rather than go silent or drop to zero. A monotonic counter that represents "requests served" or a gauge that represents "last-known interface state" is more truthful held at the last sample than reset, and a scraper that sees the frozen value can keep alerting against the same threshold throughout the outage window.
+
+A single metric scenario with a `while:` clause and `delay.close.snap_to: <value>` does this without a separate baseline POST and without DELETE-and-replace orchestration. When the gate closes, the runner fires the one-shot recovery sample, the scenario transitions to the `held` lifecycle state, and `current_values` retains the frozen sample. Scrapers that pass `?include_state=running,unresolved,held` continue to see the frozen value on every scrape; scrapers that omit `held` from the allowlist see the series drop out for the duration of the outage.
+
+```yaml title="held-counter.yaml — single scenario, frozen during outage"
+version: 2
+kind: runnable
+scenario_name: held_counter_post
+defaults:
+  rate: 1
+  duration: 1h
+  encoder:
+    type: prometheus_text
+  sink:
+    type: remote_write
+    url: ${VICTORIAMETRICS_REMOTE_WRITE_URL:-http://localhost:8428/api/v1/write}
+scenarios:
+  - id: bgp_oper_state
+    signal_type: metrics
+    name: bgp_oper_state
+    labels:
+      device: rtr-edge-01
+      peer: 10.0.0.1
+    generator:
+      type: constant
+      value: 1
+    while:
+      scenario_name: outage_signal_post
+      ref: link_state
+      op: ">"
+      value: 0
+      if_unresolved: open
+    delay:
+      close:
+        duration: 0s
+        snap_to: 1
+```
+
+The orchestration sequence:
+
+1. **Steady state.** POST `held-counter.yaml`. Because the outage signal has not arrived, `if_unresolved: open` keeps the counter at `1`. The state reads `unresolved`. Scrapers using `?include_state=running,unresolved,held` see the value.
+2. **Outage begins.** POST an outage cascade that publishes `link_state` going to `0` (the same shape used in Patterns A and B). The gate closes — the runner fires the `snap_to: 1` recovery sample, and the scenario transitions from `unresolved` (or `running`) to `held`. The frozen `1` stays visible on the pull-path. Push sinks (`remote_write`, `kafka`, `loki`, etc.) stop receiving new samples for the duration of the hold; the one recovery sample at the close edge is the last write they see.
+3. **Outage ends.** The outage cascade reopens `link_state` (or is DELETEd). The downstream transitions from `held` back to `running` and resumes emission at the configured rate. The series carries forward without a gap on the pull-path; push sinks pick up new samples at the next tick.
+
+`held` is reachable only from metric scenarios that have emitted at least one sample before the gate first closes. A snap-to-equipped scenario whose gate closes before its first emission lands in `paused` (not `held`) because there is no frozen value to retain — the next gate open then emits normally and a subsequent close can transition into `held`.
+
+The choice between Patterns A, B, and C:
+
+- **A** drops the baseline to zero contributions during the outage by gating its emission shut. Use when the baseline and the outage cascade emit different series, and "absent" is the right scrape behavior during the outage.
+- **B** replaces the baseline series with the outage cascade's values during the outage window. Use when the two emit the same series and you need the outage values to overwrite the baseline values in the scrape.
+- **C** holds a single series at its last value for the duration of the outage. Use when the right scrape behavior is "the value you last saw," with no separate baseline POST and no DELETE-and-replace orchestration.
 
 For the HTTP surface — the strict-validation flag, the `pending_ref` field, the duplicate-name 409, and the new `/stats` fields — see [Server API](../deployment/sonda-server.md#cross-post-while-refs).
 

--- a/docs/site/docs/deployment/sonda-server.md
+++ b/docs/site/docs/deployment/sonda-server.md
@@ -206,7 +206,7 @@ Post a [scenario](../configuration/scenario-files.md) YAML or JSON body to `POST
 
     The JSON body is transcoded to YAML server-side and compiled through the same pipeline as the YAML path. Any valid scenario file can be posted as JSON by converting the YAML to its JSON equivalent.
 
-The response shape depends on how many entries the compiler produces, not on the request format. A single-entry result returns the flat `{"id", "name", "state"}` body; anything that compiles to two or more entries (for example, a pack-backed entry that fans out) returns `{"scenarios": [...]}`. The `state` field reports the live lifecycle state at response time and takes one of `"pending"`, `"running"`, `"paused"`, `"unresolved"`, or `"finished"` (see [`/scenarios/{id}/stats`](#scenariosidstats) for the full enum, the `pending -> paused` transition note, and the [cross-POST `unresolved` state](#unresolved-lifecycle-state)).
+The response shape depends on how many entries the compiler produces, not on the request format. A single-entry result returns the flat `{"id", "name", "state"}` body; anything that compiles to two or more entries (for example, a pack-backed entry that fans out) returns `{"scenarios": [...]}`. The `state` field reports the live lifecycle state at response time and takes one of `"pending"`, `"running"`, `"paused"`, `"held"`, `"unresolved"`, or `"finished"` (see [`/scenarios/{id}/stats`](#scenariosidstats) for the full enum, the `pending -> paused` transition note, and the [cross-POST `unresolved` state](#unresolved-lifecycle-state)).
 
 ### Multi-scenario body
 
@@ -393,7 +393,7 @@ Without `--catalog`, a body that references a pack by name is rejected with `400
 
 ### Duplicate scenario_name returns 409
 
-When a posted body sets a top-level `scenario_name`, the server scans the active scenario map for any handle that already carries the same `scenario_name` and is in `pending`, `running`, or `paused` state. If at least one match is found the POST is rejected with `409 Conflict`; nothing is launched. The contract is explicit: the operator must `DELETE` the conflicting scenarios first, then re-post. There is no `?force=true` override -- the explicit DELETE is the only way to free the name.
+When a posted body sets a top-level `scenario_name`, the server scans the active scenario map for any handle that already carries the same `scenario_name` and is in `pending`, `running`, `paused`, `held`, or `unresolved` state. If at least one match is found the POST is rejected with `409 Conflict`; nothing is launched. The contract is explicit: the operator must `DELETE` the conflicting scenarios first, then re-post. There is no `?force=true` override -- the explicit DELETE is the only way to free the name.
 
 Anonymous bodies (no top-level `scenario_name`) bypass this check entirely — two consecutive POSTs of the same anonymous body both return 201. Finished handles are considered stale and never block a new POST — once every prior cascade with the same name reaches `finished` state, a new cascade with the same name returns 201.
 
@@ -411,7 +411,7 @@ The 409 body lists every active scenario contributing to the conflict so the ope
 }
 ```
 
-Each `conflicting_scenarios` entry carries the scenario `id` (use it with `DELETE /scenarios/{id}`), the per-entry `name` (the runtime-launched scenario name, not the file-level `scenario_name`), and the live `state` (one of `pending`, `running`, `paused`, `unresolved`). When the body produced multiple entries (multi-entry POST or pack expansion), each launched handle inherits the same file-level `scenario_name` and contributes one item to the array.
+Each `conflicting_scenarios` entry carries the scenario `id` (use it with `DELETE /scenarios/{id}`), the per-entry `name` (the runtime-launched scenario name, not the file-level `scenario_name`), and the live `state` (one of `pending`, `running`, `paused`, `held`, `unresolved`). When the body produced multiple entries (multi-entry POST or pack expansion), each launched handle inherits the same file-level `scenario_name` and contributes one item to the array.
 
 ## Cross-POST `while:` refs
 
@@ -453,13 +453,14 @@ A scenario whose cross-POST `while:` clause has no registered upstream — and w
 | `pending` | Waiting for `after:` to fire, or the first eligible tick of a local `while:` gate. |
 | `running` | Emitting events. |
 | `paused` | Local `while:` gate is closed, or a cross-POST gate's `if_unresolved: closed` is in effect. |
+| `held` | Metric scenario configured with [`delay.close.snap_to`](../configuration/scenario-files.md#recovering-prometheus-alerts-on-gate-close) whose gate has closed after at least one emission. The frozen value is retained for pull-path scrapers that opt in via `?include_state=...,held`. |
 | `unresolved` | Cross-POST `while.scenario_name:` has not been POSTed yet (with `if_unresolved: pending`), or its upstream was DELETEd. |
 | `finished` | `duration:` elapsed or shutdown signalled. Terminal. |
 
 A scenario can transition `unresolved → pending → running` once the upstream registers, and back to `unresolved` when the upstream is DELETEd or finishes its own duration. Re-POSTing the same `scenario_name:` re-resolves the downstream automatically — no client orchestration. See [Cross-POST `while:` refs](../configuration/scenario-files.md#cross-post-while-refs) for the YAML schema and the `if_unresolved:` mode reference.
 
-!!! warning "Add `unresolved` to your dashboards"
-    If you maintain Prometheus recording rules or Grafana dashboards that enumerate `state=~"pending|running|paused|finished"`, add `unresolved` to the alternation (`state=~"pending|running|paused|unresolved|finished"`) or rewrite the matcher as a negation (`state!="finished"`). Cross-POST scenarios in `unresolved` are silently dropped by exhaustive enumerations.
+!!! warning "Add `unresolved` and `held` to your dashboards"
+    If you maintain Prometheus recording rules or Grafana dashboards that enumerate `state=~"pending|running|paused|finished"`, add `unresolved` and `held` to the alternation (`state=~"pending|running|paused|held|unresolved|finished"`) or rewrite the matcher as a negation (`state!="finished"`). Cross-POST scenarios in `unresolved` and snap-to scenarios in `held` are silently dropped by exhaustive enumerations.
 
 ### `pending_ref` field on `GET /scenarios/{id}`
 
@@ -502,7 +503,7 @@ Both fields are present on every response, not just `unresolved` scenarios — `
 
 ### Duplicate name across POSTs
 
-The [`409 Conflict` rule](#duplicate-scenario_name-returns-409) extends to cross-POST scenarios: a body whose top-level `scenario_name:` collides with one already registered in the resolver — whether that earlier scenario is `pending`, `running`, `paused`, or `unresolved` — is rejected. The `conflicting_scenarios` array on the 409 response identifies which IDs to DELETE before re-POSTing. This applies both to the upstream (the body that publishes the gate signal) and to any downstream POST whose top-level `scenario_name:` is already in use.
+The [`409 Conflict` rule](#duplicate-scenario_name-returns-409) extends to cross-POST scenarios: a body whose top-level `scenario_name:` collides with one already registered in the resolver — whether that earlier scenario is `pending`, `running`, `paused`, `held`, or `unresolved` — is rejected. The `conflicting_scenarios` array on the 409 response identifies which IDs to DELETE before re-POSTing. This applies both to the upstream (the body that publishes the gate signal) and to any downstream POST whose top-level `scenario_name:` is already in use.
 
 ## API Endpoints
 
@@ -676,7 +677,7 @@ curl -s http://localhost:8080/scenarios | jq .
 }
 ```
 
-Each entry carries `id`, `name`, `state`, `elapsed_secs`, and `degraded`. The `state` field takes one of `pending`, `running`, `paused`, `unresolved`, or `finished` (see the [`state` field reference](#scenariosidstats) below for what each value means, the transition note for `pending -> paused`, and the [cross-POST `unresolved` state](#unresolved-lifecycle-state)).
+Each entry carries `id`, `name`, `state`, `elapsed_secs`, and `degraded`. The `state` field takes one of `pending`, `running`, `paused`, `held`, `unresolved`, or `finished` (see the [`state` field reference](#scenariosidstats) below for what each value means, the transition note for `pending -> paused`, and the [cross-POST `unresolved` state](#unresolved-lifecycle-state)).
 
 #### The `degraded` field
 
@@ -780,7 +781,7 @@ This is the shape to look for: rising `total_events`, `last_successful_write_at`
 | `bytes_emitted` | integer | Total bytes written to the sink. |
 | `errors` | integer | Encode or sink-write errors observed. |
 | `uptime_secs` | float | Seconds since the scenario was launched. |
-| `state` | string | One of `pending`, `running`, `paused`, `unresolved`, `finished`. See the [`while:` lifecycle diagram](../configuration/scenario-files.md#lifecycle-states) and the [cross-POST `unresolved` state](#unresolved-lifecycle-state). |
+| `state` | string | One of `pending`, `running`, `paused`, `held`, `unresolved`, `finished`. See the [`while:` lifecycle diagram](../configuration/scenario-files.md#lifecycle-states) and the [cross-POST `unresolved` state](#unresolved-lifecycle-state). |
 | `current_state_secs` | float | Seconds since the most recent state transition. See [Cross-POST `while:` refs](#cross-post-while-refs). |
 | `cumulative_resolution_attempts` | integer | Lifetime count of cross-POST resolver attempts for this scenario. `0` for local-only scenarios. See [Cross-POST `while:` refs](#cross-post-while-refs). |
 | `in_gap` | bool | `true` while a [gap window](../configuration/scenario-fields.md#gap-window) is suppressing output. |

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -523,6 +523,8 @@ pub struct GateContext {
     pub close_emit: Option<CloseEmitFn>,
     pub if_unresolved: Option<UnresolvedBehavior>,
     pub start_unresolved: bool,
+    /// Whether a gate-close should land the scenario in `Held` (snap-to opt-in) instead of `Paused`.
+    pub holds_on_close: bool,
 }
 
 impl GateContext {
@@ -537,6 +539,7 @@ impl GateContext {
             close_emit: None,
             if_unresolved: None,
             start_unresolved: false,
+            holds_on_close: false,
         }
     }
 
@@ -567,6 +570,11 @@ impl GateContext {
 
     pub fn with_start_unresolved(mut self, start_unresolved: bool) -> Self {
         self.start_unresolved = start_unresolved;
+        self
+    }
+
+    pub fn with_holds_on_close(mut self, holds_on_close: bool) -> Self {
+        self.holds_on_close = holds_on_close;
         self
     }
 }
@@ -679,7 +687,10 @@ fn gated_loop_body(
 
     let mut next_tick: u64 = 0;
 
-    let paused_zero_rate = matches!(state, ScenarioState::Unresolved | ScenarioState::Paused);
+    let paused_zero_rate = matches!(
+        state,
+        ScenarioState::Unresolved | ScenarioState::Paused | ScenarioState::Held
+    );
     write_state(stats, state, paused_zero_rate);
 
     loop {
@@ -732,8 +743,9 @@ fn gated_loop_body(
                     state = ScenarioState::Running;
                     write_state(stats, ScenarioState::Running, false);
                 } else {
-                    state = ScenarioState::Paused;
-                    write_state(stats, ScenarioState::Paused, true);
+                    let close_state = close_target_state(gate_ctx.holds_on_close, stats);
+                    state = close_state;
+                    write_state(stats, close_state, true);
                 }
             }
             ScenarioState::Running => {
@@ -795,12 +807,13 @@ fn gated_loop_body(
                         sink,
                     )?;
                 }
-                state = ScenarioState::Paused;
+                let close_state = close_target_state(gate_ctx.holds_on_close, stats);
+                state = close_state;
                 while_open = false;
-                write_state(stats, ScenarioState::Paused, true);
+                write_state(stats, close_state, true);
                 debounce.reset();
             }
-            ScenarioState::Paused => {
+            ScenarioState::Paused | ScenarioState::Held => {
                 let now = Instant::now();
                 let mut wakeup = PAUSED_POLL_INTERVAL;
                 if let Some(d) = debounce.next_wakeup(now) {
@@ -888,9 +901,11 @@ fn gated_loop_body(
                                     gate_ctx.close_emit.as_mut(),
                                     sink,
                                 )?;
-                                state = ScenarioState::Paused;
+                                let close_state =
+                                    close_target_state(gate_ctx.holds_on_close, stats);
+                                state = close_state;
                                 while_open = false;
-                                write_state(stats, ScenarioState::Paused, true);
+                                write_state(stats, close_state, true);
                                 debounce.reset();
                             }
                             SegmentExit::UpstreamGone => {
@@ -916,8 +931,10 @@ fn gated_loop_body(
                             }
                             Some(GateEdge::WhileClose) => {
                                 while_open = false;
-                                state = ScenarioState::Paused;
-                                write_state(stats, ScenarioState::Paused, true);
+                                let close_state =
+                                    close_target_state(gate_ctx.holds_on_close, stats);
+                                state = close_state;
+                                write_state(stats, close_state, true);
                                 debounce.reset();
                             }
                             Some(GateEdge::AfterFired) => {
@@ -934,6 +951,23 @@ fn gated_loop_body(
                 return Ok(LoopExit::Shutdown);
             }
         }
+    }
+}
+
+fn close_target_state(
+    holds_on_close: bool,
+    stats: Option<&Arc<RwLock<ScenarioStats>>>,
+) -> ScenarioState {
+    if !holds_on_close {
+        return ScenarioState::Paused;
+    }
+    let has_emitted = stats
+        .and_then(|s| s.read().ok().map(|st| !st.current_values.is_empty()))
+        .unwrap_or(false);
+    if has_emitted {
+        ScenarioState::Held
+    } else {
+        ScenarioState::Paused
     }
 }
 
@@ -2153,5 +2187,58 @@ mod tests {
             first_ptr.get().is_some(),
             "tick_fn must have observed at least one events_buf pointer"
         );
+    }
+
+    #[test]
+    fn close_target_state_paused_when_holds_off() {
+        assert_eq!(close_target_state(false, None), ScenarioState::Paused);
+        let stats = Arc::new(RwLock::new(ScenarioStats::default()));
+        assert_eq!(
+            close_target_state(false, Some(&stats)),
+            ScenarioState::Paused
+        );
+    }
+
+    #[test]
+    fn close_target_state_paused_when_holds_on_but_no_samples() {
+        let stats = Arc::new(RwLock::new(ScenarioStats::default()));
+        assert_eq!(
+            close_target_state(true, Some(&stats)),
+            ScenarioState::Paused,
+            "snap_to with zero emissions must remain Paused"
+        );
+        assert_eq!(
+            close_target_state(true, None),
+            ScenarioState::Paused,
+            "no stats means no emissions known — must remain Paused"
+        );
+    }
+
+    #[test]
+    fn close_target_state_held_when_holds_on_and_samples_present() {
+        use crate::model::metric::{Labels, MetricEvent};
+
+        let stats = Arc::new(RwLock::new(ScenarioStats::default()));
+        {
+            let mut st = stats.write().unwrap();
+            let event = MetricEvent::new("up".to_string(), 1.0, Labels::default())
+                .expect("valid metric name");
+            st.push_metric(event);
+        }
+        assert_eq!(close_target_state(true, Some(&stats)), ScenarioState::Held);
+    }
+
+    #[test]
+    fn gate_context_with_holds_on_close_setter_round_trip() {
+        use crate::schedule::gate_bus::{GateBus, SubscriptionSpec};
+
+        let bus = GateBus::new();
+        bus.tick(0.0);
+        let (rx, init) = bus.subscribe(SubscriptionSpec {
+            after: None,
+            while_: None,
+        });
+        let ctx = GateContext::new(rx, init).with_holds_on_close(true);
+        assert!(ctx.holds_on_close);
     }
 }

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -183,6 +183,7 @@ pub fn run_with_sink_gated(
                 ctx.delay.as_ref(),
                 Arc::clone(&encoder),
             );
+            ctx.holds_on_close = ctx.delay.as_ref().and_then(|d| d.close_snap_to).is_some();
             core_loop::gated_loop(
                 &schedule,
                 config.rate,

--- a/sonda-core/src/schedule/stats.rs
+++ b/sonda-core/src/schedule/stats.rs
@@ -21,10 +21,11 @@ pub const DEGRADED_STALENESS_NANOS: u64 = 30 * 1_000_000_000;
 /// Lifecycle position of a scenario, surfaced for `while:`-gated runs.
 ///
 /// `Pending` covers the pre-`after:` window for chained scenarios; `Running`
-/// and `Paused` reflect the live `while:` gate state; `Unresolved` marks a
-/// cross-POST `while:` reference whose upstream has not yet registered;
-/// `Finished` marks the scenario as having exited (duration expired or
-/// shutdown received).
+/// and `Paused` reflect the live `while:` gate state; `Held` is the
+/// snap-to-frozen variant of `Paused` for scenarios that opted in via
+/// `delay.close.snap_to`; `Unresolved` marks a cross-POST `while:` reference
+/// whose upstream has not yet registered; `Finished` marks the scenario as
+/// having exited (duration expired or shutdown received).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
@@ -33,6 +34,8 @@ pub enum ScenarioState {
     Pending,
     Running,
     Paused,
+    /// Frozen at the last emitted value after a gate close, opted in via `delay.close.snap_to`.
+    Held,
     Unresolved,
     Finished,
 }
@@ -614,6 +617,21 @@ mod tests {
             ..Default::default()
         };
         assert!(s.is_degraded(1_000_000_000_000_000));
+    }
+
+    #[test]
+    fn held_state_serializes_as_lowercase_held() {
+        let s = ScenarioStats {
+            state: ScenarioState::Held,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&s).expect("must serialize");
+        assert!(json.contains("\"state\":\"held\""));
+    }
+
+    #[test]
+    fn held_state_is_distinct_from_paused() {
+        assert_ne!(ScenarioState::Held, ScenarioState::Paused);
     }
 
     #[test]

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -74,7 +74,7 @@ pub struct CreatedScenariosResponse {
 pub struct ScenarioSummary {
     pub id: String,
     pub name: String,
-    /// Current state: one of `"pending"`, `"running"`, `"paused"`, `"finished"`.
+    /// Current state: one of `"pending"`, `"running"`, `"paused"`, `"held"`, `"unresolved"`, `"finished"`.
     pub state: String,
     pub elapsed_secs: f64,
     /// Whether the scenario has sink failures and no recent successful delivery.
@@ -93,7 +93,7 @@ pub struct ListScenariosResponse {
 pub struct ScenarioDetail {
     pub id: String,
     pub name: String,
-    /// Current state: one of `"pending"`, `"running"`, `"paused"`, `"finished"`.
+    /// Current state: one of `"pending"`, `"running"`, `"paused"`, `"held"`, `"unresolved"`, `"finished"`.
     pub state: String,
     pub elapsed_secs: f64,
     /// Whether the scenario has sink failures and no recent successful delivery.
@@ -120,7 +120,7 @@ pub struct DeletedScenario {
 pub struct ConflictingScenario {
     pub id: String,
     pub name: String,
-    /// One of `"pending"`, `"running"`, `"paused"`. Never `"finished"`.
+    /// One of `"pending"`, `"running"`, `"paused"`, `"held"`, `"unresolved"`. Never `"finished"`.
     pub state: String,
 }
 
@@ -186,7 +186,7 @@ pub struct DetailedStatsResponse {
     pub errors: u64,
     /// Seconds elapsed since the scenario was launched.
     pub uptime_secs: f64,
-    /// Current state: `"pending"`, `"running"`, `"paused"`, or `"finished"`.
+    /// Current state: `"pending"`, `"running"`, `"paused"`, `"held"`, `"unresolved"`, or `"finished"`.
     pub state: String,
     /// Whether the scenario is currently in a gap window (no events emitted).
     pub in_gap: bool,
@@ -256,6 +256,7 @@ fn state_string(stats: &ScenarioStats) -> &'static str {
         ScenarioState::Pending => "pending",
         ScenarioState::Running => "running",
         ScenarioState::Paused => "paused",
+        ScenarioState::Held => "held",
         ScenarioState::Unresolved => "unresolved",
         ScenarioState::Finished => "finished",
         _ => "unknown",
@@ -280,6 +281,7 @@ fn collect_active_conflicts(state: &AppState, name: &str) -> Result<Vec<Conflict
             ScenarioState::Pending
             | ScenarioState::Running
             | ScenarioState::Paused
+            | ScenarioState::Held
             | ScenarioState::Unresolved => true,
             ScenarioState::Finished => false,
             _ => false,
@@ -969,12 +971,13 @@ fn parse_include_state(raw_query: Option<&str>) -> Result<Option<Vec<ScenarioSta
             "pending" => ScenarioState::Pending,
             "running" => ScenarioState::Running,
             "paused" => ScenarioState::Paused,
+            "held" => ScenarioState::Held,
             "unresolved" => ScenarioState::Unresolved,
             "finished" => ScenarioState::Finished,
             other => {
                 return Err(format!(
                     "unknown state name '{other}' in include_state — expected one of: \
-                     pending, running, paused, unresolved, finished"
+                     pending, running, paused, held, unresolved, finished"
                 ));
             }
         };
@@ -1848,6 +1851,8 @@ scenarios:
         assert_eq!(state_string(&s), "running");
         s.state = ScenarioState::Paused;
         assert_eq!(state_string(&s), "paused");
+        s.state = ScenarioState::Held;
+        assert_eq!(state_string(&s), "held");
         s.state = ScenarioState::Unresolved;
         assert_eq!(state_string(&s), "unresolved");
         s.state = ScenarioState::Finished;
@@ -4227,7 +4232,7 @@ scenarios:
     #[test]
     fn parse_include_state_accepts_all_known_variants() {
         let states = parse_include_state(Some(
-            "include_state=pending,running,paused,unresolved,finished",
+            "include_state=pending,running,paused,held,unresolved,finished",
         ))
         .unwrap()
         .expect("filter must be present");
@@ -4237,10 +4242,19 @@ scenarios:
                 ScenarioState::Pending,
                 ScenarioState::Running,
                 ScenarioState::Paused,
+                ScenarioState::Held,
                 ScenarioState::Unresolved,
                 ScenarioState::Finished,
             ]
         );
+    }
+
+    #[test]
+    fn parse_include_state_single_held_value() {
+        let states = parse_include_state(Some("include_state=held"))
+            .unwrap()
+            .expect("filter must be present");
+        assert_eq!(states, vec![ScenarioState::Held]);
     }
 
     #[test]
@@ -4260,7 +4274,7 @@ scenarios:
             "error must quote the bad token: {err}"
         );
         assert!(
-            err.contains("pending, running, paused, unresolved, finished"),
+            err.contains("pending, running, paused, held, unresolved, finished"),
             "error must list valid options: {err}"
         );
     }

--- a/sonda-server/tests/scenarios.rs
+++ b/sonda-server/tests/scenarios.rs
@@ -1626,9 +1626,10 @@ scenarios:
         );
     }
 
-    /// Posting a v2 cascade with the new extended `delay.close` shape (struct
-    /// form with `snap_to`) accepts and runs end-to-end. The downstream
-    /// reaches `paused` after the upstream's gate closes.
+    /// Posting a v2 cascade with the extended `delay.close` shape (struct form
+    /// with `snap_to`) accepts and runs end-to-end. The downstream reaches
+    /// `held` after the upstream's gate closes — snap_to opts the scenario
+    /// into the held lifecycle state.
     const STALE_MARKER_CASCADE_YAML: &str = "\
 version: 2
 kind: runnable
@@ -1664,7 +1665,7 @@ scenarios:
 ";
 
     #[test]
-    fn post_cascade_with_extended_delay_close_form_runs_to_paused() {
+    fn post_cascade_with_extended_delay_close_form_runs_to_held() {
         let (port, _guard) = common::start_server();
         let client = common::http_client();
 
@@ -1702,8 +1703,8 @@ scenarios:
         }
 
         assert!(
-            observed.contains("paused"),
-            "downstream must reach 'paused' at least once, observed: {observed:?}"
+            observed.contains("held"),
+            "downstream with snap_to must reach 'held' at least once, observed: {observed:?}"
         );
     }
 
@@ -2724,7 +2725,7 @@ fn include_state_unknown_value_returns_400() {
         "error detail must quote the bad token: {detail}"
     );
     assert!(
-        detail.contains("pending, running, paused, unresolved, finished"),
+        detail.contains("pending, running, paused, held, unresolved, finished"),
         "error detail must list valid options: {detail}"
     );
 }
@@ -2855,5 +2856,152 @@ fn include_state_whitespace_after_comma_parses_two_states() {
         .send();
     let _ = client
         .delete(format!("{base}/scenarios/{baseline_id}"))
+        .send();
+}
+
+// ---- ?include_state=held + held lifecycle E2E --------------------------------
+
+const HELD_UPSTREAM_YAML: &str = r#"
+version: 2
+kind: runnable
+scenario_name: held_upstream_xpost
+defaults:
+  rate: 20
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: held_upstream_signal
+    signal_type: metrics
+    name: held_upstream_signal
+    generator:
+      type: sequence
+      values: [1.0, 1.0, 1.0, 0.0]
+      repeat: false
+"#;
+
+const HELD_DOWNSTREAM_YAML: &str = r#"
+version: 2
+kind: runnable
+scenario_name: held_downstream_xpost
+defaults:
+  rate: 50
+  duration: 30s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: held_downstream_metric
+    signal_type: metrics
+    name: held_downstream_metric
+    generator:
+      type: constant
+      value: 42.0
+    while:
+      ref: held_upstream_signal
+      op: '>'
+      value: 0
+      scenario_name: held_upstream_xpost
+    delay:
+      close:
+        duration: 0s
+        snap_to: 42
+"#;
+
+#[test]
+fn held_scenario_visible_via_include_state_held_and_excluded_by_running_filter() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let upstream = isfilter_post(&client, &base, HELD_UPSTREAM_YAML);
+    let upstream_id = upstream["id"].as_str().unwrap().to_string();
+    let downstream = isfilter_post(&client, &base, HELD_DOWNSTREAM_YAML);
+    let downstream_id = downstream["id"].as_str().unwrap().to_string();
+
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &downstream_id,
+        "running",
+        std::time::Duration::from_secs(3),
+    );
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &downstream_id,
+        "held",
+        std::time::Duration::from_secs(3),
+    );
+
+    let body_held = isfilter_scrape(&client, &base, "include_state=held");
+    assert!(
+        body_held.contains("held_downstream_metric"),
+        "?include_state=held must include the held scenario's frozen sample; body=\n{body_held}"
+    );
+
+    let body_running = isfilter_scrape(&client, &base, "include_state=running,unresolved");
+    assert!(
+        !body_running.contains("held_downstream_metric"),
+        "?include_state=running,unresolved must exclude the held scenario (regression pin); body=\n{body_running}"
+    );
+
+    let _ = client
+        .delete(format!("{base}/scenarios/{downstream_id}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{upstream_id}"))
+        .send();
+}
+
+#[test]
+fn post_with_existing_held_scenario_name_returns_409_with_held_in_conflicts() {
+    let (port, _guard) = common::start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = common::http_client();
+
+    let upstream = isfilter_post(&client, &base, HELD_UPSTREAM_YAML);
+    let upstream_id = upstream["id"].as_str().unwrap().to_string();
+    let downstream = isfilter_post(&client, &base, HELD_DOWNSTREAM_YAML);
+    let downstream_id = downstream["id"].as_str().unwrap().to_string();
+
+    isfilter_wait_for_state(
+        &client,
+        &base,
+        &downstream_id,
+        "held",
+        std::time::Duration::from_secs(4),
+    );
+
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(HELD_DOWNSTREAM_YAML)
+        .send()
+        .expect("re-POST must succeed at HTTP level");
+    assert_eq!(
+        resp.status().as_u16(),
+        409,
+        "re-POST of a held scenario_name must conflict"
+    );
+    let body: serde_json::Value = resp.json().expect("409 body must be JSON");
+    let conflicts = body["conflicting_scenarios"]
+        .as_array()
+        .expect("conflicting_scenarios array");
+    assert!(
+        conflicts
+            .iter()
+            .any(|c| c["state"].as_str() == Some("held")),
+        "the held scenario must appear with state='held' in conflicts; got: {body}"
+    );
+
+    let _ = client
+        .delete(format!("{base}/scenarios/{downstream_id}"))
+        .send();
+    let _ = client
+        .delete(format!("{base}/scenarios/{upstream_id}"))
         .send();
 }


### PR DESCRIPTION
## Summary

Closes the pull-path half of the counter freeze-and-hold use case. A \`while:\`-gated scenario with \`delay.close.snap_to: Some(_)\` that has emitted at least one sample now transitions to a new \`Held\` state (instead of \`Paused\`) when its gate closes.

## What changed

- \`ScenarioState::Held\` variant added on the re-exported \`sonda-core\` enum (the enum is \`#[non_exhaustive]\` so the addition is backwards-compatible for downstream library consumers).
- State machine in \`core_loop\` routes Running → Held at the gate-close edge when \`holds_on_close\` is true AND \`current_values\` is non-empty; otherwise routes Running → Paused as before. Held behaves identically to Paused as a state body (gate reopen → Running, duration/shutdown/upstream-gone → Finished).
- \`GateContext\` gains a new \`holds_on_close: bool\` field + \`with_holds_on_close(self)\` builder setter (the \`#[non_exhaustive]\` consuming-builder pattern from earlier work).
- \`get_aggregate_metrics\` accepts \`?include_state=held\` (or any allowlist containing it). Default behavior unchanged — \`?include_state=running,unresolved\` (today's cascade-replaces-baseline scrape) continues to exclude Held.
- \`collect_active_conflicts\` blocks Held alongside other active states; a re-POST of a Held scenario_name returns 409 with the Held entry in \`conflicting_scenarios\`.
- Docs: new Pattern C — Counter freeze-and-hold during outage subsection alongside Patterns A and B; comparison block extended to three rows; \`?include_state=\` enumeration updated; subtle wire-change callout present.
- Pull-path only — push sinks (remote_write, kafka, otlp, loki, http, tcp, udp, stdout, file) remain silent during Held. Push-path continuous emission is tracked separately in #439.

## Subtle wire change to be aware of

A scenario with \`snap_to\` set that previously reported \`state: "paused"\` after gate close now reports \`state: "held"\`. Any client filtering specifically on \`?include_state=paused\` to find those scenarios should switch to \`?include_state=held\`. Risk is near-zero — \`?include_state=\` shipped 3 days ago (PR #435).

## Test plan

- [x] \`cargo nextest run --workspace --all-features\` — 2859/2859 pass (baseline 2850; +9 tests: 7 unit + 2 E2E)
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo test --workspace --doc\` — clean
- [x] \`cargo test -p sonda-core --no-default-features --no-run\` — clean
- [x] \`cargo audit\` — clean (pre-existing yanked \`core2\` advisory, unchanged)
- [x] \`task site:build --strict\` — clean
- [x] E2E asserts state transitions Running → Held (not Paused) for a snap_to scenario on cross-POST gate close
- [x] Backwards-compat regression asserts \`?include_state=running,unresolved\` excludes the Held scenario

Closes #429's deferred follow-up for counter freeze-and-hold semantics on the pull path. Refs: #439 for the push-path follow-up.