### PR TITLE
feat(core): surface MemorySink via SinkConfig::Memory with optional capture

### DIFF
--- a/docs/site/docs/build/sinks.md
+++ b/docs/site/docs/build/sinks.md
@@ -66,6 +66,32 @@ sink:
   address: "127.0.0.1:9999"
 ```
 
+## memory
+
+In-process buffer sink for tests and benchmarks. Encoded bytes accumulate in a `Vec<u8>` inside the running process; no I/O happens, no destination is contacted. Use this when you want to drive a scenario through Sonda's pipeline (generator → encoder → sink) and either ignore the output or inspect it from a test harness that holds a `MemorySink` directly.
+
+When `capture: true`, each write records the `Instant` it landed alongside the bytes, keeping a ring of the most recent `max_events` entries (default `1_000_000`). The ring drops the oldest entry on overflow, so a benchmark that runs longer than the cap allows still ends up with the latest events for drift or rate analysis.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `capture` | boolean | no | `false` | Record `(Instant, bytes)` per write. |
+| `max_events` | integer | no | `1_000_000` | Cap on retained captured events when `capture: true`. |
+
+```yaml title="Memory sink (capture disabled)"
+sink:
+  type: memory
+```
+
+```yaml title="Memory sink with capture for drift measurement"
+sink:
+  type: memory
+  capture: true
+  max_events: 100000
+```
+
+!!! warning
+    This sink is for in-process inspection only — there is no destination to deliver to, so it should never be used in production scenarios. Pair it with a Rust test or benchmark harness that holds the `MemorySink` instance and reads `MemorySink::captured()` after the run.
+
 ## http_push
 
 !!! note

--- a/sonda-core/benches/scheduler_baseline.rs
+++ b/sonda-core/benches/scheduler_baseline.rs
@@ -3,11 +3,12 @@
 //! CPU%, tick-drift and dropped-tick percentage per N, and writes a markdown
 //! report alongside a stdout table.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -15,8 +16,11 @@ use sonda_core::config::{BaseScheduleConfig, ScenarioConfig, ScenarioEntry};
 use sonda_core::encoder::EncoderConfig;
 use sonda_core::generator::GeneratorConfig;
 use sonda_core::schedule::handle::ScenarioHandle;
-use sonda_core::sink::SinkConfig;
-use sonda_core::{launch_scenario, prepare_entries, OnSinkError};
+use sonda_core::schedule::runner::run_with_sink;
+use sonda_core::schedule::stats::ScenarioStats;
+use sonda_core::sink::memory::{CapturedRing, MemorySink};
+use sonda_core::sink::{Sink, SinkConfig};
+use sonda_core::{launch_scenario, prepare_entries, OnSinkError, RuntimeError, SondaError};
 use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System};
 
 const DEFAULT_SCENARIO_COUNTS: &[usize] = &[1, 10, 50, 100, 250, 500];
@@ -25,7 +29,8 @@ const DEFAULT_WARMUP_SECS: u64 = 30;
 const DEFAULT_MEASURE_SECS: u64 = 60;
 const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
 const DROPPED_TICK_TOLERANCE: f64 = 0.10;
-const NULL_SINK_PATH: &str = "/dev/null";
+const CAPTURE_RING_SIZE: usize = 1_000_000;
+const DRIFT_WARMUP_FRACTION: f64 = 0.10;
 
 fn warmup_secs() -> u64 {
     std::env::var("SONDA_BENCH_WARMUP_SECS")
@@ -59,6 +64,10 @@ struct RowResult {
     cpu_pct: f64,
     drift_mean_ms: f64,
     drift_p99_ms: f64,
+    drift_p50_us: f64,
+    drift_p90_us: f64,
+    drift_p99_us: f64,
+    drift_max_us: f64,
     dropped_pct: f64,
 }
 
@@ -70,7 +79,7 @@ struct Sample {
     per_scenario_events: Vec<u64>,
 }
 
-fn metrics_entry(name: String, rate: f64) -> ScenarioEntry {
+fn metrics_entry(name: String, rate: f64, sink: SinkConfig) -> ScenarioEntry {
     ScenarioEntry::Metrics(ScenarioConfig {
         base: BaseScheduleConfig {
             name,
@@ -81,9 +90,7 @@ fn metrics_entry(name: String, rate: f64) -> ScenarioEntry {
             cardinality_spikes: None,
             dynamic_labels: None,
             labels: None,
-            sink: SinkConfig::File {
-                path: NULL_SINK_PATH.to_string(),
-            },
+            sink,
             phase_offset: None,
             clock_group: None,
             clock_group_is_auto: None,
@@ -99,19 +106,168 @@ fn metrics_entry(name: String, rate: f64) -> ScenarioEntry {
     })
 }
 
-fn launch_n(n: usize) -> Vec<ScenarioHandle> {
-    let entries: Vec<ScenarioEntry> = (0..n)
-        .map(|i| metrics_entry(format!("bench_{i}"), RATE_HZ))
-        .collect();
-    let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
-    let mut handles = Vec::with_capacity(prepared.len());
-    for (i, p) in prepared.into_iter().enumerate() {
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let handle = launch_scenario(format!("bench_{i}"), p.entry, shutdown, p.start_delay)
-            .expect("launch_scenario must succeed");
-        handles.push(handle);
+fn metrics_config_for_capture(name: String, rate: f64) -> ScenarioConfig {
+    ScenarioConfig {
+        base: BaseScheduleConfig {
+            name,
+            rate,
+            duration: None,
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            dynamic_labels: None,
+            labels: None,
+            sink: SinkConfig::Memory {
+                capture: true,
+                max_events: Some(CAPTURE_RING_SIZE),
+            },
+            phase_offset: None,
+            clock_group: None,
+            clock_group_is_auto: None,
+            start_time: None,
+            jitter: None,
+            jitter_seed: None,
+            on_sink_error: OnSinkError::Warn,
+        },
+        generator: GeneratorConfig::Constant { value: 1.0 },
+        encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
     }
-    handles
+}
+
+struct DriftStats {
+    p50_us: f64,
+    p90_us: f64,
+    p99_us: f64,
+    max_us: f64,
+}
+
+fn compute_drift_stats(timestamps: &[Instant], rate_hz: f64) -> DriftStats {
+    if timestamps.len() < 2 {
+        return DriftStats {
+            p50_us: 0.0,
+            p90_us: 0.0,
+            p99_us: 0.0,
+            max_us: 0.0,
+        };
+    }
+    let expected_interval_us = 1_000_000.0 / rate_hz;
+    let skip = ((timestamps.len() as f64) * DRIFT_WARMUP_FRACTION).floor() as usize;
+    let trimmed = &timestamps[skip..];
+    if trimmed.len() < 2 {
+        return DriftStats {
+            p50_us: 0.0,
+            p90_us: 0.0,
+            p99_us: 0.0,
+            max_us: 0.0,
+        };
+    }
+    let mut deltas_us: Vec<f64> = Vec::with_capacity(trimmed.len() - 1);
+    for pair in trimmed.windows(2) {
+        let dt_us = pair[1].duration_since(pair[0]).as_micros() as f64;
+        deltas_us.push((dt_us - expected_interval_us).abs());
+    }
+    DriftStats {
+        p50_us: percentile(&deltas_us, 50.0),
+        p90_us: percentile(&deltas_us, 90.0),
+        p99_us: percentile(&deltas_us, 99.0),
+        max_us: deltas_us.iter().copied().fold(0.0f64, f64::max),
+    }
+}
+
+fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
+    assert!(n >= 1, "launch_n requires at least one scenario");
+    let capture_handle = Arc::new(Mutex::new(CapturedRing::new(CAPTURE_RING_SIZE)));
+
+    let mut handles = Vec::with_capacity(n);
+    handles.push(launch_capturing_scenario(
+        "bench_0".to_string(),
+        Arc::clone(&capture_handle),
+    ));
+
+    if n > 1 {
+        let entries: Vec<ScenarioEntry> = (1..n)
+            .map(|i| {
+                metrics_entry(
+                    format!("bench_{i}"),
+                    RATE_HZ,
+                    SinkConfig::Memory {
+                        capture: false,
+                        max_events: None,
+                    },
+                )
+            })
+            .collect();
+        let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
+        for (offset, p) in prepared.into_iter().enumerate() {
+            let i = offset + 1;
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let handle = launch_scenario(format!("bench_{i}"), p.entry, shutdown, p.start_delay)
+                .expect("launch_scenario must succeed");
+            handles.push(handle);
+        }
+    }
+    (handles, capture_handle)
+}
+
+// Mirrors launch_scenario for the shared-capture path; bench-local replica.
+fn launch_capturing_scenario(
+    id: String,
+    capture_handle: Arc<Mutex<CapturedRing>>,
+) -> ScenarioHandle {
+    let config = metrics_config_for_capture(id.clone(), RATE_HZ);
+    let name = config.base.name.clone();
+    let shutdown = Arc::new(AtomicBool::new(true));
+    let stats = Arc::new(RwLock::new(ScenarioStats::default()));
+    let alive = Arc::new(AtomicBool::new(true));
+    let cleaned_up = Arc::new(AtomicBool::new(true));
+    let labels: Arc<HashMap<String, String>> = Arc::new(HashMap::new());
+
+    let shutdown_for_thread = Arc::clone(&shutdown);
+    let stats_for_thread = Arc::clone(&stats);
+    let alive_for_thread = Arc::clone(&alive);
+
+    let thread = std::thread::Builder::new()
+        .name(format!("sonda-{name}"))
+        .spawn(move || -> Result<(), SondaError> {
+            struct AliveGuard(Arc<AtomicBool>);
+            impl Drop for AliveGuard {
+                fn drop(&mut self) {
+                    self.0.store(false, std::sync::atomic::Ordering::SeqCst);
+                }
+            }
+            let _guard = AliveGuard(alive_for_thread);
+
+            let sink_inner = MemorySink::with_shared_capture(capture_handle);
+            let mut sink: Box<dyn Sink> = Box::new(sink_inner);
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
+            rt.block_on(run_with_sink(
+                &config,
+                &mut sink,
+                Some(shutdown_for_thread.as_ref()),
+                Some(stats_for_thread),
+            ))
+        })
+        .expect("scenario thread must spawn");
+
+    ScenarioHandle::new(
+        id,
+        name,
+        None,
+        shutdown,
+        Some(thread),
+        Instant::now(),
+        stats,
+        RATE_HZ,
+        alive,
+        labels,
+        None,
+        cleaned_up,
+    )
 }
 
 fn stop_all(handles: &mut [ScenarioHandle]) {
@@ -186,7 +342,8 @@ fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
         "[bench] N={n}: launching scenarios at {RATE_HZ:.0} Hz \
          (warmup {warmup}s, measure {measure}s)"
     );
-    let mut handles = launch_n(n);
+
+    let (mut handles, capture_handle) = launch_n(n);
 
     thread::sleep(Duration::from_secs(warmup));
 
@@ -222,10 +379,18 @@ fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
     let drift_p99_ms = percentile(&drift_samples_ms, 99.0);
     let dropped_pct = compute_dropped_pct(&samples, &initial_events);
 
+    let captured_timestamps: Vec<Instant> = {
+        let guard = capture_handle.lock().expect("capture handle poisoned");
+        guard.events().iter().map(|(ts, _)| *ts).collect()
+    };
+    let drift = compute_drift_stats(&captured_timestamps, RATE_HZ);
+
     eprintln!(
         "[bench] N={n}: rss={rss_mb:.1}MB vsize={vsize_mb:.0}MB threads={threads} \
          cpu={cpu_pct:.1}% drift_mean={drift_mean_ms:.2}ms drift_p99={drift_p99_ms:.2}ms \
-         dropped={dropped_pct:.2}%"
+         drift_us p50={:.1} p90={:.1} p99={:.1} max={:.1} \
+         dropped={dropped_pct:.2}%",
+        drift.p50_us, drift.p90_us, drift.p99_us, drift.max_us
     );
 
     stop_all(&mut handles);
@@ -238,6 +403,10 @@ fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
         cpu_pct,
         drift_mean_ms,
         drift_p99_ms,
+        drift_p50_us: drift.p50_us,
+        drift_p90_us: drift.p90_us,
+        drift_p99_us: drift.p99_us,
+        drift_max_us: drift.max_us,
         dropped_pct,
     }
 }
@@ -318,7 +487,7 @@ fn percentile(values: &[f64], p: f64) -> f64 {
 fn print_table(rows: &[RowResult]) {
     println!();
     println!(
-        "| {:>5} | {:>9} | {:>11} | {:>7} | {:>5} | {:>20} | {:>19} | {:>14} |",
+        "| {:>5} | {:>9} | {:>11} | {:>7} | {:>5} | {:>20} | {:>19} | {:>12} | {:>12} | {:>12} | {:>11} | {:>14} |",
         "N",
         "RSS (MB)",
         "VSize (MB)",
@@ -326,15 +495,19 @@ fn print_table(rows: &[RowResult]) {
         "CPU %",
         "Tick drift mean (ms)",
         "Tick drift p99 (ms)",
+        "Drift p50 us",
+        "Drift p90 us",
+        "Drift p99 us",
+        "Drift max us",
         "Dropped-tick %"
     );
     println!(
-        "|{:-<7}|{:-<11}|{:-<13}|{:-<9}|{:-<7}|{:-<22}|{:-<21}|{:-<16}|",
-        "", "", "", "", "", "", "", ""
+        "|{:-<7}|{:-<11}|{:-<13}|{:-<9}|{:-<7}|{:-<22}|{:-<21}|{:-<14}|{:-<14}|{:-<14}|{:-<13}|{:-<16}|",
+        "", "", "", "", "", "", "", "", "", "", "", ""
     );
     for r in rows {
         println!(
-            "| {:>5} | {:>9.1} | {:>11.1} | {:>7} | {:>5.1} | {:>20.2} | {:>19.2} | {:>14.2} |",
+            "| {:>5} | {:>9.1} | {:>11.1} | {:>7} | {:>5.1} | {:>20.2} | {:>19.2} | {:>12.1} | {:>12.1} | {:>12.1} | {:>11.1} | {:>14.2} |",
             r.n,
             r.rss_mb,
             r.vsize_mb,
@@ -342,6 +515,10 @@ fn print_table(rows: &[RowResult]) {
             r.cpu_pct,
             r.drift_mean_ms,
             r.drift_p99_ms,
+            r.drift_p50_us,
+            r.drift_p90_us,
+            r.drift_p99_us,
+            r.drift_max_us,
             r.dropped_pct
         );
     }
@@ -362,25 +539,29 @@ fn render_markdown(rows: &[RowResult], warmup: u64, measure: u64) -> String {
     out.push_str("## Methodology\n\n");
     out.push_str(&format!(
         "Each row is N concurrent scenarios, each emitting at 100 events/sec via the \
-         Prometheus text encoder to a `file:/dev/null` sink (no real I/O — measures the \
-         scheduler, not the sink). {warmup}s warm-up + {measure}s measurement window. \
-         RSS / VSize / thread count / CPU% sampled every ~1s via the `sysinfo` crate; \
-         tick drift and dropped-tick rate computed from per-scenario \
-         `ScenarioStats::total_events` deltas between consecutive 1s samples (the \
-         production sinks do not expose per-event timestamps to the harness without a \
-         production-code change, so per-sample event-rate deviation is used as the \
-         scheduler-fidelity proxy). A bucket is counted as `dropped` when the observed \
-         events in the 1s window deviate from the expected count (`rate * dt`) by more \
-         than ±10%.\n\n"
+         Prometheus text encoder into a `memory` sink (no I/O — measures the scheduler, \
+         not the sink). {warmup}s warm-up + {measure}s measurement window. RSS / VSize / \
+         thread count / CPU% sampled every ~1s via the `sysinfo` crate. \
+         Tick drift is reported two ways: \n\
+         \n\
+         - **ms-level proxy** — `total_events` deltas between consecutive 1s samples. A bucket \
+         is counted as `dropped` when the observed events in the 1s window deviate from the \
+         expected count (`rate * dt`) by more than ±10%. \n\
+         - **microsecond-level direct** — the first of the N main scenarios writes through a \
+         `memory` sink with `capture: true`, retaining `(Instant, bytes)` per event across the \
+         full warm-up and measurement window. All N scenarios share the same scheduler, so the \
+         captured cadence reflects the load every scenario experiences at this N. Per-event \
+         drift is computed as `(t[i+1] - t[i]) - (1_000_000us / rate_hz)`; the first 10% of \
+         samples are dropped as warm-up jitter; p50/p90/p99/max are reported in microseconds. \n\n"
     ));
     out.push_str("## Results\n\n");
     out.push_str(
-        "| N scenarios | RSS (MB) | VSize (MB) | Threads | CPU % | Tick drift mean (ms) | Tick drift p99 (ms) | Dropped-tick % |\n",
+        "| N scenarios | RSS (MB) | VSize (MB) | Threads | CPU % | Tick drift mean (ms) | Tick drift p99 (ms) | Drift p50 (us) | Drift p90 (us) | Drift p99 (us) | Drift max (us) | Dropped-tick % |\n",
     );
-    out.push_str("|---|---|---|---|---|---|---|---|\n");
+    out.push_str("|---|---|---|---|---|---|---|---|---|---|---|---|\n");
     for r in rows {
         out.push_str(&format!(
-            "| {} | {:.1} | {:.1} | {} | {:.1} | {:.2} | {:.2} | {:.2} |\n",
+            "| {} | {:.1} | {:.1} | {} | {:.1} | {:.2} | {:.2} | {:.1} | {:.1} | {:.1} | {:.1} | {:.2} |\n",
             r.n,
             r.rss_mb,
             r.vsize_mb,
@@ -388,6 +569,10 @@ fn render_markdown(rows: &[RowResult], warmup: u64, measure: u64) -> String {
             r.cpu_pct,
             r.drift_mean_ms,
             r.drift_p99_ms,
+            r.drift_p50_us,
+            r.drift_p90_us,
+            r.drift_p99_us,
+            r.drift_max_us,
             r.dropped_pct
         ));
     }
@@ -403,15 +588,17 @@ fn inflection_paragraph(rows: &[RowResult]) -> String {
     let max_threads = rows.iter().map(|r| r.threads).max().unwrap_or(0);
     let max_rss = rows.iter().map(|r| r.rss_mb).fold(0.0f64, f64::max);
     let max_drift_p99 = rows.iter().map(|r| r.drift_p99_ms).fold(0.0f64, f64::max);
+    let max_drift_p99_us = rows.iter().map(|r| r.drift_p99_us).fold(0.0f64, f64::max);
     let max_dropped = rows.iter().map(|r| r.dropped_pct).fold(0.0f64, f64::max);
     format!(
         "Thread count grows linearly with N (peak observed: {max_threads}); RSS scales with \
          the per-thread stack reservation (peak observed: {max_rss:.1} MB). The earliest \
          metric to break under this scheduler is whichever among tick-drift p99 (peak \
-         observed: {max_drift_p99:.2} ms), dropped-tick percentage (peak observed: \
-         {max_dropped:.2}%), and CPU% saturates first as N climbs. Read the row-to-row \
-         deltas above to identify where the curve bends — the linear-thread, linear-stack \
-         growth itself is the canary for this baseline."
+         observed: {max_drift_p99:.2} ms proxy / {max_drift_p99_us:.1} us direct), \
+         dropped-tick percentage (peak observed: {max_dropped:.2}%), and CPU% saturates \
+         first as N climbs. Read the row-to-row deltas above to identify where the curve \
+         bends — the linear-thread, linear-stack growth itself is the canary for this \
+         baseline."
     )
 }
 

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -584,6 +584,7 @@ fn sink_kind_str(sink: &SinkConfig) -> &'static str {
         SinkConfig::File { .. } => "file",
         SinkConfig::Tcp { .. } => "tcp",
         SinkConfig::Udp { .. } => "udp",
+        SinkConfig::Memory { .. } => "memory",
         #[cfg(feature = "http")]
         SinkConfig::HttpPush { .. } => "http_push",
         #[cfg(not(feature = "http"))]

--- a/sonda-core/src/config/validate.rs
+++ b/sonda-core/src/config/validate.rs
@@ -761,7 +761,10 @@ pub fn validate_summary_config(config: &SummaryScenarioConfig) -> Result<(), Son
 /// validation time, not at factory time.
 pub fn validate_sink_config(sink: &SinkConfig) -> Result<(), SondaError> {
     match sink {
-        SinkConfig::Stdout | SinkConfig::File { .. } | SinkConfig::Udp { .. } => Ok(()),
+        SinkConfig::Stdout
+        | SinkConfig::File { .. }
+        | SinkConfig::Udp { .. }
+        | SinkConfig::Memory { .. } => Ok(()),
         SinkConfig::Tcp { retry, .. } => validate_retry_config_opt(retry.as_ref()),
         #[cfg(feature = "http")]
         SinkConfig::HttpPush {

--- a/sonda-core/src/sink/memory.rs
+++ b/sonda-core/src/sink/memory.rs
@@ -1,7 +1,56 @@
 //! In-memory sink for testing.
 
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
 use super::Sink;
 use crate::SondaError;
+
+/// Ring of most-recent captured `(Instant, Vec<u8>)` events with a fixed cap.
+#[derive(Debug)]
+pub struct CapturedRing {
+    events: VecDeque<(Instant, Vec<u8>)>,
+    max: usize,
+}
+
+impl CapturedRing {
+    /// Create an empty ring that retains at most `max` events.
+    pub fn new(max: usize) -> Self {
+        Self {
+            events: VecDeque::with_capacity(max),
+            max: max.max(1),
+        }
+    }
+
+    /// Append `event`, evicting the oldest entry once the cap is reached.
+    pub fn push(&mut self, event: (Instant, Vec<u8>)) {
+        if self.events.len() == self.max {
+            self.events.pop_front();
+        }
+        self.events.push_back(event);
+    }
+
+    /// Borrow the retained events in insertion order.
+    pub fn events(&self) -> &VecDeque<(Instant, Vec<u8>)> {
+        &self.events
+    }
+
+    /// Number of retained events.
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    /// Whether the ring currently holds no events.
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Configured cap on retained events.
+    pub fn capacity(&self) -> usize {
+        self.max
+    }
+}
 
 /// An in-memory sink that accumulates all written bytes in a `Vec<u8>`.
 ///
@@ -11,12 +60,45 @@ use crate::SondaError;
 pub struct MemorySink {
     /// All bytes written to this sink, in order.
     pub buffer: Vec<u8>,
+    captured: Option<Arc<Mutex<CapturedRing>>>,
 }
 
 impl MemorySink {
-    /// Create a new, empty `MemorySink`.
+    /// Create a new, empty `MemorySink` with no per-write timestamp capture.
     pub fn new() -> Self {
-        Self { buffer: Vec::new() }
+        Self {
+            buffer: Vec::new(),
+            captured: None,
+        }
+    }
+
+    /// Create a `MemorySink` that records `(Instant, bytes)` on every write,
+    /// keeping at most `max_events` of the most recent entries.
+    pub fn with_capture(max_events: usize) -> Self {
+        Self {
+            buffer: Vec::new(),
+            captured: Some(Arc::new(Mutex::new(CapturedRing::new(max_events)))),
+        }
+    }
+
+    /// Create a `MemorySink` whose timestamped writes land in `handle`.
+    pub fn with_shared_capture(handle: Arc<Mutex<CapturedRing>>) -> Self {
+        Self {
+            buffer: Vec::new(),
+            captured: Some(handle),
+        }
+    }
+
+    /// Borrow a clone of the shared capture handle, if capture is enabled.
+    pub fn capture_handle(&self) -> Option<Arc<Mutex<CapturedRing>>> {
+        self.captured.as_ref().map(Arc::clone)
+    }
+
+    /// Snapshot the currently retained capture ring, if capture is enabled.
+    pub fn captured(&self) -> Option<Vec<(Instant, Vec<u8>)>> {
+        let handle = self.captured.as_ref()?;
+        let guard = handle.lock().ok()?;
+        Some(guard.events().iter().cloned().collect())
     }
 }
 
@@ -27,13 +109,16 @@ impl Default for MemorySink {
 }
 
 impl Sink for MemorySink {
-    /// Append `data` to the internal buffer.
     fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.buffer.extend_from_slice(data);
+        if let Some(handle) = self.captured.as_ref() {
+            if let Ok(mut ring) = handle.lock() {
+                ring.push((Instant::now(), data.to_vec()));
+            }
+        }
         Ok(())
     }
 
-    /// No-op flush — all data is already in memory.
     fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
@@ -110,5 +195,85 @@ mod tests {
         let mut sink: Box<dyn Sink> = Box::new(MemorySink::new());
         sink.write(b"trait object write").unwrap();
         sink.flush().unwrap();
+    }
+
+    #[test]
+    fn new_disables_capture() {
+        let mut sink = MemorySink::new();
+        sink.write(b"x").unwrap();
+        assert!(sink.captured().is_none());
+        assert!(sink.capture_handle().is_none());
+    }
+
+    #[test]
+    fn with_capture_records_timestamped_writes() {
+        let mut sink = MemorySink::with_capture(8);
+        sink.write(b"first").unwrap();
+        sink.write(b"second").unwrap();
+        let snap = sink.captured().expect("capture enabled");
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].1, b"first");
+        assert_eq!(snap[1].1, b"second");
+        assert!(snap[1].0 >= snap[0].0);
+    }
+
+    #[test]
+    fn capture_ring_evicts_oldest_when_full() {
+        let mut sink = MemorySink::with_capture(3);
+        for i in 0..5 {
+            sink.write(format!("e{i}").as_bytes()).unwrap();
+        }
+        let snap = sink.captured().expect("capture enabled");
+        assert_eq!(snap.len(), 3);
+        assert_eq!(snap[0].1, b"e2");
+        assert_eq!(snap[1].1, b"e3");
+        assert_eq!(snap[2].1, b"e4");
+    }
+
+    #[test]
+    fn capture_handle_observes_writes_across_clones() {
+        let sink = MemorySink::with_capture(4);
+        let handle = sink.capture_handle().expect("capture enabled");
+        let mut sink = sink;
+        sink.write(b"a").unwrap();
+        sink.write(b"b").unwrap();
+        let guard = handle.lock().unwrap();
+        assert_eq!(guard.len(), 2);
+        assert_eq!(guard.events()[0].1, b"a");
+        assert_eq!(guard.events()[1].1, b"b");
+    }
+
+    #[test]
+    fn with_shared_capture_writes_through_external_handle() {
+        let handle = Arc::new(Mutex::new(CapturedRing::new(4)));
+        let mut sink = MemorySink::with_shared_capture(Arc::clone(&handle));
+        sink.write(b"shared").unwrap();
+        let guard = handle.lock().unwrap();
+        assert_eq!(guard.len(), 1);
+        assert_eq!(guard.events()[0].1, b"shared");
+    }
+
+    #[test]
+    fn buffer_remains_populated_alongside_capture() {
+        let mut sink = MemorySink::with_capture(4);
+        sink.write(b"hello").unwrap();
+        assert_eq!(&sink.buffer, b"hello");
+        assert_eq!(sink.captured().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn captured_ring_capacity_minimum_is_one() {
+        let ring = CapturedRing::new(0);
+        assert_eq!(ring.capacity(), 1);
+        assert!(ring.is_empty());
+    }
+
+    #[test]
+    fn captured_ring_len_and_is_empty_track_state() {
+        let mut ring = CapturedRing::new(2);
+        assert!(ring.is_empty());
+        ring.push((Instant::now(), vec![1]));
+        assert_eq!(ring.len(), 1);
+        assert!(!ring.is_empty());
     }
 }

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -152,6 +152,23 @@ pub enum SinkConfig {
         address: String,
     },
 
+    /// In-process memory sink for tests and benchmarks.
+    ///
+    /// When `capture` is `true`, each write records its `Instant` alongside
+    /// the bytes, bounded to the most recent `max_events` entries. When
+    /// `capture` is `false`, the sink only accumulates bytes in its buffer.
+    #[cfg_attr(feature = "config", serde(rename = "memory"))]
+    Memory {
+        /// Whether to record `(Instant, bytes)` on every write.
+        #[cfg_attr(feature = "config", serde(default))]
+        capture: bool,
+
+        /// Cap on retained captured events. Defaults to `1_000_000` when
+        /// `capture` is `true` and the field is omitted.
+        #[cfg_attr(feature = "config", serde(default))]
+        max_events: Option<usize>,
+    },
+
     /// Batch encoded events and deliver them via HTTP POST.
     ///
     /// Bytes are accumulated in a buffer until `batch_size` bytes are reached,
@@ -396,6 +413,17 @@ pub fn create_sink(
             Ok(Box::new(tcp::TcpSink::new(address, rp)?))
         }
         SinkConfig::Udp { address } => Ok(Box::new(udp::UdpSink::new(address)?)),
+        SinkConfig::Memory {
+            capture,
+            max_events,
+        } => {
+            if *capture {
+                let max = max_events.unwrap_or(1_000_000);
+                Ok(Box::new(memory::MemorySink::with_capture(max)))
+            } else {
+                Ok(Box::new(memory::MemorySink::new()))
+            }
+        }
         #[cfg(feature = "http")]
         SinkConfig::HttpPush {
             url,
@@ -1392,6 +1420,79 @@ retry:
             sink.buffer, encoded,
             "default impl must forward the encoded bytes to write() unchanged"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // SinkConfig::Memory: factory wiring and capture path
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn create_sink_memory_without_capture_returns_ok() {
+        let cfg = SinkConfig::Memory {
+            capture: false,
+            max_events: None,
+        };
+        let mut sink = create_sink(&cfg, None).unwrap();
+        sink.write(b"hello").unwrap();
+        sink.flush().unwrap();
+    }
+
+    #[test]
+    fn create_sink_memory_with_capture_returns_usable_sink() {
+        let cfg = SinkConfig::Memory {
+            capture: true,
+            max_events: Some(8),
+        };
+        let mut sink = create_sink(&cfg, None).unwrap();
+        sink.write(b"one").unwrap();
+        sink.write(b"two").unwrap();
+        sink.flush().unwrap();
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_memory_deserializes_with_type_field() {
+        let yaml = "type: memory\ncapture: true\nmax_events: 64";
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(matches!(
+            config,
+            SinkConfig::Memory {
+                capture: true,
+                max_events: Some(64)
+            }
+        ));
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_memory_defaults_when_fields_omitted() {
+        let yaml = "type: memory";
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(matches!(
+            config,
+            SinkConfig::Memory {
+                capture: false,
+                max_events: None
+            }
+        ));
+    }
+
+    #[test]
+    fn sink_config_memory_is_cloneable_and_debuggable() {
+        let cfg = SinkConfig::Memory {
+            capture: true,
+            max_events: Some(16),
+        };
+        let cloned = cfg.clone();
+        assert!(matches!(
+            cloned,
+            SinkConfig::Memory {
+                capture: true,
+                max_events: Some(16)
+            }
+        ));
+        let s = format!("{cfg:?}");
+        assert!(s.contains("Memory"));
     }
 
     #[cfg(all(not(feature = "otlp"), feature = "config"))]

--- a/sonda-server/src/routes/events.rs
+++ b/sonda-server/src/routes/events.rs
@@ -209,6 +209,7 @@ fn sink_kind(sink: &SinkConfig) -> &'static str {
         SinkConfig::File { .. } => "file",
         SinkConfig::Tcp { .. } => "tcp",
         SinkConfig::Udp { .. } => "udp",
+        SinkConfig::Memory { .. } => "memory",
         #[cfg(feature = "http")]
         SinkConfig::HttpPush { .. } => "http_push",
         #[cfg(feature = "http")]

--- a/sonda/src/sink_format.rs
+++ b/sonda/src/sink_format.rs
@@ -43,6 +43,17 @@ pub fn sink_display(sink: &SinkConfig) -> String {
         SinkConfig::File { path } => format!("file ({path})"),
         SinkConfig::Tcp { address, .. } => format!("tcp ({address})"),
         SinkConfig::Udp { address } => format!("udp ({address})"),
+        SinkConfig::Memory {
+            capture,
+            max_events,
+        } => {
+            if *capture {
+                let cap = max_events.unwrap_or(1_000_000);
+                format!("memory (capture, max_events={cap})")
+            } else {
+                "memory".to_string()
+            }
+        }
         #[cfg(feature = "http")]
         SinkConfig::HttpPush { url, .. } => format!("http_push ({url})"),
         #[cfg(not(feature = "http"))]
@@ -101,6 +112,24 @@ mod tests {
             address: "127.0.0.1:8888".to_string(),
         };
         assert_eq!(sink_display(&s), "udp (127.0.0.1:8888)");
+    }
+
+    #[test]
+    fn memory_without_capture_renders_bare() {
+        let s = SinkConfig::Memory {
+            capture: false,
+            max_events: None,
+        };
+        assert_eq!(sink_display(&s), "memory");
+    }
+
+    #[test]
+    fn memory_with_capture_renders_max_events() {
+        let s = SinkConfig::Memory {
+            capture: true,
+            max_events: Some(2048),
+        };
+        assert_eq!(sink_display(&s), "memory (capture, max_events=2048)");
     }
 
     #[cfg(feature = "http")]


### PR DESCRIPTION
Adds a new `SinkConfig::Memory { capture: bool, max_events: Option<usize> }` variant that surfaces the existing `MemorySink` through the public sink factory. When `capture: true`, the sink retains `(Instant, Vec<u8>)` per write in an O(1) `VecDeque` ring bounded by `max_events` (default 1M). The existing `pub buffer: Vec<u8>` field stays untouched for backward compatibility with existing test users.

This unlocks per-event microsecond drift measurement for the bench harness — the previous methodology used a per-1s `total_events` delta with a ±10% bucket-drop threshold that could not detect a 5% systematic drift between BEFORE and AFTER scheduler implementations.

## What changed

- **New variant `SinkConfig::Memory`**. The enum is already `#[non_exhaustive]` so the addition is non-breaking for downstream matches that use `..`. Wire spelling: `"memory"` via serde rename.
- **`MemorySink` extensions**:
  - `Option<Arc<Mutex<CapturedRing>>>` field for optional timestamped capture.
  - `CapturedRing` uses `VecDeque` for O(1) ring eviction at the `max_events` cap.
  - New constructors: `with_capture(max_events)`, `with_shared_capture(handle)`.
  - New accessors: `captured() -> Option<Vec<(Instant, Vec<u8>)>>` (snapshot), `capture_handle() -> Option<Arc<Mutex<CapturedRing>>>`.
