### PR TITLE
refactor(core): make the sink layer async-native and push the async boundary up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2250,7 @@ dependencies = [
  "serde_yaml_ng",
  "sonda-core",
  "tempfile",
+ "tokio",
  "tracing-subscriber",
 ]
 
@@ -2246,6 +2258,7 @@ dependencies = [
 name = "sonda-core"
 version = "1.14.0"
 dependencies = [
+ "async-trait",
  "bytes",
  "chrono",
  "criterion",

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -25,9 +25,10 @@ serde_yaml_ng = { workspace = true, optional = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = "0.1"
+async-trait = "0.1"
 ureq = { workspace = true, optional = true }
 rskafka = { version = "0.6.0", default-features = false, features = ["transport-tls"], optional = true }
-tokio = { version = "1", features = ["rt", "sync", "net", "time", "macros"] }
+tokio = { version = "1", features = ["rt", "sync", "net", "time", "macros", "fs", "io-std", "io-util"] }
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"], optional = true }
 rustls-pki-types = { version = "1", features = ["std"], optional = true }
@@ -45,6 +46,7 @@ rstest = { workspace = true }
 criterion = { version = "0.8", default-features = false }
 sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 tracing-test = "0.2"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [[bench]]
 name = "while_steady_state"

--- a/sonda-core/benches/scheduler_baseline.rs
+++ b/sonda-core/benches/scheduler_baseline.rs
@@ -200,10 +200,20 @@ fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
             })
             .collect();
         let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
         for (offset, p) in prepared.into_iter().enumerate() {
             let i = offset + 1;
             let shutdown = Arc::new(AtomicBool::new(true));
-            let handle = launch_scenario(format!("bench_{i}"), p.entry, shutdown, p.start_delay)
+            let handle = rt
+                .block_on(launch_scenario(
+                    format!("bench_{i}"),
+                    p.entry,
+                    shutdown,
+                    p.start_delay,
+                ))
                 .expect("launch_scenario must succeed");
             handles.push(handle);
         }

--- a/sonda-core/benches/while_steady_state.rs
+++ b/sonda-core/benches/while_steady_state.rs
@@ -47,27 +47,36 @@ fn metrics_entry(name: &str, rate: f64, duration_ms: u64) -> ScenarioEntry {
 }
 
 fn bench_baseline_ungated(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime must build");
     c.bench_function("baseline_ungated_300ms_at_1khz", |b| {
         b.iter(|| {
             let entry = metrics_entry("bench", 1000.0, 300);
             let shutdown = Arc::new(AtomicBool::new(true));
-            let mut handle = launch_scenario_with_gates(
-                "bench".to_string(),
-                None,
-                entry,
-                shutdown,
-                None,
-                None,
-                None,
-                None,
-            )
-            .unwrap();
+            let mut handle = rt
+                .block_on(launch_scenario_with_gates(
+                    "bench".to_string(),
+                    None,
+                    entry,
+                    shutdown,
+                    None,
+                    None,
+                    None,
+                    None,
+                ))
+                .unwrap();
             handle.join(Some(Duration::from_secs(2))).unwrap();
         });
     });
 }
 
 fn bench_gated_open(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime must build");
     c.bench_function("gated_open_300ms_at_1khz", |b| {
         b.iter(|| {
             let bus = Arc::new(GateBus::new());
@@ -81,17 +90,18 @@ fn bench_gated_open(c: &mut Criterion) {
             });
             let entry = metrics_entry("gated", 1000.0, 300);
             let shutdown = Arc::new(AtomicBool::new(true));
-            let mut handle = launch_scenario_with_gates(
-                "gated".to_string(),
-                None,
-                entry,
-                shutdown,
-                None,
-                Some(Arc::clone(&bus)),
-                Some(GateContext::new(rx, init).with_has_while(true)),
-                None,
-            )
-            .unwrap();
+            let mut handle = rt
+                .block_on(launch_scenario_with_gates(
+                    "gated".to_string(),
+                    None,
+                    entry,
+                    shutdown,
+                    None,
+                    Some(Arc::clone(&bus)),
+                    Some(GateContext::new(rx, init).with_has_while(true)),
+                    None,
+                ))
+                .unwrap();
             handle.join(Some(Duration::from_secs(2))).unwrap();
         });
     });

--- a/sonda-core/src/config/validate.rs
+++ b/sonda-core/src/config/validate.rs
@@ -1551,8 +1551,8 @@ sink:
     // ---- Round-trip: deserialize -> validate -> create factories -------------
 
     #[cfg(feature = "config")]
-    #[test]
-    fn round_trip_creates_generator_encoder_sink_successfully() {
+    #[tokio::test]
+    async fn round_trip_creates_generator_encoder_sink_successfully() {
         use crate::encoder::create_encoder;
         use crate::generator::create_generator;
         use crate::sink::create_sink;
@@ -1587,7 +1587,7 @@ sink:
         // Encoder must exist (just check it does not panic on creation)
         drop(encoder);
 
-        let sink = create_sink(&config.sink, None);
+        let sink = create_sink(&config.sink, None).await;
         assert!(sink.is_ok(), "sink must be created without error");
     }
 

--- a/sonda-core/src/emit.rs
+++ b/sonda-core/src/emit.rs
@@ -1,4 +1,4 @@
-//! Synchronous single-event emission.
+//! Single-event emission helpers.
 
 use std::collections::HashMap;
 
@@ -9,33 +9,33 @@ use crate::sink::{create_sink, SinkConfig};
 use crate::SondaError;
 
 /// Encode a [`LogEvent`] and deliver it through a one-shot sink.
-pub fn emit_log(
+pub async fn emit_log(
     event: &LogEvent,
     encoder: &EncoderConfig,
     sink: &SinkConfig,
     labels: Option<&HashMap<String, String>>,
 ) -> Result<(), SondaError> {
     let encoder = create_encoder(encoder)?;
-    let mut sink = create_sink(sink, labels)?;
+    let mut sink = create_sink(sink, labels).await?;
     let mut buf: Vec<u8> = Vec::new();
     encoder.encode_log(event, &mut buf)?;
-    sink.write_log_event(event, &buf)?;
-    sink.flush()
+    sink.write_log_event(event, &buf).await?;
+    sink.flush().await
 }
 
 /// Encode a [`MetricEvent`] and deliver it through a one-shot sink.
-pub fn emit_metric(
+pub async fn emit_metric(
     event: &MetricEvent,
     encoder: &EncoderConfig,
     sink: &SinkConfig,
     labels: Option<&HashMap<String, String>>,
 ) -> Result<(), SondaError> {
     let encoder = create_encoder(encoder)?;
-    let mut sink = create_sink(sink, labels)?;
+    let mut sink = create_sink(sink, labels).await?;
     let mut buf: Vec<u8> = Vec::new();
     encoder.encode_metric(event, &mut buf)?;
-    sink.write(&buf)?;
-    sink.flush()
+    sink.write(&buf).await?;
+    sink.flush().await
 }
 
 #[cfg(test)]
@@ -58,8 +58,8 @@ mod tests {
         p
     }
 
-    #[test]
-    fn emit_log_writes_encoded_line_to_sink() {
+    #[tokio::test]
+    async fn emit_log_writes_encoded_line_to_sink() {
         let path = temp_path("emit_log_writes");
         let _ = std::fs::remove_file(&path);
 
@@ -78,6 +78,7 @@ mod tests {
             },
             None,
         )
+        .await
         .expect("emit_log must succeed");
 
         let contents = std::fs::read_to_string(&path).expect("read written file");
@@ -97,8 +98,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn emit_metric_writes_encoded_line_to_sink() {
+    #[tokio::test]
+    async fn emit_metric_writes_encoded_line_to_sink() {
         let path = temp_path("emit_metric_writes");
         let _ = std::fs::remove_file(&path);
 
@@ -117,6 +118,7 @@ mod tests {
             },
             None,
         )
+        .await
         .expect("emit_metric must succeed");
 
         let contents = std::fs::read_to_string(&path).expect("read written file");
@@ -132,8 +134,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn emit_log_propagates_config_error_for_invalid_sink_config() {
+    #[tokio::test]
+    async fn emit_log_propagates_config_error_for_invalid_sink_config() {
         let event = LogEvent::new(
             Severity::Info,
             "msg".to_string(),
@@ -156,6 +158,7 @@ mod tests {
             &bad_sink,
             None,
         )
+        .await
         .expect_err("invalid retry config must fail sink construction");
 
         assert!(
@@ -165,8 +168,8 @@ mod tests {
     }
 
     #[cfg(feature = "http")]
-    #[test]
-    fn emit_log_routes_event_labels_to_loki_sink_stream() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn emit_log_routes_event_labels_to_loki_sink_stream() {
         use std::io::{BufRead, BufReader, Read, Write};
         use std::net::{TcpListener, TcpStream};
         use std::thread;
@@ -222,6 +225,7 @@ mod tests {
             },
             None,
         )
+        .await
         .expect("emit_log must succeed");
 
         let body_bytes = handle.join().expect("mock server");
@@ -238,8 +242,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn emit_metric_propagates_config_error_for_invalid_sink_config() {
+    #[tokio::test]
+    async fn emit_metric_propagates_config_error_for_invalid_sink_config() {
         let event =
             MetricEvent::new("test_metric".to_string(), 1.0, Labels::default()).expect("metric");
 
@@ -258,6 +262,7 @@ mod tests {
             &bad_sink,
             None,
         )
+        .await
         .expect_err("invalid retry config must fail sink construction");
 
         assert!(

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -308,12 +308,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn sink_file_error_produces_sink_variant() {
-        // Opening a file at an invalid path must produce SondaError::Sink.
+    #[tokio::test]
+    async fn sink_file_error_produces_sink_variant() {
         let result = sink::file::FileSink::new(std::path::Path::new(
             "/nonexistent/deeply/nested/path/output.txt",
-        ));
+        ))
+        .await;
         match result {
             Err(ref err) => {
                 assert!(
@@ -622,9 +622,8 @@ generator:
     }
 
     /// EncoderConfig, SinkConfig, and GeneratorConfig are all constructible
-    /// without deserialization and can be passed to their respective factory functions.
-    #[test]
-    fn factory_functions_work_without_deserialization() {
+    #[tokio::test]
+    async fn factory_functions_work_without_deserialization() {
         use crate::encoder::{create_encoder, EncoderConfig};
         use crate::generator::{create_generator, GeneratorConfig};
         use crate::sink::{create_sink, SinkConfig};
@@ -637,7 +636,9 @@ generator:
         let _enc = create_encoder(&enc_config).expect("encoder factory must succeed");
 
         let sink_config = SinkConfig::Stdout;
-        let _sink = create_sink(&sink_config, None).expect("sink factory must succeed");
+        let _sink = create_sink(&sink_config, None)
+            .await
+            .expect("sink factory must succeed");
     }
 
     #[test]

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -14,7 +14,7 @@ use crate::schedule::gate_bus::{GateEdge, GateReceiver, InitialState};
 use crate::schedule::stats::{ScenarioState, ScenarioStats};
 use crate::schedule::{is_in_burst, is_in_gap, is_in_spike, time_until_gap_end};
 use crate::sink::Sink;
-use crate::{RuntimeError, SondaError};
+use crate::SondaError;
 
 use super::ParsedSchedule;
 
@@ -205,26 +205,6 @@ pub(crate) async fn run_schedule_loop(
     finalize_sink(schedule, stats_for_flush.as_ref(), sink, loop_result).await
 }
 
-/// Placeholder sink swapped in for the brief window each `Box<dyn Sink>` is
-/// owned by a `spawn_blocking` task. Lives only inside `drain_writes` /
-/// `finalize_sink`; never reachable from user code. If either helper returns
-/// `Err`, the caller's `Box<dyn Sink>` may still hold this placeholder —
-/// do not retry sink operations after an error return, propagate it.
-struct NullSink;
-
-impl Sink for NullSink {
-    fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
-        Ok(())
-    }
-    fn flush(&mut self) -> Result<(), SondaError> {
-        Ok(())
-    }
-}
-
-fn take_sink(sink: &mut Box<dyn Sink>) -> Box<dyn Sink> {
-    std::mem::replace(sink, Box::new(NullSink) as Box<dyn Sink>)
-}
-
 async fn finalize_sink(
     schedule: &ParsedSchedule,
     stats: Option<&Arc<RwLock<ScenarioStats>>>,
@@ -233,22 +213,7 @@ async fn finalize_sink(
 ) -> Result<(), SondaError> {
     match loop_result {
         Ok(()) => {
-            let owned = take_sink(sink);
-            let join = tokio::task::spawn_blocking(move || {
-                let mut s = owned;
-                let r = s.flush();
-                (s, r)
-            })
-            .await;
-            let (returned_sink, flush_result) = match join {
-                Ok(pair) => pair,
-                Err(e) => {
-                    return Err(SondaError::Runtime(RuntimeError::TaskPanicked(
-                        e.to_string(),
-                    )))
-                }
-            };
-            *sink = returned_sink;
+            let flush_result = sink.flush().await;
             apply_flush_policy(schedule, stats, flush_result)
         }
         Err(e) => Err(e),
@@ -473,26 +438,10 @@ async fn drain_writes(
 ) -> Result<Option<bool>, SondaError> {
     let mut delivered: Option<bool> = None;
     for cmd in output.writes.drain(..) {
-        let owned = take_sink(sink);
-        let join = tokio::task::spawn_blocking(move || {
-            let mut s = owned;
-            let r = match cmd {
-                WriteCommand::Bytes(buf) => s.write(&buf),
-                WriteCommand::LogEvent { event, bytes } => s.write_log_event(&event, &bytes),
-            };
-            (s, r)
-        })
-        .await;
-        let (returned_sink, write_result) = match join {
-            Ok(pair) => pair,
-            Err(e) => {
-                return Err(SondaError::Runtime(RuntimeError::TaskPanicked(
-                    e.to_string(),
-                )))
-            }
-        };
-        *sink = returned_sink;
-        write_result?;
+        match cmd {
+            WriteCommand::Bytes(buf) => sink.write(&buf).await?,
+            WriteCommand::LogEvent { event, bytes } => sink.write_log_event(&event, &bytes).await?,
+        }
         delivered = Some(sink.last_write_delivered());
     }
     Ok(delivered)
@@ -593,22 +542,7 @@ async fn invoke_close_emit(
     };
     match outcome {
         Ok(()) => {
-            let owned = take_sink(sink);
-            let join = tokio::task::spawn_blocking(move || {
-                let mut s = owned;
-                let r = s.flush();
-                (s, r)
-            })
-            .await;
-            let (returned_sink, flush_result) = match join {
-                Ok(pair) => pair,
-                Err(e) => {
-                    return Err(SondaError::Runtime(RuntimeError::TaskPanicked(
-                        e.to_string(),
-                    )))
-                }
-            };
-            *sink = returned_sink;
+            let flush_result = sink.flush().await;
             apply_close_emit_policy_flush(schedule, stats, limiter, flush_result)?;
         }
         Err(e) => apply_close_emit_policy(schedule, stats, limiter, e)?,
@@ -1408,14 +1342,14 @@ impl DebounceState {
 mod tests {
     use std::sync::Mutex;
 
+    use async_trait::async_trait;
+
     use super::*;
     use crate::schedule::{BurstWindow, GapWindow};
 
     type WriteLog = Arc<Mutex<Vec<Vec<u8>>>>;
 
-    /// Shared-buffer test sink. Owns nothing; the `Arc<Mutex<...>>` handles
-    /// let tests inspect outcomes after the runner has moved the sink in
-    /// and out of `spawn_blocking`.
+    /// Shared-buffer test sink that lets tests inspect captured writes.
     struct SharedSink {
         writes: WriteLog,
         fail_at: Option<usize>,
@@ -1439,8 +1373,9 @@ mod tests {
         (Box::new(sink) as Box<dyn Sink>, writes)
     }
 
+    #[async_trait]
     impl Sink for SharedSink {
-        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
             let mut writes = self.writes.lock().expect("shared sink mutex poisoned");
             if let Some(n) = self.fail_at {
                 if writes.len() == n {
@@ -1452,7 +1387,19 @@ mod tests {
             writes.push(data.to_vec());
             Ok(())
         }
-        fn flush(&mut self) -> Result<(), SondaError> {
+        async fn flush(&mut self) -> Result<(), SondaError> {
+            Ok(())
+        }
+    }
+
+    struct NullSink;
+
+    #[async_trait]
+    impl Sink for NullSink {
+        async fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
+            Ok(())
+        }
+        async fn flush(&mut self) -> Result<(), SondaError> {
             Ok(())
         }
     }
@@ -1499,47 +1446,35 @@ mod tests {
         );
     }
 
-    /// A spawn_blocking task that panics surfaces as RuntimeError::TaskPanicked.
     struct PanicSink;
 
+    #[async_trait]
     impl Sink for PanicSink {
-        fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
+        async fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
             panic!("synthetic sink panic");
         }
-        fn flush(&mut self) -> Result<(), SondaError> {
+        async fn flush(&mut self) -> Result<(), SondaError> {
             panic!("synthetic flush panic");
         }
     }
 
     #[tokio::test]
-    async fn drain_writes_panic_in_sink_propagates_as_task_panicked() {
+    #[should_panic(expected = "synthetic sink panic")]
+    async fn drain_writes_panic_in_sink_propagates() {
         let mut sink: Box<dyn Sink> = Box::new(PanicSink);
         let mut output = TickOutput::default();
         output
             .writes
             .push(WriteCommand::Bytes(b"panic-me".to_vec()));
-        let result = drain_writes(&mut output, &mut sink).await;
-        assert!(
-            matches!(
-                result,
-                Err(SondaError::Runtime(RuntimeError::TaskPanicked(_)))
-            ),
-            "spawn_blocking panic must surface as TaskPanicked, got: {result:?}"
-        );
+        let _ = drain_writes(&mut output, &mut sink).await;
     }
 
     #[tokio::test]
-    async fn finalize_sink_panic_in_flush_propagates_as_task_panicked() {
+    #[should_panic(expected = "synthetic flush panic")]
+    async fn finalize_sink_panic_in_flush_propagates() {
         let mut sink: Box<dyn Sink> = Box::new(PanicSink);
         let schedule = minimal_schedule(None);
-        let result = finalize_sink(&schedule, None, &mut sink, Ok(())).await;
-        assert!(
-            matches!(
-                result,
-                Err(SondaError::Runtime(RuntimeError::TaskPanicked(_)))
-            ),
-            "flush panic must surface as TaskPanicked, got: {result:?}"
-        );
+        let _ = finalize_sink(&schedule, None, &mut sink, Ok(())).await;
     }
 
     #[test]

--- a/sonda-core/src/schedule/histogram_runner.rs
+++ b/sonda-core/src/schedule/histogram_runner.rs
@@ -41,7 +41,7 @@ use crate::SondaError;
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run(config: &HistogramScenarioConfig) -> Result<(), SondaError> {
-    let mut sink = create_sink(&config.sink, None)?;
+    let mut sink = create_sink(&config.sink, None).await?;
     run_with_sink(config, &mut sink, None, None).await
 }
 
@@ -75,6 +75,22 @@ pub async fn run_with_sink(
 ///
 /// Histograms cannot be `while:` upstreams (compile-time
 /// `NonMetricsTarget`), but they can be `while:`-gated downstreams.
+pub fn run_with_sink_gated_blocking(
+    config: &HistogramScenarioConfig,
+    shutdown: Option<&AtomicBool>,
+    stats: Option<Arc<RwLock<ScenarioStats>>>,
+    gate_ctx: Option<GateContext>,
+) -> Result<(), SondaError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
+    rt.block_on(async {
+        let mut sink = create_sink(&config.sink, None).await?;
+        run_with_sink_gated(config, &mut sink, shutdown, stats, gate_ctx).await
+    })
+}
+
 pub async fn run_with_sink_gated(
     config: &HistogramScenarioConfig,
     sink: &mut Box<dyn Sink>,
@@ -320,6 +336,8 @@ fn format_le_value(bound: f64) -> String {
 mod tests {
     use std::sync::Mutex;
 
+    use async_trait::async_trait;
+
     use crate::config::{BaseScheduleConfig, DistributionConfig, HistogramScenarioConfig};
     use crate::encoder::EncoderConfig;
     use crate::sink::{Sink, SinkConfig};
@@ -329,15 +347,16 @@ mod tests {
 
     struct ProbeSink(SharedBuf);
 
+    #[async_trait]
     impl Sink for ProbeSink {
-        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
             self.0
                 .lock()
                 .expect("probe sink mutex poisoned")
                 .extend_from_slice(data);
             Ok(())
         }
-        fn flush(&mut self) -> Result<(), SondaError> {
+        async fn flush(&mut self) -> Result<(), SondaError> {
             Ok(())
         }
     }

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -18,12 +18,11 @@ use crate::generator::GeneratorConfig;
 use crate::schedule::core_loop::GateContext;
 use crate::schedule::gate_bus::{GateBus, GateBusResolver};
 use crate::schedule::handle::ScenarioHandle;
-use crate::schedule::histogram_runner::run_with_sink_gated as run_histogram_with_sink_gated;
-use crate::schedule::log_runner::run_logs_with_sink_gated;
-use crate::schedule::runner::run_with_sink_gated;
+use crate::schedule::histogram_runner::run_with_sink_gated_blocking as run_histogram_with_sink_gated_blocking;
+use crate::schedule::log_runner::run_logs_with_sink_gated_blocking;
+use crate::schedule::runner::run_with_sink_gated_blocking;
 use crate::schedule::stats::{ScenarioState, ScenarioStats};
-use crate::schedule::summary_runner::run_with_sink_gated as run_summary_with_sink_gated;
-use crate::sink::create_sink;
+use crate::schedule::summary_runner::run_with_sink_gated_blocking as run_summary_with_sink_gated_blocking;
 use crate::{ConfigError, RuntimeError, SondaError};
 
 /// Extract the inner message from a [`SondaError`] for re-wrapping.
@@ -167,51 +166,18 @@ pub fn prepare_entries(entries: Vec<ScenarioEntry>) -> Result<Vec<PreparedEntry>
 }
 
 /// Launch a single scenario on a new OS thread.
-///
-/// Creates the sink, wires up the shutdown flag and the stats arc, spawns the
-/// appropriate runner (metrics, logs, histogram, or summary), and returns a
-/// [`ScenarioHandle`] for lifecycle management.
-///
-/// This is the single function that both the CLI and sonda-server call to
-/// start a scenario. No scenario launch logic exists outside this function.
-///
-/// # Parameters
-///
-/// * `id` — unique identifier for this scenario instance (e.g. a UUID string).
-/// * `entry` — the scenario configuration. The `signal_type` field selects
-///   the runner.
-/// * `shutdown` — shared shutdown flag. Pass `Arc::new(AtomicBool::new(true))`
-///   for a new scenario. The handle's [`ScenarioHandle::stop`] method sets this
-///   to `false` to request a clean exit.
-/// * `start_delay` — optional delay before the scenario begins emitting events.
-///   When `Some`, the spawned thread sleeps for this duration before entering the
-///   event loop. This enables temporal correlation in multi-scenario mode: "metric
-///   A starts immediately, metric B starts 30s later". The sleep happens inside
-///   the spawned thread, so it does not block the caller.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if the sink cannot be created. Thread spawn failures
-/// are extremely rare on modern operating systems; if the OS refuses to spawn
-/// a thread it is treated as an unrecoverable condition.
-pub fn launch_scenario(
+pub async fn launch_scenario(
     id: String,
     entry: ScenarioEntry,
     shutdown: Arc<AtomicBool>,
     start_delay: Option<Duration>,
 ) -> Result<ScenarioHandle, SondaError> {
-    launch_scenario_with_gates(id, None, entry, shutdown, start_delay, None, None, None)
+    launch_scenario_with_gates(id, None, entry, shutdown, start_delay, None, None, None).await
 }
 
 /// Launch a scenario with optional `while:` / `after:` gating wired in.
-///
-/// `scenario_name` surfaces on [`ScenarioHandle::scenario_name`]; pass `None`
-/// for anonymous bodies. `upstream_bus` is the bus this scenario PUBLISHES
-/// into (for downstream gates to read). `gate_ctx` is what THIS scenario
-/// consumes from an upstream bus. When `resolver` is `Some` AND `scenario_name`
-/// is `Some`, natural-exit cleanup unregisters the upstream bus on thread exit.
 #[allow(clippy::too_many_arguments)]
-pub fn launch_scenario_with_gates(
+pub async fn launch_scenario_with_gates(
     id: String,
     scenario_name: Option<String>,
     entry: ScenarioEntry,
@@ -311,57 +277,32 @@ pub fn launch_scenario_with_gates(
                 }
             }
 
-            // Per-scenario current-thread Tokio runtime: drives the async
-            // runner from inside the std::thread::spawn'd scenario thread.
-            // One runtime per thread keeps the blocking-task pool local to
-            // this scenario.
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
-
             match entry {
-                ScenarioEntry::Metrics(config) => {
-                    let mut sink = create_sink(&config.sink, None)?;
-                    rt.block_on(run_with_sink_gated(
-                        &config,
-                        &mut sink,
-                        Some(shutdown_for_thread.as_ref()),
-                        Some(Arc::clone(&stats_for_thread)),
-                        upstream_bus,
-                        gate_ctx,
-                    ))
-                }
-                ScenarioEntry::Logs(config) => {
-                    let mut sink = create_sink(&config.sink, config.labels.as_ref())?;
-                    rt.block_on(run_logs_with_sink_gated(
-                        &config,
-                        &mut sink,
-                        Some(shutdown_for_thread.as_ref()),
-                        Some(Arc::clone(&stats_for_thread)),
-                        gate_ctx,
-                    ))
-                }
-                ScenarioEntry::Histogram(config) => {
-                    let mut sink = create_sink(&config.sink, None)?;
-                    rt.block_on(run_histogram_with_sink_gated(
-                        &config,
-                        &mut sink,
-                        Some(shutdown_for_thread.as_ref()),
-                        Some(Arc::clone(&stats_for_thread)),
-                        gate_ctx,
-                    ))
-                }
-                ScenarioEntry::Summary(config) => {
-                    let mut sink = create_sink(&config.sink, None)?;
-                    rt.block_on(run_summary_with_sink_gated(
-                        &config,
-                        &mut sink,
-                        Some(shutdown_for_thread.as_ref()),
-                        Some(Arc::clone(&stats_for_thread)),
-                        gate_ctx,
-                    ))
-                }
+                ScenarioEntry::Metrics(config) => run_with_sink_gated_blocking(
+                    &config,
+                    Some(shutdown_for_thread.as_ref()),
+                    Some(Arc::clone(&stats_for_thread)),
+                    upstream_bus,
+                    gate_ctx,
+                ),
+                ScenarioEntry::Logs(config) => run_logs_with_sink_gated_blocking(
+                    &config,
+                    Some(shutdown_for_thread.as_ref()),
+                    Some(Arc::clone(&stats_for_thread)),
+                    gate_ctx,
+                ),
+                ScenarioEntry::Histogram(config) => run_histogram_with_sink_gated_blocking(
+                    &config,
+                    Some(shutdown_for_thread.as_ref()),
+                    Some(Arc::clone(&stats_for_thread)),
+                    gate_ctx,
+                ),
+                ScenarioEntry::Summary(config) => run_summary_with_sink_gated_blocking(
+                    &config,
+                    Some(shutdown_for_thread.as_ref()),
+                    Some(Arc::clone(&stats_for_thread)),
+                    gate_ctx,
+                ),
             }
         })
         .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
@@ -759,13 +700,14 @@ mod tests {
     // ---- launch_scenario: returns a running handle --------------------------
 
     /// launch_scenario with a metrics entry returns a handle whose thread is alive.
-    #[test]
-    fn launch_scenario_metrics_returns_running_handle() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_scenario_metrics_returns_running_handle() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = metrics_entry_indefinite("launch_metrics");
 
         let mut handle =
             launch_scenario("test-id-1".to_string(), entry, Arc::clone(&shutdown), None)
+                .await
                 .expect("launch must succeed for valid metrics entry");
 
         // The thread must be alive immediately after launch.
@@ -786,13 +728,14 @@ mod tests {
     }
 
     /// launch_scenario with a logs entry returns a handle whose thread is alive.
-    #[test]
-    fn launch_scenario_logs_returns_running_handle() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_scenario_logs_returns_running_handle() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = logs_entry_indefinite("launch_logs");
 
         let mut handle =
             launch_scenario("test-id-2".to_string(), entry, Arc::clone(&shutdown), None)
+                .await
                 .expect("launch must succeed for valid logs entry");
 
         assert!(
@@ -810,11 +753,12 @@ mod tests {
     // ---- stop() + join() exits cleanly --------------------------------------
 
     /// stop() followed by join() on a metrics scenario exits cleanly (Ok).
-    #[test]
-    fn stop_then_join_metrics_scenario_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stop_then_join_metrics_scenario_returns_ok() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = metrics_entry_indefinite("stop_join_metrics");
         let mut handle = launch_scenario("id-stop-1".to_string(), entry, shutdown, None)
+            .await
             .expect("launch must succeed");
 
         handle.stop();
@@ -830,11 +774,12 @@ mod tests {
     }
 
     /// stop() followed by join() on a logs scenario exits cleanly (Ok).
-    #[test]
-    fn stop_then_join_logs_scenario_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stop_then_join_logs_scenario_returns_ok() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = logs_entry_indefinite("stop_join_logs");
         let mut handle = launch_scenario("id-stop-2".to_string(), entry, shutdown, None)
+            .await
             .expect("launch must succeed");
 
         handle.stop();
@@ -846,11 +791,12 @@ mod tests {
     }
 
     /// A finite-duration scenario exits on its own and join() returns Ok.
-    #[test]
-    fn finite_duration_scenario_exits_naturally_and_join_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn finite_duration_scenario_exits_naturally_and_join_returns_ok() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = metrics_entry("natural_exit");
         let mut handle = launch_scenario("id-natural".to_string(), entry, shutdown, None)
+            .await
             .expect("launch must succeed");
 
         // 200ms duration — wait for it to finish, then join.
@@ -864,8 +810,8 @@ mod tests {
     // ---- stats_snapshot(): non-zero total_events after brief run ------------
 
     /// After letting a launched scenario run briefly, stats show non-zero events.
-    #[test]
-    fn stats_snapshot_shows_nonzero_events_after_brief_run() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_shows_nonzero_events_after_brief_run() {
         use std::thread;
 
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -897,6 +843,7 @@ mod tests {
 
         let mut handle =
             launch_scenario("id-stats".to_string(), entry, Arc::clone(&shutdown), None)
+                .await
                 .expect("launch must succeed");
 
         // Wait long enough for at least a few events to be emitted and stats updated.
@@ -919,8 +866,8 @@ mod tests {
     }
 
     /// Stats are also tracked for logs scenarios.
-    #[test]
-    fn stats_snapshot_shows_nonzero_events_for_logs_scenario() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_shows_nonzero_events_for_logs_scenario() {
         use std::thread;
 
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -960,6 +907,7 @@ mod tests {
             Arc::clone(&shutdown),
             None,
         )
+        .await
         .expect("launch must succeed");
 
         thread::sleep(Duration::from_millis(200));
@@ -978,11 +926,12 @@ mod tests {
     // ---- elapsed(): positive duration after launch --------------------------
 
     /// elapsed() is positive immediately after launch.
-    #[test]
-    fn elapsed_is_positive_after_launch() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn elapsed_is_positive_after_launch() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = metrics_entry_indefinite("elapsed_test");
         let mut handle = launch_scenario("id-elapsed".to_string(), entry, shutdown, None)
+            .await
             .expect("launch must succeed");
 
         let d = handle.elapsed();
@@ -999,13 +948,14 @@ mod tests {
 
     /// launch_scenario sets the shared shutdown flag to true (SeqCst), regardless
     /// of what the caller set it to beforehand.
-    #[test]
-    fn launch_scenario_resets_shutdown_flag_to_true() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_scenario_resets_shutdown_flag_to_true() {
         // Intentionally start the flag as false to verify launch forces it true.
         let shutdown = Arc::new(AtomicBool::new(false));
         let entry = metrics_entry_indefinite("flag_reset");
 
         let mut handle = launch_scenario("id-flag".to_string(), entry, Arc::clone(&shutdown), None)
+            .await
             .expect("launch must succeed");
 
         assert!(
@@ -1020,8 +970,8 @@ mod tests {
     // ---- start_delay: None starts immediately -------------------------------
 
     /// launch_scenario with start_delay=None starts emitting events immediately.
-    #[test]
-    fn launch_with_no_start_delay_emits_events_immediately() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_with_no_start_delay_emits_events_immediately() {
         use std::thread;
 
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -1052,6 +1002,7 @@ mod tests {
 
         let mut handle =
             launch_scenario("id-nodelay".to_string(), entry, Arc::clone(&shutdown), None)
+                .await
                 .expect("launch must succeed");
 
         // Wait briefly and check events have already been emitted.
@@ -1071,8 +1022,8 @@ mod tests {
 
     /// launch_scenario with start_delay=Some(500ms) does not emit events for
     /// the first ~400ms (allowing margin for thread scheduling).
-    #[test]
-    fn launch_with_start_delay_does_not_emit_during_delay() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_with_start_delay_does_not_emit_during_delay() {
         use std::thread;
 
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -1108,6 +1059,7 @@ mod tests {
             Arc::clone(&shutdown),
             Some(delay),
         )
+        .await
         .expect("launch must succeed");
 
         // Check after 100ms — should still be in the delay period.
@@ -1136,8 +1088,8 @@ mod tests {
 
     /// Sending shutdown during start_delay causes the thread to exit cleanly
     /// without hanging.
-    #[test]
-    fn shutdown_during_start_delay_exits_cleanly() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn shutdown_during_start_delay_exits_cleanly() {
         use std::thread;
         use std::time::Instant;
 
@@ -1152,6 +1104,7 @@ mod tests {
             Arc::clone(&shutdown),
             Some(delay),
         )
+        .await
         .expect("launch must succeed");
 
         // Wait 100ms then signal shutdown.
@@ -1185,8 +1138,8 @@ mod tests {
     // ---- start_delay with logs scenario -------------------------------------
 
     /// launch_scenario with start_delay works for logs scenarios too.
-    #[test]
-    fn launch_logs_with_start_delay_does_not_emit_during_delay() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_logs_with_start_delay_does_not_emit_during_delay() {
         use std::thread;
 
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -1227,6 +1180,7 @@ mod tests {
             Arc::clone(&shutdown),
             Some(delay),
         )
+        .await
         .expect("launch must succeed");
 
         // Check during the delay.
@@ -1323,8 +1277,8 @@ mod tests {
     // ---- launch_scenario: histogram runs to completion ----------------------
 
     /// A short histogram scenario launches, runs to completion, and join returns Ok.
-    #[test]
-    fn launch_histogram_scenario_runs_to_completion() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_histogram_scenario_runs_to_completion() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = histogram_entry("launch_histogram");
         let mut handle = launch_scenario(
@@ -1333,6 +1287,7 @@ mod tests {
             Arc::clone(&shutdown),
             None,
         )
+        .await
         .expect("launch must succeed for valid histogram entry");
 
         let result = handle.join(Some(Duration::from_secs(5)));
@@ -1345,12 +1300,13 @@ mod tests {
     // ---- launch_scenario: summary runs to completion -----------------------
 
     /// A short summary scenario launches, runs to completion, and join returns Ok.
-    #[test]
-    fn launch_summary_scenario_runs_to_completion() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_summary_scenario_runs_to_completion() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = summary_entry("launch_summary");
         let mut handle =
             launch_scenario("id-summary".to_string(), entry, Arc::clone(&shutdown), None)
+                .await
                 .expect("launch must succeed for valid summary entry");
 
         let result = handle.join(Some(Duration::from_secs(5)));
@@ -1653,8 +1609,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn state_remains_pending_during_start_delay_then_transitions_to_running() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn state_remains_pending_during_start_delay_then_transitions_to_running() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = metrics_entry_indefinite("delayed_state");
         let mut handle = launch_scenario(
@@ -1663,6 +1619,7 @@ mod tests {
             Arc::clone(&shutdown),
             Some(Duration::from_millis(200)),
         )
+        .await
         .expect("launch must succeed");
 
         std::thread::sleep(Duration::from_millis(50));
@@ -1683,11 +1640,12 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_non_gated_scenario_state_transitions_through_running_to_finished() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_non_gated_scenario_state_transitions_through_running_to_finished() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = metrics_entry("state_lifecycle");
         let mut handle = launch_scenario("state-id".to_string(), entry, shutdown, None)
+            .await
             .expect("launch must succeed");
 
         let mut saw_running = false;
@@ -1862,8 +1820,8 @@ mod tests {
         })
     }
 
-    #[test]
-    fn launch_metrics_scenario_with_no_type_defaults_to_gauge() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_metrics_scenario_with_no_type_defaults_to_gauge() {
         let entry = entry_with_metric_type(None);
         let mut handle = launch_scenario(
             "id-meta-gauge".to_string(),
@@ -1871,6 +1829,7 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         let meta = handle
             .prometheus_meta
@@ -1881,8 +1840,8 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_metrics_scenario_with_step_generator_defaults_to_counter() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_metrics_scenario_with_step_generator_defaults_to_counter() {
         let entry = step_entry("step_counter");
         let mut handle = launch_scenario(
             "id-meta-step".to_string(),
@@ -1890,6 +1849,7 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         let meta = handle
             .prometheus_meta
@@ -1900,8 +1860,8 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_histogram_scenario_defaults_to_histogram() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_histogram_scenario_defaults_to_histogram() {
         let entry = histogram_entry("hist_default");
         let mut handle = launch_scenario(
             "id-meta-hist".to_string(),
@@ -1909,6 +1869,7 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         let meta = handle
             .prometheus_meta
@@ -1918,8 +1879,8 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_summary_scenario_defaults_to_summary() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_summary_scenario_defaults_to_summary() {
         let entry = summary_entry("summary_default");
         let mut handle = launch_scenario(
             "id-meta-sum".to_string(),
@@ -1927,6 +1888,7 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         let meta = handle
             .prometheus_meta
@@ -1936,8 +1898,8 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_scenario_explicit_metric_type_overrides_default() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_scenario_explicit_metric_type_overrides_default() {
         let entry = entry_with_metric_type(Some(PromMetricType::Counter));
         let mut handle = launch_scenario(
             "id-meta-explicit".to_string(),
@@ -1945,6 +1907,7 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         let meta = handle
             .prometheus_meta
@@ -1955,8 +1918,8 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_log_scenario_has_no_prometheus_meta() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_log_scenario_has_no_prometheus_meta() {
         let entry = logs_entry("log_no_meta");
         let mut handle = launch_scenario(
             "id-meta-logs".to_string(),
@@ -1964,6 +1927,7 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         assert!(
             handle.prometheus_meta.is_none(),

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -34,7 +34,7 @@ use crate::SondaError;
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run_logs(config: &LogScenarioConfig) -> Result<(), SondaError> {
-    let mut sink = create_sink(&config.sink, config.labels.as_ref())?;
+    let mut sink = create_sink(&config.sink, config.labels.as_ref()).await?;
     run_logs_with_sink(config, &mut sink, None, None).await
 }
 
@@ -77,6 +77,22 @@ pub async fn run_logs_with_sink(
 ///
 /// Logs cannot be `while:` upstreams (compile-time `NonMetricsTarget`),
 /// but they can be `while:`-gated downstreams.
+pub fn run_logs_with_sink_gated_blocking(
+    config: &LogScenarioConfig,
+    shutdown: Option<&AtomicBool>,
+    stats: Option<Arc<RwLock<ScenarioStats>>>,
+    gate_ctx: Option<GateContext>,
+) -> Result<(), SondaError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
+    rt.block_on(async {
+        let mut sink = create_sink(&config.sink, config.labels.as_ref()).await?;
+        run_logs_with_sink_gated(config, &mut sink, shutdown, stats, gate_ctx).await
+    })
+}
+
 pub async fn run_logs_with_sink_gated(
     config: &LogScenarioConfig,
     sink: &mut Box<dyn Sink>,
@@ -175,6 +191,8 @@ mod tests {
     use std::collections::{BTreeMap, HashMap};
     use std::sync::Mutex;
 
+    use async_trait::async_trait;
+
     use super::*;
     use crate::config::{BaseScheduleConfig, GapConfig, LogScenarioConfig};
     use crate::encoder::EncoderConfig;
@@ -185,15 +203,16 @@ mod tests {
 
     struct ProbeSink(SharedBuf);
 
+    #[async_trait]
     impl Sink for ProbeSink {
-        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
             self.0
                 .lock()
                 .expect("probe sink mutex poisoned")
                 .extend_from_slice(data);
             Ok(())
         }
-        fn flush(&mut self) -> Result<(), SondaError> {
+        async fn flush(&mut self) -> Result<(), SondaError> {
             Ok(())
         }
     }

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -35,33 +35,41 @@ use tokio::sync::watch;
 
 /// Run all scenarios in `entries` concurrently, one OS thread per scenario.
 /// Set `shutdown` to `false` to stop all running scenarios.
-pub fn run_multi(entries: Vec<ScenarioEntry>, shutdown: Arc<AtomicBool>) -> Result<(), SondaError> {
+pub async fn run_multi(
+    entries: Vec<ScenarioEntry>,
+    shutdown: Arc<AtomicBool>,
+) -> Result<(), SondaError> {
     // Expand, validate, and resolve phase offsets for all entries atomically.
     let prepared = prepare_entries(entries)?;
 
     let mut handles = Vec::with_capacity(prepared.len());
     let mut per_handle_shutdowns: Vec<Arc<AtomicBool>> = Vec::with_capacity(prepared.len());
+    let mut errors: Vec<String> = Vec::new();
     for (i, prepared_entry) in prepared.into_iter().enumerate() {
         let id = format!("multi-{i}");
         let scenario_shutdown = Arc::new(AtomicBool::new(true));
-        let handle = launch_scenario(
+        match launch_scenario(
             id,
             prepared_entry.entry,
             Arc::clone(&scenario_shutdown),
             prepared_entry.start_delay,
-        )?;
-        per_handle_shutdowns.push(scenario_shutdown);
-        handles.push(handle);
+        )
+        .await
+        {
+            Ok(handle) => {
+                per_handle_shutdowns.push(scenario_shutdown);
+                handles.push(handle);
+            }
+            Err(e) => errors.push(e.to_string()),
+        }
     }
 
     let done = Arc::new(AtomicBool::new(false));
     let watchdog = spawn_shutdown_watchdog(shutdown, per_handle_shutdowns, Arc::clone(&done));
 
-    let mut errors: Vec<String> = Vec::new();
     for mut handle in handles {
-        match handle.join(None) {
-            Ok(()) => {}
-            Err(e) => errors.push(e.to_string()),
+        if let Err(e) = handle.join(None) {
+            errors.push(e.to_string());
         }
     }
 
@@ -117,7 +125,7 @@ pub fn signal_shutdown(shutdown: &AtomicBool) {
 /// reference must resolve inside `file`. Each handle owns an independent
 /// shutdown flag — see [`run_multi_compiled`] for the master-stop-all path.
 #[cfg(feature = "config")]
-pub fn launch_multi_compiled(
+pub async fn launch_multi_compiled(
     file: CompiledFile,
     resolver: Option<Arc<dyn GateBusResolver>>,
 ) -> Result<Vec<crate::schedule::handle::ScenarioHandle>, SondaError> {
@@ -300,7 +308,9 @@ pub fn launch_multi_compiled(
             plan.upstream_bus,
             plan.gate_ctx,
             resolver.clone(),
-        ) {
+        )
+        .await
+        {
             Ok(handle) => {
                 if let (Some(d), Some(r)) = (deferred, resolver.as_ref()) {
                     r.insert_pending(PendingResolution {
@@ -386,8 +396,11 @@ struct ActiveSubscription {
 /// Non-gated entries launch on the existing non-gated path with no per-tick
 /// overhead.
 #[cfg(feature = "config")]
-pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Result<(), SondaError> {
-    let handles = launch_multi_compiled(file, None)?;
+pub async fn run_multi_compiled(
+    file: CompiledFile,
+    shutdown: Arc<AtomicBool>,
+) -> Result<(), SondaError> {
+    let handles = launch_multi_compiled(file, None).await?;
     let per_handle_shutdowns: Vec<Arc<AtomicBool>> =
         handles.iter().map(|h| Arc::clone(&h.shutdown)).collect();
 
@@ -530,37 +543,37 @@ mod tests {
     // Happy path: multiple scenarios complete successfully
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn run_multi_with_empty_scenarios_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_empty_scenarios_returns_ok() {
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(vec![], shutdown);
+        let result = run_multi(vec![], shutdown).await;
         assert!(result.is_ok(), "empty scenario list should return Ok");
     }
 
-    #[test]
-    fn run_multi_with_single_metrics_scenario_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_single_metrics_scenario_returns_ok() {
         let entries = vec![metrics_entry_stdout("single_metric")];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_ok(),
             "single metrics scenario should complete without error"
         );
     }
 
-    #[test]
-    fn run_multi_with_single_logs_scenario_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_single_logs_scenario_returns_ok() {
         let entries = vec![logs_entry_stdout("single_logs")];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_ok(),
             "single logs scenario should complete without error"
         );
     }
 
-    #[test]
-    fn run_multi_with_metrics_and_logs_both_complete() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_metrics_and_logs_both_complete() {
         // Two scenarios concurrently — both should run to completion within
         // their 100ms durations and return Ok.
         let entries = vec![
@@ -568,22 +581,22 @@ mod tests {
             logs_entry_stdout("concurrent_logs"),
         ];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_ok(),
             "both concurrent scenarios should complete without error"
         );
     }
 
-    #[test]
-    fn run_multi_three_concurrent_scenarios_all_complete() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_three_concurrent_scenarios_all_complete() {
         let entries = vec![
             metrics_entry_stdout("m1"),
             metrics_entry_stdout("m2"),
             logs_entry_stdout("l1"),
         ];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_ok(),
             "three concurrent scenarios should all complete without error"
@@ -594,8 +607,8 @@ mod tests {
     // Shutdown flag: setting it stops all threads
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn run_multi_shutdown_flag_stops_all_threads_within_two_seconds() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_shutdown_flag_stops_all_threads_within_two_seconds() {
         // Both scenarios have no duration (would run indefinitely). We
         // signal shutdown after a short delay and verify all threads stop
         // well within 2 seconds.
@@ -665,7 +678,7 @@ mod tests {
         });
 
         let start = Instant::now();
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "shutdown should not produce an error");
@@ -690,8 +703,8 @@ mod tests {
     // Error handling: errors from individual threads are collected
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn run_multi_with_invalid_sink_config_returns_err() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_invalid_sink_config_returns_err() {
         // A file sink pointing to a path that cannot be created will fail
         // during sink construction inside the thread.
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
@@ -721,7 +734,7 @@ mod tests {
             help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_err(),
             "scenario with an invalid sink path should return Err"
@@ -733,8 +746,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn run_multi_collects_all_thread_errors() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_collects_all_thread_errors() {
         // Two scenarios both use an invalid sink — both errors should be reported.
         let entries = vec![
             ScenarioEntry::Metrics(ScenarioConfig {
@@ -791,7 +804,7 @@ mod tests {
             }),
         ];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(result.is_err(), "two failing scenarios should return Err");
         // The combined error message should contain both errors separated by "; "
         let err_msg = result.unwrap_err().to_string();
@@ -801,8 +814,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn run_multi_thread_errors_produce_runtime_not_config_variant() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_thread_errors_produce_runtime_not_config_variant() {
         // A file sink pointing to an invalid path will fail inside the thread.
         // The collected error must be Runtime::ScenariosFailed, not Config.
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
@@ -832,7 +845,7 @@ mod tests {
             help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(result.is_err(), "invalid sink must produce an error");
         let err = result.unwrap_err();
         assert!(
@@ -849,8 +862,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     /// A scenario with a minimal phase_offset ("1ms") emits events almost immediately.
-    #[test]
-    fn run_multi_with_minimal_phase_offset_emits_almost_immediately() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_minimal_phase_offset_emits_almost_immediately() {
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "minimal_offset".to_string(),
@@ -877,7 +890,7 @@ mod tests {
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
         let start = Instant::now();
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "minimal phase_offset should complete ok");
@@ -890,8 +903,8 @@ mod tests {
     }
 
     /// `phase_offset: "0s"` is accepted and treated as no delay.
-    #[test]
-    fn run_multi_accepts_zero_phase_offset() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_accepts_zero_phase_offset() {
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "zero_offset".to_string(),
@@ -917,7 +930,7 @@ mod tests {
             help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         // "0s" is treated as no delay — parse_phase_offset returns None.
         assert!(
             result.is_ok(),
@@ -927,11 +940,11 @@ mod tests {
     }
 
     /// A scenario with no phase_offset (None) preserves existing behavior.
-    #[test]
-    fn run_multi_with_no_phase_offset_preserves_behavior() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_no_phase_offset_preserves_behavior() {
         let entries = vec![metrics_entry_stdout("no_offset")];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_ok(),
             "scenario without phase_offset should work as before"
@@ -940,8 +953,8 @@ mod tests {
 
     /// Two scenarios where the second has a 500ms phase_offset: the second
     /// starts later, so total run time is at least 500ms.
-    #[test]
-    fn run_multi_respects_phase_offset_between_scenarios() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_respects_phase_offset_between_scenarios() {
         let entries = vec![
             ScenarioEntry::Metrics(ScenarioConfig {
                 base: BaseScheduleConfig {
@@ -994,7 +1007,7 @@ mod tests {
         ];
         let shutdown = Arc::new(AtomicBool::new(true));
         let start = Instant::now();
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "phase_offset multi-scenario should succeed");
@@ -1008,8 +1021,8 @@ mod tests {
     }
 
     /// Shutdown during phase_offset delay exits all scenarios cleanly.
-    #[test]
-    fn run_multi_shutdown_during_phase_offset_exits_cleanly() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_shutdown_during_phase_offset_exits_cleanly() {
         let entries = vec![
             // First scenario runs indefinitely.
             ScenarioEntry::Metrics(ScenarioConfig {
@@ -1073,7 +1086,7 @@ mod tests {
         });
 
         let start = Instant::now();
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         let elapsed = start.elapsed();
 
         assert!(
@@ -1089,8 +1102,8 @@ mod tests {
 
     /// An invalid phase_offset string causes run_multi to return an error
     /// synchronously before spawning threads.
-    #[test]
-    fn run_multi_rejects_invalid_phase_offset() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_rejects_invalid_phase_offset() {
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "bad_offset".to_string(),
@@ -1116,7 +1129,7 @@ mod tests {
             help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_err(),
             "invalid phase_offset must cause run_multi to return Err"
@@ -1129,8 +1142,8 @@ mod tests {
     }
 
     /// Scenarios with the same clock_group and different phase_offsets both complete.
-    #[test]
-    fn run_multi_with_clock_group_and_offsets() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_clock_group_and_offsets() {
         let entries = vec![
             ScenarioEntry::Metrics(ScenarioConfig {
                 base: BaseScheduleConfig {
@@ -1182,7 +1195,7 @@ mod tests {
             }),
         ];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_ok(),
             "scenarios with clock_group and offsets should complete"
@@ -1250,8 +1263,8 @@ scenarios:
     }
 
     #[cfg(feature = "config")]
-    #[test]
-    fn launch_multi_compiled_partial_cleanup_stops_already_launched_handles() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_multi_compiled_partial_cleanup_stops_already_launched_handles() {
         use crate::compile_scenario_file_compiled;
         use crate::compiler::expand::InMemoryPackResolver;
 
@@ -1283,7 +1296,9 @@ scenarios:
         let compiled =
             compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
 
-        let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+        let mut handles = launch_multi_compiled(compiled, None)
+            .await
+            .expect("launch must succeed");
         assert_eq!(handles.len(), 2, "must launch both entries");
         assert!(
             handles.iter().all(|h| h.is_alive()),
@@ -1523,8 +1538,8 @@ scenarios:
             }
         }
 
-        #[test]
-        fn t8_downstream_enters_unresolved_then_promoted_on_register_and_sweep() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t8_downstream_enters_unresolved_then_promoted_on_register_and_sweep() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1535,6 +1550,7 @@ scenarios:
             .expect("compile downstream");
 
             let handles = launch_multi_compiled(compiled, Some(Arc::clone(&resolver)))
+                .await
                 .expect("launch downstream");
             assert_eq!(handles.len(), 1);
             wait_for_state(
@@ -1556,8 +1572,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t9_downstream_first_then_upstream_post_promotes_via_sweep() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t9_downstream_first_then_upstream_post_promotes_via_sweep() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1568,6 +1584,7 @@ scenarios:
             .expect("compile downstream");
 
             let downstream_handles = launch_multi_compiled(downstream, Some(Arc::clone(&resolver)))
+                .await
                 .expect("launch downstream");
             wait_for_state(
                 &downstream_handles[0],
@@ -1579,6 +1596,7 @@ scenarios:
                 compile_scenario_file_compiled(&upstream_yaml(), &InMemoryPackResolver::new())
                     .expect("compile upstream");
             let upstream_handles = launch_multi_compiled(upstream, Some(Arc::clone(&resolver)))
+                .await
                 .expect("launch upstream");
             wait_for_state(
                 &downstream_handles[0],
@@ -1594,8 +1612,8 @@ scenarios:
         // upstream with the same scenario_name) requires the registry to push affected
         // downstreams back into `pending` on unregister — that mechanism lives with the
         // production `GateBusRegistry` implementation, not the test resolver.
-        #[test]
-        fn t10_unregister_drives_downstream_back_to_unresolved() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t10_unregister_drives_downstream_back_to_unresolved() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1603,6 +1621,7 @@ scenarios:
                 compile_scenario_file_compiled(&upstream_yaml(), &InMemoryPackResolver::new())
                     .expect("compile upstream");
             let upstream_handles = launch_multi_compiled(upstream, Some(Arc::clone(&resolver)))
+                .await
                 .expect("launch upstream");
 
             let downstream = compile_scenario_file_compiled(
@@ -1611,6 +1630,7 @@ scenarios:
             )
             .expect("compile downstream");
             let downstream_handles = launch_multi_compiled(downstream, Some(Arc::clone(&resolver)))
+                .await
                 .expect("launch downstream");
             wait_for_state(
                 &downstream_handles[0],
@@ -1644,8 +1664,8 @@ scenarios:
             stop_and_join(downstream_handles);
         }
 
-        #[test]
-        fn t11_if_unresolved_open_ticks_at_full_rate() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t11_if_unresolved_open_ticks_at_full_rate() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1654,8 +1674,9 @@ scenarios:
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let handles =
-                launch_multi_compiled(compiled, Some(Arc::clone(&resolver))).expect("launch");
+            let handles = launch_multi_compiled(compiled, Some(Arc::clone(&resolver)))
+                .await
+                .expect("launch");
             wait_for_state(
                 &handles[0],
                 ScenarioState::Unresolved,
@@ -1674,8 +1695,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t11b_if_unresolved_open_transitions_to_running_on_upstream_register() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t11b_if_unresolved_open_transitions_to_running_on_upstream_register() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1684,8 +1705,9 @@ scenarios:
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let handles =
-                launch_multi_compiled(compiled, Some(Arc::clone(&resolver))).expect("launch");
+            let handles = launch_multi_compiled(compiled, Some(Arc::clone(&resolver)))
+                .await
+                .expect("launch");
             wait_for_state(
                 &handles[0],
                 ScenarioState::Unresolved,
@@ -1721,8 +1743,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t12_if_unresolved_closed_does_not_emit() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t12_if_unresolved_closed_does_not_emit() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1731,8 +1753,9 @@ scenarios:
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let handles =
-                launch_multi_compiled(compiled, Some(Arc::clone(&resolver))).expect("launch");
+            let handles = launch_multi_compiled(compiled, Some(Arc::clone(&resolver)))
+                .await
+                .expect("launch");
             wait_for_state(
                 &handles[0],
                 ScenarioState::Unresolved,
@@ -1750,8 +1773,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t13_if_unresolved_pending_does_not_emit_and_holds_state() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t13_if_unresolved_pending_does_not_emit_and_holds_state() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1760,8 +1783,9 @@ scenarios:
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let handles =
-                launch_multi_compiled(compiled, Some(Arc::clone(&resolver))).expect("launch");
+            let handles = launch_multi_compiled(compiled, Some(Arc::clone(&resolver)))
+                .await
+                .expect("launch");
             wait_for_state(
                 &handles[0],
                 ScenarioState::Unresolved,
@@ -1777,8 +1801,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t_regress_2_local_only_while_path_unchanged() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t_regress_2_local_only_while_path_unchanged() {
             let yaml = r#"
 version: 2
 kind: runnable
@@ -1809,7 +1833,7 @@ scenarios:
 "#;
             let compiled = compile_scenario_file_compiled(yaml, &InMemoryPackResolver::new())
                 .expect("compile local-only");
-            let mut handles = launch_multi_compiled(compiled, None).expect("launch");
+            let mut handles = launch_multi_compiled(compiled, None).await.expect("launch");
             assert_eq!(handles.len(), 2);
             for h in &mut handles {
                 let _ = h.join(Some(Duration::from_secs(2)));
@@ -1818,8 +1842,8 @@ scenarios:
     }
 
     #[cfg(feature = "config")]
-    #[test]
-    fn launch_multi_compiled_gives_each_handle_an_independent_shutdown_flag() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_multi_compiled_gives_each_handle_an_independent_shutdown_flag() {
         use crate::compile_scenario_file_compiled;
         use crate::compiler::expand::InMemoryPackResolver;
 
@@ -1857,7 +1881,9 @@ scenarios:
         let compiled =
             compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
 
-        let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+        let mut handles = launch_multi_compiled(compiled, None)
+            .await
+            .expect("launch must succeed");
         assert_eq!(handles.len(), 3, "must launch all three entries");
 
         for i in 0..handles.len() {

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -37,7 +37,7 @@ use crate::SondaError;
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run(config: &ScenarioConfig) -> Result<(), SondaError> {
-    let mut sink = create_sink(&config.sink, None)?;
+    let mut sink = create_sink(&config.sink, None).await?;
     run_with_sink(config, &mut sink, None, None).await
 }
 
@@ -83,6 +83,23 @@ pub async fn run_with_sink(
 /// gates to subscribe to). `gate_ctx` is what THIS scenario consumes from
 /// an upstream bus. Both are independent — a scenario can be both an
 /// upstream (publishing) and a downstream (gated).
+pub fn run_with_sink_gated_blocking(
+    config: &ScenarioConfig,
+    shutdown: Option<&AtomicBool>,
+    stats: Option<Arc<RwLock<ScenarioStats>>>,
+    upstream_bus: Option<Arc<GateBus>>,
+    gate_ctx: Option<GateContext>,
+) -> Result<(), SondaError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
+    rt.block_on(async {
+        let mut sink = create_sink(&config.sink, None).await?;
+        run_with_sink_gated(config, &mut sink, shutdown, stats, upstream_bus, gate_ctx).await
+    })
+}
+
 pub async fn run_with_sink_gated(
     config: &ScenarioConfig,
     sink: &mut Box<dyn Sink>,
@@ -295,6 +312,8 @@ fn is_remote_write_sink(_sink: &SinkConfig) -> bool {
 mod tests {
     use std::sync::Mutex;
 
+    use async_trait::async_trait;
+
     use crate::config::{BaseScheduleConfig, GapConfig, ScenarioConfig};
     use crate::encoder::EncoderConfig;
     use crate::generator::GeneratorConfig;
@@ -305,15 +324,16 @@ mod tests {
 
     struct ProbeSink(SharedBuf);
 
+    #[async_trait]
     impl Sink for ProbeSink {
-        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
             self.0
                 .lock()
                 .expect("probe sink mutex poisoned")
                 .extend_from_slice(data);
             Ok(())
         }
-        fn flush(&mut self) -> Result<(), SondaError> {
+        async fn flush(&mut self) -> Result<(), SondaError> {
             Ok(())
         }
     }
@@ -1308,7 +1328,7 @@ mod tests {
         }
     }
 
-    fn drain_emit_to_memory(
+    async fn drain_emit_to_memory(
         emit: &mut crate::schedule::core_loop::CloseEmitFn,
         dest: &mut crate::sink::memory::MemorySink,
     ) {
@@ -1318,16 +1338,20 @@ mod tests {
         emit(&mut output).expect("close-emit must succeed");
         for cmd in output.writes.drain(..) {
             match cmd {
-                WriteCommand::Bytes(buf) => SinkTrait::write(dest, &buf).expect("memory write ok"),
+                WriteCommand::Bytes(buf) => {
+                    SinkTrait::write(dest, &buf).await.expect("memory write ok")
+                }
                 WriteCommand::LogEvent { event, bytes } => {
-                    SinkTrait::write_log_event(dest, &event, &bytes).expect("memory log write ok")
+                    SinkTrait::write_log_event(dest, &event, &bytes)
+                        .await
+                        .expect("memory log write ok")
                 }
             }
         }
     }
 
-    #[test]
-    fn close_emitter_is_idempotent_after_draining_series() {
+    #[tokio::test]
+    async fn close_emitter_is_idempotent_after_draining_series() {
         use crate::encoder::create_encoder;
         use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
         use crate::schedule::core_loop::CloseSignal;
@@ -1355,7 +1379,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut first = MemorySink::new();
-        drain_emit_to_memory(&mut emit, &mut first);
+        drain_emit_to_memory(&mut emit, &mut first).await;
         assert!(
             !first.buffer.is_empty(),
             "first invocation must emit the tracked series"
@@ -1373,15 +1397,15 @@ mod tests {
         }
 
         let mut second = MemorySink::new();
-        drain_emit_to_memory(&mut emit, &mut second);
+        drain_emit_to_memory(&mut emit, &mut second).await;
         assert!(
             second.buffer.is_empty(),
             "second invocation with no new series must emit nothing"
         );
     }
 
-    #[test]
-    fn close_emit_timestamp_strictly_after_recent_active_emissions() {
+    #[tokio::test]
+    async fn close_emit_timestamp_strictly_after_recent_active_emissions() {
         use crate::encoder::create_encoder;
         use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
         use crate::schedule::core_loop::CloseSignal;
@@ -1413,7 +1437,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut sink = MemorySink::new();
-        drain_emit_to_memory(&mut emit, &mut sink);
+        drain_emit_to_memory(&mut emit, &mut sink).await;
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().filter(|l| !l.is_empty()).collect();
@@ -1441,8 +1465,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn close_emit_emits_every_distinct_series_regardless_of_count() {
+    #[tokio::test]
+    async fn close_emit_emits_every_distinct_series_regardless_of_count() {
         use crate::encoder::create_encoder;
         use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
         use crate::schedule::core_loop::CloseSignal;
@@ -1474,15 +1498,15 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut sink = MemorySink::new();
-        drain_emit_to_memory(&mut emit, &mut sink);
+        drain_emit_to_memory(&mut emit, &mut sink).await;
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines = output.lines().filter(|l| !l.is_empty()).count();
         assert_eq!(lines, series_count);
     }
 
-    #[test]
-    fn close_emit_dedups_repeated_series_to_one_marker() {
+    #[tokio::test]
+    async fn close_emit_dedups_repeated_series_to_one_marker() {
         use crate::encoder::create_encoder;
         use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
         use crate::schedule::core_loop::CloseSignal;
@@ -1512,7 +1536,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut sink = MemorySink::new();
-        drain_emit_to_memory(&mut emit, &mut sink);
+        drain_emit_to_memory(&mut emit, &mut sink).await;
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines = output.lines().filter(|l| !l.is_empty()).count();

--- a/sonda-core/src/schedule/summary_runner.rs
+++ b/sonda-core/src/schedule/summary_runner.rs
@@ -41,7 +41,7 @@ use crate::SondaError;
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run(config: &SummaryScenarioConfig) -> Result<(), SondaError> {
-    let mut sink = create_sink(&config.sink, None)?;
+    let mut sink = create_sink(&config.sink, None).await?;
     run_with_sink(config, &mut sink, None, None).await
 }
 
@@ -75,6 +75,22 @@ pub async fn run_with_sink(
 ///
 /// Summaries cannot be `while:` upstreams (compile-time
 /// `NonMetricsTarget`), but they can be `while:`-gated downstreams.
+pub fn run_with_sink_gated_blocking(
+    config: &SummaryScenarioConfig,
+    shutdown: Option<&AtomicBool>,
+    stats: Option<Arc<RwLock<ScenarioStats>>>,
+    gate_ctx: Option<GateContext>,
+) -> Result<(), SondaError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
+    rt.block_on(async {
+        let mut sink = create_sink(&config.sink, None).await?;
+        run_with_sink_gated(config, &mut sink, shutdown, stats, gate_ctx).await
+    })
+}
+
 pub async fn run_with_sink_gated(
     config: &SummaryScenarioConfig,
     sink: &mut Box<dyn Sink>,
@@ -268,6 +284,8 @@ pub async fn run_with_sink_gated(
 mod tests {
     use std::sync::Mutex;
 
+    use async_trait::async_trait;
+
     use crate::config::{BaseScheduleConfig, DistributionConfig, SummaryScenarioConfig};
     use crate::encoder::EncoderConfig;
     use crate::sink::{Sink, SinkConfig};
@@ -277,15 +295,16 @@ mod tests {
 
     struct ProbeSink(SharedBuf);
 
+    #[async_trait]
     impl Sink for ProbeSink {
-        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
             self.0
                 .lock()
                 .expect("probe sink mutex poisoned")
                 .extend_from_slice(data);
             Ok(())
         }
-        fn flush(&mut self) -> Result<(), SondaError> {
+        async fn flush(&mut self) -> Result<(), SondaError> {
             Ok(())
         }
     }

--- a/sonda-core/src/sink/channel.rs
+++ b/sonda-core/src/sink/channel.rs
@@ -8,6 +8,8 @@
 
 use std::sync::mpsc::SyncSender;
 
+use async_trait::async_trait;
+
 use crate::sink::Sink;
 use crate::SondaError;
 
@@ -26,50 +28,37 @@ use crate::SondaError;
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,no_run
 /// use std::sync::mpsc;
 /// use sonda_core::sink::{Sink, channel::ChannelSink};
 ///
+/// # async fn doc() {
 /// let (tx, rx) = mpsc::sync_channel(10);
 /// let mut sink = ChannelSink::new(tx);
-/// sink.write(b"hello\n").unwrap();
+/// sink.write(b"hello\n").await.unwrap();
 /// let data = rx.recv().unwrap();
 /// assert_eq!(data, b"hello\n");
+/// # }
 /// ```
 pub struct ChannelSink {
     tx: SyncSender<Vec<u8>>,
 }
 
 impl ChannelSink {
-    /// Create a new `ChannelSink` that sends encoded data over `tx`.
-    ///
-    /// The backing channel must be created with [`mpsc::sync_channel`](std::sync::mpsc::sync_channel)
-    /// to enforce bounded capacity.
     pub fn new(tx: SyncSender<Vec<u8>>) -> Self {
         Self { tx }
     }
 }
 
+#[async_trait]
 impl Sink for ChannelSink {
-    /// Send a copy of `data` over the channel.
-    ///
-    /// Blocks when the channel is at capacity until the receiver drains a slot.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if the receiver has been dropped and the
-    /// channel is disconnected.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.tx
             .send(data.to_vec())
             .map_err(|e| SondaError::Sink(std::io::Error::other(e.to_string())))
     }
 
-    /// No-op flush: channel delivery is synchronous per `send` call.
-    ///
-    /// Returns `Ok(())` unconditionally because the channel has no internal
-    /// buffer beyond what the receiver has not yet consumed.
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
 }
@@ -83,90 +72,73 @@ mod tests {
     use super::*;
     use crate::sink::Sink;
 
-    // -----------------------------------------------------------------------
-    // Happy path: write and receive
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn write_sends_exact_bytes_to_receiver() {
+    #[tokio::test]
+    async fn write_sends_exact_bytes_to_receiver() {
         let (tx, rx) = mpsc::sync_channel(10);
         let mut sink = ChannelSink::new(tx);
-        sink.write(b"hello\n").unwrap();
+        sink.write(b"hello\n").await.unwrap();
         let received = rx.recv().expect("receiver should get data");
         assert_eq!(received, b"hello\n");
     }
 
-    #[test]
-    fn write_empty_slice_sends_empty_vec() {
+    #[tokio::test]
+    async fn write_empty_slice_sends_empty_vec() {
         let (tx, rx) = mpsc::sync_channel(10);
         let mut sink = ChannelSink::new(tx);
-        sink.write(b"").unwrap();
+        sink.write(b"").await.unwrap();
         let received = rx.recv().expect("receiver should get empty vec");
         assert!(received.is_empty());
     }
 
-    #[test]
-    fn multiple_writes_send_in_order() {
+    #[tokio::test]
+    async fn multiple_writes_send_in_order() {
         let (tx, rx) = mpsc::sync_channel(10);
         let mut sink = ChannelSink::new(tx);
-        sink.write(b"first\n").unwrap();
-        sink.write(b"second\n").unwrap();
-        sink.write(b"third\n").unwrap();
+        sink.write(b"first\n").await.unwrap();
+        sink.write(b"second\n").await.unwrap();
+        sink.write(b"third\n").await.unwrap();
 
         assert_eq!(rx.recv().unwrap(), b"first\n");
         assert_eq!(rx.recv().unwrap(), b"second\n");
         assert_eq!(rx.recv().unwrap(), b"third\n");
     }
 
-    #[test]
-    fn flush_always_returns_ok() {
+    #[tokio::test]
+    async fn flush_always_returns_ok() {
         let (tx, _rx) = mpsc::sync_channel(10);
         let mut sink = ChannelSink::new(tx);
-        assert!(sink.flush().is_ok());
+        assert!(sink.flush().await.is_ok());
     }
 
-    #[test]
-    fn flush_does_not_affect_channel_contents() {
+    #[tokio::test]
+    async fn flush_does_not_affect_channel_contents() {
         let (tx, rx) = mpsc::sync_channel(10);
         let mut sink = ChannelSink::new(tx);
-        sink.write(b"data").unwrap();
-        sink.flush().unwrap();
+        sink.write(b"data").await.unwrap();
+        sink.flush().await.unwrap();
         let received = rx.recv().unwrap();
         assert_eq!(received, b"data");
     }
 
-    // -----------------------------------------------------------------------
-    // Error case: disconnected receiver returns Err
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn write_after_receiver_dropped_returns_err() {
+    #[tokio::test]
+    async fn write_after_receiver_dropped_returns_err() {
         let (tx, rx) = mpsc::sync_channel::<Vec<u8>>(10);
         let mut sink = ChannelSink::new(tx);
-        // Drop the receiver — channel is now disconnected.
         drop(rx);
-        let result = sink.write(b"orphaned");
+        let result = sink.write(b"orphaned").await;
         assert!(
             result.is_err(),
             "write to disconnected channel should return Err"
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Backpressure: bounded(10), fast writes block once channel is full
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn bounded_channel_provides_backpressure_without_oom() {
-        // Channel capacity = 10. We write 20 items. The receiver drains slowly.
-        // This verifies that the producer blocks (backpressure) rather than
-        // allocating unbounded memory.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn bounded_channel_provides_backpressure_without_oom() {
         let capacity = 10usize;
         let total_writes = 20usize;
         let (tx, rx) = mpsc::sync_channel(capacity);
         let mut sink = ChannelSink::new(tx);
 
-        // Spawn a slow receiver that drains one item every 5ms.
         let receiver_handle = thread::spawn(move || {
             let mut count = 0usize;
             while count < total_writes {
@@ -178,11 +150,11 @@ mod tests {
             count
         });
 
-        // Write all 20 items. The 11th write will block until the receiver
-        // drains a slot. This must not panic or OOM — it should just block.
         for i in 0..total_writes {
             let data = format!("item-{i}\n");
-            sink.write(data.as_bytes()).expect("write should succeed");
+            sink.write(data.as_bytes())
+                .await
+                .expect("write should succeed");
         }
 
         let received_count = receiver_handle
@@ -194,25 +166,20 @@ mod tests {
         );
     }
 
-    #[test]
-    fn channel_sink_write_count_matches_receive_count() {
+    #[tokio::test]
+    async fn channel_sink_write_count_matches_receive_count() {
         let (tx, rx) = mpsc::sync_channel(100);
         let mut sink = ChannelSink::new(tx);
 
         let n = 50usize;
         for i in 0..n {
-            sink.write(format!("line {i}").as_bytes()).unwrap();
+            sink.write(format!("line {i}").as_bytes()).await.unwrap();
         }
-        // Drop the sink to close the channel so the iterator terminates.
         drop(sink);
 
         let count = rx.into_iter().count();
         assert_eq!(count, n, "should receive exactly {n} items");
     }
-
-    // -----------------------------------------------------------------------
-    // Contract: Send + Sync
-    // -----------------------------------------------------------------------
 
     #[test]
     fn channel_sink_is_send() {
@@ -226,12 +193,12 @@ mod tests {
         assert_sync::<ChannelSink>();
     }
 
-    #[test]
-    fn channel_sink_usable_as_boxed_sink_trait_object() {
+    #[tokio::test]
+    async fn channel_sink_usable_as_boxed_sink_trait_object() {
         let (tx, rx) = mpsc::sync_channel(10);
         let mut sink: Box<dyn Sink> = Box::new(ChannelSink::new(tx));
-        sink.write(b"trait object test").unwrap();
-        sink.flush().unwrap();
+        sink.write(b"trait object test").await.unwrap();
+        sink.flush().await.unwrap();
         let data = rx.recv().unwrap();
         assert_eq!(data, b"trait object test");
     }

--- a/sonda-core/src/sink/file.rs
+++ b/sonda-core/src/sink/file.rs
@@ -1,34 +1,26 @@
 //! File sink — writes encoded telemetry to a file on disk.
 
-use std::fs::{self, File};
-use std::io::{BufWriter, Write};
 use std::path::Path;
+
+use async_trait::async_trait;
+use tokio::fs::{self, File};
+use tokio::io::{AsyncWriteExt, BufWriter};
 
 use super::Sink;
 use crate::SondaError;
 
 /// A sink that writes encoded event data to a file using a buffered writer.
-///
-/// Parent directories are created automatically if they do not exist.
-/// Wraps the underlying [`File`] in a [`BufWriter`] to batch syscalls and
-/// reduce per-event overhead.
 pub struct FileSink {
     writer: BufWriter<File>,
 }
 
 impl FileSink {
-    /// Create a new `FileSink` writing to the given path.
-    ///
-    /// Creates any missing parent directories before opening the file.
-    ///
-    /// # Errors
-    ///
-    /// Returns `SondaError::Sink` if the parent directories cannot be created
-    /// or the file cannot be opened for writing.
-    pub fn new(path: &Path) -> Result<Self, SondaError> {
+    /// Open `path` for writing, creating any missing parent directories.
+    pub async fn new(path: &Path) -> Result<Self, SondaError> {
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() {
                 fs::create_dir_all(parent)
+                    .await
                     .map_err(|e| {
                         std::io::Error::new(
                             e.kind(),
@@ -44,6 +36,7 @@ impl FileSink {
         }
 
         let file = File::create(path)
+            .await
             .map_err(|e| {
                 std::io::Error::new(
                     e.kind(),
@@ -58,16 +51,18 @@ impl FileSink {
     }
 }
 
+#[async_trait]
 impl Sink for FileSink {
-    /// Write `data` to the buffered file writer.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
-        self.writer.write_all(data).map_err(SondaError::Sink)?;
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        self.writer
+            .write_all(data)
+            .await
+            .map_err(SondaError::Sink)?;
         Ok(())
     }
 
-    /// Flush any buffered bytes to the file.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.writer.flush().map_err(SondaError::Sink)?;
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        self.writer.flush().await.map_err(SondaError::Sink)?;
         Ok(())
     }
 }
@@ -78,44 +73,47 @@ mod tests {
 
     use super::*;
 
-    // ---- Happy path: write → read back ----------------------------------------
-
-    #[test]
-    fn write_to_temp_file_and_read_back_matches() {
+    #[tokio::test]
+    async fn write_to_temp_file_and_read_back_matches() {
         let dir = tempfile::tempdir().expect("create tempdir");
         let path = dir.path().join("out.txt");
 
-        let mut sink = FileSink::new(&path).expect("should open file");
-        sink.write(b"hello, sonda\n").expect("write should succeed");
-        sink.flush().expect("flush should succeed");
+        let mut sink = FileSink::new(&path).await.expect("should open file");
+        sink.write(b"hello, sonda\n")
+            .await
+            .expect("write should succeed");
+        sink.flush().await.expect("flush should succeed");
+        drop(sink);
 
         let content = fs::read(&path).expect("should read file back");
         assert_eq!(content, b"hello, sonda\n");
     }
 
-    #[test]
-    fn multiple_writes_accumulate_in_file() {
+    #[tokio::test]
+    async fn multiple_writes_accumulate_in_file() {
         let dir = tempfile::tempdir().expect("create tempdir");
         let path = dir.path().join("multi.txt");
 
-        let mut sink = FileSink::new(&path).expect("should open file");
-        sink.write(b"line1\n").expect("write 1");
-        sink.write(b"line2\n").expect("write 2");
-        sink.write(b"line3\n").expect("write 3");
-        sink.flush().expect("flush");
+        let mut sink = FileSink::new(&path).await.expect("should open file");
+        sink.write(b"line1\n").await.expect("write 1");
+        sink.write(b"line2\n").await.expect("write 2");
+        sink.write(b"line3\n").await.expect("write 3");
+        sink.flush().await.expect("flush");
+        drop(sink);
 
         let content = fs::read(&path).expect("should read file back");
         assert_eq!(content, b"line1\nline2\nline3\n");
     }
 
-    #[test]
-    fn write_empty_slice_succeeds_and_file_is_empty() {
+    #[tokio::test]
+    async fn write_empty_slice_succeeds_and_file_is_empty() {
         let dir = tempfile::tempdir().expect("create tempdir");
         let path = dir.path().join("empty.txt");
 
-        let mut sink = FileSink::new(&path).expect("should open file");
-        sink.write(b"").expect("empty write should succeed");
-        sink.flush().expect("flush should succeed");
+        let mut sink = FileSink::new(&path).await.expect("should open file");
+        sink.write(b"").await.expect("empty write should succeed");
+        sink.flush().await.expect("flush should succeed");
+        drop(sink);
 
         let content = fs::read(&path).expect("should read file back");
         assert!(
@@ -124,101 +122,89 @@ mod tests {
         );
     }
 
-    // ---- Parent directory creation --------------------------------------------
-
-    #[test]
-    fn parent_dirs_created_automatically_for_nested_path() {
+    #[tokio::test]
+    async fn parent_dirs_created_automatically_for_nested_path() {
         let base = tempfile::tempdir().expect("create tempdir");
-        // Three levels of directories that do not yet exist.
         let path = base.path().join("a").join("b").join("c").join("out.txt");
 
-        let mut sink = FileSink::new(&path).expect("should create parent dirs and open file");
-        sink.write(b"nested\n").expect("write should succeed");
-        sink.flush().expect("flush should succeed");
+        let mut sink = FileSink::new(&path)
+            .await
+            .expect("should create parent dirs and open file");
+        sink.write(b"nested\n").await.expect("write should succeed");
+        sink.flush().await.expect("flush should succeed");
+        drop(sink);
 
         assert!(path.exists(), "file should exist after write");
         let content = fs::read(&path).expect("should read file back");
         assert_eq!(content, b"nested\n");
     }
 
-    #[test]
-    fn parent_dir_creation_matches_spec_path_pattern() {
-        // Spec criterion: write to <tmp>/subdir/out.txt → dirs created.
+    #[tokio::test]
+    async fn parent_dir_creation_matches_spec_path_pattern() {
         let base = tempfile::tempdir().expect("create tempdir");
         let path = base.path().join("subdir").join("out.txt");
 
-        let mut sink = FileSink::new(&path).expect("should create parent dirs");
-        sink.write(b"spec path\n").expect("write");
-        sink.flush().expect("flush");
+        let mut sink = FileSink::new(&path)
+            .await
+            .expect("should create parent dirs");
+        sink.write(b"spec path\n").await.expect("write");
+        sink.flush().await.expect("flush");
+        drop(sink);
 
         assert!(path.exists(), "file must exist at spec-style path");
     }
 
-    // ---- Flush on drop: data appears in file after sink is dropped -----------
-
-    #[test]
-    fn flush_on_drop_data_visible_after_sink_dropped() {
+    #[tokio::test]
+    async fn flush_then_drop_persists_data() {
         let dir = tempfile::tempdir().expect("create tempdir");
         let path = dir.path().join("drop.txt");
 
         {
-            let mut sink = FileSink::new(&path).expect("should open file");
-            // Write but do NOT call flush() explicitly.
+            let mut sink = FileSink::new(&path).await.expect("should open file");
             sink.write(b"buffered data\n")
+                .await
                 .expect("write should succeed");
-            // sink is dropped here — BufWriter::drop calls flush automatically.
+            sink.flush().await.expect("flush before drop");
         }
 
         let content = fs::read(&path).expect("file must be readable after drop");
-        assert_eq!(
-            content, b"buffered data\n",
-            "BufWriter must flush on drop — data must appear in file"
-        );
+        assert_eq!(content, b"buffered data\n");
     }
 
-    // ---- Error path: permission / invalid path → SondaError::Sink -----------
-
     #[cfg(unix)]
-    #[test]
-    fn write_to_readonly_dir_returns_sink_error_with_path_in_message() {
+    #[tokio::test]
+    async fn write_to_readonly_dir_returns_sink_error_with_path_in_message() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().expect("create tempdir");
-        // Make the directory read-only so we cannot create files inside it.
         fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o555)).unwrap();
 
         let path = dir.path().join("denied.txt");
-        let result = FileSink::new(&path);
+        let result = FileSink::new(&path).await;
         assert!(result.is_err(), "should fail on read-only dir");
         let err = result.err().unwrap();
 
-        // Must be a Sink variant.
         assert!(
             matches!(err, SondaError::Sink(_)),
             "expected SondaError::Sink, got: {err:?}"
         );
-        // Error message must mention the file path.
         let msg = err.to_string();
         assert!(
             msg.contains("denied.txt") || msg.contains(dir.path().to_str().unwrap()),
             "error message should contain the path, got: {msg}"
         );
 
-        // Restore permissions so TempDir cleanup on drop can remove the directory.
         let _ = fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755));
     }
 
-    #[test]
-    fn write_to_path_under_nonexistent_root_with_no_create_perm_returns_err() {
-        // Use a clearly invalid path: a file whose "parent" is itself a file.
+    #[tokio::test]
+    async fn write_to_path_under_nonexistent_root_with_no_create_perm_returns_err() {
         let dir = tempfile::tempdir().expect("create tempdir");
-        // Create a regular file inside the tempdir.
         let blocker = dir.path().join("file.txt");
         fs::write(&blocker, b"I am a file").unwrap();
-        // Try to use that file as a directory.
         let path = blocker.join("child.txt");
 
-        let result = FileSink::new(&path);
+        let result = FileSink::new(&path).await;
         assert!(
             result.is_err(),
             "opening a path whose parent is a regular file must fail"
@@ -230,18 +216,14 @@ mod tests {
         );
     }
 
-    // ---- Trait contract: Send + Sync ----------------------------------------
-
     #[test]
     fn file_sink_is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<FileSink>();
     }
 
-    // ---- Factory wiring: SinkConfig::File → FileSink ------------------------
-
-    #[test]
-    fn create_sink_file_config_creates_file_at_path() {
+    #[tokio::test]
+    async fn create_sink_file_config_creates_file_at_path() {
         use crate::sink::create_sink;
         use crate::sink::SinkConfig;
 
@@ -251,9 +233,14 @@ mod tests {
         let config = SinkConfig::File {
             path: path.to_str().unwrap().to_string(),
         };
-        let mut sink = create_sink(&config, None).expect("factory should create FileSink");
-        sink.write(b"via factory\n").expect("write should succeed");
-        sink.flush().expect("flush should succeed");
+        let mut sink = create_sink(&config, None)
+            .await
+            .expect("factory should create FileSink");
+        sink.write(b"via factory\n")
+            .await
+            .expect("write should succeed");
+        sink.flush().await.expect("flush should succeed");
+        drop(sink);
 
         let content = fs::read(&path).expect("file should exist");
         assert_eq!(content, b"via factory\n");
@@ -279,7 +266,6 @@ mod tests {
     fn sink_config_file_deserializes_from_inline_yaml() {
         use crate::sink::SinkConfig;
 
-        // Inline mapping form with `type` field.
         let yaml = "{type: file, path: /tmp/inline.txt}";
         let config: SinkConfig = serde_yaml_ng::from_str(yaml).expect("should deserialize inline");
         match config {

--- a/sonda-core/src/sink/http.rs
+++ b/sonda-core/src/sink/http.rs
@@ -7,9 +7,11 @@
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
+
 use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
-use crate::SondaError;
+use crate::{RuntimeError, SondaError};
 
 /// Default batch size in bytes (4 KiB) — sized so low-rate scenarios flush within seconds.
 pub const DEFAULT_BATCH_SIZE: usize = 4 * 1024;
@@ -105,58 +107,6 @@ impl HttpPushSink {
         })
     }
 
-    /// Send the current batch to the configured endpoint.
-    ///
-    /// - 2xx responses are treated as success.
-    /// - 4xx (except 429) responses are logged as warnings and discarded (not
-    ///   retried — client-side errors should not block metric generation).
-    /// - 5xx, 429, and transport errors are retried according to the
-    ///   configured [`RetryPolicy`]. When no policy is configured, errors are
-    ///   returned immediately.
-    /// - The batch is always cleared (on success or failure) to prevent
-    ///   unbounded buffer growth.
-    fn send_batch(&mut self) -> Result<(), SondaError> {
-        if self.batch.is_empty() {
-            return Ok(());
-        }
-
-        // Reset on attempt, not success — the batch is cleared either way below.
-        self.last_flush_at = Instant::now();
-
-        let result = match &self.retry_policy {
-            Some(policy) => {
-                let policy = policy.clone();
-                let client = &self.client;
-                let url = &self.url;
-                let content_type = &self.content_type;
-                let headers = &self.headers;
-                let batch = &self.batch;
-                policy.execute(
-                    || Self::do_post_checked(client, url, content_type, headers, batch),
-                    Self::is_retryable,
-                )
-            }
-            None => {
-                let client = &self.client;
-                let url = &self.url;
-                let content_type = &self.content_type;
-                let headers = &self.headers;
-                Self::do_post_checked(client, url, content_type, headers, &self.batch)
-            }
-        };
-
-        self.batch.clear();
-
-        // 4xx errors (except 429) are non-retryable and treated as warn-and-discard.
-        // The batch is already cleared; suppress the error so the sink continues.
-        match &result {
-            Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
-                Ok(())
-            }
-            _ => result,
-        }
-    }
-
     /// Classify whether an error from `do_post_checked` is retryable.
     ///
     /// Transport errors and 5xx/429 HTTP errors are retryable. 4xx errors
@@ -242,35 +192,83 @@ impl HttpPushSink {
     }
 }
 
+#[async_trait]
 impl Sink for HttpPushSink {
-    /// Append encoded event data to the internal batch buffer.
-    ///
-    /// When the buffer reaches `batch_size`, the batch is automatically
-    /// flushed via an HTTP POST. Returns an error only if the auto-flush
-    /// fails.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.batch.extend_from_slice(data);
         let size_reached = self.batch.len() >= self.batch_size;
         let age_reached =
             !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
         let should_flush = size_reached || age_reached;
         if should_flush {
-            self.send_batch()?;
+            self.send_via_blocking().await?;
         }
         self.last_write_delivered = should_flush;
         Ok(())
     }
 
-    /// Flush any remaining buffered data to the HTTP endpoint.
-    ///
-    /// Safe to call multiple times. Returns `Ok(())` immediately if the
-    /// batch is empty.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.send_batch()
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        self.send_via_blocking().await
     }
 
     fn last_write_delivered(&self) -> bool {
         self.last_write_delivered
+    }
+}
+
+impl HttpPushSink {
+    /// Drain the batch into a blocking task that owns the ureq round-trip.
+    async fn send_via_blocking(&mut self) -> Result<(), SondaError> {
+        if self.batch.is_empty() {
+            return Ok(());
+        }
+        self.last_flush_at = Instant::now();
+        let body = std::mem::replace(&mut self.batch, Vec::with_capacity(self.batch_size));
+        let client = self.client.clone();
+        let url = self.url.clone();
+        let content_type = self.content_type.clone();
+        let headers = self.headers.clone();
+        let retry_policy = self.retry_policy.clone();
+        let join = tokio::task::spawn_blocking(move || {
+            do_send(
+                &client,
+                &url,
+                &content_type,
+                &headers,
+                &body,
+                retry_policy.as_ref(),
+            )
+        })
+        .await;
+        match join {
+            Ok(r) => r,
+            Err(e) => Err(SondaError::Runtime(RuntimeError::TaskPanicked(
+                e.to_string(),
+            ))),
+        }
+    }
+}
+
+fn do_send(
+    client: &ureq::Agent,
+    url: &str,
+    content_type: &str,
+    headers: &HashMap<String, String>,
+    body: &[u8],
+    retry_policy: Option<&RetryPolicy>,
+) -> Result<(), SondaError> {
+    let result = match retry_policy {
+        Some(policy) => policy.execute(
+            || HttpPushSink::do_post_checked(client, url, content_type, headers, body),
+            HttpPushSink::is_retryable,
+        ),
+        None => HttpPushSink::do_post_checked(client, url, content_type, headers, body),
+    };
+    match &result {
+        Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
+            Ok(())
+        }
+        _ => result,
     }
 }
 
@@ -432,10 +430,8 @@ mod tests {
     // Batch accumulation — no HTTP call until threshold
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn write_below_batch_size_does_not_trigger_flush() {
-        // batch_size = 1000; write 3 × 100 bytes → no request should go out.
-        // We start a server that would panic if it received a connection.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_below_batch_size_does_not_trigger_flush() {
         let (listener, url) = mock_server_listener();
 
         let mut sink = HttpPushSink::new(
@@ -448,13 +444,12 @@ mod tests {
         )
         .expect("construct sink");
 
-        // Write 300 bytes total — below the 1000-byte threshold.
         for _ in 0..3 {
-            sink.write(&[b'x'; 100]).expect("write should succeed");
+            sink.write(&[b'x'; 100])
+                .await
+                .expect("write should succeed");
         }
 
-        // Set a very short timeout so the test does not hang waiting for a
-        // connection that should never arrive.
         listener.set_nonblocking(true).expect("set non-blocking");
         let accepted = listener.accept();
         assert!(
@@ -463,11 +458,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn write_at_batch_size_triggers_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_at_batch_size_triggers_flush() {
         let (listener, url) = mock_server_listener();
 
-        // Accept exactly one request in a background thread.
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink = HttpPushSink::new(
@@ -479,16 +473,17 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        // Write exactly batch_size bytes → should auto-flush.
-        sink.write(&[b'a'; 100]).expect("write should succeed");
+        sink.write(&[b'a'; 100])
+            .await
+            .expect("write should succeed");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body.len(), 100, "server should receive exactly 100 bytes");
         assert!(body.iter().all(|&b| b == b'a'));
     }
 
-    #[test]
-    fn write_over_batch_size_triggers_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_over_batch_size_triggers_flush() {
         let (listener, url) = mock_server_listener();
 
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
@@ -496,19 +491,14 @@ mod tests {
         let mut sink =
             HttpPushSink::new(&url, "text/plain", 50, HashMap::new(), None, Duration::ZERO)
                 .expect("construct sink");
-        // Write 80 bytes → exceeds 50-byte threshold → auto-flush.
-        sink.write(&[b'z'; 80]).expect("write should succeed");
+        sink.write(&[b'z'; 80]).await.expect("write should succeed");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body.len(), 80);
     }
 
-    // -------------------------------------------------------------------------
-    // Explicit flush — remaining data sent
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn explicit_flush_sends_buffered_data() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn explicit_flush_sends_buffered_data() {
         let (listener, url) = mock_server_listener();
 
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
@@ -522,17 +512,17 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        // Write 42 bytes — well below 10 000-byte threshold.
-        sink.write(b"hello flush").expect("write");
-        sink.flush().expect("flush should send remaining data");
+        sink.write(b"hello flush").await.expect("write");
+        sink.flush()
+            .await
+            .expect("flush should send remaining data");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body, b"hello flush");
     }
 
-    #[test]
-    fn flush_on_empty_batch_is_a_no_op() {
-        // No server running — if flush() sent a request it would fail.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_on_empty_batch_is_a_no_op() {
         let mut sink = HttpPushSink::new(
             "http://127.0.0.1:19999/push",
             "text/plain",
@@ -542,15 +532,16 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        // Empty batch: flush should return Ok without making any network call.
-        assert!(sink.flush().is_ok(), "flush on empty batch must be Ok");
+        assert!(
+            sink.flush().await.is_ok(),
+            "flush on empty batch must be Ok"
+        );
     }
 
-    #[test]
-    fn flush_is_idempotent() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_is_idempotent() {
         let (listener, url) = mock_server_listener();
 
-        // First flush sends data; second flush is a no-op.
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink = HttpPushSink::new(
@@ -562,21 +553,16 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(b"data").expect("write");
-        sink.flush().expect("first flush");
+        sink.write(b"data").await.expect("write");
+        sink.flush().await.expect("first flush");
 
         let _body = handle.join().expect("mock server thread panicked");
 
-        // Second flush — batch is now empty, must succeed without panicking.
-        assert!(sink.flush().is_ok(), "second flush must also be Ok");
+        assert!(sink.flush().await.is_ok(), "second flush must also be Ok");
     }
 
-    // -------------------------------------------------------------------------
-    // last_write_delivered — buffered vs flushed
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn last_write_delivered_is_false_when_write_only_buffers() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_write_delivered_is_false_when_write_only_buffers() {
         let (listener, url) = mock_server_listener();
 
         let mut sink = HttpPushSink::new(
@@ -588,7 +574,7 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(b"buffered").expect("write buffers");
+        sink.write(b"buffered").await.expect("write buffers");
 
         assert!(
             !sink.last_write_delivered(),
@@ -598,15 +584,15 @@ mod tests {
         assert!(listener.accept().is_err(), "no flush should have fired");
     }
 
-    #[test]
-    fn last_write_delivered_is_true_when_write_triggers_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_write_delivered_is_true_when_write_triggers_flush() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink =
             HttpPushSink::new(&url, "text/plain", 4, HashMap::new(), None, Duration::ZERO)
                 .expect("construct sink");
-        sink.write(b"abcd").expect("write triggers flush");
+        sink.write(b"abcd").await.expect("write triggers flush");
 
         handle.join().expect("mock server thread panicked");
         assert!(
@@ -615,44 +601,37 @@ mod tests {
         );
     }
 
-    // -------------------------------------------------------------------------
-    // Response handling
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn two_xx_response_clears_batch_and_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn two_xx_response_clears_batch_and_returns_ok() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink =
             HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), None, Duration::ZERO)
                 .expect("construct sink");
-        // batch_size=1 → immediate flush on write.
-        let result = sink.write(b"x");
+        let result = sink.write(b"x").await;
         let _body = handle.join().expect("mock server thread panicked");
         assert!(result.is_ok(), "2xx response must return Ok");
     }
 
-    #[test]
-    fn four_xx_response_warns_and_discards_batch_returning_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn four_xx_response_warns_and_discards_batch_returning_ok() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 400));
 
         let mut sink =
             HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), None, Duration::ZERO)
                 .expect("construct sink");
-        let result = sink.write(b"x");
+        let result = sink.write(b"x").await;
         let _body = handle.join().expect("mock server thread panicked");
-        // 4xx → warn + discard, but NOT an error from the sink's perspective.
         assert!(
             result.is_ok(),
             "4xx response must return Ok (warn-and-continue)"
         );
     }
 
-    #[test]
-    fn five_xx_without_retry_returns_error_after_one_attempt() {
-        // With no retry policy, 5xx returns an error after a single attempt.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn five_xx_without_retry_returns_error_after_one_attempt() {
         let (listener, url) = mock_server_listener();
 
         let handle = thread::spawn(move || {
@@ -662,7 +641,7 @@ mod tests {
         let mut sink =
             HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), None, Duration::ZERO)
                 .expect("construct sink");
-        let result = sink.write(b"x");
+        let result = sink.write(b"x").await;
         handle.join().expect("mock server thread panicked");
         assert!(result.is_err(), "5xx without retry must return Err");
         assert!(
@@ -671,9 +650,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn five_xx_with_retry_policy_retries_and_succeeds() {
-        // With a retry policy, 5xx is retried and succeeds on the second attempt.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn five_xx_with_retry_policy_retries_and_succeeds() {
         let (listener, url) = mock_server_listener();
 
         let handle = thread::spawn(move || {
@@ -698,14 +676,13 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        let result = sink.write(b"x");
+        let result = sink.write(b"x").await;
         handle.join().expect("mock server thread panicked");
         assert!(result.is_ok(), "5xx + successful retry must return Ok");
     }
 
-    #[test]
-    fn five_xx_with_retry_policy_exhausted_returns_error() {
-        // All retries exhausted on persistent 5xx.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn five_xx_with_retry_policy_exhausted_returns_error() {
         let (listener, url) = mock_server_listener();
 
         let handle = thread::spawn(move || {
@@ -730,18 +707,13 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        let result = sink.write(b"x");
+        let result = sink.write(b"x").await;
         handle.join().expect("mock server thread panicked");
         assert!(result.is_err(), "persistent 5xx must return Err");
     }
 
-    // -------------------------------------------------------------------------
-    // Connection refused
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn flush_to_refused_port_returns_sink_error() {
-        // Bind then immediately drop — port is unused.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_to_refused_port_returns_sink_error() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
         drop(listener);
@@ -756,8 +728,8 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(b"hello").expect("write buffered ok");
-        let result = sink.flush();
+        sink.write(b"hello").await.expect("write buffered ok");
+        let result = sink.flush().await;
         assert!(result.is_err(), "flush to refused port must fail");
         assert!(
             matches!(result.err().unwrap(), SondaError::Sink(_)),
@@ -765,12 +737,8 @@ mod tests {
         );
     }
 
-    // -------------------------------------------------------------------------
-    // Body content — mock server verifies exact bytes
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn body_sent_to_server_matches_written_data() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn body_sent_to_server_matches_written_data() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
@@ -784,15 +752,15 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(payload).expect("write");
-        sink.flush().expect("flush");
+        sink.write(payload).await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body, payload);
     }
 
-    #[test]
-    fn multiple_writes_accumulated_correctly_before_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn multiple_writes_accumulated_correctly_before_flush() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
@@ -805,25 +773,20 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(b"part1").expect("write 1");
-        sink.write(b"part2").expect("write 2");
-        sink.write(b"part3").expect("write 3");
-        sink.flush().expect("flush");
+        sink.write(b"part1").await.expect("write 1");
+        sink.write(b"part2").await.expect("write 2");
+        sink.write(b"part3").await.expect("write 3");
+        sink.flush().await.expect("flush");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body, b"part1part2part3");
     }
 
-    // -------------------------------------------------------------------------
-    // Time-based flush
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn time_based_flush_fires_when_buffer_age_exceeded() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn time_based_flush_fires_when_buffer_age_exceeded() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        // batch_size large enough that size never triggers; short max_buffer_age.
         let mut sink = HttpPushSink::new(
             &url,
             "text/plain",
@@ -834,10 +797,9 @@ mod tests {
         )
         .expect("construct sink");
 
-        sink.write(b"first").expect("write 1");
+        sink.write(b"first").await.expect("write 1");
         thread::sleep(Duration::from_millis(200));
-        // Second write is past max_buffer_age → triggers a time-based flush.
-        sink.write(b"second").expect("write 2");
+        sink.write(b"second").await.expect("write 2");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(
@@ -846,8 +808,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn zero_max_buffer_age_disables_time_based_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn zero_max_buffer_age_disables_time_based_flush() {
         let (listener, url) = mock_server_listener();
 
         let mut sink = HttpPushSink::new(
@@ -860,11 +822,10 @@ mod tests {
         )
         .expect("construct sink");
 
-        sink.write(b"first").expect("write 1");
+        sink.write(b"first").await.expect("write 1");
         thread::sleep(Duration::from_millis(150));
-        sink.write(b"second").expect("write 2");
+        sink.write(b"second").await.expect("write 2");
 
-        // With time-based flush disabled, no request should have arrived.
         listener.set_nonblocking(true).expect("set non-blocking");
         assert!(
             listener.accept().is_err(),
@@ -872,12 +833,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn size_triggered_flush_resets_the_buffer_age_timer() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn size_triggered_flush_resets_the_buffer_age_timer() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        // Small batch_size, max_buffer_age comfortably longer than the test runs.
         let mut sink = HttpPushSink::new(
             &url,
             "text/plain",
@@ -888,15 +848,13 @@ mod tests {
         )
         .expect("construct sink");
 
-        // Write exactly batch_size bytes → the size trigger fires.
-        sink.write(b"abcd").expect("write fills batch");
+        sink.write(b"abcd").await.expect("write fills batch");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body, b"abcd", "size-triggered flush must deliver the batch");
 
-        // The size flush reset last_flush_at; a subsequent partial-batch write
-        // must NOT immediately time-flush against the (now closed) listener.
         sink.write(b"e")
+            .await
             .expect("partial write after a size flush must not time-flush immediately");
     }
 
@@ -1005,8 +963,8 @@ batch_size: 8192
     // Factory wiring: create_sink for HttpPush config
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn create_sink_http_push_config_with_valid_url_returns_ok() {
+    #[tokio::test]
+    async fn create_sink_http_push_config_with_valid_url_returns_ok() {
         let config = SinkConfig::HttpPush {
             url: "http://127.0.0.1:19998/push".to_string(),
             content_type: None,
@@ -1015,17 +973,15 @@ batch_size: 8192
             headers: None,
             retry: None,
         };
-        // Construction must succeed (no network call yet).
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_ok(),
             "factory must return Ok for valid http_push config"
         );
     }
 
-    #[test]
-    fn create_sink_http_push_uses_default_batch_size_when_none() {
-        // No network call on construction, so any host is fine.
+    #[tokio::test]
+    async fn create_sink_http_push_uses_default_batch_size_when_none() {
         let config = SinkConfig::HttpPush {
             url: "http://127.0.0.1:19997/push".to_string(),
             content_type: None,
@@ -1034,11 +990,11 @@ batch_size: 8192
             headers: None,
             retry: None,
         };
-        assert!(create_sink(&config, None).is_ok());
+        assert!(create_sink(&config, None).await.is_ok());
     }
 
-    #[test]
-    fn create_sink_http_push_with_invalid_url_returns_err() {
+    #[tokio::test]
+    async fn create_sink_http_push_with_invalid_url_returns_err() {
         let config = SinkConfig::HttpPush {
             url: "not-http://bad".to_string(),
             content_type: None,
@@ -1047,12 +1003,12 @@ batch_size: 8192
             headers: None,
             retry: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(result.is_err(), "invalid URL must cause factory to fail");
     }
 
-    #[test]
-    fn create_sink_http_push_sends_data_end_to_end() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_sink_http_push_sends_data_end_to_end() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
@@ -1064,9 +1020,9 @@ batch_size: 8192
             headers: None,
             retry: None,
         };
-        let mut sink = create_sink(&config, None).expect("factory ok");
-        sink.write(b"end-to-end").expect("write");
-        sink.flush().expect("flush");
+        let mut sink = create_sink(&config, None).await.expect("factory ok");
+        sink.write(b"end-to-end").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body, b"end-to-end");
@@ -1121,8 +1077,8 @@ batch_size: 8192
         (headers_map, body)
     }
 
-    #[test]
-    fn custom_headers_are_sent_with_request() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn custom_headers_are_sent_with_request() {
         let (listener, url) = mock_server_listener();
 
         let handle = thread::spawn(move || accept_one_capture_headers(&listener, 200));
@@ -1143,8 +1099,8 @@ batch_size: 8192
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(b"test-payload").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"test-payload").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let (headers, body) = handle.join().expect("mock server thread panicked");
 
@@ -1168,8 +1124,8 @@ batch_size: 8192
         assert_eq!(body, b"test-payload");
     }
 
-    #[test]
-    fn empty_custom_headers_does_not_break_request() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_custom_headers_does_not_break_request() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_capture_headers(&listener, 200));
 
@@ -1182,8 +1138,8 @@ batch_size: 8192
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(b"data").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"data").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let (headers, body) = handle.join().expect("mock server thread panicked");
         assert_eq!(
@@ -1194,8 +1150,8 @@ batch_size: 8192
         assert_eq!(body, b"data");
     }
 
-    #[test]
-    fn custom_headers_with_factory_config() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn custom_headers_with_factory_config() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_capture_headers(&listener, 200));
 
@@ -1210,9 +1166,9 @@ batch_size: 8192
             headers: Some(hdr),
             retry: None,
         };
-        let mut sink = create_sink(&config, None).expect("factory ok");
-        sink.write(b"factory-test").expect("write");
-        sink.flush().expect("flush");
+        let mut sink = create_sink(&config, None).await.expect("factory ok");
+        sink.write(b"factory-test").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let (headers, body) = handle.join().expect("mock server thread panicked");
         assert_eq!(

--- a/sonda-core/src/sink/kafka.rs
+++ b/sonda-core/src/sink/kafka.rs
@@ -1,9 +1,7 @@
 //! Kafka sink — batches encoded telemetry and delivers it as Kafka records.
 //!
 //! Uses [`rskafka`] (pure Rust, no C dependencies) to produce records to a
-//! configured topic and partition. Async operations are driven by a dedicated
-//! single-threaded [`tokio::runtime::Runtime`] stored in the struct, keeping
-//! the public [`Sink`] interface fully synchronous.
+//! configured topic and partition.
 //!
 //! Encoded bytes are accumulated in an internal buffer. When the buffer
 //! reaches [`KAFKA_BUFFER_SIZE`] bytes the buffer is automatically flushed as
@@ -27,6 +25,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use chrono::Utc;
 use rskafka::{
     client::{
@@ -36,7 +35,6 @@ use rskafka::{
     record::Record,
 };
 use rustls_pki_types::pem::PemObject;
-use tokio::runtime::Runtime;
 
 use crate::sink::retry::RetryPolicy;
 use crate::sink::{KafkaSaslConfig, KafkaTlsConfig, Sink};
@@ -53,30 +51,18 @@ pub const KAFKA_BUFFER_SIZE: usize = 64 * 1024;
 /// remaining buffered data.
 ///
 /// The sink uses [`rskafka`], a pure-Rust Kafka client with no C dependencies.
-/// Async operations are driven by a private single-threaded [`Runtime`],
-/// keeping the [`Sink`] trait interface fully synchronous.
 ///
 /// TLS and SASL authentication are supported for connecting to managed Kafka
 /// services (Confluent Cloud, AWS MSK, Aiven, etc.).
 pub struct KafkaSink {
-    /// The Kafka topic to produce records to.
     topic: String,
-    /// The broker address string (stored for error messages).
     brokers: String,
-    /// Async client for the target topic partition.
     client: rskafka::client::partition::PartitionClient,
-    /// Encoded bytes waiting to be published.
     buffer: Vec<u8>,
-    /// Tokio runtime used to drive async rskafka calls synchronously.
-    runtime: Runtime,
-    /// Optional retry policy for transient failures.
     retry_policy: Option<RetryPolicy>,
-    /// Maximum age a non-empty buffer may reach before a time-based flush.
     /// `Duration::ZERO` disables time-based flushing.
     max_buffer_age: Duration,
-    /// When the buffer was last published — drives the time-based flush check.
     last_flush_at: Instant,
-    /// Whether the most recent `write()` triggered a successful flush rather than only buffering.
     last_write_delivered: bool,
 }
 
@@ -204,7 +190,7 @@ impl KafkaSink {
     /// broker-side auto-topic-creation (`auto.create.topics.enable=true`)
     /// works out of the box. This may cause the constructor to briefly block
     /// while the broker creates the topic.
-    pub fn new(
+    pub async fn new(
         brokers: &str,
         topic: &str,
         retry_policy: Option<RetryPolicy>,
@@ -212,20 +198,6 @@ impl KafkaSink {
         sasl_config: Option<&KafkaSaslConfig>,
         max_buffer_age: Duration,
     ) -> Result<Self, SondaError> {
-        // Build a minimal single-threaded tokio runtime. This drives all
-        // async rskafka calls without making the Sink trait async.
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|e| {
-                std::io::Error::other(format!(
-                    "kafka sink: failed to build tokio runtime for broker '{}': {}",
-                    brokers, e
-                ))
-            })
-            .map_err(SondaError::Sink)?;
-
-        // Parse broker list: split on commas and trim whitespace.
         let bootstrap_brokers: Vec<String> = brokers
             .split(',')
             .map(|s| s.trim().to_owned())
@@ -239,7 +211,6 @@ impl KafkaSink {
             )));
         }
 
-        // Build optional TLS config.
         let tls_rustls = match tls_config {
             Some(tls) if tls.enabled => {
                 let cfg = build_rustls_config(tls.ca_cert.as_deref())?;
@@ -248,10 +219,8 @@ impl KafkaSink {
             _ => None,
         };
 
-        // Build optional SASL config.
         let sasl = sasl_config.map(map_sasl_config).transpose()?;
 
-        // Warn when SASL credentials will be sent over an unencrypted connection.
         if sasl.is_some() && tls_rustls.is_none() {
             eprintln!(
                 "WARNING: kafka sink: SASL authentication is configured without TLS — \
@@ -262,45 +231,39 @@ impl KafkaSink {
         let topic_str = topic.to_owned();
         let brokers_str = brokers.to_owned();
 
-        // Build the rskafka client and partition client inside the runtime.
-        let client = runtime
-            .block_on(async {
-                let mut builder = ClientBuilder::new(bootstrap_brokers);
+        let mut builder = ClientBuilder::new(bootstrap_brokers);
+        if let Some(tls) = tls_rustls {
+            builder = builder.tls_config(tls);
+        }
+        if let Some(sasl) = sasl {
+            builder = builder.sasl_config(sasl);
+        }
 
-                if let Some(tls) = tls_rustls {
-                    builder = builder.tls_config(tls);
-                }
+        let kafka_client = builder
+            .build()
+            .await
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    format!(
+                        "kafka sink: failed to connect to broker(s) '{}': {}",
+                        brokers_str, e
+                    ),
+                )
+            })
+            .map_err(SondaError::Sink)?;
 
-                if let Some(sasl) = sasl {
-                    builder = builder.sasl_config(sasl);
-                }
-
-                let kafka_client = builder.build().await.map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::ConnectionRefused,
-                        format!(
-                            "kafka sink: failed to connect to broker(s) '{}': {}",
-                            brokers_str, e
-                        ),
-                    )
-                })?;
-
-                kafka_client
-                    .partition_client(
-                        topic_str.clone(),
-                        0, // partition 0
-                        UnknownTopicHandling::Retry,
-                    )
-                    .await
-                    .map_err(|e| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::NotFound,
-                            format!(
-                                "kafka sink: failed to get partition client for topic '{}' at broker(s) '{}': {}",
-                                topic_str, brokers_str, e
-                            ),
-                        )
-                    })
+        let client = kafka_client
+            .partition_client(topic_str.clone(), 0, UnknownTopicHandling::Retry)
+            .await
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!(
+                        "kafka sink: failed to get partition client for topic '{}' at broker(s) '{}': {}",
+                        topic_str, brokers_str, e
+                    ),
+                )
             })
             .map_err(SondaError::Sink)?;
 
@@ -309,7 +272,6 @@ impl KafkaSink {
             brokers: brokers.to_owned(),
             client,
             buffer: Vec::with_capacity(KAFKA_BUFFER_SIZE),
-            runtime,
             retry_policy,
             max_buffer_age,
             last_flush_at: Instant::now(),
@@ -317,94 +279,93 @@ impl KafkaSink {
         })
     }
 
-    /// Publish the internal buffer as a single Kafka record and clear it.
-    ///
-    /// Uses the configured [`RetryPolicy`] for transient produce failures.
-    /// When no policy is configured, errors are returned immediately.
-    ///
-    /// Returns immediately without making a network call if the buffer is
-    /// empty (idempotent).
-    fn publish_buffer(&mut self) -> Result<(), SondaError> {
+    async fn publish_buffer(&mut self) -> Result<(), SondaError> {
         if self.buffer.is_empty() {
             return Ok(());
         }
-
-        // Reset on attempt, not success — the buffer is cleared either way below.
         self.last_flush_at = Instant::now();
-
-        // Swap out the buffer for a fresh pre-allocated vec. Using replace
-        // avoids an intermediate zero-capacity state that take() would produce.
         let payload = std::mem::replace(&mut self.buffer, Vec::with_capacity(KAFKA_BUFFER_SIZE));
 
-        match &self.retry_policy {
-            Some(policy) => {
-                let policy = policy.clone();
-                // The payload must be cloneable for retries — Kafka's produce
-                // consumes the Record, so we re-create it on each attempt.
-                policy.execute(
-                    || self.do_produce(&payload),
-                    |_| true, // all Kafka produce errors are retryable
-                )
-            }
-            None => self.do_produce(&payload),
-        }
-    }
-
-    /// Produce a single Kafka record from the given payload bytes.
-    fn do_produce(&mut self, payload: &[u8]) -> Result<(), SondaError> {
-        let record = Record {
-            key: None,
-            value: Some(payload.to_vec()),
-            headers: BTreeMap::new(),
-            timestamp: Utc::now(),
+        let send_once = || async {
+            let record = Record {
+                key: None,
+                value: Some(payload.clone()),
+                headers: BTreeMap::new(),
+                timestamp: Utc::now(),
+            };
+            self.client
+                .produce(vec![record], Compression::NoCompression)
+                .await
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::BrokenPipe,
+                        format!(
+                            "kafka sink: failed to produce record to topic '{}' at broker(s) '{}': {}",
+                            self.topic, self.brokers, e
+                        ),
+                    )
+                })
+                .map_err(SondaError::Sink)?;
+            Ok(())
         };
 
-        self.runtime
-            .block_on(async {
-                self.client
-                    .produce(vec![record], Compression::NoCompression)
-                    .await
-            })
-            .map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    format!(
-                        "kafka sink: failed to produce record to topic '{}' at broker(s) '{}': {}",
-                        self.topic, self.brokers, e
-                    ),
-                )
-            })
-            .map_err(SondaError::Sink)?;
-
-        Ok(())
+        if let Some(policy) = self.retry_policy.clone() {
+            run_with_retry(&policy, send_once).await
+        } else {
+            send_once().await
+        }
     }
 }
 
+async fn run_with_retry<F, Fut>(policy: &RetryPolicy, mut send_once: F) -> Result<(), SondaError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<(), SondaError>>,
+{
+    let mut last_error = match send_once().await {
+        Ok(()) => return Ok(()),
+        Err(e) => e,
+    };
+    for attempt in 0..policy.max_attempts() {
+        let backoff = policy.jittered_backoff(attempt);
+        eprintln!(
+            "sonda: retry {}/{} after {}ms (error: {})",
+            attempt + 1,
+            policy.max_attempts(),
+            backoff.as_millis(),
+            last_error,
+        );
+        tokio::time::sleep(backoff).await;
+        match send_once().await {
+            Ok(()) => return Ok(()),
+            Err(e) => last_error = e,
+        }
+    }
+    eprintln!(
+        "sonda: all {} retries exhausted (last error: {})",
+        policy.max_attempts(),
+        last_error,
+    );
+    Err(last_error)
+}
+
+#[async_trait]
 impl Sink for KafkaSink {
-    /// Append encoded event data to the internal buffer.
-    ///
-    /// When the buffer reaches [`KAFKA_BUFFER_SIZE`] bytes, the buffer is
-    /// automatically published as a single Kafka record. Returns an error
-    /// only if the automatic flush fails.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.buffer.extend_from_slice(data);
         let size_reached = self.buffer.len() >= KAFKA_BUFFER_SIZE;
         let age_reached =
             !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
         let should_flush = size_reached || age_reached;
         if should_flush {
-            self.publish_buffer()?;
+            self.publish_buffer().await?;
         }
         self.last_write_delivered = should_flush;
         Ok(())
     }
 
-    /// Flush any remaining buffered data as a Kafka record.
-    ///
-    /// Safe to call multiple times. Returns `Ok(())` immediately if the
-    /// buffer is empty.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.publish_buffer()
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        self.publish_buffer().await
     }
 
     fn last_write_delivered(&self) -> bool {
@@ -553,17 +514,9 @@ mod tests {
     // Construction failure: unreachable broker
     // -----------------------------------------------------------------------
 
-    /// Connecting to a port where no Kafka broker is listening must return a
-    /// SondaError::Sink containing the broker address in the error message.
-    ///
-    /// Ignored by default because rskafka may wait for a long TCP timeout
-    /// before returning an error. Run with `cargo test -- --ignored` when a
-    /// local Kafka broker is available and the test environment can tolerate
-    /// network delays.
-    #[test]
+    #[tokio::test]
     #[ignore = "requires network timeout which is slow; run with --ignored when desired"]
-    fn new_with_unreachable_broker_returns_sink_error() {
-        // Port 1 is privileged and will always refuse connections.
+    async fn new_with_unreachable_broker_returns_sink_error() {
         let result = KafkaSink::new(
             "127.0.0.1:1",
             "sonda-test",
@@ -571,7 +524,8 @@ mod tests {
             None,
             None,
             Duration::ZERO,
-        );
+        )
+        .await;
         match result {
             Err(err) => {
                 let msg = err.to_string();
@@ -584,11 +538,9 @@ mod tests {
         }
     }
 
-    /// An empty broker string (after trimming) should return an error before
-    /// attempting any network connection.
-    #[test]
-    fn new_with_empty_broker_string_returns_error() {
-        let result = KafkaSink::new("", "sonda-test", None, None, None, Duration::ZERO);
+    #[tokio::test]
+    async fn new_with_empty_broker_string_returns_error() {
+        let result = KafkaSink::new("", "sonda-test", None, None, None, Duration::ZERO).await;
         match result {
             Err(err) => {
                 let msg = err.to_string();
@@ -601,11 +553,10 @@ mod tests {
         }
     }
 
-    /// A broker string composed only of commas and whitespace has no valid
-    /// entries; this must be caught before any network call.
-    #[test]
-    fn new_with_whitespace_only_broker_string_returns_error() {
-        let result = KafkaSink::new("  ,  ,  ", "sonda-test", None, None, None, Duration::ZERO);
+    #[tokio::test]
+    async fn new_with_whitespace_only_broker_string_returns_error() {
+        let result =
+            KafkaSink::new("  ,  ,  ", "sonda-test", None, None, None, Duration::ZERO).await;
         assert!(
             result.is_err(),
             "broker string with only separators must be rejected"

--- a/sonda-core/src/sink/loki.rs
+++ b/sonda-core/src/sink/loki.rs
@@ -4,10 +4,12 @@
 use std::collections::{BTreeMap, HashMap};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use async_trait::async_trait;
+
 use crate::model::log::LogEvent;
 use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
-use crate::SondaError;
+use crate::{RuntimeError, SondaError};
 
 pub const DEFAULT_BATCH_SIZE: usize = 5;
 
@@ -123,13 +125,11 @@ impl LokiSink {
             .join(",")
     }
 
-    fn flush_batch(&mut self) -> Result<(), SondaError> {
+    async fn flush_batch(&mut self) -> Result<(), SondaError> {
         if self.batch.is_empty() {
             return Ok(());
         }
 
-        // Scoped so `groups`' borrows into `self.batch` drop before we mutate
-        // other `self` fields below.
         let body = {
             let groups = self.group_by_overlay();
             let stream_count = groups.len();
@@ -150,31 +150,20 @@ impl LokiSink {
         };
 
         let push_url = format!("{}/loki/api/v1/push", self.url);
-
-        // Reset on attempt, not success — the batch is cleared either way below.
         self.last_flush_at = Instant::now();
-
-        let result = match &self.retry_policy {
-            Some(policy) => {
-                let policy = policy.clone();
-                let client = &self.client;
-                policy.execute(
-                    || Self::do_post_checked(client, &push_url, &body),
-                    Self::is_retryable,
-                )
-            }
-            None => Self::do_post_checked(&self.client, &push_url, &body),
-        };
-
         self.batch.clear();
 
-        // 4xx errors (except 429) are non-retryable and treated as warn-and-discard.
-        // The batch is already cleared; suppress the error so the sink continues.
-        match &result {
-            Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
-                Ok(())
-            }
-            _ => result,
+        let client = self.client.clone();
+        let retry_policy = self.retry_policy.clone();
+        let join = tokio::task::spawn_blocking(move || {
+            do_send(&client, &push_url, &body, retry_policy.as_ref())
+        })
+        .await;
+        match join {
+            Ok(r) => r,
+            Err(e) => Err(SondaError::Runtime(RuntimeError::TaskPanicked(
+                e.to_string(),
+            ))),
         }
     }
 
@@ -229,14 +218,8 @@ impl LokiSink {
         }
     }
 
-    /// Classify whether an error from `do_post_checked` is retryable.
-    ///
-    /// Transport errors and 5xx/429 HTTP errors are retryable. 4xx errors
-    /// (except 429) are not — they are tagged with `ErrorKind::InvalidInput`
-    /// by `do_post_checked`.
     fn is_retryable(err: &SondaError) -> bool {
         if let SondaError::Sink(io_err) = err {
-            // 4xx (except 429) are tagged InvalidInput → not retryable.
             if io_err.kind() == std::io::ErrorKind::InvalidInput {
                 return false;
             }
@@ -246,19 +229,43 @@ impl LokiSink {
     }
 }
 
+fn do_send(
+    client: &ureq::Agent,
+    push_url: &str,
+    body: &str,
+    retry_policy: Option<&RetryPolicy>,
+) -> Result<(), SondaError> {
+    let result = match retry_policy {
+        Some(policy) => policy.execute(
+            || LokiSink::do_post_checked(client, push_url, body),
+            LokiSink::is_retryable,
+        ),
+        None => LokiSink::do_post_checked(client, push_url, body),
+    };
+    match &result {
+        Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
+            Ok(())
+        }
+        _ => result,
+    }
+}
+
+#[async_trait]
 impl Sink for LokiSink {
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         let ts_ns = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos()
             .to_string();
-        self.push_entry(ts_ns, data, BTreeMap::new())
+        self.push_entry(ts_ns, data, BTreeMap::new()).await
     }
 
-    fn write_log_event(&mut self, event: &LogEvent, encoded: &[u8]) -> Result<(), SondaError> {
-        // Prefer event-time over wall-clock — meaningful for log-replay
-        // scenarios where the generator sets a deterministic timestamp.
+    async fn write_log_event(
+        &mut self,
+        event: &LogEvent,
+        encoded: &[u8],
+    ) -> Result<(), SondaError> {
         let ts_ns = event
             .timestamp
             .duration_since(UNIX_EPOCH)
@@ -270,11 +277,11 @@ impl Sink for LokiSink {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        self.push_entry(ts_ns, encoded, overlay)
+        self.push_entry(ts_ns, encoded, overlay).await
     }
 
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.flush_batch()
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        self.flush_batch().await
     }
 
     fn last_write_delivered(&self) -> bool {
@@ -283,13 +290,12 @@ impl Sink for LokiSink {
 }
 
 impl LokiSink {
-    fn push_entry(
+    async fn push_entry(
         &mut self,
         timestamp_ns: String,
         data: &[u8],
         overlay: BTreeMap<String, String>,
     ) -> Result<(), SondaError> {
-        // Strip any trailing newline so log lines are clean in the Loki UI.
         let line = String::from_utf8_lossy(data);
         let line = line.trim_end_matches('\n').to_string();
 
@@ -304,7 +310,7 @@ impl LokiSink {
             !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
         let should_flush = size_reached || age_reached;
         if should_flush {
-            self.flush_batch()?;
+            self.flush_batch().await?;
         }
         self.last_write_delivered = should_flush;
 
@@ -489,8 +495,8 @@ mod tests {
 
     /// `build_envelope()` is private, so we test it indirectly by flushing a
     /// batch to a mock server and inspecting the body that arrives.
-    #[test]
-    fn flush_produces_valid_loki_push_json_envelope() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_produces_valid_loki_push_json_envelope() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -499,8 +505,8 @@ mod tests {
 
         let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"hello loki\n").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"hello loki\n").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("valid UTF-8");
@@ -548,8 +554,8 @@ mod tests {
     // Labels in stream object
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn labels_appear_in_stream_object_of_push_envelope() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn labels_appear_in_stream_object_of_push_envelope() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -559,8 +565,8 @@ mod tests {
 
         let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"test\n").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"test\n").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8 body");
@@ -579,15 +585,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn empty_labels_produce_empty_stream_object() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_labels_produce_empty_stream_object() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"line\n").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"line\n").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -604,8 +610,8 @@ mod tests {
     // Batch accumulation — no HTTP call until batch_size reached
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn write_below_batch_size_does_not_trigger_http_call() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_below_batch_size_does_not_trigger_http_call() {
         let (listener, url) = mock_loki_listener();
 
         let mut sink = LokiSink::new(url, HashMap::new(), 50, u32::MAX, None, Duration::ZERO)
@@ -614,6 +620,7 @@ mod tests {
         // Write 49 lines — one short of the 50-entry threshold.
         for i in 0..49 {
             sink.write(format!("line {i}\n").as_bytes())
+                .await
                 .expect("write should buffer");
         }
 
@@ -626,8 +633,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn write_at_batch_size_triggers_exactly_one_http_call() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_at_batch_size_triggers_exactly_one_http_call() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -636,7 +643,9 @@ mod tests {
 
         // Write exactly 50 lines → must trigger an auto-flush.
         for i in 0..50 {
-            sink.write(format!("line {i}\n").as_bytes()).expect("write");
+            sink.write(format!("line {i}\n").as_bytes())
+                .await
+                .expect("write");
         }
 
         let body_bytes = handle.join().expect("mock server thread panicked");
@@ -655,8 +664,8 @@ mod tests {
     // Explicit flush — sends remaining entries below batch_size
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn explicit_flush_sends_partial_batch() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn explicit_flush_sends_partial_batch() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -664,10 +673,10 @@ mod tests {
             .expect("construct sink");
 
         // Write only 3 lines (far below batch_size of 100).
-        sink.write(b"alpha\n").expect("write 1");
-        sink.write(b"beta\n").expect("write 2");
-        sink.write(b"gamma\n").expect("write 3");
-        sink.flush().expect("explicit flush");
+        sink.write(b"alpha\n").await.expect("write 1");
+        sink.write(b"beta\n").await.expect("write 2");
+        sink.write(b"gamma\n").await.expect("write 3");
+        sink.flush().await.expect("explicit flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -679,27 +688,27 @@ mod tests {
         assert_eq!(values.len(), 3, "all 3 partial lines must be flushed");
     }
 
-    #[test]
-    fn flush_is_idempotent() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_is_idempotent() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"once\n").expect("write");
-        sink.flush().expect("first flush sends data");
+        sink.write(b"once\n").await.expect("write");
+        sink.flush().await.expect("first flush sends data");
         let _body = handle.join().expect("mock server thread panicked");
 
         // After the first flush the batch is empty — second flush must be a no-op.
-        assert!(sink.flush().is_ok(), "second flush must return Ok");
+        assert!(sink.flush().await.is_ok(), "second flush must return Ok");
     }
 
     // -------------------------------------------------------------------------
     // Empty batch flush — no HTTP call
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn flush_on_empty_batch_is_a_noop() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_on_empty_batch_is_a_noop() {
         // Use a URL where no server is running; if flush() makes a network call it will fail.
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
@@ -711,7 +720,7 @@ mod tests {
 
         // Empty batch — must return Ok without any network I/O.
         assert!(
-            sink.flush().is_ok(),
+            sink.flush().await.is_ok(),
             "flush on empty batch must return Ok without making a network call"
         );
     }
@@ -720,13 +729,13 @@ mod tests {
     // last_write_delivered — buffered vs flushed
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn last_write_delivered_is_false_when_write_only_buffers() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_write_delivered_is_false_when_write_only_buffers() {
         let (listener, url) = mock_loki_listener();
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"buffered\n").expect("write buffers");
+        sink.write(b"buffered\n").await.expect("write buffers");
 
         assert!(
             !sink.last_write_delivered(),
@@ -736,14 +745,16 @@ mod tests {
         assert!(listener.accept().is_err(), "no flush should have fired");
     }
 
-    #[test]
-    fn last_write_delivered_is_true_when_write_triggers_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_write_delivered_is_true_when_write_triggers_flush() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 1, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"flushed\n").expect("write triggers flush");
+        sink.write(b"flushed\n")
+            .await
+            .expect("write triggers flush");
 
         handle.join().expect("mock server thread panicked");
         assert!(
@@ -756,15 +767,17 @@ mod tests {
     // Log line trailing newline stripping
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn trailing_newline_is_stripped_from_log_lines() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn trailing_newline_is_stripped_from_log_lines() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"my log line\n").expect("write with newline");
-        sink.flush().expect("flush");
+        sink.write(b"my log line\n")
+            .await
+            .expect("write with newline");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -783,15 +796,15 @@ mod tests {
     // HTTP error handling
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn five_xx_response_returns_sink_error() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn five_xx_response_returns_sink_error() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 500));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"line\n").expect("write buffered");
-        let result = sink.flush();
+        sink.write(b"line\n").await.expect("write buffered");
+        let result = sink.flush().await;
         handle.join().expect("mock server thread panicked");
 
         assert!(result.is_err(), "5xx response must return Err");
@@ -801,15 +814,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn four_xx_response_warns_and_discards_batch_returning_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn four_xx_response_warns_and_discards_batch_returning_ok() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 400));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"line\n").expect("write buffered");
-        let result = sink.flush();
+        sink.write(b"line\n").await.expect("write buffered");
+        let result = sink.flush().await;
         handle.join().expect("mock server thread panicked");
 
         // 4xx → warn + discard, but NOT an error from the sink's perspective.
@@ -819,8 +832,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn flush_to_refused_port_returns_sink_error() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_to_refused_port_returns_sink_error() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
         drop(listener);
@@ -828,8 +841,8 @@ mod tests {
         let url = format!("http://127.0.0.1:{port}");
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"line\n").expect("write buffered");
-        let result = sink.flush();
+        sink.write(b"line\n").await.expect("write buffered");
+        let result = sink.flush().await;
 
         assert!(result.is_err(), "connection refused must return Err");
         assert!(
@@ -842,16 +855,16 @@ mod tests {
     // JSON escaping in log lines and label values
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn log_line_with_double_quotes_is_properly_escaped() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn log_line_with_double_quotes_is_properly_escaped() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
         // A log line containing a JSON double-quote character.
-        sink.write(b"msg=\"hello world\"").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"msg=\"hello world\"").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -864,8 +877,8 @@ mod tests {
         assert_eq!(log_line, r#"msg="hello world""#);
     }
 
-    #[test]
-    fn label_value_with_special_characters_is_properly_escaped() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn label_value_with_special_characters_is_properly_escaped() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -874,8 +887,8 @@ mod tests {
 
         let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"line\n").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"line\n").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -892,8 +905,8 @@ mod tests {
     // Batch cleared after flush
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn batch_is_cleared_after_auto_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn batch_is_cleared_after_auto_flush() {
         let (listener, url) = mock_loki_listener();
         // Expect two sequential flushes.
         let handle = thread::spawn(move || {
@@ -905,13 +918,11 @@ mod tests {
         let mut sink = LokiSink::new(url, HashMap::new(), 2, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
 
-        // First batch: lines 0-1 → triggers auto-flush at batch_size=2.
-        sink.write(b"line 0\n").expect("write 0");
-        sink.write(b"line 1\n").expect("write 1");
+        sink.write(b"line 0\n").await.expect("write 0");
+        sink.write(b"line 1\n").await.expect("write 1");
 
-        // Second batch: lines 2-3 → triggers second auto-flush.
-        sink.write(b"line 2\n").expect("write 2");
-        sink.write(b"line 3\n").expect("write 3");
+        sink.write(b"line 2\n").await.expect("write 2");
+        sink.write(b"line 3\n").await.expect("write 3");
 
         let (first_body, second_body) = handle.join().expect("mock server thread panicked");
 
@@ -938,8 +949,8 @@ mod tests {
     // Time-based flush
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn time_based_flush_fires_when_buffer_age_exceeded() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn time_based_flush_fires_when_buffer_age_exceeded() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -954,10 +965,9 @@ mod tests {
         )
         .expect("construct sink");
 
-        sink.write(b"first\n").expect("write 1");
+        sink.write(b"first\n").await.expect("write 1");
         thread::sleep(Duration::from_millis(200));
-        // Second write is past max_buffer_age → triggers a time-based flush.
-        sink.write(b"second\n").expect("write 2");
+        sink.write(b"second\n").await.expect("write 2");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -972,16 +982,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn zero_max_buffer_age_disables_time_based_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn zero_max_buffer_age_disables_time_based_flush() {
         let (listener, url) = mock_loki_listener();
 
         let mut sink = LokiSink::new(url, HashMap::new(), 10_000, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
 
-        sink.write(b"first\n").expect("write 1");
+        sink.write(b"first\n").await.expect("write 1");
         thread::sleep(Duration::from_millis(150));
-        sink.write(b"second\n").expect("write 2");
+        sink.write(b"second\n").await.expect("write 2");
 
         // With time-based flush disabled, no request should have arrived.
         listener.set_nonblocking(true).expect("set non-blocking");
@@ -991,8 +1001,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn size_triggered_flush_resets_the_buffer_age_timer() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn size_triggered_flush_resets_the_buffer_age_timer() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1007,9 +1017,8 @@ mod tests {
         )
         .expect("construct sink");
 
-        // Fill the batch immediately — the size trigger fires.
-        sink.write(b"a\n").expect("write 1");
-        sink.write(b"b\n").expect("write 2"); // batch_size reached → size flush
+        sink.write(b"a\n").await.expect("write 1");
+        sink.write(b"b\n").await.expect("write 2");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -1020,9 +1029,8 @@ mod tests {
             "size-triggered flush must deliver the full batch"
         );
 
-        // The size flush reset last_flush_at; a subsequent partial-batch write
-        // must NOT immediately time-flush against the (now closed) listener.
         sink.write(b"c\n")
+            .await
             .expect("partial write after a size flush must not time-flush immediately");
     }
 
@@ -1118,8 +1126,8 @@ max_buffer_age: 10s
     // Factory: create_sink for Loki config
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn create_sink_loki_with_valid_url_returns_ok() {
+    #[tokio::test]
+    async fn create_sink_loki_with_valid_url_returns_ok() {
         let config = SinkConfig::Loki {
             url: "http://localhost:3100".to_string(),
             batch_size: None,
@@ -1128,13 +1136,13 @@ max_buffer_age: 10s
             retry: None,
         };
         assert!(
-            create_sink(&config, None).is_ok(),
+            create_sink(&config, None).await.is_ok(),
             "factory must return Ok for valid loki config"
         );
     }
 
-    #[test]
-    fn create_sink_loki_with_invalid_max_buffer_age_returns_err() {
+    #[tokio::test]
+    async fn create_sink_loki_with_invalid_max_buffer_age_returns_err() {
         let config = SinkConfig::Loki {
             url: "http://localhost:3100".to_string(),
             batch_size: None,
@@ -1142,15 +1150,15 @@ max_buffer_age: 10s
             max_buffer_age: Some("garbage".to_string()),
             retry: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_err(),
             "invalid max_buffer_age must cause the factory to fail"
         );
     }
 
-    #[test]
-    fn create_sink_loki_with_labels_passes_them_to_sink() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_sink_loki_with_labels_passes_them_to_sink() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1163,10 +1171,12 @@ max_buffer_age: 10s
         };
         let mut labels = HashMap::new();
         labels.insert("job".to_string(), "sonda".to_string());
-        let mut sink = create_sink(&config, Some(&labels)).expect("factory ok");
+        let mut sink = create_sink(&config, Some(&labels))
+            .await
+            .expect("factory ok");
 
-        sink.write(b"test\n").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"test\n").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -1178,8 +1188,8 @@ max_buffer_age: 10s
         );
     }
 
-    #[test]
-    fn create_sink_loki_with_none_labels_uses_empty_labels() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_sink_loki_with_none_labels_uses_empty_labels() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1190,10 +1200,10 @@ max_buffer_age: 10s
             max_buffer_age: None,
             retry: None,
         };
-        let mut sink = create_sink(&config, None).expect("factory ok");
+        let mut sink = create_sink(&config, None).await.expect("factory ok");
 
-        sink.write(b"test\n").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"test\n").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -1210,11 +1220,8 @@ max_buffer_age: 10s
         assert_eq!(DEFAULT_BATCH_SIZE, 5);
     }
 
-    #[test]
-    fn create_sink_loki_with_no_batch_size_uses_default() {
-        // Construction succeeds with `batch_size: None`; writing fewer entries
-        // than DEFAULT_BATCH_SIZE must not trigger a flush attempt against the
-        // non-existent server.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_sink_loki_with_no_batch_size_uses_default() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
         drop(listener);
@@ -1227,16 +1234,17 @@ max_buffer_age: 10s
             max_buffer_age: None,
             retry: None,
         };
-        let mut sink = create_sink(&config, None).expect("factory ok");
+        let mut sink = create_sink(&config, None).await.expect("factory ok");
 
         for i in 0..(DEFAULT_BATCH_SIZE - 1) as u32 {
             sink.write(format!("line {i}\n").as_bytes())
+                .await
                 .expect("write must succeed below batch_size");
         }
     }
 
-    #[test]
-    fn create_sink_loki_with_invalid_url_returns_err() {
+    #[tokio::test]
+    async fn create_sink_loki_with_invalid_url_returns_err() {
         let config = SinkConfig::Loki {
             url: "not-http://bad".to_string(),
             batch_size: None,
@@ -1244,7 +1252,7 @@ max_buffer_age: 10s
             max_buffer_age: None,
             retry: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(result.is_err(), "invalid URL must cause factory to fail");
     }
 
@@ -1339,8 +1347,8 @@ sink:
             .clone()
     }
 
-    #[test]
-    fn write_log_event_single_stream_when_no_per_event_labels() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_log_event_single_stream_when_no_per_event_labels() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1350,8 +1358,8 @@ sink:
         let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
         let event = make_log_event(&[], "hello");
-        sink.write_log_event(&event, b"hello").expect("write");
-        sink.flush().expect("flush");
+        sink.write_log_event(&event, b"hello").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let streams = parse_streams(handle.join().expect("mock server"));
         assert_eq!(streams.len(), 1, "no overlay → exactly one stream");
@@ -1360,8 +1368,8 @@ sink:
         assert_eq!(stream_obj["job"].as_str(), Some("sonda"));
     }
 
-    #[test]
-    fn write_log_event_multi_stream_grouping_by_event_labels() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_log_event_multi_stream_grouping_by_event_labels() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1374,10 +1382,16 @@ sink:
         let ev1 = make_log_event(&[("peer_address", "10.1.2.2")], "to peer 1");
         let ev2 = make_log_event(&[("peer_address", "10.1.7.2")], "to peer 2");
         let ev1b = make_log_event(&[("peer_address", "10.1.2.2")], "to peer 1 again");
-        sink.write_log_event(&ev1, b"line-a").expect("write 1");
-        sink.write_log_event(&ev2, b"line-b").expect("write 2");
-        sink.write_log_event(&ev1b, b"line-c").expect("write 3");
-        sink.flush().expect("flush");
+        sink.write_log_event(&ev1, b"line-a")
+            .await
+            .expect("write 1");
+        sink.write_log_event(&ev2, b"line-b")
+            .await
+            .expect("write 2");
+        sink.write_log_event(&ev1b, b"line-c")
+            .await
+            .expect("write 3");
+        sink.flush().await.expect("flush");
 
         let streams = parse_streams(handle.join().expect("mock server"));
         assert_eq!(
@@ -1404,8 +1418,8 @@ sink:
         assert_eq!(by_peer.get("10.1.7.2"), Some(&1), "ev2 alone");
     }
 
-    #[test]
-    fn write_log_event_overlay_overrides_constructor_label_on_conflict() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_log_event_overlay_overrides_constructor_label_on_conflict() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1416,8 +1430,8 @@ sink:
         let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
         let event = make_log_event(&[("region", "eu-west")], "overridden");
-        sink.write_log_event(&event, b"line").expect("write");
-        sink.flush().expect("flush");
+        sink.write_log_event(&event, b"line").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let streams = parse_streams(handle.join().expect("mock server"));
         assert_eq!(streams.len(), 1);
@@ -1434,8 +1448,8 @@ sink:
         );
     }
 
-    #[test]
-    fn flush_with_stream_count_at_cap_succeeds() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_with_stream_count_at_cap_succeeds() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1444,9 +1458,10 @@ sink:
         for i in 0..3 {
             let ev = make_log_event(&[("peer", &format!("p{i}"))], "line");
             sink.write_log_event(&ev, format!("line-{i}").as_bytes())
+                .await
                 .expect("write");
         }
-        let flush_result = sink.flush();
+        let flush_result = sink.flush().await;
         assert!(
             flush_result.is_ok(),
             "exactly-at-cap must succeed: {flush_result:?}"
@@ -1456,8 +1471,8 @@ sink:
         assert_eq!(streams.len(), 3, "all three streams must be sent");
     }
 
-    #[test]
-    fn flush_exceeding_cap_returns_helpful_error_and_clears_batch() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_exceeding_cap_returns_helpful_error_and_clears_batch() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
         drop(listener);
@@ -1468,9 +1483,10 @@ sink:
         for i in 0..3 {
             let ev = make_log_event(&[("peer", &format!("p{i}"))], "line");
             sink.write_log_event(&ev, format!("line-{i}").as_bytes())
+                .await
                 .expect("write");
         }
-        let err = sink.flush().expect_err("over-cap flush must Err");
+        let err = sink.flush().await.expect_err("over-cap flush must Err");
         let msg = err.to_string();
         assert!(
             msg.contains("3 streams"),
@@ -1486,13 +1502,13 @@ sink:
         );
 
         assert!(
-            sink.flush().is_ok(),
+            sink.flush().await.is_ok(),
             "batch must be cleared after cap error"
         );
     }
 
-    #[test]
-    fn direct_write_falls_back_to_constructor_labels_only() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn direct_write_falls_back_to_constructor_labels_only() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1501,9 +1517,11 @@ sink:
 
         let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"line via direct write").expect("write");
-        sink.write(b"another line via direct write").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"line via direct write").await.expect("write");
+        sink.write(b"another line via direct write")
+            .await
+            .expect("write");
+        sink.flush().await.expect("flush");
 
         let streams = parse_streams(handle.join().expect("mock server"));
         assert_eq!(streams.len(), 1, "direct write produces a single stream");

--- a/sonda-core/src/sink/memory.rs
+++ b/sonda-core/src/sink/memory.rs
@@ -4,6 +4,8 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use async_trait::async_trait;
+
 use super::Sink;
 use crate::SondaError;
 
@@ -15,7 +17,6 @@ pub struct CapturedRing {
 }
 
 impl CapturedRing {
-    /// Create an empty ring that retains at most `max` events.
     pub fn new(max: usize) -> Self {
         Self {
             events: VecDeque::with_capacity(max),
@@ -23,7 +24,6 @@ impl CapturedRing {
         }
     }
 
-    /// Append `event`, evicting the oldest entry once the cap is reached.
     pub fn push(&mut self, event: (Instant, Vec<u8>)) {
         if self.events.len() == self.max {
             self.events.pop_front();
@@ -31,22 +31,18 @@ impl CapturedRing {
         self.events.push_back(event);
     }
 
-    /// Borrow the retained events in insertion order.
     pub fn events(&self) -> &VecDeque<(Instant, Vec<u8>)> {
         &self.events
     }
 
-    /// Number of retained events.
     pub fn len(&self) -> usize {
         self.events.len()
     }
 
-    /// Whether the ring currently holds no events.
     pub fn is_empty(&self) -> bool {
         self.events.is_empty()
     }
 
-    /// Configured cap on retained events.
     pub fn capacity(&self) -> usize {
         self.max
     }
@@ -54,17 +50,14 @@ impl CapturedRing {
 
 /// An in-memory sink that accumulates all written bytes in a `Vec<u8>`.
 ///
-/// This sink is intended for use in tests across the project. It allows
-/// callers to inspect the exact bytes that would have been delivered to a
-/// real destination (file, socket, stdout) without any I/O.
+/// Intended for tests across the project: callers can inspect the exact bytes
+/// that would have been delivered to a real destination without any I/O.
 pub struct MemorySink {
-    /// All bytes written to this sink, in order.
     pub buffer: Vec<u8>,
     captured: Option<Arc<Mutex<CapturedRing>>>,
 }
 
 impl MemorySink {
-    /// Create a new, empty `MemorySink` with no per-write timestamp capture.
     pub fn new() -> Self {
         Self {
             buffer: Vec::new(),
@@ -72,8 +65,8 @@ impl MemorySink {
         }
     }
 
-    /// Create a `MemorySink` that records `(Instant, bytes)` on every write,
-    /// keeping at most `max_events` of the most recent entries.
+    /// Record `(Instant, bytes)` on every write, keeping the most recent
+    /// `max_events` entries.
     pub fn with_capture(max_events: usize) -> Self {
         Self {
             buffer: Vec::new(),
@@ -81,7 +74,7 @@ impl MemorySink {
         }
     }
 
-    /// Create a `MemorySink` whose timestamped writes land in `handle`.
+    /// Mirror writes into an externally-owned capture ring.
     pub fn with_shared_capture(handle: Arc<Mutex<CapturedRing>>) -> Self {
         Self {
             buffer: Vec::new(),
@@ -89,12 +82,10 @@ impl MemorySink {
         }
     }
 
-    /// Borrow a clone of the shared capture handle, if capture is enabled.
     pub fn capture_handle(&self) -> Option<Arc<Mutex<CapturedRing>>> {
         self.captured.as_ref().map(Arc::clone)
     }
 
-    /// Snapshot the currently retained capture ring, if capture is enabled.
     pub fn captured(&self) -> Option<Vec<(Instant, Vec<u8>)>> {
         let handle = self.captured.as_ref()?;
         let guard = handle.lock().ok()?;
@@ -108,8 +99,9 @@ impl Default for MemorySink {
     }
 }
 
+#[async_trait]
 impl Sink for MemorySink {
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.buffer.extend_from_slice(data);
         if let Some(handle) = self.captured.as_ref() {
             if let Ok(mut ring) = handle.lock() {
@@ -119,7 +111,7 @@ impl Sink for MemorySink {
         Ok(())
     }
 
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
 }
@@ -128,44 +120,43 @@ impl Sink for MemorySink {
 mod tests {
     use super::*;
 
-    #[test]
-    fn write_stores_exact_bytes_in_buffer() {
+    #[tokio::test]
+    async fn write_stores_exact_bytes_in_buffer() {
         let mut sink = MemorySink::new();
         let data = b"hello, world\n";
-        sink.write(data).unwrap();
+        sink.write(data).await.unwrap();
         assert_eq!(sink.buffer, data);
     }
 
-    #[test]
-    fn write_empty_slice_appends_nothing() {
+    #[tokio::test]
+    async fn write_empty_slice_appends_nothing() {
         let mut sink = MemorySink::new();
-        sink.write(b"").unwrap();
+        sink.write(b"").await.unwrap();
         assert!(sink.buffer.is_empty());
     }
 
-    #[test]
-    fn multiple_writes_accumulate_in_order() {
+    #[tokio::test]
+    async fn multiple_writes_accumulate_in_order() {
         let mut sink = MemorySink::new();
-        sink.write(b"foo").unwrap();
-        sink.write(b"bar").unwrap();
-        sink.write(b"baz").unwrap();
+        sink.write(b"foo").await.unwrap();
+        sink.write(b"bar").await.unwrap();
+        sink.write(b"baz").await.unwrap();
         assert_eq!(&sink.buffer, b"foobarbaz");
     }
 
-    #[test]
-    fn flush_is_noop_and_returns_ok() {
+    #[tokio::test]
+    async fn flush_is_noop_and_returns_ok() {
         let mut sink = MemorySink::new();
-        sink.write(b"data").unwrap();
-        let result = sink.flush();
+        sink.write(b"data").await.unwrap();
+        let result = sink.flush().await;
         assert!(result.is_ok());
-        // Buffer unchanged after flush
         assert_eq!(&sink.buffer, b"data");
     }
 
-    #[test]
-    fn flush_on_empty_sink_returns_ok() {
+    #[tokio::test]
+    async fn flush_on_empty_sink_returns_ok() {
         let mut sink = MemorySink::new();
-        assert!(sink.flush().is_ok());
+        assert!(sink.flush().await.is_ok());
     }
 
     #[test]
@@ -174,42 +165,39 @@ mod tests {
         assert!(sink.buffer.is_empty());
     }
 
-    #[test]
-    fn buffer_field_is_publicly_accessible() {
+    #[tokio::test]
+    async fn buffer_field_is_publicly_accessible() {
         let mut sink = MemorySink::new();
-        sink.write(b"inspect me").unwrap();
-        // Direct field access — confirms pub visibility
+        sink.write(b"inspect me").await.unwrap();
         assert_eq!(sink.buffer.len(), 10);
     }
 
-    /// Compile-time proof that MemorySink satisfies Send + Sync.
     #[test]
     fn memory_sink_is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<MemorySink>();
     }
 
-    /// Verify that a boxed Sink trait object compiles correctly with MemorySink.
-    #[test]
-    fn memory_sink_usable_as_boxed_sink_trait_object() {
+    #[tokio::test]
+    async fn memory_sink_usable_as_boxed_sink_trait_object() {
         let mut sink: Box<dyn Sink> = Box::new(MemorySink::new());
-        sink.write(b"trait object write").unwrap();
-        sink.flush().unwrap();
+        sink.write(b"trait object write").await.unwrap();
+        sink.flush().await.unwrap();
     }
 
-    #[test]
-    fn new_disables_capture() {
+    #[tokio::test]
+    async fn new_disables_capture() {
         let mut sink = MemorySink::new();
-        sink.write(b"x").unwrap();
+        sink.write(b"x").await.unwrap();
         assert!(sink.captured().is_none());
         assert!(sink.capture_handle().is_none());
     }
 
-    #[test]
-    fn with_capture_records_timestamped_writes() {
+    #[tokio::test]
+    async fn with_capture_records_timestamped_writes() {
         let mut sink = MemorySink::with_capture(8);
-        sink.write(b"first").unwrap();
-        sink.write(b"second").unwrap();
+        sink.write(b"first").await.unwrap();
+        sink.write(b"second").await.unwrap();
         let snap = sink.captured().expect("capture enabled");
         assert_eq!(snap.len(), 2);
         assert_eq!(snap[0].1, b"first");
@@ -217,11 +205,11 @@ mod tests {
         assert!(snap[1].0 >= snap[0].0);
     }
 
-    #[test]
-    fn capture_ring_evicts_oldest_when_full() {
+    #[tokio::test]
+    async fn capture_ring_evicts_oldest_when_full() {
         let mut sink = MemorySink::with_capture(3);
         for i in 0..5 {
-            sink.write(format!("e{i}").as_bytes()).unwrap();
+            sink.write(format!("e{i}").as_bytes()).await.unwrap();
         }
         let snap = sink.captured().expect("capture enabled");
         assert_eq!(snap.len(), 3);
@@ -230,33 +218,33 @@ mod tests {
         assert_eq!(snap[2].1, b"e4");
     }
 
-    #[test]
-    fn capture_handle_observes_writes_across_clones() {
+    #[tokio::test]
+    async fn capture_handle_observes_writes_across_clones() {
         let sink = MemorySink::with_capture(4);
         let handle = sink.capture_handle().expect("capture enabled");
         let mut sink = sink;
-        sink.write(b"a").unwrap();
-        sink.write(b"b").unwrap();
+        sink.write(b"a").await.unwrap();
+        sink.write(b"b").await.unwrap();
         let guard = handle.lock().unwrap();
         assert_eq!(guard.len(), 2);
         assert_eq!(guard.events()[0].1, b"a");
         assert_eq!(guard.events()[1].1, b"b");
     }
 
-    #[test]
-    fn with_shared_capture_writes_through_external_handle() {
+    #[tokio::test]
+    async fn with_shared_capture_writes_through_external_handle() {
         let handle = Arc::new(Mutex::new(CapturedRing::new(4)));
         let mut sink = MemorySink::with_shared_capture(Arc::clone(&handle));
-        sink.write(b"shared").unwrap();
+        sink.write(b"shared").await.unwrap();
         let guard = handle.lock().unwrap();
         assert_eq!(guard.len(), 1);
         assert_eq!(guard.events()[0].1, b"shared");
     }
 
-    #[test]
-    fn buffer_remains_populated_alongside_capture() {
+    #[tokio::test]
+    async fn buffer_remains_populated_alongside_capture() {
         let mut sink = MemorySink::with_capture(4);
-        sink.write(b"hello").unwrap();
+        sink.write(b"hello").await.unwrap();
         assert_eq!(&sink.buffer, b"hello");
         assert_eq!(sink.captured().unwrap().len(), 1);
     }

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -23,16 +23,17 @@ pub mod udp;
 use std::collections::HashMap;
 use std::path::Path;
 
+use async_trait::async_trait;
+
 use crate::model::log::LogEvent;
 use crate::SondaError;
 
 /// A sink consumes encoded bytes and delivers them to a destination.
+#[async_trait]
 pub trait Sink: Send + Sync {
-    /// Write encoded event data to the sink.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError>;
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError>;
 
-    /// Flush any buffered data to the destination.
-    fn flush(&mut self) -> Result<(), SondaError>;
+    async fn flush(&mut self) -> Result<(), SondaError>;
 
     /// Whether the most recent `write()` delivered data to the destination,
     /// or only buffered it. Non-batching sinks deliver on every write, so the
@@ -42,15 +43,14 @@ pub trait Sink: Send + Sync {
         true
     }
 
-    /// Write an encoded log event to the sink, with the originating
-    /// [`LogEvent`] alongside for sinks that build their own delivery
-    /// envelope from per-event context (e.g. labels).
-    ///
-    /// The default impl ignores the event reference and forwards to
-    /// [`Sink::write`], preserving the bytes-only contract every existing
-    /// sink relies on. Sinks that need per-event labels override this.
-    fn write_log_event(&mut self, _event: &LogEvent, encoded: &[u8]) -> Result<(), SondaError> {
-        self.write(encoded)
+    /// Write an encoded log event with originating context. Default impl
+    /// drops the event and forwards bytes to [`Sink::write`].
+    async fn write_log_event(
+        &mut self,
+        _event: &LogEvent,
+        encoded: &[u8],
+    ) -> Result<(), SondaError> {
+        self.write(encoded).await
     }
 }
 
@@ -388,11 +388,8 @@ pub enum SinkConfig {
 
 /// Create a boxed [`Sink`] from the given [`SinkConfig`].
 ///
-/// The optional `labels` parameter is used only by the Loki sink (feature
-/// `http`) to set stream labels. For all other sink types, pass `None`. Log
-/// scenarios pass the scenario-level labels here so that Loki stream labels
-/// are configured at the same level as every other signal type.
-pub fn create_sink(
+/// `labels` populates Loki stream labels; pass `None` for every other sink.
+pub async fn create_sink(
     config: &SinkConfig,
     labels: Option<&HashMap<String, String>>,
 ) -> Result<Box<dyn Sink>, SondaError> {
@@ -401,7 +398,7 @@ pub fn create_sink(
     let _ = &labels;
     match config {
         SinkConfig::Stdout => Ok(Box::new(stdout::StdoutSink::new())),
-        SinkConfig::File { path } => Ok(Box::new(file::FileSink::new(Path::new(path))?)),
+        SinkConfig::File { path } => Ok(Box::new(file::FileSink::new(Path::new(path)).await?)),
         SinkConfig::Tcp {
             address,
             retry: retry_cfg,
@@ -410,9 +407,9 @@ pub fn create_sink(
                 .as_ref()
                 .map(retry::RetryPolicy::from_config)
                 .transpose()?;
-            Ok(Box::new(tcp::TcpSink::new(address, rp)?))
+            Ok(Box::new(tcp::TcpSink::new(address, rp).await?))
         }
-        SinkConfig::Udp { address } => Ok(Box::new(udp::UdpSink::new(address)?)),
+        SinkConfig::Udp { address } => Ok(Box::new(udp::UdpSink::new(address).await?)),
         SinkConfig::Memory {
             capture,
             max_events,
@@ -490,14 +487,10 @@ pub fn create_sink(
                 None => Some(std::time::Duration::from_secs(5)),
             }
             .unwrap_or(std::time::Duration::ZERO);
-            Ok(Box::new(kafka::KafkaSink::new(
-                brokers,
-                topic,
-                rp,
-                tls.as_ref(),
-                sasl.as_ref(),
-                buffer_age,
-            )?))
+            Ok(Box::new(
+                kafka::KafkaSink::new(brokers, topic, rp, tls.as_ref(), sasl.as_ref(), buffer_age)
+                    .await?,
+            ))
         }
         #[cfg(feature = "http")]
         SinkConfig::Loki {
@@ -561,14 +554,17 @@ pub fn create_sink(
                 None => Some(std::time::Duration::from_secs(5)),
             }
             .unwrap_or(std::time::Duration::ZERO);
-            Ok(Box::new(otlp_grpc::OtlpGrpcSink::new(
-                endpoint,
-                *signal_type,
-                bs,
-                resource_attrs,
-                rp,
-                buffer_age,
-            )?))
+            Ok(Box::new(
+                otlp_grpc::OtlpGrpcSink::new(
+                    endpoint,
+                    *signal_type,
+                    bs,
+                    resource_attrs,
+                    rp,
+                    buffer_age,
+                )
+                .await?,
+            ))
         }
         #[cfg(not(feature = "http"))]
         SinkConfig::HttpPushDisabled { .. } => {
@@ -604,17 +600,17 @@ pub fn create_sink(
 mod tests {
     use super::*;
 
-    #[test]
-    fn create_sink_stdout_returns_ok() {
-        let result = create_sink(&SinkConfig::Stdout, None);
+    #[tokio::test]
+    async fn create_sink_stdout_returns_ok() {
+        let result = create_sink(&SinkConfig::Stdout, None).await;
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn create_sink_stdout_write_and_flush_succeed() {
-        let mut sink = create_sink(&SinkConfig::Stdout, None).unwrap();
-        assert!(sink.write(b"").is_ok());
-        assert!(sink.flush().is_ok());
+    #[tokio::test]
+    async fn create_sink_stdout_write_and_flush_succeed() {
+        let mut sink = create_sink(&SinkConfig::Stdout, None).await.unwrap();
+        assert!(sink.write(b"").await.is_ok());
+        assert!(sink.flush().await.is_ok());
     }
 
     #[cfg(feature = "config")]
@@ -625,13 +621,12 @@ mod tests {
         assert!(matches!(config, SinkConfig::Stdout));
     }
 
-    #[test]
-    fn sink_config_is_cloneable() {
+    #[tokio::test]
+    async fn sink_config_is_cloneable() {
         let config = SinkConfig::Stdout;
         let cloned = config.clone();
-        // Both variants should produce valid sinks
-        assert!(create_sink(&config, None).is_ok());
-        assert!(create_sink(&cloned, None).is_ok());
+        assert!(create_sink(&config, None).await.is_ok());
+        assert!(create_sink(&cloned, None).await.is_ok());
     }
 
     #[test]
@@ -969,10 +964,9 @@ sink:
     /// before returning an error. Run with `cargo test -- --ignored` when the
     /// test environment can tolerate network delays.
     #[cfg(feature = "kafka")]
-    #[test]
+    #[tokio::test]
     #[ignore = "requires network timeout which is slow; run with --ignored when desired"]
-    fn create_sink_kafka_with_unreachable_broker_returns_err() {
-        // Port 1 is privileged and will always refuse connections.
+    async fn create_sink_kafka_with_unreachable_broker_returns_err() {
         let config = SinkConfig::Kafka {
             brokers: "127.0.0.1:1".to_string(),
             topic: "sonda-test".to_string(),
@@ -981,17 +975,16 @@ sink:
             tls: None,
             sasl: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_err(),
             "create_sink should propagate the broker connection failure"
         );
     }
 
-    /// create_sink with an empty broker string returns Err immediately.
     #[cfg(feature = "kafka")]
-    #[test]
-    fn create_sink_kafka_with_empty_broker_returns_err() {
+    #[tokio::test]
+    async fn create_sink_kafka_with_empty_broker_returns_err() {
         let config = SinkConfig::Kafka {
             brokers: String::new(),
             topic: "sonda-test".to_string(),
@@ -1000,7 +993,7 @@ sink:
             tls: None,
             sasl: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_err(),
             "create_sink should reject an empty broker string"
@@ -1008,8 +1001,8 @@ sink:
     }
 
     #[cfg(feature = "kafka")]
-    #[test]
-    fn create_sink_kafka_with_invalid_max_buffer_age_returns_err() {
+    #[tokio::test]
+    async fn create_sink_kafka_with_invalid_max_buffer_age_returns_err() {
         let config = SinkConfig::Kafka {
             brokers: "127.0.0.1:9092".to_string(),
             topic: "sonda-test".to_string(),
@@ -1018,7 +1011,7 @@ sink:
             tls: None,
             sasl: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_err(),
             "create_sink should reject an unparseable max_buffer_age before connecting"
@@ -1134,11 +1127,9 @@ headers: {}
     // Feature gate: `http` feature controls HttpPush and Loki availability
     // ---------------------------------------------------------------------------
 
-    /// When the `http` feature is enabled, `SinkConfig::HttpPush` must be
-    /// constructible and the factory must produce a valid sink.
     #[cfg(feature = "http")]
-    #[test]
-    fn http_feature_enables_http_push_variant() {
+    #[tokio::test]
+    async fn http_feature_enables_http_push_variant() {
         let config = SinkConfig::HttpPush {
             url: "http://127.0.0.1:19999/push".to_string(),
             content_type: None,
@@ -1147,18 +1138,16 @@ headers: {}
             headers: None,
             retry: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_ok(),
             "HttpPush variant must be available when http feature is enabled"
         );
     }
 
-    /// When the `http` feature is enabled, `SinkConfig::Loki` must be
-    /// constructible and the factory must produce a valid sink.
     #[cfg(feature = "http")]
-    #[test]
-    fn http_feature_enables_loki_variant() {
+    #[tokio::test]
+    async fn http_feature_enables_loki_variant() {
         let config = SinkConfig::Loki {
             url: "http://127.0.0.1:19999".to_string(),
             batch_size: None,
@@ -1166,7 +1155,7 @@ headers: {}
             max_buffer_age: None,
             retry: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_ok(),
             "Loki variant must be available when http feature is enabled"
@@ -1193,12 +1182,9 @@ headers: {}
         assert!(matches!(config, SinkConfig::Loki { .. }));
     }
 
-    /// Non-HTTP sinks (stdout, file, tcp, udp) must remain available
-    /// regardless of the `http` feature flag.
-    #[test]
-    fn non_http_sinks_available_without_http_feature() {
-        // This test compiles and runs with or without the `http` feature.
-        assert!(create_sink(&SinkConfig::Stdout, None).is_ok());
+    #[tokio::test]
+    async fn non_http_sinks_available_without_http_feature() {
+        assert!(create_sink(&SinkConfig::Stdout, None).await.is_ok());
     }
 
     // ---------------------------------------------------------------------------
@@ -1294,10 +1280,11 @@ retry:
     }
 
     #[cfg(not(feature = "kafka"))]
-    #[test]
-    fn create_sink_kafka_disabled_returns_feature_hint_error() {
+    #[tokio::test]
+    async fn create_sink_kafka_disabled_returns_feature_hint_error() {
         let config = SinkConfig::KafkaDisabled {};
         let err = create_sink(&config, None)
+            .await
             .err()
             .expect("must return Err for disabled variant");
         let msg = err.to_string();
@@ -1321,10 +1308,11 @@ retry:
     }
 
     #[cfg(not(feature = "http"))]
-    #[test]
-    fn create_sink_http_push_disabled_returns_feature_hint_error() {
+    #[tokio::test]
+    async fn create_sink_http_push_disabled_returns_feature_hint_error() {
         let config = SinkConfig::HttpPushDisabled {};
         let err = create_sink(&config, None)
+            .await
             .err()
             .expect("must return Err for disabled variant");
         let msg = err.to_string();
@@ -1348,10 +1336,11 @@ retry:
     }
 
     #[cfg(not(feature = "http"))]
-    #[test]
-    fn create_sink_loki_disabled_returns_feature_hint_error() {
+    #[tokio::test]
+    async fn create_sink_loki_disabled_returns_feature_hint_error() {
         let config = SinkConfig::LokiDisabled {};
         let err = create_sink(&config, None)
+            .await
             .err()
             .expect("must return Err for disabled variant");
         let msg = err.to_string();
@@ -1375,10 +1364,11 @@ retry:
     }
 
     #[cfg(not(feature = "remote-write"))]
-    #[test]
-    fn create_sink_remote_write_disabled_returns_feature_hint_error() {
+    #[tokio::test]
+    async fn create_sink_remote_write_disabled_returns_feature_hint_error() {
         let config = SinkConfig::RemoteWriteDisabled {};
         let err = create_sink(&config, None)
+            .await
             .err()
             .expect("must return Err for disabled variant");
         let msg = err.to_string();
@@ -1392,8 +1382,8 @@ retry:
         );
     }
 
-    #[test]
-    fn default_write_log_event_forwards_encoded_bytes_to_write() {
+    #[tokio::test]
+    async fn default_write_log_event_forwards_encoded_bytes_to_write() {
         use crate::model::log::{LogEvent, Severity};
         use crate::model::metric::Labels;
         use memory::MemorySink;
@@ -1410,10 +1400,8 @@ retry:
         );
         let encoded = b"<encoded payload>";
 
-        // MemorySink does not override `write_log_event`, so the call must
-        // route through the default impl and end up appended to `buffer`
-        // exactly as `write(encoded)` would.
         sink.write_log_event(&event, encoded)
+            .await
             .expect("default write_log_event must succeed");
 
         assert_eq!(
@@ -1422,31 +1410,27 @@ retry:
         );
     }
 
-    // ---------------------------------------------------------------------------
-    // SinkConfig::Memory: factory wiring and capture path
-    // ---------------------------------------------------------------------------
-
-    #[test]
-    fn create_sink_memory_without_capture_returns_ok() {
+    #[tokio::test]
+    async fn create_sink_memory_without_capture_returns_ok() {
         let cfg = SinkConfig::Memory {
             capture: false,
             max_events: None,
         };
-        let mut sink = create_sink(&cfg, None).unwrap();
-        sink.write(b"hello").unwrap();
-        sink.flush().unwrap();
+        let mut sink = create_sink(&cfg, None).await.unwrap();
+        sink.write(b"hello").await.unwrap();
+        sink.flush().await.unwrap();
     }
 
-    #[test]
-    fn create_sink_memory_with_capture_returns_usable_sink() {
+    #[tokio::test]
+    async fn create_sink_memory_with_capture_returns_usable_sink() {
         let cfg = SinkConfig::Memory {
             capture: true,
             max_events: Some(8),
         };
-        let mut sink = create_sink(&cfg, None).unwrap();
-        sink.write(b"one").unwrap();
-        sink.write(b"two").unwrap();
-        sink.flush().unwrap();
+        let mut sink = create_sink(&cfg, None).await.unwrap();
+        sink.write(b"one").await.unwrap();
+        sink.write(b"two").await.unwrap();
+        sink.flush().await.unwrap();
     }
 
     #[cfg(feature = "config")]
@@ -1505,10 +1489,11 @@ retry:
     }
 
     #[cfg(not(feature = "otlp"))]
-    #[test]
-    fn create_sink_otlp_grpc_disabled_returns_feature_hint_error() {
+    #[tokio::test]
+    async fn create_sink_otlp_grpc_disabled_returns_feature_hint_error() {
         let config = SinkConfig::OtlpGrpcDisabled {};
         let err = create_sink(&config, None)
+            .await
             .err()
             .expect("must return Err for disabled variant");
         let msg = err.to_string();

--- a/sonda-core/src/sink/otlp_grpc.rs
+++ b/sonda-core/src/sink/otlp_grpc.rs
@@ -10,19 +10,14 @@
 //!    accumulated items into an `ExportMetricsServiceRequest` or
 //!    `ExportLogsServiceRequest`, and sends it via gRPC unary call.
 //!
-//! Async gRPC operations are driven by a dedicated single-threaded
-//! [`tokio::runtime::Runtime`] stored in the struct, keeping the public
-//! [`Sink`] interface fully synchronous. This is the same pattern used by
-//! the Kafka sink.
-//!
 //! Requires the `otlp` feature flag.
 
 use std::marker::PhantomData;
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use bytes::Buf;
 use prost::Message;
-use tokio::runtime::Runtime;
 use tonic::client::Grpc;
 use tonic::codec::{Codec, Decoder, Encoder as TonicEncoder};
 use tonic::transport::Channel;
@@ -150,38 +145,21 @@ pub enum OtlpSignalType {
 
 /// Delivers OTLP protobuf telemetry to an OpenTelemetry Collector via gRPC.
 ///
-/// The sink accumulates encoded data points in an internal batch. When the
-/// batch reaches `batch_size` entries, or when `flush()` is called, the batch
-/// is wrapped in the appropriate OTLP export request and sent via gRPC unary
-/// call to the configured endpoint.
-///
-/// Uses a private single-threaded [`Runtime`] to drive async tonic calls,
-/// keeping the [`Sink`] trait interface fully synchronous.
+/// Encoded data points accumulate in an internal batch. When the batch reaches
+/// `batch_size`, or when `flush()` is called, the batch is wrapped in the
+/// appropriate OTLP export request and sent via a tonic gRPC unary call.
 pub struct OtlpGrpcSink {
-    /// Tokio runtime used to drive async tonic calls synchronously.
-    runtime: Runtime,
-    /// The gRPC channel (connection) to the OTLP endpoint.
     channel: Channel,
-    /// Accumulated metrics waiting to be sent.
     metric_batch: Vec<Metric>,
-    /// Accumulated log records waiting to be sent.
     log_batch: Vec<LogRecord>,
-    /// Flush threshold in number of data points / log records.
     batch_size: usize,
-    /// Whether this sink handles metrics or logs.
     signal_type: OtlpSignalType,
-    /// Resource attributes derived from scenario labels.
     resource_attrs: Vec<KeyValue>,
-    /// The endpoint URL string (stored for error messages).
     endpoint: String,
-    /// Optional retry policy for transient failures.
     retry_policy: Option<RetryPolicy>,
-    /// Maximum age a non-empty batch may reach before a time-based flush.
     /// `Duration::ZERO` disables time-based flushing.
     max_buffer_age: Duration,
-    /// When a batch was last sent — drives the time-based flush check.
     last_flush_at: Instant,
-    /// Whether the most recent `write()` triggered a successful flush rather than only buffering.
     last_write_delivered: bool,
 }
 
@@ -199,13 +177,7 @@ impl OtlpGrpcSink {
     /// - `max_buffer_age` — maximum age a non-empty batch may reach before a
     ///   time-based flush. `Duration::ZERO` disables time-based flushing.
     ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if:
-    /// - The tokio runtime cannot be created.
-    /// - The endpoint URL cannot be parsed.
-    /// - The gRPC connection cannot be established.
-    pub fn new(
+    pub async fn new(
         endpoint: &str,
         signal_type: OtlpSignalType,
         batch_size: usize,
@@ -213,46 +185,29 @@ impl OtlpGrpcSink {
         retry_policy: Option<RetryPolicy>,
         max_buffer_age: Duration,
     ) -> Result<Self, SondaError> {
-        // Build a minimal single-threaded tokio runtime.
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
+        let endpoint_str = endpoint.to_owned();
+        let channel = Channel::from_shared(endpoint_str.clone())
             .map_err(|e| {
                 std::io::Error::other(format!(
-                    "otlp grpc sink: failed to build tokio runtime for '{}': {}",
-                    endpoint, e
+                    "otlp grpc sink: invalid endpoint '{}': {}",
+                    endpoint_str, e
                 ))
             })
-            .map_err(SondaError::Sink)?;
-
-        let endpoint_str = endpoint.to_owned();
-
-        // Connect to the gRPC endpoint.
-        let channel = runtime
-            .block_on(async {
-                Channel::from_shared(endpoint_str.clone())
-                    .map_err(|e| {
-                        std::io::Error::other(format!(
-                            "otlp grpc sink: invalid endpoint '{}': {}",
-                            endpoint_str, e
-                        ))
-                    })?
-                    .connect()
-                    .await
-                    .map_err(|e| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::ConnectionRefused,
-                            format!(
-                                "otlp grpc sink: failed to connect to '{}': {}",
-                                endpoint_str, e
-                            ),
-                        )
-                    })
+            .map_err(SondaError::Sink)?
+            .connect()
+            .await
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    format!(
+                        "otlp grpc sink: failed to connect to '{}': {}",
+                        endpoint_str, e
+                    ),
+                )
             })
             .map_err(SondaError::Sink)?;
 
         Ok(Self {
-            runtime,
             channel,
             metric_batch: Vec::with_capacity(batch_size),
             log_batch: Vec::with_capacity(batch_size),
@@ -282,114 +237,70 @@ impl OtlpGrpcSink {
         }
     }
 
-    /// Flush the metric batch as an `ExportMetricsServiceRequest` via gRPC.
-    ///
-    /// Uses the configured [`RetryPolicy`] for transient gRPC failures.
-    fn flush_metrics(&mut self) -> Result<(), SondaError> {
+    async fn flush_metrics(&mut self) -> Result<(), SondaError> {
         if self.metric_batch.is_empty() {
             return Ok(());
         }
-
-        // Reset on attempt, not success — the batch is cleared either way below.
         self.last_flush_at = Instant::now();
-
         let metrics =
             std::mem::replace(&mut self.metric_batch, Vec::with_capacity(self.batch_size));
 
-        match &self.retry_policy {
-            Some(policy) => {
-                let policy = policy.clone();
-                // Clone metrics for potential retries since send_grpc_unary
-                // consumes the request.
-                policy.execute(
-                    || {
-                        let request = ExportMetricsServiceRequest {
-                            resource_metrics: vec![ResourceMetrics {
-                                resource: Some(self.build_resource()),
-                                scope_metrics: vec![ScopeMetrics {
-                                    scope: Some(Self::build_scope()),
-                                    metrics: metrics.clone(),
-                                }],
-                            }],
-                        };
-                        self.send_grpc_unary::<
-                            ExportMetricsServiceRequest,
-                            ExportMetricsServiceResponse,
-                        >(request, METRICS_EXPORT_PATH)
-                    },
-                    Self::is_retryable,
-                )
-            }
-            None => {
-                let request = ExportMetricsServiceRequest {
-                    resource_metrics: vec![ResourceMetrics {
-                        resource: Some(self.build_resource()),
-                        scope_metrics: vec![ScopeMetrics {
-                            scope: Some(Self::build_scope()),
-                            metrics,
-                        }],
+        let channel = self.channel.clone();
+        let endpoint = self.endpoint.clone();
+        let resource = self.build_resource();
+        let send_once = || async {
+            let request = ExportMetricsServiceRequest {
+                resource_metrics: vec![ResourceMetrics {
+                    resource: Some(resource.clone()),
+                    scope_metrics: vec![ScopeMetrics {
+                        scope: Some(Self::build_scope()),
+                        metrics: metrics.clone(),
                     }],
-                };
-                self.send_grpc_unary::<ExportMetricsServiceRequest, ExportMetricsServiceResponse>(
-                    request,
-                    METRICS_EXPORT_PATH,
-                )
-            }
-        }
+                }],
+            };
+            send_grpc_unary::<ExportMetricsServiceRequest, ExportMetricsServiceResponse>(
+                channel.clone(),
+                &endpoint,
+                request,
+                METRICS_EXPORT_PATH,
+            )
+            .await
+        };
+
+        run_with_retry(self.retry_policy.as_ref(), send_once).await
     }
 
-    /// Flush the log batch as an `ExportLogsServiceRequest` via gRPC.
-    ///
-    /// Uses the configured [`RetryPolicy`] for transient gRPC failures.
-    fn flush_logs(&mut self) -> Result<(), SondaError> {
+    async fn flush_logs(&mut self) -> Result<(), SondaError> {
         if self.log_batch.is_empty() {
             return Ok(());
         }
-
-        // Reset on attempt, not success — the batch is cleared either way below.
         self.last_flush_at = Instant::now();
-
         let log_records =
             std::mem::replace(&mut self.log_batch, Vec::with_capacity(self.batch_size));
 
-        match &self.retry_policy {
-            Some(policy) => {
-                let policy = policy.clone();
-                policy.execute(
-                    || {
-                        let request = ExportLogsServiceRequest {
-                            resource_logs: vec![ResourceLogs {
-                                resource: Some(self.build_resource()),
-                                scope_logs: vec![ScopeLogs {
-                                    scope: Some(Self::build_scope()),
-                                    log_records: log_records.clone(),
-                                }],
-                            }],
-                        };
-                        self.send_grpc_unary::<ExportLogsServiceRequest, ExportLogsServiceResponse>(
-                            request,
-                            LOGS_EXPORT_PATH,
-                        )
-                    },
-                    Self::is_retryable,
-                )
-            }
-            None => {
-                let request = ExportLogsServiceRequest {
-                    resource_logs: vec![ResourceLogs {
-                        resource: Some(self.build_resource()),
-                        scope_logs: vec![ScopeLogs {
-                            scope: Some(Self::build_scope()),
-                            log_records,
-                        }],
+        let channel = self.channel.clone();
+        let endpoint = self.endpoint.clone();
+        let resource = self.build_resource();
+        let send_once = || async {
+            let request = ExportLogsServiceRequest {
+                resource_logs: vec![ResourceLogs {
+                    resource: Some(resource.clone()),
+                    scope_logs: vec![ScopeLogs {
+                        scope: Some(Self::build_scope()),
+                        log_records: log_records.clone(),
                     }],
-                };
-                self.send_grpc_unary::<ExportLogsServiceRequest, ExportLogsServiceResponse>(
-                    request,
-                    LOGS_EXPORT_PATH,
-                )
-            }
-        }
+                }],
+            };
+            send_grpc_unary::<ExportLogsServiceRequest, ExportLogsServiceResponse>(
+                channel.clone(),
+                &endpoint,
+                request,
+                LOGS_EXPORT_PATH,
+            )
+            .await
+        };
+
+        run_with_retry(self.retry_policy.as_ref(), send_once).await
     }
 
     /// Classify whether a gRPC error is retryable.
@@ -417,52 +328,91 @@ impl OtlpGrpcSink {
         }
         false
     }
-
-    /// Send a gRPC unary call using the custom prost codec.
-    fn send_grpc_unary<T, U>(&mut self, request: T, path: &'static str) -> Result<(), SondaError>
-    where
-        T: Message + 'static,
-        U: Message + Default + 'static,
-    {
-        let channel = self.channel.clone();
-        let endpoint = self.endpoint.clone();
-
-        let result = self.runtime.block_on(async {
-            let mut client = Grpc::new(channel);
-            client.ready().await.map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::ConnectionRefused,
-                    format!("otlp grpc sink: service not ready at '{}': {}", endpoint, e),
-                )
-            })?;
-
-            let grpc_path = http::uri::PathAndQuery::from_static(path);
-            let codec: OtlpCodec<T, U> = OtlpCodec::default();
-            let tonic_request = tonic::Request::new(request);
-
-            client
-                .unary(tonic_request, grpc_path, codec)
-                .await
-                .map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        format!("otlp grpc sink: gRPC call to '{}' failed: {}", endpoint, e),
-                    )
-                })?;
-
-            Ok::<(), std::io::Error>(())
-        });
-
-        result.map_err(SondaError::Sink)
-    }
 }
 
+async fn send_grpc_unary<T, U>(
+    channel: Channel,
+    endpoint: &str,
+    request: T,
+    path: &'static str,
+) -> Result<(), SondaError>
+where
+    T: Message + 'static,
+    U: Message + Default + 'static,
+{
+    let mut client = Grpc::new(channel);
+    client
+        .ready()
+        .await
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                format!("otlp grpc sink: service not ready at '{}': {}", endpoint, e),
+            )
+        })
+        .map_err(SondaError::Sink)?;
+
+    let grpc_path = http::uri::PathAndQuery::from_static(path);
+    let codec: OtlpCodec<T, U> = OtlpCodec::default();
+    let tonic_request = tonic::Request::new(request);
+
+    client
+        .unary(tonic_request, grpc_path, codec)
+        .await
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                format!("otlp grpc sink: gRPC call to '{}' failed: {}", endpoint, e),
+            )
+        })
+        .map_err(SondaError::Sink)?;
+    Ok(())
+}
+
+async fn run_with_retry<F, Fut>(
+    policy: Option<&RetryPolicy>,
+    mut send_once: F,
+) -> Result<(), SondaError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<(), SondaError>>,
+{
+    let mut last_error = match send_once().await {
+        Ok(()) => return Ok(()),
+        Err(e) => e,
+    };
+    let Some(policy) = policy else {
+        return Err(last_error);
+    };
+    for attempt in 0..policy.max_attempts() {
+        if !OtlpGrpcSink::is_retryable(&last_error) {
+            return Err(last_error);
+        }
+        let backoff = policy.jittered_backoff(attempt);
+        eprintln!(
+            "sonda: retry {}/{} after {}ms (error: {})",
+            attempt + 1,
+            policy.max_attempts(),
+            backoff.as_millis(),
+            last_error,
+        );
+        tokio::time::sleep(backoff).await;
+        match send_once().await {
+            Ok(()) => return Ok(()),
+            Err(e) => last_error = e,
+        }
+    }
+    eprintln!(
+        "sonda: all {} retries exhausted (last error: {})",
+        policy.max_attempts(),
+        last_error,
+    );
+    Err(last_error)
+}
+
+#[async_trait]
 impl Sink for OtlpGrpcSink {
-    /// Accept length-prefixed OTLP protobuf bytes from the encoder.
-    ///
-    /// Parses each message from the data and adds it to the internal batch.
-    /// When the batch reaches `batch_size` entries, an automatic flush is triggered.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         match self.signal_type {
             OtlpSignalType::Metrics => {
                 let metrics = otlp::parse_length_prefixed_metrics(data)?;
@@ -472,7 +422,7 @@ impl Sink for OtlpGrpcSink {
                     && self.last_flush_at.elapsed() >= self.max_buffer_age;
                 let should_flush = size_reached || age_reached;
                 if should_flush {
-                    self.flush_metrics()?;
+                    self.flush_metrics().await?;
                 }
                 self.last_write_delivered = should_flush;
             }
@@ -484,7 +434,7 @@ impl Sink for OtlpGrpcSink {
                     && self.last_flush_at.elapsed() >= self.max_buffer_age;
                 let should_flush = size_reached || age_reached;
                 if should_flush {
-                    self.flush_logs()?;
+                    self.flush_logs().await?;
                 }
                 self.last_write_delivered = should_flush;
             }
@@ -492,14 +442,10 @@ impl Sink for OtlpGrpcSink {
         Ok(())
     }
 
-    /// Flush any remaining buffered data to the OTLP endpoint.
-    ///
-    /// Safe to call multiple times. Returns `Ok(())` immediately if the batch
-    /// is empty.
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         match self.signal_type {
-            OtlpSignalType::Metrics => self.flush_metrics(),
-            OtlpSignalType::Logs => self.flush_logs(),
+            OtlpSignalType::Metrics => self.flush_metrics().await,
+            OtlpSignalType::Logs => self.flush_logs().await,
         }
     }
 
@@ -520,24 +466,14 @@ mod tests {
     // Helpers
     // -----------------------------------------------------------------------
 
-    /// Build a sink with a lazy (non-connecting) channel pointed at a dead
-    /// address. `write()` buffers without network I/O; only a triggered flush
-    /// reaches the channel, where it fails — letting tests assert on buffer
-    /// state and on whether a flush was attempted, without a live collector.
+    /// Build a sink with a lazy (non-connecting) channel pointed at a dead address.
     fn lazy_sink(
         signal_type: OtlpSignalType,
         batch_size: usize,
         max_buffer_age: Duration,
     ) -> OtlpGrpcSink {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("build runtime");
-        let channel = runtime.block_on(async {
-            tonic::transport::Endpoint::from_static("http://127.0.0.1:1").connect_lazy()
-        });
+        let channel = tonic::transport::Endpoint::from_static("http://127.0.0.1:1").connect_lazy();
         OtlpGrpcSink {
-            runtime,
             channel,
             metric_batch: Vec::with_capacity(batch_size),
             log_batch: Vec::with_capacity(batch_size),
@@ -821,11 +757,9 @@ signal_type: logs
     // Construction failure: unreachable endpoint
     // -----------------------------------------------------------------------
 
-    /// Connecting to a port where no OTLP collector is listening must return a
-    /// SondaError::Sink.
-    #[test]
+    #[tokio::test]
     #[ignore = "requires network timeout; run with --ignored when desired"]
-    fn new_with_unreachable_endpoint_returns_sink_error() {
+    async fn new_with_unreachable_endpoint_returns_sink_error() {
         let result = OtlpGrpcSink::new(
             "http://127.0.0.1:1",
             OtlpSignalType::Metrics,
@@ -833,7 +767,8 @@ signal_type: logs
             vec![],
             None,
             Duration::ZERO,
-        );
+        )
+        .await;
         match result {
             Err(err) => {
                 let msg = err.to_string();
@@ -846,9 +781,8 @@ signal_type: logs
         }
     }
 
-    /// An invalid endpoint URL (not parseable) should return an error.
-    #[test]
-    fn new_with_invalid_endpoint_returns_error() {
+    #[tokio::test]
+    async fn new_with_invalid_endpoint_returns_error() {
         let result = OtlpGrpcSink::new(
             "not a url",
             OtlpSignalType::Metrics,
@@ -856,7 +790,8 @@ signal_type: logs
             vec![],
             None,
             Duration::ZERO,
-        );
+        )
+        .await;
         assert!(result.is_err(), "invalid endpoint URL must be rejected");
     }
 
@@ -939,22 +874,21 @@ sink:
     // Time-based flush
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn time_based_flush_fires_when_buffer_age_exceeded() {
-        // Large batch_size so size never triggers; short max_buffer_age.
+    #[tokio::test]
+    async fn time_based_flush_fires_when_buffer_age_exceeded() {
         let mut sink = lazy_sink(
             OtlpSignalType::Metrics,
             1_000_000,
             Duration::from_millis(50),
         );
 
-        sink.write(&one_metric_bytes("first")).expect("write 1");
+        sink.write(&one_metric_bytes("first"))
+            .await
+            .expect("write 1");
         assert_eq!(sink.metric_batch.len(), 1, "first write only buffers");
 
-        std::thread::sleep(Duration::from_millis(200));
-        // Second write is past max_buffer_age → triggers a time-based flush.
-        // The lazy channel has no peer, so the flush attempt fails.
-        let result = sink.write(&one_metric_bytes("second"));
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let result = sink.write(&one_metric_bytes("second")).await;
         assert!(
             result.is_err(),
             "second write past max_buffer_age must attempt a flush"
@@ -965,15 +899,15 @@ sink:
         );
     }
 
-    #[test]
-    fn time_based_flush_fires_for_log_signal() {
+    #[tokio::test]
+    async fn time_based_flush_fires_for_log_signal() {
         let mut sink = lazy_sink(OtlpSignalType::Logs, 1_000_000, Duration::from_millis(50));
 
-        sink.write(&one_log_bytes()).expect("write 1");
+        sink.write(&one_log_bytes()).await.expect("write 1");
         assert_eq!(sink.log_batch.len(), 1, "first write only buffers");
 
-        std::thread::sleep(Duration::from_millis(200));
-        let result = sink.write(&one_log_bytes());
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let result = sink.write(&one_log_bytes()).await;
         assert!(
             result.is_err(),
             "second log write past max_buffer_age must attempt a flush"
@@ -984,16 +918,21 @@ sink:
         );
     }
 
-    #[test]
-    fn zero_max_buffer_age_disables_time_based_flush() {
-        // Large batch_size, zero max_buffer_age — neither trigger should fire.
+    #[tokio::test]
+    async fn zero_max_buffer_age_disables_time_based_flush() {
         let mut sink = lazy_sink(OtlpSignalType::Metrics, 1_000_000, Duration::ZERO);
 
-        sink.write(&one_metric_bytes("first")).expect("write 1");
-        std::thread::sleep(Duration::from_millis(150));
-        sink.write(&one_metric_bytes("second")).expect("write 2");
-        std::thread::sleep(Duration::from_millis(150));
-        sink.write(&one_metric_bytes("third")).expect("write 3");
+        sink.write(&one_metric_bytes("first"))
+            .await
+            .expect("write 1");
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        sink.write(&one_metric_bytes("second"))
+            .await
+            .expect("write 2");
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        sink.write(&one_metric_bytes("third"))
+            .await
+            .expect("write 3");
 
         assert_eq!(
             sink.metric_batch.len(),
@@ -1002,41 +941,35 @@ sink:
         );
     }
 
-    #[test]
-    fn size_triggered_flush_still_works_and_resets_the_timer() {
-        // Small batch_size, max_buffer_age longer than the test runs.
+    #[tokio::test]
+    async fn size_triggered_flush_still_works_and_resets_the_timer() {
         let mut sink = lazy_sink(OtlpSignalType::Metrics, 2, Duration::from_secs(60));
 
-        sink.write(&one_metric_bytes("a")).expect("write 1 buffers");
+        sink.write(&one_metric_bytes("a"))
+            .await
+            .expect("write 1 buffers");
         assert_eq!(sink.metric_batch.len(), 1, "below batch_size: no flush");
 
-        // Second write fills the batch → size-triggered flush attempt.
-        let result = sink.write(&one_metric_bytes("b"));
+        let result = sink.write(&one_metric_bytes("b")).await;
         assert!(result.is_err(), "filling the batch must attempt a flush");
         assert!(
             sink.metric_batch.is_empty(),
             "size-triggered flush must drain the batch"
         );
 
-        // The size flush reset last_flush_at; a subsequent partial write must
-        // not immediately time-flush.
         sink.write(&one_metric_bytes("c"))
+            .await
             .expect("partial write after a size flush must not time-flush immediately");
         assert_eq!(sink.metric_batch.len(), 1, "partial write only buffers");
     }
 
-    // -----------------------------------------------------------------------
-    // last_write_delivered — buffered case
-    //
-    // Only the buffered case is unit-testable: the lazy channel has no peer,
-    // so a triggered flush always fails. Flushed-success is verified live.
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn last_write_delivered_is_false_when_metric_write_only_buffers() {
+    #[tokio::test]
+    async fn last_write_delivered_is_false_when_metric_write_only_buffers() {
         let mut sink = lazy_sink(OtlpSignalType::Metrics, 1_000_000, Duration::ZERO);
 
-        sink.write(&one_metric_bytes("buffered")).expect("write 1");
+        sink.write(&one_metric_bytes("buffered"))
+            .await
+            .expect("write 1");
 
         assert!(
             !sink.last_write_delivered(),
@@ -1044,11 +977,11 @@ sink:
         );
     }
 
-    #[test]
-    fn last_write_delivered_is_false_when_log_write_only_buffers() {
+    #[tokio::test]
+    async fn last_write_delivered_is_false_when_log_write_only_buffers() {
         let mut sink = lazy_sink(OtlpSignalType::Logs, 1_000_000, Duration::ZERO);
 
-        sink.write(&one_log_bytes()).expect("write 1");
+        sink.write(&one_log_bytes()).await.expect("write 1");
 
         assert!(
             !sink.last_write_delivered(),
@@ -1056,12 +989,8 @@ sink:
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Factory wiring: create_sink max_buffer_age parsing
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn create_sink_otlp_grpc_with_invalid_max_buffer_age_returns_err() {
+    #[tokio::test]
+    async fn create_sink_otlp_grpc_with_invalid_max_buffer_age_returns_err() {
         let config = SinkConfig::OtlpGrpc {
             endpoint: "http://127.0.0.1:1".to_string(),
             signal_type: OtlpSignalType::Metrics,
@@ -1070,7 +999,7 @@ sink:
             retry: None,
         };
         assert!(
-            create_sink(&config, None).is_err(),
+            create_sink(&config, None).await.is_err(),
             "invalid max_buffer_age must cause the factory to fail"
         );
     }

--- a/sonda-core/src/sink/remote_write.rs
+++ b/sonda-core/src/sink/remote_write.rs
@@ -18,12 +18,13 @@
 
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use prost::Message;
 
 use crate::encoder::remote_write::{parse_length_prefixed_timeseries, TimeSeries, WriteRequest};
 use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
-use crate::{EncoderError, SondaError};
+use crate::{EncoderError, RuntimeError, SondaError};
 
 /// Default batch size in TimeSeries entries — sized so low-rate scenarios flush within seconds.
 pub const DEFAULT_BATCH_SIZE: usize = 5;
@@ -108,87 +109,6 @@ impl RemoteWriteSink {
         })
     }
 
-    /// Build a WriteRequest from the current batch, prost-encode, snappy-compress,
-    /// and HTTP POST to the configured endpoint.
-    ///
-    /// Clears the batch on success or on unrecoverable error (to prevent unbounded
-    /// buffer growth).
-    fn send_batch(&mut self) -> Result<(), SondaError> {
-        if self.batch.is_empty() {
-            return Ok(());
-        }
-
-        // Reset on attempt, not success — the batch is cleared either way below.
-        self.last_flush_at = Instant::now();
-
-        // Build one WriteRequest containing all accumulated TimeSeries.
-        let write_request = WriteRequest {
-            timeseries: std::mem::take(&mut self.batch),
-        };
-
-        // Prost-encode the WriteRequest.
-        let encoded_len = write_request.encoded_len();
-        let mut proto_bytes = Vec::with_capacity(encoded_len);
-        write_request.encode(&mut proto_bytes).map_err(|e| {
-            SondaError::Encoder(EncoderError::Other(format!("protobuf encode error: {e}")))
-        })?;
-
-        // Snappy-compress using raw (block) format.
-        let mut snappy_encoder = snap::raw::Encoder::new();
-        let compressed = snappy_encoder.compress_vec(&proto_bytes).map_err(|e| {
-            SondaError::Encoder(EncoderError::Other(format!(
-                "snappy compression error: {e}"
-            )))
-        })?;
-
-        // POST with retry if configured.
-        let result = match &self.retry_policy {
-            Some(policy) => {
-                let policy = policy.clone();
-                policy.execute(|| self.do_post_checked(&compressed), Self::is_retryable)
-            }
-            None => self.do_post_checked(&compressed),
-        };
-
-        // 4xx errors (except 429) are non-retryable and treated as warn-and-discard.
-        match &result {
-            Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
-                Ok(())
-            }
-            _ => result,
-        }
-    }
-
-    /// Perform a single HTTP POST and classify the response.
-    ///
-    /// - 2xx: `Ok(())`.
-    /// - 4xx (except 429): warns and returns non-retryable `Err`.
-    /// - 429, 5xx, transport: retryable `Err`.
-    fn do_post_checked(&self, body: &[u8]) -> Result<(), SondaError> {
-        let status = self.do_post(body)?;
-
-        if (200..300).contains(&status) {
-            return Ok(());
-        }
-
-        if (400..500).contains(&status) && status != 429 {
-            eprintln!(
-                "sonda: remote_write sink: received HTTP {} from '{}'; discarding batch",
-                status, self.url
-            );
-            return Err(SondaError::Sink(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("HTTP {} from '{}'", status, self.url),
-            )));
-        }
-
-        Err(SondaError::Sink(std::io::Error::other(format!(
-            "HTTP {} from '{}'",
-            status, self.url
-        ))))
-    }
-
-    /// Classify whether an error is retryable.
     fn is_retryable(err: &SondaError) -> bool {
         if let SondaError::Sink(io_err) = err {
             let msg = io_err.to_string();
@@ -200,16 +120,30 @@ impl RemoteWriteSink {
         false
     }
 
-    /// Perform a single HTTP POST of snappy-compressed protobuf to the endpoint.
-    ///
-    /// Sets the required Prometheus remote write headers:
-    /// - `Content-Type: application/x-protobuf`
-    /// - `Content-Encoding: snappy`
-    /// - `X-Prometheus-Remote-Write-Version: 0.1.0`
-    fn do_post(&self, body: &[u8]) -> Result<u16, SondaError> {
-        let response = self
-            .client
-            .post(&self.url)
+    fn do_post_checked_at(client: &ureq::Agent, url: &str, body: &[u8]) -> Result<(), SondaError> {
+        let status = Self::do_post_at(client, url, body)?;
+        if (200..300).contains(&status) {
+            return Ok(());
+        }
+        if (400..500).contains(&status) && status != 429 {
+            eprintln!(
+                "sonda: remote_write sink: received HTTP {} from '{}'; discarding batch",
+                status, url
+            );
+            return Err(SondaError::Sink(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("HTTP {} from '{}'", status, url),
+            )));
+        }
+        Err(SondaError::Sink(std::io::Error::other(format!(
+            "HTTP {} from '{}'",
+            status, url
+        ))))
+    }
+
+    fn do_post_at(client: &ureq::Agent, url: &str, body: &[u8]) -> Result<u16, SondaError> {
+        let response = client
+            .post(url)
             .set("Content-Type", "application/x-protobuf")
             .set("Content-Encoding", "snappy")
             .set("X-Prometheus-Remote-Write-Version", "0.1.0")
@@ -220,18 +154,15 @@ impl RemoteWriteSink {
             Err(ureq::Error::Status(code, _)) => Ok(code),
             Err(e) => Err(SondaError::Sink(std::io::Error::new(
                 std::io::ErrorKind::ConnectionRefused,
-                format!("remote write to '{}' failed: {}", self.url, e),
+                format!("remote write to '{}' failed: {}", url, e),
             ))),
         }
     }
 }
 
+#[async_trait]
 impl Sink for RemoteWriteSink {
-    /// Accept length-prefixed TimeSeries bytes from the encoder.
-    ///
-    /// Parses each `TimeSeries` from the data and adds it to the internal batch.
-    /// When the batch reaches `batch_size` entries, an automatic flush is triggered.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         let timeseries_list = parse_length_prefixed_timeseries(data)?;
         self.batch.extend(timeseries_list);
 
@@ -240,24 +171,77 @@ impl Sink for RemoteWriteSink {
             !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
         let should_flush = size_reached || age_reached;
         if should_flush {
-            self.send_batch()?;
+            self.send_via_blocking().await?;
         }
         self.last_write_delivered = should_flush;
 
         Ok(())
     }
 
-    /// Flush any remaining buffered TimeSeries to the remote write endpoint.
-    ///
-    /// Builds one `WriteRequest` containing all buffered `TimeSeries`, prost-encodes,
-    /// snappy-compresses, and HTTP POSTs the result. Safe to call multiple times;
-    /// returns `Ok(())` immediately if the batch is empty.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.send_batch()
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        self.send_via_blocking().await
     }
 
     fn last_write_delivered(&self) -> bool {
         self.last_write_delivered
+    }
+}
+
+impl RemoteWriteSink {
+    async fn send_via_blocking(&mut self) -> Result<(), SondaError> {
+        if self.batch.is_empty() {
+            return Ok(());
+        }
+        self.last_flush_at = Instant::now();
+        let write_request = WriteRequest {
+            timeseries: std::mem::take(&mut self.batch),
+        };
+        let encoded_len = write_request.encoded_len();
+        let mut proto_bytes = Vec::with_capacity(encoded_len);
+        write_request.encode(&mut proto_bytes).map_err(|e| {
+            SondaError::Encoder(EncoderError::Other(format!("protobuf encode error: {e}")))
+        })?;
+        let mut snappy_encoder = snap::raw::Encoder::new();
+        let compressed = snappy_encoder.compress_vec(&proto_bytes).map_err(|e| {
+            SondaError::Encoder(EncoderError::Other(format!(
+                "snappy compression error: {e}"
+            )))
+        })?;
+
+        let client = self.client.clone();
+        let url = self.url.clone();
+        let retry_policy = self.retry_policy.clone();
+        let join = tokio::task::spawn_blocking(move || {
+            do_send(&client, &url, &compressed, retry_policy.as_ref())
+        })
+        .await;
+        match join {
+            Ok(r) => r,
+            Err(e) => Err(SondaError::Runtime(RuntimeError::TaskPanicked(
+                e.to_string(),
+            ))),
+        }
+    }
+}
+
+fn do_send(
+    client: &ureq::Agent,
+    url: &str,
+    body: &[u8],
+    retry_policy: Option<&RetryPolicy>,
+) -> Result<(), SondaError> {
+    let result = match retry_policy {
+        Some(policy) => policy.execute(
+            || RemoteWriteSink::do_post_checked_at(client, url, body),
+            RemoteWriteSink::is_retryable,
+        ),
+        None => RemoteWriteSink::do_post_checked_at(client, url, body),
+    };
+    match &result {
+        Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
+            Ok(())
+        }
+        _ => result,
     }
 }
 
@@ -366,13 +350,13 @@ mod tests {
     // Batch accumulation and explicit flush
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn write_below_batch_size_does_not_trigger_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_below_batch_size_does_not_trigger_flush() {
         let (listener, url) = mock_server_listener();
 
         let mut sink =
             RemoteWriteSink::new(&url, 100, None, Duration::ZERO).expect("construct sink");
-        sink.write(&encode_one("cpu", 1.0)).expect("write");
+        sink.write(&encode_one("cpu", 1.0)).await.expect("write");
 
         listener.set_nonblocking(true).expect("set non-blocking");
         assert!(
@@ -381,32 +365,30 @@ mod tests {
         );
     }
 
-    #[test]
-    fn explicit_flush_sends_buffered_data() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn explicit_flush_sends_buffered_data() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink =
             RemoteWriteSink::new(&url, 10_000, None, Duration::ZERO).expect("construct sink");
-        sink.write(&encode_one("cpu", 1.0)).expect("write");
-        sink.flush().expect("flush");
+        sink.write(&encode_one("cpu", 1.0)).await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body = handle.join().expect("mock server thread panicked");
         let request = decode_write_request(&body);
         assert_eq!(request.timeseries.len(), 1, "flush must deliver the batch");
     }
 
-    // -------------------------------------------------------------------------
-    // last_write_delivered — buffered vs flushed
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn last_write_delivered_is_false_when_write_only_buffers() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_write_delivered_is_false_when_write_only_buffers() {
         let (listener, url) = mock_server_listener();
 
         let mut sink =
             RemoteWriteSink::new(&url, 100, None, Duration::ZERO).expect("construct sink");
-        sink.write(&encode_one("cpu", 1.0)).expect("write buffers");
+        sink.write(&encode_one("cpu", 1.0))
+            .await
+            .expect("write buffers");
 
         assert!(
             !sink.last_write_delivered(),
@@ -416,13 +398,14 @@ mod tests {
         assert!(listener.accept().is_err(), "no flush should have fired");
     }
 
-    #[test]
-    fn last_write_delivered_is_true_when_write_triggers_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_write_delivered_is_true_when_write_triggers_flush() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink = RemoteWriteSink::new(&url, 1, None, Duration::ZERO).expect("construct sink");
         sink.write(&encode_one("cpu", 1.0))
+            .await
             .expect("write triggers flush");
 
         handle.join().expect("mock server thread panicked");
@@ -432,23 +415,21 @@ mod tests {
         );
     }
 
-    // -------------------------------------------------------------------------
-    // Time-based flush
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn time_based_flush_fires_when_buffer_age_exceeded() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn time_based_flush_fires_when_buffer_age_exceeded() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        // batch_size large enough that size never triggers; short max_buffer_age.
         let mut sink = RemoteWriteSink::new(&url, 10_000, None, Duration::from_millis(50))
             .expect("construct sink");
 
-        sink.write(&encode_one("first", 1.0)).expect("write 1");
+        sink.write(&encode_one("first", 1.0))
+            .await
+            .expect("write 1");
         thread::sleep(Duration::from_millis(200));
-        // Second write is past max_buffer_age → triggers a time-based flush.
-        sink.write(&encode_one("second", 2.0)).expect("write 2");
+        sink.write(&encode_one("second", 2.0))
+            .await
+            .expect("write 2");
 
         let body = handle.join().expect("mock server thread panicked");
         let request = decode_write_request(&body);
@@ -459,18 +440,21 @@ mod tests {
         );
     }
 
-    #[test]
-    fn zero_max_buffer_age_disables_time_based_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn zero_max_buffer_age_disables_time_based_flush() {
         let (listener, url) = mock_server_listener();
 
         let mut sink =
             RemoteWriteSink::new(&url, 10_000, None, Duration::ZERO).expect("construct sink");
 
-        sink.write(&encode_one("first", 1.0)).expect("write 1");
+        sink.write(&encode_one("first", 1.0))
+            .await
+            .expect("write 1");
         thread::sleep(Duration::from_millis(150));
-        sink.write(&encode_one("second", 2.0)).expect("write 2");
+        sink.write(&encode_one("second", 2.0))
+            .await
+            .expect("write 2");
 
-        // With time-based flush disabled, no request should have arrived.
         listener.set_nonblocking(true).expect("set non-blocking");
         assert!(
             listener.accept().is_err(),
@@ -478,18 +462,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn size_triggered_flush_resets_the_buffer_age_timer() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn size_triggered_flush_resets_the_buffer_age_timer() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        // Small batch_size, max_buffer_age comfortably longer than the test runs.
         let mut sink =
             RemoteWriteSink::new(&url, 2, None, Duration::from_secs(60)).expect("construct sink");
 
-        // Fill the batch — the size trigger fires.
-        sink.write(&encode_one("a", 1.0)).expect("write 1");
-        sink.write(&encode_one("b", 2.0)).expect("write 2");
+        sink.write(&encode_one("a", 1.0)).await.expect("write 1");
+        sink.write(&encode_one("b", 2.0)).await.expect("write 2");
 
         let body = handle.join().expect("mock server thread panicked");
         let request = decode_write_request(&body);
@@ -499,29 +481,24 @@ mod tests {
             "size-triggered flush must deliver the full batch"
         );
 
-        // The size flush reset last_flush_at; a subsequent partial-batch write
-        // must NOT immediately time-flush against the (now closed) listener.
         sink.write(&encode_one("c", 3.0))
+            .await
             .expect("partial write after a size flush must not time-flush immediately");
     }
 
-    // -------------------------------------------------------------------------
-    // Factory wiring: create_sink for RemoteWrite config
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn create_sink_remote_write_with_valid_url_returns_ok() {
+    #[tokio::test]
+    async fn create_sink_remote_write_with_valid_url_returns_ok() {
         let config = SinkConfig::RemoteWrite {
             url: "http://127.0.0.1:19999/api/v1/write".to_string(),
             batch_size: None,
             max_buffer_age: None,
             retry: None,
         };
-        assert!(create_sink(&config, None).is_ok());
+        assert!(create_sink(&config, None).await.is_ok());
     }
 
-    #[test]
-    fn create_sink_remote_write_with_invalid_max_buffer_age_returns_err() {
+    #[tokio::test]
+    async fn create_sink_remote_write_with_invalid_max_buffer_age_returns_err() {
         let config = SinkConfig::RemoteWrite {
             url: "http://127.0.0.1:19999/api/v1/write".to_string(),
             batch_size: None,
@@ -529,7 +506,7 @@ mod tests {
             retry: None,
         };
         assert!(
-            create_sink(&config, None).is_err(),
+            create_sink(&config, None).await.is_err(),
             "invalid max_buffer_age must cause the factory to fail"
         );
     }

--- a/sonda-core/src/sink/retry.rs
+++ b/sonda-core/src/sink/retry.rs
@@ -173,6 +173,11 @@ impl RetryPolicy {
         Err(last_error)
     }
 
+    /// Configured retry-count cap (number of retries after the initial attempt).
+    pub fn max_attempts(&self) -> u32 {
+        self.max_attempts
+    }
+
     /// Compute a jittered backoff duration for the given attempt index (0-based).
     ///
     /// Uses exponential backoff with full jitter:
@@ -180,7 +185,7 @@ impl RetryPolicy {
     ///
     /// The jitter RNG is seeded from the backoff nanos and the current thread ID
     /// to avoid synchronized retries across sinks.
-    fn jittered_backoff(&self, attempt: u32) -> Duration {
+    pub fn jittered_backoff(&self, attempt: u32) -> Duration {
         // Compute the exponential base: initial_backoff * 2^attempt, capped at
         // max_backoff. Use checked_shl to avoid overflow for large attempt values.
         let multiplier: u32 = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);

--- a/sonda-core/src/sink/stdout.rs
+++ b/sonda-core/src/sink/stdout.rs
@@ -1,24 +1,20 @@
 //! Buffered stdout sink.
 
-use std::io::{BufWriter, Stdout, Write};
+use async_trait::async_trait;
+use tokio::io::{AsyncWriteExt, BufWriter, Stdout};
 
 use super::Sink;
 use crate::SondaError;
 
 /// A sink that writes encoded event data to stdout using a buffered writer.
-///
-/// Wraps `std::io::stdout()` in a [`BufWriter`] to avoid issuing a syscall for
-/// every event. Call [`flush`](StdoutSink::flush) to force any buffered data to
-/// be written before the program exits.
 pub struct StdoutSink {
     writer: BufWriter<Stdout>,
 }
 
 impl StdoutSink {
-    /// Create a new `StdoutSink` backed by buffered stdout.
     pub fn new() -> Self {
         Self {
-            writer: BufWriter::new(std::io::stdout()),
+            writer: BufWriter::new(tokio::io::stdout()),
         }
     }
 }
@@ -29,16 +25,18 @@ impl Default for StdoutSink {
     }
 }
 
+#[async_trait]
 impl Sink for StdoutSink {
-    /// Write `data` to the buffered stdout writer.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
-        self.writer.write_all(data).map_err(SondaError::Sink)?;
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        self.writer
+            .write_all(data)
+            .await
+            .map_err(SondaError::Sink)?;
         Ok(())
     }
 
-    /// Flush any buffered bytes to stdout.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.writer.flush().map_err(SondaError::Sink)?;
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        self.writer.flush().await.map_err(SondaError::Sink)?;
         Ok(())
     }
 }
@@ -57,26 +55,23 @@ mod tests {
         let _sink = StdoutSink::default();
     }
 
-    #[test]
-    fn write_and_flush_do_not_error() {
+    #[tokio::test]
+    async fn write_and_flush_do_not_error() {
         let mut sink = StdoutSink::new();
-        // Writing empty bytes is a valid no-op that still exercises the code path.
-        let write_result = sink.write(b"");
+        let write_result = sink.write(b"").await;
         assert!(write_result.is_ok());
-        let flush_result = sink.flush();
+        let flush_result = sink.flush().await;
         assert!(flush_result.is_ok());
     }
 
-    #[test]
-    fn write_non_empty_data_does_not_error() {
+    #[tokio::test]
+    async fn write_non_empty_data_does_not_error() {
         let mut sink = StdoutSink::new();
-        let result = sink.write(b"up{} 1 1700000000000\n");
+        let result = sink.write(b"up{} 1 1700000000000\n").await;
         assert!(result.is_ok());
-        // Flush to ensure buffered data is pushed through
-        assert!(sink.flush().is_ok());
+        assert!(sink.flush().await.is_ok());
     }
 
-    /// Compile-time proof that StdoutSink satisfies Send + Sync.
     #[test]
     fn stdout_sink_is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}

--- a/sonda-core/src/sink/tcp.rs
+++ b/sonda-core/src/sink/tcp.rs
@@ -1,43 +1,24 @@
 //! TCP sink — delivers encoded telemetry over a persistent TCP connection.
-//!
-//! When a retry policy is configured, the sink attempts to reconnect on
-//! write or flush failures before retrying the operation.
 
-use std::io::{BufWriter, Write};
-use std::net::TcpStream;
+use async_trait::async_trait;
+use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::net::TcpStream;
 
 use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
 use crate::SondaError;
 
-/// Delivers encoded telemetry data over a TCP connection.
-///
-/// The underlying [`TcpStream`] is wrapped in a [`BufWriter`] to batch
-/// writes and reduce syscall overhead. When a [`RetryPolicy`] is configured,
-/// write and flush failures trigger a reconnection attempt before retrying.
+/// Delivers encoded telemetry over a buffered TCP connection.
 pub struct TcpSink {
     writer: BufWriter<TcpStream>,
-    /// Target address stored for reconnection and error messages.
     addr: String,
-    /// Optional retry policy for transient failures.
     retry_policy: Option<RetryPolicy>,
 }
 
 impl TcpSink {
-    /// Connect to `addr` and create a new [`TcpSink`].
-    ///
-    /// # Arguments
-    ///
-    /// - `addr` — remote address to connect to, e.g. `"127.0.0.1:9999"`.
-    /// - `retry_policy` — optional retry policy for transient failures.
-    ///   When `None`, errors are returned immediately (no retry).
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if the connection cannot be established
-    /// (e.g., connection refused, invalid address).
-    pub fn new(addr: &str, retry_policy: Option<RetryPolicy>) -> Result<Self, SondaError> {
+    pub async fn new(addr: &str, retry_policy: Option<RetryPolicy>) -> Result<Self, SondaError> {
         let stream = TcpStream::connect(addr)
+            .await
             .map_err(|e| std::io::Error::new(e.kind(), format!("TCP connect to {addr}: {e}")))
             .map_err(SondaError::Sink)?;
         Ok(Self {
@@ -47,9 +28,9 @@ impl TcpSink {
         })
     }
 
-    /// Attempt to reconnect to the stored address, replacing the writer.
-    fn reconnect(&mut self) -> Result<(), SondaError> {
+    async fn reconnect(&mut self) -> Result<(), SondaError> {
         let stream = TcpStream::connect(&self.addr)
+            .await
             .map_err(|e| {
                 std::io::Error::new(e.kind(), format!("TCP reconnect to {}: {e}", self.addr))
             })
@@ -57,82 +38,94 @@ impl TcpSink {
         self.writer = BufWriter::new(stream);
         Ok(())
     }
-}
 
-impl Sink for TcpSink {
-    /// Write `data` to the buffered TCP stream.
-    ///
-    /// When a retry policy is configured, failures trigger reconnection
-    /// attempts before retrying the write.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
-        let initial_result = self
-            .writer
+    async fn write_once(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        self.writer
             .write_all(data)
+            .await
             .map_err(|e| std::io::Error::new(e.kind(), format!("TCP write to {}: {e}", self.addr)))
-            .map_err(SondaError::Sink);
-
-        match initial_result {
-            Ok(()) => Ok(()),
-            Err(first_err) => {
-                if let Some(policy) = self.retry_policy.clone() {
-                    // On failure, reconnect and retry.
-                    policy.execute(
-                        || {
-                            self.reconnect()?;
-                            self.writer
-                                .write_all(data)
-                                .map_err(|e| {
-                                    std::io::Error::new(
-                                        e.kind(),
-                                        format!("TCP write to {}: {e}", self.addr),
-                                    )
-                                })
-                                .map_err(SondaError::Sink)
-                        },
-                        |_| true, // all TCP errors are retryable
-                    )
-                } else {
-                    Err(first_err)
-                }
-            }
-        }
+            .map_err(SondaError::Sink)
     }
 
-    /// Flush buffered data to the TCP stream.
-    ///
-    /// When a retry policy is configured, failures trigger reconnection
-    /// attempts before retrying the flush.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        let initial_result = self
-            .writer
+    async fn flush_once(&mut self) -> Result<(), SondaError> {
+        self.writer
             .flush()
+            .await
             .map_err(|e| std::io::Error::new(e.kind(), format!("TCP flush to {}: {e}", self.addr)))
-            .map_err(SondaError::Sink);
+            .map_err(SondaError::Sink)
+    }
+}
 
-        match initial_result {
-            Ok(()) => Ok(()),
-            Err(first_err) => {
-                if let Some(policy) = self.retry_policy.clone() {
-                    policy.execute(
-                        || {
-                            self.reconnect()?;
-                            self.writer
-                                .flush()
-                                .map_err(|e| {
-                                    std::io::Error::new(
-                                        e.kind(),
-                                        format!("TCP flush to {}: {e}", self.addr),
-                                    )
-                                })
-                                .map_err(SondaError::Sink)
-                        },
-                        |_| true,
-                    )
-                } else {
-                    Err(first_err)
-                }
+#[async_trait]
+impl Sink for TcpSink {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        let mut last_error = match self.write_once(data).await {
+            Ok(()) => return Ok(()),
+            Err(e) => e,
+        };
+        let Some(policy) = self.retry_policy.clone() else {
+            return Err(last_error);
+        };
+        for attempt in 0..policy.max_attempts() {
+            let backoff = policy.jittered_backoff(attempt);
+            eprintln!(
+                "sonda: retry {}/{} after {}ms (error: {})",
+                attempt + 1,
+                policy.max_attempts(),
+                backoff.as_millis(),
+                last_error,
+            );
+            tokio::time::sleep(backoff).await;
+            if let Err(e) = self.reconnect().await {
+                last_error = e;
+                continue;
+            }
+            match self.write_once(data).await {
+                Ok(()) => return Ok(()),
+                Err(e) => last_error = e,
             }
         }
+        eprintln!(
+            "sonda: all {} retries exhausted (last error: {})",
+            policy.max_attempts(),
+            last_error,
+        );
+        Err(last_error)
+    }
+
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        let mut last_error = match self.flush_once().await {
+            Ok(()) => return Ok(()),
+            Err(e) => e,
+        };
+        let Some(policy) = self.retry_policy.clone() else {
+            return Err(last_error);
+        };
+        for attempt in 0..policy.max_attempts() {
+            let backoff = policy.jittered_backoff(attempt);
+            eprintln!(
+                "sonda: retry {}/{} after {}ms (error: {})",
+                attempt + 1,
+                policy.max_attempts(),
+                backoff.as_millis(),
+                last_error,
+            );
+            tokio::time::sleep(backoff).await;
+            if let Err(e) = self.reconnect().await {
+                last_error = e;
+                continue;
+            }
+            match self.flush_once().await {
+                Ok(()) => return Ok(()),
+                Err(e) => last_error = e,
+            }
+        }
+        eprintln!(
+            "sonda: all {} retries exhausted (last error: {})",
+            policy.max_attempts(),
+            last_error,
+        );
+        Err(last_error)
     }
 }
 
@@ -145,20 +138,16 @@ mod tests {
     use super::*;
     use crate::sink::{create_sink, SinkConfig};
 
-    /// Bind a listener on an OS-assigned port and return (listener, addr_string).
     fn ephemeral_listener() -> (TcpListener, String) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
         let addr = listener.local_addr().expect("local addr").to_string();
         (listener, addr)
     }
 
-    // ---- Happy path: write + flush → data received on listener ---------------
-
-    #[test]
-    fn tcp_write_and_flush_data_arrives_at_listener() {
+    #[tokio::test]
+    async fn tcp_write_and_flush_data_arrives_at_listener() {
         let (listener, addr) = ephemeral_listener();
 
-        // Accept one connection in a background thread so we don't deadlock.
         let receiver = thread::spawn(move || {
             let (mut stream, _) = listener.accept().expect("accept");
             let mut buf = Vec::new();
@@ -166,18 +155,21 @@ mod tests {
             buf
         });
 
-        let mut sink = TcpSink::new(&addr, None).expect("connect should succeed");
-        sink.write(b"hello tcp\n").expect("write should succeed");
-        sink.flush().expect("flush should succeed");
-        // Drop the sink to close the connection so the receiver can finish.
+        let mut sink = TcpSink::new(&addr, None)
+            .await
+            .expect("connect should succeed");
+        sink.write(b"hello tcp\n")
+            .await
+            .expect("write should succeed");
+        sink.flush().await.expect("flush should succeed");
         drop(sink);
 
         let received = receiver.join().expect("receiver thread panicked");
         assert_eq!(received, b"hello tcp\n");
     }
 
-    #[test]
-    fn tcp_multiple_writes_arrive_in_order() {
+    #[tokio::test]
+    async fn tcp_multiple_writes_arrive_in_order() {
         let (listener, addr) = ephemeral_listener();
 
         let receiver = thread::spawn(move || {
@@ -187,19 +179,19 @@ mod tests {
             buf
         });
 
-        let mut sink = TcpSink::new(&addr, None).expect("connect");
-        sink.write(b"line1\n").expect("write 1");
-        sink.write(b"line2\n").expect("write 2");
-        sink.write(b"line3\n").expect("write 3");
-        sink.flush().expect("flush");
+        let mut sink = TcpSink::new(&addr, None).await.expect("connect");
+        sink.write(b"line1\n").await.expect("write 1");
+        sink.write(b"line2\n").await.expect("write 2");
+        sink.write(b"line3\n").await.expect("write 3");
+        sink.flush().await.expect("flush");
         drop(sink);
 
         let received = receiver.join().expect("receiver thread");
         assert_eq!(received, b"line1\nline2\nline3\n");
     }
 
-    #[test]
-    fn tcp_write_empty_slice_succeeds() {
+    #[tokio::test]
+    async fn tcp_write_empty_slice_succeeds() {
         let (listener, addr) = ephemeral_listener();
 
         let receiver = thread::spawn(move || {
@@ -209,25 +201,22 @@ mod tests {
             buf
         });
 
-        let mut sink = TcpSink::new(&addr, None).expect("connect");
-        sink.write(b"").expect("empty write should succeed");
-        sink.flush().expect("flush");
+        let mut sink = TcpSink::new(&addr, None).await.expect("connect");
+        sink.write(b"").await.expect("empty write should succeed");
+        sink.flush().await.expect("flush");
         drop(sink);
 
         let received = receiver.join().expect("receiver thread");
         assert!(received.is_empty());
     }
 
-    // ---- Error path: connection refused → SondaError::Sink ------------------
-
-    #[test]
-    fn tcp_connect_to_unused_port_returns_sink_error() {
-        // Find a port that is not listening by binding then dropping.
+    #[tokio::test]
+    async fn tcp_connect_to_unused_port_returns_sink_error() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let addr = listener.local_addr().expect("local addr").to_string();
-        drop(listener); // Port is now free and not listening.
+        drop(listener);
 
-        let result = TcpSink::new(&addr, None);
+        let result = TcpSink::new(&addr, None).await;
         assert!(result.is_err(), "connecting to closed port must fail");
         let err = result.err().unwrap();
         assert!(
@@ -236,13 +225,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn tcp_connect_refused_error_message_contains_address() {
+    #[tokio::test]
+    async fn tcp_connect_refused_error_message_contains_address() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let addr = listener.local_addr().expect("local addr").to_string();
         drop(listener);
 
-        let result = TcpSink::new(&addr, None);
+        let result = TcpSink::new(&addr, None).await;
         let err = result.err().unwrap();
         let msg = err.to_string();
         assert!(
@@ -251,11 +240,9 @@ mod tests {
         );
     }
 
-    // ---- Address parsing: invalid address → SondaError::Sink ----------------
-
-    #[test]
-    fn tcp_invalid_address_string_returns_sink_error() {
-        let result = TcpSink::new("not-a-host", None);
+    #[tokio::test]
+    async fn tcp_invalid_address_string_returns_sink_error() {
+        let result = TcpSink::new("not-a-host", None).await;
         assert!(result.is_err(), "invalid address must fail");
         assert!(
             matches!(result.err().unwrap(), SondaError::Sink(_)),
@@ -263,17 +250,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn tcp_valid_address_connects_successfully() {
+    #[tokio::test]
+    async fn tcp_valid_address_connects_successfully() {
         let (listener, addr) = ephemeral_listener();
         let _receiver = thread::spawn(move || {
             let _ = listener.accept();
         });
-        let result = TcpSink::new(&addr, None);
+        let result = TcpSink::new(&addr, None).await;
         assert!(result.is_ok(), "valid address must connect");
     }
-
-    // ---- Trait contract: Send + Sync -----------------------------------------
 
     #[test]
     fn tcp_sink_is_send_and_sync() {
@@ -281,10 +266,8 @@ mod tests {
         assert_send_sync::<TcpSink>();
     }
 
-    // ---- Factory wiring: SinkConfig::Tcp → TcpSink --------------------------
-
-    #[test]
-    fn create_sink_tcp_config_connects_and_delivers_data() {
+    #[tokio::test]
+    async fn create_sink_tcp_config_connects_and_delivers_data() {
         let (listener, addr) = ephemeral_listener();
 
         let receiver = thread::spawn(move || {
@@ -298,9 +281,11 @@ mod tests {
             address: addr.clone(),
             retry: None,
         };
-        let mut sink = create_sink(&config, None).expect("factory should create TcpSink");
-        sink.write(b"via factory\n").expect("write");
-        sink.flush().expect("flush");
+        let mut sink = create_sink(&config, None)
+            .await
+            .expect("factory should create TcpSink");
+        sink.write(b"via factory\n").await.expect("write");
+        sink.flush().await.expect("flush");
         drop(sink);
 
         let received = receiver.join().expect("receiver thread");

--- a/sonda-core/src/sink/udp.rs
+++ b/sonda-core/src/sink/udp.rs
@@ -1,21 +1,17 @@
 //! UDP sink — delivers encoded telemetry as individual datagrams.
 
-use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
+use std::net::{SocketAddr, ToSocketAddrs};
+
+use async_trait::async_trait;
+use tokio::net::UdpSocket;
 
 use crate::sink::Sink;
 use crate::SondaError;
 
-/// Maximum UDP payload size for a single datagram (IPv4).
-///
-/// The theoretical maximum is 65507 bytes (65535 − 20 IP header − 8 UDP header).
-/// Payloads larger than this cannot be sent as a single datagram.
+/// Maximum UDP payload size for a single datagram (IPv4: 65535 − 20 − 8).
 const MAX_UDP_PAYLOAD: usize = 65507;
 
 /// Delivers encoded telemetry data as UDP datagrams.
-///
-/// Each call to [`write`](UdpSink::write) sends one datagram. UDP is
-/// connectionless — no connection is established at construction time;
-/// a local ephemeral port is bound and the target address is stored.
 pub struct UdpSink {
     socket: UdpSocket,
     target: SocketAddr,
@@ -23,16 +19,7 @@ pub struct UdpSink {
 
 impl UdpSink {
     /// Bind an ephemeral local port and resolve `addr` for outgoing datagrams.
-    ///
-    /// `addr` may be a `"host:port"` string where the host is either a numeric
-    /// IP address or a DNS hostname. DNS resolution is performed at construction
-    /// time using [`ToSocketAddrs`]; the first resolved address is used.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if `addr` cannot be resolved, yields no
-    /// addresses, or if the local socket cannot be bound.
-    pub fn new(addr: &str) -> Result<Self, SondaError> {
+    pub async fn new(addr: &str) -> Result<Self, SondaError> {
         let target: SocketAddr = addr
             .to_socket_addrs()
             .map_err(|e| {
@@ -49,27 +36,22 @@ impl UdpSink {
                     format!("UDP address {addr} resolved to no addresses"),
                 ))
             })?;
-        // Bind on the wildcard address, matching the IP version of the target.
         let bind_addr = if target.is_ipv6() {
             ":::0"
         } else {
             "0.0.0.0:0"
         };
         let socket = UdpSocket::bind(bind_addr)
+            .await
             .map_err(|e| std::io::Error::new(e.kind(), format!("UDP bind for {addr}: {e}")))
             .map_err(SondaError::Sink)?;
         Ok(Self { socket, target })
     }
 }
 
+#[async_trait]
 impl Sink for UdpSink {
-    /// Send `data` as a single UDP datagram to the target address.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if `data` exceeds `MAX_UDP_PAYLOAD`
-    /// (65507 bytes) or if the underlying `send_to` fails.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         if data.len() > MAX_UDP_PAYLOAD {
             return Err(SondaError::Sink(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -83,27 +65,26 @@ impl Sink for UdpSink {
         }
         self.socket
             .send_to(data, self.target)
+            .await
             .map_err(|e| std::io::Error::new(e.kind(), format!("UDP send_to {}: {e}", self.target)))
             .map_err(SondaError::Sink)?;
         Ok(())
     }
 
-    /// No-op for UDP — datagrams are not buffered.
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::net::UdpSocket;
+    use std::net::UdpSocket as StdUdpSocket;
 
     use super::*;
     use crate::sink::{create_sink, SinkConfig};
 
-    /// Bind a receiving UDP socket on an OS-assigned port. Returns (socket, addr_string).
-    fn ephemeral_receiver() -> (UdpSocket, String) {
-        let socket = UdpSocket::bind("127.0.0.1:0").expect("bind receiver");
+    fn ephemeral_receiver() -> (StdUdpSocket, String) {
+        let socket = StdUdpSocket::bind("127.0.0.1:0").expect("bind receiver");
         socket
             .set_read_timeout(Some(std::time::Duration::from_secs(2)))
             .expect("set timeout");
@@ -111,27 +92,27 @@ mod tests {
         (socket, addr)
     }
 
-    // ---- Happy path: write → recv matches ------------------------------------
-
-    #[test]
-    fn udp_write_datagram_arrives_at_receiver() {
+    #[tokio::test]
+    async fn udp_write_datagram_arrives_at_receiver() {
         let (receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
-        sink.write(b"hello udp\n").expect("write should succeed");
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
+        sink.write(b"hello udp\n")
+            .await
+            .expect("write should succeed");
 
         let mut buf = [0u8; 1024];
         let (len, _src) = receiver.recv_from(&mut buf).expect("recv_from");
         assert_eq!(&buf[..len], b"hello udp\n");
     }
 
-    #[test]
-    fn udp_multiple_writes_each_arrive_as_separate_datagram() {
+    #[tokio::test]
+    async fn udp_multiple_writes_each_arrive_as_separate_datagram() {
         let (receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
-        sink.write(b"datagram1").expect("write 1");
-        sink.write(b"datagram2").expect("write 2");
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
+        sink.write(b"datagram1").await.expect("write 1");
+        sink.write(b"datagram2").await.expect("write 2");
 
         let mut buf = [0u8; 1024];
         let (len1, _) = receiver.recv_from(&mut buf).expect("recv 1");
@@ -141,39 +122,35 @@ mod tests {
         assert_eq!(&buf[..len2], b"datagram2");
     }
 
-    #[test]
-    fn udp_write_empty_datagram_succeeds() {
+    #[tokio::test]
+    async fn udp_write_empty_datagram_succeeds() {
         let (receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
-        sink.write(b"").expect("empty write should succeed");
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
+        sink.write(b"").await.expect("empty write should succeed");
 
         let mut buf = [0u8; 1024];
         let (len, _) = receiver.recv_from(&mut buf).expect("recv");
         assert_eq!(len, 0);
     }
 
-    #[test]
-    fn udp_flush_is_noop_and_always_succeeds() {
+    #[tokio::test]
+    async fn udp_flush_is_noop_and_always_succeeds() {
         let (_receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
-        // Call flush multiple times — all must succeed (idempotent no-op).
-        sink.flush().expect("flush 1 should succeed");
-        sink.flush().expect("flush 2 should succeed");
-        sink.flush().expect("flush 3 should succeed");
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
+        sink.flush().await.expect("flush 1 should succeed");
+        sink.flush().await.expect("flush 2 should succeed");
+        sink.flush().await.expect("flush 3 should succeed");
     }
 
-    // ---- Oversized payload → SondaError::Sink --------------------------------
-
-    #[test]
-    fn udp_oversized_payload_returns_sink_error() {
+    #[tokio::test]
+    async fn udp_oversized_payload_returns_sink_error() {
         let (_receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
-        // 65508 bytes exceeds the 65507-byte limit.
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
         let oversized = vec![0u8; MAX_UDP_PAYLOAD + 1];
-        let result = sink.write(&oversized);
+        let result = sink.write(&oversized).await;
         assert!(result.is_err(), "oversized payload must return Err");
         let err = result.err().unwrap();
         assert!(
@@ -182,47 +159,38 @@ mod tests {
         );
     }
 
-    #[test]
-    fn udp_oversized_payload_error_message_mentions_sizes() {
+    #[tokio::test]
+    async fn udp_oversized_payload_error_message_mentions_sizes() {
         let (_receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
         let oversized = vec![0u8; MAX_UDP_PAYLOAD + 1];
-        let err = sink.write(&oversized).err().unwrap();
+        let err = sink.write(&oversized).await.err().unwrap();
         let msg = err.to_string();
-        // Message must include both the actual size and the limit.
         assert!(
             msg.contains("65508") || msg.contains("65507"),
             "error message should mention payload sizes; got: {msg}"
         );
     }
 
-    #[test]
-    fn udp_exactly_max_payload_succeeds() {
+    #[tokio::test]
+    async fn udp_exactly_max_payload_succeeds() {
         let (receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
         let max_payload = vec![0xABu8; MAX_UDP_PAYLOAD];
-        // This may fail at the OS level on loopback if the kernel refuses the
-        // datagram size, but must not fail in the size-check logic.
-        let result = sink.write(&max_payload);
-        // Whether the OS accepts it depends on system config; at minimum the
-        // size guard must not reject it.
+        let result = sink.write(&max_payload).await;
         if result.is_ok() {
             let mut buf = vec![0u8; MAX_UDP_PAYLOAD + 1];
             if let Ok((len, _)) = receiver.recv_from(&mut buf) {
                 assert_eq!(len, MAX_UDP_PAYLOAD);
             }
         }
-        // If the OS rejected it for other reasons that is acceptable — only
-        // the implementation's size guard is being tested here.
     }
 
-    // ---- Address parsing: invalid address → SondaError::Sink ----------------
-
-    #[test]
-    fn udp_invalid_address_string_returns_sink_error() {
-        let result = UdpSink::new("not-a-host");
+    #[tokio::test]
+    async fn udp_invalid_address_string_returns_sink_error() {
+        let result = UdpSink::new("not-a-host").await;
         assert!(result.is_err(), "invalid address must fail");
         assert!(
             matches!(result.err().unwrap(), SondaError::Sink(_)),
@@ -230,9 +198,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn udp_invalid_address_error_message_contains_address() {
-        let result = UdpSink::new("not-a-host");
+    #[tokio::test]
+    async fn udp_invalid_address_error_message_contains_address() {
+        let result = UdpSink::new("not-a-host").await;
         let err = result.err().unwrap();
         let msg = err.to_string();
         assert!(
@@ -241,14 +209,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn udp_valid_address_creates_sink_successfully() {
+    #[tokio::test]
+    async fn udp_valid_address_creates_sink_successfully() {
         let (_receiver, addr) = ephemeral_receiver();
-        let result = UdpSink::new(&addr);
+        let result = UdpSink::new(&addr).await;
         assert!(result.is_ok(), "valid address must succeed");
     }
-
-    // ---- Trait contract: Send + Sync -----------------------------------------
 
     #[test]
     fn udp_sink_is_send_and_sync() {
@@ -256,17 +222,17 @@ mod tests {
         assert_send_sync::<UdpSink>();
     }
 
-    // ---- Factory wiring: SinkConfig::Udp → UdpSink --------------------------
-
-    #[test]
-    fn create_sink_udp_config_delivers_datagram() {
+    #[tokio::test]
+    async fn create_sink_udp_config_delivers_datagram() {
         let (receiver, addr) = ephemeral_receiver();
 
         let config = SinkConfig::Udp {
             address: addr.clone(),
         };
-        let mut sink = create_sink(&config, None).expect("factory should create UdpSink");
-        sink.write(b"via factory\n").expect("write");
+        let mut sink = create_sink(&config, None)
+            .await
+            .expect("factory should create UdpSink");
+        sink.write(b"via factory\n").await.expect("write");
 
         let mut buf = [0u8; 1024];
         let (len, _) = receiver.recv_from(&mut buf).expect("recv");

--- a/sonda-core/tests/common/mod.rs
+++ b/sonda-core/tests/common/mod.rs
@@ -162,8 +162,9 @@ struct CapturingSink {
     buffer: Arc<Mutex<Vec<u8>>>,
 }
 
+#[async_trait::async_trait]
 impl Sink for CapturingSink {
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         let mut guard = self
             .buffer
             .lock()
@@ -172,7 +173,7 @@ impl Sink for CapturingSink {
         Ok(())
     }
 
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
 }

--- a/sonda-core/tests/encoder_sink_matrix.rs
+++ b/sonda-core/tests/encoder_sink_matrix.rs
@@ -72,25 +72,27 @@ enum Op {
     StdoutSink,
 }
 
-fn check_memory_nonempty(bytes: &[u8], enc: &str) {
+async fn check_memory_nonempty(bytes: &[u8], enc: &str) {
     let mut sink = MemorySink::new();
-    sink.write(bytes).unwrap();
-    sink.flush().unwrap();
+    sink.write(bytes).await.unwrap();
+    sink.flush().await.unwrap();
     assert!(!sink.buffer.is_empty(), "{enc} encoder produced no output");
 }
 
-fn check_file_roundtrip(bytes: &[u8], tag: &str) {
+async fn check_file_roundtrip(bytes: &[u8], tag: &str) {
     let path = tmp_matrix_path(tag);
     let _ = std::fs::remove_file(&path);
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-    let mut sink = sonda_core::sink::file::FileSink::new(Path::new(&path)).unwrap();
-    sink.write(bytes).unwrap();
-    sink.flush().unwrap();
+    let mut sink = sonda_core::sink::file::FileSink::new(Path::new(&path))
+        .await
+        .unwrap();
+    sink.write(bytes).await.unwrap();
+    sink.flush().await.unwrap();
     drop(sink);
     assert_eq!(std::fs::read(&path).unwrap(), bytes);
 }
 
-fn check_tcp_delivery(bytes: &[u8]) {
+async fn check_tcp_delivery(bytes: &[u8]) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap().to_string();
     let expected = bytes.to_vec();
@@ -100,37 +102,49 @@ fn check_tcp_delivery(bytes: &[u8]) {
         s.read_to_end(&mut buf).unwrap();
         buf
     });
-    let mut sink = sonda_core::sink::tcp::TcpSink::new(&addr, None).unwrap();
-    sink.write(bytes).unwrap();
-    sink.flush().unwrap();
+    let mut sink = sonda_core::sink::tcp::TcpSink::new(&addr, None)
+        .await
+        .unwrap();
+    sink.write(bytes).await.unwrap();
+    sink.flush().await.unwrap();
     drop(sink);
     assert_eq!(rx.join().unwrap(), expected);
 }
 
-fn check_udp_delivery(bytes: &[u8]) {
+async fn check_udp_delivery(bytes: &[u8]) {
     let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
     socket
         .set_read_timeout(Some(Duration::from_secs(2)))
         .unwrap();
     let addr = socket.local_addr().unwrap().to_string();
-    let mut sink = sonda_core::sink::udp::UdpSink::new(&addr).unwrap();
-    sink.write(bytes).unwrap();
+    let mut sink = sonda_core::sink::udp::UdpSink::new(&addr).await.unwrap();
+    sink.write(bytes).await.unwrap();
     let mut buf = vec![0u8; 4096];
     let (len, _) = socket.recv_from(&mut buf).unwrap();
     assert_eq!(&buf[..len], bytes);
 }
 
-fn check_stdout(bytes: &[u8]) {
+async fn check_stdout(bytes: &[u8]) {
     let mut sink = sonda_core::sink::stdout::StdoutSink::new();
-    assert!(sink.write(bytes).is_ok());
-    assert!(sink.flush().is_ok());
+    assert!(sink.write(bytes).await.is_ok());
+    assert!(sink.flush().await.is_ok());
 }
 
 // ---------------------------------------------------------------------------
 // Encoder families
 // ---------------------------------------------------------------------------
 
-/// Prometheus text encoder: memory-shape checks + all delivery sinks.
+async fn run_op(bytes: &[u8], op: Op, tag: &str) {
+    match op {
+        Op::MemoryNonempty => check_memory_nonempty(bytes, tag).await,
+        Op::MemoryContainsIdentifier | Op::MemoryEndsNewline => unreachable!("handled inline"),
+        Op::FileSink => check_file_roundtrip(bytes, tag).await,
+        Op::TcpSink => check_tcp_delivery(bytes).await,
+        Op::UdpSink => check_udp_delivery(bytes).await,
+        Op::StdoutSink => check_stdout(bytes).await,
+    }
+}
+
 #[rstest]
 #[rustfmt::skip]
 #[case::memory_produces_nonempty_output(       Op::MemoryNonempty)]
@@ -140,21 +154,17 @@ fn check_stdout(bytes: &[u8]) {
 #[case::tcp_data_arrives_at_listener(          Op::TcpSink)]
 #[case::udp_datagram_arrives_at_receiver(      Op::UdpSink)]
 #[case::stdout_write_and_flush_succeed(        Op::StdoutSink)]
-fn prometheus_encoder_cases(#[case] op: Op) {
+#[tokio::test(flavor = "multi_thread")]
+async fn prometheus_encoder_cases(#[case] op: Op) {
     let config = EncoderConfig::PrometheusText { precision: None };
     let bytes = encode_event(&config, &test_event());
     match op {
-        Op::MemoryNonempty           => check_memory_nonempty(&bytes, "prometheus"),
         Op::MemoryContainsIdentifier => assert!(std::str::from_utf8(&bytes).unwrap().contains("matrix_test_metric")),
         Op::MemoryEndsNewline        => assert_eq!(*bytes.last().unwrap(), b'\n'),
-        Op::FileSink                 => check_file_roundtrip(&bytes, "prometheus"),
-        Op::TcpSink                  => check_tcp_delivery(&bytes),
-        Op::UdpSink                  => check_udp_delivery(&bytes),
-        Op::StdoutSink               => check_stdout(&bytes),
+        other                        => run_op(&bytes, other, "prometheus").await,
     }
 }
 
-/// InfluxDB Line Protocol encoder: memory-shape checks + all delivery sinks.
 #[rstest]
 #[rustfmt::skip]
 #[case::memory_produces_nonempty_output(       Op::MemoryNonempty)]
@@ -164,25 +174,21 @@ fn prometheus_encoder_cases(#[case] op: Op) {
 #[case::tcp_data_arrives_at_listener(          Op::TcpSink)]
 #[case::udp_datagram_arrives_at_receiver(      Op::UdpSink)]
 #[case::stdout_write_and_flush_succeed(        Op::StdoutSink)]
-fn influx_encoder_cases(#[case] op: Op) {
+#[tokio::test(flavor = "multi_thread")]
+async fn influx_encoder_cases(#[case] op: Op) {
     let config = EncoderConfig::InfluxLineProtocol { field_key: None, precision: None };
     let bytes = encode_event(&config, &test_event());
     match op {
-        Op::MemoryNonempty           => check_memory_nonempty(&bytes, "influx"),
         Op::MemoryContainsIdentifier => assert!(std::str::from_utf8(&bytes).unwrap().contains("matrix_test_metric")),
         Op::MemoryEndsNewline => {
             let text = std::str::from_utf8(&bytes).unwrap().trim_end_matches('\n').to_owned();
             let ts = text.split_whitespace().last().unwrap();
             assert!(ts.len() >= 19, "influx timestamp must be >=19 digits (nanosecond precision): {ts}");
         }
-        Op::FileSink   => check_file_roundtrip(&bytes, "influx"),
-        Op::TcpSink    => check_tcp_delivery(&bytes),
-        Op::UdpSink    => check_udp_delivery(&bytes),
-        Op::StdoutSink => check_stdout(&bytes),
+        other => run_op(&bytes, other, "influx").await,
     }
 }
 
-/// JSON Lines encoder: memory-shape checks + all delivery sinks.
 #[rstest]
 #[rustfmt::skip]
 #[case::memory_produces_nonempty_output(       Op::MemoryNonempty)]
@@ -192,20 +198,17 @@ fn influx_encoder_cases(#[case] op: Op) {
 #[case::tcp_data_arrives_at_listener(          Op::TcpSink)]
 #[case::udp_datagram_arrives_at_receiver(      Op::UdpSink)]
 #[case::stdout_write_and_flush_succeed(        Op::StdoutSink)]
-fn json_encoder_cases(#[case] op: Op) {
+#[tokio::test(flavor = "multi_thread")]
+async fn json_encoder_cases(#[case] op: Op) {
     let config = EncoderConfig::JsonLines { precision: None };
     let bytes = encode_event(&config, &test_event());
     match op {
-        Op::MemoryNonempty => check_memory_nonempty(&bytes, "json"),
         Op::MemoryContainsIdentifier => {
             let line = std::str::from_utf8(&bytes).unwrap().trim_end_matches('\n');
             assert!(serde_json::from_str::<serde_json::Value>(line).unwrap().is_object());
         }
         Op::MemoryEndsNewline => assert_eq!(*bytes.last().unwrap(), b'\n'),
-        Op::FileSink   => check_file_roundtrip(&bytes, "json"),
-        Op::TcpSink    => check_tcp_delivery(&bytes),
-        Op::UdpSink    => check_udp_delivery(&bytes),
-        Op::StdoutSink => check_stdout(&bytes),
+        other => run_op(&bytes, other, "json").await,
     }
 }
 
@@ -284,7 +287,8 @@ fn accept_http_ok(listener: &TcpListener) -> Vec<u8> {
 #[case::prometheus_http_push_body_matches(EncoderConfig::PrometheusText { precision: None },                            "text/plain; version=0.0.4")]
 #[case::influx_http_push_body_matches(    EncoderConfig::InfluxLineProtocol { field_key: None, precision: None },       "text/plain")]
 #[case::json_http_push_body_matches(      EncoderConfig::JsonLines { precision: None },                                 "application/x-ndjson")]
-fn encoder_http_push_body_matches(#[case] config: EncoderConfig, #[case] ct: &str) {
+#[tokio::test(flavor = "multi_thread")]
+async fn encoder_http_push_body_matches(#[case] config: EncoderConfig, #[case] ct: &str) {
     let (listener, url) = http_listener_url();
     let bytes = encode_event(&config, &test_event());
     let expected = bytes.clone();
@@ -292,8 +296,8 @@ fn encoder_http_push_body_matches(#[case] config: EncoderConfig, #[case] ct: &st
     let mut sink =
         sonda_core::sink::http::HttpPushSink::new(&url, ct, 10_000, HashMap::new(), None, Duration::ZERO)
             .unwrap();
-    sink.write(&bytes).unwrap();
-    sink.flush().unwrap();
+    sink.write(&bytes).await.unwrap();
+    sink.flush().await.unwrap();
     assert_eq!(server.join().unwrap(), expected);
 }
 
@@ -325,7 +329,11 @@ mod kafka_matrix {
             tls: None,
             sasl: None,
         };
-        let result = sonda_core::sink::create_sink(&cfg, None);
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(sonda_core::sink::create_sink(&cfg, None));
         let Err(e) = result else {
             panic!("expected Err from create_sink with empty broker, got Ok");
         };
@@ -362,15 +370,15 @@ mod otlp_matrix {
         )
     }
 
-    #[test]
-    fn otlp_x_memory_metric_produces_nonempty_output() {
+    #[tokio::test]
+    async fn otlp_x_memory_metric_produces_nonempty_output() {
         let mut buf = Vec::new();
         OtlpEncoder::new()
             .encode_metric(&test_event(), &mut buf)
             .unwrap();
         let mut sink = MemorySink::new();
-        sink.write(&buf).unwrap();
-        sink.flush().unwrap();
+        sink.write(&buf).await.unwrap();
+        sink.flush().await.unwrap();
         assert!(!sink.buffer.is_empty());
     }
 
@@ -383,15 +391,15 @@ mod otlp_matrix {
         assert_lp(&buf);
     }
 
-    #[test]
-    fn otlp_x_memory_log_produces_nonempty_output() {
+    #[tokio::test]
+    async fn otlp_x_memory_log_produces_nonempty_output() {
         let mut buf = Vec::new();
         OtlpEncoder::new()
             .encode_log(&log_event(Severity::Info, "msg"), &mut buf)
             .unwrap();
         let mut sink = MemorySink::new();
-        sink.write(&buf).unwrap();
-        sink.flush().unwrap();
+        sink.write(&buf).await.unwrap();
+        sink.flush().await.unwrap();
         assert!(!sink.buffer.is_empty());
     }
 
@@ -404,8 +412,8 @@ mod otlp_matrix {
         assert_lp(&buf);
     }
 
-    #[test]
-    fn otlp_x_memory_multi_metric_accumulates_in_sink() {
+    #[tokio::test]
+    async fn otlp_x_memory_multi_metric_accumulates_in_sink() {
         let enc = OtlpEncoder::new();
         let mut sink = MemorySink::new();
         for i in 0..3u64 {
@@ -415,9 +423,9 @@ mod otlp_matrix {
                 MetricEvent::with_timestamp("otlp_multi".to_owned(), i as f64, labels, ts).unwrap();
             let mut buf = Vec::new();
             enc.encode_metric(&event, &mut buf).unwrap();
-            sink.write(&buf).unwrap();
+            sink.write(&buf).await.unwrap();
         }
-        sink.flush().unwrap();
+        sink.flush().await.unwrap();
         assert!(sink.buffer.len() > 12);
     }
 }
@@ -432,7 +440,8 @@ mod otlp_matrix {
 #[case::prometheus_multi_event_accumulates_lines(EncoderConfig::PrometheusText { precision: None },                      "multi_event",  false)]
 #[case::influx_multi_event_accumulates_lines(    EncoderConfig::InfluxLineProtocol { field_key: None, precision: None }, "multi_influx", false)]
 #[case::json_multi_event_accumulates_lines(      EncoderConfig::JsonLines { precision: None },                           "multi_json",   true)]
-fn multi_event_pipeline_accumulates_correct_lines(
+#[tokio::test]
+async fn multi_event_pipeline_accumulates_correct_lines(
     #[case] config: EncoderConfig,
     #[case] metric_name: &str,
     #[case] validate_json: bool,
@@ -445,9 +454,9 @@ fn multi_event_pipeline_accumulates_correct_lines(
         let event = MetricEvent::with_timestamp(metric_name.to_owned(), i as f64, labels, ts).unwrap();
         let mut buf = Vec::new();
         encoder.encode_metric(&event, &mut buf).unwrap();
-        sink.write(&buf).unwrap();
+        sink.write(&buf).await.unwrap();
     }
-    sink.flush().unwrap();
+    sink.flush().await.unwrap();
     let text = std::str::from_utf8(&sink.buffer).unwrap();
     let lines: Vec<&str> = text.lines().collect();
     assert_eq!(lines.len(), 5);

--- a/sonda-core/tests/sink_error_policy.rs
+++ b/sonda-core/tests/sink_error_policy.rs
@@ -104,8 +104,8 @@ fn build_log_entry(name: &str, sink: SinkConfig, policy: OnSinkError) -> Scenari
     })
 }
 
-#[test]
-fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
+#[tokio::test(flavor = "multi_thread")]
+async fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
     let (listener, url) = mock_loki_listener();
     let stop = Arc::new(AtomicBool::new(false));
     let stop_listener = Arc::clone(&stop);
@@ -131,6 +131,7 @@ fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
         Arc::clone(&shutdown),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(800));
@@ -166,8 +167,8 @@ fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
     );
 }
 
-#[test]
-fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
+#[tokio::test(flavor = "multi_thread")]
+async fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
     // Bind then drop a listener so the port is guaranteed free — every flush
     // against it will fail to connect.
     let dead_url = {
@@ -195,6 +196,7 @@ fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
         Arc::clone(&shutdown),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     handle.join(Some(Duration::from_secs(3))).expect("join Ok");
@@ -217,8 +219,8 @@ fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
     );
 }
 
-#[test]
-fn fail_policy_exits_thread_with_sink_error() {
+#[tokio::test(flavor = "multi_thread")]
+async fn fail_policy_exits_thread_with_sink_error() {
     let (listener, url) = mock_loki_listener();
     let stop = Arc::new(AtomicBool::new(false));
     let stop_listener = Arc::clone(&stop);
@@ -244,6 +246,7 @@ fn fail_policy_exits_thread_with_sink_error() {
         Arc::clone(&shutdown),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     let join_result = handle.join(Some(Duration::from_secs(5)));

--- a/sonda-core/tests/start_time_shift.rs
+++ b/sonda-core/tests/start_time_shift.rs
@@ -25,15 +25,16 @@ type SharedBuf = Arc<Mutex<Vec<u8>>>;
 
 struct ProbeSink(SharedBuf);
 
+#[async_trait::async_trait]
 impl Sink for ProbeSink {
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.0
             .lock()
             .expect("probe sink mutex poisoned")
             .extend_from_slice(data);
         Ok(())
     }
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
 }

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -36,12 +36,13 @@ struct CaptureSink {
     buf: Arc<Mutex<Vec<u8>>>,
 }
 
+#[async_trait::async_trait]
 impl Sink for CaptureSink {
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.buf.lock().unwrap().extend_from_slice(data);
         Ok(())
     }
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
 }

--- a/sonda-core/tests/while_close_workshop_repro.rs
+++ b/sonda-core/tests/while_close_workshop_repro.rs
@@ -128,8 +128,8 @@ fn label_value<'a>(ts: &'a TimeSeries, name: &str) -> Option<&'a str> {
         .map(|l| l.value.as_str())
 }
 
-#[test]
-fn workshop_paused_finished_cascade_emits_stale_marker_via_multi_runner() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_cascade_emits_stale_marker_via_multi_runner() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     // Workshop YAML compressed: 1500ms run, 200ms up / 400ms down (cycle 600ms).
@@ -191,7 +191,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     // Wait for both threads to finish (they exit when duration expires).
@@ -258,8 +260,8 @@ scenarios:
     );
 }
 
-#[test]
-fn workshop_paused_finished_cascade_default_batch_size_emits_stale_marker() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_cascade_default_batch_size_emits_stale_marker() {
     // Same scenario as above but WITHOUT explicit batch_size — falls to
     // DEFAULT_BATCH_SIZE = 5. close-emit writes one stale TimeSeries which
     // alone does NOT trigger auto-flush. Verifies invoke_close_emit's
@@ -309,7 +311,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
 
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut handles = handles;
@@ -363,8 +367,8 @@ scenarios:
 /// stats issue, this exposes it.
 ///
 /// Expectation: every gated metric has >=1 stale-NaN sample reach the wire.
-#[test]
-fn workshop_paused_finished_multi_entry_cascade_each_metric_emits_stale_marker() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_multi_entry_cascade_each_metric_emits_stale_marker() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     // Same compressed timing as Test workshop_paused_finished_cascade_emits_stale_marker_via_multi_runner
@@ -504,7 +508,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 8, "must launch primary + 7 downstream");
 
     let deadline = Instant::now() + Duration::from_secs(6);
@@ -587,8 +593,8 @@ scenarios:
 ///
 /// Compressed here: 5s duration, 600ms up / 1200ms down (cycle 1.8s), 200ms
 /// open / 0s close. ~2.7 cycles → at least 2 running→paused transitions.
-#[test]
-fn workshop_paused_finished_real_timescale_emits_stale_marker() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_real_timescale_emits_stale_marker() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     let yaml = format!(
@@ -635,7 +641,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(10);
@@ -1387,8 +1395,8 @@ scenarios:
     );
 }
 
-#[test]
-fn workshop_close_emit_timestamp_strictly_greater_than_active_emissions() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_close_emit_timestamp_strictly_greater_than_active_emissions() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     let yaml = format!(
@@ -1437,7 +1445,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1484,8 +1494,8 @@ scenarios:
     assert_close_ts_strictly_after_preceding_actives(&active_ts, &close_ts);
 }
 
-#[test]
-fn workshop_close_emit_stale_marker_timestamp_strictly_greater_than_active_emissions() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_close_emit_stale_marker_timestamp_strictly_greater_than_active_emissions() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     let yaml = format!(
@@ -1532,7 +1542,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1693,8 +1705,8 @@ scenarios:
 /// TCP capture listener. Asserts at least one `bgp_oper_state` sample with
 /// value=0.0 reaches the wire AND that no stale-NaN sample is emitted (snap_to
 /// REPLACES the stale marker).
-#[test]
-fn workshop_snap_to_zero_reaches_wire_via_multi_runner() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_snap_to_zero_reaches_wire_via_multi_runner() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     let yaml = format!(
@@ -1734,7 +1746,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + gated_metric");
 
     let deadline = Instant::now() + Duration::from_secs(5);

--- a/sonda-core/tests/while_local_upstream_finishes.rs
+++ b/sonda-core/tests/while_local_upstream_finishes.rs
@@ -55,8 +55,8 @@ fn wait_for_not_alive(handle: &ScenarioHandle, timeout: Duration) {
     );
 }
 
-#[test]
-fn local_downstream_finishes_when_upstream_duration_expires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn local_downstream_finishes_when_upstream_duration_expires() {
     let yaml = r#"
 version: 2
 kind: runnable
@@ -89,7 +89,9 @@ scenarios:
 
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let mut handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2);
 
     {
@@ -108,8 +110,8 @@ scenarios:
     }
 }
 
-#[test]
-fn local_cascade_a_b_c_all_finish_when_a_finishes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn local_cascade_a_b_c_all_finish_when_a_finishes() {
     let yaml = r#"
 version: 2
 kind: runnable
@@ -153,7 +155,9 @@ scenarios:
 
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let mut handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 3);
 
     for id in ["a", "b", "c"] {
@@ -169,8 +173,8 @@ scenarios:
     }
 }
 
-#[test]
-fn local_downstream_paused_finishes_when_upstream_finishes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn local_downstream_paused_finishes_when_upstream_finishes() {
     // A non-repeating sequence drops below threshold on tick 1 and stays
     // there for the rest of the upstream's life. The downstream is
     // therefore reliably Paused (not Running) at the moment the upstream
@@ -209,7 +213,9 @@ scenarios:
 
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let mut handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2);
 
     {
@@ -229,8 +235,8 @@ scenarios:
     }
 }
 
-#[test]
-fn local_downstream_running_finishes_when_upstream_finishes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn local_downstream_running_finishes_when_upstream_finishes() {
     // Constant value > threshold keeps the downstream Running until the
     // upstream's duration expires.
     let yaml = r#"
@@ -265,7 +271,9 @@ scenarios:
 
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let mut handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2);
 
     {

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -92,8 +92,8 @@ fn while_gt_zero() -> SubscriptionSpec {
     }
 }
 
-#[test]
-fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
     // Upstream metric oscillates 0 → 1 → 0 across 600ms; downstream gated
     // by `while: ref=upstream op=">" value=0`. Drive the bus directly so
     // the test is deterministic.
@@ -115,6 +115,7 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
         Some(gate_ctx),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Initially paused.
@@ -145,8 +146,8 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscription() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscription() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0); // gate open before subscription
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -164,6 +165,7 @@ fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscriptio
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(150));
@@ -181,8 +183,8 @@ fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscriptio
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
     let bus = Arc::new(GateBus::new());
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -200,6 +202,7 @@ fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(150));
@@ -211,8 +214,8 @@ fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_no_catch_up_burst_on_resume() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_no_catch_up_burst_on_resume() {
     // Verify A1h: after a long pause, resume must emit at the configured
     // rate, not "catch up" with a burst of events.
     let bus = Arc::new(GateBus::new());
@@ -231,6 +234,7 @@ fn while_runtime_no_catch_up_burst_on_resume() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Phase 1: open then close after 200ms running.
@@ -299,8 +303,8 @@ fn metrics_entry_with_generator(
     })
 }
 
-#[test]
-fn while_runtime_sequence_generator_preserves_position_across_pause() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_sequence_generator_preserves_position_across_pause() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -326,6 +330,7 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Phase 1: emit ~3 events (150ms at 20/s). Single series → one entry.
@@ -368,8 +373,8 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
     );
 }
 
-#[test]
-fn while_runtime_ramp_generator_slope_preserved_across_pause() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_ramp_generator_slope_preserved_across_pause() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -396,6 +401,7 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Phase 1: ~10 ticks emitted (200ms at 50/s). Single series → one entry.
@@ -436,8 +442,8 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
     );
 }
 
-#[test]
-fn while_runtime_finished_state_after_duration_expires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_finished_state_after_duration_expires() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -454,6 +460,7 @@ fn while_runtime_finished_state_after_duration_expires() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     handle
@@ -463,8 +470,8 @@ fn while_runtime_finished_state_after_duration_expires() {
     assert!(matches!(snap.state, ScenarioState::Finished));
 }
 
-#[test]
-fn while_runtime_multiple_downstreams_share_one_upstream() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_multiple_downstreams_share_one_upstream() {
     // A2: two downstreams subscribe to the same upstream bus. Both must
     // transition together when the gate edge arrives.
     let bus = Arc::new(GateBus::new());
@@ -485,6 +492,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
         Some(GateContext::new(rx_a, init_a).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch a must succeed");
 
     let mut handle_b = launch_scenario_with_gates(
@@ -497,6 +505,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
         Some(GateContext::new(rx_b, init_b).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch b must succeed");
 
     // Both paused.
@@ -516,8 +525,8 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
     handle_b.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_logs_signal_can_be_gated_downstream() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_logs_signal_can_be_gated_downstream() {
     // BGP UPDOWN log scenario: a logs entry gated by `while:` must
     // transition through pending/running/paused.
     let bus = Arc::new(GateBus::new());
@@ -536,6 +545,7 @@ fn while_runtime_logs_signal_can_be_gated_downstream() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(50));
@@ -564,8 +574,8 @@ fn while_runtime_logs_signal_can_be_gated_downstream() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_delay_open_debounces_pause_to_running_transition() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_delay_open_debounces_pause_to_running_transition() {
     // A2a: delay.open debounces close→open. Sub during gate-closed
     // (pending → paused), then open: must wait at least delay.open
     // before emitting events.
@@ -596,6 +606,7 @@ fn while_runtime_delay_open_debounces_pause_to_running_transition() {
         ),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     bus.tick(1.0);
@@ -622,8 +633,8 @@ fn while_runtime_delay_open_debounces_pause_to_running_transition() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_strict_lt_threshold_gating() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_strict_lt_threshold_gating() {
     // Inverse direction: `while: ref=src op="<" value=10` opens when
     // upstream drops below threshold.
     let bus = Arc::new(GateBus::new());
@@ -650,6 +661,7 @@ fn while_runtime_strict_lt_threshold_gating() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(50));
@@ -663,8 +675,8 @@ fn while_runtime_strict_lt_threshold_gating() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn scenario_restart_does_not_leak_gate_bus() {
+#[tokio::test(flavor = "multi_thread")]
+async fn scenario_restart_does_not_leak_gate_bus() {
     // Risk #4 from phases.md: spawn 50 short-lived gated scenarios in
     // a loop, assert the bus's Arc count returns to baseline after each
     // scenario finishes.
@@ -685,6 +697,7 @@ fn scenario_restart_does_not_leak_gate_bus() {
             Some(GateContext::new(rx, init).with_has_while(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         handle
             .join(Some(Duration::from_secs(2)))
@@ -700,8 +713,8 @@ fn scenario_restart_does_not_leak_gate_bus() {
     );
 }
 
-#[test]
-fn while_runtime_delay_close_debounces_running_to_paused_transition() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_delay_close_debounces_running_to_paused_transition() {
     // delay.close: a brief gate-close-then-reopen within the debounce
     // window must NOT pause the scenario; a sustained close (≥ delay.close)
     // does. Mirrors the delay.open debounce test but for the opposite
@@ -733,6 +746,7 @@ fn while_runtime_delay_close_debounces_running_to_paused_transition() {
         ),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(150));
@@ -767,8 +781,8 @@ fn while_runtime_delay_close_debounces_running_to_paused_transition() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
     // Subscribe with both after: and while: on the same upstream. Initial
     // value 1 → after-not-fired (op="<", threshold=1, strict), gate closed
     // (op="<", threshold=1, strict) — state = Pending. Drive value to 0
@@ -809,6 +823,7 @@ fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
         ),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(80));
@@ -834,8 +849,8 @@ fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
     // Use a single upstream where after.op=">" threshold=100 and
     // while.op="<" threshold=10. Sequence:
     //
@@ -879,6 +894,7 @@ fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
         ),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Pending: gate is initially open but after has not fired.
@@ -918,8 +934,8 @@ fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
     // While Pending (after not yet satisfied), repeated WhileOpen /
     // WhileClose edges on the same upstream must not transition the
     // scenario out of Pending. Single-bus approach: after.op=">"
@@ -960,6 +976,7 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
         ),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Toggle the gate several times while still Pending. None of these
@@ -998,8 +1015,8 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
     // Subscribe with after.op=">" threshold=100 at value=5: after has not
     // fired, gate is irrelevant (after gates Pending entry). Broadcast
     // UpstreamGone while still Pending. With if_unresolved=None, the
@@ -1037,6 +1054,7 @@ fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
         ),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(80));
@@ -1073,12 +1091,12 @@ fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_steady_within_5pct_of_baseline() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_steady_within_5pct_of_baseline() {
     // Perf-regression gate (A10): a scenario with `while:` open the entire
     // run must produce within 5% of the event count of the same scenario
     // without `while:`. Both runs are short (300ms) to keep the test fast.
-    fn run_baseline() -> u64 {
+    async fn run_baseline() -> u64 {
         let entry = metrics_entry("baseline", 1000.0, 300);
         let shutdown = Arc::new(AtomicBool::new(true));
         let mut handle = launch_scenario_with_gates(
@@ -1091,12 +1109,13 @@ fn while_runtime_steady_within_5pct_of_baseline() {
             None,
             None,
         )
+        .await
         .unwrap();
         handle.join(Some(Duration::from_secs(2))).unwrap();
         handle.stats_snapshot().total_events
     }
 
-    fn run_gated_open() -> u64 {
+    async fn run_gated_open() -> u64 {
         let bus = Arc::new(GateBus::new());
         bus.tick(1.0);
         let (rx, init) = bus.subscribe(while_gt_zero());
@@ -1112,17 +1131,18 @@ fn while_runtime_steady_within_5pct_of_baseline() {
             Some(GateContext::new(rx, init).with_has_while(true)),
             None,
         )
+        .await
         .unwrap();
         handle.join(Some(Duration::from_secs(2))).unwrap();
         handle.stats_snapshot().total_events
     }
 
     // Warm-up to stabilize TLB / page-fault behavior.
-    let _ = run_baseline();
-    let _ = run_gated_open();
+    let _ = run_baseline().await;
+    let _ = run_gated_open().await;
 
-    let baseline = run_baseline();
-    let gated = run_gated_open();
+    let baseline = run_baseline().await;
+    let gated = run_gated_open().await;
 
     let baseline_f = baseline as f64;
     let gated_f = gated as f64;
@@ -1231,8 +1251,8 @@ scenarios:
         .expect("legacy delay.close shorthand must still parse");
 }
 
-#[test]
-fn nan_upstream_value_keeps_downstream_paused() {
+#[tokio::test(flavor = "multi_thread")]
+async fn nan_upstream_value_keeps_downstream_paused() {
     let bus = Arc::new(GateBus::new());
     bus.tick(f64::NAN);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -1254,6 +1274,7 @@ fn nan_upstream_value_keeps_downstream_paused() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Re-publish NaN periodically to confirm the runtime defense holds

--- a/sonda-server/CLAUDE.md
+++ b/sonda-server/CLAUDE.md
@@ -26,7 +26,7 @@ src/
 │   ├── health.rs       ← GET /health → {"status": "ok"}
 │   ├── events.rs       ← POST /events: synchronous single-event emission. Tagged-enum
 │                         request body, dispatches on signal_type, builds LogEvent/MetricEvent,
-│                         delegates to sonda_core::emit::{emit_log, emit_metric} via spawn_blocking.
+│                         awaits sonda_core::emit::{emit_log, emit_metric} directly.
 │                         Maps SondaError variants to HTTP status (Config→422, Sink→502, others→500).
 │   ├── sink_warnings.rs ← shared loopback pre-flight helpers (extract_host,
 │                          is_loopback_host, sink_loopback_warnings, collect_warnings_for_sink,

--- a/sonda-server/src/routes/events.rs
+++ b/sonda-server/src/routes/events.rs
@@ -95,9 +95,7 @@ pub async fn post_events(State(_state): State<AppState>, body: axum::body::Bytes
             };
             let sink_type = sink_kind(&sink);
             let labels_for_sink = (!labels.is_empty()).then_some(labels);
-            let result =
-                run_blocking(move || emit_log(&event, &encoder, &sink, labels_for_sink.as_ref()))
-                    .await;
+            let result = emit_log(&event, &encoder, &sink, labels_for_sink.as_ref()).await;
             ("logs", sink_type, result)
         }
         EventRequest::Metrics {
@@ -112,10 +110,7 @@ pub async fn post_events(State(_state): State<AppState>, body: axum::body::Bytes
             };
             let sink_type = sink_kind(&sink);
             let labels_for_sink = (!labels.is_empty()).then_some(labels);
-            let result = run_blocking(move || {
-                emit_metric(&event, &encoder, &sink, labels_for_sink.as_ref())
-            })
-            .await;
+            let result = emit_metric(&event, &encoder, &sink, labels_for_sink.as_ref()).await;
             ("metrics", sink_type, result)
         }
     };
@@ -178,18 +173,6 @@ fn labels_from_map(map: &HashMap<String, String>) -> Result<Labels, SondaError> 
     }
     let pairs: Vec<(&str, &str)> = map.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
     Labels::from_pairs(&pairs)
-}
-
-async fn run_blocking<F>(f: F) -> Result<(), SondaError>
-where
-    F: FnOnce() -> Result<(), SondaError> + Send + 'static,
-{
-    match tokio::task::spawn_blocking(f).await {
-        Ok(r) => r,
-        Err(_join_err) => Err(SondaError::Runtime(
-            sonda_core::RuntimeError::ThreadPanicked,
-        )),
-    }
 }
 
 fn error_response(err: SondaError) -> Response {

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -597,13 +597,15 @@ async fn launch_compiled(
     warnings: Vec<String>,
 ) -> Result<Response, Response> {
     let resolver: Arc<dyn sonda_core::GateBusResolver> = state.gate_bus_registry.clone();
-    let mut handles = launch_multi_compiled(compiled, Some(resolver)).map_err(|e| {
-        warn!(error = %e, "POST /scenarios: failed to launch scenarios");
-        match e {
-            sonda_core::SondaError::Config(_) => unprocessable(e),
-            _ => internal_error(e),
-        }
-    })?;
+    let mut handles = launch_multi_compiled(compiled, Some(resolver))
+        .await
+        .map_err(|e| {
+            warn!(error = %e, "POST /scenarios: failed to launch scenarios");
+            match e {
+                sonda_core::SondaError::Config(_) => unprocessable(e),
+                _ => internal_error(e),
+            }
+        })?;
 
     if handles.is_empty() {
         warn!("POST /scenarios: gated launch produced zero handles");

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -156,4 +156,4 @@ This crate depends on:
 - `owo-colors` for colored terminal output (with `supports-colors` feature for auto-detection)
 - `dialoguer` for interactive terminal prompts in `sonda new` (pure Rust, musl-compatible)
 
-It should NOT depend on: `axum`, `tokio`, `hyper`, or any server-related crate.
+It depends on `tokio` (runtime construction in `main` to drive the async `launch_scenario` API). It should NOT depend on: `axum`, `hyper`, or any server-specific HTTP crate.

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -34,6 +34,7 @@ owo-colors = { version = "4", features = ["supports-colors"] }
 serde_json = { workspace = true }
 dialoguer = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -56,8 +56,12 @@ fn run() -> anyhow::Result<()> {
     let verbosity = Verbosity::from_flags(cli.quiet, cli.verbose);
     let catalog = cli.catalog.as_deref();
 
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
     match cli.command {
-        Commands::Run(ref args) => run_scenario(args, &cli, catalog, verbosity, &running)?,
+        Commands::Run(ref args) => run_scenario(&rt, args, &cli, catalog, verbosity, &running)?,
         Commands::List(ref args) => list_catalog(args, catalog)?,
         Commands::Show(ref args) => show_entry(args, catalog)?,
         Commands::New(ref args) => new::run(args)?,
@@ -67,6 +71,7 @@ fn run() -> anyhow::Result<()> {
 }
 
 fn run_scenario(
+    rt: &tokio::runtime::Runtime,
     args: &cli::RunArgs,
     cli_opts: &Cli,
     catalog: Option<&std::path::Path>,
@@ -87,7 +92,7 @@ fn run_scenario(
         if verbosity == Verbosity::Verbose {
             status::print_version();
         }
-        run_compiled_with_progress(compiled, running, verbosity)?;
+        run_compiled_with_progress(rt, compiled, running, verbosity)?;
         return Ok(());
     }
 
@@ -101,9 +106,9 @@ fn run_scenario(
 
     if prepared.len() == 1 {
         let p = prepared.into_iter().next().expect("len checked above");
-        run_single_scenario("cli-run".to_string(), p, running, verbosity)?;
+        run_single_scenario(rt, "cli-run".to_string(), p, running, verbosity)?;
     } else {
-        launch_and_join_prepared("cli-run", prepared, running, verbosity)?;
+        launch_and_join_prepared(rt, "cli-run", prepared, running, verbosity)?;
     }
     Ok(())
 }
@@ -196,19 +201,21 @@ fn handle_pre_launch(prepared: &[PreparedEntry], verbosity: Verbosity, dry_run: 
 }
 
 fn run_single_scenario(
+    rt: &tokio::runtime::Runtime,
     name: String,
     prepared: PreparedEntry,
     running: &Arc<AtomicBool>,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
     status::print_start(&prepared.entry, verbosity, None);
-    let mut handle = sonda_core::launch_scenario(
-        name,
-        prepared.entry,
-        Arc::clone(running),
-        prepared.start_delay,
-    )
-    .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let mut handle = rt
+        .block_on(sonda_core::launch_scenario(
+            name,
+            prepared.entry,
+            Arc::clone(running),
+            prepared.start_delay,
+        ))
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
     let progress = maybe_start_progress(&handle, verbosity);
     let join_result = handle.join(None);
     if let Some(p) = progress {
@@ -268,6 +275,7 @@ struct StopInfo {
 }
 
 fn launch_and_join_prepared(
+    rt: &tokio::runtime::Runtime,
     id_prefix: &str,
     prepared: Vec<PreparedEntry>,
     running: &Arc<AtomicBool>,
@@ -286,7 +294,13 @@ fn launch_and_join_prepared(
             p.entry.clock_group_is_auto(),
         ));
         let id = format!("{id_prefix}-{i}");
-        let handle = sonda_core::launch_scenario(id, p.entry, Arc::clone(running), p.start_delay)
+        let handle = rt
+            .block_on(sonda_core::launch_scenario(
+                id,
+                p.entry,
+                Arc::clone(running),
+                p.start_delay,
+            ))
             .map_err(|e| anyhow::anyhow!("{}", e))?;
         handles.push(handle);
     }
@@ -346,11 +360,15 @@ fn launch_and_join_prepared(
 }
 
 fn run_compiled_with_progress(
+    rt: &tokio::runtime::Runtime,
     compiled: sonda_core::compiler::compile_after::CompiledFile,
     running: &Arc<AtomicBool>,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
-    let handles = sonda_core::schedule::multi_runner::launch_multi_compiled(compiled, None)
+    let handles = rt
+        .block_on(sonda_core::schedule::multi_runner::launch_multi_compiled(
+            compiled, None,
+        ))
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
     let per_handle_shutdowns: Vec<Arc<AtomicBool>> =


### PR DESCRIPTION
## Summary

Replaces the sync `Sink` trait + private-`Runtime`-per-sink pattern with an
`#[async_trait]`-backed async trait. The two sinks that previously owned
private `tokio::runtime::Runtime` fields (`OtlpGrpcSink`, `KafkaSink`) drop
them entirely and connect/write through the ambient runtime via `.await`.
`launch_scenario` and `launch_multi_compiled` also become async, the CLI
builds one tokio runtime in `main`, and the HTTP route awaits the launch
directly.

## Changes

- **Async `Sink` trait** via `async_trait = "0.1"`. `async fn write`,
  `async fn flush`, `async fn write_log_event` (default-impl forwarding to
  `write`, with Loki's override preserved).
- **Sync-I/O sinks** migrate to Tokio-native I/O — `tokio::io::stdout`,
  `tokio::fs::File`, `tokio::net::TcpStream`, `tokio::net::UdpSocket`.
  No `spawn_blocking` for these paths.
- **`ureq`-based sinks** (`http`, `loki`, `remote_write`) wrap the HTTP
  round-trip in `tokio::task::spawn_blocking` inside the sink impl. Loki's
  sink-side override for stream-label promotion is preserved.
- **`channel` and `memory` sinks** stay sync internally; the async `write`
  is just `Ok(())` after a cheap push.
- **`OtlpGrpcSink` and `KafkaSink`** drop their private `Runtime` fields.
  Construction is `async fn new`; tonic's `Channel::from_shared(...).connect().await`
  and `rskafka`'s producer run directly in async context.
- **`launch_scenario` and `launch_multi_compiled`** become `pub async fn`.
  The sync API's old private current-thread runtime is gone.
- **CLI runtime construction**: `sonda/src/main.rs` builds one
  `tokio::runtime::Builder::new_multi_thread().enable_all().build()` and
  `block_on`s the launch sites. `sonda` now depends on `tokio` with the
  `rt-multi-thread` feature.
- **HTTP route**: `sonda-server/src/routes/scenarios.rs` awaits
  `launch_multi_compiled` directly. `sonda-server/src/routes/events.rs`
  awaits `emit_log` / `emit_metric` directly; the `run_blocking` helper is
  removed.
- **Phase 2c `spawn_blocking` wraps** in `sonda-core/src/schedule/core_loop.rs`
  collapse (three sites: `drain_writes`, `finalize_sink`, `invoke_close_emit`).
  Sinks own the boundary now; runners just `.await`.
- **`run_multi`** collects per-entry launch errors instead of `?`-aborting,
  preserving the `run_multi_collects_all_thread_errors` test contract.
- **TCP-sink loopback / unresolvable pre-flight contract** is preserved:
  the route handler's string-based warning happens before launch, and the
  actual TCP connect is deferred to the worker thread's `_blocking` helper
  where failures surface through the `on_sink_error: Warn` policy. POSTing
  a scenario with an unreachable TCP target still returns 201 + warning,
  not 500.
- Test conversions to `#[tokio::test(flavor = "multi_thread")]` across
  `sonda-core/src/schedule/{launch,multi_runner}.rs` and four integration
  test files. Bench harnesses gain a multi-thread runtime in setup.

## Semver

Stays `refactor(core):` despite the public trait and launch-API changes:
no known external embedders.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace --all-features` — 2884 / 2884
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::await_holding_lock`
- [x] `cargo clippy -p sonda-core --no-default-features -- -D warnings`
- [x] `cargo test -p sonda-core --no-default-features --no-run`
- [x] `cargo fmt --all -- --check`
- [x] `cargo audit`
- [x] `cargo nextest run -p sonda-core --all-features --test while_close_workshop_repro` — 11 / 11, 0 skipped (binary-driving integration check)