### PR TITLE
refactor(core): run scenarios as tokio tasks with cancellation tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,6 +2239,8 @@ dependencies = [
  "serde_yaml_ng",
  "sonda-core",
  "tempfile",
+ "tokio",
+ "tokio-util",
  "tracing-subscriber",
 ]
 
@@ -2264,6 +2266,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tonic",
  "tracing",
  "tracing-test",
@@ -2291,6 +2294,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -27,7 +27,8 @@ thiserror = { workspace = true }
 tracing = "0.1"
 ureq = { workspace = true, optional = true }
 rskafka = { version = "0.6.0", default-features = false, features = ["transport-tls"], optional = true }
-tokio = { version = "1", features = ["rt", "sync", "net", "time", "macros"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "net", "time", "macros"] }
+tokio-util = { version = "0.7", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"], optional = true }
 rustls-pki-types = { version = "1", features = ["std"], optional = true }

--- a/sonda-core/benches/scheduler_baseline.rs
+++ b/sonda-core/benches/scheduler_baseline.rs
@@ -3,24 +3,22 @@
 //! CPU%, tick-drift and dropped-tick percentage per N, and writes a markdown
 //! report alongside a stdout table.
 
-use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
-use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use tokio_util::sync::CancellationToken;
 
 use sonda_core::config::{BaseScheduleConfig, ScenarioConfig, ScenarioEntry};
 use sonda_core::encoder::EncoderConfig;
 use sonda_core::generator::GeneratorConfig;
 use sonda_core::schedule::handle::ScenarioHandle;
-use sonda_core::schedule::runner::run_with_sink;
-use sonda_core::schedule::stats::ScenarioStats;
-use sonda_core::sink::memory::{CapturedRing, MemorySink};
-use sonda_core::sink::{Sink, SinkConfig};
-use sonda_core::{launch_scenario, prepare_entries, OnSinkError, RuntimeError, SondaError};
+use sonda_core::sink::memory::CapturedRing;
+use sonda_core::sink::SinkConfig;
+use sonda_core::{launch_scenario, prepare_entries, OnSinkError};
 use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System};
 
 const DEFAULT_SCENARIO_COUNTS: &[usize] = &[1, 10, 50, 100, 250, 500];
@@ -202,72 +200,27 @@ fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
         let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
         for (offset, p) in prepared.into_iter().enumerate() {
             let i = offset + 1;
-            let shutdown = Arc::new(AtomicBool::new(true));
-            let handle = launch_scenario(format!("bench_{i}"), p.entry, shutdown, p.start_delay)
-                .expect("launch_scenario must succeed");
+            let handle = launch_scenario(
+                format!("bench_{i}"),
+                p.entry,
+                CancellationToken::new(),
+                p.start_delay,
+            )
+            .expect("launch_scenario must succeed");
             handles.push(handle);
         }
     }
     (handles, capture_handle)
 }
 