- **Factory wiring**: `create_sink` registers the `Memory` variant.
- **Four exhaustive-match sites updated** for the new variant: `compiler/normalize.rs::sink_kind_str`, `config/validate.rs::validate_sink_config`, `sonda-server/src/routes/events.rs::sink_kind`, `sonda/src/sink_format.rs::sink_display`.
- **Bench harness**:
  - N main scenarios use `SinkConfig::Memory { capture: false }` (drops the `/dev/null` I/O from the prior baseline).
  - Scenario 0 uses `SinkConfig::Memory { capture: true }` with a shared `Arc<Mutex<CapturedRing>>` handle the bench retains.
  - At the end of the measurement window the bench walks scenario 0's per-event timestamps and reports drift in microseconds (p50 / p90 / p99 / max) alongside the existing ms-level proxy columns.
- **One-paragraph user-facing docs addition** at `docs/site/docs/build/sinks.md` framing the sink as in-process inspection only, not for production.

## Drift measurement under load

Scenario 0 runs alongside the other N-1 scenarios across the full warm-up + measurement window, so the captured cadence reflects the load every scenario at this N experiences. The previous methodology — a probe scenario that ran solo before the N main scenarios spawned — reported drift on an idle CPU and could not detect under-load regression. That methodology is replaced; `measure_drift_us` and the `SONDA_BENCH_DRIFT_PROBE_SECS` env var are gone.

## Bench smoke

At N=1: drift mean 13.33 ms / p99 19.80 ms (proxy); drift p50 1.21 ms / p99 4.57 ms (direct).
At N=10: proxy shows expected degradation (mean 20.0 ms, p99 30.0 ms); microsecond columns will spread further on a saturated host (host-specific — the 11-core M3 Pro at N=10 isn't loaded enough to push the per-tick view).

## Public surface change

`SinkConfig::Memory` variant added. The enum's `#[non_exhaustive]` attribute means existing matches with `..` keep compiling. New types/methods on `MemorySink` are additive; the existing `pub buffer: Vec<u8>` field is unchanged.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 2884/2884 pass (+15 from prior baseline 2869)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::await_holding_lock` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo test -p sonda-core --no-default-features --no-run` — clean
- [x] `cargo audit` — clean (pre-existing yanked `core2` only)
- [x] Bench smoke at N=1 and N=10 — microsecond drift columns populate; proxy shows expected scaling