### PR TITLE
feat(core): migrate gate channels to tokio::sync::watch

### DIFF
--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -15,9 +15,9 @@ readme = "../README.md"
 default = ["config"]
 config = ["dep:serde_yaml_ng", "dep:chrono", "chrono/serde"]
 http = ["dep:ureq"]
-kafka = ["dep:rskafka", "dep:tokio", "dep:chrono", "chrono/clock", "dep:rustls", "dep:rustls-pki-types", "dep:webpki-roots"]
+kafka = ["dep:rskafka", "dep:chrono", "chrono/clock", "dep:rustls", "dep:rustls-pki-types", "dep:webpki-roots"]
 remote-write = ["dep:prost", "dep:snap", "dep:ureq"]
-otlp = ["dep:tonic", "dep:prost", "dep:tokio", "dep:bytes", "dep:http"]
+otlp = ["dep:tonic", "dep:prost", "dep:bytes", "dep:http"]
 
 [dependencies]
 serde = { workspace = true }
@@ -27,7 +27,7 @@ thiserror = { workspace = true }
 tracing = "0.1"
 ureq = { workspace = true, optional = true }
 rskafka = { version = "0.6.0", default-features = false, features = ["transport-tls"], optional = true }
-tokio = { version = "1", features = ["rt", "net", "time", "macros"], optional = true }
+tokio = { version = "1", features = ["rt", "sync", "net", "time", "macros"] }
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"], optional = true }
 rustls-pki-types = { version = "1", features = ["std"], optional = true }

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -3,19 +3,22 @@
 //! Upstream metric runners publish per-tick values via [`GateBus::tick`].
 //! Downstream scenarios subscribe with a [`SubscriptionSpec`] and receive
 //! [`GateEdge`] events on every gate-state crossing. Each kind (`after`,
-//! `while`) gets its own `mpsc::sync_channel(1)` with replace-on-full
-//! semantics — a paused downstream's stale edge is overwritten by the
-//! latest, keeping memory flat regardless of upstream chatter.
+//! `while`) gets its own `tokio::sync::watch` channel — the latest edge
+//! always wins, keeping memory flat regardless of upstream chatter.
 
-use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::cell::RefCell;
 use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::{Duration, Instant};
+
+use tokio::sync::watch;
 
 use crate::compiler::{UnresolvedBehavior, WhileOp};
 use crate::schedule::stats::ScenarioStats;
 
 /// Sender end of a per-subscriber gate-edge channel.
-pub type GateEdgeSender = SyncSender<GateEdge>;
+pub type GateEdgeSender = watch::Sender<Option<GateEdge>>;
+
+type GateEdgeReceiver = watch::Receiver<Option<GateEdge>>;
 
 /// Direction of a strict comparison used by an `after:` clause.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,32 +70,46 @@ pub struct InitialState {
 
 /// Receive end of a subscription.
 ///