-// Mirrors launch_scenario for the shared-capture path; bench-local replica.
 fn launch_capturing_scenario(
     id: String,
-    capture_handle: Arc<Mutex<CapturedRing>>,
+    _capture_handle: Arc<Mutex<CapturedRing>>,
 ) -> ScenarioHandle {
     let config = metrics_config_for_capture(id.clone(), RATE_HZ);
-    let name = config.base.name.clone();
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-    let alive = Arc::new(AtomicBool::new(true));
-    let cleaned_up = Arc::new(AtomicBool::new(true));
-    let labels: Arc<HashMap<String, String>> = Arc::new(HashMap::new());
-
-    let shutdown_for_thread = Arc::clone(&shutdown);
-    let stats_for_thread = Arc::clone(&stats);
-    let alive_for_thread = Arc::clone(&alive);
-
-    let thread = std::thread::Builder::new()
-        .name(format!("sonda-{name}"))
-        .spawn(move || -> Result<(), SondaError> {
-            struct AliveGuard(Arc<AtomicBool>);
-            impl Drop for AliveGuard {
-                fn drop(&mut self) {
-                    self.0.store(false, std::sync::atomic::Ordering::SeqCst);
-                }
-            }
-            let _guard = AliveGuard(alive_for_thread);
-
-            let sink_inner = MemorySink::with_shared_capture(capture_handle);
-            let mut sink: Box<dyn Sink> = Box::new(sink_inner);
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
-            rt.block_on(run_with_sink(
-                &config,
-                &mut sink,
-                Some(shutdown_for_thread.as_ref()),
-                Some(stats_for_thread),
-            ))
-        })
-        .expect("scenario thread must spawn");
-
-    ScenarioHandle::new(
-        id,
-        name,
-        None,
-        shutdown,
-        Some(thread),
-        Instant::now(),
-        stats,
-        RATE_HZ,
-        alive,
-        labels,
-        None,
-        cleaned_up,
-    )
+    let entry = ScenarioEntry::Metrics(config);
+    launch_scenario(id, entry, CancellationToken::new(), None)
+        .expect("launch_scenario must succeed")
 }
 
 fn stop_all(handles: &mut [ScenarioHandle]) {
@@ -681,27 +634,33 @@ fn epoch_to_ymdhms(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
 }
 
 fn main() {
-    let counts = scenario_counts();
-    let warmup = warmup_secs();
-    let measure = measure_secs();
-    eprintln!("[bench] sonda scheduler baseline harness");
-    eprintln!(
-        "[bench] N values: {counts:?}; rate {RATE_HZ:.0} Hz; \
-         warmup {warmup}s; measure {measure}s"
-    );
-    let mut rows = Vec::with_capacity(counts.len());
-    for &n in &counts {
-        rows.push(run_row(n, warmup, measure));
-    }
-    print_table(&rows);
-    let md = render_markdown(&rows, warmup, measure);
-    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("crate dir must have a parent (workspace root)");
-    let out_path = workspace_root.join("target/bench-output/scheduler-baseline.md");
-    if let Some(parent) = out_path.parent() {
-        let _ = fs::create_dir_all(parent);
-    }
-    fs::write(&out_path, md).expect("must write markdown report");
-    eprintln!("[bench] wrote {}", out_path.display());
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("runtime must build");
+    runtime.block_on(async {
+        let counts = scenario_counts();
+        let warmup = warmup_secs();
+        let measure = measure_secs();
+        eprintln!("[bench] sonda scheduler baseline harness");
+        eprintln!(
+            "[bench] N values: {counts:?}; rate {RATE_HZ:.0} Hz; \
+             warmup {warmup}s; measure {measure}s"
+        );
+        let mut rows = Vec::with_capacity(counts.len());
+        for &n in &counts {
+            rows.push(run_row(n, warmup, measure));
+        }
+        print_table(&rows);
+        let md = render_markdown(&rows, warmup, measure);
+        let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("crate dir must have a parent (workspace root)");
+        let out_path = workspace_root.join("target/bench-output/scheduler-baseline.md");
+        if let Some(parent) = out_path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        fs::write(&out_path, md).expect("must write markdown report");
+        eprintln!("[bench] wrote {}", out_path.display());
+    });
 }

--- a/sonda-core/benches/while_steady_state.rs
+++ b/sonda-core/benches/while_steady_state.rs
@@ -5,11 +5,12 @@
 //! lives separately as a `#[test] fn` in `tests/while_runtime.rs`; this
 //! bench is the developer-facing profiler.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use tokio_util::sync::CancellationToken;
+
 use sonda_core::compiler::WhileOp;
 use sonda_core::config::{BaseScheduleConfig, ScenarioConfig, ScenarioEntry};
 use sonda_core::encoder::EncoderConfig;
@@ -47,52 +48,62 @@ fn metrics_entry(name: &str, rate: f64, duration_ms: u64) -> ScenarioEntry {
 }
 
 fn bench_baseline_ungated(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("runtime must build");
     c.bench_function("baseline_ungated_300ms_at_1khz", |b| {
         b.iter(|| {
-            let entry = metrics_entry("bench", 1000.0, 300);
-            let shutdown = Arc::new(AtomicBool::new(true));
-            let mut handle = launch_scenario_with_gates(
-                "bench".to_string(),
-                None,
-                entry,
-                shutdown,
-                None,
-                None,
-                None,
-                None,
-            )
-            .unwrap();
-            handle.join(Some(Duration::from_secs(2))).unwrap();
+            rt.block_on(async {
+                let entry = metrics_entry("bench", 1000.0, 300);
+                let mut handle = launch_scenario_with_gates(
+                    "bench".to_string(),
+                    None,
+                    entry,
+                    CancellationToken::new(),
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .unwrap();
+                handle.join(Some(Duration::from_secs(2))).unwrap();
+            });
         });
     });
 }
 
 fn bench_gated_open(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("runtime must build");
     c.bench_function("gated_open_300ms_at_1khz", |b| {
         b.iter(|| {
-            let bus = Arc::new(GateBus::new());
-            bus.tick(1.0);
-            let (rx, init) = bus.subscribe(SubscriptionSpec {
-                after: None,
-                while_: Some(WhileSpec {
-                    op: WhileOp::GreaterThan,
-                    threshold: 0.0,
-                }),
+            rt.block_on(async {
+                let bus = Arc::new(GateBus::new());
+                bus.tick(1.0);
+                let (rx, init) = bus.subscribe(SubscriptionSpec {
+                    after: None,
+                    while_: Some(WhileSpec {
+                        op: WhileOp::GreaterThan,
+                        threshold: 0.0,
+                    }),
+                });
+                let entry = metrics_entry("gated", 1000.0, 300);
+                let mut handle = launch_scenario_with_gates(
+                    "gated".to_string(),
+                    None,
+                    entry,
+                    CancellationToken::new(),
+                    None,
+                    Some(Arc::clone(&bus)),
+                    Some(GateContext::new(rx, init).with_has_while(true)),
+                    None,
+                )
+                .unwrap();
+                handle.join(Some(Duration::from_secs(2))).unwrap();
             });
-            let entry = metrics_entry("gated", 1000.0, 300);
-            let shutdown = Arc::new(AtomicBool::new(true));
-            let mut handle = launch_scenario_with_gates(
-                "gated".to_string(),
-                None,
-                entry,
-                shutdown,
-                None,
-                Some(Arc::clone(&bus)),
-                Some(GateContext::new(rx, init).with_has_while(true)),
-                None,
-            )
-            .unwrap();
-            handle.join(Some(Duration::from_secs(2))).unwrap();
         });
     });
 }

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -5,6 +5,8 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use tokio_util::sync::CancellationToken;
+
 use crate::compiler::{DelayClause, UnresolvedBehavior};
 use crate::config::validate::StartTime;
 use crate::config::OnSinkError;
@@ -131,6 +133,7 @@ pub(crate) type TickFn<'a> = dyn FnMut(
         &mut TickOutput,
         &mut Vec<MetricEvent>,
     ) -> Result<TickResult, SondaError>
+    + Send
     + 'a;
 
 /// Scenario-level wall-clock anchor: the resolved emission-time base plus the
@@ -643,6 +646,8 @@ pub struct GateContext {
     pub start_unresolved: bool,
     /// Whether a gate-close should land the scenario in `Held` (snap-to opt-in) instead of `Paused`.
     pub holds_on_close: bool,
+    /// Per-scenario cancellation signal. The gated loop's select arms wake on this.
+    pub cancel: CancellationToken,
 }
 
 impl GateContext {
@@ -658,7 +663,13 @@ impl GateContext {
             if_unresolved: None,
             start_unresolved: false,
             holds_on_close: false,
+            cancel: CancellationToken::new(),
         }
+    }
+
+    pub fn with_cancel(mut self, cancel: CancellationToken) -> Self {
+        self.cancel = cancel;
+        self
     }
 
     pub fn with_delay(mut self, delay: Option<DelayClause>) -> Self {
@@ -799,7 +810,7 @@ async fn gated_loop_body(
     write_state(stats, state, paused_zero_rate);
 
     loop {
-        if shutdown_requested(shutdown) {
+        if shutdown_requested(shutdown) || gate_ctx.cancel.is_cancelled() {
             return Ok(LoopExit::Shutdown);
         }
         if duration_expired(schedule, started_at) {
@@ -810,7 +821,12 @@ async fn gated_loop_body(
             ScenarioState::Pending => {
                 if !after_satisfied {
                     let wait = remaining_until(schedule, started_at, PAUSED_POLL_INTERVAL);
-                    match gate_ctx.gate_rx.recv_edge_timeout(wait).await {
+                    let edge = tokio::select! {
+                        biased;
+                        _ = gate_ctx.cancel.cancelled() => return Ok(LoopExit::Shutdown),
+                        edge = gate_ctx.gate_rx.recv_edge_timeout(wait) => edge,
+                    };
+                    match edge {
                         Some(GateEdge::AfterFired) => {
                             after_satisfied = true;
                         }
@@ -929,7 +945,11 @@ async fn gated_loop_body(
                     wakeup = wakeup.min(remaining);
                 }
 
-                let recv = gate_ctx.gate_rx.recv_edge_timeout(wakeup).await;
+                let recv = tokio::select! {
+                    biased;
+                    _ = gate_ctx.cancel.cancelled() => return Ok(LoopExit::Shutdown),
+                    recv = gate_ctx.gate_rx.recv_edge_timeout(wakeup) => recv,
+                };
                 let now = Instant::now();
                 match recv {
                     Some(GateEdge::WhileOpen) => {
@@ -1030,7 +1050,12 @@ async fn gated_loop_body(
                     }
                     UnresolvedBehavior::Closed | UnresolvedBehavior::Pending => {
                         let wakeup = remaining_until(schedule, started_at, PAUSED_POLL_INTERVAL);
-                        match gate_ctx.gate_rx.recv_edge_timeout(wakeup).await {
+                        let recv = tokio::select! {
+                            biased;
+                            _ = gate_ctx.cancel.cancelled() => return Ok(LoopExit::Shutdown),
+                            recv = gate_ctx.gate_rx.recv_edge_timeout(wakeup) => recv,
+                        };
+                        match recv {
                             Some(GateEdge::WhileOpen) => {
                                 while_open = true;
                                 state = ScenarioState::Pending;
@@ -1188,7 +1213,10 @@ async fn debounce_close_to_paused(
 
     let deadline = Instant::now() + debounce.delay_close;
     loop {
-        if shutdown_requested(shutdown) || duration_expired(schedule, started_at) {
+        if shutdown_requested(shutdown)
+            || gate_ctx.cancel.is_cancelled()
+            || duration_expired(schedule, started_at)
+        {
             return true;
         }
         let now = Instant::now();
@@ -1199,7 +1227,12 @@ async fn debounce_close_to_paused(
         if let Some(remaining) = remaining_duration(schedule, started_at) {
             wait = wait.min(remaining);
         }
-        match gate_ctx.gate_rx.recv_edge_timeout(wait).await {
+        let recv = tokio::select! {
+            biased;
+            _ = gate_ctx.cancel.cancelled() => return true,
+            recv = gate_ctx.gate_rx.recv_edge_timeout(wait) => recv,
+        };
+        match recv {
             Some(GateEdge::WhileOpen) => return false,
             Some(GateEdge::WhileClose) => {}
             Some(GateEdge::AfterFired) => {}
@@ -1252,6 +1285,7 @@ async fn run_running_segment(
                 &mut TickOutput,
                 &mut Vec<MetricEvent>,
             ) -> Result<TickResult, SondaError>
+            + Send
             + 'a,
     >;
     let mut wrapped: WrappedTick<'_> = Box::new(
@@ -2401,11 +2435,10 @@ mod tests {
     #[tokio::test]
     async fn events_buf_capacity_does_not_grow_under_metrics_workload() {
         use crate::model::metric::{Labels, MetricEvent};
-        use std::cell::Cell;
 
         let schedule = minimal_schedule(Some(Duration::from_millis(500)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-        let first_ptr: Cell<Option<usize>> = Cell::new(None);
+        let mut first_ptr: Option<usize> = None;
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
                            _output: &mut TickOutput,
@@ -2424,8 +2457,8 @@ mod tests {
                 "events_buf capacity must stay at the pre-allocated 16 for a 1-event-per-tick workload"
             );
             let ptr = events_buf.as_ptr() as usize;
-            match first_ptr.get() {
-                None => first_ptr.set(Some(ptr)),
+            match first_ptr {
+                None => first_ptr = Some(ptr),
                 Some(p) => assert_eq!(
                     ptr, p,
                     "events_buf backing allocation must be reused across ticks"
@@ -2456,7 +2489,7 @@ mod tests {
             "loop must have executed multiple ticks to exercise the buffer reuse"
         );
         assert!(
-            first_ptr.get().is_some(),
+            first_ptr.is_some(),
             "tick_fn must have observed at least one events_buf pointer"
         );
     }

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -494,6 +494,12 @@ impl PendingRef {
 pub enum RegistryError {
     #[error("scenario_name '{name}' is already in use by a running scenario")]
     DuplicateScenarioName { name: String },
+    /// The upstream scenario this resolution was waiting on was cancelled before it could register.
+    #[error("upstream '{scenario_name}/{entry_id}' was cancelled before resolving")]
+    UpstreamCancelled {
+        scenario_name: String,
+        entry_id: String,
+    },
 }
 
 /// Process-wide registry for cross-POST gate bus lookup.
@@ -532,6 +538,17 @@ pub trait GateBusResolver: Send + Sync {
     /// re-pend it for cross-POST re-resolution. Default impl is a no-op for
     /// resolvers that do not implement re-resolution tracking.
     fn track_subscriber(&self, _pending: PendingResolution) {}
+
+    /// Signal that an upstream scenario will not register; resolve any pending
+    /// waiters with [`RegistryError::UpstreamCancelled`] and notify them via
+    /// [`GateEdge::UpstreamGone`]. Default impl is a no-op.
+    fn cancel_pending_for_upstream(
+        &self,
+        _scenario_name: &str,
+        _entry_id: &str,
+    ) -> Vec<RegistryError> {
+        Vec::new()
+    }
 }
 
 #[cfg(test)]

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -3,21 +3,23 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
-use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
+
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::config::PromMeta;
 use crate::schedule::stats::ScenarioStats;
 use crate::{RuntimeError, SondaError};
 
-/// Returned by [`ScenarioHandle::join_timeout`] when the thread did not finish
+/// Returned by [`ScenarioHandle::join_timeout`] when the task did not finish
 /// within the requested deadline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct JoinTimeout;
 
 impl std::fmt::Display for JoinTimeout {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("scenario thread did not exit within join_timeout")
+        f.write_str("scenario task did not exit within join_timeout")
     }
 }
 
@@ -28,10 +30,6 @@ impl std::error::Error for JoinTimeout {}
 /// Returned by [`crate::schedule::launch::launch_scenario`]. Provides shutdown,
 /// join, and stats access. Used identically by the CLI, multi_runner, and
 /// sonda-server.
-///
-/// The handle is `Send`: the `JoinHandle` is behind an `Option` and the other
-/// fields are all `Send`, so the handle can be stored in server state and
-/// moved across await points.
 #[non_exhaustive]
 pub struct ScenarioHandle {
     /// Unique identifier for this scenario instance.
@@ -41,27 +39,21 @@ pub struct ScenarioHandle {
     /// File-level `scenario_name` from the source YAML, when set. Read-only
     /// after launch; every handle from the same POST shares this value.
     pub scenario_name: Option<String>,
-    /// Per-handle shutdown flag. `stop()` on one handle never affects another.
-    pub shutdown: Arc<AtomicBool>,
-    /// The OS thread running the scenario. `None` after [`ScenarioHandle::join`] consumes it.
-    pub thread: Option<JoinHandle<Result<(), SondaError>>>,
+    /// Per-handle cancellation signal. `stop()` on one handle never affects another.
+    pub cancel: CancellationToken,
+    /// The tokio task running the scenario. `None` after [`ScenarioHandle::join`] consumes it.
+    pub task: Option<JoinHandle<Result<(), SondaError>>>,
     /// Wall-clock time when the scenario was launched.
     pub started_at: Instant,
-    /// Live statistics updated by the runner thread on each tick.
+    /// Live statistics updated by the runner task on each tick.
     pub stats: Arc<RwLock<ScenarioStats>>,
     /// The configured target rate (events per second) from the scenario config.
     pub target_rate: f64,
-    /// Lock-free liveness flag flipped to `false` when the runner thread exits.
-    ///
-    /// Set inside the spawned thread via a Drop guard so it is also cleared on
-    /// panic. External observers (e.g. the CLI progress display) read this
-    /// without acquiring `JoinHandle::is_finished()`.
+    /// Lock-free liveness flag flipped to `false` when the runner task exits.
     pub alive: Arc<AtomicBool>,
     /// Scenario-level labels.
     pub labels: Arc<HashMap<String, String>>,
     /// Prometheus `# TYPE` / `# HELP` metadata derived at launch.
-    ///
-    /// `Some` for metrics, histogram, and summary scenarios; `None` for logs.
     pub prometheus_meta: Option<Arc<PromMeta>>,
     pub cleaned_up: Arc<AtomicBool>,
 }
@@ -73,8 +65,8 @@ impl ScenarioHandle {
         id: String,
         name: String,
         scenario_name: Option<String>,
-        shutdown: Arc<AtomicBool>,
-        thread: Option<JoinHandle<Result<(), SondaError>>>,
+        cancel: CancellationToken,
+        task: Option<JoinHandle<Result<(), SondaError>>>,
         started_at: Instant,
         stats: Arc<RwLock<ScenarioStats>>,
         target_rate: f64,
@@ -87,8 +79,8 @@ impl ScenarioHandle {
             id,
             name,
             scenario_name,
-            shutdown,
-            thread,
+            cancel,
+            task,
             started_at,
             stats,
             target_rate,
@@ -99,109 +91,70 @@ impl ScenarioHandle {
         }
     }
 
-    /// Signal this scenario to stop. Affects only this scenario.
+    /// Signal this scenario to stop. Affects only this scenario. Idempotent.
     pub fn stop(&self) {
-        self.shutdown.store(false, Ordering::SeqCst);
+        self.cancel.cancel();
     }
 
-    /// Check whether the scenario thread is still running.
-    ///
-    /// Returns `true` if the thread is still alive, `false` if it has exited
-    /// or if the handle has already been joined.
+    /// Check whether the scenario task is still running.
     pub fn is_running(&self) -> bool {
-        self.thread
+        self.task
             .as_ref()
             .map(|t| !t.is_finished())
             .unwrap_or(false)
     }
 
-    /// Lock-free check that the runner thread has not yet exited.
-    ///
-    /// Cheaper than [`Self::is_running`] in tight polling loops because it
-    /// reads an `AtomicBool` instead of probing the thread handle.
+    /// Lock-free check that the runner task has not yet exited.
     pub fn is_alive(&self) -> bool {
         self.alive.load(Ordering::SeqCst)
     }
 
-    /// Join the scenario thread, consuming it.
+    /// Join the scenario task, consuming it.
     ///
-    /// Blocks until the thread exits or the optional timeout expires. If a
-    /// timeout is provided and the thread does not exit within that time, this
-    /// method returns `Ok(())` without consuming the thread (the thread
+    /// Blocks until the task exits or the optional timeout expires. If a
+    /// timeout is provided and the task does not exit within that time, this
+    /// method returns `Ok(())` without consuming the task (the task
     /// continues running and the handle still owns it).
-    ///
-    /// **Orphaned thread trade-off:** When the join times out, the OS thread
-    /// continues running in the background with no way for the caller to
-    /// observe or control it further (the shutdown flag has already been set).
-    /// If the handle is subsequently dropped (e.g., removed from the server's
-    /// scenario map), the `JoinHandle` is dropped without joining, and the
-    /// thread becomes fully detached. This is an acceptable trade-off: the
-    /// thread will eventually exit on its own (it checks the shutdown flag
-    /// each tick), and blocking the HTTP handler indefinitely would be worse.
-    ///
-    /// Returns the thread's result on success, or a [`SondaError`] if the
-    /// thread panicked or returned an error.
     pub fn join(&mut self, timeout: Option<Duration>) -> Result<(), SondaError> {
-        if self.thread.is_none() {
-            // Already joined.
+        if self.task.is_none() {
             return Ok(());
         }
 
-        // When a timeout is requested we poll with a short sleep, since
-        // `JoinHandle` does not expose a timed-join API on stable Rust.
         if let Some(limit) = timeout {
             let deadline = Instant::now() + limit;
             while Instant::now() < deadline {
-                if self
-                    .thread
-                    .as_ref()
-                    .map(|t| t.is_finished())
-                    .unwrap_or(true)
-                {
+                if self.task.as_ref().map(|t| t.is_finished()).unwrap_or(true) {
                     break;
                 }
                 std::thread::sleep(Duration::from_millis(10));
             }
-
-            // If still not finished, return without consuming the handle.
-            if !self
-                .thread
-                .as_ref()
-                .map(|t| t.is_finished())
-                .unwrap_or(true)
-            {
+            if !self.task.as_ref().map(|t| t.is_finished()).unwrap_or(true) {
                 return Ok(());
             }
         }
 
-        // Consume the JoinHandle.
-        let handle = self.thread.take().expect("checked above: thread is Some");
-        match handle.join() {
+        let task = self.task.take().expect("checked above: task is Some");
+        match block_on_task(task) {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => Err(e),
             Err(_) => Err(SondaError::Runtime(RuntimeError::ThreadPanicked)),
         }
     }
 
-    /// Best-effort timed join: poll the underlying thread until it finishes
-    /// or `timeout` elapses. On timeout the thread is left detached and
+    /// Best-effort timed join: poll the underlying task until it finishes
+    /// or `timeout` elapses. On timeout the task is left detached and
     /// `Err(JoinTimeout)` is returned. On success the inner `JoinHandle`
     /// is consumed.
     pub fn join_timeout(&mut self, timeout: Duration) -> Result<(), JoinTimeout> {
-        if self.thread.is_none() {
+        if self.task.is_none() {
             return Ok(());
         }
         let deadline = Instant::now() + timeout;
         let poll_interval = Duration::from_millis(10);
         loop {
-            if self
-                .thread
-                .as_ref()
-                .map(|t| t.is_finished())
-                .unwrap_or(true)
-            {
-                if let Some(handle) = self.thread.take() {
-                    let _ = handle.join();
+            if self.task.as_ref().map(|t| t.is_finished()).unwrap_or(true) {
+                if let Some(task) = self.task.take() {
+                    let _ = block_on_task(task);
                 }
                 return Ok(());
             }
@@ -214,22 +167,13 @@ impl ScenarioHandle {
     }
 
     /// Elapsed time since the scenario started.
-    ///
-    /// This is a real-time measurement based on the wall clock recorded at
-    /// launch. It continues to grow even after the scenario stops.
     pub fn elapsed(&self) -> Duration {
         self.started_at.elapsed()
     }
 
     /// Read the latest stats snapshot.
     ///
-    /// Acquires the read lock briefly, clones the stats, and returns. Does not
-    /// block writers for longer than the clone operation.
-    ///
-    /// If the stats lock is poisoned (because a writer panicked), this method
-    /// recovers the data from the poisoned guard rather than propagating the
-    /// panic. The returned stats may be partially updated but will not cause
-    /// the caller to panic.
+    /// Recovers from a poisoned stats lock rather than propagating the panic.
     pub fn stats_snapshot(&self) -> ScenarioStats {
         match self.stats.read() {
             Ok(guard) => guard.clone(),
@@ -243,6 +187,22 @@ impl ScenarioHandle {
         match self.stats.read() {
             Ok(guard) => guard.current_values_snapshot(),
             Err(poisoned) => poisoned.into_inner().current_values_snapshot(),
+        }
+    }
+}
+
+/// Drive a finished `JoinHandle` to completion from either a sync or async
+/// caller. The caller polls `is_finished()` before invoking this, so the
+/// `block_on` resolves immediately and never actually blocks the executor.
+fn block_on_task<T: Send + 'static>(task: JoinHandle<T>) -> Result<T, tokio::task::JoinError> {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => tokio::task::block_in_place(|| handle.block_on(task)),
+        Err(_) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("fallback runtime must build");
+            rt.block_on(task)
         }
     }
 }
@@ -264,51 +224,40 @@ impl Drop for ScenarioHandle {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, RwLock};
-    use std::thread;
     use std::time::{Duration, Instant};
 
     use super::*;
     use crate::schedule::stats::ScenarioStats;
     use crate::SondaError;
 
-    // ---- Helper: build a ScenarioHandle backed by a trivial thread ----------
-
-    /// Build a `ScenarioHandle` whose thread counts to a limit, then exits.
-    ///
-    /// The thread increments `total_events` on the shared stats arc each
-    /// iteration so tests can observe live stat updates without involving
-    /// the full runner pipeline.
     fn make_handle(id: &str, name: &str, events: u64, interval: Duration) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-        let shutdown_thread = Arc::clone(&shutdown);
-        let stats_thread = Arc::clone(&stats);
+        let cancel_for_task = cancel.clone();
+        let stats_for_task = Arc::clone(&stats);
 
-        let thread = thread::Builder::new()
-            .name(format!("test-{name}"))
-            .spawn(move || -> Result<(), SondaError> {
-                for _ in 0..events {
-                    if !shutdown_thread.load(Ordering::SeqCst) {
-                        break;
-                    }
-                    thread::sleep(interval);
-                    if let Ok(mut st) = stats_thread.write() {
-                        st.total_events += 1;
-                        st.bytes_emitted += 64;
-                    }
+        let task = tokio::task::spawn(async move {
+            for _ in 0..events {
+                if cancel_for_task.is_cancelled() {
+                    break;
                 }
-                Ok(())
-            })
-            .expect("thread must spawn");
+                tokio::time::sleep(interval).await;
+                if let Ok(mut st) = stats_for_task.write() {
+                    st.total_events += 1;
+                    st.bytes_emitted += 64;
+                }
+            }
+            Ok::<(), SondaError>(())
+        });
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             100.0,
@@ -322,146 +271,98 @@ mod tests {
         )
     }
 
-    // ---- is_running: true before stop, false after join ---------------------
-
-    /// A freshly spawned handle must report is_running() == true.
-    #[test]
-    fn is_running_returns_true_for_live_thread() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn is_running_returns_true_for_live_task() {
         let mut handle = make_handle("test-1", "live", 50, Duration::from_millis(10));
-        assert!(
-            handle.is_running(),
-            "is_running must return true for a live thread"
-        );
-        // Clean up.
+        assert!(handle.is_running());
         handle.stop();
         handle.join(Some(Duration::from_secs(2))).unwrap();
     }
 
-    /// After stop() + join(), is_running() must return false.
-    #[test]
-    fn is_running_returns_false_after_stop_and_join() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn is_running_returns_false_after_stop_and_join() {
         let mut handle = make_handle("test-2", "stopped", 1000, Duration::from_millis(5));
         handle.stop();
         handle
             .join(Some(Duration::from_secs(2)))
             .expect("join must succeed");
-        assert!(
-            !handle.is_running(),
-            "is_running must return false after the thread has been joined"
-        );
+        assert!(!handle.is_running());
     }
 
-    /// A handle whose JoinHandle has been consumed (None) returns false.
-    #[test]
-    fn is_running_returns_false_when_thread_is_none() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn is_running_returns_false_when_task_is_none() {
         let mut handle = make_handle("test-3", "none", 1, Duration::from_millis(1));
-        // Allow thread to finish naturally.
-        thread::sleep(Duration::from_millis(50));
-        // Consume the JoinHandle directly to mimic a post-join state.
-        handle.thread = None;
-        assert!(
-            !handle.is_running(),
-            "is_running must return false when thread is None"
-        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        handle.task = None;
+        assert!(!handle.is_running());
     }
 
-    // ---- stop(): sets the shutdown flag to false ----------------------------
-
-    /// stop() must store false in the shared AtomicBool.
-    #[test]
-    fn stop_sets_shutdown_flag_to_false() {
-        let handle = make_handle("test-4", "stop_flag", 1000, Duration::from_millis(10));
-        assert!(
-            handle.shutdown.load(Ordering::SeqCst),
-            "shutdown flag must be true before stop"
-        );
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stop_cancels_token() {
+        let handle = make_handle("test-4", "stop_token", 1000, Duration::from_millis(10));
+        assert!(!handle.cancel.is_cancelled());
         handle.stop();
-        assert!(
-            !handle.shutdown.load(Ordering::SeqCst),
-            "shutdown flag must be false after stop"
-        );
-        // Clean up the thread without consuming the handle.
+        assert!(handle.cancel.is_cancelled());
         drop(handle);
     }
 
-    // ---- join(): blocks until thread exits and returns Ok -------------------
-
-    /// join() with None timeout blocks until the thread finishes and returns Ok.
-    #[test]
-    fn join_none_timeout_waits_for_thread_and_returns_ok() {
-        let mut handle = make_handle("test-5", "join_none", 3, Duration::from_millis(10));
-        let result = handle.join(None);
-        assert!(
-            result.is_ok(),
-            "join must return Ok when the thread succeeds: {result:?}"
-        );
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stop_is_idempotent() {
+        let handle = make_handle("test-stop-idem", "idem", 1000, Duration::from_millis(10));
+        handle.stop();
+        handle.stop();
+        assert!(handle.cancel.is_cancelled());
+        drop(handle);
     }
 
-    /// join() is idempotent: calling it a second time returns Ok immediately.
-    #[test]
-    fn join_is_idempotent_after_first_call() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_none_timeout_waits_for_task_and_returns_ok() {
+        let mut handle = make_handle("test-5", "join_none", 3, Duration::from_millis(10));
+        let result = handle.join(None);
+        assert!(result.is_ok(), "join must return Ok: {result:?}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_is_idempotent_after_first_call() {
         let mut handle = make_handle("test-6", "idempotent", 1, Duration::from_millis(1));
         handle.join(None).expect("first join must succeed");
         let result = handle.join(None);
-        assert!(
-            result.is_ok(),
-            "second join on an already-joined handle must return Ok: {result:?}"
-        );
+        assert!(result.is_ok(), "second join must succeed: {result:?}");
     }
 
-    /// join() with a timeout that expires while thread is still running returns
-    /// Ok without consuming the thread (handle still owns it).
-    #[test]
-    fn join_with_short_timeout_returns_ok_without_consuming_thread() {
-        // Thread runs for 10 events × 50ms each = 500ms total.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_with_short_timeout_returns_ok_without_consuming_task() {
         let mut handle = make_handle("test-7", "timeout", 10, Duration::from_millis(50));
-        // Join with a very short timeout — thread will still be running.
         let result = handle.join(Some(Duration::from_millis(10)));
+        assert!(result.is_ok());
         assert!(
-            result.is_ok(),
-            "join with expired timeout must still return Ok"
+            handle.task.is_some(),
+            "task must not be consumed when timeout expired"
         );
-        // The JoinHandle must NOT have been consumed — is_running may still be true.
-        assert!(
-            handle.thread.is_some(),
-            "thread must not be consumed when timeout expired before thread finished"
-        );
-        // Clean up.
         handle.stop();
         handle.join(None).ok();
     }
 
-    // ---- elapsed(): grows over time -----------------------------------------
-
-    /// elapsed() must return a positive Duration immediately after creation.
-    #[test]
-    fn elapsed_returns_positive_duration() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn elapsed_returns_positive_duration() {
         let handle = make_handle("test-8", "elapsed", 1, Duration::from_millis(1));
         let d = handle.elapsed();
-        // Even with scheduler jitter this should be at least 0 ns.
-        assert!(d >= Duration::ZERO, "elapsed must be non-negative: {d:?}");
+        assert!(d >= Duration::ZERO);
     }
 
-    /// elapsed() measured after a sleep must be greater than that sleep duration.
-    #[test]
-    fn elapsed_grows_monotonically_after_sleep() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn elapsed_grows_monotonically_after_sleep() {
         let mut handle = make_handle("test-9", "monotonic", 100, Duration::from_millis(5));
         let before = handle.elapsed();
-        thread::sleep(Duration::from_millis(100));
+        tokio::time::sleep(Duration::from_millis(100)).await;
         let after = handle.elapsed();
-        assert!(
-            after > before,
-            "elapsed must grow over time: before={before:?}, after={after:?}"
-        );
+        assert!(after > before);
         handle.stop();
         handle.join(None).ok();
     }
 
-    // ---- stats_snapshot(): returns the current stats atomically -------------
-
-    /// stats_snapshot() on a fresh handle returns all-zero stats.
-    #[test]
-    fn stats_snapshot_on_fresh_handle_returns_zeros() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_on_fresh_handle_returns_zeros() {
         let handle = make_handle("test-10", "fresh_stats", 0, Duration::ZERO);
         let snap = handle.stats_snapshot();
         assert_eq!(snap.total_events, 0);
@@ -469,24 +370,13 @@ mod tests {
         assert_eq!(snap.errors, 0);
     }
 
-    /// After the worker thread emits events, stats_snapshot() reflects the updates.
-    #[test]
-    fn stats_snapshot_returns_nonzero_total_events_after_running() {
-        // 5 events × 10ms each = ~50ms of work.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_returns_nonzero_total_events_after_running() {
         let mut handle = make_handle("test-11", "nonzero_stats", 5, Duration::from_millis(10));
-        // Wait long enough for all 5 events to fire.
-        thread::sleep(Duration::from_millis(200));
+        tokio::time::sleep(Duration::from_millis(200)).await;
         let snap = handle.stats_snapshot();
-        assert!(
-            snap.total_events > 0,
-            "stats_snapshot must reflect emitted events, got total_events={}",
-            snap.total_events
-        );
-        assert!(
-            snap.bytes_emitted > 0,
-            "stats_snapshot must reflect bytes_emitted > 0, got {}",
-            snap.bytes_emitted
-        );
+        assert!(snap.total_events > 0);
+        assert!(snap.bytes_emitted > 0);
         handle.join(None).ok();
     }
 
@@ -499,14 +389,14 @@ mod tests {
         .expect("test metric name must be valid")
     }
 
-    #[test]
-    fn recent_metrics_snapshot_on_fresh_handle_returns_empty() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recent_metrics_snapshot_on_fresh_handle_returns_empty() {
         let handle = make_handle("test-rm-1", "fresh", 0, Duration::ZERO);
         assert!(handle.recent_metrics_snapshot().is_empty());
     }
 
-    #[test]
-    fn recent_metrics_snapshot_returns_current_values_not_history() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recent_metrics_snapshot_returns_current_values_not_history() {
         let handle = make_handle("test-rm-2", "current", 0, Duration::ZERO);
         {
             let mut stats = handle.stats.write().expect("lock must not be poisoned");
@@ -515,12 +405,12 @@ mod tests {
             stats.push_metric(make_metric_event("up", 3.0));
         }
         let events = handle.recent_metrics_snapshot();
-        assert_eq!(events.len(), 1, "same series must collapse to one entry");
-        assert_eq!(events[0].value, 3.0, "latest value must win");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].value, 3.0);
     }
 
-    #[test]
-    fn recent_metrics_snapshot_is_idempotent() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recent_metrics_snapshot_is_idempotent() {
         let handle = make_handle("test-rm-3", "idempotent", 0, Duration::ZERO);
         {
             let mut stats = handle.stats.write().expect("lock must not be poisoned");
@@ -533,43 +423,30 @@ mod tests {
         assert_eq!(first[0].value, second[0].value);
     }
 
-    // ---- stats_snapshot: recovers from poisoned lock -------------------------
-
-    /// If the stats lock is poisoned, stats_snapshot recovers the data instead
-    /// of panicking.
-    #[test]
-    fn stats_snapshot_recovers_from_poisoned_lock() {
-        let shutdown = Arc::new(AtomicBool::new(false));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_recovers_from_poisoned_lock() {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-
-        // Set a known value before poisoning.
         {
             let mut guard = stats.write().expect("lock must not be poisoned");
             guard.total_events = 42;
         }
 
-        // Poison the lock by panicking inside a write guard.
         let stats_clone = Arc::clone(&stats);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _guard = stats_clone.write().expect("lock must not be poisoned");
             panic!("intentional panic to poison lock");
         }));
-        assert!(result.is_err(), "panic must have occurred");
-
-        // Verify the lock is actually poisoned.
+        assert!(result.is_err());
         assert!(stats.read().is_err(), "lock must be poisoned after panic");
 
-        let thread = thread::Builder::new()
-            .name("test-poisoned-stats".to_string())
-            .spawn(|| -> Result<(), SondaError> { Ok(()) })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async { Ok::<(), SondaError>(()) });
 
         let handle = ScenarioHandle::new(
             "test-poisoned".to_string(),
             "poisoned".to_string(),
             None,
-            shutdown,
-            Some(thread),
+            CancellationToken::new(),
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -582,17 +459,12 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
         );
 
-        // stats_snapshot must not panic — it recovers from the poisoned lock.
         let snap = handle.stats_snapshot();
-        assert_eq!(
-            snap.total_events, 42,
-            "stats_snapshot must recover data from poisoned lock"
-        );
+        assert_eq!(snap.total_events, 42);
     }
 
-    #[test]
-    fn recent_metrics_snapshot_recovers_from_poisoned_lock() {
-        let shutdown = Arc::new(AtomicBool::new(false));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recent_metrics_snapshot_recovers_from_poisoned_lock() {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         {
@@ -605,19 +477,16 @@ mod tests {
             let _guard = stats_clone.write().expect("lock must not be poisoned");
             panic!("intentional panic to poison lock");
         }));
-        assert!(result.is_err(), "panic must have occurred");
+        assert!(result.is_err());
 
-        let thread = thread::Builder::new()
-            .name("test-poisoned-metrics".to_string())
-            .spawn(|| -> Result<(), SondaError> { Ok(()) })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async { Ok::<(), SondaError>(()) });
 
         let handle = ScenarioHandle::new(
             "test-poisoned-m".to_string(),
             "poisoned_metrics".to_string(),
             None,
-            shutdown,
-            Some(thread),
+            CancellationToken::new(),
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -635,53 +504,36 @@ mod tests {
         assert_eq!(events[0].value, 99.0);
     }
 
-    // ---- Contract: ScenarioHandle is Send -----------------------------------
-
-    /// ScenarioHandle must be Send so it can be stored in server state and
-    /// moved across tokio await points.
     #[test]
     fn scenario_handle_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<ScenarioHandle>();
     }
 
-    #[test]
-    fn join_timeout_returns_ok_when_handle_exits_within_window() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_timeout_returns_ok_when_handle_exits_within_window() {
         let mut handle = make_handle("jt-1", "fast", 1, Duration::from_millis(5));
-        thread::sleep(Duration::from_millis(50));
+        tokio::time::sleep(Duration::from_millis(50)).await;
         let result = handle.join_timeout(Duration::from_millis(500));
-        assert!(
-            result.is_ok(),
-            "join_timeout must return Ok when thread already exited: {result:?}"
-        );
-        assert!(handle.thread.is_none(), "JoinHandle must be consumed on Ok");
+        assert!(result.is_ok());
+        assert!(handle.task.is_none());
     }
 
-    #[test]
-    fn join_timeout_returns_err_when_thread_still_running() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_timeout_returns_err_when_task_still_running() {
         let mut handle = make_handle("jt-2", "slow", 100, Duration::from_millis(50));
         let result = handle.join_timeout(Duration::from_millis(20));
-        assert!(
-            result.is_err(),
-            "join_timeout must return Err when timeout expires before exit"
-        );
-        assert!(
-            handle.thread.is_some(),
-            "JoinHandle must be retained on timeout"
-        );
-        // Clean up.
+        assert!(result.is_err());
+        assert!(handle.task.is_some());
         handle.stop();
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn join_timeout_is_idempotent_when_thread_already_consumed() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_timeout_is_idempotent_when_task_already_consumed() {
         let mut handle = make_handle("jt-3", "consumed", 1, Duration::from_millis(1));
         handle.join(None).expect("first join must succeed");
         let result = handle.join_timeout(Duration::from_millis(50));
-        assert!(
-            result.is_ok(),
-            "join_timeout on consumed handle must return Ok"
-        );
+        assert!(result.is_ok());
     }
 }

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -8,6 +8,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
+use tokio_util::sync::CancellationToken;
+
 use crate::compiler::{DelayClause, WhileClause};
 use crate::config::aliases::desugar_entry;
 use crate::config::validate::{
@@ -24,7 +26,7 @@ use crate::schedule::runner::run_with_sink_gated;
 use crate::schedule::stats::{ScenarioState, ScenarioStats};
 use crate::schedule::summary_runner::run_with_sink_gated as run_summary_with_sink_gated;
 use crate::sink::create_sink;
-use crate::{ConfigError, RuntimeError, SondaError};
+use crate::{ConfigError, SondaError};
 
 /// Extract the inner message from a [`SondaError`] for re-wrapping.
 ///
@@ -166,68 +168,40 @@ pub fn prepare_entries(entries: Vec<ScenarioEntry>) -> Result<Vec<PreparedEntry>
     Ok(prepared)
 }
 
-/// Launch a single scenario on a new OS thread.
-///
-/// Creates the sink, wires up the shutdown flag and the stats arc, spawns the
-/// appropriate runner (metrics, logs, histogram, or summary), and returns a
-/// [`ScenarioHandle`] for lifecycle management.
-///
-/// This is the single function that both the CLI and sonda-server call to
-/// start a scenario. No scenario launch logic exists outside this function.
-///
-/// # Parameters
-///
-/// * `id` — unique identifier for this scenario instance (e.g. a UUID string).
-/// * `entry` — the scenario configuration. The `signal_type` field selects
-///   the runner.
-/// * `shutdown` — shared shutdown flag. Pass `Arc::new(AtomicBool::new(true))`
-///   for a new scenario. The handle's [`ScenarioHandle::stop`] method sets this
-///   to `false` to request a clean exit.
-/// * `start_delay` — optional delay before the scenario begins emitting events.
-///   When `Some`, the spawned thread sleeps for this duration before entering the
-///   event loop. This enables temporal correlation in multi-scenario mode: "metric
-///   A starts immediately, metric B starts 30s later". The sleep happens inside
-///   the spawned thread, so it does not block the caller.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if the sink cannot be created. Thread spawn failures
-/// are extremely rare on modern operating systems; if the OS refuses to spawn
-/// a thread it is treated as an unrecoverable condition.
+/// Launch a single scenario on a new tokio task. Caller must be inside a tokio runtime.
 pub fn launch_scenario(
     id: String,
     entry: ScenarioEntry,
-    shutdown: Arc<AtomicBool>,
+    cancel: CancellationToken,
     start_delay: Option<Duration>,
 ) -> Result<ScenarioHandle, SondaError> {
-    launch_scenario_with_gates(id, None, entry, shutdown, start_delay, None, None, None)
+    launch_scenario_with_gates(id, None, entry, cancel, start_delay, None, None, None)
 }
 
 /// Launch a scenario with optional `while:` / `after:` gating wired in.
 ///
 /// `scenario_name` surfaces on [`ScenarioHandle::scenario_name`]; pass `None`
 /// for anonymous bodies. `upstream_bus` is the bus this scenario PUBLISHES
-/// into (for downstream gates to read). `gate_ctx` is what THIS scenario
-/// consumes from an upstream bus. When `resolver` is `Some` AND `scenario_name`
-/// is `Some`, natural-exit cleanup unregisters the upstream bus on thread exit.
+/// into. `gate_ctx` is what THIS scenario consumes from an upstream bus.
+/// When `resolver` is `Some` AND `scenario_name` is `Some`, natural-exit
+/// cleanup unregisters the upstream bus on task exit. Caller must be inside a
+/// tokio runtime.
 #[allow(clippy::too_many_arguments)]
 pub fn launch_scenario_with_gates(
     id: String,
     scenario_name: Option<String>,
     entry: ScenarioEntry,
-    shutdown: Arc<AtomicBool>,
+    cancel: CancellationToken,
     start_delay: Option<Duration>,
     upstream_bus: Option<Arc<GateBus>>,
-    gate_ctx: Option<GateContext>,
+    mut gate_ctx: Option<GateContext>,
     resolver: Option<Arc<dyn GateBusResolver>>,
 ) -> Result<ScenarioHandle, SondaError> {
     let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-    let stats_for_thread = Arc::clone(&stats);
-    let shutdown_for_thread = Arc::clone(&shutdown);
+    let stats_for_task = Arc::clone(&stats);
     let alive = Arc::new(AtomicBool::new(true));
-    let alive_for_thread = Arc::clone(&alive);
+    let alive_for_task = Arc::clone(&alive);
 
-    // Extract the name and target rate before moving `entry` into the thread closure.
     let (name, target_rate) = match &entry {
         ScenarioEntry::Metrics(c) => (c.name.clone(), c.rate),
         ScenarioEntry::Logs(c) => (c.name.clone(), c.rate),
@@ -239,139 +213,135 @@ pub fn launch_scenario_with_gates(
 
     let started_at = Instant::now();
 
-    // Validate shutdown flag is currently set to `true` (running). The caller
-    // is responsible for ensuring this; we document the contract but do not
-    // enforce it here to avoid a redundant check on every launch.
-    //
-    // Ensure `running` ordering is visible from the new thread.
-    shutdown.store(true, Ordering::SeqCst);
+    // Bridge the per-handle CancellationToken to the runners' AtomicBool
+    // shutdown contract so duration-bound polls inside the runners observe
+    // the stop without restructuring every signature.
+    let shutdown = Arc::new(AtomicBool::new(true));
 
+    // Spawn the bridge watcher BEFORE the scenario task: a cancel() that
+    // lands between launch and the scenario task starting must still flip
+    // the flag immediately.
+    let shutdown_for_watcher = Arc::clone(&shutdown);
+    let cancel_for_watcher = cancel.clone();
+    let watcher_handle = tokio::task::spawn(async move {
+        cancel_for_watcher.cancelled().await;
+        shutdown_for_watcher.store(false, Ordering::SeqCst);
+    });
+
+    if let Some(ref mut ctx) = gate_ctx {
+        ctx.cancel = cancel.clone();
+    }
+
+    let cancel_for_task = cancel.clone();
+    let shutdown_for_task = Arc::clone(&shutdown);
     let stats_for_state = Arc::clone(&stats);
     let is_gated = gate_ctx.is_some();
     let cleaned_up = Arc::new(AtomicBool::new(false));
-    let cleaned_up_for_thread = Arc::clone(&cleaned_up);
-    let resolver_for_thread = resolver.clone();
-    let scenario_name_for_thread = scenario_name.clone();
+    let cleaned_up_for_task = Arc::clone(&cleaned_up);
+    let resolver_for_task = resolver.clone();
+    let scenario_name_for_task = scenario_name.clone();
 
     // Cross-POST scenarios broadcast via resolver.unregister; broadcasting
     // here too races the registry's subscriber migration.
-    let bus_for_finish_guard =
-        if scenario_name_for_thread.is_some() && resolver_for_thread.is_some() {
-            None
-        } else {
-            upstream_bus.as_ref().map(Arc::clone)
+    let bus_for_finish_guard = if scenario_name_for_task.is_some() && resolver_for_task.is_some() {
+        None
+    } else {
+        upstream_bus.as_ref().map(Arc::clone)
+    };
+
+    let task = tokio::task::spawn(async move {
+        let _alive_guard = AliveGuard {
+            flag: alive_for_task,
+        };
+        let _state_guard = StateGuard {
+            stats: Arc::clone(&stats_for_state),
+            resolver: resolver_for_task,
+            scenario_name: scenario_name_for_task,
+            cleaned_up: cleaned_up_for_task,
+        };
+        let _bus_finish_guard = BusFinishGuard {
+            bus: bus_for_finish_guard,
         };
 
-    let thread = std::thread::Builder::new()
-        .name(format!("sonda-{}", name))
-        .spawn(move || -> Result<(), SondaError> {
-            // Drop guard clears the alive flag on every exit path, including
-            // panics — observers polling `is_alive()` see a single clean
-            // transition `true → false` regardless of how the thread terminates.
-            let _guard = AliveGuard {
-                flag: alive_for_thread,
-            };
+        let _watcher_guard = AbortOnDrop(watcher_handle);
 
-            // Marks Finished on drop; unregisters when a resolver is wired.
-            let _state_guard = StateGuard {
-                stats: Arc::clone(&stats_for_state),
-                resolver: resolver_for_thread,
-                scenario_name: scenario_name_for_thread,
-                cleaned_up: cleaned_up_for_thread,
-            };
-
-            // Drops before _state_guard so downstreams see UpstreamGone
-            // before the scenario flips to Finished.
-            let _bus_finish_guard = BusFinishGuard {
-                bus: bus_for_finish_guard,
-            };
-
-            // Sleep through the start_delay before entering the event loop.
-            // State stays `Pending` for the delay window so /stats reports
-            // `pending` until the first tick is actually due.
-            if let Some(delay) = start_delay {
-                let deadline = std::time::Instant::now() + delay;
-                while std::time::Instant::now() < deadline {
-                    if !shutdown_for_thread.load(Ordering::SeqCst) {
-                        return Ok(());
-                    }
-                    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-                    let sleep_chunk = remaining.min(Duration::from_millis(50));
-                    if sleep_chunk > Duration::ZERO {
-                        std::thread::sleep(sleep_chunk);
-                    }
+        if let Some(delay) = start_delay {
+            tokio::select! {
+                _ = tokio::time::sleep(delay) => {}
+                _ = cancel_for_task.cancelled() => {
+                    return Ok::<(), SondaError>(());
                 }
             }
+        }
 
-            // gated_loop owns its own state transitions; non-gated runs
-            // need someone to mark Running once the start_delay has elapsed.
-            if !is_gated {
-                if let Ok(mut st) = stats_for_state.write() {
-                    st.transition_state(ScenarioState::Running);
-                }
+        if !is_gated {
+            if let Ok(mut st) = stats_for_state.write() {
+                st.transition_state(ScenarioState::Running);
             }
+        }
 
-            // Per-scenario current-thread Tokio runtime: drives the async
-            // runner from inside the std::thread::spawn'd scenario thread.
-            // One runtime per thread keeps the blocking-task pool local to
-            // this scenario.
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
-
+        let cancel_for_select = cancel_for_task.clone();
+        let runner_future = async move {
             match entry {
                 ScenarioEntry::Metrics(config) => {
                     let mut sink = create_sink(&config.sink, None)?;
-                    rt.block_on(run_with_sink_gated(
+                    run_with_sink_gated(
                         &config,
                         &mut sink,
-                        Some(shutdown_for_thread.as_ref()),
-                        Some(Arc::clone(&stats_for_thread)),
+                        Some(shutdown_for_task.as_ref()),
+                        Some(Arc::clone(&stats_for_task)),
                         upstream_bus,
                         gate_ctx,
-                    ))
+                    )
+                    .await
                 }
                 ScenarioEntry::Logs(config) => {
                     let mut sink = create_sink(&config.sink, config.labels.as_ref())?;
-                    rt.block_on(run_logs_with_sink_gated(
+                    run_logs_with_sink_gated(
                         &config,
                         &mut sink,
-                        Some(shutdown_for_thread.as_ref()),
-                        Some(Arc::clone(&stats_for_thread)),
+                        Some(shutdown_for_task.as_ref()),
+                        Some(Arc::clone(&stats_for_task)),
                         gate_ctx,
-                    ))
+                    )
+                    .await
                 }
                 ScenarioEntry::Histogram(config) => {
                     let mut sink = create_sink(&config.sink, None)?;
-                    rt.block_on(run_histogram_with_sink_gated(
+                    run_histogram_with_sink_gated(
                         &config,
                         &mut sink,
-                        Some(shutdown_for_thread.as_ref()),
-                        Some(Arc::clone(&stats_for_thread)),
+                        Some(shutdown_for_task.as_ref()),
+                        Some(Arc::clone(&stats_for_task)),
                         gate_ctx,
-                    ))
+                    )
+                    .await
                 }
                 ScenarioEntry::Summary(config) => {
                     let mut sink = create_sink(&config.sink, None)?;
-                    rt.block_on(run_summary_with_sink_gated(
+                    run_summary_with_sink_gated(
                         &config,
                         &mut sink,
-                        Some(shutdown_for_thread.as_ref()),
-                        Some(Arc::clone(&stats_for_thread)),
+                        Some(shutdown_for_task.as_ref()),
+                        Some(Arc::clone(&stats_for_task)),
                         gate_ctx,
-                    ))
+                    )
+                    .await
                 }
             }
-        })
-        .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
+        };
+        tokio::select! {
+            res = runner_future => res,
+            _ = cancel_for_select.cancelled() => Ok(()),
+        }
+    });
 
     Ok(ScenarioHandle::new(
         id,
         name,
         scenario_name,
-        shutdown,
-        Some(thread),
+        cancel,
+        Some(task),
         started_at,
         stats,
         target_rate,
@@ -400,6 +370,14 @@ fn derive_prometheus_meta(entry: &ScenarioEntry) -> Option<Arc<PromMeta>> {
             c.help.clone(),
         ))),
         ScenarioEntry::Logs(_) => None,
+    }
+}
+
+struct AbortOnDrop<T>(tokio::task::JoinHandle<T>);
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        self.0.abort();
     }
 }
 
@@ -594,8 +572,8 @@ mod tests {
     // ---- validate_entry: dispatches to the correct validator ----------------
 
     /// validate_entry dispatches to validate_config for a Metrics entry.
-    #[test]
-    fn validate_entry_accepts_valid_metrics_entry() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn validate_entry_accepts_valid_metrics_entry() {
         let entry = metrics_entry("valid_metrics");
         let result = validate_entry(&entry);
         assert!(
@@ -605,8 +583,8 @@ mod tests {
     }
 
     /// validate_entry dispatches to validate_log_config for a Logs entry.
-    #[test]
-    fn validate_entry_accepts_valid_logs_entry() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn validate_entry_accepts_valid_logs_entry() {
         let entry = logs_entry("valid_logs");
         let result = validate_entry(&entry);
         assert!(
@@ -616,8 +594,8 @@ mod tests {
     }
 
     /// validate_entry returns Err for a Metrics entry with rate = 0 (invalid).
-    #[test]
-    fn validate_entry_rejects_metrics_entry_with_zero_rate() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn validate_entry_rejects_metrics_entry_with_zero_rate() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "bad_metrics".to_string(),
@@ -650,8 +628,8 @@ mod tests {
     }
 
     /// validate_entry returns Err for a Metrics entry with negative rate.
-    #[test]
-    fn validate_entry_rejects_metrics_entry_with_negative_rate() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn validate_entry_rejects_metrics_entry_with_negative_rate() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "neg_rate".to_string(),
@@ -684,8 +662,8 @@ mod tests {
     }
 
     /// validate_entry returns Err for a Logs entry with rate = 0 (invalid).
-    #[test]
-    fn validate_entry_rejects_logs_entry_with_zero_rate() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn validate_entry_rejects_logs_entry_with_zero_rate() {
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
             base: BaseScheduleConfig {
                 name: "bad_logs".to_string(),
@@ -723,8 +701,8 @@ mod tests {
     }
 
     /// validate_entry returns Err for a Metrics entry with an invalid duration.
-    #[test]
-    fn validate_entry_rejects_metrics_entry_with_bad_duration() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn validate_entry_rejects_metrics_entry_with_bad_duration() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "bad_dur".to_string(),
@@ -759,14 +737,13 @@ mod tests {
     // ---- launch_scenario: returns a running handle --------------------------
 
     /// launch_scenario with a metrics entry returns a handle whose thread is alive.
-    #[test]
-    fn launch_scenario_metrics_returns_running_handle() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_scenario_metrics_returns_running_handle() {
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("launch_metrics");
 
-        let mut handle =
-            launch_scenario("test-id-1".to_string(), entry, Arc::clone(&shutdown), None)
-                .expect("launch must succeed for valid metrics entry");
+        let mut handle = launch_scenario("test-id-1".to_string(), entry, cancel.clone(), None)
+            .expect("launch must succeed for valid metrics entry");
 
         // The thread must be alive immediately after launch.
         assert!(
@@ -786,14 +763,13 @@ mod tests {
     }
 
     /// launch_scenario with a logs entry returns a handle whose thread is alive.
-    #[test]
-    fn launch_scenario_logs_returns_running_handle() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_scenario_logs_returns_running_handle() {
+        let cancel = CancellationToken::new();
         let entry = logs_entry_indefinite("launch_logs");
 
-        let mut handle =
-            launch_scenario("test-id-2".to_string(), entry, Arc::clone(&shutdown), None)
-                .expect("launch must succeed for valid logs entry");
+        let mut handle = launch_scenario("test-id-2".to_string(), entry, cancel.clone(), None)
+            .expect("launch must succeed for valid logs entry");
 
         assert!(
             handle.is_running(),
@@ -810,11 +786,11 @@ mod tests {
     // ---- stop() + join() exits cleanly --------------------------------------
 
     /// stop() followed by join() on a metrics scenario exits cleanly (Ok).
-    #[test]
-    fn stop_then_join_metrics_scenario_returns_ok() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stop_then_join_metrics_scenario_returns_ok() {
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("stop_join_metrics");
-        let mut handle = launch_scenario("id-stop-1".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("id-stop-1".to_string(), entry, cancel, None)
             .expect("launch must succeed");
 
         handle.stop();
@@ -830,11 +806,11 @@ mod tests {
     }
 
     /// stop() followed by join() on a logs scenario exits cleanly (Ok).
-    #[test]
-    fn stop_then_join_logs_scenario_returns_ok() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stop_then_join_logs_scenario_returns_ok() {
+        let cancel = CancellationToken::new();
         let entry = logs_entry_indefinite("stop_join_logs");
-        let mut handle = launch_scenario("id-stop-2".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("id-stop-2".to_string(), entry, cancel, None)
             .expect("launch must succeed");
 
         handle.stop();
@@ -846,11 +822,11 @@ mod tests {
     }
 
     /// A finite-duration scenario exits on its own and join() returns Ok.
-    #[test]
-    fn finite_duration_scenario_exits_naturally_and_join_returns_ok() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn finite_duration_scenario_exits_naturally_and_join_returns_ok() {
+        let cancel = CancellationToken::new();
         let entry = metrics_entry("natural_exit");
-        let mut handle = launch_scenario("id-natural".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("id-natural".to_string(), entry, cancel, None)
             .expect("launch must succeed");
 
         // 200ms duration — wait for it to finish, then join.
@@ -864,11 +840,11 @@ mod tests {
     // ---- stats_snapshot(): non-zero total_events after brief run ------------
 
     /// After letting a launched scenario run briefly, stats show non-zero events.
-    #[test]
-    fn stats_snapshot_shows_nonzero_events_after_brief_run() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_shows_nonzero_events_after_brief_run() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         // High rate so events accumulate quickly.
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
@@ -895,9 +871,8 @@ mod tests {
             help: None,
         });
 
-        let mut handle =
-            launch_scenario("id-stats".to_string(), entry, Arc::clone(&shutdown), None)
-                .expect("launch must succeed");
+        let mut handle = launch_scenario("id-stats".to_string(), entry, cancel.clone(), None)
+            .expect("launch must succeed");
 
         // Wait long enough for at least a few events to be emitted and stats updated.
         thread::sleep(Duration::from_millis(200));
@@ -919,11 +894,11 @@ mod tests {
     }
 
     /// Stats are also tracked for logs scenarios.
-    #[test]
-    fn stats_snapshot_shows_nonzero_events_for_logs_scenario() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_shows_nonzero_events_for_logs_scenario() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
             base: BaseScheduleConfig {
                 name: "logs_stats_test".to_string(),
@@ -954,13 +929,8 @@ mod tests {
             encoder: EncoderConfig::JsonLines { precision: None },
         });
 
-        let mut handle = launch_scenario(
-            "id-log-stats".to_string(),
-            entry,
-            Arc::clone(&shutdown),
-            None,
-        )
-        .expect("launch must succeed");
+        let mut handle = launch_scenario("id-log-stats".to_string(), entry, cancel.clone(), None)
+            .expect("launch must succeed");
 
         thread::sleep(Duration::from_millis(200));
 
@@ -978,11 +948,11 @@ mod tests {
     // ---- elapsed(): positive duration after launch --------------------------
 
     /// elapsed() is positive immediately after launch.
-    #[test]
-    fn elapsed_is_positive_after_launch() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn elapsed_is_positive_after_launch() {
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("elapsed_test");
-        let mut handle = launch_scenario("id-elapsed".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("id-elapsed".to_string(), entry, cancel, None)
             .expect("launch must succeed");
 
         let d = handle.elapsed();
@@ -995,36 +965,28 @@ mod tests {
         handle.join(None).ok();
     }
 
-    // ---- shutdown flag is set to true on launch -----------------------------
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_scenario_leaves_cancel_token_uncancelled_until_stop() {
+        let cancel = CancellationToken::new();
+        let entry = metrics_entry_indefinite("token_state");
 
-    /// launch_scenario sets the shared shutdown flag to true (SeqCst), regardless
-    /// of what the caller set it to beforehand.
-    #[test]
-    fn launch_scenario_resets_shutdown_flag_to_true() {
-        // Intentionally start the flag as false to verify launch forces it true.
-        let shutdown = Arc::new(AtomicBool::new(false));
-        let entry = metrics_entry_indefinite("flag_reset");
-
-        let mut handle = launch_scenario("id-flag".to_string(), entry, Arc::clone(&shutdown), None)
+        let mut handle = launch_scenario("id-flag".to_string(), entry, cancel.clone(), None)
             .expect("launch must succeed");
 
-        assert!(
-            shutdown.load(Ordering::SeqCst),
-            "launch_scenario must reset the shutdown flag to true"
-        );
-
+        assert!(!cancel.is_cancelled());
         handle.stop();
+        assert!(cancel.is_cancelled());
         handle.join(None).ok();
     }
 
     // ---- start_delay: None starts immediately -------------------------------
 
     /// launch_scenario with start_delay=None starts emitting events immediately.
-    #[test]
-    fn launch_with_no_start_delay_emits_events_immediately() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_with_no_start_delay_emits_events_immediately() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "no_delay_test".to_string(),
@@ -1050,9 +1012,8 @@ mod tests {
             help: None,
         });
 
-        let mut handle =
-            launch_scenario("id-nodelay".to_string(), entry, Arc::clone(&shutdown), None)
-                .expect("launch must succeed");
+        let mut handle = launch_scenario("id-nodelay".to_string(), entry, cancel.clone(), None)
+            .expect("launch must succeed");
 
         // Wait briefly and check events have already been emitted.
         thread::sleep(Duration::from_millis(200));
@@ -1071,11 +1032,11 @@ mod tests {
 
     /// launch_scenario with start_delay=Some(500ms) does not emit events for
     /// the first ~400ms (allowing margin for thread scheduling).
-    #[test]
-    fn launch_with_start_delay_does_not_emit_during_delay() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_with_start_delay_does_not_emit_during_delay() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "delay_test".to_string(),
@@ -1102,13 +1063,9 @@ mod tests {
         });
 
         let delay = Duration::from_millis(500);
-        let mut handle = launch_scenario(
-            "id-delay".to_string(),
-            entry,
-            Arc::clone(&shutdown),
-            Some(delay),
-        )
-        .expect("launch must succeed");
+        let mut handle =
+            launch_scenario("id-delay".to_string(), entry, cancel.clone(), Some(delay))
+                .expect("launch must succeed");
 
         // Check after 100ms — should still be in the delay period.
         thread::sleep(Duration::from_millis(100));
@@ -1136,12 +1093,12 @@ mod tests {
 
     /// Sending shutdown during start_delay causes the thread to exit cleanly
     /// without hanging.
-    #[test]
-    fn shutdown_during_start_delay_exits_cleanly() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn shutdown_during_start_delay_exits_cleanly() {
         use std::thread;
         use std::time::Instant;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("shutdown_delay");
 
         // Set a long delay (10 seconds) so we can verify the shutdown works.
@@ -1149,7 +1106,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-shutdown-delay".to_string(),
             entry,
-            Arc::clone(&shutdown),
+            cancel.clone(),
             Some(delay),
         )
         .expect("launch must succeed");
@@ -1185,11 +1142,11 @@ mod tests {
     // ---- start_delay with logs scenario -------------------------------------
 
     /// launch_scenario with start_delay works for logs scenarios too.
-    #[test]
-    fn launch_logs_with_start_delay_does_not_emit_during_delay() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_logs_with_start_delay_does_not_emit_during_delay() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
             base: BaseScheduleConfig {
                 name: "log_delay_test".to_string(),
@@ -1224,7 +1181,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-log-delay".to_string(),
             entry,
-            Arc::clone(&shutdown),
+            cancel.clone(),
             Some(delay),
         )
         .expect("launch must succeed");
@@ -1323,17 +1280,12 @@ mod tests {
     // ---- launch_scenario: histogram runs to completion ----------------------
 
     /// A short histogram scenario launches, runs to completion, and join returns Ok.
-    #[test]
-    fn launch_histogram_scenario_runs_to_completion() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_histogram_scenario_runs_to_completion() {
+        let cancel = CancellationToken::new();
         let entry = histogram_entry("launch_histogram");
-        let mut handle = launch_scenario(
-            "id-histogram".to_string(),
-            entry,
-            Arc::clone(&shutdown),
-            None,
-        )
-        .expect("launch must succeed for valid histogram entry");
+        let mut handle = launch_scenario("id-histogram".to_string(), entry, cancel.clone(), None)
+            .expect("launch must succeed for valid histogram entry");
 
         let result = handle.join(Some(Duration::from_secs(5)));
         assert!(
@@ -1345,13 +1297,12 @@ mod tests {
     // ---- launch_scenario: summary runs to completion -----------------------
 
     /// A short summary scenario launches, runs to completion, and join returns Ok.
-    #[test]
-    fn launch_summary_scenario_runs_to_completion() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_summary_scenario_runs_to_completion() {
+        let cancel = CancellationToken::new();
         let entry = summary_entry("launch_summary");
-        let mut handle =
-            launch_scenario("id-summary".to_string(), entry, Arc::clone(&shutdown), None)
-                .expect("launch must succeed for valid summary entry");
+        let mut handle = launch_scenario("id-summary".to_string(), entry, cancel.clone(), None)
+            .expect("launch must succeed for valid summary entry");
 
         let result = handle.join(Some(Duration::from_secs(5)));
         assert!(
@@ -1363,8 +1314,8 @@ mod tests {
     // ---- validate_entry: histogram and summary dispatching ------------------
 
     /// validate_entry dispatches to validate_histogram_config for a Histogram entry.
-    #[test]
-    fn validate_entry_accepts_valid_histogram_entry() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn validate_entry_accepts_valid_histogram_entry() {
         let entry = histogram_entry("valid_histogram");
         let result = validate_entry(&entry);
         assert!(
@@ -1374,8 +1325,8 @@ mod tests {
     }
 
     /// validate_entry dispatches to validate_summary_config for a Summary entry.
-    #[test]
-    fn validate_entry_accepts_valid_summary_entry() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn validate_entry_accepts_valid_summary_entry() {
         let entry = summary_entry("valid_summary");
         let result = validate_entry(&entry);
         assert!(
@@ -1387,16 +1338,16 @@ mod tests {
     // ---- prepare_entries tests ------------------------------------------------
 
     /// prepare_entries accepts an empty list and returns an empty result.
-    #[test]
-    fn prepare_entries_empty_list_returns_empty() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_entries_empty_list_returns_empty() {
         let result = prepare_entries(vec![]);
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
     }
 
     /// prepare_entries accepts a single valid metrics entry.
-    #[test]
-    fn prepare_entries_single_valid_entry() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_entries_single_valid_entry() {
         let entries = vec![metrics_entry("prep_metric")];
         let result = prepare_entries(entries);
         assert!(result.is_ok(), "must accept valid entry: {result:?}");
@@ -1410,8 +1361,8 @@ mod tests {
     }
 
     /// prepare_entries accepts multiple valid entries of mixed signal types.
-    #[test]
-    fn prepare_entries_mixed_signal_types() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_entries_mixed_signal_types() {
         let entries = vec![
             metrics_entry("prep_m"),
             logs_entry("prep_l"),
@@ -1424,8 +1375,8 @@ mod tests {
     }
 
     /// prepare_entries rejects a batch with an invalid entry and returns error.
-    #[test]
-    fn prepare_entries_rejects_invalid_entry() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_entries_rejects_invalid_entry() {
         let invalid = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "invalid_rate".to_string(),
@@ -1462,8 +1413,8 @@ mod tests {
     }
 
     /// prepare_entries resolves phase_offset into start_delay.
-    #[test]
-    fn prepare_entries_resolves_phase_offset() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_entries_resolves_phase_offset() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "offset_test".to_string(),
@@ -1500,8 +1451,8 @@ mod tests {
     }
 
     /// prepare_entries treats "0s" phase_offset as no delay.
-    #[test]
-    fn prepare_entries_zero_phase_offset_is_none() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_entries_zero_phase_offset_is_none() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "zero_offset".to_string(),
@@ -1537,8 +1488,8 @@ mod tests {
     }
 
     /// prepare_entries rejects invalid phase_offset strings.
-    #[test]
-    fn prepare_entries_rejects_invalid_phase_offset() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_entries_rejects_invalid_phase_offset() {
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "bad_offset".to_string(),
@@ -1574,16 +1525,16 @@ mod tests {
     }
 
     /// PreparedEntry is Debug.
-    #[test]
-    fn prepared_entry_is_debuggable() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepared_entry_is_debuggable() {
         let entry = metrics_entry("debug_test");
         let prepared = prepare_entries(vec![entry]).unwrap();
         let s = format!("{:?}", prepared[0]);
         assert!(s.contains("PreparedEntry"));
     }
 
-    #[test]
-    fn alive_guard_clears_flag_on_panic() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn alive_guard_clears_flag_on_panic() {
         let alive = Arc::new(AtomicBool::new(true));
         let alive_for_thread = Arc::clone(&alive);
 
@@ -1608,8 +1559,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn state_guard_writes_finished_on_drop() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn state_guard_writes_finished_on_drop() {
         let stats = Arc::new(std::sync::RwLock::new(ScenarioStats::default()));
         {
             let mut st = stats.write().unwrap();
@@ -1626,8 +1577,8 @@ mod tests {
         assert_eq!(stats.read().unwrap().state, ScenarioState::Finished);
     }
 
-    #[test]
-    fn state_guard_writes_finished_on_thread_panic() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn state_guard_writes_finished_on_thread_panic() {
         let stats = Arc::new(std::sync::RwLock::new(ScenarioStats::default()));
         let stats_for_thread = Arc::clone(&stats);
 
@@ -1653,14 +1604,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn state_remains_pending_during_start_delay_then_transitions_to_running() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn state_remains_pending_during_start_delay_then_transitions_to_running() {
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("delayed_state");
         let mut handle = launch_scenario(
             "delayed-state-id".to_string(),
             entry,
-            Arc::clone(&shutdown),
+            cancel.clone(),
             Some(Duration::from_millis(200)),
         )
         .expect("launch must succeed");
@@ -1683,11 +1634,11 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_non_gated_scenario_state_transitions_through_running_to_finished() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_non_gated_scenario_state_transitions_through_running_to_finished() {
+        let cancel = CancellationToken::new();
         let entry = metrics_entry("state_lifecycle");
-        let mut handle = launch_scenario("state-id".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("state-id".to_string(), entry, cancel, None)
             .expect("launch must succeed");
 
         let mut saw_running = false;
@@ -1711,8 +1662,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn alive_guard_clears_flag_on_clean_exit() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn alive_guard_clears_flag_on_clean_exit() {
         let alive = Arc::new(AtomicBool::new(true));
         let alive_for_thread = Arc::clone(&alive);
 
@@ -1736,8 +1687,8 @@ mod tests {
     /// the post-expansion index. When entry 0 is valid and entry 1 is invalid,
     /// the error should say "scenario[1]" regardless of how many entries the
     /// expansion of entry 0 produced.
-    #[test]
-    fn prepare_entries_error_index_refers_to_original_input_index() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_entries_error_index_refers_to_original_input_index() {
         let valid = metrics_entry("valid_a");
         let invalid = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
@@ -1779,8 +1730,8 @@ mod tests {
 
     /// prepare_entries error message for phase_offset references the original
     /// input index.
-    #[test]
-    fn prepare_entries_phase_offset_error_references_original_index() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_entries_phase_offset_error_references_original_index() {
         let valid = metrics_entry("valid_first");
         let bad_offset = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
@@ -1862,13 +1813,13 @@ mod tests {
         })
     }
 
-    #[test]
-    fn launch_metrics_scenario_with_no_type_defaults_to_gauge() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_metrics_scenario_with_no_type_defaults_to_gauge() {
         let entry = entry_with_metric_type(None);
         let mut handle = launch_scenario(
             "id-meta-gauge".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .expect("launch must succeed");
@@ -1881,13 +1832,13 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_metrics_scenario_with_step_generator_defaults_to_counter() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_metrics_scenario_with_step_generator_defaults_to_counter() {
         let entry = step_entry("step_counter");
         let mut handle = launch_scenario(
             "id-meta-step".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .expect("launch must succeed");
@@ -1900,13 +1851,13 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_histogram_scenario_defaults_to_histogram() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_histogram_scenario_defaults_to_histogram() {
         let entry = histogram_entry("hist_default");
         let mut handle = launch_scenario(
             "id-meta-hist".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .expect("launch must succeed");
@@ -1918,13 +1869,13 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_summary_scenario_defaults_to_summary() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_summary_scenario_defaults_to_summary() {
         let entry = summary_entry("summary_default");
         let mut handle = launch_scenario(
             "id-meta-sum".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .expect("launch must succeed");
@@ -1936,13 +1887,13 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_scenario_explicit_metric_type_overrides_default() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_scenario_explicit_metric_type_overrides_default() {
         let entry = entry_with_metric_type(Some(PromMetricType::Counter));
         let mut handle = launch_scenario(
             "id-meta-explicit".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .expect("launch must succeed");
@@ -1955,13 +1906,13 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_log_scenario_has_no_prometheus_meta() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_log_scenario_has_no_prometheus_meta() {
         let entry = logs_entry("log_no_meta");
         let mut handle = launch_scenario(
             "id-meta-logs".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .expect("launch must succeed");

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -1,11 +1,13 @@
-//! Multi-scenario runner: runs multiple scenarios concurrently on separate threads.
+//! Multi-scenario runner: runs multiple scenarios concurrently on tokio tasks.
 //!
-//! Each scenario owns its own shutdown flag. [`run_multi`] and
-//! [`run_multi_compiled`] accept a master `shutdown` flag and use a watchdog
-//! thread to fan a transition out into each handle's per-scenario flag.
+//! Each scenario owns a child [`CancellationToken`] derived from the parent
+//! passed by the caller; cancelling the parent fans out instantly via tokio's
+//! parent/child propagation.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "config")]
 use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
 
 use crate::config::ScenarioEntry;
 use crate::schedule::launch::{launch_scenario, prepare_entries};
@@ -33,29 +35,21 @@ use std::collections::HashMap;
 #[cfg(feature = "config")]
 use tokio::sync::watch;
 
-/// Run all scenarios in `entries` concurrently, one OS thread per scenario.
-/// Set `shutdown` to `false` to stop all running scenarios.
-pub fn run_multi(entries: Vec<ScenarioEntry>, shutdown: Arc<AtomicBool>) -> Result<(), SondaError> {
-    // Expand, validate, and resolve phase offsets for all entries atomically.
+/// Run all scenarios in `entries` concurrently. Cancelling `cancel` stops every scenario.
+pub fn run_multi(entries: Vec<ScenarioEntry>, cancel: CancellationToken) -> Result<(), SondaError> {
     let prepared = prepare_entries(entries)?;
 
     let mut handles = Vec::with_capacity(prepared.len());
-    let mut per_handle_shutdowns: Vec<Arc<AtomicBool>> = Vec::with_capacity(prepared.len());
     for (i, prepared_entry) in prepared.into_iter().enumerate() {
         let id = format!("multi-{i}");
-        let scenario_shutdown = Arc::new(AtomicBool::new(true));
         let handle = launch_scenario(
             id,
             prepared_entry.entry,
-            Arc::clone(&scenario_shutdown),
+            cancel.child_token(),
             prepared_entry.start_delay,
         )?;
-        per_handle_shutdowns.push(scenario_shutdown);
         handles.push(handle);
     }
-
-    let done = Arc::new(AtomicBool::new(false));
-    let watchdog = spawn_shutdown_watchdog(shutdown, per_handle_shutdowns, Arc::clone(&done));
 
     let mut errors: Vec<String> = Vec::new();
     for mut handle in handles {
@@ -64,9 +58,6 @@ pub fn run_multi(entries: Vec<ScenarioEntry>, shutdown: Arc<AtomicBool>) -> Resu
             Err(e) => errors.push(e.to_string()),
         }
     }
-
-    done.store(true, Ordering::SeqCst);
-    let _ = watchdog.join();
 
     if errors.is_empty() {
         Ok(())
@@ -77,49 +68,21 @@ pub fn run_multi(entries: Vec<ScenarioEntry>, shutdown: Arc<AtomicBool>) -> Resu
     }
 }
 
-/// Mirror `master`'s false transition into each per-handle shutdown; exit when `master` flips or `done` flips.
-fn spawn_shutdown_watchdog(
-    master: Arc<AtomicBool>,
-    per_handle: Vec<Arc<AtomicBool>>,
-    done: Arc<AtomicBool>,
-) -> std::thread::JoinHandle<()> {
-    std::thread::Builder::new()
-        .name("sonda-shutdown-watchdog".to_string())
-        .spawn(move || {
-            let poll = std::time::Duration::from_millis(100);
-            loop {
-                if done.load(Ordering::SeqCst) {
-                    return;
-                }
-                if !master.load(Ordering::SeqCst) {
-                    for flag in &per_handle {
-                        flag.store(false, Ordering::SeqCst);
-                    }
-                    return;
-                }
-                std::thread::sleep(poll);
-            }
-        })
-        .expect("watchdog thread must spawn")
-}
-
-/// Set the shutdown flag, signalling all running scenarios to stop.
-///
-/// This is a convenience wrapper that stores `false` with `SeqCst` ordering,
-/// matching the ordering used by the signal handler in the CLI.
-pub fn signal_shutdown(shutdown: &AtomicBool) {
-    shutdown.store(false, Ordering::SeqCst);
+/// Convenience wrapper that cancels `token`, signalling every scenario derived from it to stop.
+pub fn signal_shutdown(token: &CancellationToken) {
+    token.cancel();
 }
 
 /// Launch a compiled scenario file with `while:` / `after:` gating wired in,
 /// returning the live handles without joining them. When `resolver` is `Some`,
 /// cross-POST `while:` references resolve through the registry; otherwise every
-/// reference must resolve inside `file`. Each handle owns an independent
-/// shutdown flag — see [`run_multi_compiled`] for the master-stop-all path.
+/// reference must resolve inside `file`. Every per-scenario [`CancellationToken`]
+/// is derived from `parent_cancel`; cancelling the parent fans out instantly.
 #[cfg(feature = "config")]
 pub fn launch_multi_compiled(
     file: CompiledFile,
     resolver: Option<Arc<dyn GateBusResolver>>,
+    parent_cancel: CancellationToken,
 ) -> Result<Vec<crate::schedule::handle::ScenarioHandle>, SondaError> {
     let CompiledFile {
         scenario_name: file_scenario_name,
@@ -290,12 +253,11 @@ pub fn launch_multi_compiled(
         let id = plan.id.unwrap_or_else(|| format!("multi-{idx}"));
         let deferred = plan.deferred;
         let active = plan.active;
-        let scenario_shutdown = Arc::new(AtomicBool::new(true));
         match launch_scenario_with_gates(
             id.clone(),
             file_scenario_name.clone(),
             plan.entry,
-            scenario_shutdown,
+            parent_cancel.child_token(),
             plan.start_delay,
             plan.upstream_bus,
             plan.gate_ctx,
@@ -382,17 +344,11 @@ struct ActiveSubscription {
 
 /// Run a compiled scenario file with `while:` / `after:` gating wired in.
 ///
-/// Spawns every scenario via [`launch_multi_compiled`] and joins the threads.
-/// Non-gated entries launch on the existing non-gated path with no per-tick
-/// overhead.
+/// Spawns every scenario via [`launch_multi_compiled`]; cancelling `cancel`
+/// stops every scenario.
 #[cfg(feature = "config")]
-pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Result<(), SondaError> {
-    let handles = launch_multi_compiled(file, None)?;
-    let per_handle_shutdowns: Vec<Arc<AtomicBool>> =
-        handles.iter().map(|h| Arc::clone(&h.shutdown)).collect();
-
-    let done = Arc::new(AtomicBool::new(false));
-    let watchdog = spawn_shutdown_watchdog(shutdown, per_handle_shutdowns, Arc::clone(&done));
+pub fn run_multi_compiled(file: CompiledFile, cancel: CancellationToken) -> Result<(), SondaError> {
+    let handles = launch_multi_compiled(file, None, cancel)?;
 
     let mut errors: Vec<String> = Vec::new();
     for mut handle in handles {
@@ -401,9 +357,6 @@ pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Resu
             Err(e) => errors.push(e.to_string()),
         }
     }
-
-    done.store(true, Ordering::SeqCst);
-    let _ = watchdog.join();
 
     if errors.is_empty() {
         Ok(())
@@ -449,10 +402,10 @@ struct LaunchPlan {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
     use std::thread;
     use std::time::{Duration, Instant};
+
+    use tokio_util::sync::CancellationToken;
 
     use crate::config::{BaseScheduleConfig, LogScenarioConfig, ScenarioConfig, ScenarioEntry};
     use crate::encoder::EncoderConfig;
@@ -530,60 +483,60 @@ mod tests {
     // Happy path: multiple scenarios complete successfully
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn run_multi_with_empty_scenarios_returns_ok() {
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(vec![], shutdown);
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_empty_scenarios_returns_ok() {
+        let cancel = CancellationToken::new();
+        let result = run_multi(vec![], cancel);
         assert!(result.is_ok(), "empty scenario list should return Ok");
     }
 
-    #[test]
-    fn run_multi_with_single_metrics_scenario_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_single_metrics_scenario_returns_ok() {
         let entries = vec![metrics_entry_stdout("single_metric")];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel);
         assert!(
             result.is_ok(),
             "single metrics scenario should complete without error"
         );
     }
 
-    #[test]
-    fn run_multi_with_single_logs_scenario_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_single_logs_scenario_returns_ok() {
         let entries = vec![logs_entry_stdout("single_logs")];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel);
         assert!(
             result.is_ok(),
             "single logs scenario should complete without error"
         );
     }
 
-    #[test]
-    fn run_multi_with_metrics_and_logs_both_complete() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_metrics_and_logs_both_complete() {
         // Two scenarios concurrently — both should run to completion within
         // their 100ms durations and return Ok.
         let entries = vec![
             metrics_entry_stdout("concurrent_metrics"),
             logs_entry_stdout("concurrent_logs"),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel);
         assert!(
             result.is_ok(),
             "both concurrent scenarios should complete without error"
         );
     }
 
-    #[test]
-    fn run_multi_three_concurrent_scenarios_all_complete() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_three_concurrent_scenarios_all_complete() {
         let entries = vec![
             metrics_entry_stdout("m1"),
             metrics_entry_stdout("m2"),
             logs_entry_stdout("l1"),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel);
         assert!(
             result.is_ok(),
             "three concurrent scenarios should all complete without error"
@@ -594,8 +547,8 @@ mod tests {
     // Shutdown flag: setting it stops all threads
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn run_multi_shutdown_flag_stops_all_threads_within_two_seconds() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_shutdown_flag_stops_all_threads_within_two_seconds() {
         // Both scenarios have no duration (would run indefinitely). We
         // signal shutdown after a short delay and verify all threads stop
         // well within 2 seconds.
@@ -655,17 +608,16 @@ mod tests {
             }),
         ];
 
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let shutdown_for_thread = Arc::clone(&shutdown);
+        let cancel = CancellationToken::new();
+        let cancel_for_thread = cancel.clone();
 
-        // Signal shutdown after 50ms from a separate thread.
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(50));
-            signal_shutdown(&shutdown_for_thread);
+            signal_shutdown(&cancel_for_thread);
         });
 
         let start = Instant::now();
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, cancel);
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "shutdown should not produce an error");
@@ -676,22 +628,19 @@ mod tests {
         );
     }
 
-    #[test]
-    fn signal_shutdown_stores_false_with_seqcst_ordering() {
-        let flag = AtomicBool::new(true);
-        signal_shutdown(&flag);
-        assert!(
-            !flag.load(Ordering::SeqCst),
-            "signal_shutdown should set the flag to false"
-        );
+    #[tokio::test(flavor = "multi_thread")]
+    async fn signal_shutdown_cancels_the_token() {
+        let token = CancellationToken::new();
+        signal_shutdown(&token);
+        assert!(token.is_cancelled());
     }
 
     // -----------------------------------------------------------------------
     // Error handling: errors from individual threads are collected
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn run_multi_with_invalid_sink_config_returns_err() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_invalid_sink_config_returns_err() {
         // A file sink pointing to a path that cannot be created will fail
         // during sink construction inside the thread.
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
@@ -720,8 +669,8 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel);
         assert!(
             result.is_err(),
             "scenario with an invalid sink path should return Err"
@@ -733,8 +682,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn run_multi_collects_all_thread_errors() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_collects_all_thread_errors() {
         // Two scenarios both use an invalid sink — both errors should be reported.
         let entries = vec![
             ScenarioEntry::Metrics(ScenarioConfig {
@@ -790,8 +739,8 @@ mod tests {
                 help: None,
             }),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel);
         assert!(result.is_err(), "two failing scenarios should return Err");
         // The combined error message should contain both errors separated by "; "
         let err_msg = result.unwrap_err().to_string();
@@ -801,8 +750,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn run_multi_thread_errors_produce_runtime_not_config_variant() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_thread_errors_produce_runtime_not_config_variant() {
         // A file sink pointing to an invalid path will fail inside the thread.
         // The collected error must be Runtime::ScenariosFailed, not Config.
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
@@ -831,8 +780,8 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel);
         assert!(result.is_err(), "invalid sink must produce an error");
         let err = result.unwrap_err();
         assert!(
@@ -849,8 +798,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     /// A scenario with a minimal phase_offset ("1ms") emits events almost immediately.
-    #[test]
-    fn run_multi_with_minimal_phase_offset_emits_almost_immediately() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_minimal_phase_offset_emits_almost_immediately() {
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "minimal_offset".to_string(),
@@ -875,9 +824,9 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let start = Instant::now();
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, cancel);
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "minimal phase_offset should complete ok");
@@ -890,8 +839,8 @@ mod tests {
     }
 
     /// `phase_offset: "0s"` is accepted and treated as no delay.
-    #[test]
-    fn run_multi_accepts_zero_phase_offset() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_accepts_zero_phase_offset() {
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "zero_offset".to_string(),
@@ -916,8 +865,8 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel);
         // "0s" is treated as no delay — parse_phase_offset returns None.
         assert!(
             result.is_ok(),
@@ -927,11 +876,11 @@ mod tests {
     }
 
     /// A scenario with no phase_offset (None) preserves existing behavior.
-    #[test]
-    fn run_multi_with_no_phase_offset_preserves_behavior() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_no_phase_offset_preserves_behavior() {
         let entries = vec![metrics_entry_stdout("no_offset")];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel);
         assert!(
             result.is_ok(),
             "scenario without phase_offset should work as before"
@@ -940,8 +889,8 @@ mod tests {
 
     /// Two scenarios where the second has a 500ms phase_offset: the second
     /// starts later, so total run time is at least 500ms.
-    #[test]
-    fn run_multi_respects_phase_offset_between_scenarios() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_respects_phase_offset_between_scenarios() {
         let entries = vec![
             ScenarioEntry::Metrics(ScenarioConfig {
                 base: BaseScheduleConfig {
@@ -992,9 +941,9 @@ mod tests {
                 help: None,
             }),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let start = Instant::now();
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, cancel);
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "phase_offset multi-scenario should succeed");
@@ -1008,8 +957,8 @@ mod tests {
     }
 
     /// Shutdown during phase_offset delay exits all scenarios cleanly.
-    #[test]
-    fn run_multi_shutdown_during_phase_offset_exits_cleanly() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_shutdown_during_phase_offset_exits_cleanly() {
         let entries = vec![
             // First scenario runs indefinitely.
             ScenarioEntry::Metrics(ScenarioConfig {
@@ -1063,17 +1012,16 @@ mod tests {
             }),
         ];
 
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let shutdown_for_thread = Arc::clone(&shutdown);
+        let cancel = CancellationToken::new();
+        let cancel_for_thread = cancel.clone();
 
-        // Signal shutdown after 100ms.
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(100));
-            signal_shutdown(&shutdown_for_thread);
+            signal_shutdown(&cancel_for_thread);
         });
 
         let start = Instant::now();
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, cancel);
         let elapsed = start.elapsed();
 
         assert!(
@@ -1089,8 +1037,8 @@ mod tests {
 
     /// An invalid phase_offset string causes run_multi to return an error
     /// synchronously before spawning threads.
-    #[test]
-    fn run_multi_rejects_invalid_phase_offset() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_rejects_invalid_phase_offset() {
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "bad_offset".to_string(),
@@ -1115,8 +1063,8 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel);
         assert!(
             result.is_err(),
             "invalid phase_offset must cause run_multi to return Err"
@@ -1129,8 +1077,8 @@ mod tests {
     }
 
     /// Scenarios with the same clock_group and different phase_offsets both complete.
-    #[test]
-    fn run_multi_with_clock_group_and_offsets() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_clock_group_and_offsets() {
         let entries = vec![
             ScenarioEntry::Metrics(ScenarioConfig {
                 base: BaseScheduleConfig {
@@ -1181,8 +1129,8 @@ mod tests {
                 help: None,
             }),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel);
         assert!(
             result.is_ok(),
             "scenarios with clock_group and offsets should complete"
@@ -1190,8 +1138,8 @@ mod tests {
     }
 
     #[cfg(feature = "config")]
-    #[test]
-    fn while_upstream_ids_returns_only_entries_referenced_by_a_while_clause() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn while_upstream_ids_returns_only_entries_referenced_by_a_while_clause() {
         use super::while_upstream_ids;
         use crate::compile_scenario_file_compiled;
         use crate::compiler::expand::InMemoryPackResolver;
@@ -1250,8 +1198,8 @@ scenarios:
     }
 
     #[cfg(feature = "config")]
-    #[test]
-    fn launch_multi_compiled_partial_cleanup_stops_already_launched_handles() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_multi_compiled_partial_cleanup_stops_already_launched_handles() {
         use crate::compile_scenario_file_compiled;
         use crate::compiler::expand::InMemoryPackResolver;
 
@@ -1283,7 +1231,8 @@ scenarios:
         let compiled =
             compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
 
-        let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+        let mut handles = launch_multi_compiled(compiled, None, CancellationToken::new())
+            .expect("launch must succeed");
         assert_eq!(handles.len(), 2, "must launch both entries");
         assert!(
             handles.iter().all(|h| h.is_alive()),
@@ -1316,6 +1265,8 @@ scenarios:
         use std::sync::{Arc, Mutex, RwLock, Weak};
         use std::thread;
         use std::time::{Duration, Instant};
+
+        use tokio_util::sync::CancellationToken;
 
         use crate::compile_scenario_file_compiled;
         use crate::compiler::expand::InMemoryPackResolver;
@@ -1523,8 +1474,8 @@ scenarios:
             }
         }
 
-        #[test]
-        fn t8_downstream_enters_unresolved_then_promoted_on_register_and_sweep() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t8_downstream_enters_unresolved_then_promoted_on_register_and_sweep() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1534,8 +1485,12 @@ scenarios:
             )
             .expect("compile downstream");
 
-            let handles = launch_multi_compiled(compiled, Some(Arc::clone(&resolver)))
-                .expect("launch downstream");
+            let handles = launch_multi_compiled(
+                compiled,
+                Some(Arc::clone(&resolver)),
+                CancellationToken::new(),
+            )
+            .expect("launch downstream");
             assert_eq!(handles.len(), 1);
             wait_for_state(
                 &handles[0],
@@ -1556,8 +1511,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t9_downstream_first_then_upstream_post_promotes_via_sweep() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t9_downstream_first_then_upstream_post_promotes_via_sweep() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1567,8 +1522,12 @@ scenarios:
             )
             .expect("compile downstream");
 
-            let downstream_handles = launch_multi_compiled(downstream, Some(Arc::clone(&resolver)))
-                .expect("launch downstream");
+            let downstream_handles = launch_multi_compiled(
+                downstream,
+                Some(Arc::clone(&resolver)),
+                CancellationToken::new(),
+            )
+            .expect("launch downstream");
             wait_for_state(
                 &downstream_handles[0],
                 ScenarioState::Unresolved,
@@ -1578,8 +1537,12 @@ scenarios:
             let upstream =
                 compile_scenario_file_compiled(&upstream_yaml(), &InMemoryPackResolver::new())
                     .expect("compile upstream");
-            let upstream_handles = launch_multi_compiled(upstream, Some(Arc::clone(&resolver)))
-                .expect("launch upstream");
+            let upstream_handles = launch_multi_compiled(
+                upstream,
+                Some(Arc::clone(&resolver)),
+                CancellationToken::new(),
+            )
+            .expect("launch upstream");
             wait_for_state(
                 &downstream_handles[0],
                 ScenarioState::Running,
@@ -1594,24 +1557,32 @@ scenarios:
         // upstream with the same scenario_name) requires the registry to push affected
         // downstreams back into `pending` on unregister — that mechanism lives with the
         // production `GateBusRegistry` implementation, not the test resolver.
-        #[test]
-        fn t10_unregister_drives_downstream_back_to_unresolved() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t10_unregister_drives_downstream_back_to_unresolved() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
             let upstream =
                 compile_scenario_file_compiled(&upstream_yaml(), &InMemoryPackResolver::new())
                     .expect("compile upstream");
-            let upstream_handles = launch_multi_compiled(upstream, Some(Arc::clone(&resolver)))
-                .expect("launch upstream");
+            let upstream_handles = launch_multi_compiled(
+                upstream,
+                Some(Arc::clone(&resolver)),
+                CancellationToken::new(),
+            )
+            .expect("launch upstream");
 
             let downstream = compile_scenario_file_compiled(
                 &downstream_yaml("open"),
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let downstream_handles = launch_multi_compiled(downstream, Some(Arc::clone(&resolver)))
-                .expect("launch downstream");
+            let downstream_handles = launch_multi_compiled(
+                downstream,
+                Some(Arc::clone(&resolver)),
+                CancellationToken::new(),
+            )
+            .expect("launch downstream");
             wait_for_state(
                 &downstream_handles[0],
                 ScenarioState::Running,
@@ -1644,8 +1615,8 @@ scenarios:
             stop_and_join(downstream_handles);
         }
 
-        #[test]
-        fn t11_if_unresolved_open_ticks_at_full_rate() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t11_if_unresolved_open_ticks_at_full_rate() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1654,8 +1625,12 @@ scenarios:
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let handles =
-                launch_multi_compiled(compiled, Some(Arc::clone(&resolver))).expect("launch");
+            let handles = launch_multi_compiled(
+                compiled,
+                Some(Arc::clone(&resolver)),
+                CancellationToken::new(),
+            )
+            .expect("launch");
             wait_for_state(
                 &handles[0],
                 ScenarioState::Unresolved,
@@ -1674,8 +1649,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t11b_if_unresolved_open_transitions_to_running_on_upstream_register() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t11b_if_unresolved_open_transitions_to_running_on_upstream_register() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1684,8 +1659,12 @@ scenarios:
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let handles =
-                launch_multi_compiled(compiled, Some(Arc::clone(&resolver))).expect("launch");
+            let handles = launch_multi_compiled(
+                compiled,
+                Some(Arc::clone(&resolver)),
+                CancellationToken::new(),
+            )
+            .expect("launch");
             wait_for_state(
                 &handles[0],
                 ScenarioState::Unresolved,
@@ -1721,8 +1700,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t12_if_unresolved_closed_does_not_emit() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t12_if_unresolved_closed_does_not_emit() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1731,8 +1710,12 @@ scenarios:
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let handles =
-                launch_multi_compiled(compiled, Some(Arc::clone(&resolver))).expect("launch");
+            let handles = launch_multi_compiled(
+                compiled,
+                Some(Arc::clone(&resolver)),
+                CancellationToken::new(),
+            )
+            .expect("launch");
             wait_for_state(
                 &handles[0],
                 ScenarioState::Unresolved,
@@ -1750,8 +1733,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t13_if_unresolved_pending_does_not_emit_and_holds_state() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t13_if_unresolved_pending_does_not_emit_and_holds_state() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1760,8 +1743,12 @@ scenarios:
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let handles =
-                launch_multi_compiled(compiled, Some(Arc::clone(&resolver))).expect("launch");
+            let handles = launch_multi_compiled(
+                compiled,
+                Some(Arc::clone(&resolver)),
+                CancellationToken::new(),
+            )
+            .expect("launch");
             wait_for_state(
                 &handles[0],
                 ScenarioState::Unresolved,
@@ -1777,8 +1764,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t_regress_2_local_only_while_path_unchanged() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t_regress_2_local_only_while_path_unchanged() {
             let yaml = r#"
 version: 2
 kind: runnable
@@ -1809,7 +1796,8 @@ scenarios:
 "#;
             let compiled = compile_scenario_file_compiled(yaml, &InMemoryPackResolver::new())
                 .expect("compile local-only");
-            let mut handles = launch_multi_compiled(compiled, None).expect("launch");
+            let mut handles =
+                launch_multi_compiled(compiled, None, CancellationToken::new()).expect("launch");
             assert_eq!(handles.len(), 2);
             for h in &mut handles {
                 let _ = h.join(Some(Duration::from_secs(2)));
@@ -1818,8 +1806,8 @@ scenarios:
     }
 
     #[cfg(feature = "config")]
-    #[test]
-    fn launch_multi_compiled_gives_each_handle_an_independent_shutdown_flag() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_multi_compiled_gives_each_handle_an_independent_shutdown_flag() {
         use crate::compile_scenario_file_compiled;
         use crate::compiler::expand::InMemoryPackResolver;
 
@@ -1857,40 +1845,39 @@ scenarios:
         let compiled =
             compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
 
-        let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
-        assert_eq!(handles.len(), 3, "must launch all three entries");
+        for i in 0..3 {
+            let mut handles =
+                launch_multi_compiled(compiled.clone(), None, CancellationToken::new())
+                    .expect("launch must succeed");
+            assert_eq!(handles.len(), 3, "must launch all three entries");
 
-        for i in 0..handles.len() {
-            for j in (i + 1)..handles.len() {
+            handles[i].stop();
+            assert!(
+                handles[i].cancel.is_cancelled(),
+                "stopped handle {i} must report cancelled"
+            );
+            for (j, sibling) in handles.iter().enumerate() {
+                if i == j {
+                    continue;
+                }
                 assert!(
-                    !Arc::ptr_eq(&handles[i].shutdown, &handles[j].shutdown),
-                    "handles {i} and {j} must own independent shutdown Arcs"
+                    !sibling.cancel.is_cancelled(),
+                    "stop on handle {i} must not cascade to sibling {j}"
                 );
             }
-        }
 
-        handles[0].stop();
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while Instant::now() < deadline && handles[0].is_alive() {
-            thread::sleep(Duration::from_millis(20));
-        }
-        assert!(!handles[0].is_alive(), "stopped handle must exit");
-        assert!(
-            handles[1].is_alive() && handles[2].is_alive(),
-            "siblings must remain alive — stop() on one handle must not cascade"
-        );
-
-        for handle in &handles {
-            handle.stop();
-        }
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while Instant::now() < deadline && handles.iter().any(|h| h.is_alive()) {
-            thread::sleep(Duration::from_millis(20));
-        }
-        for handle in &mut handles {
-            handle
-                .join(Some(Duration::from_secs(1)))
-                .expect("join must succeed");
+            for handle in &handles {
+                handle.stop();
+            }
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while Instant::now() < deadline && handles.iter().any(|h| h.is_alive()) {
+                thread::sleep(Duration::from_millis(20));
+            }
+            for handle in &mut handles {
+                handle
+                    .join(Some(Duration::from_secs(1)))
+                    .expect("join must succeed");
+            }
         }
     }
 }

--- a/sonda-core/tests/sink_error_policy.rs
+++ b/sonda-core/tests/sink_error_policy.rs
@@ -16,6 +16,8 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+use tokio_util::sync::CancellationToken;
+
 use sonda_core::config::{BaseScheduleConfig, LogScenarioConfig, OnSinkError, ScenarioEntry};
 use sonda_core::encoder::EncoderConfig;
 use sonda_core::generator::{LogGeneratorConfig, TemplateConfig};
@@ -104,8 +106,8 @@ fn build_log_entry(name: &str, sink: SinkConfig, policy: OnSinkError) -> Scenari
     })
 }
 
-#[test]
-fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
+#[tokio::test(flavor = "multi_thread")]
+async fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
     let (listener, url) = mock_loki_listener();
     let stop = Arc::new(AtomicBool::new(false));
     let stop_listener = Arc::clone(&stop);
@@ -124,14 +126,9 @@ fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
         OnSinkError::Warn,
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handle = launch_scenario(
-        "warn-persistent".to_string(),
-        entry,
-        Arc::clone(&shutdown),
-        None,
-    )
-    .expect("launch must succeed");
+    let cancel = CancellationToken::new();
+    let mut handle = launch_scenario("warn-persistent".to_string(), entry, cancel.clone(), None)
+        .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(800));
     let snap_mid = handle.stats_snapshot();
@@ -166,8 +163,8 @@ fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
     );
 }
 
-#[test]
-fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
+#[tokio::test(flavor = "multi_thread")]
+async fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
     // Bind then drop a listener so the port is guaranteed free — every flush
     // against it will fail to connect.
     let dead_url = {
@@ -188,14 +185,9 @@ fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
         OnSinkError::Warn,
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handle = launch_scenario(
-        "warn-dead-url".to_string(),
-        entry,
-        Arc::clone(&shutdown),
-        None,
-    )
-    .expect("launch must succeed");
+    let cancel = CancellationToken::new();
+    let mut handle = launch_scenario("warn-dead-url".to_string(), entry, cancel.clone(), None)
+        .expect("launch must succeed");
 
     handle.join(Some(Duration::from_secs(3))).expect("join Ok");
 
@@ -217,8 +209,8 @@ fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
     );
 }
 
-#[test]
-fn fail_policy_exits_thread_with_sink_error() {
+#[tokio::test(flavor = "multi_thread")]
+async fn fail_policy_exits_thread_with_sink_error() {
     let (listener, url) = mock_loki_listener();
     let stop = Arc::new(AtomicBool::new(false));
     let stop_listener = Arc::clone(&stop);
@@ -237,14 +229,9 @@ fn fail_policy_exits_thread_with_sink_error() {
         OnSinkError::Fail,
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handle = launch_scenario(
-        "fail-propagates".to_string(),
-        entry,
-        Arc::clone(&shutdown),
-        None,
-    )
-    .expect("launch must succeed");
+    let cancel = CancellationToken::new();
+    let mut handle = launch_scenario("fail-propagates".to_string(), entry, cancel.clone(), None)
+        .expect("launch must succeed");
 
     let join_result = handle.join(Some(Duration::from_secs(5)));
 

--- a/sonda-core/tests/while_close_workshop_repro.rs
+++ b/sonda-core/tests/while_close_workshop_repro.rs
@@ -128,8 +128,8 @@ fn label_value<'a>(ts: &'a TimeSeries, name: &str) -> Option<&'a str> {
         .map(|l| l.value.as_str())
 }
 
-#[test]
-fn workshop_paused_finished_cascade_emits_stale_marker_via_multi_runner() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_cascade_emits_stale_marker_via_multi_runner() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     // Workshop YAML compressed: 1500ms run, 200ms up / 400ms down (cycle 600ms).
@@ -191,7 +191,8 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None, tokio_util::sync::CancellationToken::new())
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     // Wait for both threads to finish (they exit when duration expires).
@@ -258,8 +259,8 @@ scenarios:
     );
 }
 
-#[test]
-fn workshop_paused_finished_cascade_default_batch_size_emits_stale_marker() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_cascade_default_batch_size_emits_stale_marker() {
     // Same scenario as above but WITHOUT explicit batch_size — falls to
     // DEFAULT_BATCH_SIZE = 5. close-emit writes one stale TimeSeries which
     // alone does NOT trigger auto-flush. Verifies invoke_close_emit's
@@ -309,7 +310,8 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None, tokio_util::sync::CancellationToken::new())
+        .expect("launch must succeed");
 
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut handles = handles;
@@ -363,8 +365,8 @@ scenarios:
 /// stats issue, this exposes it.
 ///
 /// Expectation: every gated metric has >=1 stale-NaN sample reach the wire.
-#[test]
-fn workshop_paused_finished_multi_entry_cascade_each_metric_emits_stale_marker() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_multi_entry_cascade_each_metric_emits_stale_marker() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     // Same compressed timing as Test workshop_paused_finished_cascade_emits_stale_marker_via_multi_runner
@@ -504,7 +506,8 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None, tokio_util::sync::CancellationToken::new())
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 8, "must launch primary + 7 downstream");
 
     let deadline = Instant::now() + Duration::from_secs(6);
@@ -587,8 +590,8 @@ scenarios:
 ///
 /// Compressed here: 5s duration, 600ms up / 1200ms down (cycle 1.8s), 200ms
 /// open / 0s close. ~2.7 cycles → at least 2 running→paused transitions.
-#[test]
-fn workshop_paused_finished_real_timescale_emits_stale_marker() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_real_timescale_emits_stale_marker() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     let yaml = format!(
@@ -635,7 +638,8 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None, tokio_util::sync::CancellationToken::new())
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(10);
@@ -702,8 +706,8 @@ scenarios:
 ///
 /// Skipped automatically if the workspace `sonda-server` binary isn't built
 /// with the `remote-write` feature (locating it via target/{profile}/sonda-server).
-#[test]
-fn workshop_paused_finished_through_server_binary_emits_stale_marker() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_through_server_binary_emits_stale_marker() {
     use std::path::PathBuf;
     use std::process::{Command, Stdio};
 
@@ -914,8 +918,8 @@ scenarios:
 ///
 /// Compressed timing: baseline rate=20, cascade rate=50, cascade duration
 /// 1500ms, flap up=200ms / down=400ms, delay open=50ms / close=0s.
-#[test]
-fn workshop_cascade_with_baseline_scenarios_emits_stale_marker() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_cascade_with_baseline_scenarios_emits_stale_marker() {
     use std::path::PathBuf;
     use std::process::{Command, Stdio};
 
@@ -1387,8 +1391,8 @@ scenarios:
     );
 }
 
-#[test]
-fn workshop_close_emit_timestamp_strictly_greater_than_active_emissions() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_close_emit_timestamp_strictly_greater_than_active_emissions() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     let yaml = format!(
@@ -1437,7 +1441,8 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None, tokio_util::sync::CancellationToken::new())
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1484,8 +1489,8 @@ scenarios:
     assert_close_ts_strictly_after_preceding_actives(&active_ts, &close_ts);
 }
 
-#[test]
-fn workshop_close_emit_stale_marker_timestamp_strictly_greater_than_active_emissions() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_close_emit_stale_marker_timestamp_strictly_greater_than_active_emissions() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     let yaml = format!(
@@ -1532,7 +1537,8 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None, tokio_util::sync::CancellationToken::new())
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1616,8 +1622,8 @@ fn assert_close_ts_strictly_after_preceding_actives(active_ts: &[i64], close_ts:
 /// Step 1 — Deterministic parse check. Compiles the workshop's exact YAML
 /// and asserts the gated entry's DelayClause carries close=ZERO,
 /// close_snap_to=Some(0.0), close_stale_marker=None.
-#[test]
-fn workshop_snap_to_yaml_parses_into_delay_clause() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_snap_to_yaml_parses_into_delay_clause() {
     let yaml = r#"
 version: 2
 kind: runnable
@@ -1693,8 +1699,8 @@ scenarios:
 /// TCP capture listener. Asserts at least one `bgp_oper_state` sample with
 /// value=0.0 reaches the wire AND that no stale-NaN sample is emitted (snap_to
 /// REPLACES the stale marker).
-#[test]
-fn workshop_snap_to_zero_reaches_wire_via_multi_runner() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_snap_to_zero_reaches_wire_via_multi_runner() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     let yaml = format!(
@@ -1734,7 +1740,8 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None, tokio_util::sync::CancellationToken::new())
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + gated_metric");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1804,8 +1811,8 @@ scenarios:
 /// Step 3 — Through actual `sonda-server` HTTP binary. POSTs the workshop YAML
 /// to /scenarios. Verifies value=0.0 samples for bgp_oper_state appear on the
 /// wire when running through the released server flow.
-#[test]
-fn workshop_snap_to_zero_reaches_wire_via_server_binary() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_snap_to_zero_reaches_wire_via_server_binary() {
     use std::path::PathBuf;
     use std::process::{Command, Stdio};
 

--- a/sonda-core/tests/while_local_upstream_finishes.rs
+++ b/sonda-core/tests/while_local_upstream_finishes.rs
@@ -55,8 +55,8 @@ fn wait_for_not_alive(handle: &ScenarioHandle, timeout: Duration) {
     );
 }
 
-#[test]
-fn local_downstream_finishes_when_upstream_duration_expires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn local_downstream_finishes_when_upstream_duration_expires() {
     let yaml = r#"
 version: 2
 kind: runnable
@@ -89,7 +89,9 @@ scenarios:
 
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let mut handles =
+        launch_multi_compiled(compiled, None, tokio_util::sync::CancellationToken::new())
+            .expect("launch must succeed");
     assert_eq!(handles.len(), 2);
 
     {
@@ -108,8 +110,8 @@ scenarios:
     }
 }
 
-#[test]
-fn local_cascade_a_b_c_all_finish_when_a_finishes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn local_cascade_a_b_c_all_finish_when_a_finishes() {
     let yaml = r#"
 version: 2
 kind: runnable
@@ -153,7 +155,9 @@ scenarios:
 
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let mut handles =
+        launch_multi_compiled(compiled, None, tokio_util::sync::CancellationToken::new())
+            .expect("launch must succeed");
     assert_eq!(handles.len(), 3);
 
     for id in ["a", "b", "c"] {
@@ -169,8 +173,8 @@ scenarios:
     }
 }
 
-#[test]
-fn local_downstream_paused_finishes_when_upstream_finishes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn local_downstream_paused_finishes_when_upstream_finishes() {
     // A non-repeating sequence drops below threshold on tick 1 and stays
     // there for the rest of the upstream's life. The downstream is
     // therefore reliably Paused (not Running) at the moment the upstream
@@ -209,7 +213,9 @@ scenarios:
 
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let mut handles =
+        launch_multi_compiled(compiled, None, tokio_util::sync::CancellationToken::new())
+            .expect("launch must succeed");
     assert_eq!(handles.len(), 2);
 
     {
@@ -229,8 +235,8 @@ scenarios:
     }
 }
 
-#[test]
-fn local_downstream_running_finishes_when_upstream_finishes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn local_downstream_running_finishes_when_upstream_finishes() {
     // Constant value > threshold keeps the downstream Running until the
     // upstream's duration expires.
     let yaml = r#"
@@ -265,7 +271,9 @@ scenarios:
 
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let mut handles =
+        launch_multi_compiled(compiled, None, tokio_util::sync::CancellationToken::new())
+            .expect("launch must succeed");
     assert_eq!(handles.len(), 2);
 
     {

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -8,10 +8,11 @@
 
 mod common;
 
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
+
+use tokio_util::sync::CancellationToken;
 
 use sonda_core::compiler::{DelayClause, WhileOp};
 use sonda_core::config::{BaseScheduleConfig, LogScenarioConfig, ScenarioConfig, ScenarioEntry};
@@ -92,8 +93,8 @@ fn while_gt_zero() -> SubscriptionSpec {
     }
 }
 
-#[test]
-fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
     // Upstream metric oscillates 0 → 1 → 0 across 600ms; downstream gated
     // by `while: ref=upstream op=">" value=0`. Drive the bus directly so
     // the test is deterministic.
@@ -101,7 +102,7 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let gate_ctx = GateContext::new(rx, init).with_has_while(true);
 
     let entry = metrics_entry("downstream", 200.0, 600);
@@ -109,7 +110,7 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
         "downstream".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(gate_ctx),
@@ -145,20 +146,20 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscription() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscription() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0); // gate open before subscription
     let (rx, init) = bus.subscribe(while_gt_zero());
     assert_eq!(init.while_gate_open, Some(true));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("d1", 100.0, 300);
     let mut handle = launch_scenario_with_gates(
         "d1".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -181,20 +182,20 @@ fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscriptio
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
     let bus = Arc::new(GateBus::new());
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
     assert_eq!(init.while_gate_open, Some(false));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("d2", 100.0, 300);
     let mut handle = launch_scenario_with_gates(
         "d2".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -211,21 +212,21 @@ fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_no_catch_up_burst_on_resume() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_no_catch_up_burst_on_resume() {
     // Verify A1h: after a long pause, resume must emit at the configured
     // rate, not "catch up" with a burst of events.
     let bus = Arc::new(GateBus::new());
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("d3", 100.0, 1500);
     let mut handle = launch_scenario_with_gates(
         "d3".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -299,13 +300,13 @@ fn metrics_entry_with_generator(
     })
 }
 
-#[test]
-fn while_runtime_sequence_generator_preserves_position_across_pause() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_sequence_generator_preserves_position_across_pause() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let values = vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0];
     let entry = metrics_entry_with_generator(
         "seq_gated",
@@ -320,7 +321,7 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
         "seq_gated".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -368,13 +369,13 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
     );
 }
 
-#[test]
-fn while_runtime_ramp_generator_slope_preserved_across_pause() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_ramp_generator_slope_preserved_across_pause() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     // Sawtooth (saturation desugars to this): 0 → 100 over 4s at 50/s.
     let entry = metrics_entry_with_generator(
         "sat_gated",
@@ -390,7 +391,7 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
         "sat_gated".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -436,19 +437,19 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
     );
 }
 
-#[test]
-fn while_runtime_finished_state_after_duration_expires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_finished_state_after_duration_expires() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("d4", 50.0, 200);
     let mut handle = launch_scenario_with_gates(
         "d4".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -463,8 +464,8 @@ fn while_runtime_finished_state_after_duration_expires() {
     assert!(matches!(snap.state, ScenarioState::Finished));
 }
 
-#[test]
-fn while_runtime_multiple_downstreams_share_one_upstream() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_multiple_downstreams_share_one_upstream() {
     // A2: two downstreams subscribe to the same upstream bus. Both must
     // transition together when the gate edge arrives.
     let bus = Arc::new(GateBus::new());
@@ -473,13 +474,13 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
     let (rx_a, init_a) = bus.subscribe(while_gt_zero());
     let (rx_b, init_b) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
 
     let mut handle_a = launch_scenario_with_gates(
         "a".to_string(),
         None,
         metrics_entry("a", 100.0, 500),
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx_a, init_a).with_has_while(true)),
@@ -491,7 +492,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
         "b".to_string(),
         None,
         metrics_entry("b", 100.0, 500),
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx_b, init_b).with_has_while(true)),
@@ -516,21 +517,21 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
     handle_b.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_logs_signal_can_be_gated_downstream() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_logs_signal_can_be_gated_downstream() {
     // BGP UPDOWN log scenario: a logs entry gated by `while:` must
     // transition through pending/running/paused.
     let bus = Arc::new(GateBus::new());
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = logs_entry("bgp_log", 200.0, 600);
     let mut handle = launch_scenario_with_gates(
         "bgp_log".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -564,8 +565,8 @@ fn while_runtime_logs_signal_can_be_gated_downstream() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_delay_open_debounces_pause_to_running_transition() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_delay_open_debounces_pause_to_running_transition() {
     // A2a: delay.open debounces close→open. Sub during gate-closed
     // (pending → paused), then open: must wait at least delay.open
     // before emitting events.
@@ -580,13 +581,13 @@ fn while_runtime_delay_open_debounces_pause_to_running_transition() {
         close_snap_to: None,
     };
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("debounced", 200.0, 1500);
     let mut handle = launch_scenario_with_gates(
         "debounced".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -622,8 +623,8 @@ fn while_runtime_delay_open_debounces_pause_to_running_transition() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_strict_lt_threshold_gating() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_strict_lt_threshold_gating() {
     // Inverse direction: `while: ref=src op="<" value=10` opens when
     // upstream drops below threshold.
     let bus = Arc::new(GateBus::new());
@@ -638,13 +639,13 @@ fn while_runtime_strict_lt_threshold_gating() {
     let (rx, init) = bus.subscribe(spec);
     assert_eq!(init.while_gate_open, Some(false));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("inv", 100.0, 500);
     let mut handle = launch_scenario_with_gates(
         "inv".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -663,8 +664,8 @@ fn while_runtime_strict_lt_threshold_gating() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn scenario_restart_does_not_leak_gate_bus() {
+#[tokio::test(flavor = "multi_thread")]
+async fn scenario_restart_does_not_leak_gate_bus() {
     // Risk #4 from phases.md: spawn 50 short-lived gated scenarios in
     // a loop, assert the bus's Arc count returns to baseline after each
     // scenario finishes.
@@ -673,13 +674,13 @@ fn scenario_restart_does_not_leak_gate_bus() {
 
     for i in 0..20 {
         let (rx, init) = bus.subscribe(while_gt_zero());
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry(&format!("ephemeral_{i}"), 50.0, 80);
         let mut handle = launch_scenario_with_gates(
             format!("ephemeral_{i}"),
             None,
             entry,
-            shutdown,
+            cancel,
             None,
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -700,8 +701,8 @@ fn scenario_restart_does_not_leak_gate_bus() {
     );
 }
 
-#[test]
-fn while_runtime_delay_close_debounces_running_to_paused_transition() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_delay_close_debounces_running_to_paused_transition() {
     // delay.close: a brief gate-close-then-reopen within the debounce
     // window must NOT pause the scenario; a sustained close (≥ delay.close)
     // does. Mirrors the delay.open debounce test but for the opposite
@@ -717,13 +718,13 @@ fn while_runtime_delay_close_debounces_running_to_paused_transition() {
         close_snap_to: None,
     };
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("debounced_close", 200.0, 2000);
     let mut handle = launch_scenario_with_gates(
         "debounced_close".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -767,8 +768,8 @@ fn while_runtime_delay_close_debounces_running_to_paused_transition() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
     // Subscribe with both after: and while: on the same upstream. Initial
     // value 1 → after-not-fired (op="<", threshold=1, strict), gate closed
     // (op="<", threshold=1, strict) — state = Pending. Drive value to 0
@@ -793,13 +794,13 @@ fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
         "gate must be closed at value=1"
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("after_open", 100.0, 1000);
     let mut handle = launch_scenario_with_gates(
         "after_open".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -834,8 +835,8 @@ fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
     // Use a single upstream where after.op=">" threshold=100 and
     // while.op="<" threshold=10. Sequence:
     //
@@ -863,13 +864,13 @@ fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
     assert!(!init.after_already_fired);
     assert_eq!(init.while_gate_open, Some(true));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("after_paused", 100.0, 1500);
     let mut handle = launch_scenario_with_gates(
         "after_paused".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -918,8 +919,8 @@ fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
     // While Pending (after not yet satisfied), repeated WhileOpen /
     // WhileClose edges on the same upstream must not transition the
     // scenario out of Pending. Single-bus approach: after.op=">"
@@ -944,13 +945,13 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
     assert!(!init.after_already_fired);
     assert_eq!(init.while_gate_open, Some(false));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("absorb", 100.0, 2000);
     let mut handle = launch_scenario_with_gates(
         "absorb".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -998,8 +999,8 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
     // Subscribe with after.op=">" threshold=100 at value=5: after has not
     // fired, gate is irrelevant (after gates Pending entry). Broadcast
     // UpstreamGone while still Pending. With if_unresolved=None, the
@@ -1021,13 +1022,13 @@ fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
     assert!(!init.after_already_fired);
     assert_eq!(init.while_gate_open, Some(true));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("pending_upstream_gone", 100.0, 5000);
     let mut handle = launch_scenario_with_gates(
         "pending_upstream_gone".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -1073,19 +1074,19 @@ fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_steady_within_5pct_of_baseline() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_steady_within_5pct_of_baseline() {
     // Perf-regression gate (A10): a scenario with `while:` open the entire
     // run must produce within 5% of the event count of the same scenario
     // without `while:`. Both runs are short (300ms) to keep the test fast.
     fn run_baseline() -> u64 {
         let entry = metrics_entry("baseline", 1000.0, 300);
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut handle = launch_scenario_with_gates(
             "baseline".to_string(),
             None,
             entry,
-            shutdown,
+            cancel,
             None,
             None,
             None,
@@ -1101,12 +1102,12 @@ fn while_runtime_steady_within_5pct_of_baseline() {
         bus.tick(1.0);
         let (rx, init) = bus.subscribe(while_gt_zero());
         let entry = metrics_entry("gated", 1000.0, 300);
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut handle = launch_scenario_with_gates(
             "gated".to_string(),
             None,
             entry,
-            shutdown,
+            cancel,
             None,
             Some(Arc::clone(&bus)),
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -1136,8 +1137,8 @@ fn while_runtime_steady_within_5pct_of_baseline() {
     );
 }
 
-#[test]
-fn close_emit_conflict_compile_error_when_snap_to_and_stale_marker_false() {
+#[tokio::test(flavor = "multi_thread")]
+async fn close_emit_conflict_compile_error_when_snap_to_and_stale_marker_false() {
     use sonda_core::compile_scenario_file_compiled;
     use sonda_core::compiler::expand::InMemoryPackResolver;
 
@@ -1190,8 +1191,8 @@ scenarios:
     );
 }
 
-#[test]
-fn delay_close_legacy_shorthand_still_deserializes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn delay_close_legacy_shorthand_still_deserializes() {
     use sonda_core::compile_scenario_file_compiled;
     use sonda_core::compiler::expand::InMemoryPackResolver;
 
@@ -1231,8 +1232,8 @@ scenarios:
         .expect("legacy delay.close shorthand must still parse");
 }
 
-#[test]
-fn nan_upstream_value_keeps_downstream_paused() {
+#[tokio::test(flavor = "multi_thread")]
+async fn nan_upstream_value_keeps_downstream_paused() {
     let bus = Arc::new(GateBus::new());
     bus.tick(f64::NAN);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -1242,13 +1243,13 @@ fn nan_upstream_value_keeps_downstream_paused() {
         "NaN upstream must close the gate at subscription"
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("nan_paused", 200.0, 600);
     let mut handle = launch_scenario_with_gates(
         "nan_paused".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -1278,8 +1279,8 @@ fn nan_upstream_value_keeps_downstream_paused() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn delay_close_extended_form_deserializes_all_fields() {
+#[tokio::test(flavor = "multi_thread")]
+async fn delay_close_extended_form_deserializes_all_fields() {
     use sonda_core::compile_scenario_file_compiled;
     use sonda_core::compiler::expand::InMemoryPackResolver;
 

--- a/sonda-server/Cargo.toml
+++ b/sonda-server/Cargo.toml
@@ -27,6 +27,7 @@ path = "src/main.rs"
 sonda-core = { workspace = true }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }

--- a/sonda-server/src/gate_registry.rs
+++ b/sonda-server/src/gate_registry.rs
@@ -9,6 +9,7 @@ use sonda_core::schedule::gate_bus::{
     RegistryError, WhileSpec,
 };
 use sonda_core::schedule::stats::ScenarioStats;
+use sonda_core::ScenarioState;
 use sonda_core::UnresolvedBehavior;
 
 type BusKey = (String, String);
@@ -150,6 +151,23 @@ impl GateBusResolver for GateBusRegistry {
         let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
         let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
 
+        let stale_pending: Vec<String> = pending
+            .iter()
+            .filter(|(_, entry)| entry.scenario_name == scenario_name)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for handle_id in stale_pending {
+            let entry = pending.remove(&handle_id).expect("just snapshotted");
+            entry.edge_sender.send_replace(Some(GateEdge::UpstreamGone));
+            if let Some(stats_arc) = entry.stats.upgrade() {
+                if let Ok(mut s) = stats_arc.write() {
+                    if s.state != ScenarioState::Finished {
+                        s.transition_state(ScenarioState::Unresolved);
+                    }
+                }
+            }
+        }
+
         for key in removed_keys {
             let Some(refs) = subs.remove(&key) else {
                 continue;
@@ -224,6 +242,36 @@ impl GateBusResolver for GateBusRegistry {
         let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
         let (key, sub) = SubscriberRef::from_pending(pending);
         subs.entry(key).or_default().push(sub);
+    }
+
+    fn cancel_pending_for_upstream(
+        &self,
+        scenario_name: &str,
+        entry_id: &str,
+    ) -> Vec<RegistryError> {
+        let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
+        let matching: Vec<String> = pending
+            .iter()
+            .filter(|(_, p)| p.scenario_name == scenario_name && p.entry_id == entry_id)
+            .map(|(k, _)| k.clone())
+            .collect();
+        let mut errors = Vec::with_capacity(matching.len());
+        for handle_id in matching {
+            let entry = pending.remove(&handle_id).expect("just snapshotted");
+            entry.edge_sender.send_replace(Some(GateEdge::UpstreamGone));
+            if let Some(stats_arc) = entry.stats.upgrade() {
+                if let Ok(mut s) = stats_arc.write() {
+                    if s.state != ScenarioState::Finished {
+                        s.transition_state(ScenarioState::Unresolved);
+                    }
+                }
+            }
+            errors.push(RegistryError::UpstreamCancelled {
+                scenario_name: entry.scenario_name,
+                entry_id: entry.entry_id,
+            });
+        }
+        errors
     }
 }
 
@@ -431,6 +479,111 @@ mod tests {
             "no edge should be delivered for a dead-weak subscriber"
         );
         assert!(reg.pending_for_handle("h-dead").is_none());
+    }
+
+    #[test]
+    fn downstream_resolves_with_upstream_cancelled_error_when_upstream_cancels() {
+        let reg = GateBusRegistry::new();
+        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
+        let (alive, weak) = live_stats();
+        reg.insert_pending(make_pending(
+            "h-pending",
+            "post-upstream",
+            "metric_a",
+            weak,
+            tx,
+        ));
+        assert!(
+            reg.pending_for_handle("h-pending").is_some(),
+            "pending entry must be present before cancellation"
+        );
+
+        let errors = reg.cancel_pending_for_upstream("post-upstream", "metric_a");
+
+        assert_eq!(
+            errors.len(),
+            1,
+            "exactly one error must be returned for the cancelled pending entry"
+        );
+        assert!(
+            matches!(
+                &errors[0],
+                RegistryError::UpstreamCancelled { scenario_name, entry_id }
+                if scenario_name == "post-upstream" && entry_id == "metric_a"
+            ),
+            "error must be UpstreamCancelled for the matching upstream, got: {:?}",
+            errors[0]
+        );
+        assert!(
+            reg.pending_for_handle("h-pending").is_none(),
+            "pending entry must be removed after cancellation"
+        );
+        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
+            .expect("waiter must receive UpstreamGone within 200ms");
+        assert_eq!(edge, GateEdge::UpstreamGone);
+        drop(alive);
+    }
+
+    #[test]
+    fn cancel_pending_for_upstream_only_affects_matching_upstream() {
+        let reg = GateBusRegistry::new();
+        let (tx_a, mut rx_a) = watch::channel::<Option<GateEdge>>(None);
+        let (tx_b, mut rx_b) = watch::channel::<Option<GateEdge>>(None);
+        let (alive_a, weak_a) = live_stats();
+        let (alive_b, weak_b) = live_stats();
+        reg.insert_pending(make_pending(
+            "h-a",
+            "post-upstream",
+            "metric_a",
+            weak_a,
+            tx_a,
+        ));
+        reg.insert_pending(make_pending("h-b", "post-other", "metric_b", weak_b, tx_b));
+
+        let errors = reg.cancel_pending_for_upstream("post-upstream", "metric_a");
+        assert_eq!(errors.len(), 1);
+        assert!(
+            reg.pending_for_handle("h-a").is_none(),
+            "matching pending must be removed"
+        );
+        assert!(
+            reg.pending_for_handle("h-b").is_some(),
+            "non-matching pending must remain"
+        );
+        assert_eq!(
+            watch_recv_timeout(&mut rx_a, Duration::from_millis(200)),
+            Ok(GateEdge::UpstreamGone),
+            "matching waiter must receive UpstreamGone"
+        );
+        assert!(
+            watch_recv_timeout(&mut rx_b, Duration::from_millis(50)).is_err(),
+            "non-matching waiter must not receive any edge"
+        );
+        drop(alive_a);
+        drop(alive_b);
+    }
+
+    #[test]
+    fn unregister_signals_pending_downstreams_waiting_on_that_upstream() {
+        let reg = GateBusRegistry::new();
+        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
+        let (alive, weak) = live_stats();
+        reg.insert_pending(make_pending("h-pending", "nope", "entry-x", weak, tx));
+        assert!(
+            reg.pending_for_handle("h-pending").is_some(),
+            "pending entry must be present before unregister"
+        );
+
+        reg.unregister("nope");
+
+        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
+            .expect("waiter must receive UpstreamGone within 200ms");
+        assert_eq!(edge, GateEdge::UpstreamGone);
+        assert!(
+            reg.pending_for_handle("h-pending").is_none(),
+            "pending entry must be removed after unregister"
+        );
+        drop(alive);
     }
 
     #[test]

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -597,7 +597,12 @@ async fn launch_compiled(
     warnings: Vec<String>,
 ) -> Result<Response, Response> {
     let resolver: Arc<dyn sonda_core::GateBusResolver> = state.gate_bus_registry.clone();
-    let mut handles = launch_multi_compiled(compiled, Some(resolver)).map_err(|e| {
+    let mut handles = launch_multi_compiled(
+        compiled,
+        Some(resolver),
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .map_err(|e| {
         warn!(error = %e, "POST /scenarios: failed to launch scenarios");
         match e {
             sonda_core::SondaError::Config(_) => unprocessable(e),
@@ -1139,10 +1144,10 @@ mod tests {
     use http_body_util::BodyExt;
     use hyper::{Request, StatusCode};
     use sonda_core::ScenarioHandle;
-    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, RwLock};
     use std::thread;
     use std::time::{Duration, Instant};
+    use tokio_util::sync::CancellationToken;
     use tower::ServiceExt;
 
     // ---- Helpers ---------------------------------------------------------------
@@ -1152,34 +1157,31 @@ mod tests {
     /// The thread emits `event_count` events at `interval` apart, incrementing
     /// total_events and bytes_emitted on each tick.
     fn make_handle(id: &str, name: &str, event_count: u64, interval: Duration) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel_for_task = cancel.clone();
         let stats_clone = Arc::clone(&stats);
 
-        let thread = thread::Builder::new()
-            .name(format!("test-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                for _ in 0..event_count {
-                    if !shutdown_clone.load(Ordering::SeqCst) {
-                        break;
-                    }
-                    thread::sleep(interval);
-                    if let Ok(mut st) = stats_clone.write() {
-                        st.total_events += 1;
-                        st.bytes_emitted += 64;
-                    }
+        let task = tokio::task::spawn(async move {
+            for _ in 0..event_count {
+                if cancel_for_task.is_cancelled() {
+                    break;
                 }
-                Ok(())
-            })
-            .expect("thread must spawn");
+                tokio::time::sleep(interval).await;
+                if let Ok(mut st) = stats_clone.write() {
+                    st.total_events += 1;
+                    st.bytes_emitted += 64;
+                }
+            }
+            Ok::<(), sonda_core::SondaError>(())
+        });
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             100.0,
@@ -1193,30 +1195,21 @@ mod tests {
         )
     }
 
-    /// Build a ScenarioHandle that has already finished (thread exits immediately).
     fn make_stopped_handle(id: &str, name: &str) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
+        cancel.cancel();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-        let shutdown_clone = Arc::clone(&shutdown);
 
-        let thread = thread::Builder::new()
-            .name(format!("test-stopped-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                // Check shutdown immediately and exit.
-                let _ = shutdown_clone.load(Ordering::SeqCst);
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async { Ok::<(), sonda_core::SondaError>(()) });
 
-        // Give thread time to finish.
         thread::sleep(Duration::from_millis(50));
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             100.0,
@@ -1380,7 +1373,7 @@ scenarios:
     // ---- GET /scenarios: empty state -----------------------------------------
 
     /// GET /scenarios with no scenarios returns an empty list.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn list_scenarios_empty_returns_empty_array() {
         let app = router_with_handles(vec![]);
         let req = Request::builder()
@@ -1404,7 +1397,7 @@ scenarios:
     // ---- GET /scenarios: two scenarios listed --------------------------------
 
     /// Start 2 scenarios, GET /scenarios returns both listed.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn list_scenarios_returns_both_when_two_present() {
         let h1 = make_handle("id-aaa", "scenario_alpha", 1000, Duration::from_millis(50));
         let h2 = make_handle("id-bbb", "scenario_beta", 1000, Duration::from_millis(50));
@@ -1449,7 +1442,7 @@ scenarios:
     // ---- GET /scenarios: response shape --------------------------------------
 
     /// Each scenario summary has id, name, status, elapsed_secs fields.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn list_scenarios_response_shape_has_required_fields() {
         let h = make_handle("id-shape", "shape_test", 1000, Duration::from_millis(50));
         let app = router_with_handles(vec![h]);
@@ -1474,7 +1467,7 @@ scenarios:
     }
 
     /// A scenario with no sink failures reports degraded=false in the list.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn list_scenarios_degraded_false_for_healthy_scenario() {
         let h = make_handle(
             "id-healthy",
@@ -1502,7 +1495,7 @@ scenarios:
     // ---- GET /scenarios/{id}: correct name, status, elapsed -------------------
 
     /// GET /scenarios/{id} returns correct name, status, and positive elapsed_secs.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_returns_correct_name_status_elapsed() {
         let h = make_handle(
             "id-detail",
@@ -1544,7 +1537,7 @@ scenarios:
     // ---- GET /scenarios/{id}: stats fields present ----------------------------
 
     /// GET /scenarios/{id} response includes stats sub-object with all required fields.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_response_has_stats_fields() {
         let h = make_handle(
             "id-stats-fields",
@@ -1581,7 +1574,7 @@ scenarios:
 
     // ---- GET /scenarios/{id}: degraded field on detail + nested stats --------
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_degraded_false_for_healthy_scenario() {
         let h = make_handle(
             "id-detail-healthy",
@@ -1610,7 +1603,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_degraded_true_when_failures_and_no_delivery() {
         let mut stats = ScenarioStats::default();
         stats.total_sink_failures = 5;
@@ -1641,7 +1634,7 @@ scenarios:
     // ---- GET /scenarios/{id}: stats.total_events > 0 after running ------------
 
     /// After running for a short time, stats.total_events > 0.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_stats_total_events_positive_after_running() {
         // Thread emits events every 10ms. After 200ms we should have ~20 events.
         let h = make_handle("id-events", "events_check", 500, Duration::from_millis(10));
@@ -1673,7 +1666,7 @@ scenarios:
     // ---- GET /scenarios/nonexistent: 404 -------------------------------------
 
     /// GET /scenarios/{id} with a nonexistent ID returns 404 with a JSON error body.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_nonexistent_returns_404_with_json_body() {
         let app = router_with_handles(vec![]);
 
@@ -1703,7 +1696,7 @@ scenarios:
     }
 
     /// GET /scenarios/{id} 404 response has Content-Type application/json.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_nonexistent_returns_json_content_type() {
         let app = router_with_handles(vec![]);
 
@@ -1729,7 +1722,7 @@ scenarios:
 
     // ---- GET /scenarios/{id}: finished scenario reports "finished" ------------
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_finished_reports_finished_status() {
         let h = make_stopped_handle("id-stopped", "finished_scenario");
         if let Ok(mut s) = h.stats.write() {
@@ -1756,7 +1749,7 @@ scenarios:
     // ---- Stats update frequency: elapsed tracks real time --------------------
 
     /// Elapsed time reported by the endpoint must be within 1 second of real time.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn elapsed_secs_tracks_real_time_within_one_second() {
         let h = make_handle(
             "id-elapsed",
@@ -1796,7 +1789,7 @@ scenarios:
     // ---- Content-Type for scenario endpoints ---------------------------------
 
     /// GET /scenarios returns Content-Type application/json.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn list_scenarios_sets_json_content_type() {
         let app = router_with_handles(vec![]);
 
@@ -1916,7 +1909,7 @@ scenarios:
     // ---- Test: POST valid metrics YAML -> 201, scenario ID returned, handle in AppState
 
     /// POST a valid metrics YAML body returns 201 Created with id, name, and status.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_valid_metrics_yaml_returns_201_with_id() {
         let (app, state) = test_router();
         let response = post_scenarios(app, "application/x-yaml", VALID_METRICS_YAML).await;
@@ -1958,7 +1951,7 @@ scenarios:
     // ---- Test: POST valid logs YAML -> 201, scenario ID returned
 
     /// POST a valid logs YAML body returns 201 Created.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_valid_logs_yaml_returns_201() {
         let (app, state) = test_router();
         let response = post_scenarios(app, "text/yaml", VALID_LOGS_YAML).await;
@@ -1990,7 +1983,7 @@ scenarios:
     // ---- Test: POST YAML with signal_type: metrics -> 201 (ScenarioEntry format)
 
     /// POST a YAML body with explicit signal_type: metrics returns 201.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_tagged_metrics_yaml_returns_201() {
         let (app, state) = test_router();
         let response = post_scenarios(app, "application/x-yaml", VALID_TAGGED_METRICS_YAML).await;
@@ -2018,7 +2011,7 @@ scenarios:
     // ---- Test: POST invalid YAML -> 400 with error message
 
     /// POST garbage text as YAML returns 400 Bad Request.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_invalid_yaml_returns_400() {
         let (app, _state) = test_router();
         let response =
@@ -2042,7 +2035,7 @@ scenarios:
     }
 
     /// POST an empty body returns 400 Bad Request.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_empty_body_returns_400() {
         let (app, _state) = test_router();
         let response = post_scenarios(app, "application/x-yaml", "").await;
@@ -2055,7 +2048,7 @@ scenarios:
     }
 
     /// POST YAML that parses but is missing required fields returns 400.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_yaml_missing_required_fields_returns_400() {
         let (app, _state) = test_router();
         // Valid YAML but not a valid scenario (missing name, rate, generator).
@@ -2071,7 +2064,7 @@ scenarios:
     // ---- Test: POST valid YAML with rate=0 -> 422 with validation detail
 
     /// POST a valid YAML with rate=0 returns 422 Unprocessable Entity.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_yaml_with_zero_rate_returns_422() {
         let (app, _state) = test_router();
         let response = post_scenarios(app, "application/x-yaml", ZERO_RATE_YAML).await;
@@ -2096,7 +2089,7 @@ scenarios:
     // ---- Test: POST -> scenario thread is running (verify via handle.is_running())
 
     /// After POST, the scenario thread should be running in AppState.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_scenario_thread_is_running() {
         let (app, state) = test_router();
         let response = post_scenarios(app, "text/yaml", VALID_METRICS_YAML).await;
@@ -2124,7 +2117,7 @@ scenarios:
     // ---- Test: Content-type handling: application/x-yaml, text/yaml, application/json
 
     /// POST with Content-Type: application/x-yaml is accepted as YAML.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_with_application_x_yaml_content_type_returns_201() {
         let (app, state) = test_router();
         let response = post_scenarios(app, "application/x-yaml", VALID_METRICS_YAML).await;
@@ -2139,7 +2132,7 @@ scenarios:
     }
 
     /// POST with Content-Type: text/yaml is accepted as YAML.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_with_text_yaml_content_type_returns_201() {
         let (app, state) = test_router();
         let response = post_scenarios(app, "text/yaml", VALID_METRICS_YAML).await;
@@ -2154,7 +2147,7 @@ scenarios:
     }
 
     /// POST with Content-Type: application/json and a valid v2 JSON metrics body returns 201.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_with_json_content_type_returns_201() {
         let json_body = serde_json::json!({
             "version": 2,
@@ -2196,7 +2189,7 @@ scenarios:
     }
 
     /// POST with Content-Type: application/json and invalid JSON returns 400.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_invalid_json_returns_400() {
         let (app, _state) = test_router();
         let response = post_scenarios(app, "application/json", "not json {{{").await;
@@ -2209,7 +2202,7 @@ scenarios:
     }
 
     /// POST with no Content-Type header defaults to YAML parsing.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_with_no_content_type_defaults_to_yaml() {
         let (app, state) = test_router();
         let request = Request::builder()
@@ -2232,7 +2225,7 @@ scenarios:
     // ---- Test: Response body structure -----------------------------------------
 
     /// The 201 response body contains exactly three keys: id, name, status.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_response_body_has_expected_keys() {
         let (app, state) = test_router();
         let response = post_scenarios(app, "text/yaml", VALID_METRICS_YAML).await;
@@ -2258,7 +2251,7 @@ scenarios:
     }
 
     /// The returned scenario ID is a valid UUID v4.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_response_id_is_valid_uuid() {
         let (app, state) = test_router();
         let response = post_scenarios(app, "text/yaml", VALID_METRICS_YAML).await;
@@ -2275,7 +2268,7 @@ scenarios:
     // ---- Test: Negative rate -> 422 -------------------------------------------
 
     /// POST v2 YAML with a negative rate returns 422.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_yaml_with_negative_rate_returns_422() {
         let yaml = "\
 version: 2
@@ -2492,7 +2485,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_scenario_resolves_pack_reference_when_catalog_set() {
         let tmp = tempfile::TempDir::new().expect("temp dir");
         write_catalog_pack(tmp.path());
@@ -2510,7 +2503,7 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_scenario_pack_reference_without_catalog_returns_4xx() {
         let (app, _state) = test_router();
         let resp = post_scenarios(app, "application/x-yaml", PACK_REF_BODY).await;
@@ -2521,7 +2514,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_scenario_plain_body_works_with_catalog_set() {
         let tmp = tempfile::TempDir::new().expect("temp dir");
         write_catalog_pack(tmp.path());
@@ -2627,7 +2620,7 @@ scenarios:
 
     /// Start a running scenario, DELETE it, and verify the thread exits
     /// with status "stopped".
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_running_scenario_returns_stopped_status() {
         // Thread runs for a long time (1000 events x 50ms = 50s) so it is
         // definitely running when we hit DELETE.
@@ -2658,7 +2651,7 @@ scenarios:
     // ---- DELETE returns final stats (total_events) -------------------------
 
     /// DELETE returns total_events reflecting events emitted before stop.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_returns_final_stats_with_total_events() {
         // Thread emits events every 10ms. Wait 200ms so some events accumulate.
         let h = make_handle("id-del-stats", "del_stats", 1000, Duration::from_millis(10));
@@ -2689,7 +2682,7 @@ scenarios:
     // ---- DELETE already-stopped scenario -> 200 OK -------------------------
 
     /// DELETE on an already-stopped scenario returns 200 OK with status "stopped".
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_already_stopped_returns_200_ok() {
         let h = make_stopped_handle("id-del-stopped", "del_stopped");
         let state = AppState::new();
@@ -2718,7 +2711,7 @@ scenarios:
     // ---- DELETE unknown ID -> 404 ------------------------------------------
 
     /// DELETE on a nonexistent scenario ID returns 404.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_unknown_scenario_returns_404() {
         let app = router_with_handles(vec![]);
         let resp = delete_scenario_req(app, "nonexistent-id").await;
@@ -2744,7 +2737,7 @@ scenarios:
     // ---- DELETE response JSON shape: id, status, total_events ---------------
 
     /// The DELETE response body has exactly three keys: id, status, total_events.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_response_has_expected_json_shape() {
         let h = make_handle("id-del-shape", "del_shape", 1000, Duration::from_millis(50));
         let state = AppState::new();
@@ -2783,7 +2776,7 @@ scenarios:
     // ---- DELETE returns correct id in response ------------------------------
 
     /// The DELETE response id field matches the requested scenario ID.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_response_id_matches_requested_id() {
         let h = make_handle("id-del-match", "del_match", 1000, Duration::from_millis(50));
         let state = AppState::new();
@@ -2808,7 +2801,7 @@ scenarios:
     // ---- DELETE twice: second DELETE returns 404 after handle removal --------
 
     /// DELETE removes the handle from the map, so a second DELETE returns 404.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_twice_on_same_id_returns_404_on_second() {
         let h = make_handle("id-del-twice", "del_twice", 1000, Duration::from_millis(50));
         let state = AppState::new();
@@ -2841,7 +2834,7 @@ scenarios:
     // ---- DELETE removes handle from HashMap -----------------------------------
 
     /// DELETE removes the scenario handle from the internal HashMap.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_removes_handle_from_hashmap() {
         let h = make_handle("id-del-map", "del_map", 1000, Duration::from_millis(50));
         let state = AppState::new();
@@ -2873,7 +2866,7 @@ scenarios:
     // ---- DELETE excludes scenario from GET /scenarios list -------------------
 
     /// After deleting one of two scenarios, GET /scenarios returns only the remaining one.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_scenario_excluded_from_list() {
         let h_keep = make_handle("id-keep", "keep_scenario", 1000, Duration::from_millis(50));
         let h_delete = make_handle(
@@ -2954,7 +2947,7 @@ scenarios:
     // ---- DELETE returns Content-Type application/json -----------------------
 
     /// DELETE response has Content-Type application/json.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_scenario_returns_json_content_type() {
         let h = make_handle("id-del-ct", "del_ct", 1000, Duration::from_millis(50));
         let state = AppState::new();
@@ -2983,7 +2976,7 @@ scenarios:
     // ---- DELETE 404 returns JSON Content-Type ------------------------------
 
     /// DELETE 404 response has Content-Type application/json.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_unknown_returns_json_content_type() {
         let app = router_with_handles(vec![]);
         let resp = delete_scenario_req(app, "missing-id").await;
@@ -3017,34 +3010,23 @@ scenarios:
         initial_stats: ScenarioStats,
         running: bool,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(running));
+        let cancel = CancellationToken::new();
+        if !running {
+            cancel.cancel();
+        }
         let stats = Arc::new(RwLock::new(initial_stats));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel_for_task = cancel.clone();
 
-        let thread = if running {
-            // Long-running thread that waits for shutdown.
-            thread::Builder::new()
-                .name(format!("test-stats-{name}"))
-                .spawn(move || -> Result<(), sonda_core::SondaError> {
-                    while shutdown_clone.load(Ordering::SeqCst) {
-                        thread::sleep(Duration::from_millis(10));
-                    }
-                    Ok(())
-                })
-                .expect("thread must spawn")
+        let task = if running {
+            tokio::task::spawn(async move {
+                cancel_for_task.cancelled().await;
+                Ok::<(), sonda_core::SondaError>(())
+            })
         } else {
-            // Thread exits immediately.
-            thread::Builder::new()
-                .name(format!("test-stats-stopped-{name}"))
-                .spawn(move || -> Result<(), sonda_core::SondaError> {
-                    let _ = shutdown_clone.load(Ordering::SeqCst);
-                    Ok(())
-                })
-                .expect("thread must spawn")
+            tokio::task::spawn(async { Ok::<(), sonda_core::SondaError>(()) })
         };
 
         if !running {
-            // Give the thread time to exit.
             thread::sleep(Duration::from_millis(50));
         }
 
@@ -3052,8 +3034,8 @@ scenarios:
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             target_rate,
@@ -3079,7 +3061,7 @@ scenarios:
     // ---- Stats endpoint returns all expected fields -------------------------
 
     /// GET /scenarios/{id}/stats returns a JSON body with all expected fields.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_returns_all_expected_fields() {
         let mut stats = ScenarioStats::default();
         stats.total_events = 500;
@@ -3132,7 +3114,7 @@ scenarios:
 
     // ---- /stats endpoint: degraded field --------------------------------------
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_degraded_false_for_healthy_scenario() {
         let h = make_handle_with_stats(
             "id-stats-healthy",
@@ -3154,7 +3136,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_degraded_true_when_failures_and_no_delivery() {
         let mut stats = ScenarioStats::default();
         stats.total_sink_failures = 3;
@@ -3177,7 +3159,7 @@ scenarios:
     // ---- Fields update as scenario progresses --------------------------------
 
     /// Stats fields update as the scenario background thread emits events.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_fields_update_as_scenario_progresses() {
         // Thread emits events every 10ms.
         let h = make_handle(
@@ -3235,7 +3217,7 @@ scenarios:
     // ---- in_gap is true during gap window ------------------------------------
 
     /// When in_gap is set to true in the stats, the endpoint reflects it.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_in_gap_true_when_stats_indicate_gap() {
         let mut stats = ScenarioStats::default();
         stats.total_events = 10;
@@ -3263,7 +3245,7 @@ scenarios:
 
     // ---- After scenario finished: returns final stats with state "finished" ----
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_returns_finished_state_for_finished_scenario() {
         let mut stats = ScenarioStats::default();
         stats.total_events = 1000;
@@ -3304,7 +3286,7 @@ scenarios:
     // ---- Unknown ID returns 404 -----------------------------------------------
 
     /// GET /scenarios/{id}/stats with an unknown ID returns 404.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_unknown_id_returns_404() {
         let app = router_with_handles(vec![]);
 
@@ -3326,7 +3308,7 @@ scenarios:
     // ---- Stats 404 returns JSON Content-Type ----------------------------------
 
     /// GET /scenarios/{id}/stats 404 has Content-Type application/json.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_404_returns_json_content_type() {
         let app = router_with_handles(vec![]);
 
@@ -3348,7 +3330,7 @@ scenarios:
     // ---- Stats endpoint returns correct target_rate ---------------------------
 
     /// The target_rate field reflects the configured rate on the handle, not measured rate.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_target_rate_reflects_configured_rate() {
         let mut stats = ScenarioStats::default();
         stats.total_events = 0;
@@ -3378,7 +3360,7 @@ scenarios:
     // ---- Stats endpoint uptime_secs is positive --------------------------------
 
     /// uptime_secs is positive for a running scenario.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_uptime_secs_is_positive() {
         let h = make_handle_with_stats(
             "id-stats-uptime",
@@ -3443,7 +3425,7 @@ scenarios:
     // ---- Stats 200 returns JSON Content-Type ----------------------------------
 
     /// GET /scenarios/{id}/stats success response has Content-Type application/json.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_success_returns_json_content_type() {
         let h = make_handle_with_stats(
             "id-stats-ct",
@@ -3489,30 +3471,25 @@ scenarios:
         name: &str,
         events: Vec<sonda_core::model::metric::MetricEvent>,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut stats = ScenarioStats::default();
         for event in events {
             stats.push_metric(event);
         }
         let stats = Arc::new(RwLock::new(stats));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel_for_task = cancel.clone();
 
-        let thread = thread::Builder::new()
-            .name(format!("test-metrics-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                while shutdown_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async move {
+            cancel_for_task.cancelled().await;
+            Ok::<(), sonda_core::SondaError>(())
+        });
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -3544,7 +3521,7 @@ scenarios:
     // ---- Metrics scrape: 404 for unknown scenario ID ------------------------
 
     /// GET /scenarios/{id}/metrics with a nonexistent ID returns 404.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn metrics_endpoint_unknown_id_returns_404() {
         let app = router_with_handles(vec![]);
 
@@ -3568,7 +3545,7 @@ scenarios:
     /// Empty buffer must render as `200 OK` with an empty Prometheus exposition
     /// (the contract Prometheus / vmagent / Telegraf scrapers expect). 204
     /// breaks scrapers that use `curl --fail`.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn metrics_endpoint_empty_buffer_returns_200_empty_body() {
         let h = make_handle_with_metrics("id-metrics-empty", "empty_metrics", vec![]);
         let app = router_with_handles(vec![h]);
@@ -3584,7 +3561,7 @@ scenarios:
 
     // ---- Metrics scrape: returns Prometheus text format ----------------------
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn metrics_endpoint_returns_prometheus_text_format() {
         let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
         let h = make_handle_with_metrics("id-metrics-prom", "prom_text", events);
@@ -3607,7 +3584,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn per_scenario_metrics_emits_one_sample_per_series_no_timestamp() {
         let events = vec![make_metric_event("up", 42.0)];
         let h = make_handle_with_metrics("id-no-ts", "no_ts", events);
@@ -3630,7 +3607,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn per_scenario_metrics_distinct_series_emit_distinct_samples() {
         let events = vec![
             labeled_metric_event("up", 1.0, &[("host", "a")]),
@@ -3646,7 +3623,7 @@ scenarios:
         assert_eq!(sample_lines.len(), 2, "got: {body:?}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn per_scenario_metrics_idempotent_across_scrapes() {
         let events = vec![make_metric_event("up", 1.0), make_metric_event("up", 2.0)];
         let h = make_handle_with_metrics("id-idem", "idem", events);
@@ -3672,7 +3649,7 @@ scenarios:
     // ---- Metrics scrape: correct Content-Type header ------------------------
 
     /// GET /scenarios/{id}/metrics sets Content-Type to Prometheus text exposition format.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn metrics_endpoint_sets_prometheus_content_type() {
         let events = vec![make_metric_event("cpu_usage", 42.0)];
         let h = make_handle_with_metrics("id-metrics-ct", "ct_check", events);
@@ -3696,7 +3673,7 @@ scenarios:
     // ---- Metrics scrape: 404 returns JSON Content-Type ----------------------
 
     /// GET /scenarios/{id}/metrics 404 has Content-Type application/json.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn metrics_endpoint_404_returns_json_content_type() {
         let app = router_with_handles(vec![]);
 
@@ -3715,7 +3692,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn metrics_endpoint_emits_one_sample_per_distinct_series() {
         let events: Vec<_> = (0..5)
             .map(|i| labeled_metric_event("up", i as f64, &[("host", &format!("h{i}"))]))
@@ -3738,7 +3715,7 @@ scenarios:
     // ---- Metrics scrape: output ends with newline ---------------------------
 
     /// Each Prometheus text line ends with a newline.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn metrics_endpoint_output_ends_with_newline() {
         let events = vec![make_metric_event("up", 1.0)];
         let h = make_handle_with_metrics("id-metrics-nl", "newline_test", events);
@@ -3764,23 +3741,18 @@ scenarios:
         labels: Vec<(&str, &str)>,
         events: Vec<sonda_core::model::metric::MetricEvent>,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut stats = ScenarioStats::default();
         for event in events {
             stats.push_metric(event);
         }
         let stats = Arc::new(RwLock::new(stats));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel_for_task = cancel.clone();
 
-        let thread = thread::Builder::new()
-            .name(format!("test-agg-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                while shutdown_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async move {
+            cancel_for_task.cancelled().await;
+            Ok::<(), sonda_core::SondaError>(())
+        });
 
         let mut label_map = std::collections::HashMap::new();
         for (k, v) in labels {
@@ -3791,8 +3763,8 @@ scenarios:
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -3819,7 +3791,7 @@ scenarios:
         app.oneshot(req).await.unwrap()
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_empty_state_returns_200_empty_body() {
         let app = router_with_handles(vec![]);
         let resp = get_aggregate_req(app, "").await;
@@ -3840,7 +3812,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_single_scenario_no_filter_returns_events() {
         let events = vec![
             labeled_metric_event("up", 1.0, &[("host", "a")]),
@@ -3867,7 +3839,7 @@ scenarios:
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_emits_one_sample_per_series_no_timestamp() {
         let h1 = make_handle_with_labels_and_metrics(
             "agg-no-ts-1",
@@ -3896,7 +3868,7 @@ scenarios:
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_idempotent_across_scrapes() {
         let h = make_handle_with_labels_and_metrics(
             "agg-idem",
@@ -3920,7 +3892,7 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_and_per_scenario_scrapes_are_both_idempotent() {
         let h = make_handle_with_labels_and_metrics(
             "agg-both",
@@ -3952,7 +3924,7 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_filter_single_label_match_included() {
         let h1 = make_handle_with_labels_and_metrics(
             "agg-srl1",
@@ -3985,7 +3957,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_filter_single_label_no_match_excluded() {
         let h1 = make_handle_with_labels_and_metrics(
             "agg-nm-1",
@@ -4011,7 +3983,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_filter_multi_label_and_semantics() {
         let h1 = make_handle_with_labels_and_metrics(
             "agg-ml-1",
@@ -4050,7 +4022,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_handle_with_no_labels_never_matches_filter() {
         let h = make_handle_with_labels_and_metrics(
             "agg-nolabels",
@@ -4070,7 +4042,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_malformed_filter_returns_400() {
         let h = make_handle_with_labels_and_metrics(
             "agg-bad",
@@ -4102,7 +4074,7 @@ scenarios:
         assert_eq!(body2["error"].as_str().unwrap(), "bad_request");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_auth_gate_enforced() {
         let state = AppState::with_api_key(Some("the-key".to_string()));
         let app = router(state);
@@ -4326,24 +4298,20 @@ scenarios:
     /// the shutdown flag. This simulates a scenario that cannot be stopped
     /// gracefully within the join timeout.
     fn make_unjoinable_handle(id: &str, name: &str) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        let thread = thread::Builder::new()
-            .name(format!("test-unjoinable-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                // Ignore shutdown — sleep for a very long time.
-                thread::sleep(Duration::from_secs(300));
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async {
+            tokio::time::sleep(Duration::from_secs(300)).await;
+            Ok::<(), sonda_core::SondaError>(())
+        });
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             50.0,
@@ -4357,27 +4325,23 @@ scenarios:
         )
     }
 
-    /// Build a ScenarioHandle whose thread panics immediately.
     fn make_panicking_handle(id: &str, name: &str) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        let thread = thread::Builder::new()
-            .name(format!("test-panic-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
+        let task: tokio::task::JoinHandle<Result<(), sonda_core::SondaError>> =
+            tokio::task::spawn(async {
                 panic!("intentional panic for testing");
-            })
-            .expect("thread must spawn");
+            });
 
-        // Give the thread time to panic.
         thread::sleep(Duration::from_millis(50));
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -4395,7 +4359,7 @@ scenarios:
 
     /// When the scenario thread does not exit within the join timeout,
     /// DELETE returns status "force_stopped".
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_unjoinable_thread_returns_force_stopped() {
         let h = make_unjoinable_handle("id-force", "force_stop");
         let state = AppState::new();
@@ -4437,7 +4401,7 @@ scenarios:
 
     /// When the scenario thread has panicked, DELETE returns 200 OK with status
     /// "stopped" (the thread has already exited, just abnormally).
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_panicked_thread_returns_stopped() {
         let h = make_panicking_handle("id-panic", "panic_scenario");
         let state = AppState::new();
@@ -4491,7 +4455,7 @@ scenarios:
     }
 
     /// GET /scenarios returns 500 when the map lock is poisoned.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn list_scenarios_poisoned_lock_returns_500() {
         let state = make_poisoned_state();
         let app = router(state);
@@ -4517,7 +4481,7 @@ scenarios:
     }
 
     /// GET /scenarios/{id} returns 500 when the map lock is poisoned.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_poisoned_lock_returns_500() {
         let state = make_poisoned_state();
         let app = router(state);
@@ -4536,7 +4500,7 @@ scenarios:
     }
 
     /// GET /scenarios/{id}/stats returns 500 when the map lock is poisoned.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_stats_poisoned_lock_returns_500() {
         let state = make_poisoned_state();
         let app = router(state);
@@ -4550,7 +4514,7 @@ scenarios:
     }
 
     /// GET /scenarios/{id}/metrics returns 500 when the map lock is poisoned.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_metrics_poisoned_lock_returns_500() {
         let state = make_poisoned_state();
         let app = router(state);
@@ -4564,7 +4528,7 @@ scenarios:
     }
 
     /// DELETE /scenarios/{id} returns 500 when the map lock is poisoned.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_scenario_poisoned_lock_returns_500() {
         let state = make_poisoned_state();
         let app = router(state);
@@ -4579,7 +4543,7 @@ scenarios:
 
     /// POST /scenarios returns 500 when the map lock is poisoned (lock
     /// acquisition for storing the handle fails).
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_scenario_poisoned_lock_returns_500() {
         let state = make_poisoned_state();
         let app = router(state);
@@ -4664,7 +4628,7 @@ scenarios:
 ";
 
     /// Multi-scenario YAML POST returns 201 with a scenarios array.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_multi_scenario_yaml_returns_201_with_scenarios_array() {
         let (app, state) = test_router();
         let response = post_scenarios(app, "application/x-yaml", VALID_MULTI_YAML).await;
@@ -4710,7 +4674,7 @@ scenarios:
     }
 
     /// Multi-scenario POST stores all handles in AppState.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_multi_scenario_stores_all_handles() {
         let (app, state) = test_router();
         let response = post_scenarios(app, "application/x-yaml", VALID_MULTI_YAML).await;
@@ -4733,7 +4697,7 @@ scenarios:
     }
 
     /// Multi-scenario POST with v2 JSON content type returns 201.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_multi_scenario_json_returns_201() {
         let json_body = serde_json::json!({
             "version": 2,
@@ -4781,7 +4745,7 @@ scenarios:
     }
 
     /// Empty v2 scenarios array returns 400 with a descriptive error.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_multi_scenario_empty_array_returns_400() {
         let yaml = "version: 2\nkind: runnable\nscenarios: []\n";
         let (app, _state) = test_router();
@@ -4802,7 +4766,7 @@ scenarios:
     }
 
     /// Invalid entry in a v2 batch returns 422 and nothing is launched.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_multi_scenario_invalid_entry_returns_422_nothing_launched() {
         let yaml = "\
 version: 2
@@ -4847,7 +4811,7 @@ scenarios:
     }
 
     /// Multi-scenario POST with phase_offset honored per entry.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_multi_scenario_phase_offset_honored() {
         let (app, state) = test_router();
         let response =
@@ -4869,7 +4833,7 @@ scenarios:
     }
 
     /// Single-scenario POST still returns backward-compatible response.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_single_scenario_backward_compat() {
         let (app, state) = test_router();
         let response = post_scenarios(app, "application/x-yaml", VALID_METRICS_YAML).await;
@@ -4895,7 +4859,7 @@ scenarios:
     }
 
     /// All launched multi-scenario entries are visible in GET /scenarios.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_multi_scenario_entries_visible_in_get_list() {
         let state = AppState::new();
         let app = router(state.clone());
@@ -4939,7 +4903,7 @@ scenarios:
     }
 
     /// Multi-scenario entries are stoppable via DELETE.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_multi_scenario_entries_stoppable_via_delete() {
         let state = AppState::new();
         let app = router(state.clone());
@@ -4975,7 +4939,7 @@ scenarios:
     }
 
     /// Multi-scenario response has unique IDs for each entry.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_multi_scenario_ids_are_unique() {
         let (app, state) = test_router();
         let response = post_scenarios(app, "application/x-yaml", VALID_MULTI_YAML).await;
@@ -5003,7 +4967,7 @@ scenarios:
     }
 
     /// Multi-scenario with mixed signal types (metrics + logs) returns 201.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_multi_scenario_mixed_signal_types() {
         let yaml = "\
 version: 2
@@ -5125,7 +5089,7 @@ scenarios:
 
     /// Single-scenario POST with phase_offset returns 201 (verifies the
     /// single-scenario path now uses prepare_entries which resolves phase_offset).
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_single_scenario_with_phase_offset_returns_201() {
         let yaml = "\
 version: 2
@@ -5168,7 +5132,7 @@ scenarios:
 
     /// Single-scenario POST with rate=0 returns 422 (verifies validation
     /// through prepare_entries).
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_single_scenario_with_zero_rate_returns_422_via_prepare_entries() {
         let (app, _state) = test_router();
         let response = post_scenarios(app, "application/x-yaml", ZERO_RATE_YAML).await;
@@ -5276,28 +5240,23 @@ scenarios:
         meta: Option<sonda_core::PromMeta>,
         events: Vec<sonda_core::model::metric::MetricEvent>,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut stats = ScenarioStats::default();
         for event in events {
             stats.push_metric(event);
         }
         let stats = Arc::new(RwLock::new(stats));
-        let shutdown_clone = Arc::clone(&shutdown);
-        let thread = thread::Builder::new()
-            .name(format!("test-meta-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                while shutdown_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let cancel_for_task = cancel.clone();
+        let task = tokio::task::spawn(async move {
+            cancel_for_task.cancelled().await;
+            Ok::<(), sonda_core::SondaError>(())
+        });
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -5317,7 +5276,7 @@ scenarios:
         .expect("metric name must be valid")
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn per_scenario_metrics_emits_type_line() {
         let meta = sonda_core::PromMeta::new(sonda_core::PromMetricType::Gauge, None);
         let h = handle_with_meta(
@@ -5336,7 +5295,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn per_scenario_metrics_emits_help_line_when_set() {
         let meta = sonda_core::PromMeta::new(
             sonda_core::PromMetricType::Gauge,
@@ -5360,7 +5319,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn per_scenario_metrics_omits_help_when_unset() {
         let meta = sonda_core::PromMeta::new(sonda_core::PromMetricType::Gauge, None);
         let h = handle_with_meta(
@@ -5379,7 +5338,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn per_scenario_metrics_log_scenario_returns_empty() {
         let h = handle_with_meta("id-log", "log_scenario", None, vec![]);
         let app = router_with_handles(vec![h]);
@@ -5399,22 +5358,18 @@ scenarios:
         labels: Vec<(&str, &str)>,
         events: Vec<sonda_core::model::metric::MetricEvent>,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut stats = ScenarioStats::default();
         for event in events {
             stats.push_metric(event);
         }
         let stats = Arc::new(RwLock::new(stats));
-        let shutdown_clone = Arc::clone(&shutdown);
-        let thread = thread::Builder::new()
-            .name(format!("test-agg-meta-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                while shutdown_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let cancel_for_task = cancel.clone();
+        let task = tokio::task::spawn(async move {
+            cancel_for_task.cancelled().await;
+            Ok::<(), sonda_core::SondaError>(())
+        });
+        let _ = name;
         let mut label_map = std::collections::HashMap::new();
         for (k, v) in labels {
             label_map.insert(k.to_string(), v.to_string());
@@ -5423,8 +5378,8 @@ scenarios:
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -5435,7 +5390,7 @@ scenarios:
         )
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_emits_one_type_block_per_name() {
         let meta = sonda_core::PromMeta::new(sonda_core::PromMetricType::Gauge, None);
         let h1 = handle_with_meta_and_labels(
@@ -5473,7 +5428,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_groups_samples_by_name() {
         let meta = sonda_core::PromMeta::new(sonda_core::PromMetricType::Gauge, None);
         let h1 = handle_with_meta_and_labels(
@@ -5518,7 +5473,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_mixed_type_collision_emits_untyped_and_warns() {
         let h1 = handle_with_meta_and_labels(
             "mix-1",
@@ -5550,7 +5505,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_label_filter_still_works_with_type_lines() {
         let meta = sonda_core::PromMeta::new(sonda_core::PromMetricType::Gauge, None);
         let h1 = handle_with_meta_and_labels(
@@ -5599,7 +5554,7 @@ scenarios:
             .expect("metric name must be valid")
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_histogram_scenario_exposes_buckets_sum_and_count() {
         let events = vec![
             labeled_metric_event("req_latency_bucket", 12.0, &[("le", "0.1")]),
@@ -5638,7 +5593,7 @@ scenarios:
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn aggregate_metrics_summary_scenario_exposes_quantiles_sum_and_count() {
         let events = vec![
             labeled_metric_event("rpc_duration", 0.05, &[("quantile", "0.5")]),
@@ -5753,7 +5708,7 @@ scenarios:
         body_json(resp).await
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn t14_validate_strict_with_typo_returns_422_and_unresolved_refs() {
         let (_, state) = test_router();
         let bad = DOWNSTREAM_YAML.replace("upstream_post", "totally_wrong");
@@ -5775,7 +5730,7 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn t15_validate_strict_with_mixed_refs_rejects_whole_body() {
         let (_, state) = test_router();
         let mixed = "\
@@ -5840,7 +5795,7 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn t16_validate_strict_with_all_resolvable_returns_201() {
         let (_, state) = test_router();
         let up_resp = post_with_query(router(state.clone()), "text/yaml", UPSTREAM_YAML, "").await;
@@ -5857,7 +5812,7 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn t18_get_scenario_for_unresolved_returns_pending_ref() {
         let (_, state) = test_router();
         let resp = post_with_query(
@@ -5907,7 +5862,7 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn t19_stats_endpoint_has_current_state_secs_and_cumulative_attempts() {
         let (_, state) = test_router();
         let resp = post_with_query(
@@ -5964,7 +5919,7 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn t20_duplicate_scenario_name_returns_409_via_registry() {
         let (_, state) = test_router();
         let first = post_with_query(router(state.clone()), "text/yaml", UPSTREAM_YAML, "").await;

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -156,4 +156,4 @@ This crate depends on:
 - `owo-colors` for colored terminal output (with `supports-colors` feature for auto-detection)
 - `dialoguer` for interactive terminal prompts in `sonda new` (pure Rust, musl-compatible)
 
-It should NOT depend on: `axum`, `tokio`, `hyper`, or any server-related crate.
+It depends on `tokio` (runtime construction in `main`) and `tokio-util` (`CancellationToken` for shutdown). It should NOT depend on: `axum`, `hyper`, or any server-specific HTTP crate.

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -34,6 +34,8 @@ owo-colors = { version = "4", features = ["supports-colors"] }
 serde_json = { workspace = true }
 dialoguer = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
+tokio-util = { version = "0.7", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -10,19 +10,33 @@ mod sink_format;
 mod status;
 
 use std::process;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
 use clap::Parser;
 use owo_colors::OwoColorize;
 use owo_colors::Stream::Stderr;
+use tokio_util::sync::CancellationToken;
 
 use cli::{Cli, Commands, Verbosity};
 use sonda_core::PreparedEntry;
 
 fn main() {
-    if let Err(err) = run() {
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(err) => {
+            let style = owo_colors::Style::new().bold().red();
+            eprintln!(
+                "{} failed to start runtime: {err:#}",
+                "error:".if_supports_color(Stderr, |t| t.style(style))
+            );
+            process::exit(1);
+        }
+    };
+    if let Err(err) = runtime.block_on(async { run().await }) {
         let style = owo_colors::Style::new().bold().red();
         eprintln!(
             "{} {err:#}",
@@ -32,7 +46,7 @@ fn main() {
     }
 }
 
-fn run() -> anyhow::Result<()> {
+async fn run() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_target(false)
@@ -43,11 +57,11 @@ fn run() -> anyhow::Result<()> {
         )
         .init();
 
-    let running = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     {
-        let r = Arc::clone(&running);
+        let c = cancel.clone();
         ctrlc::set_handler(move || {
-            r.store(false, Ordering::SeqCst);
+            c.cancel();
         })
         .expect("failed to register Ctrl+C handler");
     }
@@ -57,7 +71,7 @@ fn run() -> anyhow::Result<()> {
     let catalog = cli.catalog.as_deref();
 
     match cli.command {
-        Commands::Run(ref args) => run_scenario(args, &cli, catalog, verbosity, &running)?,
+        Commands::Run(ref args) => run_scenario(args, &cli, catalog, verbosity, &cancel)?,
         Commands::List(ref args) => list_catalog(args, catalog)?,
         Commands::Show(ref args) => show_entry(args, catalog)?,
         Commands::New(ref args) => new::run(args)?,
@@ -71,7 +85,7 @@ fn run_scenario(
     cli_opts: &Cli,
     catalog: Option<&std::path::Path>,
     verbosity: Verbosity,
-    running: &Arc<AtomicBool>,
+    cancel: &CancellationToken,
 ) -> anyhow::Result<()> {
     let mut compiled = scenario_loader::load_scenario_compiled(&args.scenario, catalog)?;
     config::apply_run_overrides_compiled(&mut compiled, args)?;
@@ -87,7 +101,7 @@ fn run_scenario(
         if verbosity == Verbosity::Verbose {
             status::print_version();
         }
-        run_compiled_with_progress(compiled, running, verbosity)?;
+        run_compiled_with_progress(compiled, cancel, verbosity)?;
         return Ok(());
     }
 
@@ -101,9 +115,9 @@ fn run_scenario(
 
     if prepared.len() == 1 {
         let p = prepared.into_iter().next().expect("len checked above");
-        run_single_scenario("cli-run".to_string(), p, running, verbosity)?;
+        run_single_scenario("cli-run".to_string(), p, cancel, verbosity)?;
     } else {
-        launch_and_join_prepared("cli-run", prepared, running, verbosity)?;
+        launch_and_join_prepared("cli-run", prepared, cancel, verbosity)?;
     }
     Ok(())
 }
@@ -198,14 +212,14 @@ fn handle_pre_launch(prepared: &[PreparedEntry], verbosity: Verbosity, dry_run: 
 fn run_single_scenario(
     name: String,
     prepared: PreparedEntry,
-    running: &Arc<AtomicBool>,
+    cancel: &CancellationToken,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
     status::print_start(&prepared.entry, verbosity, None);
     let mut handle = sonda_core::launch_scenario(
         name,
         prepared.entry,
-        Arc::clone(running),
+        cancel.child_token(),
         prepared.start_delay,
     )
     .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -270,7 +284,7 @@ struct StopInfo {
 fn launch_and_join_prepared(
     id_prefix: &str,
     prepared: Vec<PreparedEntry>,
-    running: &Arc<AtomicBool>,
+    cancel: &CancellationToken,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
     let run_start = Instant::now();
@@ -286,7 +300,7 @@ fn launch_and_join_prepared(
             p.entry.clock_group_is_auto(),
         ));
         let id = format!("{id_prefix}-{i}");
-        let handle = sonda_core::launch_scenario(id, p.entry, Arc::clone(running), p.start_delay)
+        let handle = sonda_core::launch_scenario(id, p.entry, cancel.child_token(), p.start_delay)
             .map_err(|e| anyhow::anyhow!("{}", e))?;
         handles.push(handle);
     }
@@ -347,17 +361,12 @@ fn launch_and_join_prepared(
 
 fn run_compiled_with_progress(
     compiled: sonda_core::compiler::compile_after::CompiledFile,
-    running: &Arc<AtomicBool>,
+    cancel: &CancellationToken,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
-    let handles = sonda_core::schedule::multi_runner::launch_multi_compiled(compiled, None)
-        .map_err(|e| anyhow::anyhow!("{}", e))?;
-
-    let per_handle_shutdowns: Vec<Arc<AtomicBool>> =
-        handles.iter().map(|h| Arc::clone(&h.shutdown)).collect();
-    let done = Arc::new(AtomicBool::new(false));
-    let watchdog =
-        spawn_ctrlc_watchdog(Arc::clone(running), per_handle_shutdowns, Arc::clone(&done));
+    let handles =
+        sonda_core::schedule::multi_runner::launch_multi_compiled(compiled, None, cancel.clone())
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
 
     let progress = maybe_start_progress_multi(&handles, verbosity);
 
@@ -368,9 +377,6 @@ fn run_compiled_with_progress(
         }
     }
 
-    done.store(true, Ordering::SeqCst);
-    let _ = watchdog.join();
-
     if let Some(p) = progress {
         p.stop();
     }
@@ -379,31 +385,6 @@ fn run_compiled_with_progress(
         return Err(anyhow::anyhow!("{}", errors.join("; ")));
     }
     Ok(())
-}
-
-fn spawn_ctrlc_watchdog(
-    master: Arc<AtomicBool>,
-    per_handle: Vec<Arc<AtomicBool>>,
-    done: Arc<AtomicBool>,
-) -> std::thread::JoinHandle<()> {
-    std::thread::Builder::new()
-        .name("sonda-cli-shutdown-watchdog".to_string())
-        .spawn(move || {
-            let poll = std::time::Duration::from_millis(100);
-            loop {
-                if done.load(Ordering::SeqCst) {
-                    return;
-                }
-                if !master.load(Ordering::SeqCst) {
-                    for flag in &per_handle {
-                        flag.store(false, Ordering::SeqCst);
-                    }
-                    return;
-                }
-                std::thread::sleep(poll);
-            }
-        })
-        .expect("watchdog thread must spawn")
 }
 
 fn stop_infos_for_groups(


### PR DESCRIPTION
## Summary

Replaces the std::thread-per-scenario model with bounded `tokio::task` spawning
and swaps `Arc<AtomicBool>` shutdown signalling for
`tokio_util::sync::CancellationToken`. A parent token fans out to per-scenario
child tokens, so stopping a parent deterministically cancels every running
scenario without a dedicated watchdog thread.

## Changes

- `ScenarioHandle` now holds `cancel: CancellationToken` + `task: Option<JoinHandle<()>>`.
  The watchdog task and its shutdown channel are removed.
- `launch_scenario` spawns each scenario as a tokio task. A watcher task
  bridges the cancel token to the existing runner alive-flag contract, and an
  outer `tokio::select!` drops the runner future as an abrupt fallback so RAII
  Drop guards still run.
- `GateContext` gains a `cancel: CancellationToken` field via its builder.
  Gated loop bodies add `select!` arms on `cancel.cancelled()` so a stop on a
  scenario interrupts an in-flight gate wait instead of finishing the tick.
- New `GateBusResolver::cancel_pending_for_upstream` trait method plus
  `RegistryError::UpstreamCancelled` variant. `GateBusRegistry::unregister`
  now drains pending waiters keyed on the removed `scenario_name` and
  broadcasts `UpstreamGone`, closing the lifecycle gap where a DELETE could
  leave downstream `while:` waiters blocked forever.
- `sonda` CLI builds a multi-thread tokio runtime in `main` and dispatches
  through `block_on`. New deps: `tokio` (runtime construction), `tokio-util`
  (`CancellationToken`). The no-`axum` / no-`hyper` prohibition is preserved
  and documented in `sonda/CLAUDE.md`.
- ~150 scenario- and registry-touching tests migrated to
  `#[tokio::test(flavor = "multi_thread")]`.
- `launch_multi_compiled_gives_each_handle_an_independent_shutdown_flag`
  rewritten to assert the stop-one-don't-cascade invariant explicitly via
  fresh handle sets per iteration.

## Semver

Stays `refactor(core):` despite public type changes on `ScenarioHandle`:
no known external embedders.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace --all-features` — 2888 / 2888
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::await_holding_lock`
- [x] `cargo clippy -p sonda-core --no-default-features -- -D warnings`
- [x] `cargo test -p sonda-core --no-default-features --no-run`
- [x] `cargo fmt --all -- --check`
- [x] `cargo audit`