### PR TITLE
refactor(core): wrap sink I/O in spawn_blocking and propagate async fn to runners

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,7 @@ clap = { version = "4", features = ["derive"] }
 ureq = { version = "2", default-features = false, features = ["tls"] }
 insta = { version = "1.40", features = ["json", "yaml"] }
 rstest = "0.26"
+
+[workspace.lints.clippy]
+# Holding a std::sync lock across an .await deadlocks the runtime.
+await_holding_lock = "deny"

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -53,3 +53,6 @@ harness = false
 [[bench]]
 name = "scheduler_baseline"
 harness = false
+
+[lints]
+workspace = true

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -241,6 +241,10 @@ pub enum RuntimeError {
     /// [`ConfigError`] when collected at the multi-runner level.
     #[error("{0}")]
     ScenariosFailed(String),
+
+    /// A `tokio::task::spawn_blocking` task panicked or was cancelled.
+    #[error("blocking task failed: {0}")]
+    TaskPanicked(String),
 }
 
 #[cfg(test)]

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -189,30 +189,66 @@ pub type CloseEmitFn = Box<dyn FnMut(&mut TickOutput) -> Result<(), SondaError> 
 
 /// Run the shared schedule loop until duration expires or shutdown is
 /// signalled, then flush the sink and apply the sink-error policy.