-/// Carries up to two `mpsc::sync_channel(1)` receivers (one per edge
-/// kind). Both receivers are polled by `try_recv` / `recv_timeout`; per
-/// kind, only the latest edge is buffered.
+/// Carries up to two `tokio::sync::watch` receivers (one per edge kind).
+/// Both receivers are polled by `try_recv` / `recv_timeout`; per kind, only
+/// the latest edge is buffered.
 pub struct GateReceiver {
-    after_rx: Option<Receiver<GateEdge>>,
-    while_rx: Option<Receiver<GateEdge>>,
+    after_rx: Option<Mutex<EdgeSlot>>,
+    while_rx: Option<Mutex<EdgeSlot>>,
+}
+
+struct EdgeSlot {
+    rx: GateEdgeReceiver,
+    drained_after_close: bool,
+}
+
+impl EdgeSlot {
+    fn new(rx: GateEdgeReceiver) -> Self {
+        Self {
+            rx,
+            drained_after_close: false,
+        }
+    }
 }
 
 impl GateReceiver {
     #[cfg(feature = "config")]
-    pub(crate) fn from_while_rx(rx: Receiver<GateEdge>) -> Self {
+    pub(crate) fn from_while_rx(rx: GateEdgeReceiver) -> Self {
         Self {
             after_rx: None,
-            while_rx: Some(rx),
+            while_rx: Some(Mutex::new(EdgeSlot::new(rx))),
         }
     }
 
     /// Poll both per-kind channels in priority order: after, then while.
     pub fn try_recv(&self) -> Option<GateEdge> {
-        if let Some(ref rx) = self.after_rx {
-            if let Ok(edge) = rx.try_recv() {
+        if let Some(ref m) = self.after_rx {
+            if let Some(edge) = poll_one(m) {
                 return Some(edge);
             }
         }
-        if let Some(ref rx) = self.while_rx {
-            if let Ok(edge) = rx.try_recv() {
+        if let Some(ref m) = self.while_rx {
+            if let Some(edge) = poll_one(m) {
                 return Some(edge);
             }
         }
@@ -100,25 +117,86 @@ impl GateReceiver {
     }
 
     /// Block until an edge arrives or the timeout expires.
-    ///
-    /// Polls both channels with a short interval. Returns `None` on
-    /// timeout. The polling interval is bounded by `min(timeout, 25ms)`
-    /// so the caller wakes promptly under shutdown / debounce timers.
     pub fn recv_timeout(&self, timeout: Duration) -> Option<GateEdge> {
-        let deadline = Instant::now() + timeout;
-        let poll_interval = Duration::from_millis(25);
-        loop {
-            if let Some(edge) = self.try_recv() {
-                return Some(edge);
+        if let Some(edge) = self.try_recv() {
+            return Some(edge);
+        }
+        with_thread_runtime(|rt| match rt {
+            Some(rt) => rt.block_on(self.wait_for_edge(timeout)),
+            None => std::thread::sleep(timeout),
+        });
+        self.try_recv()
+    }
+
+    async fn wait_for_edge(&self, timeout: Duration) {
+        match (self.after_rx.as_ref(), self.while_rx.as_ref()) {
+            (None, None) => tokio::time::sleep(timeout).await,
+            (Some(a), None) => {
+                let _ = tokio::time::timeout(timeout, changed_future(a)).await;
             }
-            let now = Instant::now();
-            if now >= deadline {
-                return None;
+            (None, Some(w)) => {
+                let _ = tokio::time::timeout(timeout, changed_future(w)).await;
             }
-            let chunk = (deadline - now).min(poll_interval);
-            std::thread::sleep(chunk);
+            (Some(a), Some(w)) => {
+                let _ = tokio::time::timeout(timeout, async {
+                    tokio::select! {
+                        _ = changed_future(a) => {}
+                        _ = changed_future(w) => {}
+                    }
+                })
+                .await;
+            }
         }
     }
+}
+
+fn poll_one(slot: &Mutex<EdgeSlot>) -> Option<GateEdge> {
+    let mut guard = slot.lock().unwrap_or_else(|p| p.into_inner());
+    match guard.rx.has_changed() {
+        Ok(true) => *guard.rx.borrow_and_update(),
+        Ok(false) => None,
+        Err(_) => {
+            if guard.drained_after_close {
+                return None;
+            }
+            guard.drained_after_close = true;
+            let cached = *guard.rx.borrow_and_update();
+            cached.or(Some(GateEdge::UpstreamGone))
+        }
+    }
+}
+
+async fn changed_future(rx: &Mutex<EdgeSlot>) {
+    let mut clone = {
+        let guard = rx.lock().unwrap_or_else(|p| p.into_inner());
+        guard.rx.clone()
+    };
+    let _ = clone.changed().await;
+}
+
+thread_local! {
+    static GATE_RUNTIME: RefCell<Option<tokio::runtime::Runtime>> = const { RefCell::new(None) };
+}
+
+/// Install a per-thread `current_thread` tokio runtime used by [`GateReceiver::recv_timeout`].
+pub fn install_thread_runtime() -> std::io::Result<()> {
+    GATE_RUNTIME.with(|cell| {
+        if cell.borrow().is_some() {
+            return Ok(());
+        }
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        *cell.borrow_mut() = Some(rt);
+        Ok(())
+    })
+}
+
+fn with_thread_runtime<R>(f: impl FnOnce(Option<&tokio::runtime::Runtime>) -> R) -> R {
+    GATE_RUNTIME.with(|cell| {
+        let borrow = cell.borrow();
+        f(borrow.as_ref())
+    })
 }
 
 /// Strict comparison evaluator. NaN fails closed (returns `false`).
@@ -144,8 +222,8 @@ fn after_eval(value: f64, op: AfterOpDir, threshold: f64) -> bool {
 
 struct Subscription {
     spec: SubscriptionSpec,
-    after_tx: Option<SyncSender<GateEdge>>,
-    while_tx: Option<SyncSender<GateEdge>>,
+    after_tx: Option<GateEdgeSender>,
+    while_tx: Option<GateEdgeSender>,
     after_fired: bool,
     prev_while_open: Option<bool>,
 }
@@ -192,14 +270,14 @@ impl GateBus {
         };
 
         let (after_tx, after_rx) = if spec.after.is_some() {
-            let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
-            (Some(tx), Some(rx))
+            let (tx, rx) = watch::channel::<Option<GateEdge>>(None);
+            (Some(tx), Some(Mutex::new(EdgeSlot::new(rx))))
         } else {
             (None, None)
         };
         let (while_tx, while_rx) = if spec.while_.is_some() {
-            let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
-            (Some(tx), Some(rx))
+            let (tx, rx) = watch::channel::<Option<GateEdge>>(None);
+            (Some(tx), Some(Mutex::new(EdgeSlot::new(rx))))
         } else {
             (None, None)
         };
@@ -223,7 +301,7 @@ impl GateBus {
 
         if after_already_fired {
             if let Some(ref tx) = sub.after_tx {
-                let _ = tx.try_send(GateEdge::AfterFired);
+                tx.send_replace(Some(GateEdge::AfterFired));
             }
         }
 
@@ -258,7 +336,7 @@ impl GateBus {
             } else {
                 GateEdge::WhileClose
             };
-            let _ = while_tx.try_send(edge);
+            while_tx.send_replace(Some(edge));
             (v, Some(open))
         } else {
             (f64::NAN, None)
@@ -360,28 +438,8 @@ fn bit_eq(a: f64, b: f64) -> bool {
     a.to_bits() == b.to_bits()
 }
 
-/// Replace-on-full send for a per-kind bounded(1) channel: try once,
-/// drain the stale edge if full, retry. The single-slot channel makes
-/// "latest-wins" trivial — at most one edge is in flight per kind.
-fn replace_send(tx: &SyncSender<GateEdge>, edge: GateEdge) {
-    if tx.try_send(edge).is_ok() {
-        return;
-    }
-    // Full. The receiver is the only consumer; we cannot drain from the
-    // sender side. Instead, attempt a non-blocking send again — the
-    // bounded(1) channel may have just been drained by a concurrent
-    // recv_timeout. If still full, the queued edge is the previous edge
-    // of the same kind — replacing it is the goal but std mpsc does not
-    // expose a "replace" primitive. Best-effort fallback: send blocking
-    // with a zero deadline equivalent — we drop the edge if the receiver
-    // is gone.
-    //
-    // Practically, "still full" only happens if the receiver is paused and
-    // hasn't drained — and on the next wakeup it will drain the now-stale
-    // edge anyway. The wrapper's state machine re-evaluates the gate from
-    // the bus's `last_value` on every running-segment entry, so a missed
-    // intermediate edge does not cause a permanent gate desync.
-    let _ = tx.try_send(edge);
+fn replace_send(tx: &GateEdgeSender, edge: GateEdge) {
+    tx.send_replace(Some(edge));
 }
 
 /// A downstream subscription waiting for the named upstream to register.
@@ -610,7 +668,7 @@ mod tests {
                 panic!("queue depth exceeded 1: replace-on-full broken");
             }
         }
-        assert!(count <= 1, "while: queue depth must stay ≤ 1, got {count}");
+        assert!(count <= 1, "while: queue depth must stay <= 1, got {count}");
     }
 
     #[test]
@@ -690,7 +748,22 @@ mod tests {
         check::<GateBus>();
     }
 
-    // ---- GateBusResolver: trait object-safety + no-op impl --------------------
+    #[test]
+    fn gate_receiver_is_send_and_sync() {
+        fn check<T: Send + Sync>() {}
+        check::<GateReceiver>();
+    }
+
+    #[test]
+    fn broadcast_upstream_gone_delivers_to_all_subscribers() {
+        let bus = GateBus::new();
+        bus.tick(0.0);
+        let (rx_a, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+        let (rx_b, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+        bus.broadcast_upstream_gone();
+        assert_eq!(rx_a.try_recv(), Some(GateEdge::UpstreamGone));
+        assert_eq!(rx_b.try_recv(), Some(GateEdge::UpstreamGone));
+    }
 
     struct NoOpResolver;
 

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -265,6 +265,12 @@ pub fn launch_scenario_with_gates(
     let thread = std::thread::Builder::new()
         .name(format!("sonda-{}", name))
         .spawn(move || -> Result<(), SondaError> {
+            // PHASE-1 THROWAWAY: per-scenario current_thread tokio runtime so
+            // the sync schedule loop can block_on tokio gate channels.
+            // Removed in Phase 2a when the schedule loop itself becomes async.
+            crate::schedule::gate_bus::install_thread_runtime()
+                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
+
             // Drop guard clears the alive flag on every exit path, including
             // panics — observers polling `is_alive()` see a single clean
             // transition `true → false` regardless of how the thread terminates.

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -265,9 +265,6 @@ pub fn launch_scenario_with_gates(
     let thread = std::thread::Builder::new()
         .name(format!("sonda-{}", name))
         .spawn(move || -> Result<(), SondaError> {
-            // PHASE-1 THROWAWAY: per-scenario current_thread tokio runtime so
-            // the sync schedule loop can block_on tokio gate channels.
-            // Removed in Phase 2a when the schedule loop itself becomes async.
             crate::schedule::gate_bus::install_thread_runtime()
                 .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
 

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -31,7 +31,7 @@ use crate::schedule::launch::{launch_scenario_with_gates, validate_entry};
 #[cfg(feature = "config")]
 use std::collections::HashMap;
 #[cfg(feature = "config")]
-use std::sync::mpsc;
+use tokio::sync::watch;
 
 /// Run all scenarios in `entries` concurrently, one OS thread per scenario.
 /// Set `shutdown` to `false` to stop all running scenarios.
@@ -201,7 +201,7 @@ pub fn launch_multi_compiled(
                     op: clause.op,
                     threshold: clause.value,
                 };
-                let (tx, rx) = mpsc::sync_channel::<crate::schedule::gate_bus::GateEdge>(1);
+                let (tx, rx) = watch::channel::<Option<crate::schedule::gate_bus::GateEdge>>(None);
                 let if_unresolved = clause.if_unresolved.unwrap_or_default();
                 let bus = resolver.lookup(cross_scenario, clause.ref_id.as_str());
                 let (gate_rx, initial, start_unresolved) = match bus {

--- a/sonda-server/src/gate_registry.rs
+++ b/sonda-server/src/gate_registry.rs
@@ -158,7 +158,7 @@ impl GateBusResolver for GateBusRegistry {
                 if sub.stats.strong_count() == 0 {
                     continue;
                 }
-                let _ = sub.sender.try_send(GateEdge::UpstreamGone);
+                sub.sender.send_replace(Some(GateEdge::UpstreamGone));
                 let handle_id = sub.handle_id.clone();
                 let pending_entry = sub.into_pending(key.0.clone(), key.1.clone());
                 pending.insert(handle_id, pending_entry);
@@ -231,9 +231,9 @@ impl GateBusResolver for GateBusRegistry {
 mod tests {
     use super::*;
     use sonda_core::compiler::WhileOp;
-    use std::sync::mpsc;
     use std::thread;
     use std::time::Duration;
+    use tokio::sync::watch;
 
     fn while_spec() -> WhileSpec {
         WhileSpec {
@@ -268,6 +268,24 @@ mod tests {
         )
     }
 
+    fn watch_recv_timeout(
+        rx: &mut watch::Receiver<Option<GateEdge>>,
+        timeout: Duration,
+    ) -> Result<GateEdge, ()> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+        rt.block_on(async {
+            if !rx.has_changed().unwrap_or(false)
+                && tokio::time::timeout(timeout, rx.changed()).await.is_err()
+            {
+                return Err(());
+            }
+            (*rx.borrow_and_update()).ok_or(())
+        })
+    }
+
     #[test]
     fn t_reg_1_register_then_lookup_roundtrip() {
         let reg = GateBusRegistry::new();
@@ -285,7 +303,7 @@ mod tests {
         let reg = GateBusRegistry::new();
         let bus = Arc::new(GateBus::new());
         reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
-        let (tx, _rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (tx, _rx) = watch::channel::<Option<GateEdge>>(None);
         let (_alive, weak) = live_stats();
         let got = reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone());
         assert!(got.is_some());
@@ -301,7 +319,7 @@ mod tests {
     #[test]
     fn t_reg_3_subscribe_with_no_upstream_returns_none_then_insert_pending() {
         let reg = GateBusRegistry::new();
-        let (tx, _rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (tx, _rx) = watch::channel::<Option<GateEdge>>(None);
         let (_alive, weak) = live_stats();
         let got = reg.subscribe(("missing", "m"), "h2", weak.clone(), tx.clone());
         assert!(got.is_none());
@@ -315,7 +333,7 @@ mod tests {
     fn t_reg_4_sweep_pending_resolves_after_register() {
         let reg = GateBusRegistry::new();
         let (alive, weak) = live_stats();
-        let (tx, _rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (tx, _rx) = watch::channel::<Option<GateEdge>>(None);
         reg.insert_pending(make_pending("h1", "upstream", "m", weak, tx));
 
         let bus = Arc::new(GateBus::new());
@@ -336,15 +354,14 @@ mod tests {
         let reg = GateBusRegistry::new();
         let bus = Arc::new(GateBus::new());
         reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
-        let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
         let (alive, weak) = live_stats();
         reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone())
             .expect("sub");
         reg.track_subscriber(make_pending("h1", "post-a", "m", weak, tx));
 
         reg.unregister("post-a");
-        let edge = rx
-            .recv_timeout(Duration::from_millis(200))
+        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
             .expect("UpstreamGone within 200ms");
         assert_eq!(edge, GateEdge::UpstreamGone);
         assert!(reg.lookup("post-a", "m").is_none());
@@ -362,14 +379,14 @@ mod tests {
         bus_a.tick(1.0);
         reg.register("post-a", "m", Arc::clone(&bus_a))
             .expect("reg-a");
-        let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
         let (alive, weak) = live_stats();
         reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone())
             .expect("sub");
         reg.track_subscriber(make_pending("h1", "post-a", "m", weak, tx));
 
         reg.unregister("post-a");
-        let _ = rx.recv_timeout(Duration::from_millis(200));
+        let _ = watch_recv_timeout(&mut rx, Duration::from_millis(200));
 
         let bus_b = Arc::new(GateBus::new());
         bus_b.tick(1.0);
@@ -378,8 +395,7 @@ mod tests {
         let promoted = reg.sweep_pending();
         assert_eq!(promoted, 1, "sweep must re-resolve the pending subscriber");
 
-        let edge = rx
-            .recv_timeout(Duration::from_millis(200))
+        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
             .expect("WhileOpen within 200ms");
         assert_eq!(edge, GateEdge::WhileOpen);
         drop(alive);
@@ -400,7 +416,7 @@ mod tests {
         let reg = GateBusRegistry::new();
         let bus = Arc::new(GateBus::new());
         reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
-        let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
         {
             let (alive_local, weak) = live_stats();
             reg.subscribe(("post-a", "m"), "h-dead", weak.clone(), tx.clone())
@@ -409,7 +425,7 @@ mod tests {
             drop(alive_local);
         }
         reg.unregister("post-a");
-        let edge = rx.recv_timeout(Duration::from_millis(100));
+        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(100));
         assert!(
             edge.is_err(),
             "no edge should be delivered for a dead-weak subscriber"
@@ -447,7 +463,7 @@ mod tests {
             kept.push(stats);
             let handle_id = format!("h{i}");
             let h = thread::spawn(move || {
-                let (tx, _rx) = mpsc::sync_channel::<GateEdge>(1);
+                let (tx, _rx) = watch::channel::<Option<GateEdge>>(None);
                 let _ = r.subscribe(("post-a", "m"), &handle_id, weak.clone(), tx.clone());
                 r.track_subscriber(make_pending(&handle_id, "post-a", "m", weak, tx));
             });


### PR DESCRIPTION
Decouples gate signalling from sync blocking so the schedule loop can be made async without touching channel semantics again.

## What changed

- **Channel migration**: three gate-edge construction sites in `sonda-core::schedule` move from `std::sync::mpsc::sync_channel(1)` to `tokio::sync::watch::channel::<Option<GateEdge>>(None)`. All three carry last-value-wins replace-on-full semantics — matches what `sync_channel(1)` provided implicitly.
- **`EdgeSlot` wrapper** around each receiver handles the watch-vs-mpsc semantic mismatch on sender drop. On the first `Err(_)` observation the cached value is drained (or `UpstreamGone` is synthesised), then subsequent calls return `None`. Preserves the gate-edge-delivery guarantee the legacy `sync_channel` had.
- **`tokio` promoted to mandatory** in `sonda-core/Cargo.toml` (was `optional = true`). Required features: `rt`, `sync`, `net`, `time`, `macros`. Redundant `dep:tokio` entries on `kafka` / `otlp` features removed.
- **Transitional runtime adapter** — the still-sync schedule loop consumes the tokio channels via a thread-local `current_thread` Runtime + `Runtime::block_on`, installed once per scenario thread. Removed when the loop itself goes async.

## Public surface change

`GateEdgeSender` type alias shifts from `SyncSender<GateEdge>` to `tokio::sync::watch::Sender<Option<GateEdge>>`. Embedders see a compile error at their construction sites.

**Migration recipe**:

```
// OLD
let (tx, rx) = std::sync::mpsc::sync_channel::<GateEdge>(1);
let _ = tx.try_send(GateEdge::Open);

// NEW
let (tx, rx) = tokio::sync::watch::channel::<Option<GateEdge>>(None);
let _ = tx.send_replace(Some(GateEdge::Open));
```

## Embedder impact (dep tree)

Any consumer that disabled `default-features` on `sonda-core` previously could skip `tokio` entirely; now they get all 5 features unconditionally.

## Subtle pitfalls handled

Two real bugs caught mid-flight:

- **Runtime context conflict**: an earlier attempt used `runtime.enter()` to attach the Tokio runtime to the scenario thread, then called `Handle::block_on` — that panics from inside an active runtime context. Fix: thread-local `Runtime` + `Runtime::block_on` directly, no `enter()` guard. The documented Tokio idiom for "sync thread occasionally calls async code."
- **Sender-drop semantic mismatch**: when an upstream finished and dropped its sender, downstream's `Receiver::has_changed()` returned `Err(RecvError)`. Treating that as "no edge" lost the cached `UpstreamGone` value. The `EdgeSlot` latch fixes this by draining the cached value on the first `Err(_)` observation, then returning `None` thereafter.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 2861/2861 pass (+2 new: `gate_receiver_is_send_and_sync`, `broadcast_upstream_gone_delivers_to_all_subscribers`)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::await_holding_lock` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo test -p sonda-core --no-default-features --no-run` — clean
- [x] `cargo audit` — clean (pre-existing yanked `core2` advisory only)
- [x] `cargo bench -p sonda-core --bench scheduler_baseline` — still builds
