### PR TITLE
refactor(core): hoist sink writes out of TickFn into the dispatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,10 +1352,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "once_cell"
@@ -2232,6 +2260,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "snap",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2346,6 +2375,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.39.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -3040,6 +3083,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,6 +3114,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3079,6 +3154,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3180,6 +3265,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use crate::compiler::{DelayClause, UnresolvedBehavior};
 use crate::config::validate::StartTime;
 use crate::config::OnSinkError;
+use crate::model::log::LogEvent;
 use crate::model::metric::MetricEvent;
 use crate::schedule::gate_bus::{GateEdge, GateReceiver, InitialState};
 use crate::schedule::stats::{ScenarioState, ScenarioStats};
@@ -105,14 +106,31 @@ pub(crate) struct TickContext<'a> {
     pub wall_clock: SystemTime,
 }
 
-/// A per-tick callback that performs signal-specific work.
-///
-/// Called once per scheduled tick with the sink threaded as a parameter so
-/// that gated runs can additionally invoke a separate close-emit closure on
-/// the same sink without a borrow split. The `events_buf` is pre-cleared by
-/// the loop before each call; the callback pushes any emitted metric events
-/// into it so the loop can drain them into stats without per-tick allocation.
-pub(crate) type TickFn<'a> = dyn FnMut(&TickContext<'_>, &mut dyn Sink, &mut Vec<MetricEvent>) -> Result<TickResult, SondaError>
+/// A pending sink write produced by a tick callback.
+pub enum WriteCommand {
+    Bytes(Vec<u8>),
+    LogEvent { event: LogEvent, bytes: Vec<u8> },
+}
+
+/// Buffer of pending sink writes emitted by a tick callback.
+#[derive(Default)]
+pub struct TickOutput {
+    pub writes: Vec<WriteCommand>,
+}
+
+impl TickOutput {
+    pub fn clear(&mut self) {
+        self.writes.clear();
+    }
+}
+
+/// A per-tick callback that encodes events into `output`; the loop drains the
+/// queue to the sink. The `events_buf` is pre-cleared before each call.
+pub(crate) type TickFn<'a> = dyn FnMut(
+        &TickContext<'_>,
+        &mut TickOutput,
+        &mut Vec<MetricEvent>,
+    ) -> Result<TickResult, SondaError>
     + 'a;
 
 /// Scenario-level wall-clock anchor: the resolved emission-time base plus the
@@ -166,33 +184,11 @@ pub enum CloseSignal {
 }
 
 /// Per-scenario callback invoked on every committed `running → paused`
-/// transition. Logs/histograms/summaries pass `None`. The [`CloseSignal`]
-/// (StaleMarker vs SnapTo) is captured at build time, so the closure takes
-/// only the sink to write into.
-pub type CloseEmitFn = Box<dyn FnMut(&mut dyn Sink) -> Result<(), SondaError> + Send>;
+/// transition. Closures push markers into the supplied [`TickOutput`].
+pub type CloseEmitFn = Box<dyn FnMut(&mut TickOutput) -> Result<(), SondaError> + Send>;
 