-pub(crate) fn run_schedule_loop(
+pub(crate) async fn run_schedule_loop(
     schedule: &ParsedSchedule,
     rate: f64,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<(), SondaError> {
     let stats_for_flush = stats.clone();
     let loop_result = run_schedule_loop_with_initial_tick(
         schedule, rate, shutdown, stats, 0, None, None, sink, tick_fn,
-    );
-    finalize_sink(schedule, stats_for_flush.as_ref(), sink, loop_result)
+    )
+    .await;
+    finalize_sink(schedule, stats_for_flush.as_ref(), sink, loop_result).await
 }
 
-fn finalize_sink(
+/// Placeholder sink swapped in for the brief window each `Box<dyn Sink>` is
+/// owned by a `spawn_blocking` task. Lives only inside `drain_writes` /
+/// `finalize_sink`; never reachable from user code. If either helper returns
+/// `Err`, the caller's `Box<dyn Sink>` may still hold this placeholder —
+/// do not retry sink operations after an error return, propagate it.
+struct NullSink;
+
+impl Sink for NullSink {
+    fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
+        Ok(())
+    }
+    fn flush(&mut self) -> Result<(), SondaError> {
+        Ok(())
+    }
+}
+
+fn take_sink(sink: &mut Box<dyn Sink>) -> Box<dyn Sink> {
+    std::mem::replace(sink, Box::new(NullSink) as Box<dyn Sink>)
+}
+
+async fn finalize_sink(
     schedule: &ParsedSchedule,
     stats: Option<&Arc<RwLock<ScenarioStats>>>,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     loop_result: Result<(), SondaError>,
 ) -> Result<(), SondaError> {
     match loop_result {
         Ok(()) => {
-            let flush_result = sink.flush();
+            let owned = take_sink(sink);
+            let join = tokio::task::spawn_blocking(move || {
+                let mut s = owned;
+                let r = s.flush();
+                (s, r)
+            })
+            .await;
+            let (returned_sink, flush_result) = match join {
+                Ok(pair) => pair,
+                Err(e) => {
+                    return Err(SondaError::Runtime(RuntimeError::TaskPanicked(
+                        e.to_string(),
+                    )))
+                }
+            };
+            *sink = returned_sink;
             apply_flush_policy(schedule, stats, flush_result)
         }
         Err(e) => Err(e),
@@ -223,7 +259,7 @@ fn finalize_sink(
 /// last tick reached on exit through `last_tick_out`. Used by `gated_loop` to
 /// continue the tick counter across pause/resume instead of restarting at 0.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn run_schedule_loop_with_initial_tick(
+pub(crate) async fn run_schedule_loop_with_initial_tick(
     schedule: &ParsedSchedule,
     rate: f64,
     shutdown: Option<&AtomicBool>,
@@ -231,7 +267,7 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
     initial_tick: u64,
     last_tick_out: Option<&AtomicU64>,
     wall: Option<WallClock>,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<(), SondaError> {
     let base_interval = Duration::from_secs_f64(1.0 / rate);
@@ -337,7 +373,7 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
         events_buf.clear();
         tick_output.clear();
         let tick_outcome = match tick_fn(&ctx, &mut tick_output, &mut events_buf) {
-            Ok(mut result) => match drain_writes(&mut tick_output, sink) {
+            Ok(mut result) => match drain_writes(&mut tick_output, sink).await {
                 Ok(Some(delivered)) => {
                     result.delivered = delivered;
                     Ok(result)
@@ -431,13 +467,32 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
     Ok(())
 }
 
-fn drain_writes(output: &mut TickOutput, sink: &mut dyn Sink) -> Result<Option<bool>, SondaError> {
+async fn drain_writes(
+    output: &mut TickOutput,
+    sink: &mut Box<dyn Sink>,
+) -> Result<Option<bool>, SondaError> {
     let mut delivered: Option<bool> = None;
     for cmd in output.writes.drain(..) {
-        match cmd {
-            WriteCommand::Bytes(buf) => sink.write(&buf)?,
-            WriteCommand::LogEvent { event, bytes } => sink.write_log_event(&event, &bytes)?,
-        }
+        let owned = take_sink(sink);
+        let join = tokio::task::spawn_blocking(move || {
+            let mut s = owned;
+            let r = match cmd {
+                WriteCommand::Bytes(buf) => s.write(&buf),
+                WriteCommand::LogEvent { event, bytes } => s.write_log_event(&event, &bytes),
+            };
+            (s, r)
+        })
+        .await;
+        let (returned_sink, write_result) = match join {
+            Ok(pair) => pair,
+            Err(e) => {
+                return Err(SondaError::Runtime(RuntimeError::TaskPanicked(
+                    e.to_string(),
+                )))
+            }
+        };
+        *sink = returned_sink;
+        write_result?;
         delivered = Some(sink.last_write_delivered());
     }
     Ok(delivered)
@@ -521,25 +576,40 @@ fn apply_close_emit_policy_flush(
 
 /// Called on every committed `running → paused` transition AND on the
 /// single tail exit of `gated_loop`.
-fn invoke_close_emit(
+async fn invoke_close_emit(
     schedule: &ParsedSchedule,
     stats: Option<&Arc<RwLock<ScenarioStats>>>,
     limiter: &mut SinkErrorRateLimiter,
     close_emit: Option<&mut CloseEmitFn>,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
 ) -> Result<(), SondaError> {
     let Some(emit) = close_emit else {
         return Ok(());
     };
     let mut output = TickOutput::default();
-    let outcome = emit(&mut output).and_then(|()| {
-        drain_writes(&mut output, sink)?;
-        Ok(())
-    });
+    let outcome = match emit(&mut output) {
+        Ok(()) => drain_writes(&mut output, sink).await.map(|_| ()),
+        Err(e) => Err(e),
+    };
     match outcome {
         Ok(()) => {
-            let flush = sink.flush();
-            apply_close_emit_policy_flush(schedule, stats, limiter, flush)?;
+            let owned = take_sink(sink);
+            let join = tokio::task::spawn_blocking(move || {
+                let mut s = owned;
+                let r = s.flush();
+                (s, r)
+            })
+            .await;
+            let (returned_sink, flush_result) = match join {
+                Ok(pair) => pair,
+                Err(e) => {
+                    return Err(SondaError::Runtime(RuntimeError::TaskPanicked(
+                        e.to_string(),
+                    )))
+                }
+            };
+            *sink = returned_sink;
+            apply_close_emit_policy_flush(schedule, stats, limiter, flush_result)?;
         }
         Err(e) => apply_close_emit_policy(schedule, stats, limiter, e)?,
     }
@@ -644,19 +714,19 @@ impl GateContext {
 /// `current_rate` is reset to 0.0 and `elapsed_secs` keeps wall-clocking
 /// (the underlying `started_at` Instant inside `ScenarioHandle` runs
 /// against wall time regardless of pause state).
-pub(crate) fn gated_loop(
+pub(crate) async fn gated_loop(
     schedule: &ParsedSchedule,
     rate: f64,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     mut gate_ctx: GateContext,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<(), SondaError> {
     let mut close_warn_limiter = SinkErrorRateLimiter::new();
 
     let stats_for_flush = stats.clone();
-    let gated_result = run_on_thread_runtime(gated_loop_body(
+    let body_result = gated_loop_body(
         schedule,
         rate,
         shutdown,
@@ -665,30 +735,27 @@ pub(crate) fn gated_loop(
         &mut close_warn_limiter,
         sink,
         tick_fn,
-    ))
-    .and_then(|body_result| match body_result {
+    )
+    .await;
+    let gated_result = match body_result {
         Ok(LoopExit::Shutdown | LoopExit::DurationExpired | LoopExit::UpstreamFinished) => {
-            invoke_close_emit(
+            match invoke_close_emit(
                 schedule,
                 stats.as_ref(),
                 &mut close_warn_limiter,
                 gate_ctx.close_emit.as_mut(),
                 sink,
-            )?;
-            finish(stats)
+            )
+            .await
+            {
+                Ok(()) => finish(stats),
+                Err(e) => Err(e),
+            }
         }
         Err(e) => Err(e),
-    });
+    };
 
-    finalize_sink(schedule, stats_for_flush.as_ref(), sink, gated_result)
-}
-
-fn run_on_thread_runtime<F: std::future::Future>(fut: F) -> Result<F::Output, SondaError> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
-    Ok(rt.block_on(fut))
+    finalize_sink(schedule, stats_for_flush.as_ref(), sink, gated_result).await
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -699,7 +766,7 @@ async fn gated_loop_body(
     stats: Option<&Arc<RwLock<ScenarioStats>>>,
     gate_ctx: &mut GateContext,
     close_warn_limiter: &mut SinkErrorRateLimiter,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<LoopExit, SondaError> {
     let started_at = Instant::now();
@@ -799,7 +866,8 @@ async fn gated_loop_body(
                     sink,
                     tick_fn,
                     false,
-                )?;
+                )
+                .await?;
                 next_tick = last_tick.load(Ordering::SeqCst);
 
                 if shutdown_requested(shutdown) {
@@ -818,7 +886,8 @@ async fn gated_loop_body(
                         close_warn_limiter,
                         gate_ctx.close_emit.as_mut(),
                         sink,
-                    )?;
+                    )
+                    .await?;
                     state = ScenarioState::Unresolved;
                     while_open = false;
                     write_state(stats, ScenarioState::Unresolved, true);
@@ -841,7 +910,8 @@ async fn gated_loop_body(
                         close_warn_limiter,
                         gate_ctx.close_emit.as_mut(),
                         sink,
-                    )?;
+                    )
+                    .await?;
                 }
                 let close_state = close_target_state(gate_ctx.holds_on_close, stats);
                 state = close_state;
@@ -919,7 +989,8 @@ async fn gated_loop_body(
                             sink,
                             tick_fn,
                             true,
-                        )?;
+                        )
+                        .await?;
                         next_tick = last_tick.load(Ordering::SeqCst);
 
                         if shutdown_requested(shutdown) {
@@ -936,7 +1007,8 @@ async fn gated_loop_body(
                                     close_warn_limiter,
                                     gate_ctx.close_emit.as_mut(),
                                     sink,
-                                )?;
+                                )
+                                .await?;
                                 let close_state =
                                     close_target_state(gate_ctx.holds_on_close, stats);
                                 state = close_state;
@@ -1146,7 +1218,7 @@ async fn debounce_close_to_paused(
 /// captures the next tick the inner loop would have fired so the next segment
 /// continues from there.
 #[allow(clippy::too_many_arguments)]
-fn run_running_segment(
+async fn run_running_segment(
     schedule: &ParsedSchedule,
     rate: f64,
     shutdown: Option<&AtomicBool>,
@@ -1156,7 +1228,7 @@ fn run_running_segment(
     initial_tick: u64,
     last_tick: Arc<AtomicU64>,
     wall: WallClock,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     tick_fn: &mut TickFn<'_>,
     exit_on_while_open: bool,
 ) -> Result<SegmentExit, SondaError> {
@@ -1233,7 +1305,8 @@ fn run_running_segment(
         Some(wall),
         sink,
         wrapped.as_mut(),
-    )?;
+    )
+    .await?;
 
     Ok(if saw_gone.load(Ordering::SeqCst) {
         SegmentExit::UpstreamGone
@@ -1333,33 +1406,50 @@ impl DebounceState {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
     use crate::schedule::{BurstWindow, GapWindow};
 
-    struct NullSink;
-    impl Sink for NullSink {
-        fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
-            Ok(())
-        }
-        fn flush(&mut self) -> Result<(), SondaError> {
-            Ok(())
-        }
-    }
+    type WriteLog = Arc<Mutex<Vec<Vec<u8>>>>;
 
-    struct CapturingSink {
-        writes: Vec<Vec<u8>>,
+    /// Shared-buffer test sink. Owns nothing; the `Arc<Mutex<...>>` handles
+    /// let tests inspect outcomes after the runner has moved the sink in
+    /// and out of `spawn_blocking`.
+    struct SharedSink {
+        writes: WriteLog,
         fail_at: Option<usize>,
     }
-    impl Sink for CapturingSink {
+
+    fn shared_sink() -> (Box<dyn Sink>, WriteLog) {
+        let writes: WriteLog = Arc::new(Mutex::new(Vec::new()));
+        let sink = SharedSink {
+            writes: Arc::clone(&writes),
+            fail_at: None,
+        };
+        (Box::new(sink) as Box<dyn Sink>, writes)
+    }
+
+    fn shared_sink_failing(fail_at: usize) -> (Box<dyn Sink>, WriteLog) {
+        let writes: WriteLog = Arc::new(Mutex::new(Vec::new()));
+        let sink = SharedSink {
+            writes: Arc::clone(&writes),
+            fail_at: Some(fail_at),
+        };
+        (Box::new(sink) as Box<dyn Sink>, writes)
+    }
+
+    impl Sink for SharedSink {
         fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+            let mut writes = self.writes.lock().expect("shared sink mutex poisoned");
             if let Some(n) = self.fail_at {
-                if self.writes.len() == n {
+                if writes.len() == n {
                     return Err(SondaError::Sink(std::io::Error::other(
                         "capturing sink test failure",
                     )));
                 }
             }
-            self.writes.push(data.to_vec());
+            writes.push(data.to_vec());
             Ok(())
         }
         fn flush(&mut self) -> Result<(), SondaError> {
@@ -1367,44 +1457,88 @@ mod tests {
         }
     }
 
-    #[test]
-    fn drain_writes_preserves_command_order() {
-        let mut sink = CapturingSink {
-            writes: Vec::new(),
-            fail_at: None,
-        };
+    fn null_sink() -> Box<dyn Sink> {
+        Box::new(NullSink) as Box<dyn Sink>
+    }
+
+    #[tokio::test]
+    async fn drain_writes_preserves_command_order() {
+        let (mut sink, writes) = shared_sink();
         let mut output = TickOutput::default();
         output.writes.push(WriteCommand::Bytes(b"first".to_vec()));
         output.writes.push(WriteCommand::Bytes(b"second".to_vec()));
         output.writes.push(WriteCommand::Bytes(b"third".to_vec()));
-        let delivered = drain_writes(&mut output, &mut sink).expect("drain must succeed");
+        let delivered = drain_writes(&mut output, &mut sink)
+            .await
+            .expect("drain must succeed");
+        let captured = writes.lock().unwrap().clone();
         assert_eq!(
-            sink.writes,
+            captured,
             vec![b"first".to_vec(), b"second".to_vec(), b"third".to_vec()]
         );
         assert!(output.writes.is_empty(), "queue must be empty after drain");
         assert_eq!(delivered, Some(true));
     }
 
-    #[test]
-    fn drain_writes_short_circuits_on_sink_error() {
-        let mut sink = CapturingSink {
-            writes: Vec::new(),
-            fail_at: Some(1),
-        };
+    #[tokio::test]
+    async fn drain_writes_short_circuits_on_sink_error() {
+        let (mut sink, writes) = shared_sink_failing(1);
         let mut output = TickOutput::default();
         output.writes.push(WriteCommand::Bytes(b"first".to_vec()));
         output.writes.push(WriteCommand::Bytes(b"second".to_vec()));
         output.writes.push(WriteCommand::Bytes(b"third".to_vec()));
-        let result = drain_writes(&mut output, &mut sink);
+        let result = drain_writes(&mut output, &mut sink).await;
         assert!(
             result.is_err(),
             "sink error must propagate from drain_writes"
         );
         assert_eq!(
-            sink.writes,
+            *writes.lock().unwrap(),
             vec![b"first".to_vec()],
             "only writes before the error must reach the sink"
+        );
+    }
+
+    /// A spawn_blocking task that panics surfaces as RuntimeError::TaskPanicked.
+    struct PanicSink;
+
+    impl Sink for PanicSink {
+        fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
+            panic!("synthetic sink panic");
+        }
+        fn flush(&mut self) -> Result<(), SondaError> {
+            panic!("synthetic flush panic");
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_writes_panic_in_sink_propagates_as_task_panicked() {
+        let mut sink: Box<dyn Sink> = Box::new(PanicSink);
+        let mut output = TickOutput::default();
+        output
+            .writes
+            .push(WriteCommand::Bytes(b"panic-me".to_vec()));
+        let result = drain_writes(&mut output, &mut sink).await;
+        assert!(
+            matches!(
+                result,
+                Err(SondaError::Runtime(RuntimeError::TaskPanicked(_)))
+            ),
+            "spawn_blocking panic must surface as TaskPanicked, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalize_sink_panic_in_flush_propagates_as_task_panicked() {
+        let mut sink: Box<dyn Sink> = Box::new(PanicSink);
+        let schedule = minimal_schedule(None);
+        let result = finalize_sink(&schedule, None, &mut sink, Ok(())).await;
+        assert!(
+            matches!(
+                result,
+                Err(SondaError::Runtime(RuntimeError::TaskPanicked(_)))
+            ),
+            "flush panic must surface as TaskPanicked, got: {result:?}"
         );
     }
 
@@ -1439,8 +1573,8 @@ mod tests {
     // ---- Basic loop: runs for duration, emits events -------------------------
 
     /// The loop emits events at the configured rate for the configured duration.
-    #[test]
-    fn loop_emits_events_for_duration() {
+    #[tokio::test]
+    async fn loop_emits_events_for_duration() {
         let schedule = minimal_schedule(Some(Duration::from_millis(500)));
 
         let mut event_count: u64 = 0;
@@ -1455,14 +1589,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             20.0, // 20 events/sec for 500ms = ~10 events
             None,
             None,
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         assert!(
@@ -1478,8 +1614,8 @@ mod tests {
     // ---- Shutdown flag: stops the loop early --------------------------------
 
     /// Clearing the shutdown flag stops the loop before duration expires.
-    #[test]
-    fn loop_stops_on_shutdown_flag() {
+    #[tokio::test]
+    async fn loop_stops_on_shutdown_flag() {
         use std::sync::atomic::AtomicBool;
 
         let schedule = minimal_schedule(None); // indefinite
@@ -1504,14 +1640,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             Some(shutdown_arc.as_ref()),
             None,
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         handle.join().expect("thread must complete");
@@ -1525,8 +1663,8 @@ mod tests {
     // ---- Gap window: suppresses events during gap ---------------------------
 
     /// Events are suppressed during a gap window.
-    #[test]
-    fn loop_suppresses_events_during_gap() {
+    #[tokio::test]
+    async fn loop_suppresses_events_during_gap() {
         let schedule = ParsedSchedule {
             total_duration: Some(Duration::from_secs(2)),
             gap_window: Some(GapWindow {
@@ -1553,7 +1691,9 @@ mod tests {
             })
         };
 
-        run_schedule_loop(&schedule, 100.0, None, None, &mut NullSink, &mut tick_fn)
+        let mut sink = null_sink();
+        run_schedule_loop(&schedule, 100.0, None, None, &mut sink, &mut tick_fn)
+            .await
             .expect("loop must succeed");
 
         // Only ~100 events from the first 1s before the gap kicks in.
@@ -1566,8 +1706,8 @@ mod tests {
     // ---- Burst window: increases event rate ---------------------------------
 
     /// Burst window increases the effective rate.
-    #[test]
-    fn loop_increases_rate_during_burst() {
+    #[tokio::test]
+    async fn loop_increases_rate_during_burst() {
         let schedule = ParsedSchedule {
             total_duration: Some(Duration::from_secs(1)),
             gap_window: None,
@@ -1595,7 +1735,9 @@ mod tests {
             })
         };
 
-        run_schedule_loop(&schedule, 10.0, None, None, &mut NullSink, &mut tick_fn)
+        let mut sink = null_sink();
+        run_schedule_loop(&schedule, 10.0, None, None, &mut sink, &mut tick_fn)
+            .await
             .expect("loop must succeed");
 
         // Without burst: ~10 events. With 5x burst: ~50 events.
@@ -1608,8 +1750,8 @@ mod tests {
     // ---- Stats tracking: updates stats arc ----------------------------------
 
     /// Stats are updated correctly when a stats arc is provided.
-    #[test]
-    fn loop_updates_stats() {
+    #[tokio::test]
+    async fn loop_updates_stats() {
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
@@ -1623,14 +1765,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
@@ -1649,8 +1793,8 @@ mod tests {
     // ---- Stats tracking: metric events pushed to buffer ---------------------
 
     /// When the tick callback returns a MetricEvent, it is pushed to the stats buffer.
-    #[test]
-    fn loop_pushes_metric_events_to_stats_buffer() {
+    #[tokio::test]
+    async fn loop_pushes_metric_events_to_stats_buffer() {
         use crate::model::metric::{Labels, MetricEvent};
 
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
@@ -1669,14 +1813,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
@@ -1689,8 +1835,8 @@ mod tests {
     // ---- Tick context: spike windows are passed to callback -----------------
 
     /// The tick callback receives spike windows in the context.
-    #[test]
-    fn loop_passes_spike_windows_to_tick_fn() {
+    #[tokio::test]
+    async fn loop_passes_spike_windows_to_tick_fn() {
         use crate::config::SpikeStrategy;
         use crate::schedule::CardinalitySpikeWindow;
 
@@ -1727,7 +1873,9 @@ mod tests {
             })
         };
 
-        run_schedule_loop(&schedule, 100.0, None, None, &mut NullSink, &mut tick_fn)
+        let mut sink = null_sink();
+        run_schedule_loop(&schedule, 100.0, None, None, &mut sink, &mut tick_fn)
+            .await
             .expect("loop must succeed");
 
         assert!(
@@ -1738,8 +1886,8 @@ mod tests {
 
     // ---- Error propagation: encoder errors propagate regardless of policy ----
 
-    #[test]
-    fn loop_propagates_encoder_error_under_warn_policy() {
+    #[tokio::test]
+    async fn loop_propagates_encoder_error_under_warn_policy() {
         let schedule = minimal_schedule(Some(Duration::from_secs(10)));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
@@ -1751,7 +1899,8 @@ mod tests {
             )))
         };
 
-        let result = run_schedule_loop(&schedule, 10.0, None, None, &mut NullSink, &mut tick_fn);
+        let mut sink = null_sink();
+        let result = run_schedule_loop(&schedule, 10.0, None, None, &mut sink, &mut tick_fn).await;
 
         assert!(
             matches!(result, Err(SondaError::Encoder(_))),
@@ -1759,8 +1908,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn loop_propagates_sink_error_under_fail_policy() {
+    #[tokio::test]
+    async fn loop_propagates_sink_error_under_fail_policy() {
         let mut schedule = minimal_schedule(Some(Duration::from_secs(10)));
         schedule.on_sink_error = OnSinkError::Fail;
 
@@ -1771,7 +1920,8 @@ mod tests {
             Err(SondaError::Sink(std::io::Error::other("test error")))
         };
 
-        let result = run_schedule_loop(&schedule, 10.0, None, None, &mut NullSink, &mut tick_fn);
+        let mut sink = null_sink();
+        let result = run_schedule_loop(&schedule, 10.0, None, None, &mut sink, &mut tick_fn).await;
 
         assert!(
             matches!(result, Err(SondaError::Sink(_))),
@@ -1779,8 +1929,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn fail_policy_records_stats_before_propagating() {
+    #[tokio::test]
+    async fn fail_policy_records_stats_before_propagating() {
         let mut schedule = minimal_schedule(Some(Duration::from_secs(10)));
         schedule.on_sink_error = OnSinkError::Fail;
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
@@ -1795,14 +1945,16 @@ mod tests {
             )))
         };
 
+        let mut sink = null_sink();
         let result = run_schedule_loop(
             &schedule,
             10.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
-        );
+        )
+        .await;
 
         assert!(
             matches!(result, Err(SondaError::Sink(_))),
@@ -1832,8 +1984,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn loop_swallows_sink_error_under_warn_policy_and_continues() {
+    #[tokio::test]
+    async fn loop_swallows_sink_error_under_warn_policy_and_continues() {
         // 200ms run with rate=50: ~10 ticks. All return sink errors. Loop
         // must complete without propagating.
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
@@ -1845,7 +1997,8 @@ mod tests {
             Err(SondaError::Sink(std::io::Error::other("transient")))
         };
 
-        let result = run_schedule_loop(&schedule, 50.0, None, None, &mut NullSink, &mut tick_fn);
+        let mut sink = null_sink();
+        let result = run_schedule_loop(&schedule, 50.0, None, None, &mut sink, &mut tick_fn).await;
 
         assert!(
             result.is_ok(),
@@ -1853,8 +2006,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn warn_policy_updates_sink_failure_stats() {
+    #[tokio::test]
+    async fn warn_policy_updates_sink_failure_stats() {
         let schedule = minimal_schedule(Some(Duration::from_millis(150)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
@@ -1868,14 +2021,16 @@ mod tests {
             )))
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("warn policy must complete");
 
         let st = stats.read().expect("stats lock");
@@ -1895,8 +2050,8 @@ mod tests {
         assert!(st.errors > 0, "errors counter must increment too");
     }
 
-    #[test]
-    fn alternating_ok_err_resets_consecutive_failures() {
+    #[tokio::test]
+    async fn alternating_ok_err_resets_consecutive_failures() {
         let schedule = minimal_schedule(Some(Duration::from_millis(300)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
         let mut counter: u64 = 0;
@@ -1916,14 +2071,16 @@ mod tests {
             }
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("warn must succeed");
 
         let st = stats.read().expect("stats lock");
@@ -1937,8 +2094,8 @@ mod tests {
         assert!(st.last_successful_write_at.is_some());
     }
 
-    #[test]
-    fn buffered_write_does_not_update_delivery_health_stats() {
+    #[tokio::test]
+    async fn buffered_write_does_not_update_delivery_health_stats() {
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
@@ -1952,14 +2109,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         let st = stats.read().expect("stats lock");
@@ -1981,8 +2140,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn delivered_write_updates_delivery_health_stats() {
+    #[tokio::test]
+    async fn delivered_write_updates_delivery_health_stats() {
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
@@ -1996,14 +2155,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         let st = stats.read().expect("stats lock");
@@ -2076,7 +2237,14 @@ mod tests {
             }
         };
 
-        let result = run_schedule_loop(&schedule, 30.0, None, None, &mut NullSink, &mut tick_fn);
+        let mut sink = null_sink();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(run_schedule_loop(
+            &schedule, 30.0, None, None, &mut sink, &mut tick_fn,
+        ));
 
         match expected {
             PolicyOutcome::Ok => assert!(result.is_ok(), "must complete: {result:?}"),
@@ -2141,8 +2309,8 @@ mod tests {
 
     // ---- Contract: TickResult fields ----------------------------------------
 
-    #[test]
-    fn run_schedule_loop_with_initial_tick_seeds_first_tick_value() {
+    #[tokio::test]
+    async fn run_schedule_loop_with_initial_tick_seeds_first_tick_value() {
         let schedule = minimal_schedule(Some(Duration::from_millis(150)));
         let observed_first = std::sync::Mutex::new(None::<u64>);
 
@@ -2160,6 +2328,7 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop_with_initial_tick(
             &schedule,
             50.0,
@@ -2168,9 +2337,10 @@ mod tests {
             30,
             None,
             None,
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         assert_eq!(
@@ -2180,8 +2350,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn run_schedule_loop_with_initial_tick_reports_last_tick() {
+    #[tokio::test]
+    async fn run_schedule_loop_with_initial_tick_reports_last_tick() {
         let schedule = minimal_schedule(Some(Duration::from_millis(150)));
         let last_tick = AtomicU64::new(0);
 
@@ -2195,6 +2365,7 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop_with_initial_tick(
             &schedule,
             50.0,
@@ -2203,9 +2374,10 @@ mod tests {
             10,
             Some(&last_tick),
             None,
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         let final_tick = last_tick.load(Ordering::SeqCst);
@@ -2226,8 +2398,8 @@ mod tests {
         assert!(result.delivered);
     }
 
-    #[test]
-    fn events_buf_capacity_does_not_grow_under_metrics_workload() {
+    #[tokio::test]
+    async fn events_buf_capacity_does_not_grow_under_metrics_workload() {
         use crate::model::metric::{Labels, MetricEvent};
         use std::cell::Cell;
 
@@ -2266,14 +2438,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         let st = stats.read().expect("lock");

--- a/sonda-core/src/schedule/histogram_runner.rs
+++ b/sonda-core/src/schedule/histogram_runner.rs
@@ -40,9 +40,9 @@ use crate::SondaError;
 /// # Errors
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-pub fn run(config: &HistogramScenarioConfig) -> Result<(), SondaError> {
+pub async fn run(config: &HistogramScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, None)?;
-    run_with_sink(config, sink.as_mut(), None, None)
+    run_with_sink(config, &mut sink, None, None).await
 }
 
 /// Run a histogram scenario to completion, writing encoded events into the
@@ -62,22 +62,22 @@ pub fn run(config: &HistogramScenarioConfig) -> Result<(), SondaError> {
 /// # Errors
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-pub fn run_with_sink(
+pub async fn run_with_sink(
     config: &HistogramScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_with_sink_gated(config, sink, shutdown, stats, None)
+    run_with_sink_gated(config, sink, shutdown, stats, None).await
 }
 
 /// Run a histogram scenario with optional `while:` / `after:` gating.
 ///
 /// Histograms cannot be `while:` upstreams (compile-time
 /// `NonMetricsTarget`), but they can be `while:`-gated downstreams.
-pub fn run_with_sink_gated(
+pub async fn run_with_sink_gated(
     config: &HistogramScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
@@ -277,23 +277,29 @@ pub fn run_with_sink_gated(
     };
 
     match gate_ctx {
-        None => core_loop::run_schedule_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            sink,
-            &mut tick_fn,
-        ),
-        Some(ctx) => core_loop::gated_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            ctx,
-            sink,
-            &mut tick_fn,
-        ),
+        None => {
+            core_loop::run_schedule_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
+        Some(ctx) => {
+            core_loop::gated_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                ctx,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
     }
 }
 
@@ -312,10 +318,35 @@ fn format_le_value(bound: f64) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use crate::config::{BaseScheduleConfig, DistributionConfig, HistogramScenarioConfig};
     use crate::encoder::EncoderConfig;
-    use crate::sink::memory::MemorySink;
-    use crate::sink::SinkConfig;
+    use crate::sink::{Sink, SinkConfig};
+    use crate::SondaError;
+
+    type SharedBuf = std::sync::Arc<Mutex<Vec<u8>>>;
+
+    struct ProbeSink(SharedBuf);
+
+    impl Sink for ProbeSink {
+        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+            self.0
+                .lock()
+                .expect("probe sink mutex poisoned")
+                .extend_from_slice(data);
+            Ok(())
+        }
+        fn flush(&mut self) -> Result<(), SondaError> {
+            Ok(())
+        }
+    }
+
+    fn probe_sink() -> (Box<dyn Sink>, SharedBuf) {
+        let buf: SharedBuf = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let sink: Box<dyn Sink> = Box::new(ProbeSink(SharedBuf::clone(&buf)));
+        (sink, buf)
+    }
 
     /// Build a minimal HistogramScenarioConfig for testing.
     fn make_config(
@@ -355,23 +386,31 @@ mod tests {
 
     // ---- Run completes without error ----------------------------------------
 
-    #[test]
-    fn run_completes_for_short_duration() {
+    #[tokio::test]
+    async fn run_completes_for_short_duration() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("histogram run must succeed");
-        assert!(!sink.buffer.is_empty(), "histogram run must produce output");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("histogram run must succeed");
+        assert!(
+            !buf.lock().unwrap().is_empty(),
+            "histogram run must produce output"
+        );
     }
 
     // ---- Output contains expected series names ------------------------------
 
-    #[test]
-    fn output_contains_bucket_count_sum_series() {
+    #[tokio::test]
+    async fn output_contains_bucket_count_sum_series() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
 
         assert!(
             output.contains("http_request_duration_seconds_bucket{"),
@@ -389,13 +428,16 @@ mod tests {
 
     // ---- le label present on bucket events -----------------------------------
 
-    #[test]
-    fn bucket_events_have_le_label() {
+    #[tokio::test]
+    async fn bucket_events_have_le_label() {
         let config = make_config(50.0, "100ms", Some(vec![0.1, 0.5, 1.0]));
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
 
         // Check for specific le values.
         assert!(
@@ -410,34 +452,39 @@ mod tests {
 
     // ---- Gap suppresses output -----------------------------------------------
 
-    #[test]
-    fn gap_suppresses_histogram_output() {
+    #[tokio::test]
+    async fn gap_suppresses_histogram_output() {
         let mut config = make_config(100.0, "2s", None);
         config.base.gaps = Some(crate::config::GapConfig {
             every: "1s".to_string(),
             r#for: "500ms".to_string(),
         });
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
         // With gaps, we should have less output than without.
         // Just verify it ran successfully and produced some output.
         assert!(
-            !sink.buffer.is_empty(),
+            !buf.lock().unwrap().is_empty(),
             "histogram with gaps must still produce some output"
         );
     }
 
     // ---- Custom buckets are used --------------------------------------------
 
-    #[test]
-    fn custom_buckets_appear_in_output() {
+    #[tokio::test]
+    async fn custom_buckets_appear_in_output() {
         let config = make_config(50.0, "100ms", Some(vec![1.0, 5.0, 10.0]));
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         // Should have events for le="1", le="5", le="10", and le="+Inf"
         assert!(output.contains("le=\"1\""), "expected le=\"1\" in output");
         assert!(
@@ -463,17 +510,20 @@ mod tests {
 
     // ---- Labels from config are included ------------------------------------
 
-    #[test]
-    fn config_labels_appear_in_output() {
+    #[tokio::test]
+    async fn config_labels_appear_in_output() {
         let mut config = make_config(50.0, "100ms", Some(vec![1.0]));
         let mut label_map = std::collections::HashMap::new();
         label_map.insert("method".to_string(), "GET".to_string());
         config.base.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         assert!(
             output.contains("method=\"GET\""),
             "config labels must appear in output"

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -311,47 +311,56 @@ pub fn launch_scenario_with_gates(
                 }
             }
 
+            // Per-scenario current-thread Tokio runtime: drives the async
+            // runner from inside the std::thread::spawn'd scenario thread.
+            // One runtime per thread keeps the blocking-task pool local to
+            // this scenario.
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
+
             match entry {
                 ScenarioEntry::Metrics(config) => {
                     let mut sink = create_sink(&config.sink, None)?;
-                    run_with_sink_gated(
+                    rt.block_on(run_with_sink_gated(
                         &config,
-                        sink.as_mut(),
+                        &mut sink,
                         Some(shutdown_for_thread.as_ref()),
                         Some(Arc::clone(&stats_for_thread)),
                         upstream_bus,
                         gate_ctx,
-                    )
+                    ))
                 }
                 ScenarioEntry::Logs(config) => {
                     let mut sink = create_sink(&config.sink, config.labels.as_ref())?;
-                    run_logs_with_sink_gated(
+                    rt.block_on(run_logs_with_sink_gated(
                         &config,
-                        sink.as_mut(),
+                        &mut sink,
                         Some(shutdown_for_thread.as_ref()),
                         Some(Arc::clone(&stats_for_thread)),
                         gate_ctx,
-                    )
+                    ))
                 }
                 ScenarioEntry::Histogram(config) => {
                     let mut sink = create_sink(&config.sink, None)?;
-                    run_histogram_with_sink_gated(
+                    rt.block_on(run_histogram_with_sink_gated(
                         &config,
-                        sink.as_mut(),
+                        &mut sink,
                         Some(shutdown_for_thread.as_ref()),
                         Some(Arc::clone(&stats_for_thread)),
                         gate_ctx,
-                    )
+                    ))
                 }
                 ScenarioEntry::Summary(config) => {
                     let mut sink = create_sink(&config.sink, None)?;
-                    run_summary_with_sink_gated(
+                    rt.block_on(run_summary_with_sink_gated(
                         &config,
-                        sink.as_mut(),
+                        &mut sink,
                         Some(shutdown_for_thread.as_ref()),
                         Some(Arc::clone(&stats_for_thread)),
                         gate_ctx,
-                    )
+                    ))
                 }
             }
         })

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -33,9 +33,9 @@ use crate::SondaError;
 /// # Errors
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-pub fn run_logs(config: &LogScenarioConfig) -> Result<(), SondaError> {
+pub async fn run_logs(config: &LogScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, config.labels.as_ref())?;
-    run_logs_with_sink(config, sink.as_mut(), None, None)
+    run_logs_with_sink(config, &mut sink, None, None).await
 }
 
 /// Run a log scenario to completion, writing encoded events into the provided sink.
@@ -64,22 +64,22 @@ pub fn run_logs(config: &LogScenarioConfig) -> Result<(), SondaError> {
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 /// If an error occurs during the loop and flushing also fails, the loop error
 /// is returned (the flush error is discarded to preserve the original cause).
-pub fn run_logs_with_sink(
+pub async fn run_logs_with_sink(
     config: &LogScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_logs_with_sink_gated(config, sink, shutdown, stats, None)
+    run_logs_with_sink_gated(config, sink, shutdown, stats, None).await
 }
 
 /// Run a log scenario with optional `while:` / `after:` gating.
 ///
 /// Logs cannot be `while:` upstreams (compile-time `NonMetricsTarget`),
 /// but they can be `while:`-gated downstreams.
-pub fn run_logs_with_sink_gated(
+pub async fn run_logs_with_sink_gated(
     config: &LogScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
@@ -144,36 +144,65 @@ pub fn run_logs_with_sink_gated(
     };
 
     match gate_ctx {
-        None => core_loop::run_schedule_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            sink,
-            &mut tick_fn,
-        ),
-        Some(ctx) => core_loop::gated_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            ctx,
-            sink,
-            &mut tick_fn,
-        ),
+        None => {
+            core_loop::run_schedule_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
+        Some(ctx) => {
+            core_loop::gated_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                ctx,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, HashMap};
+    use std::sync::Mutex;
 
     use super::*;
     use crate::config::{BaseScheduleConfig, GapConfig, LogScenarioConfig};
     use crate::encoder::EncoderConfig;
     use crate::generator::{LogGeneratorConfig, TemplateConfig};
-    use crate::sink::memory::MemorySink;
     use crate::sink::SinkConfig;
+
+    type SharedBuf = Arc<Mutex<Vec<u8>>>;
+
+    struct ProbeSink(SharedBuf);
+
+    impl Sink for ProbeSink {
+        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+            self.0
+                .lock()
+                .expect("probe sink mutex poisoned")
+                .extend_from_slice(data);
+            Ok(())
+        }
+        fn flush(&mut self) -> Result<(), SondaError> {
+            Ok(())
+        }
+    }
+
+    fn probe_sink() -> (Box<dyn Sink>, SharedBuf) {
+        let buf: SharedBuf = Arc::new(Mutex::new(Vec::new()));
+        let sink: Box<dyn Sink> = Box::new(ProbeSink(SharedBuf::clone(&buf)));
+        (sink, buf)
+    }
 
     /// Build a minimal valid `LogScenarioConfig` for use in tests.
     ///
@@ -220,15 +249,18 @@ mod tests {
     ///
     /// At rate=10 and duration=1s we expect 10 events (within ±3 tolerance to
     /// accommodate OS scheduling jitter without making the test fragile).
-    #[test]
-    fn run_logs_with_sink_rate_10_duration_1s_produces_approx_10_lines() {
+    #[tokio::test]
+    async fn run_logs_with_sink_rate_10_duration_1s_produces_approx_10_lines() {
         let config = make_config(10.0, Some("1s"));
-        let mut sink = MemorySink::new();
+        let (mut sink, buf) = probe_sink();
 
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
         // Count newline-terminated JSON lines.
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let line_count = output.lines().count();
         assert!(
             (7..=13).contains(&line_count),
@@ -237,14 +269,17 @@ mod tests {
     }
 
     /// Every emitted line must be non-empty valid JSON with a `message` key.
-    #[test]
-    fn run_logs_with_sink_each_line_is_valid_json() {
+    #[tokio::test]
+    async fn run_logs_with_sink_each_line_is_valid_json() {
         let config = make_config(10.0, Some("1s"));
-        let mut sink = MemorySink::new();
+        let (mut sink, buf) = probe_sink();
 
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             let parsed: serde_json::Value = serde_json::from_str(line)
                 .unwrap_or_else(|e| panic!("line is not valid JSON: {e}\nline: {line}"));
@@ -261,15 +296,15 @@ mod tests {
 
     /// If the shutdown flag is cleared (false) before the scenario would
     /// naturally finish, the runner must exit cleanly without error.
-    #[test]
-    fn run_logs_with_sink_shutdown_flag_stops_runner() {
+    #[tokio::test]
+    async fn run_logs_with_sink_shutdown_flag_stops_runner() {
         use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::Arc;
         use std::thread;
         use std::time::Duration;
 
         let config = make_config(5.0, None); // runs indefinitely without shutdown
-        let mut sink = MemorySink::new();
+        let (mut sink, _buf) = probe_sink();
         let shutdown = Arc::new(AtomicBool::new(true));
 
         let flag_clone = Arc::clone(&shutdown);
@@ -279,7 +314,7 @@ mod tests {
             flag_clone.store(false, Ordering::SeqCst);
         });
 
-        let result = run_logs_with_sink(&config, &mut sink, Some(shutdown.as_ref()), None);
+        let result = run_logs_with_sink(&config, &mut sink, Some(shutdown.as_ref()), None).await;
         assert!(
             result.is_ok(),
             "runner must return Ok when stopped via shutdown flag"
@@ -296,8 +331,8 @@ mod tests {
     /// and run for 500ms — the scenario starts in a non-gap period initially
     /// but then immediately transitions into the gap for the rest of the run,
     /// so zero or very few events are emitted.
-    #[test]
-    fn run_logs_with_sink_gap_suppresses_output() {
+    #[tokio::test]
+    async fn run_logs_with_sink_gap_suppresses_output() {
         // gap: every=10s, for=9s → gap starts at 1s.
         // duration=2s → after 1s of normal events, 1s is spent in a gap.
         let mut config = make_config(100.0, Some("2s"));
@@ -306,10 +341,13 @@ mod tests {
             r#for: "9s".to_string(), // gap from second 1 to second 10
         });
 
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         let line_count = output.lines().count();
         // Only ~100 events from the first second (before the gap). The gap covers
         // seconds 1–10, so the remaining 1s of the 2s run is silent.
@@ -325,15 +363,17 @@ mod tests {
 
     /// When a finite duration is set, the runner must exit at the right time.
     /// Verify this is respected by running at low rate for 500ms.
-    #[test]
-    fn run_logs_with_sink_duration_500ms_exits_promptly() {
+    #[tokio::test]
+    async fn run_logs_with_sink_duration_500ms_exits_promptly() {
         use std::time::Instant;
 
         let config = make_config(5.0, Some("500ms"));
-        let mut sink = MemorySink::new();
+        let (mut sink, _buf) = probe_sink();
 
         let t0 = Instant::now();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("must not error");
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("must not error");
         let elapsed = t0.elapsed();
 
         // Should exit within 2 seconds of the 500ms duration.
@@ -503,18 +543,21 @@ sink:
 
     /// When labels are configured, every emitted JSON line must include the
     /// labels object with the correct key-value pairs.
-    #[test]
-    fn run_logs_with_sink_labels_appear_in_json_output() {
+    #[tokio::test]
+    async fn run_logs_with_sink_labels_appear_in_json_output() {
         let mut config = make_config(10.0, Some("1s"));
         let mut label_map = HashMap::new();
         label_map.insert("device".to_string(), "wlan0".to_string());
         label_map.insert("hostname".to_string(), "router_01".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(
             !lines.is_empty(),
@@ -537,13 +580,16 @@ sink:
 
     /// When no labels are configured, the labels object in JSON output must be
     /// empty (not absent).
-    #[test]
-    fn run_logs_with_sink_no_labels_produces_empty_labels_object() {
+    #[tokio::test]
+    async fn run_logs_with_sink_no_labels_produces_empty_labels_object() {
         let config = make_config(10.0, Some("500ms"));
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             let parsed: serde_json::Value = serde_json::from_str(line)
                 .unwrap_or_else(|e| panic!("line is not valid JSON: {e}\nline: {line}"));
@@ -556,8 +602,8 @@ sink:
     }
 
     /// Labels in syslog encoder should appear as structured data.
-    #[test]
-    fn run_logs_with_sink_labels_appear_in_syslog_output() {
+    #[tokio::test]
+    async fn run_logs_with_sink_labels_appear_in_syslog_output() {
         let mut config = make_config(10.0, Some("500ms"));
         config.encoder = EncoderConfig::Syslog {
             hostname: None,
@@ -567,10 +613,13 @@ sink:
         label_map.insert("env".to_string(), "prod".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(
             !lines.is_empty(),
@@ -616,8 +665,8 @@ sink:
 
     /// When the entire run is inside a spike window, every JSON line must
     /// contain the spike label key in the labels object.
-    #[test]
-    fn run_logs_with_sink_spike_labels_appear_during_spike_window() {
+    #[tokio::test]
+    async fn run_logs_with_sink_spike_labels_appear_during_spike_window() {
         let spike = crate::config::CardinalitySpikeConfig {
             label: "pod_name".to_string(),
             every: "10s".to_string(),
@@ -628,11 +677,14 @@ sink:
             seed: None,
         };
         let config = make_config_with_spike(10.0, Some("1s"), spike);
-        let mut sink = MemorySink::new();
+        let (mut sink, buf) = probe_sink();
 
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(
             !lines.is_empty(),
@@ -655,13 +707,16 @@ sink:
     }
 
     /// When no spike windows are configured, labels object must not contain spike keys.
-    #[test]
-    fn run_logs_with_sink_no_spike_config_produces_no_spike_labels() {
+    #[tokio::test]
+    async fn run_logs_with_sink_no_spike_config_produces_no_spike_labels() {
         let config = make_config(10.0, Some("500ms"));
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             let parsed: serde_json::Value = serde_json::from_str(line)
                 .unwrap_or_else(|e| panic!("line is not valid JSON: {e}\nline: {line}"));
@@ -688,8 +743,8 @@ sink:
     }
 
     /// Dynamic labels with counter strategy appear in every JSON log line.
-    #[test]
-    fn run_logs_dynamic_labels_counter_appear_in_output() {
+    #[tokio::test]
+    async fn run_logs_dynamic_labels_counter_appear_in_output() {
         let config = make_config_with_dynamic_labels(
             10.0,
             Some("1s"),
@@ -701,10 +756,13 @@ sink:
                 },
             }],
         );
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(!lines.is_empty(), "runner must produce output");
 
@@ -724,8 +782,8 @@ sink:
     }
 
     /// Dynamic labels with values list cycle through values in log output.
-    #[test]
-    fn run_logs_dynamic_labels_values_list_cycle_in_output() {
+    #[tokio::test]
+    async fn run_logs_dynamic_labels_values_list_cycle_in_output() {
         let config = make_config_with_dynamic_labels(
             10.0,
             Some("1s"),
@@ -736,10 +794,13 @@ sink:
                 },
             }],
         );
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(!lines.is_empty());
 
@@ -768,8 +829,8 @@ sink:
     }
 
     /// Cardinality ceiling is respected in log output.
-    #[test]
-    fn run_logs_dynamic_labels_respects_cardinality_ceiling() {
+    #[tokio::test]
+    async fn run_logs_dynamic_labels_respects_cardinality_ceiling() {
         let config = make_config_with_dynamic_labels(
             50.0,
             Some("1s"),
@@ -781,10 +842,13 @@ sink:
                 },
             }],
         );
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let mut distinct_values = std::collections::HashSet::new();
         for line in output.lines() {
             let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
@@ -801,8 +865,8 @@ sink:
     }
 
     /// Dynamic labels and static labels coexist in log output.
-    #[test]
-    fn run_logs_dynamic_labels_and_static_labels_coexist() {
+    #[tokio::test]
+    async fn run_logs_dynamic_labels_and_static_labels_coexist() {
         let mut config = make_config_with_dynamic_labels(
             10.0,
             Some("1s"),
@@ -818,10 +882,13 @@ sink:
         label_map.insert("env".to_string(), "staging".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             let parsed: serde_json::Value = serde_json::from_str(line)
                 .unwrap_or_else(|e| panic!("line is not valid JSON: {e}\nline: {line}"));
@@ -837,8 +904,8 @@ sink:
     }
 
     /// Dynamic label wins on key collision with static label in log output.
-    #[test]
-    fn run_logs_dynamic_label_wins_on_key_collision() {
+    #[tokio::test]
+    async fn run_logs_dynamic_label_wins_on_key_collision() {
         let mut config = make_config_with_dynamic_labels(
             10.0,
             Some("500ms"),
@@ -854,10 +921,13 @@ sink:
         label_map.insert("hostname".to_string(), "static-value".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             let parsed: serde_json::Value = serde_json::from_str(line)
                 .unwrap_or_else(|e| panic!("line is not valid JSON: {e}\nline: {line}"));

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -36,9 +36,9 @@ use crate::SondaError;
 /// # Errors
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-pub fn run(config: &ScenarioConfig) -> Result<(), SondaError> {
+pub async fn run(config: &ScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, None)?;
-    run_with_sink(config, sink.as_mut(), None, None)
+    run_with_sink(config, &mut sink, None, None).await
 }
 
 /// Run a scenario to completion, writing encoded events into the provided sink.
@@ -68,13 +68,13 @@ pub fn run(config: &ScenarioConfig) -> Result<(), SondaError> {
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 /// If an error occurs during the loop and flushing also fails, the loop error
 /// is returned (the flush error is discarded to preserve the original cause).
-pub fn run_with_sink(
+pub async fn run_with_sink(
     config: &ScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_with_sink_gated(config, sink, shutdown, stats, None, None)
+    run_with_sink_gated(config, sink, shutdown, stats, None, None).await
 }
 
 /// Run a metric scenario with optional `while:` / `after:` gating.
@@ -83,9 +83,9 @@ pub fn run_with_sink(
 /// gates to subscribe to). `gate_ctx` is what THIS scenario consumes from
 /// an upstream bus. Both are independent — a scenario can be both an
 /// upstream (publishing) and a downstream (gated).
-pub fn run_with_sink_gated(
+pub async fn run_with_sink_gated(
     config: &ScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     upstream_bus: Option<Arc<GateBus>>,
@@ -168,14 +168,17 @@ pub fn run_with_sink_gated(
     };
 
     match gate_ctx {
-        None => core_loop::run_schedule_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            sink,
-            &mut tick_fn,
-        ),
+        None => {
+            core_loop::run_schedule_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
         Some(mut ctx) => {
             ctx.close_emit = build_close_emit(
                 config,
@@ -193,6 +196,7 @@ pub fn run_with_sink_gated(
                 sink,
                 &mut tick_fn,
             )
+            .await
         }
     }
 }
@@ -289,11 +293,36 @@ fn is_remote_write_sink(_sink: &SinkConfig) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use crate::config::{BaseScheduleConfig, GapConfig, ScenarioConfig};
     use crate::encoder::EncoderConfig;
     use crate::generator::GeneratorConfig;
-    use crate::sink::memory::MemorySink;
-    use crate::sink::SinkConfig;
+    use crate::sink::{Sink, SinkConfig};
+    use crate::SondaError;
+
+    type SharedBuf = std::sync::Arc<Mutex<Vec<u8>>>;
+
+    struct ProbeSink(SharedBuf);
+
+    impl Sink for ProbeSink {
+        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+            self.0
+                .lock()
+                .expect("probe sink mutex poisoned")
+                .extend_from_slice(data);
+            Ok(())
+        }
+        fn flush(&mut self) -> Result<(), SondaError> {
+            Ok(())
+        }
+    }
+
+    fn probe_sink() -> (Box<dyn Sink>, SharedBuf) {
+        let buf: SharedBuf = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let sink: Box<dyn Sink> = Box::new(ProbeSink(SharedBuf::clone(&buf)));
+        (sink, buf)
+    }
 
     /// Build a minimal ScenarioConfig suitable for a short integration run.
     fn make_config(rate: f64, duration: &str, gaps: Option<GapConfig>) -> ScenarioConfig {
@@ -326,10 +355,10 @@ mod tests {
     // ---- run: basic correctness ----------------------------------------------
 
     /// run() with a short duration should complete without error.
-    #[test]
-    fn run_completes_without_error_for_short_duration() {
+    #[tokio::test]
+    async fn run_completes_without_error_for_short_duration() {
         let config = make_config(100.0, "100ms", None);
-        let result = super::run(&config);
+        let result = super::run(&config).await;
         assert!(
             result.is_ok(),
             "run must succeed for valid config: {result:?}"
@@ -340,13 +369,16 @@ mod tests {
 
     /// At rate=100 for 1 second we expect approximately 100 newline-terminated events.
     /// We allow a ±20% window to accommodate scheduling jitter.
-    #[test]
-    fn integration_rate_100_duration_1s_emits_approximately_100_events() {
+    #[tokio::test]
+    async fn integration_rate_100_duration_1s_emits_approximately_100_events() {
         let config = make_config(100.0, "1s", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
         assert!(
             (80..=120).contains(&newlines),
             "expected ~100 events (80–120), got {newlines}"
@@ -354,13 +386,16 @@ mod tests {
     }
 
     /// Each emitted line is valid UTF-8 and starts with the metric name.
-    #[test]
-    fn integration_output_lines_start_with_metric_name() {
+    #[tokio::test]
+    async fn integration_output_lines_start_with_metric_name() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             assert!(
                 line.starts_with("up"),
@@ -370,16 +405,16 @@ mod tests {
     }
 
     /// Each emitted Prometheus line ends with a newline.
-    #[test]
-    fn integration_output_ends_with_newline() {
+    #[tokio::test]
+    async fn integration_output_ends_with_newline() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        assert!(
-            sink.buffer.ends_with(b"\n"),
-            "output must end with a newline"
-        );
+        let captured = buf.lock().unwrap();
+        assert!(captured.ends_with(b"\n"), "output must end with a newline");
     }
 
     // ---- Integration: gap suppresses events ----------------------------------
@@ -388,8 +423,8 @@ mod tests {
     /// 500 events because the gap suppresses approximately 1 second of output per
     /// 3-second cycle (~100 events lost from the first gap, plus ~100 from the
     /// second). We use 380 as a conservative upper bound below 500.
-    #[test]
-    fn integration_gap_suppresses_events() {
+    #[tokio::test]
+    async fn integration_gap_suppresses_events() {
         let config = make_config(
             100.0,
             "5s",
@@ -398,10 +433,13 @@ mod tests {
                 r#for: "1s".to_string(),
             }),
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
         assert!(
             newlines < 500,
             "gap must suppress events: expected < 500, got {newlines}"
@@ -416,41 +454,44 @@ mod tests {
     // ---- run: invalid config is rejected -------------------------------------
 
     /// A config with an unparseable duration returns Err.
-    #[test]
-    fn run_with_invalid_duration_returns_err() {
+    #[tokio::test]
+    async fn run_with_invalid_duration_returns_err() {
         let mut config = make_config(100.0, "bad_duration", None);
         // Manually set an invalid duration string.
         config.duration = Some("not_a_duration".to_string());
-        let result = super::run(&config);
+        let result = super::run(&config).await;
         assert!(result.is_err(), "invalid duration must return Err");
     }
 
     /// A config with an invalid gap duration returns Err.
-    #[test]
-    fn run_with_invalid_gap_every_returns_err() {
+    #[tokio::test]
+    async fn run_with_invalid_gap_every_returns_err() {
         let mut config = make_config(100.0, "1s", None);
         config.gaps = Some(GapConfig {
             every: "bad".to_string(),
             r#for: "1s".to_string(),
         });
-        let result = super::run(&config);
+        let result = super::run(&config).await;
         assert!(result.is_err(), "invalid gap.every must return Err");
     }
 
     // ---- run: labels appear in output ---------------------------------------
 
     /// When labels are configured they appear in the encoded output.
-    #[test]
-    fn integration_labels_appear_in_output() {
+    #[tokio::test]
+    async fn integration_labels_appear_in_output() {
         let mut config = make_config(50.0, "100ms", None);
         let mut label_map = std::collections::HashMap::new();
         label_map.insert("host".to_string(), "server1".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         assert!(
             output.contains("host=\"server1\""),
             "label must appear in output, got:\n{output}"
@@ -499,8 +540,8 @@ mod tests {
     /// The burst occupies [0, burst_for) of each burst_every cycle.
     /// With burst_every=10s and burst_for=9s, the first 1s of the run is always
     /// inside a burst (cycle_pos=0..1 < 9), so effective_interval = base/5.
-    #[test]
-    fn integration_burst_increases_event_count() {
+    #[tokio::test]
+    async fn integration_burst_increases_event_count() {
         let config = make_config_with_burst(
             10.0,
             "1s",
@@ -511,10 +552,13 @@ mod tests {
                 multiplier: 5.0,
             }),
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
         // Without burst: ~10 events. With 5x burst for entire 1s: ~50 events.
         // We allow a wide range to accommodate scheduling jitter.
         assert!(
@@ -531,8 +575,8 @@ mod tests {
     /// The first 1s of the run is in a burst (rate=500), the second 1s is not (rate=100).
     /// Total expected events: ~500 + ~100 = ~600.
     /// We use a range of 400–800 to accommodate scheduling jitter.
-    #[test]
-    fn integration_burst_then_normal_produces_mixed_rate() {
+    #[tokio::test]
+    async fn integration_burst_then_normal_produces_mixed_rate() {
         let config = make_config_with_burst(
             100.0,
             "2s",
@@ -543,10 +587,13 @@ mod tests {
                 multiplier: 5.0,
             }),
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
         // Without any burst: ~200 events. With burst for first 1s: ~600.
         assert!(
             newlines > 200,
@@ -588,8 +635,8 @@ mod tests {
     /// During [1s, 3s): gap wins → 0 events.
     /// Total: only ~500 events (much less than 100*3=300 without gap/burst,
     /// and much less than 500*2+100*1 with burst only).
-    #[test]
-    fn integration_gap_wins_over_burst_suppresses_events() {
+    #[tokio::test]
+    async fn integration_gap_wins_over_burst_suppresses_events() {
         // Gap occupies [every-for, every) = [3-2, 3) = [1s, 3s) per cycle.
         // Burst occupies [0, burst_for) = [0, 2.5s) per cycle.
         // Overlap: [1s, 2.5s) — gap wins here.
@@ -607,10 +654,13 @@ mod tests {
                 multiplier: 5.0,
             }),
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
 
         // During gap: 0 events. During [0,1s) with burst (5x): ~500 events.
         // But the run exits after 3s total, and the gap sleeps through most of it.
@@ -634,8 +684,8 @@ mod tests {
     /// Simpler gap-wins-over-burst test: run for 100ms with no gap and burst
     /// to establish a baseline, then run with both gap and burst where the
     /// gap covers the entire duration — expect zero events.
-    #[test]
-    fn integration_gap_covering_full_window_produces_zero_events_even_with_burst() {
+    #[tokio::test]
+    async fn integration_gap_covering_full_window_produces_zero_events_even_with_burst() {
         // Gap: every=1s, for=500ms → gap occupies [500ms, 1000ms) in each 1s cycle.
         // Run for 200ms starting at cycle_pos approaching 500ms.
         //
@@ -664,10 +714,16 @@ mod tests {
                 multiplier: 5.0,
             }),
         );
-        let mut sink_no_gap = MemorySink::new();
+        let (mut sink_no_gap, buf_no_gap) = probe_sink();
         super::run_with_sink(&config_no_gap_burst, &mut sink_no_gap, None, None)
+            .await
             .expect("run must succeed");
-        let events_burst_only = sink_no_gap.buffer.iter().filter(|&&b| b == b'\n').count();
+        let events_burst_only = buf_no_gap
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|&&b| b == b'\n')
+            .count();
 
         // With the burst for 900ms of each 1s cycle, over 500ms we'd expect ~4500 events.
         // This shows burst is working.
@@ -684,11 +740,13 @@ mod tests {
                 multiplier: 5.0,
             }),
         );
-        let mut sink_gap_burst = MemorySink::new();
+        let (mut sink_gap_burst, buf_gap_burst) = probe_sink();
         super::run_with_sink(&config_gap_and_burst, &mut sink_gap_burst, None, None)
+            .await
             .expect("run must succeed");
-        let events_gap_and_burst = sink_gap_burst
-            .buffer
+        let events_gap_and_burst = buf_gap_burst
+            .lock()
+            .unwrap()
             .iter()
             .filter(|&&b| b == b'\n')
             .count();
@@ -706,15 +764,16 @@ mod tests {
 
     // ---- Integration: stats buffer receives metric events ---------------------
 
-    #[test]
-    fn runner_pushes_metric_events_to_stats_current_values() {
+    #[tokio::test]
+    async fn runner_pushes_metric_events_to_stats_current_values() {
         use std::sync::{Arc, RwLock};
 
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
+        let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
         super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
+            .await
             .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
@@ -726,30 +785,34 @@ mod tests {
 
     /// When no stats arc is provided (None), the runner does not panic and
     /// still produces output normally.
-    #[test]
-    fn runner_without_stats_does_not_push_metrics() {
+    #[tokio::test]
+    async fn runner_without_stats_does_not_push_metrics() {
         let config = make_config(50.0, "100ms", None);
-        let mut sink = MemorySink::new();
+        let (mut sink, buf) = probe_sink();
 
         // Pass None for stats — should work fine without buffering.
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
         assert!(
             newlines > 0,
             "runner without stats must still produce output"
         );
     }
 
-    #[test]
-    fn runner_stats_current_values_have_correct_metric_name() {
+    #[tokio::test]
+    async fn runner_stats_current_values_have_correct_metric_name() {
         use std::sync::{Arc, RwLock};
 
         let config = make_config(50.0, "100ms", None);
-        let mut sink = MemorySink::new();
+        let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
         super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
+            .await
             .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
@@ -759,8 +822,8 @@ mod tests {
     }
 
     /// The shutdown flag stops the runner even during a burst window.
-    #[test]
-    fn shutdown_flag_stops_run_during_burst() {
+    #[tokio::test]
+    async fn shutdown_flag_stops_run_during_burst() {
         use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::Arc;
 
@@ -784,15 +847,18 @@ mod tests {
             shutdown_clone.store(false, Ordering::SeqCst);
         });
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, Some(&shutdown), None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, Some(&shutdown), None)
+            .await
+            .expect("run must succeed");
         handle.join().expect("thread must complete");
 
         // The run stopped after ~200ms due to shutdown flag.
         // At rate=1000 with 5x burst: ~1000 events in 200ms.
         // We just assert it stopped without hanging (the test would time out otherwise)
         // and produced some output.
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
         assert!(
             newlines > 0,
             "some events must have been emitted before shutdown"
@@ -835,8 +901,8 @@ mod tests {
 
     /// When the entire run is inside a spike window, every output line must
     /// contain the spike label key.
-    #[test]
-    fn integration_spike_labels_appear_during_spike_window() {
+    #[tokio::test]
+    async fn integration_spike_labels_appear_during_spike_window() {
         let spike = crate::config::CardinalitySpikeConfig {
             label: "pod_name".to_string(),
             every: "10s".to_string(),
@@ -848,10 +914,13 @@ mod tests {
         };
         // Run for 500ms inside a spike window (spike occupies 0..9s of each 10s cycle)
         let config = make_config_with_spike(50.0, "500ms", spike);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             assert!(
                 line.contains("pod_name="),
@@ -861,13 +930,16 @@ mod tests {
     }
 
     /// When no spike windows are configured, output does not contain spike labels.
-    #[test]
-    fn integration_no_spike_config_produces_no_spike_labels() {
+    #[tokio::test]
+    async fn integration_no_spike_config_produces_no_spike_labels() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             assert!(
                 !line.contains("pod_name="),
@@ -877,8 +949,8 @@ mod tests {
     }
 
     /// Counter strategy produces unique values bounded by cardinality.
-    #[test]
-    fn integration_spike_counter_strategy_produces_bounded_values() {
+    #[tokio::test]
+    async fn integration_spike_counter_strategy_produces_bounded_values() {
         let spike = crate::config::CardinalitySpikeConfig {
             label: "pod_name".to_string(),
             every: "10s".to_string(),
@@ -889,10 +961,13 @@ mod tests {
             seed: None,
         };
         let config = make_config_with_spike(50.0, "500ms", spike);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let mut seen_values = std::collections::HashSet::new();
         for line in output.lines() {
             // Extract value of pod_name from Prometheus output like: pod_name="pod-0"
@@ -917,8 +992,8 @@ mod tests {
     }
 
     /// Stats correctly reports `in_cardinality_spike` during a spike window.
-    #[test]
-    fn integration_spike_stats_reports_in_cardinality_spike() {
+    #[tokio::test]
+    async fn integration_spike_stats_reports_in_cardinality_spike() {
         use std::sync::{Arc, RwLock};
 
         let spike = crate::config::CardinalitySpikeConfig {
@@ -931,10 +1006,11 @@ mod tests {
             seed: None,
         };
         let config = make_config_with_spike(50.0, "200ms", spike);
-        let mut sink = MemorySink::new();
+        let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
         super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
+            .await
             .expect("run must succeed");
 
         // The entire 200ms run is inside the spike window (0..9s of 10s cycle).
@@ -949,15 +1025,16 @@ mod tests {
     // ---- Arc sharing: name and labels are reference-counted, not deep-cloned ---
 
     /// All metric events buffered in stats must share the same Arc<str> name
-    #[test]
-    fn current_values_holds_one_entry_for_single_series_scenario() {
+    #[tokio::test]
+    async fn current_values_holds_one_entry_for_single_series_scenario() {
         use std::sync::{Arc, RwLock};
 
         let config = make_config(200.0, "100ms", None);
-        let mut sink = MemorySink::new();
+        let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
         super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
+            .await
             .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
@@ -975,8 +1052,8 @@ mod tests {
     }
 
     /// Invalid metric name in config is caught before the hot loop, not during.
-    #[test]
-    fn invalid_metric_name_returns_config_error_before_loop() {
+    #[tokio::test]
+    async fn invalid_metric_name_returns_config_error_before_loop() {
         let config = ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "123-invalid".to_string(),
@@ -1001,8 +1078,8 @@ mod tests {
             metric_type: None,
             help: None,
         };
-        let mut sink = MemorySink::new();
-        let result = super::run_with_sink(&config, &mut sink, None, None);
+        let (mut sink, _buf) = probe_sink();
+        let result = super::run_with_sink(&config, &mut sink, None, None).await;
         assert!(
             matches!(result, Err(crate::SondaError::Config(ref e)) if e.to_string().contains("123-invalid")),
             "expected Config error for invalid name, got: {result:?}"
@@ -1044,8 +1121,8 @@ mod tests {
     }
 
     /// Dynamic labels with counter strategy appear in every Prometheus line.
-    #[test]
-    fn dynamic_labels_counter_appear_in_metric_output() {
+    #[tokio::test]
+    async fn dynamic_labels_counter_appear_in_metric_output() {
         let config = make_config_with_dynamic_labels(
             10.0,
             "1s",
@@ -1057,10 +1134,13 @@ mod tests {
                 },
             }],
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(
             !lines.is_empty(),
@@ -1076,8 +1156,8 @@ mod tests {
     }
 
     /// Dynamic labels with values list cycle through the values.
-    #[test]
-    fn dynamic_labels_values_list_cycle_in_metric_output() {
+    #[tokio::test]
+    async fn dynamic_labels_values_list_cycle_in_metric_output() {
         let config = make_config_with_dynamic_labels(
             10.0,
             "1s",
@@ -1088,10 +1168,13 @@ mod tests {
                 },
             }],
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(!lines.is_empty());
 
@@ -1113,8 +1196,8 @@ mod tests {
     }
 
     /// Cardinality ceiling is respected: only cardinality distinct values appear.
-    #[test]
-    fn dynamic_labels_counter_respects_cardinality_ceiling_in_output() {
+    #[tokio::test]
+    async fn dynamic_labels_counter_respects_cardinality_ceiling_in_output() {
         let config = make_config_with_dynamic_labels(
             50.0,
             "1s",
@@ -1126,10 +1209,13 @@ mod tests {
                 },
             }],
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         let mut distinct_values = std::collections::HashSet::new();
         for line in output.lines() {
             // Extract the hostname="..." value
@@ -1149,8 +1235,8 @@ mod tests {
     }
 
     /// Dynamic labels and static labels coexist: both appear in output.
-    #[test]
-    fn dynamic_labels_and_static_labels_coexist_in_output() {
+    #[tokio::test]
+    async fn dynamic_labels_and_static_labels_coexist_in_output() {
         let mut config = make_config_with_dynamic_labels(
             10.0,
             "1s",
@@ -1166,10 +1252,13 @@ mod tests {
         label_map.insert("env".to_string(), "prod".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         for line in output.lines() {
             assert!(
                 line.contains("env=\"prod\""),
@@ -1183,8 +1272,8 @@ mod tests {
     }
 
     /// Dynamic label wins on key collision with static label.
-    #[test]
-    fn dynamic_label_wins_on_key_collision_with_static() {
+    #[tokio::test]
+    async fn dynamic_label_wins_on_key_collision_with_static() {
         let mut config = make_config_with_dynamic_labels(
             10.0,
             "500ms",
@@ -1200,10 +1289,13 @@ mod tests {
         label_map.insert("hostname".to_string(), "static-value".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         for line in output.lines() {
             assert!(
                 line.contains("hostname=\"dynamic-"),

--- a/sonda-core/src/schedule/summary_runner.rs
+++ b/sonda-core/src/schedule/summary_runner.rs
@@ -40,9 +40,9 @@ use crate::SondaError;
 /// # Errors
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-pub fn run(config: &SummaryScenarioConfig) -> Result<(), SondaError> {
+pub async fn run(config: &SummaryScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, None)?;
-    run_with_sink(config, sink.as_mut(), None, None)
+    run_with_sink(config, &mut sink, None, None).await
 }
 
 /// Run a summary scenario to completion, writing encoded events into the
@@ -62,22 +62,22 @@ pub fn run(config: &SummaryScenarioConfig) -> Result<(), SondaError> {
 /// # Errors
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-pub fn run_with_sink(
+pub async fn run_with_sink(
     config: &SummaryScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_with_sink_gated(config, sink, shutdown, stats, None)
+    run_with_sink_gated(config, sink, shutdown, stats, None).await
 }
 
 /// Run a summary scenario with optional `while:` / `after:` gating.
 ///
 /// Summaries cannot be `while:` upstreams (compile-time
 /// `NonMetricsTarget`), but they can be `while:`-gated downstreams.
-pub fn run_with_sink_gated(
+pub async fn run_with_sink_gated(
     config: &SummaryScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
@@ -238,32 +238,63 @@ pub fn run_with_sink_gated(
     };
 
     match gate_ctx {
-        None => core_loop::run_schedule_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            sink,
-            &mut tick_fn,
-        ),
-        Some(ctx) => core_loop::gated_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            ctx,
-            sink,
-            &mut tick_fn,
-        ),
+        None => {
+            core_loop::run_schedule_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
+        Some(ctx) => {
+            core_loop::gated_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                ctx,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use crate::config::{BaseScheduleConfig, DistributionConfig, SummaryScenarioConfig};
     use crate::encoder::EncoderConfig;
-    use crate::sink::memory::MemorySink;
-    use crate::sink::SinkConfig;
+    use crate::sink::{Sink, SinkConfig};
+    use crate::SondaError;
+
+    type SharedBuf = std::sync::Arc<Mutex<Vec<u8>>>;
+
+    struct ProbeSink(SharedBuf);
+
+    impl Sink for ProbeSink {
+        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+            self.0
+                .lock()
+                .expect("probe sink mutex poisoned")
+                .extend_from_slice(data);
+            Ok(())
+        }
+        fn flush(&mut self) -> Result<(), SondaError> {
+            Ok(())
+        }
+    }
+
+    fn probe_sink() -> (Box<dyn Sink>, SharedBuf) {
+        let buf: SharedBuf = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let sink: Box<dyn Sink> = Box::new(ProbeSink(SharedBuf::clone(&buf)));
+        (sink, buf)
+    }
 
     /// Build a minimal SummaryScenarioConfig for testing.
     fn make_config(
@@ -306,23 +337,31 @@ mod tests {
 
     // ---- Run completes without error ----------------------------------------
 
-    #[test]
-    fn run_completes_for_short_duration() {
+    #[tokio::test]
+    async fn run_completes_for_short_duration() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("summary run must succeed");
-        assert!(!sink.buffer.is_empty(), "summary run must produce output");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("summary run must succeed");
+        assert!(
+            !buf.lock().unwrap().is_empty(),
+            "summary run must produce output"
+        );
     }
 
     // ---- Output contains expected series names ------------------------------
 
-    #[test]
-    fn output_contains_quantile_count_sum_series() {
+    #[tokio::test]
+    async fn output_contains_quantile_count_sum_series() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
 
         assert!(
             output.contains("rpc_duration_seconds{"),
@@ -340,13 +379,16 @@ mod tests {
 
     // ---- quantile label present on quantile events ---------------------------
 
-    #[test]
-    fn quantile_events_have_quantile_label() {
+    #[tokio::test]
+    async fn quantile_events_have_quantile_label() {
         let config = make_config(50.0, "100ms", Some(vec![0.5, 0.99]));
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
 
         assert!(
             output.contains("quantile=\"0.5\""),
@@ -360,36 +402,41 @@ mod tests {
 
     // ---- Gap suppresses output -----------------------------------------------
 
-    #[test]
-    fn gap_suppresses_summary_output() {
+    #[tokio::test]
+    async fn gap_suppresses_summary_output() {
         let mut config = make_config(100.0, "2s", None);
         config.base.gaps = Some(crate::config::GapConfig {
             every: "1s".to_string(),
             r#for: "500ms".to_string(),
         });
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
         assert!(
-            !sink.buffer.is_empty(),
+            !buf.lock().unwrap().is_empty(),
             "summary with gaps must still produce some output"
         );
     }
 
     // ---- Labels from config are included ------------------------------------
 
-    #[test]
-    fn config_labels_appear_in_output() {
+    #[tokio::test]
+    async fn config_labels_appear_in_output() {
         let mut config = make_config(50.0, "100ms", Some(vec![0.5]));
         let mut label_map = std::collections::HashMap::new();
         label_map.insert("service".to_string(), "auth".to_string());
         config.base.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         assert!(
             output.contains("service=\"auth\""),
             "config labels must appear in output"

--- a/sonda-core/tests/common/mod.rs
+++ b/sonda-core/tests/common/mod.rs
@@ -251,9 +251,9 @@ pub fn run_and_capture_stdout(entries: Vec<ScenarioEntry>) -> Vec<u8> {
                     }
                 }
 
-                let mut sink = CapturingSink {
+                let mut sink: Box<dyn Sink> = Box::new(CapturingSink {
                     buffer: buffer_for_thread,
-                };
+                });
                 run_entry_with_sink(&entry, &mut sink)
             })
             .expect("failed to spawn parity harness thread");
@@ -345,22 +345,36 @@ pub fn normalize_timestamps(bytes: &[u8]) -> Vec<u8> {
 ///
 /// The runner is driven with `shutdown: None` (the scenario's own
 /// `duration:` field bounds the run) and `stats: None` (parity tests do
-/// not inspect stats).
-fn run_entry_with_sink(entry: &ScenarioEntry, sink: &mut dyn Sink) -> Result<(), SondaError> {
-    // All four runners take the same shape: &Config, &mut dyn Sink,
-    // Option<&AtomicBool>, Option<Arc<RwLock<ScenarioStats>>>.
+/// not inspect stats). The async runner is driven from a per-call
+/// `current_thread` Tokio runtime so callers stay sync.
+fn run_entry_with_sink(entry: &ScenarioEntry, sink: &mut Box<dyn Sink>) -> Result<(), SondaError> {
     const NONE_ATOMIC: Option<&AtomicBool> = None;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime for test runner must build");
     match entry {
-        ScenarioEntry::Metrics(config) => runner::run_with_sink(config, sink, NONE_ATOMIC, None),
-        ScenarioEntry::Logs(config) => {
-            log_runner::run_logs_with_sink(config, sink, NONE_ATOMIC, None)
+        ScenarioEntry::Metrics(config) => {
+            rt.block_on(runner::run_with_sink(config, sink, NONE_ATOMIC, None))
         }
-        ScenarioEntry::Histogram(config) => {
-            histogram_runner::run_with_sink(config, sink, NONE_ATOMIC, None)
-        }
-        ScenarioEntry::Summary(config) => {
-            summary_runner::run_with_sink(config, sink, NONE_ATOMIC, None)
-        }
+        ScenarioEntry::Logs(config) => rt.block_on(log_runner::run_logs_with_sink(
+            config,
+            sink,
+            NONE_ATOMIC,
+            None,
+        )),
+        ScenarioEntry::Histogram(config) => rt.block_on(histogram_runner::run_with_sink(
+            config,
+            sink,
+            NONE_ATOMIC,
+            None,
+        )),
+        ScenarioEntry::Summary(config) => rt.block_on(summary_runner::run_with_sink(
+            config,
+            sink,
+            NONE_ATOMIC,
+            None,
+        )),
         // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary
         // (integration tests are a separate crate), so a wildcard arm is
         // required. A future signal variant has no runner wired in here yet.

--- a/sonda-core/tests/start_time_shift.rs
+++ b/sonda-core/tests/start_time_shift.rs
@@ -4,7 +4,7 @@
 #![cfg(feature = "config")]
 
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -18,9 +18,31 @@ use sonda_core::generator::{GeneratorConfig, LogGeneratorConfig, TemplateConfig}
 use sonda_core::schedule::gate_bus::{GateBus, SubscriptionSpec, WhileSpec};
 use sonda_core::schedule::stats::ScenarioStats;
 use sonda_core::schedule::{histogram_runner, log_runner, runner, summary_runner, GateContext};
-use sonda_core::sink::memory::MemorySink;
-use sonda_core::sink::SinkConfig;
-use sonda_core::OnSinkError;
+use sonda_core::sink::{Sink, SinkConfig};
+use sonda_core::{OnSinkError, SondaError};
+
+type SharedBuf = Arc<Mutex<Vec<u8>>>;
+
+struct ProbeSink(SharedBuf);
+
+impl Sink for ProbeSink {
+    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        self.0
+            .lock()
+            .expect("probe sink mutex poisoned")
+            .extend_from_slice(data);
+        Ok(())
+    }
+    fn flush(&mut self) -> Result<(), SondaError> {
+        Ok(())
+    }
+}
+
+fn probe_sink() -> (Box<dyn Sink>, SharedBuf) {
+    let buf: SharedBuf = Arc::new(Mutex::new(Vec::new()));
+    let sink: Box<dyn Sink> = Box::new(ProbeSink(SharedBuf::clone(&buf)));
+    (sink, buf)
+}
 
 fn base(name: &str, rate: f64, duration: &str, start_time: Option<&str>) -> BaseScheduleConfig {
     BaseScheduleConfig {
@@ -81,16 +103,19 @@ fn now_ms() -> i128 {
         .as_millis() as i128
 }
 
-#[test]
-fn metric_absolute_past_start_time_anchors_first_event_at_exact_instant() {
+#[tokio::test]
+async fn metric_absolute_past_start_time_anchors_first_event_at_exact_instant() {
     // 2026-05-08T14:00:00Z = 1_778_248_800 s since epoch.
     let anchor_ms: i128 = 1_778_248_800_000;
     let config = metric_config("up", 5.0, "1s", Some("2026-05-08T14:00:00Z"));
 
-    let mut sink = MemorySink::new();
-    runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+    let (mut sink, buf) = probe_sink();
+    runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
 
-    let timestamps = prometheus_timestamps_ms(&sink.buffer);
+    let captured = buf.lock().unwrap();
+    let timestamps = prometheus_timestamps_ms(&captured);
     assert!(
         timestamps.len() >= 2,
         "need at least 2 events to check advancement, got {}",
@@ -135,16 +160,19 @@ fn metric_absolute_past_start_time_anchors_first_event_at_exact_instant() {
     );
 }
 
-#[test]
-fn metric_relative_future_offset_shifts_events_ahead() {
+#[tokio::test]
+async fn metric_relative_future_offset_shifts_events_ahead() {
     let before = now_ms();
     let config = metric_config("up", 10.0, "400ms", Some("+24h"));
 
-    let mut sink = MemorySink::new();
-    runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+    let (mut sink, buf) = probe_sink();
+    runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
     let after = now_ms();
 
-    let timestamps = prometheus_timestamps_ms(&sink.buffer);
+    let captured = buf.lock().unwrap();
+    let timestamps = prometheus_timestamps_ms(&captured);
     assert!(!timestamps.is_empty(), "expected emitted events");
 
     let shift = Duration::from_secs(24 * 3600).as_millis() as i128;
@@ -159,16 +187,19 @@ fn metric_relative_future_offset_shifts_events_ahead() {
     );
 }
 
-#[test]
-fn metric_relative_past_offset_shifts_events_back() {
+#[tokio::test]
+async fn metric_relative_past_offset_shifts_events_back() {
     let before = now_ms();
     let config = metric_config("up", 10.0, "400ms", Some("-7d"));
 
-    let mut sink = MemorySink::new();
-    runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+    let (mut sink, buf) = probe_sink();
+    runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
     let after = now_ms();
 
-    let timestamps = prometheus_timestamps_ms(&sink.buffer);
+    let captured = buf.lock().unwrap();
+    let timestamps = prometheus_timestamps_ms(&captured);
     assert!(!timestamps.is_empty(), "expected emitted events");
 
     let shift = Duration::from_secs(7 * 86_400).as_millis() as i128;
@@ -188,16 +219,19 @@ fn omitted_start_time_yields_now_variant() {
     assert_eq!(parse_start_time("now").unwrap(), StartTime::Now);
 }
 
-#[test]
-fn metric_without_start_time_emits_at_real_now() {
+#[tokio::test]
+async fn metric_without_start_time_emits_at_real_now() {
     let before = now_ms();
     let config = metric_config("up", 10.0, "400ms", None);
 
-    let mut sink = MemorySink::new();
-    runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+    let (mut sink, buf) = probe_sink();
+    runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
     let after = now_ms();
 
-    let timestamps = prometheus_timestamps_ms(&sink.buffer);
+    let captured = buf.lock().unwrap();
+    let timestamps = prometheus_timestamps_ms(&captured);
     assert!(!timestamps.is_empty(), "expected emitted events");
     for ts in &timestamps {
         assert!(
@@ -225,16 +259,19 @@ fn assert_all_in_past_window(timestamps: &[i128]) {
     }
 }
 
-#[test]
-fn metric_signal_honours_absolute_past_shift() {
+#[tokio::test]
+async fn metric_signal_honours_absolute_past_shift() {
     let config = metric_config("up", 5.0, "600ms", Some(ANCHOR_RFC3339));
-    let mut sink = MemorySink::new();
-    runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
-    assert_all_in_past_window(&prometheus_timestamps_ms(&sink.buffer));
+    let (mut sink, buf) = probe_sink();
+    runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
+    let captured = buf.lock().unwrap();
+    assert_all_in_past_window(&prometheus_timestamps_ms(&captured));
 }
 
-#[test]
-fn log_signal_honours_absolute_past_shift() {
+#[tokio::test]
+async fn log_signal_honours_absolute_past_shift() {
     let config = LogScenarioConfig {
         base: base("logshift", 5.0, "600ms", Some(ANCHOR_RFC3339)),
         generator: LogGeneratorConfig::Template {
@@ -248,12 +285,15 @@ fn log_signal_honours_absolute_past_shift() {
         encoder: EncoderConfig::JsonLines { precision: None },
     };
 
-    let mut sink = MemorySink::new();
-    log_runner::run_logs_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+    let (mut sink, buf) = probe_sink();
+    log_runner::run_logs_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
 
     // JSON Lines stamps an RFC 3339 millis timestamp; the year is sufficient
     // to confirm the log event carries the shifted wall_clock, not real now.
-    let text = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+    let captured = buf.lock().unwrap();
+    let text = std::str::from_utf8(&captured).expect("valid UTF-8");
     let lines: Vec<&str> = text.lines().filter(|l| !l.is_empty()).collect();
     assert!(!lines.is_empty(), "expected emitted log lines");
     for line in &lines {
@@ -264,8 +304,8 @@ fn log_signal_honours_absolute_past_shift() {
     }
 }
 
-#[test]
-fn histogram_signal_honours_absolute_past_shift() {
+#[tokio::test]
+async fn histogram_signal_honours_absolute_past_shift() {
     let config = HistogramScenarioConfig {
         base: base("latency", 5.0, "600ms", Some(ANCHOR_RFC3339)),
         buckets: Some(vec![0.1, 0.5, 1.0]),
@@ -281,13 +321,16 @@ fn histogram_signal_honours_absolute_past_shift() {
         help: None,
     };
 
-    let mut sink = MemorySink::new();
-    histogram_runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
-    assert_all_in_past_window(&prometheus_timestamps_ms(&sink.buffer));
+    let (mut sink, buf) = probe_sink();
+    histogram_runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
+    let captured = buf.lock().unwrap();
+    assert_all_in_past_window(&prometheus_timestamps_ms(&captured));
 }
 
-#[test]
-fn summary_signal_honours_absolute_past_shift() {
+#[tokio::test]
+async fn summary_signal_honours_absolute_past_shift() {
     let config = SummaryScenarioConfig {
         base: base("rpc_duration", 5.0, "600ms", Some(ANCHOR_RFC3339)),
         quantiles: Some(vec![0.5, 0.9]),
@@ -303,9 +346,12 @@ fn summary_signal_honours_absolute_past_shift() {
         help: None,
     };
 
-    let mut sink = MemorySink::new();
-    summary_runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
-    assert_all_in_past_window(&prometheus_timestamps_ms(&sink.buffer));
+    let (mut sink, buf) = probe_sink();
+    summary_runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
+    let captured = buf.lock().unwrap();
+    assert_all_in_past_window(&prometheus_timestamps_ms(&captured));
 }
 
 #[test]
@@ -330,15 +376,21 @@ fn gated_close_emit_marker_lands_in_shifted_window() {
     };
 
     let config = metric_config("gated", 50.0, "2000ms", Some(ANCHOR_RFC3339));
-    let mut sink = MemorySink::new();
+    let (sink_init, buf) = probe_sink();
     let stats = Arc::new(RwLock::new(ScenarioStats::default()));
     let stats_for_thread = Arc::clone(&stats);
     let bus_for_thread = Arc::clone(&bus);
+    let buf_for_assert = SharedBuf::clone(&buf);
 
     let runner_handle = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        runner::run_with_sink_gated(
+        let mut sink = sink_init;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(runner::run_with_sink_gated(
             &config,
             &mut sink,
             Some(shutdown.as_ref()),
@@ -349,18 +401,18 @@ fn gated_close_emit_marker_lands_in_shifted_window() {
                     .with_delay(Some(delay))
                     .with_has_while(true),
             ),
-        )
+        ))
         .expect("gated runner must succeed");
-        sink
     });
 
     // Let the scenario accumulate shifted emissions, then close the gate so
     // the running → paused commit fires the close-emit marker.
     thread::sleep(Duration::from_millis(150));
     bus.tick(0.0);
-    let sink_after = runner_handle.join().expect("runner joined");
+    runner_handle.join().expect("runner joined");
 
-    let timestamps = prometheus_timestamps_ms(&sink_after.buffer);
+    let captured = buf_for_assert.lock().unwrap();
+    let timestamps = prometheus_timestamps_ms(&captured);
     assert!(
         timestamps.len() >= 2,
         "expected running samples plus a close marker, got {}",

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -105,7 +105,7 @@ fn run_with_capture(
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
 
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
@@ -123,14 +123,19 @@ fn run_with_capture(
         let gate_ctx = GateContext::new(rx, init)
             .with_delay(delay)
             .with_has_while(true);
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown.as_ref()),
             Some(stats_for_runner),
             None,
             Some(gate_ctx),
-        )
+        ))
         .expect("runner must succeed");
         let _ = bus_for_thread;
     });
@@ -292,8 +297,6 @@ fn stale_marker_disabled_emits_no_close_sample() {
 
 #[test]
 fn non_remote_write_sink_no_close_marker_by_default() {
-    use sonda_core::sink::memory::MemorySink;
-
     let bus = Arc::new(GateBus::new());
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -323,7 +326,9 @@ fn non_remote_write_sink_no_close_marker_by_default() {
         help: None,
     };
 
-    let mut sink = MemorySink::new();
+    let probe = CaptureSink::default();
+    let buf_handle = Arc::clone(&probe.buf);
+    let sink_for_thread: Box<dyn Sink> = Box::new(probe);
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -333,29 +338,34 @@ fn non_remote_write_sink_no_close_marker_by_default() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink,
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
-        )
+        ))
         .expect("runner must succeed");
-        sink
     });
 
     thread::sleep(Duration::from_millis(50));
     bus.tick(1.0);
     thread::sleep(Duration::from_millis(150));
     bus.tick(0.0);
-    let sink_after = runner.join().expect("runner joined");
+    runner.join().expect("runner joined");
 
     // Every emitted line must be a running-state sample with value 1.0
     // (the constant generator). A close-emit closure on a non-remote-write
     // sink with no `snap_to` should never be installed, so no additional
     // `NaN` (StaleMarker) or `0` (SnapTo(0)) sample line can appear.
-    let text = std::str::from_utf8(&sink_after.buffer).expect("utf-8");
+    let captured = buf_handle.lock().unwrap();
+    let text = std::str::from_utf8(&captured).expect("utf-8");
     let lines: Vec<&str> = text.lines().filter(|l| !l.is_empty()).collect();
     for line in &lines {
         let value_token = line
@@ -375,8 +385,6 @@ fn non_remote_write_sink_no_close_marker_by_default() {
 
 #[test]
 fn non_remote_write_sink_with_snap_to_emits_one_sample() {
-    use sonda_core::sink::memory::MemorySink;
-
     let bus = Arc::new(GateBus::new());
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -413,7 +421,9 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
         help: None,
     };
 
-    let mut sink = MemorySink::new();
+    let probe = CaptureSink::default();
+    let buf_handle = Arc::clone(&probe.buf);
+    let sink_for_thread: Box<dyn Sink> = Box::new(probe);
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -423,7 +433,12 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink,
             Some(shutdown.as_ref()),
@@ -434,21 +449,21 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
                     .with_delay(Some(delay))
                     .with_has_while(true),
             ),
-        )
+        ))
         .expect("runner must succeed");
-        sink
     });
 
     thread::sleep(Duration::from_millis(50));
     bus.tick(1.0);
     thread::sleep(Duration::from_millis(150));
     bus.tick(0.0);
-    let sink_after = runner.join().expect("runner joined");
+    runner.join().expect("runner joined");
 
     // Tokenize each line as `<name> <value> <timestamp>` rather than substring
     // match — the assertion stays robust if PrometheusText ever renders integer
     // values as `99.0` or trailing whitespace differently.
-    let text = std::str::from_utf8(&sink_after.buffer).expect("utf-8");
+    let captured = buf_handle.lock().unwrap();
+    let text = std::str::from_utf8(&captured).expect("utf-8");
     let snap_count = text
         .lines()
         .filter(|l| !l.is_empty())
@@ -480,7 +495,7 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -520,7 +535,12 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown.as_ref()),
@@ -531,7 +551,7 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
                     .with_delay(Some(delay))
                     .with_has_while(true),
             ),
-        )
+        ))
         .expect("runner must succeed");
     });
 
@@ -579,7 +599,7 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -619,14 +639,19 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
-        )
+        ))
         .expect("runner must succeed");
     });
 
@@ -653,8 +678,6 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
 
 #[test]
 fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
-    use sonda_core::sink::memory::MemorySink;
-
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -691,7 +714,9 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
         help: None,
     };
 
-    let mut sink = MemorySink::new();
+    let probe = CaptureSink::default();
+    let buf_handle = Arc::clone(&probe.buf);
+    let sink_for_thread: Box<dyn Sink> = Box::new(probe);
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -701,7 +726,12 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink,
             Some(shutdown.as_ref()),
@@ -712,16 +742,16 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
                     .with_delay(Some(delay))
                     .with_has_while(true),
             ),
-        )
+        ))
         .expect("runner must succeed");
-        sink
     });
 
     // Gate stays open for the whole 200ms duration — the loop exits via
     // LoopExit::DurationExpired, not a running→paused commit.
-    let sink_after = runner.join().expect("runner joined");
+    runner.join().expect("runner joined");
 
-    let text = std::str::from_utf8(&sink_after.buffer).expect("utf-8");
+    let captured = buf_handle.lock().unwrap();
+    let text = std::str::from_utf8(&captured).expect("utf-8");
     let snap_count = text
         .lines()
         .filter(|l| !l.is_empty())
@@ -754,7 +784,7 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -794,7 +824,12 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown.as_ref()),
@@ -810,7 +845,7 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
                     }))
                     .with_has_while(true),
             ),
-        )
+        ))
         .expect("runner must succeed");
     });
 
@@ -846,7 +881,7 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -886,14 +921,19 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
-        )
+        ))
         .expect("runner must succeed");
     });
 
@@ -928,7 +968,7 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -968,7 +1008,12 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown.as_ref()),
@@ -984,7 +1029,7 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
                     }))
                     .with_has_while(true),
             ),
-        )
+        ))
         .expect("runner must succeed");
     });
 
@@ -1024,7 +1069,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -1065,14 +1110,19 @@ fn shutdown_while_gate_open_emits_stale_marker() {
     let shutdown_for_thread = Arc::clone(&shutdown);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown_for_thread.as_ref()),
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
-        )
+        ))
         .expect("runner must succeed");
     });
 

--- a/sonda-server/Cargo.toml
+++ b/sonda-server/Cargo.toml
@@ -47,3 +47,6 @@ libc = "0.2"
 tempfile = "3"
 insta = { workspace = true, features = ["filters", "redactions"] }
 rstest = { workspace = true }
+
+[lints]
+workspace = true

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -39,3 +39,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tempfile = "3"
 insta = { workspace = true, features = ["filters"] }
 rstest = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
The 12 public runner functions across the four runner files (metric / log / histogram / summary) become `async fn`. The dispatcher helpers `drain_writes` and `finalize_sink` wrap each sink call in `tokio::task::spawn_blocking` so synchronous sink I/O cannot stall the runtime. The per-scenario `current_thread` Tokio runtime install moves from `gated_loop` (where the previous async-loop PR put it) up to `launch.rs` where it wraps both gated and non-gated runner-thread bodies uniformly. `clippy::await_holding_lock` promotes from warn to deny workspace-wide.

## What changed

- **12 public runner functions** become `pub async fn` across `runner.rs`, `log_runner.rs`, `histogram_runner.rs`, `summary_runner.rs`. `run_schedule_loop` and `run_schedule_loop_with_initial_tick` become `async fn`.
- **`drain_writes` and `finalize_sink` wrap sink calls in `spawn_blocking`**. Pattern: `std::mem::replace` the inner `Box<dyn Sink>` against a private `NullSink` placeholder, hand the real box to the closure by value, put it back when the JoinHandle resolves.
- **Sink trait stays sync** per the design contract. No `async-trait`. Runner sink parameter changes from `&mut dyn Sink` to `&mut Box<dyn Sink>` to support the mem::replace pattern.
- **`RuntimeError::TaskPanicked(String)`** new variant for `JoinError` propagation. `RuntimeError` is `#[non_exhaustive]` so non-breaking.
- **Runtime install moves** from `gated_loop` to `launch.rs:318-321` — wraps gated + non-gated paths uniformly inside the `std::thread::Builder::spawn` body (after `start_delay`, before `match entry`).
- **Workspace lint promotion**: `[workspace.lints.clippy] await_holding_lock = "deny"` in the root `Cargo.toml`, with `[lints] workspace = true` on each crate. Orchestrator gate command also passes `-D clippy::await_holding_lock` belt-and-suspenders.
- **Two new unit tests** verify the JoinError → TaskPanicked propagation path via a real `PanicSink` (not a synthetic `Err`) — one in `drain_writes`, one in `finalize_sink`.
- **~85 in-tree test sites** that called the runners directly were converted to `#[tokio::test]` or wrapped in `Runtime::new().unwrap().block_on(...)`.

## Public surface change

`&mut dyn Sink` → `&mut Box<dyn Sink>` on all 12 public runner functions. Embedders see compile errors at their call sites. Per the same-no-embedders semver policy, this stays `refactor(core):`.

`RuntimeError::TaskPanicked(String)` added — `#[non_exhaustive]` makes the addition non-breaking for matches that include `..`.

## NullSink placeholder safety

`NullSink` is private to `core_loop` and never observable from user code under any non-error path. On `Err` return from `drain_writes` or `finalize_sink`, the caller's `Box<dyn Sink>` may still hold the placeholder; the doc-comment tells maintainers not to retry sink operations after an error return. Traced through every error-propagation site: no path observes the `NullSink` post-error.

## Bench smoke

At N=1: drift mean **10.00 ms** (prior baseline 15.00 ms), p99 **19.80 ms** (prior 19.90 ms), 0% dropped. The spawn_blocking move-and-return overhead is invisible at low scenario count on this host. Thread count grew from 2 to 3 — the per-scenario `current_thread` runtime adds one worker thread.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 2869/2869 pass (baseline 2867, +2 new)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::await_holding_lock` — clean (deny-level now)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo test -p sonda-core --no-default-features --no-run` — clean
- [x] `cargo audit` — clean (pre-existing yanked `core2` advisory only)
- [x] Bench smoke at N=1 within drift target

## Phase 3 readiness

The runner call sites in `launch.rs:326-363` are already `rt.block_on(<async runner call>)`. The follow-up that replaces `std::thread::Builder::spawn(move || { rt.block_on(...) })` with `tokio::task::spawn(async { ... })` on a shared multi-thread runtime becomes nearly mechanical.

## Non-blocking note for a future enhancement

`Err(TaskPanicked)` doesn't write `last_sink_error` on the scenario stats (parity with how `ThreadPanicked` was historically handled). Surfacing panics in the per-scenario `/stats` endpoint folds naturally into the upcoming self-instrumentation work. Out of scope here.