-/// Run the shared schedule loop until duration expires or shutdown is signalled.
-///
-/// This function owns the entire rate-control loop: shutdown detection, duration
-/// checking, gap window sleeping, burst window effective interval, deadline-based
-/// sleep, and stats updating. The signal-specific work (event generation,
-/// encoding, sink writing) is delegated to `tick_fn`.
-///
-/// The caller is responsible for flushing the sink after this function returns.
-/// This design avoids a double-borrow conflict: the tick closure already holds
-/// `&mut sink` for per-tick writes, so the loop cannot also own it for flushing.
-///
-/// # Parameters
-///
-/// * `schedule` — the parsed schedule configuration (duration, windows).
-/// * `rate` — target events per second.
-/// * `shutdown` — optional atomic flag; when cleared the loop exits cleanly.
-/// * `stats` — optional shared stats for live telemetry.
-/// * `tick_fn` — per-tick callback for signal-specific work.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if the tick callback fails.
+/// Run the shared schedule loop until duration expires or shutdown is
+/// signalled, then flush the sink and apply the sink-error policy.
 pub(crate) fn run_schedule_loop(
     schedule: &ParsedSchedule,
     rate: f64,
@@ -201,9 +197,26 @@ pub(crate) fn run_schedule_loop(
     sink: &mut dyn Sink,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<(), SondaError> {
-    run_schedule_loop_with_initial_tick(
+    let stats_for_flush = stats.clone();
+    let loop_result = run_schedule_loop_with_initial_tick(
         schedule, rate, shutdown, stats, 0, None, None, sink, tick_fn,
-    )
+    );
+    finalize_sink(schedule, stats_for_flush.as_ref(), sink, loop_result)
+}
+
+fn finalize_sink(
+    schedule: &ParsedSchedule,
+    stats: Option<&Arc<RwLock<ScenarioStats>>>,
+    sink: &mut dyn Sink,
+    loop_result: Result<(), SondaError>,
+) -> Result<(), SondaError> {
+    match loop_result {
+        Ok(()) => {
+            let flush_result = sink.flush();
+            apply_flush_policy(schedule, stats, flush_result)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// Run the schedule loop starting from `initial_tick`, optionally reporting the
@@ -241,6 +254,9 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
     // Sized to cover typical histogram (10 buckets + 3) and summary
     // (~6 quantiles + 2) without reallocating.
     let mut events_buf: Vec<MetricEvent> = Vec::with_capacity(16);
+    let mut tick_output = TickOutput {
+        writes: Vec::with_capacity(16),
+    };
 
     loop {
         // Check shutdown flag first — highest priority exit path.
@@ -319,7 +335,21 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
             wall_clock: wall.wall_at(start, elapsed),
         };
         events_buf.clear();
-        let tick_outcome = tick_fn(&ctx, sink, &mut events_buf);
+        tick_output.clear();
+        let tick_outcome = match tick_fn(&ctx, &mut tick_output, &mut events_buf) {
+            Ok(mut result) => match drain_writes(&mut tick_output, sink) {
+                Ok(Some(delivered)) => {
+                    result.delivered = delivered;
+                    Ok(result)
+                }
+                Ok(None) => Ok(result),
+                Err(e) => Err(e),
+            },
+            Err(e) => {
+                tick_output.clear();
+                Err(e)
+            }
+        };
 
         // Determine spike state for stats (check all spike windows).
         let currently_in_spike = schedule
@@ -399,6 +429,18 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
         out.store(tick, Ordering::SeqCst);
     }
     Ok(())
+}
+
+fn drain_writes(output: &mut TickOutput, sink: &mut dyn Sink) -> Result<Option<bool>, SondaError> {
+    let mut delivered: Option<bool> = None;
+    for cmd in output.writes.drain(..) {
+        match cmd {
+            WriteCommand::Bytes(buf) => sink.write(&buf)?,
+            WriteCommand::LogEvent { event, bytes } => sink.write_log_event(&event, &bytes)?,
+        }
+        delivered = Some(sink.last_write_delivered());
+    }
+    Ok(delivered)
 }
 
 /// Apply the scenario's sink-error policy to a flush call made at scenario
@@ -489,11 +531,17 @@ fn invoke_close_emit(
     let Some(emit) = close_emit else {
         return Ok(());
     };
-    if let Err(e) = emit(sink) {
-        apply_close_emit_policy(schedule, stats, limiter, e)?;
-    } else {
-        let flush = sink.flush();
-        apply_close_emit_policy_flush(schedule, stats, limiter, flush)?;
+    let mut output = TickOutput::default();
+    let outcome = emit(&mut output).and_then(|()| {
+        drain_writes(&mut output, sink)?;
+        Ok(())
+    });
+    match outcome {
+        Ok(()) => {
+            let flush = sink.flush();
+            apply_close_emit_policy_flush(schedule, stats, limiter, flush)?;
+        }
+        Err(e) => apply_close_emit_policy(schedule, stats, limiter, e)?,
     }
     Ok(())
 }
@@ -607,7 +655,8 @@ pub(crate) fn gated_loop(
 ) -> Result<(), SondaError> {
     let mut close_warn_limiter = SinkErrorRateLimiter::new();
 
-    let body_result = run_on_thread_runtime(gated_loop_body(
+    let stats_for_flush = stats.clone();
+    let gated_result = run_on_thread_runtime(gated_loop_body(
         schedule,
         rate,
         shutdown,
@@ -616,30 +665,9 @@ pub(crate) fn gated_loop(
         &mut close_warn_limiter,
         sink,
         tick_fn,
-    ))?;
-
-    match body_result {
-        Ok(LoopExit::Shutdown) => {
-            invoke_close_emit(
-                schedule,
-                stats.as_ref(),
-                &mut close_warn_limiter,
-                gate_ctx.close_emit.as_mut(),
-                sink,
-            )?;
-            finish(stats)
-        }
-        Ok(LoopExit::DurationExpired) => {
-            invoke_close_emit(
-                schedule,
-                stats.as_ref(),
-                &mut close_warn_limiter,
-                gate_ctx.close_emit.as_mut(),
-                sink,
-            )?;
-            finish(stats)
-        }
-        Ok(LoopExit::UpstreamFinished) => {
+    ))
+    .and_then(|body_result| match body_result {
+        Ok(LoopExit::Shutdown | LoopExit::DurationExpired | LoopExit::UpstreamFinished) => {
             invoke_close_emit(
                 schedule,
                 stats.as_ref(),
@@ -650,7 +678,9 @@ pub(crate) fn gated_loop(
             finish(stats)
         }
         Err(e) => Err(e),
-    }
+    });
+
+    finalize_sink(schedule, stats_for_flush.as_ref(), sink, gated_result)
 }
 
 fn run_on_thread_runtime<F: std::future::Future>(fut: F) -> Result<F::Output, SondaError> {
@@ -1147,17 +1177,17 @@ fn run_running_segment(
     type WrappedTick<'a> = Box<
         dyn FnMut(
                 &TickContext<'_>,
-                &mut dyn Sink,
+                &mut TickOutput,
                 &mut Vec<MetricEvent>,
             ) -> Result<TickResult, SondaError>
             + 'a,
     >;
     let mut wrapped: WrappedTick<'_> = Box::new(
         move |ctx: &TickContext<'_>,
-              s: &mut dyn Sink,
+              output: &mut TickOutput,
               events_buf: &mut Vec<MetricEvent>|
               -> Result<TickResult, SondaError> {
-            let outcome = tick_fn(ctx, s, events_buf);
+            let outcome = tick_fn(ctx, output, events_buf);
 
             // Poll for gate edges after the tick. On WhileClose, break out.
             while let Some(edge) = gate_rx.try_recv() {
@@ -1316,6 +1346,68 @@ mod tests {
         }
     }
 
+    struct CapturingSink {
+        writes: Vec<Vec<u8>>,
+        fail_at: Option<usize>,
+    }
+    impl Sink for CapturingSink {
+        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+            if let Some(n) = self.fail_at {
+                if self.writes.len() == n {
+                    return Err(SondaError::Sink(std::io::Error::other(
+                        "capturing sink test failure",
+                    )));
+                }
+            }
+            self.writes.push(data.to_vec());
+            Ok(())
+        }
+        fn flush(&mut self) -> Result<(), SondaError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn drain_writes_preserves_command_order() {
+        let mut sink = CapturingSink {
+            writes: Vec::new(),
+            fail_at: None,
+        };
+        let mut output = TickOutput::default();
+        output.writes.push(WriteCommand::Bytes(b"first".to_vec()));
+        output.writes.push(WriteCommand::Bytes(b"second".to_vec()));
+        output.writes.push(WriteCommand::Bytes(b"third".to_vec()));
+        let delivered = drain_writes(&mut output, &mut sink).expect("drain must succeed");
+        assert_eq!(
+            sink.writes,
+            vec![b"first".to_vec(), b"second".to_vec(), b"third".to_vec()]
+        );
+        assert!(output.writes.is_empty(), "queue must be empty after drain");
+        assert_eq!(delivered, Some(true));
+    }
+
+    #[test]
+    fn drain_writes_short_circuits_on_sink_error() {
+        let mut sink = CapturingSink {
+            writes: Vec::new(),
+            fail_at: Some(1),
+        };
+        let mut output = TickOutput::default();
+        output.writes.push(WriteCommand::Bytes(b"first".to_vec()));
+        output.writes.push(WriteCommand::Bytes(b"second".to_vec()));
+        output.writes.push(WriteCommand::Bytes(b"third".to_vec()));
+        let result = drain_writes(&mut output, &mut sink);
+        assert!(
+            result.is_err(),
+            "sink error must propagate from drain_writes"
+        );
+        assert_eq!(
+            sink.writes,
+            vec![b"first".to_vec()],
+            "only writes before the error must reach the sink"
+        );
+    }
+
     #[test]
     fn loop_exit_variants_are_exhaustive_for_clean_exits() {
         fn assert_clean_exit_match(le: LoopExit) {
@@ -1353,7 +1445,7 @@ mod tests {
 
         let mut event_count: u64 = 0;
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             event_count += 1;
@@ -1402,7 +1494,7 @@ mod tests {
         });
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             event_count += 1;
@@ -1451,7 +1543,7 @@ mod tests {
 
         let mut event_count: u64 = 0;
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             event_count += 1;
@@ -1493,7 +1585,7 @@ mod tests {
 
         let mut event_count: u64 = 0;
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             event_count += 1;
@@ -1522,7 +1614,7 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Ok(TickResult {
@@ -1565,7 +1657,7 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             let event = MetricEvent::new("test".to_string(), 1.0, Labels::default())
@@ -1623,7 +1715,7 @@ mod tests {
 
         let mut saw_spike_windows = false;
         let mut tick_fn = |ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             if !ctx.spike_windows.is_empty() {
@@ -1651,7 +1743,7 @@ mod tests {
         let schedule = minimal_schedule(Some(Duration::from_secs(10)));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Err(SondaError::Encoder(crate::EncoderError::NotSupported(
@@ -1673,7 +1765,7 @@ mod tests {
         schedule.on_sink_error = OnSinkError::Fail;
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Err(SondaError::Sink(std::io::Error::other("test error")))
@@ -1694,7 +1786,7 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Err(SondaError::Sink(std::io::Error::new(
@@ -1747,7 +1839,7 @@ mod tests {
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Err(SondaError::Sink(std::io::Error::other("transient")))
@@ -1767,7 +1859,7 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Err(SondaError::Sink(std::io::Error::new(
@@ -1810,7 +1902,7 @@ mod tests {
         let mut counter: u64 = 0;
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             counter += 1;
@@ -1851,7 +1943,7 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Ok(TickResult {
@@ -1895,7 +1987,7 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Ok(TickResult {
@@ -1972,7 +2064,7 @@ mod tests {
         let mut schedule = minimal_schedule(Some(Duration::from_millis(150)));
         schedule.on_sink_error = policy;
 
-        let mut tick_fn = |_ctx: &TickContext<'_>, _sink: &mut dyn Sink, _events_buf: &mut Vec<MetricEvent>| -> Result<TickResult, SondaError> {
+        let mut tick_fn = |_ctx: &TickContext<'_>, _output: &mut TickOutput, _events_buf: &mut Vec<MetricEvent>| -> Result<TickResult, SondaError> {
             match err_kind {
                 ErrKind::Sink => Err(SondaError::Sink(std::io::Error::other(
                     "matrix",
@@ -2055,7 +2147,7 @@ mod tests {
         let observed_first = std::sync::Mutex::new(None::<u64>);
 
         let mut tick_fn = |ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             let mut g = observed_first.lock().unwrap();
@@ -2094,7 +2186,7 @@ mod tests {
         let last_tick = AtomicU64::new(0);
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Ok(TickResult {
@@ -2144,7 +2236,7 @@ mod tests {
         let first_ptr: Cell<Option<usize>> = Cell::new(None);
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             let event =

--- a/sonda-core/src/schedule/histogram_runner.rs
+++ b/sonda-core/src/schedule/histogram_runner.rs
@@ -22,7 +22,9 @@ use crate::config::HistogramScenarioConfig;
 use crate::encoder::create_encoder;
 use crate::generator::histogram::{to_distribution, HistogramGenerator, DEFAULT_HISTOGRAM_BUCKETS};
 use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
-use crate::schedule::core_loop::{self, GateContext, TickContext, TickResult};
+use crate::schedule::core_loop::{
+    self, GateContext, TickContext, TickOutput, TickResult, WriteCommand,
+};
 use crate::schedule::is_in_spike;
 use crate::schedule::stats::ScenarioStats;
 use crate::schedule::ParsedSchedule;
@@ -149,7 +151,7 @@ pub fn run_with_sink_gated(
     let mut buf: Vec<u8> = Vec::with_capacity(1024);
 
     let mut tick_fn = |ctx: &TickContext<'_>,
-                       sink: &mut dyn Sink,
+                       output: &mut TickOutput,
                        events_buf: &mut Vec<MetricEvent>|
      -> Result<TickResult, SondaError> {
         let wall_now = ctx.wall_clock;
@@ -189,7 +191,9 @@ pub fn run_with_sink_gated(
             buf.clear();
             encoder.encode_metric(&event, &mut buf)?;
             total_bytes += buf.len() as u64;
-            sink.write(&buf)?;
+            output
+                .writes
+                .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
             events_buf.push(event);
         }
 
@@ -217,7 +221,9 @@ pub fn run_with_sink_gated(
             buf.clear();
             encoder.encode_metric(&event, &mut buf)?;
             total_bytes += buf.len() as u64;
-            sink.write(&buf)?;
+            output
+                .writes
+                .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
             events_buf.push(event);
         }
 
@@ -245,7 +251,9 @@ pub fn run_with_sink_gated(
         buf.clear();
         encoder.encode_metric(&sum_event, &mut buf)?;
         total_bytes += buf.len() as u64;
-        sink.write(&buf)?;
+        output
+            .writes
+            .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
         events_buf.push(sum_event);
 
         let count_event = MetricEvent::from_parts(
@@ -257,19 +265,18 @@ pub fn run_with_sink_gated(
         buf.clear();
         encoder.encode_metric(&count_event, &mut buf)?;
         total_bytes += buf.len() as u64;
-        sink.write(&buf)?;
+        output
+            .writes
+            .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
         events_buf.push(count_event);
-
-        let delivered = sink.last_write_delivered();
 
         Ok(TickResult {
             bytes_written: total_bytes,
-            delivered,
+            delivered: true,
         })
     };
 
-    let stats_for_flush = stats.clone();
-    let loop_result = match gate_ctx {
+    match gate_ctx {
         None => core_loop::run_schedule_loop(
             &schedule,
             config.rate,
@@ -287,12 +294,6 @@ pub fn run_with_sink_gated(
             sink,
             &mut tick_fn,
         ),
-    };
-
-    let flush_result = sink.flush();
-    match loop_result {
-        Ok(()) => core_loop::apply_flush_policy(&schedule, stats_for_flush.as_ref(), flush_result),
-        Err(e) => Err(e),
     }
 }
 

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -13,7 +13,9 @@ use crate::config::LogScenarioConfig;
 use crate::encoder::create_encoder;
 use crate::generator::create_log_generator;
 use crate::model::metric::{Labels, MetricEvent};
-use crate::schedule::core_loop::{self, GateContext, TickContext, TickResult};
+use crate::schedule::core_loop::{
+    self, GateContext, TickContext, TickOutput, TickResult, WriteCommand,
+};
 use crate::schedule::is_in_spike;
 use crate::schedule::stats::ScenarioStats;
 use crate::schedule::ParsedSchedule;
@@ -105,7 +107,7 @@ pub fn run_logs_with_sink_gated(
     let mut buf: Vec<u8> = Vec::with_capacity(512);
 
     let mut tick_fn = |ctx: &TickContext<'_>,
-                       sink: &mut dyn Sink,
+                       output: &mut TickOutput,
                        _events_buf: &mut Vec<MetricEvent>|
      -> Result<TickResult, SondaError> {
         let mut event = generator.generate(ctx.tick);
@@ -130,17 +132,18 @@ pub fn run_logs_with_sink_gated(
         buf.clear();
         encoder.encode_log(&event, &mut buf)?;
         let bytes_written = buf.len() as u64;
-        sink.write_log_event(&event, &buf)?;
-        let delivered = sink.last_write_delivered();
+        output.writes.push(WriteCommand::LogEvent {
+            event,
+            bytes: std::mem::take(&mut buf),
+        });
 
         Ok(TickResult {
             bytes_written,
-            delivered,
+            delivered: true,
         })
     };
 
-    let stats_for_flush = stats.clone();
-    let loop_result = match gate_ctx {
+    match gate_ctx {
         None => core_loop::run_schedule_loop(
             &schedule,
             config.rate,
@@ -158,12 +161,6 @@ pub fn run_logs_with_sink_gated(
             sink,
             &mut tick_fn,
         ),
-    };
-
-    let flush_result = sink.flush();
-    match loop_result {
-        Ok(()) => core_loop::apply_flush_policy(&schedule, stats_for_flush.as_ref(), flush_result),
-        Err(e) => Err(e),
     }
 }
 

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -16,7 +16,7 @@ use crate::encoder::create_encoder;
 use crate::generator::create_generator;
 use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
 use crate::schedule::core_loop::{
-    self, CloseEmitFn, CloseSignal, GateContext, TickContext, TickResult,
+    self, CloseEmitFn, CloseSignal, GateContext, TickContext, TickOutput, TickResult, WriteCommand,
 };
 use crate::schedule::gate_bus::GateBus;
 use crate::schedule::is_in_spike;
@@ -117,7 +117,7 @@ pub fn run_with_sink_gated(
 
     let upstream_bus_for_tick = upstream_bus.clone();
     let mut tick_fn = |ctx: &TickContext<'_>,
-                       sink: &mut dyn Sink,
+                       output: &mut TickOutput,
                        events_buf: &mut Vec<MetricEvent>|
      -> Result<TickResult, SondaError> {
         let wall_now = ctx.wall_clock;
@@ -155,19 +155,19 @@ pub fn run_with_sink_gated(
         buf.clear();
         encoder.encode_metric(&event, &mut buf)?;
         let bytes_written = buf.len() as u64;
-        sink.write(&buf)?;
-        let delivered = sink.last_write_delivered();
+        output
+            .writes
+            .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
 
         events_buf.push(event);
 
         Ok(TickResult {
             bytes_written,
-            delivered,
+            delivered: true,
         })
     };
 
-    let stats_for_flush = stats.clone();
-    let loop_result = match gate_ctx {
+    match gate_ctx {
         None => core_loop::run_schedule_loop(
             &schedule,
             config.rate,
@@ -194,12 +194,6 @@ pub fn run_with_sink_gated(
                 &mut tick_fn,
             )
         }
-    };
-
-    let flush_result = sink.flush();
-    match loop_result {
-        Ok(()) => core_loop::apply_flush_policy(&schedule, stats_for_flush.as_ref(), flush_result),
-        Err(e) => Err(e),
     }
 }
 
@@ -254,7 +248,8 @@ fn make_close_emitter(
         CloseSignal::SnapTo(v) => v,
     };
 
-    Box::new(move |sink: &mut dyn Sink| -> Result<(), SondaError> {
+    let mut buf: Vec<u8> = Vec::with_capacity(256);
+    Box::new(move |output: &mut TickOutput| -> Result<(), SondaError> {
         let (series, watermark) = match stats.write() {
             Ok(mut st) => st.drain_close_emit_series(),
             Err(p) => p.into_inner().drain_close_emit_series(),
@@ -270,12 +265,13 @@ fn make_close_emitter(
             None => SystemTime::now(),
         };
 
-        let mut buf: Vec<u8> = Vec::with_capacity(256);
         for (name, labels) in series {
             buf.clear();
             let marker = MetricEvent::from_parts(name, value, labels, close_ts);
             encoder.encode_metric(&marker, &mut buf)?;
-            sink.write(&buf)?;
+            output
+                .writes
+                .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
         }
         Ok(())
     })
@@ -1220,6 +1216,24 @@ mod tests {
         }
     }
 
+    fn drain_emit_to_memory(
+        emit: &mut crate::schedule::core_loop::CloseEmitFn,
+        dest: &mut crate::sink::memory::MemorySink,
+    ) {
+        use crate::schedule::core_loop::{TickOutput, WriteCommand};
+        use crate::sink::Sink as SinkTrait;
+        let mut output = TickOutput::default();
+        emit(&mut output).expect("close-emit must succeed");
+        for cmd in output.writes.drain(..) {
+            match cmd {
+                WriteCommand::Bytes(buf) => SinkTrait::write(dest, &buf).expect("memory write ok"),
+                WriteCommand::LogEvent { event, bytes } => {
+                    SinkTrait::write_log_event(dest, &event, &bytes).expect("memory log write ok")
+                }
+            }
+        }
+    }
+
     #[test]
     fn close_emitter_is_idempotent_after_draining_series() {
         use crate::encoder::create_encoder;
@@ -1249,7 +1263,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut first = MemorySink::new();
-        emit(&mut first).expect("first call ok");
+        drain_emit_to_memory(&mut emit, &mut first);
         assert!(
             !first.buffer.is_empty(),
             "first invocation must emit the tracked series"
@@ -1267,7 +1281,7 @@ mod tests {
         }
 
         let mut second = MemorySink::new();
-        emit(&mut second).expect("second call ok");
+        drain_emit_to_memory(&mut emit, &mut second);
         assert!(
             second.buffer.is_empty(),
             "second invocation with no new series must emit nothing"
@@ -1307,7 +1321,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut sink = MemorySink::new();
-        emit(&mut sink).expect("close-emit must succeed");
+        drain_emit_to_memory(&mut emit, &mut sink);
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().filter(|l| !l.is_empty()).collect();
@@ -1368,7 +1382,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut sink = MemorySink::new();
-        emit(&mut sink).expect("close-emit must succeed");
+        drain_emit_to_memory(&mut emit, &mut sink);
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines = output.lines().filter(|l| !l.is_empty()).count();
@@ -1406,7 +1420,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut sink = MemorySink::new();
-        emit(&mut sink).expect("close-emit must succeed");
+        drain_emit_to_memory(&mut emit, &mut sink);
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines = output.lines().filter(|l| !l.is_empty()).count();

--- a/sonda-core/src/schedule/summary_runner.rs
+++ b/sonda-core/src/schedule/summary_runner.rs
@@ -22,7 +22,9 @@ use crate::encoder::create_encoder;
 use crate::generator::histogram::to_distribution;
 use crate::generator::summary::{SummaryGenerator, DEFAULT_SUMMARY_QUANTILES};
 use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
-use crate::schedule::core_loop::{self, GateContext, TickContext, TickResult};
+use crate::schedule::core_loop::{
+    self, GateContext, TickContext, TickOutput, TickResult, WriteCommand,
+};
 use crate::schedule::is_in_spike;
 use crate::schedule::stats::ScenarioStats;
 use crate::schedule::ParsedSchedule;
@@ -144,7 +146,7 @@ pub fn run_with_sink_gated(
     let mut buf: Vec<u8> = Vec::with_capacity(1024);
 
     let mut tick_fn = |ctx: &TickContext<'_>,
-                       sink: &mut dyn Sink,
+                       output: &mut TickOutput,
                        events_buf: &mut Vec<MetricEvent>|
      -> Result<TickResult, SondaError> {
         let wall_now = ctx.wall_clock;
@@ -180,7 +182,9 @@ pub fn run_with_sink_gated(
             buf.clear();
             encoder.encode_metric(&event, &mut buf)?;
             total_bytes += buf.len() as u64;
-            sink.write(&buf)?;
+            output
+                .writes
+                .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
             events_buf.push(event);
         }
 
@@ -208,7 +212,9 @@ pub fn run_with_sink_gated(
         buf.clear();
         encoder.encode_metric(&sum_event, &mut buf)?;
         total_bytes += buf.len() as u64;
-        sink.write(&buf)?;
+        output
+            .writes
+            .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
         events_buf.push(sum_event);
 
         let count_event = MetricEvent::from_parts(
@@ -220,19 +226,18 @@ pub fn run_with_sink_gated(
         buf.clear();
         encoder.encode_metric(&count_event, &mut buf)?;
         total_bytes += buf.len() as u64;
-        sink.write(&buf)?;
+        output
+            .writes
+            .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
         events_buf.push(count_event);
-
-        let delivered = sink.last_write_delivered();
 
         Ok(TickResult {
             bytes_written: total_bytes,
-            delivered,
+            delivered: true,
         })
     };
 
-    let stats_for_flush = stats.clone();
-    let loop_result = match gate_ctx {
+    match gate_ctx {
         None => core_loop::run_schedule_loop(
             &schedule,
             config.rate,
@@ -250,12 +255,6 @@ pub fn run_with_sink_gated(
             sink,
             &mut tick_fn,
         ),
-    };
-
-    let flush_result = sink.flush();
-    match loop_result {
-        Ok(()) => core_loop::apply_flush_policy(&schedule, stats_for_flush.as_ref(), flush_result),
-        Err(e) => Err(e),
     }
 }
 


### PR DESCRIPTION
`TickFn` closures no longer touch the sink. They produce a queue of `WriteCommand` entries; the loop dispatcher (`run_schedule_loop_with_initial_tick` and its close-emit-emitting siblings) owns the sink and performs every sink call. This is foundation-laying for a follow-up that will wrap each sink call at the dispatcher in `tokio::task::spawn_blocking` — pulling the writes out of the closure first means the wrap lands cleanly later.

## What changed

- **New types in `core_loop`**: `pub enum WriteCommand { Bytes(Vec<u8>), LogEvent { event, bytes } }` and `pub struct TickOutput { writes: Vec<WriteCommand> }`. Marked `pub` (not `pub(crate)`) because the existing `pub CloseEmitFn` field on the public `GateContext` re-export references them — `private_interfaces` would fire otherwise. Both types are new to the public surface.
- **`TickFn` signature**: drops `&mut dyn Sink`, adds `&mut TickOutput`. `CloseEmitFn` restructures analogously and reuses `TickOutput` (the wire shape is identical for both paths).
- **All four runner closures** (metric, log, histogram, summary) rewrite to push `WriteCommand` values into the output queue instead of calling sink methods directly. The 14 sink call sites that lived inside those closures move to the dispatcher.
- **`drain_writes` helper** in core_loop consumes the queue, calls `sink.write` or `sink.write_log_event` per command, short-circuits on the first sink error. Records `last_write_delivered()` after each drain for the per-tick `TickResult.delivered` field.
- **`finalize_sink` helper** handles the post-loop `sink.flush` + `apply_flush_policy` sequence, called once at scenario end from `run_schedule_loop` and `gated_loop`. Gated scenarios still flush once at scenario termination, not per gate-open/close segment.
- **Two direct unit tests** for `drain_writes` cover command-order preservation and short-circuit-on-sink-error.

## Allocation discipline

- **Single-event runner** (`runner.rs`): one `Vec<u8>` per tick via `mem::take`, same as before.
- **Multi-event runners** (`histogram_runner`: N+3 commands/tick; `summary_runner`: quantiles+2 commands/tick): now allocate one `Vec` per command rather than reusing a single buffer across writes within a tick. Per-allocation size unchanged (~256 bytes); allocator pressure rises proportionally to events/tick. Forward-compatible with the upcoming spawn_blocking ownership transfer — owned bytes cross threads cleanly. Tracked for an explicit high-cardinality histogram perf check before the rewrite ships.

## Public-surface impact

`TickFn` / `WriteCommand` / `TickOutput` are new types. No behavior change visible to embedders. No existing public field type changes.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 2867/2867 pass (baseline 2865 + 2 new `drain_writes` unit tests)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::await_holding_lock` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo test -p sonda-core --no-default-features --no-run` — clean
- [x] `cargo audit` — clean (pre-existing yanked `core2` advisory only)
- [x] Bench smoke at N=1: drift mean 15.0 ms, p99 19.9 ms, 0% dropped — exact match to the prior landing-branch baseline (the WriteCommand indirection is invisible on the hot path at N=1)

Cargo.lock catches up to a `sysinfo` dev-dep added in a recent PR that the prior workspace build had not yet flushed through.
