### PR TITLE
refactor(core): run scenarios as tokio tasks with cancellation tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Full design rationale is in `docs/architecture.md`. Key decisions:
 - Cargo workspace for parallel compilation and clean dep isolation.
 - Trait objects (`Box<dyn Trait>`) for generators, encoders, sinks — extensible without dispatch changes.
 - YAML for all scenario config; CLI flags and `SONDA_*` env vars override.
-- Sync-first (std::thread + mpsc). Tokio only in sonda-server.
+- Tokio-first: scenarios run as `tokio::task::spawn` tasks on a shared multi-thread runtime.
 - Static binary (musl). Pure-Rust deps only (rustls, not openssl).
 
 ## Extension Points

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,6 +2251,7 @@ dependencies = [
  "sonda-core",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing-subscriber",
 ]
 
@@ -2277,6 +2278,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tonic",
  "tracing",
  "tracing-test",
@@ -2304,6 +2306,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -28,7 +28,8 @@ tracing = "0.1"
 async-trait = "0.1"
 ureq = { workspace = true, optional = true }
 rskafka = { version = "0.6.0", default-features = false, features = ["transport-tls"], optional = true }
-tokio = { version = "1", features = ["rt", "sync", "net", "time", "macros", "fs", "io-std", "io-util"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "net", "time", "macros", "fs", "io-std", "io-util"] }
+tokio-util = { version = "0.7", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"], optional = true }
 rustls-pki-types = { version = "1", features = ["std"], optional = true }

--- a/sonda-core/benches/scheduler_baseline.rs
+++ b/sonda-core/benches/scheduler_baseline.rs
@@ -20,7 +20,7 @@ use sonda_core::schedule::runner::run_with_sink;
 use sonda_core::schedule::stats::ScenarioStats;
 use sonda_core::sink::memory::{CapturedRing, MemorySink};
 use sonda_core::sink::{Sink, SinkConfig};
-use sonda_core::{launch_scenario, prepare_entries, OnSinkError, RuntimeError, SondaError};
+use sonda_core::{launch_scenario, prepare_entries, OnSinkError};
 use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System};
 
 const DEFAULT_SCENARIO_COUNTS: &[usize] = &[1, 10, 50, 100, 250, 500];
@@ -180,8 +180,15 @@ fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
     assert!(n >= 1, "launch_n requires at least one scenario");
     let capture_handle = Arc::new(Mutex::new(CapturedRing::new(CAPTURE_RING_SIZE)));
 
+    let rt: &'static tokio::runtime::Runtime = Box::leak(Box::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build"),
+    ));
     let mut handles = Vec::with_capacity(n);
     handles.push(launch_capturing_scenario(
+        rt,
         "bench_0".to_string(),
         Arc::clone(&capture_handle),
     ));
@@ -200,18 +207,14 @@ fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
             })
             .collect();
         let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .expect("tokio runtime must build");
         for (offset, p) in prepared.into_iter().enumerate() {
             let i = offset + 1;
-            let shutdown = Arc::new(AtomicBool::new(true));
+            let cancel = sonda_core::CancellationToken::new();
             let handle = rt
                 .block_on(launch_scenario(
                     format!("bench_{i}"),
                     p.entry,
-                    shutdown,
+                    cancel,
                     p.start_delay,
                 ))
                 .expect("launch_scenario must succeed");
@@ -223,53 +226,42 @@ fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
 
 // Mirrors launch_scenario for the shared-capture path; bench-local replica.
 fn launch_capturing_scenario(
+    rt: &tokio::runtime::Runtime,
     id: String,
     capture_handle: Arc<Mutex<CapturedRing>>,
 ) -> ScenarioHandle {
     let config = metrics_config_for_capture(id.clone(), RATE_HZ);
     let name = config.base.name.clone();
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = sonda_core::CancellationToken::new();
     let stats = Arc::new(RwLock::new(ScenarioStats::default()));
     let alive = Arc::new(AtomicBool::new(true));
     let cleaned_up = Arc::new(AtomicBool::new(true));
     let labels: Arc<HashMap<String, String>> = Arc::new(HashMap::new());
 
-    let shutdown_for_thread = Arc::clone(&shutdown);
-    let stats_for_thread = Arc::clone(&stats);
-    let alive_for_thread = Arc::clone(&alive);
+    let cancel_for_task = cancel.clone();
+    let stats_for_task = Arc::clone(&stats);
+    let alive_for_task = Arc::clone(&alive);
 
-    let thread = std::thread::Builder::new()
-        .name(format!("sonda-{name}"))
-        .spawn(move || -> Result<(), SondaError> {
-            struct AliveGuard(Arc<AtomicBool>);
-            impl Drop for AliveGuard {
-                fn drop(&mut self) {
-                    self.0.store(false, std::sync::atomic::Ordering::SeqCst);
-                }
+    let task = rt.spawn(async move {
+        struct AliveGuard(Arc<AtomicBool>);
+        impl Drop for AliveGuard {
+            fn drop(&mut self) {
+                self.0.store(false, std::sync::atomic::Ordering::SeqCst);
             }
-            let _guard = AliveGuard(alive_for_thread);
+        }
+        let _guard = AliveGuard(alive_for_task);
 
-            let sink_inner = MemorySink::with_shared_capture(capture_handle);
-            let mut sink: Box<dyn Sink> = Box::new(sink_inner);
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
-            rt.block_on(run_with_sink(
-                &config,
-                &mut sink,
-                Some(shutdown_for_thread.as_ref()),
-                Some(stats_for_thread),
-            ))
-        })
-        .expect("scenario thread must spawn");
+        let sink_inner = MemorySink::with_shared_capture(capture_handle);
+        let mut sink: Box<dyn Sink> = Box::new(sink_inner);
+        run_with_sink(&config, &mut sink, &cancel_for_task, Some(stats_for_task)).await
+    });
 
     ScenarioHandle::new(
         id,
         name,
         None,
-        shutdown,
-        Some(thread),
+        cancel,
+        Some(task),
         Instant::now(),
         stats,
         RATE_HZ,

--- a/sonda-core/benches/while_steady_state.rs
+++ b/sonda-core/benches/while_steady_state.rs
@@ -5,7 +5,6 @@
 //! lives separately as a `#[test] fn` in `tests/while_runtime.rs`; this
 //! bench is the developer-facing profiler.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -54,13 +53,13 @@ fn bench_baseline_ungated(c: &mut Criterion) {
     c.bench_function("baseline_ungated_300ms_at_1khz", |b| {
         b.iter(|| {
             let entry = metrics_entry("bench", 1000.0, 300);
-            let shutdown = Arc::new(AtomicBool::new(true));
+            let cancel = sonda_core::CancellationToken::new();
             let mut handle = rt
                 .block_on(launch_scenario_with_gates(
                     "bench".to_string(),
                     None,
                     entry,
-                    shutdown,
+                    cancel,
                     None,
                     None,
                     None,
@@ -89,13 +88,13 @@ fn bench_gated_open(c: &mut Criterion) {
                 }),
             });
             let entry = metrics_entry("gated", 1000.0, 300);
-            let shutdown = Arc::new(AtomicBool::new(true));
+            let cancel = sonda_core::CancellationToken::new();
             let mut handle = rt
                 .block_on(launch_scenario_with_gates(
                     "gated".to_string(),
                     None,
                     entry,
-                    shutdown,
+                    cancel,
                     None,
                     Some(Arc::clone(&bus)),
                     Some(GateContext::new(rx, init).with_has_while(true)),

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -63,6 +63,7 @@ pub use schedule::gate_bus::{
 pub use schedule::handle::ScenarioHandle;
 pub use schedule::launch::{launch_scenario, prepare_entries, validate_entry, PreparedEntry};
 pub use schedule::stats::{ScenarioState, ScenarioStats};
+pub use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "config")]
 pub use compiler::prepare::PrepareError;
@@ -245,6 +246,13 @@ pub enum RuntimeError {
     /// A `tokio::task::spawn_blocking` task panicked or was cancelled.
     #[error("blocking task failed: {0}")]
     TaskPanicked(String),
+
+    /// A scenario task could not be joined safely in the current runtime context.
+    #[error("scenario task aborted: {reason}")]
+    TaskAborted {
+        /// Why the task could not be joined (e.g., called from a current_thread runtime).
+        reason: &'static str,
+    },
 }
 
 #[cfg(test)]

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -1,9 +1,10 @@
 //! Shared schedule loop for metrics, logs, histograms, and summaries.
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, RwLock};
-use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use tokio_util::sync::CancellationToken;
 
 use crate::compiler::{DelayClause, UnresolvedBehavior};
 use crate::config::validate::StartTime;
@@ -131,6 +132,7 @@ pub(crate) type TickFn<'a> = dyn FnMut(
         &mut TickOutput,
         &mut Vec<MetricEvent>,
     ) -> Result<TickResult, SondaError>
+    + Send
     + 'a;
 
 /// Scenario-level wall-clock anchor: the resolved emission-time base plus the
@@ -187,19 +189,19 @@ pub enum CloseSignal {
 /// transition. Closures push markers into the supplied [`TickOutput`].
 pub type CloseEmitFn = Box<dyn FnMut(&mut TickOutput) -> Result<(), SondaError> + Send>;
 
-/// Run the shared schedule loop until duration expires or shutdown is
+/// Run the shared schedule loop until duration expires or cancellation is
 /// signalled, then flush the sink and apply the sink-error policy.
 pub(crate) async fn run_schedule_loop(
     schedule: &ParsedSchedule,
     rate: f64,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     sink: &mut Box<dyn Sink>,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<(), SondaError> {
     let stats_for_flush = stats.clone();
     let loop_result = run_schedule_loop_with_initial_tick(
-        schedule, rate, shutdown, stats, 0, None, None, sink, tick_fn,
+        schedule, rate, cancel, stats, 0, None, None, sink, tick_fn,
     )
     .await;
     finalize_sink(schedule, stats_for_flush.as_ref(), sink, loop_result).await
@@ -227,7 +229,7 @@ async fn finalize_sink(
 pub(crate) async fn run_schedule_loop_with_initial_tick(
     schedule: &ParsedSchedule,
     rate: f64,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     initial_tick: u64,
     last_tick_out: Option<&AtomicU64>,
@@ -260,11 +262,8 @@ pub(crate) async fn run_schedule_loop_with_initial_tick(
     };
 
     loop {
-        // Check shutdown flag first — highest priority exit path.
-        if let Some(flag) = shutdown {
-            if !flag.load(Ordering::SeqCst) {
-                break;
-            }
+        if cancel.is_cancelled() {
+            break;
         }
 
         let elapsed = start.elapsed();
@@ -289,7 +288,7 @@ pub(crate) async fn run_schedule_loop_with_initial_tick(
                 }
                 let sleep_for = time_until_gap_end(elapsed, gap);
                 if sleep_for > Duration::ZERO {
-                    thread::sleep(sleep_for);
+                    tokio::time::sleep(sleep_for).await;
                 }
                 // After sleeping through the gap, reset the deadline so we
                 // don't try to catch up for suppressed events. Re-derive
@@ -324,7 +323,7 @@ pub(crate) async fn run_schedule_loop_with_initial_tick(
         // Deadline-based rate control.
         let now = Instant::now();
         if now < next_deadline {
-            thread::sleep(next_deadline - now);
+            tokio::time::sleep(next_deadline - now).await;
         }
 
         // Invoke the signal-specific tick callback.
@@ -651,7 +650,7 @@ impl GateContext {
 pub(crate) async fn gated_loop(
     schedule: &ParsedSchedule,
     rate: f64,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     mut gate_ctx: GateContext,
     sink: &mut Box<dyn Sink>,
@@ -663,7 +662,7 @@ pub(crate) async fn gated_loop(
     let body_result = gated_loop_body(
         schedule,
         rate,
-        shutdown,
+        cancel,
         stats.as_ref(),
         &mut gate_ctx,
         &mut close_warn_limiter,
@@ -696,7 +695,7 @@ pub(crate) async fn gated_loop(
 async fn gated_loop_body(
     schedule: &ParsedSchedule,
     rate: f64,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<&Arc<RwLock<ScenarioStats>>>,
     gate_ctx: &mut GateContext,
     close_warn_limiter: &mut SinkErrorRateLimiter,
@@ -733,7 +732,7 @@ async fn gated_loop_body(
     write_state(stats, state, paused_zero_rate);
 
     loop {
-        if shutdown_requested(shutdown) {
+        if cancel.is_cancelled() {
             return Ok(LoopExit::Shutdown);
         }
         if duration_expired(schedule, started_at) {
@@ -744,7 +743,14 @@ async fn gated_loop_body(
             ScenarioState::Pending => {
                 if !after_satisfied {
                     let wait = remaining_until(schedule, started_at, PAUSED_POLL_INTERVAL);
-                    match gate_ctx.gate_rx.recv_edge_timeout(wait).await {
+                    let edge = tokio::select! {
+                        biased;
+                        _ = cancel.cancelled() => {
+                            return Ok(LoopExit::Shutdown);
+                        }
+                        e = gate_ctx.gate_rx.recv_edge_timeout(wait) => e,
+                    };
+                    match edge {
                         Some(GateEdge::AfterFired) => {
                             after_satisfied = true;
                         }
@@ -785,15 +791,13 @@ async fn gated_loop_body(
                 }
             }
             ScenarioState::Running => {
-                let segment_running = Arc::new(AtomicBool::new(true));
                 let last_tick = Arc::new(AtomicU64::new(next_tick));
                 let exit = run_running_segment(
                     schedule,
                     rate,
-                    shutdown,
+                    cancel,
                     stats.cloned(),
                     gate_ctx,
-                    &segment_running,
                     next_tick,
                     Arc::clone(&last_tick),
                     wall,
@@ -804,7 +808,7 @@ async fn gated_loop_body(
                 .await?;
                 next_tick = last_tick.load(Ordering::SeqCst);
 
-                if shutdown_requested(shutdown) {
+                if cancel.is_cancelled() {
                     return Ok(LoopExit::Shutdown);
                 }
                 if duration_expired(schedule, started_at) {
@@ -829,10 +833,8 @@ async fn gated_loop_body(
                     continue;
                 }
                 if exit == SegmentExit::WhileClose
-                    && !debounce_close_to_paused(
-                        schedule, started_at, shutdown, gate_ctx, &debounce,
-                    )
-                    .await
+                    && !debounce_close_to_paused(schedule, started_at, cancel, gate_ctx, &debounce)
+                        .await
                 {
                     while_open = true;
                     continue;
@@ -863,7 +865,13 @@ async fn gated_loop_body(
                     wakeup = wakeup.min(remaining);
                 }
 
-                let recv = gate_ctx.gate_rx.recv_edge_timeout(wakeup).await;
+                let recv = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        return Ok(LoopExit::Shutdown);
+                    }
+                    r = gate_ctx.gate_rx.recv_edge_timeout(wakeup) => r,
+                };
                 let now = Instant::now();
                 match recv {
                     Some(GateEdge::WhileOpen) => {
@@ -908,15 +916,13 @@ async fn gated_loop_body(
                 let mode = gate_ctx.if_unresolved.unwrap_or_default();
                 match mode {
                     UnresolvedBehavior::Open => {
-                        let segment_running = Arc::new(AtomicBool::new(true));
                         let last_tick = Arc::new(AtomicU64::new(next_tick));
                         let exit = run_running_segment(
                             schedule,
                             rate,
-                            shutdown,
+                            cancel,
                             stats.cloned(),
                             gate_ctx,
-                            &segment_running,
                             next_tick,
                             Arc::clone(&last_tick),
                             wall,
@@ -927,7 +933,7 @@ async fn gated_loop_body(
                         .await?;
                         next_tick = last_tick.load(Ordering::SeqCst);
 
-                        if shutdown_requested(shutdown) {
+                        if cancel.is_cancelled() {
                             return Ok(LoopExit::Shutdown);
                         }
                         if duration_expired(schedule, started_at) {
@@ -964,7 +970,14 @@ async fn gated_loop_body(
                     }
                     UnresolvedBehavior::Closed | UnresolvedBehavior::Pending => {
                         let wakeup = remaining_until(schedule, started_at, PAUSED_POLL_INTERVAL);
-                        match gate_ctx.gate_rx.recv_edge_timeout(wakeup).await {
+                        let recv = tokio::select! {
+                            biased;
+                            _ = cancel.cancelled() => {
+                                return Ok(LoopExit::Shutdown);
+                            }
+                            r = gate_ctx.gate_rx.recv_edge_timeout(wakeup) => r,
+                        };
+                        match recv {
                             Some(GateEdge::WhileOpen) => {
                                 while_open = true;
                                 state = ScenarioState::Pending;
@@ -1011,10 +1024,6 @@ fn close_target_state(
     } else {
         ScenarioState::Paused
     }
-}
-
-fn shutdown_requested(shutdown: Option<&AtomicBool>) -> bool {
-    shutdown.map(|f| !f.load(Ordering::SeqCst)).unwrap_or(false)
 }
 
 fn duration_expired(schedule: &ParsedSchedule, started_at: Instant) -> bool {
@@ -1112,7 +1121,7 @@ enum LoopExit {
 async fn debounce_close_to_paused(
     schedule: &ParsedSchedule,
     started_at: Instant,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     gate_ctx: &mut GateContext,
     debounce: &DebounceState,
 ) -> bool {
@@ -1122,7 +1131,7 @@ async fn debounce_close_to_paused(
 
     let deadline = Instant::now() + debounce.delay_close;
     loop {
-        if shutdown_requested(shutdown) || duration_expired(schedule, started_at) {
+        if cancel.is_cancelled() || duration_expired(schedule, started_at) {
             return true;
         }
         let now = Instant::now();
@@ -1133,7 +1142,12 @@ async fn debounce_close_to_paused(
         if let Some(remaining) = remaining_duration(schedule, started_at) {
             wait = wait.min(remaining);
         }
-        match gate_ctx.gate_rx.recv_edge_timeout(wait).await {
+        let recv = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return true,
+            r = gate_ctx.gate_rx.recv_edge_timeout(wait) => r,
+        };
+        match recv {
             Some(GateEdge::WhileOpen) => return false,
             Some(GateEdge::WhileClose) => {}
             Some(GateEdge::AfterFired) => {}
@@ -1145,7 +1159,7 @@ async fn debounce_close_to_paused(
 
 /// Run one `Running` segment: a fresh `run_schedule_loop` with a wrapped
 /// `tick_fn` that polls the gate channel after every successful tick.
-/// On `WhileClose` the segment_running flag is cleared so the inner loop
+/// On `WhileClose` the segment cancellation token fires so the inner loop
 /// exits at its top-of-loop shutdown check.
 ///
 /// `initial_tick` seeds the inner loop's tick counter on resume; `last_tick`
@@ -1155,10 +1169,9 @@ async fn debounce_close_to_paused(
 async fn run_running_segment(
     schedule: &ParsedSchedule,
     rate: f64,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: &mut GateContext,
-    segment_running: &Arc<AtomicBool>,
     initial_tick: u64,
     last_tick: Arc<AtomicU64>,
     wall: WallClock,
@@ -1166,18 +1179,11 @@ async fn run_running_segment(
     tick_fn: &mut TickFn<'_>,
     exit_on_while_open: bool,
 ) -> Result<SegmentExit, SondaError> {
-    let saw_close = Arc::new(AtomicBool::new(false));
-    let saw_gone = Arc::new(AtomicBool::new(false));
-    let saw_open = Arc::new(AtomicBool::new(false));
+    let segment_cancel = cancel.child_token();
+    let observed: Arc<AtomicU8> = Arc::new(AtomicU8::new(SEGMENT_EXIT_NONE));
 
-    // The inner loop's `shutdown` parameter wants "true = keep running."
-    // We pass our segment flag, and we additionally drain the user
-    // shutdown into the segment flag inside the wrapped tick.
-    let user_shutdown_for_wrapper = shutdown;
-    let segment_for_wrapper = Arc::clone(segment_running);
-    let saw_close_for_wrapper = Arc::clone(&saw_close);
-    let saw_gone_for_wrapper = Arc::clone(&saw_gone);
-    let saw_open_for_wrapper = Arc::clone(&saw_open);
+    let segment_for_wrapper = segment_cancel.clone();
+    let observed_for_wrapper = Arc::clone(&observed);
     let gate_rx = &mut gate_ctx.gate_rx;
 
     type WrappedTick<'a> = Box<
@@ -1186,6 +1192,7 @@ async fn run_running_segment(
                 &mut TickOutput,
                 &mut Vec<MetricEvent>,
             ) -> Result<TickResult, SondaError>
+            + Send
             + 'a,
     >;
     let mut wrapped: WrappedTick<'_> = Box::new(
@@ -1195,33 +1202,23 @@ async fn run_running_segment(
               -> Result<TickResult, SondaError> {
             let outcome = tick_fn(ctx, output, events_buf);
 
-            // Poll for gate edges after the tick. On WhileClose, break out.
             while let Some(edge) = gate_rx.try_recv() {
                 match edge {
                     GateEdge::WhileClose => {
-                        saw_close_for_wrapper.store(true, Ordering::SeqCst);
-                        segment_for_wrapper.store(false, Ordering::SeqCst);
+                        observed_for_wrapper.store(SEGMENT_EXIT_WHILE_CLOSE, Ordering::SeqCst);
+                        segment_for_wrapper.cancel();
                     }
                     GateEdge::WhileOpen => {
                         if exit_on_while_open {
-                            saw_open_for_wrapper.store(true, Ordering::SeqCst);
-                            segment_for_wrapper.store(false, Ordering::SeqCst);
+                            observed_for_wrapper.store(SEGMENT_EXIT_WHILE_OPEN, Ordering::SeqCst);
+                            segment_for_wrapper.cancel();
                         }
                     }
-                    GateEdge::AfterFired => {
-                        // Already past the after gate.
-                    }
+                    GateEdge::AfterFired => {}
                     GateEdge::UpstreamGone => {
-                        saw_gone_for_wrapper.store(true, Ordering::SeqCst);
-                        segment_for_wrapper.store(false, Ordering::SeqCst);
+                        observed_for_wrapper.store(SEGMENT_EXIT_UPSTREAM_GONE, Ordering::SeqCst);
+                        segment_for_wrapper.cancel();
                     }
-                }
-            }
-
-            // Honor user shutdown immediately (don't wait for next loop iter).
-            if let Some(user) = user_shutdown_for_wrapper {
-                if !user.load(Ordering::SeqCst) {
-                    segment_for_wrapper.store(false, Ordering::SeqCst);
                 }
             }
 
@@ -1232,7 +1229,7 @@ async fn run_running_segment(
     run_schedule_loop_with_initial_tick(
         schedule,
         rate,
-        Some(segment_running.as_ref()),
+        &segment_cancel,
         stats,
         initial_tick,
         Some(last_tick.as_ref()),
@@ -1242,15 +1239,21 @@ async fn run_running_segment(
     )
     .await?;
 
-    Ok(if saw_gone.load(Ordering::SeqCst) {
-        SegmentExit::UpstreamGone
-    } else if saw_close.load(Ordering::SeqCst) {
-        SegmentExit::WhileClose
-    } else if saw_open.load(Ordering::SeqCst) {
-        SegmentExit::WhileOpen
-    } else {
-        SegmentExit::ShutdownOrDuration
-    })
+    Ok(decode_segment_exit(observed.load(Ordering::SeqCst)))
+}
+
+const SEGMENT_EXIT_NONE: u8 = 0;
+const SEGMENT_EXIT_WHILE_CLOSE: u8 = 1;
+const SEGMENT_EXIT_UPSTREAM_GONE: u8 = 2;
+const SEGMENT_EXIT_WHILE_OPEN: u8 = 3;
+
+fn decode_segment_exit(code: u8) -> SegmentExit {
+    match code {
+        SEGMENT_EXIT_UPSTREAM_GONE => SegmentExit::UpstreamGone,
+        SEGMENT_EXIT_WHILE_CLOSE => SegmentExit::WhileClose,
+        SEGMENT_EXIT_WHILE_OPEN => SegmentExit::WhileOpen,
+        _ => SegmentExit::ShutdownOrDuration,
+    }
 }
 
 /// Open / close debounce timers for `while:` transitions.
@@ -1527,8 +1530,8 @@ mod tests {
         let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
-            20.0, // 20 events/sec for 500ms = ~10 events
-            None,
+            20.0,
+            &CancellationToken::new(),
             None,
             &mut sink,
             &mut tick_fn,
@@ -1548,20 +1551,17 @@ mod tests {
 
     // ---- Shutdown flag: stops the loop early --------------------------------
 
-    /// Clearing the shutdown flag stops the loop before duration expires.
+    /// Cancelling the token stops the loop before duration expires.
     #[tokio::test]
-    async fn loop_stops_on_shutdown_flag() {
-        use std::sync::atomic::AtomicBool;
-
-        let schedule = minimal_schedule(None); // indefinite
+    async fn loop_stops_on_cancel() {
+        let schedule = minimal_schedule(None);
         let mut event_count: u64 = 0;
 
-        // Spawn a thread to clear the flag after 200ms.
-        let shutdown_arc = Arc::new(AtomicBool::new(true));
-        let flag_clone = Arc::clone(&shutdown_arc);
+        let cancel = CancellationToken::new();
+        let cancel_for_thread = cancel.clone();
         let handle = std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(200));
-            flag_clone.store(false, Ordering::SeqCst);
+            cancel_for_thread.cancel();
         });
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
@@ -1576,23 +1576,13 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        run_schedule_loop(
-            &schedule,
-            50.0,
-            Some(shutdown_arc.as_ref()),
-            None,
-            &mut sink,
-            &mut tick_fn,
-        )
-        .await
-        .expect("loop must succeed");
+        run_schedule_loop(&schedule, 50.0, &cancel, None, &mut sink, &mut tick_fn)
+            .await
+            .expect("loop must succeed");
 
         handle.join().expect("thread must complete");
 
-        assert!(
-            event_count > 0,
-            "some events should have been emitted before shutdown"
-        );
+        assert!(event_count > 0);
     }
 
     // ---- Gap window: suppresses events during gap ---------------------------
@@ -1627,9 +1617,16 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        run_schedule_loop(&schedule, 100.0, None, None, &mut sink, &mut tick_fn)
-            .await
-            .expect("loop must succeed");
+        run_schedule_loop(
+            &schedule,
+            100.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
+        )
+        .await
+        .expect("loop must succeed");
 
         // Only ~100 events from the first 1s before the gap kicks in.
         assert!(
@@ -1671,9 +1668,16 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        run_schedule_loop(&schedule, 10.0, None, None, &mut sink, &mut tick_fn)
-            .await
-            .expect("loop must succeed");
+        run_schedule_loop(
+            &schedule,
+            10.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
+        )
+        .await
+        .expect("loop must succeed");
 
         // Without burst: ~10 events. With 5x burst: ~50 events.
         assert!(
@@ -1704,7 +1708,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -1752,7 +1756,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -1809,9 +1813,16 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        run_schedule_loop(&schedule, 100.0, None, None, &mut sink, &mut tick_fn)
-            .await
-            .expect("loop must succeed");
+        run_schedule_loop(
+            &schedule,
+            100.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
+        )
+        .await
+        .expect("loop must succeed");
 
         assert!(
             saw_spike_windows,
@@ -1835,7 +1846,15 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        let result = run_schedule_loop(&schedule, 10.0, None, None, &mut sink, &mut tick_fn).await;
+        let result = run_schedule_loop(
+            &schedule,
+            10.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
+        )
+        .await;
 
         assert!(
             matches!(result, Err(SondaError::Encoder(_))),
@@ -1856,7 +1875,15 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        let result = run_schedule_loop(&schedule, 10.0, None, None, &mut sink, &mut tick_fn).await;
+        let result = run_schedule_loop(
+            &schedule,
+            10.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
+        )
+        .await;
 
         assert!(
             matches!(result, Err(SondaError::Sink(_))),
@@ -1884,7 +1911,7 @@ mod tests {
         let result = run_schedule_loop(
             &schedule,
             10.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -1933,7 +1960,15 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        let result = run_schedule_loop(&schedule, 50.0, None, None, &mut sink, &mut tick_fn).await;
+        let result = run_schedule_loop(
+            &schedule,
+            50.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
+        )
+        .await;
 
         assert!(
             result.is_ok(),
@@ -1960,7 +1995,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -2010,7 +2045,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -2048,7 +2083,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -2094,7 +2129,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -2178,7 +2213,12 @@ mod tests {
             .build()
             .unwrap();
         let result = rt.block_on(run_schedule_loop(
-            &schedule, 30.0, None, None, &mut sink, &mut tick_fn,
+            &schedule,
+            30.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
         ));
 
         match expected {
@@ -2267,7 +2307,7 @@ mod tests {
         run_schedule_loop_with_initial_tick(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             None,
             30,
             None,
@@ -2304,7 +2344,7 @@ mod tests {
         run_schedule_loop_with_initial_tick(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             None,
             10,
             Some(&last_tick),
@@ -2336,11 +2376,10 @@ mod tests {
     #[tokio::test]
     async fn events_buf_capacity_does_not_grow_under_metrics_workload() {
         use crate::model::metric::{Labels, MetricEvent};
-        use std::cell::Cell;
 
         let schedule = minimal_schedule(Some(Duration::from_millis(500)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-        let first_ptr: Cell<Option<usize>> = Cell::new(None);
+        let mut first_ptr: Option<usize> = None;
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
                            _output: &mut TickOutput,
@@ -2348,23 +2387,12 @@ mod tests {
          -> Result<TickResult, SondaError> {
             let event =
                 MetricEvent::new("test".to_string(), 1.0, Labels::default()).expect("valid name");
-            assert_eq!(
-                events_buf.len(),
-                0,
-                "events_buf must be cleared by the loop before each tick"
-            );
-            assert_eq!(
-                events_buf.capacity(),
-                16,
-                "events_buf capacity must stay at the pre-allocated 16 for a 1-event-per-tick workload"
-            );
+            assert_eq!(events_buf.len(), 0);
+            assert_eq!(events_buf.capacity(), 16);
             let ptr = events_buf.as_ptr() as usize;
-            match first_ptr.get() {
-                None => first_ptr.set(Some(ptr)),
-                Some(p) => assert_eq!(
-                    ptr, p,
-                    "events_buf backing allocation must be reused across ticks"
-                ),
+            match first_ptr {
+                None => first_ptr = Some(ptr),
+                Some(p) => assert_eq!(ptr, p, "events_buf backing allocation must be reused"),
             }
             events_buf.push(event);
             Ok(TickResult {
@@ -2377,7 +2405,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -2390,10 +2418,7 @@ mod tests {
             st.total_events > 1,
             "loop must have executed multiple ticks to exercise the buffer reuse"
         );
-        assert!(
-            first_ptr.get().is_some(),
-            "tick_fn must have observed at least one events_buf pointer"
-        );
+        assert!(first_ptr.is_some());
     }
 
     #[test]

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -144,8 +144,19 @@ impl GateReceiver {
         if let Some(edge) = self.try_recv() {
             return Some(edge);
         }
-        let _ = tokio::time::timeout(timeout, self.wait_for_change()).await;
-        self.try_recv()
+        let deadline = tokio::time::Instant::now() + timeout;
+        let poll_interval = std::time::Duration::from_millis(2);
+        loop {
+            if let Some(edge) = self.try_recv() {
+                return Some(edge);
+            }
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return None;
+            }
+            let sleep = (deadline - now).min(poll_interval);
+            tokio::time::sleep(sleep).await;
+        }
     }
 
     async fn wait_for_change(&mut self) {
@@ -494,6 +505,12 @@ impl PendingRef {
 pub enum RegistryError {
     #[error("scenario_name '{name}' is already in use by a running scenario")]
     DuplicateScenarioName { name: String },
+    /// The upstream scenario this resolution was waiting on was cancelled before it could register.
+    #[error("upstream '{scenario_name}/{entry_id}' was cancelled before resolving")]
+    UpstreamCancelled {
+        scenario_name: String,
+        entry_id: String,
+    },
 }
 
 /// Process-wide registry for cross-POST gate bus lookup.
@@ -532,6 +549,17 @@ pub trait GateBusResolver: Send + Sync {
     /// re-pend it for cross-POST re-resolution. Default impl is a no-op for
     /// resolvers that do not implement re-resolution tracking.
     fn track_subscriber(&self, _pending: PendingResolution) {}
+
+    /// Signal that an upstream scenario will not register; resolve any pending
+    /// waiters with [`RegistryError::UpstreamCancelled`] and notify them via
+    /// [`GateEdge::UpstreamGone`]. Default impl is a no-op.
+    fn cancel_pending_for_upstream(
+        &self,
+        _scenario_name: &str,
+        _entry_id: &str,
+    ) -> Vec<RegistryError> {
+        Vec::new()
+    }
 }
 
 #[cfg(test)]

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -3,65 +3,44 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
-use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
+
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::config::PromMeta;
 use crate::schedule::stats::ScenarioStats;
-use crate::{RuntimeError, SondaError};
+use crate::SondaError;
 
-/// Returned by [`ScenarioHandle::join_timeout`] when the thread did not finish
+/// Returned by [`ScenarioHandle::join_timeout`] when the task did not finish
 /// within the requested deadline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct JoinTimeout;
 
 impl std::fmt::Display for JoinTimeout {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("scenario thread did not exit within join_timeout")
+        f.write_str("scenario task did not exit within join_timeout")
     }
 }
 
 impl std::error::Error for JoinTimeout {}
 
 /// A running scenario's lifecycle handle.
-///
-/// Returned by [`crate::schedule::launch::launch_scenario`]. Provides shutdown,
-/// join, and stats access. Used identically by the CLI, multi_runner, and
-/// sonda-server.
-///
-/// The handle is `Send`: the `JoinHandle` is behind an `Option` and the other
-/// fields are all `Send`, so the handle can be stored in server state and
-/// moved across await points.
 #[non_exhaustive]
 pub struct ScenarioHandle {
-    /// Unique identifier for this scenario instance.
     pub id: String,
-    /// Human-readable scenario name (from config).
     pub name: String,
-    /// File-level `scenario_name` from the source YAML, when set. Read-only
-    /// after launch; every handle from the same POST shares this value.
     pub scenario_name: Option<String>,
-    /// Per-handle shutdown flag. `stop()` on one handle never affects another.
-    pub shutdown: Arc<AtomicBool>,
-    /// The OS thread running the scenario. `None` after [`ScenarioHandle::join`] consumes it.
-    pub thread: Option<JoinHandle<Result<(), SondaError>>>,
-    /// Wall-clock time when the scenario was launched.
+    /// Per-handle cancellation token. `stop()` on one handle never affects another.
+    pub cancel: CancellationToken,
+    /// The tokio task running the scenario. `None` after [`ScenarioHandle::join`] consumes it.
+    pub task: Option<JoinHandle<Result<(), SondaError>>>,
     pub started_at: Instant,
-    /// Live statistics updated by the runner thread on each tick.
     pub stats: Arc<RwLock<ScenarioStats>>,
-    /// The configured target rate (events per second) from the scenario config.
     pub target_rate: f64,
-    /// Lock-free liveness flag flipped to `false` when the runner thread exits.
-    ///
-    /// Set inside the spawned thread via a Drop guard so it is also cleared on
-    /// panic. External observers (e.g. the CLI progress display) read this
-    /// without acquiring `JoinHandle::is_finished()`.
+    /// Lock-free liveness flag flipped to `false` when the runner exits.
     pub alive: Arc<AtomicBool>,
-    /// Scenario-level labels.
     pub labels: Arc<HashMap<String, String>>,
-    /// Prometheus `# TYPE` / `# HELP` metadata derived at launch.
-    ///
-    /// `Some` for metrics, histogram, and summary scenarios; `None` for logs.
     pub prometheus_meta: Option<Arc<PromMeta>>,
     pub cleaned_up: Arc<AtomicBool>,
 }
@@ -73,8 +52,8 @@ impl ScenarioHandle {
         id: String,
         name: String,
         scenario_name: Option<String>,
-        shutdown: Arc<AtomicBool>,
-        thread: Option<JoinHandle<Result<(), SondaError>>>,
+        cancel: CancellationToken,
+        task: Option<JoinHandle<Result<(), SondaError>>>,
         started_at: Instant,
         stats: Arc<RwLock<ScenarioStats>>,
         target_rate: f64,
@@ -87,8 +66,8 @@ impl ScenarioHandle {
             id,
             name,
             scenario_name,
-            shutdown,
-            thread,
+            cancel,
+            task,
             started_at,
             stats,
             target_rate,
@@ -101,107 +80,134 @@ impl ScenarioHandle {
 
     /// Signal this scenario to stop. Affects only this scenario.
     pub fn stop(&self) {
-        self.shutdown.store(false, Ordering::SeqCst);
+        self.cancel.cancel();
     }
 
-    /// Check whether the scenario thread is still running.
-    ///
-    /// Returns `true` if the thread is still alive, `false` if it has exited
-    /// or if the handle has already been joined.
+    /// Check whether the scenario task is still running.
     pub fn is_running(&self) -> bool {
-        self.thread
+        self.task
             .as_ref()
             .map(|t| !t.is_finished())
             .unwrap_or(false)
     }
 
-    /// Lock-free check that the runner thread has not yet exited.
-    ///
-    /// Cheaper than [`Self::is_running`] in tight polling loops because it
-    /// reads an `AtomicBool` instead of probing the thread handle.
+    /// Lock-free check that the runner has not yet exited.
     pub fn is_alive(&self) -> bool {
         self.alive.load(Ordering::SeqCst)
     }
 
-    /// Join the scenario thread, consuming it.
-    ///
-    /// Blocks until the thread exits or the optional timeout expires. If a
-    /// timeout is provided and the thread does not exit within that time, this
-    /// method returns `Ok(())` without consuming the thread (the thread
-    /// continues running and the handle still owns it).
-    ///
-    /// **Orphaned thread trade-off:** When the join times out, the OS thread
-    /// continues running in the background with no way for the caller to
-    /// observe or control it further (the shutdown flag has already been set).
-    /// If the handle is subsequently dropped (e.g., removed from the server's
-    /// scenario map), the `JoinHandle` is dropped without joining, and the
-    /// thread becomes fully detached. This is an acceptable trade-off: the
-    /// thread will eventually exit on its own (it checks the shutdown flag
-    /// each tick), and blocking the HTTP handler indefinitely would be worse.
-    ///
-    /// Returns the thread's result on success, or a [`SondaError`] if the
-    /// thread panicked or returned an error.
-    pub fn join(&mut self, timeout: Option<Duration>) -> Result<(), SondaError> {
-        if self.thread.is_none() {
-            // Already joined.
+    /// Await the scenario task to completion within the optional timeout.
+    /// On timeout the handle still owns the task and the caller can retry.
+    pub async fn join_async(&mut self, timeout: Option<Duration>) -> Result<(), SondaError> {
+        if self.task.is_none() {
             return Ok(());
         }
 
-        // When a timeout is requested we poll with a short sleep, since
-        // `JoinHandle` does not expose a timed-join API on stable Rust.
-        if let Some(limit) = timeout {
-            let deadline = Instant::now() + limit;
-            while Instant::now() < deadline {
-                if self
-                    .thread
-                    .as_ref()
-                    .map(|t| t.is_finished())
-                    .unwrap_or(true)
-                {
+        if let Some(t) = timeout {
+            let deadline = Instant::now() + t;
+            loop {
+                if self.task.as_ref().map(|t| t.is_finished()).unwrap_or(true) {
                     break;
                 }
-                std::thread::sleep(Duration::from_millis(10));
-            }
-
-            // If still not finished, return without consuming the handle.
-            if !self
-                .thread
-                .as_ref()
-                .map(|t| t.is_finished())
-                .unwrap_or(true)
-            {
-                return Ok(());
+                let now = Instant::now();
+                if now >= deadline {
+                    return Ok(());
+                }
+                let remaining = deadline.saturating_duration_since(now);
+                tokio::time::sleep(remaining.min(Duration::from_millis(10))).await;
             }
         }
 
-        // Consume the JoinHandle.
-        let handle = self.thread.take().expect("checked above: thread is Some");
-        match handle.join() {
+        let task = self.task.take().expect("task present at this point");
+        match task.await {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => Err(e),
-            Err(_) => Err(SondaError::Runtime(RuntimeError::ThreadPanicked)),
+            Err(join_err) => {
+                if join_err.is_cancelled() {
+                    Ok(())
+                } else {
+                    Err(SondaError::Runtime(crate::RuntimeError::ThreadPanicked))
+                }
+            }
         }
     }
 
-    /// Best-effort timed join: poll the underlying thread until it finishes
-    /// or `timeout` elapses. On timeout the thread is left detached and
-    /// `Err(JoinTimeout)` is returned. On success the inner `JoinHandle`
-    /// is consumed.
+    /// Synchronously join the scenario task and return its result.
+    ///
+    /// Returns `Err(RuntimeError::TaskAborted)` if called from an ambient
+    /// current_thread runtime — blocking there would deadlock; use [`join_async`](Self::join_async).
+    pub fn join(&mut self, timeout: Option<Duration>) -> Result<(), SondaError> {
+        if self.task.is_none() {
+            return Ok(());
+        }
+
+        let deadline = timeout.map(|t| Instant::now() + t);
+        loop {
+            if self.task.as_ref().map(|t| t.is_finished()).unwrap_or(true) {
+                break;
+            }
+            match deadline {
+                Some(d) => {
+                    let now = Instant::now();
+                    if now >= d {
+                        return Ok(());
+                    }
+                    let remaining = d.saturating_duration_since(now);
+                    std::thread::sleep(remaining.min(Duration::from_millis(10)));
+                }
+                None => std::thread::sleep(Duration::from_millis(10)),
+            }
+        }
+
+        let task = self.task.take().expect("checked above: task is Some");
+        let result = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                if matches!(
+                    handle.runtime_flavor(),
+                    tokio::runtime::RuntimeFlavor::MultiThread
+                ) {
+                    tokio::task::block_in_place(|| handle.block_on(task))
+                } else {
+                    task.abort();
+                    return Err(SondaError::Runtime(crate::RuntimeError::TaskAborted {
+                        reason: "join() called from a current_thread tokio runtime; \
+                                 use join_async() instead",
+                    }));
+                }
+            }
+            Err(_) => {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
+                rt.block_on(task)
+            }
+        };
+        match result {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(e),
+            Err(join_err) => {
+                if join_err.is_cancelled() {
+                    Ok(())
+                } else {
+                    Err(SondaError::Runtime(crate::RuntimeError::ThreadPanicked))
+                }
+            }
+        }
+    }
+
+    /// Best-effort timed join: poll the underlying task until it finishes
+    /// or `timeout` elapses.
     pub fn join_timeout(&mut self, timeout: Duration) -> Result<(), JoinTimeout> {
-        if self.thread.is_none() {
+        if self.task.is_none() {
             return Ok(());
         }
         let deadline = Instant::now() + timeout;
         let poll_interval = Duration::from_millis(10);
         loop {
-            if self
-                .thread
-                .as_ref()
-                .map(|t| t.is_finished())
-                .unwrap_or(true)
-            {
-                if let Some(handle) = self.thread.take() {
-                    let _ = handle.join();
+            if self.task.as_ref().map(|t| t.is_finished()).unwrap_or(true) {
+                if let Some(task) = self.task.take() {
+                    task.abort();
                 }
                 return Ok(());
             }
@@ -214,22 +220,11 @@ impl ScenarioHandle {
     }
 
     /// Elapsed time since the scenario started.
-    ///
-    /// This is a real-time measurement based on the wall clock recorded at
-    /// launch. It continues to grow even after the scenario stops.
     pub fn elapsed(&self) -> Duration {
         self.started_at.elapsed()
     }
 
     /// Read the latest stats snapshot.
-    ///
-    /// Acquires the read lock briefly, clones the stats, and returns. Does not
-    /// block writers for longer than the clone operation.
-    ///
-    /// If the stats lock is poisoned (because a writer panicked), this method
-    /// recovers the data from the poisoned guard rather than propagating the
-    /// panic. The returned stats may be partially updated but will not cause
-    /// the caller to panic.
     pub fn stats_snapshot(&self) -> ScenarioStats {
         match self.stats.read() {
             Ok(guard) => guard.clone(),
@@ -266,53 +261,45 @@ impl Drop for ScenarioHandle {
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, RwLock};
-    use std::thread;
     use std::time::{Duration, Instant};
 
     use super::*;
     use crate::schedule::stats::ScenarioStats;
     use crate::SondaError;
 
-    // ---- Helper: build a ScenarioHandle backed by a trivial thread ----------
-
-    /// Build a `ScenarioHandle` whose thread counts to a limit, then exits.
-    ///
-    /// The thread increments `total_events` on the shared stats arc each
-    /// iteration so tests can observe live stat updates without involving
-    /// the full runner pipeline.
     fn make_handle(id: &str, name: &str, events: u64, interval: Duration) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-        let shutdown_thread = Arc::clone(&shutdown);
-        let stats_thread = Arc::clone(&stats);
+        let cancel_for_task = cancel.clone();
+        let stats_task = Arc::clone(&stats);
+        let alive = Arc::new(AtomicBool::new(true));
+        let alive_for_task = Arc::clone(&alive);
 
-        let thread = thread::Builder::new()
-            .name(format!("test-{name}"))
-            .spawn(move || -> Result<(), SondaError> {
-                for _ in 0..events {
-                    if !shutdown_thread.load(Ordering::SeqCst) {
-                        break;
-                    }
-                    thread::sleep(interval);
-                    if let Ok(mut st) = stats_thread.write() {
-                        st.total_events += 1;
-                        st.bytes_emitted += 64;
-                    }
+        let task = tokio::task::spawn(async move {
+            for _ in 0..events {
+                if cancel_for_task.is_cancelled() {
+                    break;
                 }
-                Ok(())
-            })
-            .expect("thread must spawn");
+                tokio::time::sleep(interval).await;
+                if let Ok(mut st) = stats_task.write() {
+                    st.total_events += 1;
+                    st.bytes_emitted += 64;
+                }
+            }
+            alive_for_task.store(false, Ordering::SeqCst);
+            Ok::<_, SondaError>(())
+        });
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             100.0,
-            Arc::new(AtomicBool::new(true)),
+            alive,
             Arc::new(HashMap::new()),
             Some(Arc::new(PromMeta::new(
                 crate::config::PromMetricType::Gauge,
@@ -322,146 +309,86 @@ mod tests {
         )
     }
 
-    // ---- is_running: true before stop, false after join ---------------------
-
-    /// A freshly spawned handle must report is_running() == true.
-    #[test]
-    fn is_running_returns_true_for_live_thread() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn is_running_returns_true_for_live_task() {
         let mut handle = make_handle("test-1", "live", 50, Duration::from_millis(10));
-        assert!(
-            handle.is_running(),
-            "is_running must return true for a live thread"
-        );
-        // Clean up.
+        assert!(handle.is_running());
         handle.stop();
         handle.join(Some(Duration::from_secs(2))).unwrap();
     }
 
-    /// After stop() + join(), is_running() must return false.
-    #[test]
-    fn is_running_returns_false_after_stop_and_join() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn is_running_returns_false_after_stop_and_join() {
         let mut handle = make_handle("test-2", "stopped", 1000, Duration::from_millis(5));
         handle.stop();
         handle
             .join(Some(Duration::from_secs(2)))
             .expect("join must succeed");
-        assert!(
-            !handle.is_running(),
-            "is_running must return false after the thread has been joined"
-        );
+        assert!(!handle.is_running());
     }
 
-    /// A handle whose JoinHandle has been consumed (None) returns false.
-    #[test]
-    fn is_running_returns_false_when_thread_is_none() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn is_running_returns_false_when_task_is_none() {
         let mut handle = make_handle("test-3", "none", 1, Duration::from_millis(1));
-        // Allow thread to finish naturally.
-        thread::sleep(Duration::from_millis(50));
-        // Consume the JoinHandle directly to mimic a post-join state.
-        handle.thread = None;
-        assert!(
-            !handle.is_running(),
-            "is_running must return false when thread is None"
-        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        handle.task = None;
+        assert!(!handle.is_running());
     }
 
-    // ---- stop(): sets the shutdown flag to false ----------------------------
-
-    /// stop() must store false in the shared AtomicBool.
-    #[test]
-    fn stop_sets_shutdown_flag_to_false() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stop_cancels_token() {
         let handle = make_handle("test-4", "stop_flag", 1000, Duration::from_millis(10));
-        assert!(
-            handle.shutdown.load(Ordering::SeqCst),
-            "shutdown flag must be true before stop"
-        );
+        assert!(!handle.cancel.is_cancelled());
         handle.stop();
-        assert!(
-            !handle.shutdown.load(Ordering::SeqCst),
-            "shutdown flag must be false after stop"
-        );
-        // Clean up the thread without consuming the handle.
+        assert!(handle.cancel.is_cancelled());
         drop(handle);
     }
 
-    // ---- join(): blocks until thread exits and returns Ok -------------------
-
-    /// join() with None timeout blocks until the thread finishes and returns Ok.
-    #[test]
-    fn join_none_timeout_waits_for_thread_and_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_none_timeout_waits_for_task_and_returns_ok() {
         let mut handle = make_handle("test-5", "join_none", 3, Duration::from_millis(10));
         let result = handle.join(None);
-        assert!(
-            result.is_ok(),
-            "join must return Ok when the thread succeeds: {result:?}"
-        );
+        assert!(result.is_ok(), "{result:?}");
     }
 
-    /// join() is idempotent: calling it a second time returns Ok immediately.
-    #[test]
-    fn join_is_idempotent_after_first_call() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_is_idempotent_after_first_call() {
         let mut handle = make_handle("test-6", "idempotent", 1, Duration::from_millis(1));
         handle.join(None).expect("first join must succeed");
         let result = handle.join(None);
-        assert!(
-            result.is_ok(),
-            "second join on an already-joined handle must return Ok: {result:?}"
-        );
+        assert!(result.is_ok(), "{result:?}");
     }
 
-    /// join() with a timeout that expires while thread is still running returns
-    /// Ok without consuming the thread (handle still owns it).
-    #[test]
-    fn join_with_short_timeout_returns_ok_without_consuming_thread() {
-        // Thread runs for 10 events × 50ms each = 500ms total.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_with_short_timeout_returns_ok_without_consuming_task() {
         let mut handle = make_handle("test-7", "timeout", 10, Duration::from_millis(50));
-        // Join with a very short timeout — thread will still be running.
         let result = handle.join(Some(Duration::from_millis(10)));
-        assert!(
-            result.is_ok(),
-            "join with expired timeout must still return Ok"
-        );
-        // The JoinHandle must NOT have been consumed — is_running may still be true.
-        assert!(
-            handle.thread.is_some(),
-            "thread must not be consumed when timeout expired before thread finished"
-        );
-        // Clean up.
+        assert!(result.is_ok());
+        assert!(handle.task.is_some());
         handle.stop();
         handle.join(None).ok();
     }
 
-    // ---- elapsed(): grows over time -----------------------------------------
-
-    /// elapsed() must return a positive Duration immediately after creation.
-    #[test]
-    fn elapsed_returns_positive_duration() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn elapsed_returns_positive_duration() {
         let handle = make_handle("test-8", "elapsed", 1, Duration::from_millis(1));
         let d = handle.elapsed();
-        // Even with scheduler jitter this should be at least 0 ns.
-        assert!(d >= Duration::ZERO, "elapsed must be non-negative: {d:?}");
+        assert!(d >= Duration::ZERO);
     }
 
-    /// elapsed() measured after a sleep must be greater than that sleep duration.
-    #[test]
-    fn elapsed_grows_monotonically_after_sleep() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn elapsed_grows_monotonically_after_sleep() {
         let mut handle = make_handle("test-9", "monotonic", 100, Duration::from_millis(5));
         let before = handle.elapsed();
-        thread::sleep(Duration::from_millis(100));
+        tokio::time::sleep(Duration::from_millis(100)).await;
         let after = handle.elapsed();
-        assert!(
-            after > before,
-            "elapsed must grow over time: before={before:?}, after={after:?}"
-        );
+        assert!(after > before);
         handle.stop();
         handle.join(None).ok();
     }
 
-    // ---- stats_snapshot(): returns the current stats atomically -------------
-
-    /// stats_snapshot() on a fresh handle returns all-zero stats.
-    #[test]
-    fn stats_snapshot_on_fresh_handle_returns_zeros() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_on_fresh_handle_returns_zeros() {
         let handle = make_handle("test-10", "fresh_stats", 0, Duration::ZERO);
         let snap = handle.stats_snapshot();
         assert_eq!(snap.total_events, 0);
@@ -469,24 +396,13 @@ mod tests {
         assert_eq!(snap.errors, 0);
     }
 
-    /// After the worker thread emits events, stats_snapshot() reflects the updates.
-    #[test]
-    fn stats_snapshot_returns_nonzero_total_events_after_running() {
-        // 5 events × 10ms each = ~50ms of work.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_returns_nonzero_total_events_after_running() {
         let mut handle = make_handle("test-11", "nonzero_stats", 5, Duration::from_millis(10));
-        // Wait long enough for all 5 events to fire.
-        thread::sleep(Duration::from_millis(200));
+        tokio::time::sleep(Duration::from_millis(200)).await;
         let snap = handle.stats_snapshot();
-        assert!(
-            snap.total_events > 0,
-            "stats_snapshot must reflect emitted events, got total_events={}",
-            snap.total_events
-        );
-        assert!(
-            snap.bytes_emitted > 0,
-            "stats_snapshot must reflect bytes_emitted > 0, got {}",
-            snap.bytes_emitted
-        );
+        assert!(snap.total_events > 0);
+        assert!(snap.bytes_emitted > 0);
         handle.join(None).ok();
     }
 
@@ -499,14 +415,14 @@ mod tests {
         .expect("test metric name must be valid")
     }
 
-    #[test]
-    fn recent_metrics_snapshot_on_fresh_handle_returns_empty() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recent_metrics_snapshot_on_fresh_handle_returns_empty() {
         let handle = make_handle("test-rm-1", "fresh", 0, Duration::ZERO);
         assert!(handle.recent_metrics_snapshot().is_empty());
     }
 
-    #[test]
-    fn recent_metrics_snapshot_returns_current_values_not_history() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recent_metrics_snapshot_returns_current_values_not_history() {
         let handle = make_handle("test-rm-2", "current", 0, Duration::ZERO);
         {
             let mut stats = handle.stats.write().expect("lock must not be poisoned");
@@ -515,12 +431,12 @@ mod tests {
             stats.push_metric(make_metric_event("up", 3.0));
         }
         let events = handle.recent_metrics_snapshot();
-        assert_eq!(events.len(), 1, "same series must collapse to one entry");
-        assert_eq!(events[0].value, 3.0, "latest value must win");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].value, 3.0);
     }
 
-    #[test]
-    fn recent_metrics_snapshot_is_idempotent() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recent_metrics_snapshot_is_idempotent() {
         let handle = make_handle("test-rm-3", "idempotent", 0, Duration::ZERO);
         {
             let mut stats = handle.stats.write().expect("lock must not be poisoned");
@@ -533,43 +449,32 @@ mod tests {
         assert_eq!(first[0].value, second[0].value);
     }
 
-    // ---- stats_snapshot: recovers from poisoned lock -------------------------
-
-    /// If the stats lock is poisoned, stats_snapshot recovers the data instead
-    /// of panicking.
-    #[test]
-    fn stats_snapshot_recovers_from_poisoned_lock() {
-        let shutdown = Arc::new(AtomicBool::new(false));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_recovers_from_poisoned_lock() {
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        // Set a known value before poisoning.
         {
             let mut guard = stats.write().expect("lock must not be poisoned");
             guard.total_events = 42;
         }
 
-        // Poison the lock by panicking inside a write guard.
         let stats_clone = Arc::clone(&stats);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _guard = stats_clone.write().expect("lock must not be poisoned");
             panic!("intentional panic to poison lock");
         }));
-        assert!(result.is_err(), "panic must have occurred");
+        assert!(result.is_err());
+        assert!(stats.read().is_err());
 
-        // Verify the lock is actually poisoned.
-        assert!(stats.read().is_err(), "lock must be poisoned after panic");
-
-        let thread = thread::Builder::new()
-            .name("test-poisoned-stats".to_string())
-            .spawn(|| -> Result<(), SondaError> { Ok(()) })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async { Ok::<_, SondaError>(()) });
 
         let handle = ScenarioHandle::new(
             "test-poisoned".to_string(),
             "poisoned".to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -582,17 +487,13 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
         );
 
-        // stats_snapshot must not panic — it recovers from the poisoned lock.
         let snap = handle.stats_snapshot();
-        assert_eq!(
-            snap.total_events, 42,
-            "stats_snapshot must recover data from poisoned lock"
-        );
+        assert_eq!(snap.total_events, 42);
     }
 
-    #[test]
-    fn recent_metrics_snapshot_recovers_from_poisoned_lock() {
-        let shutdown = Arc::new(AtomicBool::new(false));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recent_metrics_snapshot_recovers_from_poisoned_lock() {
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         {
@@ -605,19 +506,16 @@ mod tests {
             let _guard = stats_clone.write().expect("lock must not be poisoned");
             panic!("intentional panic to poison lock");
         }));
-        assert!(result.is_err(), "panic must have occurred");
+        assert!(result.is_err());
 
-        let thread = thread::Builder::new()
-            .name("test-poisoned-metrics".to_string())
-            .spawn(|| -> Result<(), SondaError> { Ok(()) })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async { Ok::<_, SondaError>(()) });
 
         let handle = ScenarioHandle::new(
             "test-poisoned-m".to_string(),
             "poisoned_metrics".to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -635,53 +533,52 @@ mod tests {
         assert_eq!(events[0].value, 99.0);
     }
 
-    // ---- Contract: ScenarioHandle is Send -----------------------------------
-
-    /// ScenarioHandle must be Send so it can be stored in server state and
-    /// moved across tokio await points.
     #[test]
     fn scenario_handle_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<ScenarioHandle>();
     }
 
-    #[test]
-    fn join_timeout_returns_ok_when_handle_exits_within_window() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_timeout_returns_ok_when_handle_exits_within_window() {
         let mut handle = make_handle("jt-1", "fast", 1, Duration::from_millis(5));
-        thread::sleep(Duration::from_millis(50));
+        tokio::time::sleep(Duration::from_millis(50)).await;
         let result = handle.join_timeout(Duration::from_millis(500));
-        assert!(
-            result.is_ok(),
-            "join_timeout must return Ok when thread already exited: {result:?}"
-        );
-        assert!(handle.thread.is_none(), "JoinHandle must be consumed on Ok");
+        assert!(result.is_ok(), "{result:?}");
+        assert!(handle.task.is_none());
     }
 
-    #[test]
-    fn join_timeout_returns_err_when_thread_still_running() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_timeout_returns_err_when_task_still_running() {
         let mut handle = make_handle("jt-2", "slow", 100, Duration::from_millis(50));
         let result = handle.join_timeout(Duration::from_millis(20));
-        assert!(
-            result.is_err(),
-            "join_timeout must return Err when timeout expires before exit"
-        );
-        assert!(
-            handle.thread.is_some(),
-            "JoinHandle must be retained on timeout"
-        );
-        // Clean up.
+        assert!(result.is_err());
+        assert!(handle.task.is_some());
         handle.stop();
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn join_timeout_is_idempotent_when_thread_already_consumed() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_timeout_is_idempotent_when_task_already_consumed() {
         let mut handle = make_handle("jt-3", "consumed", 1, Duration::from_millis(1));
         handle.join(None).expect("first join must succeed");
         let result = handle.join_timeout(Duration::from_millis(50));
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn join_from_current_thread_runtime_returns_task_aborted_err() {
+        let mut handle = make_handle("jt-ct", "current_thread", 1, Duration::from_millis(1));
+        // Let the task finish before the sync join polls it — `std::thread::sleep`
+        // inside join would otherwise starve the only current_thread worker.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let result = handle.join(None);
         assert!(
-            result.is_ok(),
-            "join_timeout on consumed handle must return Ok"
+            matches!(
+                result,
+                Err(SondaError::Runtime(crate::RuntimeError::TaskAborted { .. }))
+            ),
+            "join from current_thread runtime must return TaskAborted, got: {result:?}"
         );
     }
 }

--- a/sonda-core/src/schedule/histogram_runner.rs
+++ b/sonda-core/src/schedule/histogram_runner.rs
@@ -1,22 +1,8 @@
 //! The histogram scenario event loop.
-//!
-//! The histogram runner ties together the [`HistogramGenerator`], encoder, and
-//! sink with the shared schedule loop from
-//! [`core_loop::run_schedule_loop`](super::core_loop::run_schedule_loop).
-//!
-//! Each tick, the runner:
-//! 1. Advances the histogram generator to get a [`HistogramSample`].
-//! 2. For each bucket boundary, creates a `MetricEvent` with name
-//!    `{base}_bucket` and an `le="{bound}"` label.
-//! 3. Creates a `+Inf` bucket event (`le="+Inf"`, value = total count).
-//! 4. Creates `{base}_count` and `{base}_sum` events.
-//! 5. Encodes all events and writes them to the sink.
-//!
-//! The core loop is unchanged — all histogram-specific logic lives in the
-//! per-tick closure.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
+
+use tokio_util::sync::CancellationToken;
 
 use crate::config::HistogramScenarioConfig;
 use crate::encoder::create_encoder;
@@ -31,70 +17,26 @@ use crate::schedule::ParsedSchedule;
 use crate::sink::{create_sink, Sink};
 use crate::SondaError;
 
-/// Run a histogram scenario to completion, emitting encoded histogram events
-/// at the configured rate.
-///
-/// This is the primary entry point. It constructs a sink from the config and
-/// delegates to [`run_with_sink`] with no shutdown flag and no stats collection.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
+/// Run a histogram scenario to completion at the configured rate.
 pub async fn run(config: &HistogramScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, None).await?;
-    run_with_sink(config, &mut sink, None, None).await
+    let cancel = CancellationToken::new();
+    run_with_sink(config, &mut sink, &cancel, None).await
 }
 
-/// Run a histogram scenario to completion, writing encoded events into the
-/// provided sink.
-///
-/// Builds the histogram generator, encoder, and label sets from the config,
-/// then delegates to the shared schedule loop. The per-tick closure generates
-/// multiple `MetricEvent`s per tick (one per bucket + `+Inf` + `_count` + `_sum`).
-///
-/// # Parameters
-///
-/// * `config` — the histogram scenario configuration.
-/// * `sink` — the destination for encoded metric events.
-/// * `shutdown` — optional atomic flag for clean shutdown.
-/// * `stats` — optional shared stats for live telemetry.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run_with_sink(
     config: &HistogramScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_with_sink_gated(config, sink, shutdown, stats, None).await
-}
-
-/// Run a histogram scenario with optional `while:` / `after:` gating.
-///
-/// Histograms cannot be `while:` upstreams (compile-time
-/// `NonMetricsTarget`), but they can be `while:`-gated downstreams.
-pub fn run_with_sink_gated_blocking(
-    config: &HistogramScenarioConfig,
-    shutdown: Option<&AtomicBool>,
-    stats: Option<Arc<RwLock<ScenarioStats>>>,
-    gate_ctx: Option<GateContext>,
-) -> Result<(), SondaError> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
-    rt.block_on(async {
-        let mut sink = create_sink(&config.sink, None).await?;
-        run_with_sink_gated(config, &mut sink, shutdown, stats, gate_ctx).await
-    })
+    run_with_sink_gated(config, sink, cancel, stats, None).await
 }
 
 pub async fn run_with_sink_gated(
     config: &HistogramScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
 ) -> Result<(), SondaError> {
@@ -294,21 +236,14 @@ pub async fn run_with_sink_gated(
 
     match gate_ctx {
         None => {
-            core_loop::run_schedule_loop(
-                &schedule,
-                config.rate,
-                shutdown,
-                stats,
-                sink,
-                &mut tick_fn,
-            )
-            .await
+            core_loop::run_schedule_loop(&schedule, config.rate, cancel, stats, sink, &mut tick_fn)
+                .await
         }
         Some(ctx) => {
             core_loop::gated_loop(
                 &schedule,
                 config.rate,
-                shutdown,
+                cancel,
                 stats,
                 ctx,
                 sink,
@@ -337,6 +272,7 @@ mod tests {
     use std::sync::Mutex;
 
     use async_trait::async_trait;
+    use tokio_util::sync::CancellationToken;
 
     use crate::config::{BaseScheduleConfig, DistributionConfig, HistogramScenarioConfig};
     use crate::encoder::EncoderConfig;
@@ -409,7 +345,7 @@ mod tests {
     async fn run_completes_for_short_duration() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("histogram run must succeed");
         assert!(
@@ -424,7 +360,7 @@ mod tests {
     async fn output_contains_bucket_count_sum_series() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -451,7 +387,7 @@ mod tests {
     async fn bucket_events_have_le_label() {
         let config = make_config(50.0, "100ms", Some(vec![0.1, 0.5, 1.0]));
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -480,7 +416,7 @@ mod tests {
         });
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -498,7 +434,7 @@ mod tests {
     async fn custom_buckets_appear_in_output() {
         let config = make_config(50.0, "100ms", Some(vec![1.0, 5.0, 10.0]));
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -537,7 +473,7 @@ mod tests {
         config.base.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -1,12 +1,10 @@
 //! Unified scenario launch API.
-//!
-//! This module is the single authoritative location for the "validate →
-//! create sink → spawn runner → manage lifecycle" pattern. Both the CLI and
-//! sonda-server call [`launch_scenario`]; neither duplicates this logic.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
+
+use tokio_util::sync::CancellationToken;
 
 use crate::compiler::{DelayClause, WhileClause};
 use crate::config::aliases::desugar_entry;
@@ -18,12 +16,13 @@ use crate::generator::GeneratorConfig;
 use crate::schedule::core_loop::GateContext;
 use crate::schedule::gate_bus::{GateBus, GateBusResolver};
 use crate::schedule::handle::ScenarioHandle;
-use crate::schedule::histogram_runner::run_with_sink_gated_blocking as run_histogram_with_sink_gated_blocking;
-use crate::schedule::log_runner::run_logs_with_sink_gated_blocking;
-use crate::schedule::runner::run_with_sink_gated_blocking;
+use crate::schedule::histogram_runner::run_with_sink_gated as run_histogram_with_sink_gated;
+use crate::schedule::log_runner::run_logs_with_sink_gated;
+use crate::schedule::runner::run_with_sink_gated;
 use crate::schedule::stats::{ScenarioState, ScenarioStats};
-use crate::schedule::summary_runner::run_with_sink_gated_blocking as run_summary_with_sink_gated_blocking;
-use crate::{ConfigError, RuntimeError, SondaError};
+use crate::schedule::summary_runner::run_with_sink_gated as run_summary_with_sink_gated;
+use crate::sink::create_sink;
+use crate::{ConfigError, SondaError};
 
 /// Extract the inner message from a [`SondaError`] for re-wrapping.
 ///
@@ -165,14 +164,14 @@ pub fn prepare_entries(entries: Vec<ScenarioEntry>) -> Result<Vec<PreparedEntry>
     Ok(prepared)
 }
 
-/// Launch a single scenario on a new OS thread.
+/// Launch a single scenario as a tokio task.
 pub async fn launch_scenario(
     id: String,
     entry: ScenarioEntry,
-    shutdown: Arc<AtomicBool>,
+    cancel: CancellationToken,
     start_delay: Option<Duration>,
 ) -> Result<ScenarioHandle, SondaError> {
-    launch_scenario_with_gates(id, None, entry, shutdown, start_delay, None, None, None).await
+    launch_scenario_with_gates(id, None, entry, cancel, start_delay, None, None, None).await
 }
 
 /// Launch a scenario with optional `while:` / `after:` gating wired in.
@@ -181,19 +180,18 @@ pub async fn launch_scenario_with_gates(
     id: String,
     scenario_name: Option<String>,
     entry: ScenarioEntry,
-    shutdown: Arc<AtomicBool>,
+    cancel: CancellationToken,
     start_delay: Option<Duration>,
     upstream_bus: Option<Arc<GateBus>>,
     gate_ctx: Option<GateContext>,
     resolver: Option<Arc<dyn GateBusResolver>>,
 ) -> Result<ScenarioHandle, SondaError> {
     let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-    let stats_for_thread = Arc::clone(&stats);
-    let shutdown_for_thread = Arc::clone(&shutdown);
+    let stats_for_task = Arc::clone(&stats);
     let alive = Arc::new(AtomicBool::new(true));
-    let alive_for_thread = Arc::clone(&alive);
+    let alive_for_task = Arc::clone(&alive);
+    let cancel_for_task = cancel.clone();
 
-    // Extract the name and target rate before moving `entry` into the thread closure.
     let (name, target_rate) = match &entry {
         ScenarioEntry::Metrics(c) => (c.name.clone(), c.rate),
         ScenarioEntry::Logs(c) => (c.name.clone(), c.rate),
@@ -205,114 +203,123 @@ pub async fn launch_scenario_with_gates(
 
     let started_at = Instant::now();
 
-    // Validate shutdown flag is currently set to `true` (running). The caller
-    // is responsible for ensuring this; we document the contract but do not
-    // enforce it here to avoid a redundant check on every launch.
-    //
-    // Ensure `running` ordering is visible from the new thread.
-    shutdown.store(true, Ordering::SeqCst);
-
     let stats_for_state = Arc::clone(&stats);
     let is_gated = gate_ctx.is_some();
     let cleaned_up = Arc::new(AtomicBool::new(false));
-    let cleaned_up_for_thread = Arc::clone(&cleaned_up);
-    let resolver_for_thread = resolver.clone();
-    let scenario_name_for_thread = scenario_name.clone();
+    let cleaned_up_for_task = Arc::clone(&cleaned_up);
+    let resolver_for_task = resolver.clone();
+    let scenario_name_for_task = scenario_name.clone();
 
     // Cross-POST scenarios broadcast via resolver.unregister; broadcasting
     // here too races the registry's subscriber migration.
-    let bus_for_finish_guard =
-        if scenario_name_for_thread.is_some() && resolver_for_thread.is_some() {
-            None
-        } else {
-            upstream_bus.as_ref().map(Arc::clone)
+    let bus_for_finish_guard = if scenario_name_for_task.is_some() && resolver_for_task.is_some() {
+        None
+    } else {
+        upstream_bus.as_ref().map(Arc::clone)
+    };
+
+    let task = tokio::task::spawn(async move {
+        // Drop guard clears the alive flag on every exit path, including
+        // panics — observers polling `is_alive()` see a single clean
+        // transition `true → false` regardless of how the task terminates.
+        let _alive_guard = AliveGuard {
+            flag: alive_for_task,
         };
 
-    let thread = std::thread::Builder::new()
-        .name(format!("sonda-{}", name))
-        .spawn(move || -> Result<(), SondaError> {
-            // Drop guard clears the alive flag on every exit path, including
-            // panics — observers polling `is_alive()` see a single clean
-            // transition `true → false` regardless of how the thread terminates.
-            let _guard = AliveGuard {
-                flag: alive_for_thread,
-            };
+        // Marks Finished on drop; unregisters when a resolver is wired.
+        let _state_guard = StateGuard {
+            stats: Arc::clone(&stats_for_state),
+            resolver: resolver_for_task,
+            scenario_name: scenario_name_for_task,
+            cleaned_up: cleaned_up_for_task,
+        };
 
-            // Marks Finished on drop; unregisters when a resolver is wired.
-            let _state_guard = StateGuard {
-                stats: Arc::clone(&stats_for_state),
-                resolver: resolver_for_thread,
-                scenario_name: scenario_name_for_thread,
-                cleaned_up: cleaned_up_for_thread,
-            };
+        // Drops before _state_guard so downstreams see UpstreamGone
+        // before the scenario flips to Finished.
+        let _bus_finish_guard = BusFinishGuard {
+            bus: bus_for_finish_guard,
+        };
 
-            // Drops before _state_guard so downstreams see UpstreamGone
-            // before the scenario flips to Finished.
-            let _bus_finish_guard = BusFinishGuard {
-                bus: bus_for_finish_guard,
-            };
-
-            // Sleep through the start_delay before entering the event loop.
-            // State stays `Pending` for the delay window so /stats reports
-            // `pending` until the first tick is actually due.
+        let cancel_for_outer = cancel_for_task.clone();
+        let runner = async move {
             if let Some(delay) = start_delay {
-                let deadline = std::time::Instant::now() + delay;
-                while std::time::Instant::now() < deadline {
-                    if !shutdown_for_thread.load(Ordering::SeqCst) {
-                        return Ok(());
+                tokio::select! {
+                    _ = cancel_for_task.cancelled() => {
+                        return Ok::<_, SondaError>(());
                     }
-                    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-                    let sleep_chunk = remaining.min(Duration::from_millis(50));
-                    if sleep_chunk > Duration::ZERO {
-                        std::thread::sleep(sleep_chunk);
-                    }
+                    _ = tokio::time::sleep(delay) => {}
                 }
             }
 
-            // gated_loop owns its own state transitions; non-gated runs
-            // need someone to mark Running once the start_delay has elapsed.
             if !is_gated {
                 if let Ok(mut st) = stats_for_state.write() {
                     st.transition_state(ScenarioState::Running);
                 }
             }
 
+            let sink_labels = entry.base().labels.clone();
+            let mut sink = create_sink(&entry.base().sink, sink_labels.as_ref()).await?;
+
             match entry {
-                ScenarioEntry::Metrics(config) => run_with_sink_gated_blocking(
-                    &config,
-                    Some(shutdown_for_thread.as_ref()),
-                    Some(Arc::clone(&stats_for_thread)),
-                    upstream_bus,
-                    gate_ctx,
-                ),
-                ScenarioEntry::Logs(config) => run_logs_with_sink_gated_blocking(
-                    &config,
-                    Some(shutdown_for_thread.as_ref()),
-                    Some(Arc::clone(&stats_for_thread)),
-                    gate_ctx,
-                ),
-                ScenarioEntry::Histogram(config) => run_histogram_with_sink_gated_blocking(
-                    &config,
-                    Some(shutdown_for_thread.as_ref()),
-                    Some(Arc::clone(&stats_for_thread)),
-                    gate_ctx,
-                ),
-                ScenarioEntry::Summary(config) => run_summary_with_sink_gated_blocking(
-                    &config,
-                    Some(shutdown_for_thread.as_ref()),
-                    Some(Arc::clone(&stats_for_thread)),
-                    gate_ctx,
-                ),
+                ScenarioEntry::Metrics(config) => {
+                    run_with_sink_gated(
+                        &config,
+                        &mut sink,
+                        &cancel_for_task,
+                        Some(Arc::clone(&stats_for_task)),
+                        upstream_bus,
+                        gate_ctx,
+                    )
+                    .await
+                }
+                ScenarioEntry::Logs(config) => {
+                    run_logs_with_sink_gated(
+                        &config,
+                        &mut sink,
+                        &cancel_for_task,
+                        Some(Arc::clone(&stats_for_task)),
+                        gate_ctx,
+                    )
+                    .await
+                }
+                ScenarioEntry::Histogram(config) => {
+                    run_histogram_with_sink_gated(
+                        &config,
+                        &mut sink,
+                        &cancel_for_task,
+                        Some(Arc::clone(&stats_for_task)),
+                        gate_ctx,
+                    )
+                    .await
+                }
+                ScenarioEntry::Summary(config) => {
+                    run_summary_with_sink_gated(
+                        &config,
+                        &mut sink,
+                        &cancel_for_task,
+                        Some(Arc::clone(&stats_for_task)),
+                        gate_ctx,
+                    )
+                    .await
+                }
             }
-        })
-        .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
+        };
+
+        // `biased` polls the cancel arm first, so an in-flight `tokio::time::sleep`
+        // inside the runner is dropped on cancel rather than awaited to completion.
+        tokio::select! {
+            biased;
+            _ = cancel_for_outer.cancelled() => Ok::<_, SondaError>(()),
+            result = runner => result,
+        }
+    });
 
     Ok(ScenarioHandle::new(
         id,
         name,
         scenario_name,
-        shutdown,
-        Some(thread),
+        cancel,
+        Some(task),
         started_at,
         stats,
         target_rate,
@@ -397,12 +404,12 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use super::*;
     use crate::config::{
-        BaseScheduleConfig, DistributionConfig, HistogramScenarioConfig, LogScenarioConfig,
-        ScenarioConfig, ScenarioEntry, SummaryScenarioConfig,
+        BaseScheduleConfig, DistributionConfig, GapConfig, HistogramScenarioConfig,
+        LogScenarioConfig, ScenarioConfig, ScenarioEntry, SummaryScenarioConfig,
     };
     use crate::encoder::EncoderConfig;
     use crate::generator::{GeneratorConfig, LogGeneratorConfig, TemplateConfig};
@@ -702,13 +709,12 @@ mod tests {
     /// launch_scenario with a metrics entry returns a handle whose thread is alive.
     #[tokio::test(flavor = "multi_thread")]
     async fn launch_scenario_metrics_returns_running_handle() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("launch_metrics");
 
-        let mut handle =
-            launch_scenario("test-id-1".to_string(), entry, Arc::clone(&shutdown), None)
-                .await
-                .expect("launch must succeed for valid metrics entry");
+        let mut handle = launch_scenario("test-id-1".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed for valid metrics entry");
 
         // The thread must be alive immediately after launch.
         assert!(
@@ -730,13 +736,12 @@ mod tests {
     /// launch_scenario with a logs entry returns a handle whose thread is alive.
     #[tokio::test(flavor = "multi_thread")]
     async fn launch_scenario_logs_returns_running_handle() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = logs_entry_indefinite("launch_logs");
 
-        let mut handle =
-            launch_scenario("test-id-2".to_string(), entry, Arc::clone(&shutdown), None)
-                .await
-                .expect("launch must succeed for valid logs entry");
+        let mut handle = launch_scenario("test-id-2".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed for valid logs entry");
 
         assert!(
             handle.is_running(),
@@ -755,9 +760,9 @@ mod tests {
     /// stop() followed by join() on a metrics scenario exits cleanly (Ok).
     #[tokio::test(flavor = "multi_thread")]
     async fn stop_then_join_metrics_scenario_returns_ok() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("stop_join_metrics");
-        let mut handle = launch_scenario("id-stop-1".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("id-stop-1".to_string(), entry, cancel, None)
             .await
             .expect("launch must succeed");
 
@@ -776,9 +781,9 @@ mod tests {
     /// stop() followed by join() on a logs scenario exits cleanly (Ok).
     #[tokio::test(flavor = "multi_thread")]
     async fn stop_then_join_logs_scenario_returns_ok() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = logs_entry_indefinite("stop_join_logs");
-        let mut handle = launch_scenario("id-stop-2".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("id-stop-2".to_string(), entry, cancel, None)
             .await
             .expect("launch must succeed");
 
@@ -793,9 +798,9 @@ mod tests {
     /// A finite-duration scenario exits on its own and join() returns Ok.
     #[tokio::test(flavor = "multi_thread")]
     async fn finite_duration_scenario_exits_naturally_and_join_returns_ok() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry("natural_exit");
-        let mut handle = launch_scenario("id-natural".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("id-natural".to_string(), entry, cancel, None)
             .await
             .expect("launch must succeed");
 
@@ -814,7 +819,7 @@ mod tests {
     async fn stats_snapshot_shows_nonzero_events_after_brief_run() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         // High rate so events accumulate quickly.
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
@@ -841,10 +846,9 @@ mod tests {
             help: None,
         });
 
-        let mut handle =
-            launch_scenario("id-stats".to_string(), entry, Arc::clone(&shutdown), None)
-                .await
-                .expect("launch must succeed");
+        let mut handle = launch_scenario("id-stats".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed");
 
         // Wait long enough for at least a few events to be emitted and stats updated.
         thread::sleep(Duration::from_millis(200));
@@ -870,7 +874,7 @@ mod tests {
     async fn stats_snapshot_shows_nonzero_events_for_logs_scenario() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
             base: BaseScheduleConfig {
                 name: "logs_stats_test".to_string(),
@@ -901,14 +905,9 @@ mod tests {
             encoder: EncoderConfig::JsonLines { precision: None },
         });
 
-        let mut handle = launch_scenario(
-            "id-log-stats".to_string(),
-            entry,
-            Arc::clone(&shutdown),
-            None,
-        )
-        .await
-        .expect("launch must succeed");
+        let mut handle = launch_scenario("id-log-stats".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed");
 
         thread::sleep(Duration::from_millis(200));
 
@@ -928,9 +927,9 @@ mod tests {
     /// elapsed() is positive immediately after launch.
     #[tokio::test(flavor = "multi_thread")]
     async fn elapsed_is_positive_after_launch() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("elapsed_test");
-        let mut handle = launch_scenario("id-elapsed".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("id-elapsed".to_string(), entry, cancel, None)
             .await
             .expect("launch must succeed");
 
@@ -944,29 +943,6 @@ mod tests {
         handle.join(None).ok();
     }
 
-    // ---- shutdown flag is set to true on launch -----------------------------
-
-    /// launch_scenario sets the shared shutdown flag to true (SeqCst), regardless
-    /// of what the caller set it to beforehand.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn launch_scenario_resets_shutdown_flag_to_true() {
-        // Intentionally start the flag as false to verify launch forces it true.
-        let shutdown = Arc::new(AtomicBool::new(false));
-        let entry = metrics_entry_indefinite("flag_reset");
-
-        let mut handle = launch_scenario("id-flag".to_string(), entry, Arc::clone(&shutdown), None)
-            .await
-            .expect("launch must succeed");
-
-        assert!(
-            shutdown.load(Ordering::SeqCst),
-            "launch_scenario must reset the shutdown flag to true"
-        );
-
-        handle.stop();
-        handle.join(None).ok();
-    }
-
     // ---- start_delay: None starts immediately -------------------------------
 
     /// launch_scenario with start_delay=None starts emitting events immediately.
@@ -974,7 +950,7 @@ mod tests {
     async fn launch_with_no_start_delay_emits_events_immediately() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "no_delay_test".to_string(),
@@ -1000,10 +976,9 @@ mod tests {
             help: None,
         });
 
-        let mut handle =
-            launch_scenario("id-nodelay".to_string(), entry, Arc::clone(&shutdown), None)
-                .await
-                .expect("launch must succeed");
+        let mut handle = launch_scenario("id-nodelay".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed");
 
         // Wait briefly and check events have already been emitted.
         thread::sleep(Duration::from_millis(200));
@@ -1026,7 +1001,7 @@ mod tests {
     async fn launch_with_start_delay_does_not_emit_during_delay() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "delay_test".to_string(),
@@ -1053,14 +1028,10 @@ mod tests {
         });
 
         let delay = Duration::from_millis(500);
-        let mut handle = launch_scenario(
-            "id-delay".to_string(),
-            entry,
-            Arc::clone(&shutdown),
-            Some(delay),
-        )
-        .await
-        .expect("launch must succeed");
+        let mut handle =
+            launch_scenario("id-delay".to_string(), entry, cancel.clone(), Some(delay))
+                .await
+                .expect("launch must succeed");
 
         // Check after 100ms — should still be in the delay period.
         thread::sleep(Duration::from_millis(100));
@@ -1093,7 +1064,7 @@ mod tests {
         use std::thread;
         use std::time::Instant;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("shutdown_delay");
 
         // Set a long delay (10 seconds) so we can verify the shutdown works.
@@ -1101,7 +1072,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-shutdown-delay".to_string(),
             entry,
-            Arc::clone(&shutdown),
+            cancel.clone(),
             Some(delay),
         )
         .await
@@ -1142,7 +1113,7 @@ mod tests {
     async fn launch_logs_with_start_delay_does_not_emit_during_delay() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
             base: BaseScheduleConfig {
                 name: "log_delay_test".to_string(),
@@ -1177,7 +1148,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-log-delay".to_string(),
             entry,
-            Arc::clone(&shutdown),
+            cancel.clone(),
             Some(delay),
         )
         .await
@@ -1279,16 +1250,11 @@ mod tests {
     /// A short histogram scenario launches, runs to completion, and join returns Ok.
     #[tokio::test(flavor = "multi_thread")]
     async fn launch_histogram_scenario_runs_to_completion() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = histogram_entry("launch_histogram");
-        let mut handle = launch_scenario(
-            "id-histogram".to_string(),
-            entry,
-            Arc::clone(&shutdown),
-            None,
-        )
-        .await
-        .expect("launch must succeed for valid histogram entry");
+        let mut handle = launch_scenario("id-histogram".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed for valid histogram entry");
 
         let result = handle.join(Some(Duration::from_secs(5)));
         assert!(
@@ -1302,12 +1268,11 @@ mod tests {
     /// A short summary scenario launches, runs to completion, and join returns Ok.
     #[tokio::test(flavor = "multi_thread")]
     async fn launch_summary_scenario_runs_to_completion() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = summary_entry("launch_summary");
-        let mut handle =
-            launch_scenario("id-summary".to_string(), entry, Arc::clone(&shutdown), None)
-                .await
-                .expect("launch must succeed for valid summary entry");
+        let mut handle = launch_scenario("id-summary".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed for valid summary entry");
 
         let result = handle.join(Some(Duration::from_secs(5)));
         assert!(
@@ -1611,12 +1576,12 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn state_remains_pending_during_start_delay_then_transitions_to_running() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("delayed_state");
         let mut handle = launch_scenario(
             "delayed-state-id".to_string(),
             entry,
-            Arc::clone(&shutdown),
+            cancel.clone(),
             Some(Duration::from_millis(200)),
         )
         .await
@@ -1642,9 +1607,9 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn launch_non_gated_scenario_state_transitions_through_running_to_finished() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry("state_lifecycle");
-        let mut handle = launch_scenario("state-id".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("state-id".to_string(), entry, cancel, None)
             .await
             .expect("launch must succeed");
 
@@ -1826,7 +1791,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-meta-gauge".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .await
@@ -1846,7 +1811,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-meta-step".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .await
@@ -1866,7 +1831,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-meta-hist".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .await
@@ -1885,7 +1850,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-meta-sum".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .await
@@ -1904,7 +1869,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-meta-explicit".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .await
@@ -1924,7 +1889,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-meta-logs".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .await
@@ -1935,5 +1900,62 @@ mod tests {
         );
         handle.stop();
         handle.join(Some(Duration::from_secs(2))).ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancel_during_gap_sleep_exits_within_200ms() {
+        let cancel = CancellationToken::new();
+        let entry = ScenarioEntry::Metrics(ScenarioConfig {
+            base: BaseScheduleConfig {
+                name: "cancel_during_gap_sleep".to_string(),
+                rate: 100.0,
+                duration: None,
+                gaps: Some(GapConfig {
+                    every: "3s".to_string(),
+                    r#for: "2900ms".to_string(),
+                }),
+                bursts: None,
+                cardinality_spikes: None,
+                dynamic_labels: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+                clock_group_is_auto: None,
+                start_time: None,
+                jitter: None,
+                jitter_seed: None,
+                on_sink_error: crate::OnSinkError::Warn,
+            },
+            generator: GeneratorConfig::Constant { value: 1.0 },
+            encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
+        });
+
+        let mut handle = launch_scenario(
+            "cancel-gap-sleep-id".to_string(),
+            entry,
+            cancel.clone(),
+            None,
+        )
+        .await
+        .expect("launch must succeed");
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let cancel_at = Instant::now();
+        handle.stop();
+        let join_result = handle.join_async(Some(Duration::from_millis(500))).await;
+        let exit_duration = cancel_at.elapsed();
+
+        assert!(
+            join_result.is_ok(),
+            "join_async must complete within 500ms; got {join_result:?}"
+        );
+        assert!(
+            exit_duration < Duration::from_millis(200),
+            "cancel-to-exit must be under 200ms; took {exit_duration:?}"
+        );
     }
 }

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -1,13 +1,8 @@
 //! The log scenario event loop.
-//!
-//! The log runner ties together the log generator, encoder, and sink with the
-//! shared schedule loop from [`core_loop::run_schedule_loop`](super::core_loop::run_schedule_loop).
-//! Only the log-specific per-tick work (log event generation, label injection,
-//! encoding) lives here; all schedule infrastructure (rate control, gap/burst/spike
-//! windows, stats tracking, shutdown handling) is in the shared loop.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
+
+use tokio_util::sync::CancellationToken;
 
 use crate::config::LogScenarioConfig;
 use crate::encoder::create_encoder;
@@ -23,80 +18,26 @@ use crate::sink::{create_sink, Sink};
 use crate::SondaError;
 
 /// Run a log scenario to completion, emitting encoded log events at the configured rate.
-///
-/// This is the primary entry point. It constructs a sink from the config and
-/// delegates to [`run_logs_with_sink`] with no shutdown flag and no stats collection.
-///
-/// This function blocks the calling thread until the scenario duration has
-/// elapsed. If no duration is specified in the config it runs indefinitely.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run_logs(config: &LogScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, config.labels.as_ref()).await?;
-    run_logs_with_sink(config, &mut sink, None, None).await
+    let cancel = CancellationToken::new();
+    run_logs_with_sink(config, &mut sink, &cancel, None).await
 }
 
 /// Run a log scenario to completion, writing encoded events into the provided sink.
-///
-/// This function builds the log generator, encoder, and label set from the
-/// config, then delegates to the shared schedule loop via
-/// [`core_loop::run_schedule_loop`](super::core_loop::run_schedule_loop).
-/// The log-specific per-tick work (event generation, label injection, encoding,
-/// and sink writing) is captured in a closure passed to the shared loop.
-///
-/// # Parameters
-///
-/// * `config` — the log scenario configuration.
-/// * `sink` — the destination for encoded log events.
-/// * `shutdown` — an optional atomic flag; when set to `false` the loop exits
-///   cleanly after the current tick, flushes the sink, and returns `Ok(())`.
-///   Pass `None` if no external shutdown signal is needed (e.g., in tests).
-/// * `stats` — an optional shared stats object. When `Some`, the runner updates
-///   `total_events`, `bytes_emitted`, `current_rate`, `in_gap`, `in_burst`, and
-///   `errors` on each tick. The write lock is held only for the brief counter
-///   update, not during encode/write. Pass `None` to skip stats collection with
-///   no overhead (e.g., in direct CLI usage or tests).
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-/// If an error occurs during the loop and flushing also fails, the loop error
-/// is returned (the flush error is discarded to preserve the original cause).
 pub async fn run_logs_with_sink(
     config: &LogScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_logs_with_sink_gated(config, sink, shutdown, stats, None).await
-}
-
-/// Run a log scenario with optional `while:` / `after:` gating.
-///
-/// Logs cannot be `while:` upstreams (compile-time `NonMetricsTarget`),
-/// but they can be `while:`-gated downstreams.
-pub fn run_logs_with_sink_gated_blocking(
-    config: &LogScenarioConfig,
-    shutdown: Option<&AtomicBool>,
-    stats: Option<Arc<RwLock<ScenarioStats>>>,
-    gate_ctx: Option<GateContext>,
-) -> Result<(), SondaError> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
-    rt.block_on(async {
-        let mut sink = create_sink(&config.sink, config.labels.as_ref()).await?;
-        run_logs_with_sink_gated(config, &mut sink, shutdown, stats, gate_ctx).await
-    })
+    run_logs_with_sink_gated(config, sink, cancel, stats, None).await
 }
 
 pub async fn run_logs_with_sink_gated(
     config: &LogScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
 ) -> Result<(), SondaError> {
@@ -161,21 +102,14 @@ pub async fn run_logs_with_sink_gated(
 
     match gate_ctx {
         None => {
-            core_loop::run_schedule_loop(
-                &schedule,
-                config.rate,
-                shutdown,
-                stats,
-                sink,
-                &mut tick_fn,
-            )
-            .await
+            core_loop::run_schedule_loop(&schedule, config.rate, cancel, stats, sink, &mut tick_fn)
+                .await
         }
         Some(ctx) => {
             core_loop::gated_loop(
                 &schedule,
                 config.rate,
-                shutdown,
+                cancel,
                 stats,
                 ctx,
                 sink,
@@ -273,7 +207,7 @@ mod tests {
         let config = make_config(10.0, Some("1s"));
         let (mut sink, buf) = probe_sink();
 
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -293,7 +227,7 @@ mod tests {
         let config = make_config(10.0, Some("1s"));
         let (mut sink, buf) = probe_sink();
 
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -313,31 +247,25 @@ mod tests {
     // Shutdown flag: setting the flag stops the runner before duration expires
     // -------------------------------------------------------------------------
 
-    /// If the shutdown flag is cleared (false) before the scenario would
-    /// naturally finish, the runner must exit cleanly without error.
+    /// Cancelling the token before the scenario would naturally finish causes
+    /// the runner to exit cleanly.
     #[tokio::test]
-    async fn run_logs_with_sink_shutdown_flag_stops_runner() {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::Arc;
+    async fn run_logs_with_sink_cancel_stops_runner() {
         use std::thread;
         use std::time::Duration;
 
-        let config = make_config(5.0, None); // runs indefinitely without shutdown
+        let config = make_config(5.0, None);
         let (mut sink, _buf) = probe_sink();
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
 
-        let flag_clone = Arc::clone(&shutdown);
-        // Clear the shutdown flag after 300ms so the runner exits soon.
+        let cancel_for_thread = cancel.clone();
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(300));
-            flag_clone.store(false, Ordering::SeqCst);
+            cancel_for_thread.cancel();
         });
 
-        let result = run_logs_with_sink(&config, &mut sink, Some(shutdown.as_ref()), None).await;
-        assert!(
-            result.is_ok(),
-            "runner must return Ok when stopped via shutdown flag"
-        );
+        let result = run_logs_with_sink(&config, &mut sink, &cancel, None).await;
+        assert!(result.is_ok());
     }
 
     // -------------------------------------------------------------------------
@@ -361,7 +289,7 @@ mod tests {
         });
 
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -390,7 +318,7 @@ mod tests {
         let (mut sink, _buf) = probe_sink();
 
         let t0 = Instant::now();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("must not error");
         let elapsed = t0.elapsed();
@@ -571,7 +499,7 @@ sink:
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -603,7 +531,7 @@ sink:
     async fn run_logs_with_sink_no_labels_produces_empty_labels_object() {
         let config = make_config(10.0, Some("500ms"));
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -633,7 +561,7 @@ sink:
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -698,7 +626,7 @@ sink:
         let config = make_config_with_spike(10.0, Some("1s"), spike);
         let (mut sink, buf) = probe_sink();
 
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -730,7 +658,7 @@ sink:
     async fn run_logs_with_sink_no_spike_config_produces_no_spike_labels() {
         let config = make_config(10.0, Some("500ms"));
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -776,7 +704,7 @@ sink:
             }],
         );
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -814,7 +742,7 @@ sink:
             }],
         );
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -862,7 +790,7 @@ sink:
             }],
         );
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -902,7 +830,7 @@ sink:
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -941,7 +869,7 @@ sink:
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -1,11 +1,9 @@
-//! Multi-scenario runner: runs multiple scenarios concurrently on separate threads.
-//!
-//! Each scenario owns its own shutdown flag. [`run_multi`] and
-//! [`run_multi_compiled`] accept a master `shutdown` flag and use a watchdog
-//! thread to fan a transition out into each handle's per-scenario flag.
+//! Multi-scenario runner: runs multiple scenarios concurrently as tokio tasks.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "config")]
 use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
 
 use crate::config::ScenarioEntry;
 use crate::schedule::launch::{launch_scenario, prepare_entries};
@@ -33,48 +31,29 @@ use std::collections::HashMap;
 #[cfg(feature = "config")]
 use tokio::sync::watch;
 
-/// Run all scenarios in `entries` concurrently, one OS thread per scenario.
-/// Set `shutdown` to `false` to stop all running scenarios.
+/// Run all scenarios in `entries` concurrently; cancel `parent_cancel` to stop them.
 pub async fn run_multi(
     entries: Vec<ScenarioEntry>,
-    shutdown: Arc<AtomicBool>,
+    parent_cancel: CancellationToken,
 ) -> Result<(), SondaError> {
-    // Expand, validate, and resolve phase offsets for all entries atomically.
     let prepared = prepare_entries(entries)?;
 
     let mut handles = Vec::with_capacity(prepared.len());
-    let mut per_handle_shutdowns: Vec<Arc<AtomicBool>> = Vec::with_capacity(prepared.len());
     let mut errors: Vec<String> = Vec::new();
     for (i, prepared_entry) in prepared.into_iter().enumerate() {
         let id = format!("multi-{i}");
-        let scenario_shutdown = Arc::new(AtomicBool::new(true));
-        match launch_scenario(
-            id,
-            prepared_entry.entry,
-            Arc::clone(&scenario_shutdown),
-            prepared_entry.start_delay,
-        )
-        .await
-        {
-            Ok(handle) => {
-                per_handle_shutdowns.push(scenario_shutdown);
-                handles.push(handle);
-            }
+        let child = parent_cancel.child_token();
+        match launch_scenario(id, prepared_entry.entry, child, prepared_entry.start_delay).await {
+            Ok(handle) => handles.push(handle),
             Err(e) => errors.push(e.to_string()),
         }
     }
 
-    let done = Arc::new(AtomicBool::new(false));
-    let watchdog = spawn_shutdown_watchdog(shutdown, per_handle_shutdowns, Arc::clone(&done));
-
     for mut handle in handles {
-        if let Err(e) = handle.join(None) {
+        if let Err(e) = handle.join_async(None).await {
             errors.push(e.to_string());
         }
     }
-
-    done.store(true, Ordering::SeqCst);
-    let _ = watchdog.join();
 
     if errors.is_empty() {
         Ok(())
@@ -85,45 +64,9 @@ pub async fn run_multi(
     }
 }
 
-/// Mirror `master`'s false transition into each per-handle shutdown; exit when `master` flips or `done` flips.
-fn spawn_shutdown_watchdog(
-    master: Arc<AtomicBool>,
-    per_handle: Vec<Arc<AtomicBool>>,
-    done: Arc<AtomicBool>,
-) -> std::thread::JoinHandle<()> {
-    std::thread::Builder::new()
-        .name("sonda-shutdown-watchdog".to_string())
-        .spawn(move || {
-            let poll = std::time::Duration::from_millis(100);
-            loop {
-                if done.load(Ordering::SeqCst) {
-                    return;
-                }
-                if !master.load(Ordering::SeqCst) {
-                    for flag in &per_handle {
-                        flag.store(false, Ordering::SeqCst);
-                    }
-                    return;
-                }
-                std::thread::sleep(poll);
-            }
-        })
-        .expect("watchdog thread must spawn")
-}
-
-/// Set the shutdown flag, signalling all running scenarios to stop.
-///
-/// This is a convenience wrapper that stores `false` with `SeqCst` ordering,
-/// matching the ordering used by the signal handler in the CLI.
-pub fn signal_shutdown(shutdown: &AtomicBool) {
-    shutdown.store(false, Ordering::SeqCst);
-}
-
-/// Launch a compiled scenario file with `while:` / `after:` gating wired in,
-/// returning the live handles without joining them. When `resolver` is `Some`,
-/// cross-POST `while:` references resolve through the registry; otherwise every
-/// reference must resolve inside `file`. Each handle owns an independent
-/// shutdown flag — see [`run_multi_compiled`] for the master-stop-all path.
+/// Launch a compiled scenario file with `while:` / `after:` gating wired in.
+/// Each handle owns an independent cancellation token; see [`run_multi_compiled`]
+/// for the master-stop-all path.
 #[cfg(feature = "config")]
 pub async fn launch_multi_compiled(
     file: CompiledFile,
@@ -298,12 +241,12 @@ pub async fn launch_multi_compiled(
         let id = plan.id.unwrap_or_else(|| format!("multi-{idx}"));
         let deferred = plan.deferred;
         let active = plan.active;
-        let scenario_shutdown = Arc::new(AtomicBool::new(true));
+        let scenario_cancel = CancellationToken::new();
         match launch_scenario_with_gates(
             id.clone(),
             file_scenario_name.clone(),
             plan.entry,
-            scenario_shutdown,
+            scenario_cancel,
             plan.start_delay,
             plan.upstream_bus,
             plan.gate_ctx,
@@ -391,21 +334,21 @@ struct ActiveSubscription {
 }
 
 /// Run a compiled scenario file with `while:` / `after:` gating wired in.
-///
-/// Spawns every scenario via [`launch_multi_compiled`] and joins the threads.
-/// Non-gated entries launch on the existing non-gated path with no per-tick
-/// overhead.
 #[cfg(feature = "config")]
 pub async fn run_multi_compiled(
     file: CompiledFile,
-    shutdown: Arc<AtomicBool>,
+    parent_cancel: CancellationToken,
 ) -> Result<(), SondaError> {
     let handles = launch_multi_compiled(file, None).await?;
-    let per_handle_shutdowns: Vec<Arc<AtomicBool>> =
-        handles.iter().map(|h| Arc::clone(&h.shutdown)).collect();
-
-    let done = Arc::new(AtomicBool::new(false));
-    let watchdog = spawn_shutdown_watchdog(shutdown, per_handle_shutdowns, Arc::clone(&done));
+    let cancel_watcher = parent_cancel.clone();
+    let watcher_cancels: Vec<CancellationToken> =
+        handles.iter().map(|h| h.cancel.clone()).collect();
+    let watcher = tokio::task::spawn(async move {
+        cancel_watcher.cancelled().await;
+        for c in &watcher_cancels {
+            c.cancel();
+        }
+    });
 
     let mut errors: Vec<String> = Vec::new();
     for mut handle in handles {
@@ -415,8 +358,8 @@ pub async fn run_multi_compiled(
         }
     }
 
-    done.store(true, Ordering::SeqCst);
-    let _ = watchdog.join();
+    watcher.abort();
+    let _ = watcher.await;
 
     if errors.is_empty() {
         Ok(())
@@ -462,10 +405,10 @@ struct LaunchPlan {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
     use std::thread;
     use std::time::{Duration, Instant};
+
+    use tokio_util::sync::CancellationToken;
 
     use crate::config::{BaseScheduleConfig, LogScenarioConfig, ScenarioConfig, ScenarioEntry};
     use crate::encoder::EncoderConfig;
@@ -474,7 +417,7 @@ mod tests {
 
     #[cfg(feature = "config")]
     use super::launch_multi_compiled;
-    use super::{run_multi, signal_shutdown};
+    use super::run_multi;
 
     /// Build a minimal metrics `ScenarioEntry` that writes to stdout.
     /// Duration of "100ms" ensures the thread exits quickly.
@@ -545,16 +488,16 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn run_multi_with_empty_scenarios_returns_ok() {
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(vec![], shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(vec![], cancel).await;
         assert!(result.is_ok(), "empty scenario list should return Ok");
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn run_multi_with_single_metrics_scenario_returns_ok() {
         let entries = vec![metrics_entry_stdout("single_metric")];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_ok(),
             "single metrics scenario should complete without error"
@@ -564,8 +507,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn run_multi_with_single_logs_scenario_returns_ok() {
         let entries = vec![logs_entry_stdout("single_logs")];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_ok(),
             "single logs scenario should complete without error"
@@ -580,8 +523,8 @@ mod tests {
             metrics_entry_stdout("concurrent_metrics"),
             logs_entry_stdout("concurrent_logs"),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_ok(),
             "both concurrent scenarios should complete without error"
@@ -595,8 +538,8 @@ mod tests {
             metrics_entry_stdout("m2"),
             logs_entry_stdout("l1"),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_ok(),
             "three concurrent scenarios should all complete without error"
@@ -604,11 +547,11 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Shutdown flag: setting it stops all threads
+    // Cancel propagation
     // -----------------------------------------------------------------------
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn run_multi_shutdown_flag_stops_all_threads_within_two_seconds() {
+    async fn run_multi_parent_cancel_stops_all_tasks_within_two_seconds() {
         // Both scenarios have no duration (would run indefinitely). We
         // signal shutdown after a short delay and verify all threads stop
         // well within 2 seconds.
@@ -668,34 +611,23 @@ mod tests {
             }),
         ];
 
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let shutdown_for_thread = Arc::clone(&shutdown);
+        let cancel = CancellationToken::new();
+        let cancel_for_thread = cancel.clone();
 
-        // Signal shutdown after 50ms from a separate thread.
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(50));
-            signal_shutdown(&shutdown_for_thread);
+            cancel_for_thread.cancel();
         });
 
         let start = Instant::now();
-        let result = run_multi(entries, shutdown).await;
+        let result = run_multi(entries, cancel).await;
         let elapsed = start.elapsed();
 
-        assert!(result.is_ok(), "shutdown should not produce an error");
+        assert!(result.is_ok());
         assert!(
             elapsed < Duration::from_secs(2),
-            "run_multi should return within 2 seconds of shutdown signal, took {:?}",
+            "run_multi should return within 2 seconds, took {:?}",
             elapsed
-        );
-    }
-
-    #[test]
-    fn signal_shutdown_stores_false_with_seqcst_ordering() {
-        let flag = AtomicBool::new(true);
-        signal_shutdown(&flag);
-        assert!(
-            !flag.load(Ordering::SeqCst),
-            "signal_shutdown should set the flag to false"
         );
     }
 
@@ -733,8 +665,8 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_err(),
             "scenario with an invalid sink path should return Err"
@@ -803,8 +735,8 @@ mod tests {
                 help: None,
             }),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(result.is_err(), "two failing scenarios should return Err");
         // The combined error message should contain both errors separated by "; "
         let err_msg = result.unwrap_err().to_string();
@@ -844,8 +776,8 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(result.is_err(), "invalid sink must produce an error");
         let err = result.unwrap_err();
         assert!(
@@ -888,9 +820,9 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let start = Instant::now();
-        let result = run_multi(entries, shutdown).await;
+        let result = run_multi(entries, cancel).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "minimal phase_offset should complete ok");
@@ -929,8 +861,8 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         // "0s" is treated as no delay — parse_phase_offset returns None.
         assert!(
             result.is_ok(),
@@ -943,8 +875,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn run_multi_with_no_phase_offset_preserves_behavior() {
         let entries = vec![metrics_entry_stdout("no_offset")];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_ok(),
             "scenario without phase_offset should work as before"
@@ -1005,9 +937,9 @@ mod tests {
                 help: None,
             }),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let start = Instant::now();
-        let result = run_multi(entries, shutdown).await;
+        let result = run_multi(entries, cancel).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "phase_offset multi-scenario should succeed");
@@ -1076,26 +1008,22 @@ mod tests {
             }),
         ];
 
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let shutdown_for_thread = Arc::clone(&shutdown);
+        let cancel = CancellationToken::new();
+        let cancel_for_thread = cancel.clone();
 
-        // Signal shutdown after 100ms.
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(100));
-            signal_shutdown(&shutdown_for_thread);
+            cancel_for_thread.cancel();
         });
 
         let start = Instant::now();
-        let result = run_multi(entries, shutdown).await;
+        let result = run_multi(entries, cancel).await;
         let elapsed = start.elapsed();
 
-        assert!(
-            result.is_ok(),
-            "shutdown during phase_offset should not produce an error"
-        );
+        assert!(result.is_ok());
         assert!(
             elapsed < Duration::from_secs(2),
-            "run_multi must exit promptly when shutdown during phase_offset, took {:?}",
+            "run_multi must exit promptly, took {:?}",
             elapsed
         );
     }
@@ -1128,8 +1056,8 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_err(),
             "invalid phase_offset must cause run_multi to return Err"
@@ -1194,8 +1122,8 @@ mod tests {
                 help: None,
             }),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_ok(),
             "scenarios with clock_group and offsets should complete"
@@ -1843,7 +1771,7 @@ scenarios:
 
     #[cfg(feature = "config")]
     #[tokio::test(flavor = "multi_thread")]
-    async fn launch_multi_compiled_gives_each_handle_an_independent_shutdown_flag() {
+    async fn launch_multi_compiled_gives_each_handle_an_independent_cancel_token() {
         use crate::compile_scenario_file_compiled;
         use crate::compiler::expand::InMemoryPackResolver;
 
@@ -1885,15 +1813,6 @@ scenarios:
             .await
             .expect("launch must succeed");
         assert_eq!(handles.len(), 3, "must launch all three entries");
-
-        for i in 0..handles.len() {
-            for j in (i + 1)..handles.len() {
-                assert!(
-                    !Arc::ptr_eq(&handles[i].shutdown, &handles[j].shutdown),
-                    "handles {i} and {j} must own independent shutdown Arcs"
-                );
-            }
-        }
 
         handles[0].stop();
         let deadline = Instant::now() + Duration::from_secs(2);

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -1,15 +1,9 @@
 //! The metric scenario event loop.
-//!
-//! The runner ties together all sonda-core components: it reads a
-//! [`ScenarioConfig`], builds the generator, encoder, and sink, then delegates
-//! to the shared [`core_loop::run_schedule_loop`](super::core_loop::run_schedule_loop)
-//! for rate control, gap/burst/spike window handling, stats tracking, and
-//! shutdown management. Only the metric-specific event generation and encoding
-//! logic lives here.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime};
+
+use tokio_util::sync::CancellationToken;
 
 use crate::config::ScenarioConfig;
 use crate::encoder::create_encoder;
@@ -26,84 +20,26 @@ use crate::sink::{create_sink, Sink, SinkConfig};
 use crate::SondaError;
 
 /// Run a scenario to completion, emitting encoded metric events at the configured rate.
-///
-/// This is the primary entry point. It constructs a sink from the config and then
-/// delegates to [`run_with_sink`] with no shutdown flag and no stats collection.
-///
-/// This function blocks the calling thread until the scenario duration has
-/// elapsed. If no duration is specified in the config it runs indefinitely.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run(config: &ScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, None).await?;
-    run_with_sink(config, &mut sink, None, None).await
+    let cancel = CancellationToken::new();
+    run_with_sink(config, &mut sink, &cancel, None).await
 }
 
 /// Run a scenario to completion, writing encoded events into the provided sink.
-///
-/// This function builds the metric generator, encoder, and label set from the
-/// config, then delegates to the shared schedule loop via
-/// [`core_loop::run_schedule_loop`](super::core_loop::run_schedule_loop).
-/// The metric-specific per-tick work (value generation, label spike injection,
-/// `MetricEvent` construction, encoding, and sink writing) is captured in a
-/// closure passed to the shared loop.
-///
-/// # Parameters
-///
-/// * `config` — the scenario configuration.
-/// * `sink` — the destination for encoded metric events.
-/// * `shutdown` — an optional atomic flag; when set to `false` the loop exits
-///   cleanly after the current tick, flushes the sink, and returns `Ok(())`.
-///   Pass `None` if no external shutdown signal is needed (e.g., in tests).
-/// * `stats` — an optional shared stats object. When `Some`, the runner updates
-///   `total_events`, `bytes_emitted`, `current_rate`, `in_gap`, `in_burst`, and
-///   `errors` on each tick. The write lock is held only for the brief counter
-///   update, not during encode/write. Pass `None` to skip stats collection with
-///   no overhead (e.g., in direct CLI usage or tests).
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-/// If an error occurs during the loop and flushing also fails, the loop error
-/// is returned (the flush error is discarded to preserve the original cause).
 pub async fn run_with_sink(
     config: &ScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_with_sink_gated(config, sink, shutdown, stats, None, None).await
-}
-
-/// Run a metric scenario with optional `while:` / `after:` gating.
-///
-/// `upstream_bus` is the bus this scenario PUBLISHES into (for downstream
-/// gates to subscribe to). `gate_ctx` is what THIS scenario consumes from
-/// an upstream bus. Both are independent — a scenario can be both an
-/// upstream (publishing) and a downstream (gated).
-pub fn run_with_sink_gated_blocking(
-    config: &ScenarioConfig,
-    shutdown: Option<&AtomicBool>,
-    stats: Option<Arc<RwLock<ScenarioStats>>>,
-    upstream_bus: Option<Arc<GateBus>>,
-    gate_ctx: Option<GateContext>,
-) -> Result<(), SondaError> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
-    rt.block_on(async {
-        let mut sink = create_sink(&config.sink, None).await?;
-        run_with_sink_gated(config, &mut sink, shutdown, stats, upstream_bus, gate_ctx).await
-    })
+    run_with_sink_gated(config, sink, cancel, stats, None, None).await
 }
 
 pub async fn run_with_sink_gated(
     config: &ScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     upstream_bus: Option<Arc<GateBus>>,
     gate_ctx: Option<GateContext>,
@@ -186,15 +122,8 @@ pub async fn run_with_sink_gated(
 
     match gate_ctx {
         None => {
-            core_loop::run_schedule_loop(
-                &schedule,
-                config.rate,
-                shutdown,
-                stats,
-                sink,
-                &mut tick_fn,
-            )
-            .await
+            core_loop::run_schedule_loop(&schedule, config.rate, cancel, stats, sink, &mut tick_fn)
+                .await
         }
         Some(mut ctx) => {
             ctx.close_emit = build_close_emit(
@@ -207,7 +136,7 @@ pub async fn run_with_sink_gated(
             core_loop::gated_loop(
                 &schedule,
                 config.rate,
-                shutdown,
+                cancel,
                 stats,
                 ctx,
                 sink,
@@ -313,6 +242,7 @@ mod tests {
     use std::sync::Mutex;
 
     use async_trait::async_trait;
+    use tokio_util::sync::CancellationToken;
 
     use crate::config::{BaseScheduleConfig, GapConfig, ScenarioConfig};
     use crate::encoder::EncoderConfig;
@@ -393,7 +323,7 @@ mod tests {
     async fn integration_rate_100_duration_1s_emits_approximately_100_events() {
         let config = make_config(100.0, "1s", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -410,7 +340,7 @@ mod tests {
     async fn integration_output_lines_start_with_metric_name() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -429,7 +359,7 @@ mod tests {
     async fn integration_output_ends_with_newline() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -454,7 +384,7 @@ mod tests {
             }),
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -506,7 +436,7 @@ mod tests {
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -573,7 +503,7 @@ mod tests {
             }),
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -608,7 +538,7 @@ mod tests {
             }),
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -675,7 +605,7 @@ mod tests {
             }),
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -735,9 +665,14 @@ mod tests {
             }),
         );
         let (mut sink_no_gap, buf_no_gap) = probe_sink();
-        super::run_with_sink(&config_no_gap_burst, &mut sink_no_gap, None, None)
-            .await
-            .expect("run must succeed");
+        super::run_with_sink(
+            &config_no_gap_burst,
+            &mut sink_no_gap,
+            &CancellationToken::new(),
+            None,
+        )
+        .await
+        .expect("run must succeed");
         let events_burst_only = buf_no_gap
             .lock()
             .unwrap()
@@ -761,9 +696,14 @@ mod tests {
             }),
         );
         let (mut sink_gap_burst, buf_gap_burst) = probe_sink();
-        super::run_with_sink(&config_gap_and_burst, &mut sink_gap_burst, None, None)
-            .await
-            .expect("run must succeed");
+        super::run_with_sink(
+            &config_gap_and_burst,
+            &mut sink_gap_burst,
+            &CancellationToken::new(),
+            None,
+        )
+        .await
+        .expect("run must succeed");
         let events_gap_and_burst = buf_gap_burst
             .lock()
             .unwrap()
@@ -792,9 +732,14 @@ mod tests {
         let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
-        super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
-            .await
-            .expect("run must succeed");
+        super::run_with_sink(
+            &config,
+            &mut sink,
+            &CancellationToken::new(),
+            Some(Arc::clone(&stats)),
+        )
+        .await
+        .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
         assert!(
@@ -811,7 +756,7 @@ mod tests {
         let (mut sink, buf) = probe_sink();
 
         // Pass None for stats — should work fine without buffering.
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -831,9 +776,14 @@ mod tests {
         let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
-        super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
-            .await
-            .expect("run must succeed");
+        super::run_with_sink(
+            &config,
+            &mut sink,
+            &CancellationToken::new(),
+            Some(Arc::clone(&stats)),
+        )
+        .await
+        .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
         for event in st.current_values.values() {
@@ -841,15 +791,12 @@ mod tests {
         }
     }
 
-    /// The shutdown flag stops the runner even during a burst window.
+    /// Cancelling the token stops the runner even during a burst window.
     #[tokio::test]
-    async fn shutdown_flag_stops_run_during_burst() {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::Arc;
-
+    async fn cancel_stops_run_during_burst() {
         let config = make_config_with_burst(
             1000.0,
-            "60s", // long duration — shutdown flag stops it
+            "60s",
             None,
             Some(crate::config::BurstConfig {
                 every: "10s".to_string(),
@@ -858,17 +805,16 @@ mod tests {
             }),
         );
 
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel = CancellationToken::new();
+        let cancel_for_thread = cancel.clone();
 
-        // Set the flag to false after a short delay to trigger shutdown.
         let handle = std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(200));
-            shutdown_clone.store(false, Ordering::SeqCst);
+            cancel_for_thread.cancel();
         });
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, Some(&shutdown), None)
+        super::run_with_sink(&config, &mut sink, &cancel, None)
             .await
             .expect("run must succeed");
         handle.join().expect("thread must complete");
@@ -935,7 +881,7 @@ mod tests {
         // Run for 500ms inside a spike window (spike occupies 0..9s of each 10s cycle)
         let config = make_config_with_spike(50.0, "500ms", spike);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -954,7 +900,7 @@ mod tests {
     async fn integration_no_spike_config_produces_no_spike_labels() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -982,7 +928,7 @@ mod tests {
         };
         let config = make_config_with_spike(50.0, "500ms", spike);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -1029,9 +975,14 @@ mod tests {
         let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
-        super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
-            .await
-            .expect("run must succeed");
+        super::run_with_sink(
+            &config,
+            &mut sink,
+            &CancellationToken::new(),
+            Some(Arc::clone(&stats)),
+        )
+        .await
+        .expect("run must succeed");
 
         // The entire 200ms run is inside the spike window (0..9s of 10s cycle).
         // The final stats snapshot should show in_cardinality_spike = true.
@@ -1053,9 +1004,14 @@ mod tests {
         let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
-        super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
-            .await
-            .expect("run must succeed");
+        super::run_with_sink(
+            &config,
+            &mut sink,
+            &CancellationToken::new(),
+            Some(Arc::clone(&stats)),
+        )
+        .await
+        .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
         assert_eq!(
@@ -1099,7 +1055,8 @@ mod tests {
             help: None,
         };
         let (mut sink, _buf) = probe_sink();
-        let result = super::run_with_sink(&config, &mut sink, None, None).await;
+        let result =
+            super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None).await;
         assert!(
             matches!(result, Err(crate::SondaError::Config(ref e)) if e.to_string().contains("123-invalid")),
             "expected Config error for invalid name, got: {result:?}"
@@ -1155,7 +1112,7 @@ mod tests {
             }],
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -1189,7 +1146,7 @@ mod tests {
             }],
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -1230,7 +1187,7 @@ mod tests {
             }],
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -1273,7 +1230,7 @@ mod tests {
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -1310,7 +1267,7 @@ mod tests {
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 

--- a/sonda-core/src/schedule/summary_runner.rs
+++ b/sonda-core/src/schedule/summary_runner.rs
@@ -1,21 +1,8 @@
 //! The summary scenario event loop.
-//!
-//! The summary runner ties together the [`SummaryGenerator`], encoder, and
-//! sink with the shared schedule loop from
-//! [`core_loop::run_schedule_loop`](super::core_loop::run_schedule_loop).
-//!
-//! Each tick, the runner:
-//! 1. Advances the summary generator to get a [`SummarySample`].
-//! 2. For each quantile target, creates a `MetricEvent` with the base name
-//!    and a `quantile="{q}"` label.
-//! 3. Creates `{base}_count` and `{base}_sum` events.
-//! 4. Encodes all events and writes them to the sink.
-//!
-//! The core loop is unchanged — all summary-specific logic lives in the
-//! per-tick closure.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
+
+use tokio_util::sync::CancellationToken;
 
 use crate::config::SummaryScenarioConfig;
 use crate::encoder::create_encoder;
@@ -31,70 +18,26 @@ use crate::schedule::ParsedSchedule;
 use crate::sink::{create_sink, Sink};
 use crate::SondaError;
 
-/// Run a summary scenario to completion, emitting encoded summary events
-/// at the configured rate.
-///
-/// This is the primary entry point. It constructs a sink from the config and
-/// delegates to [`run_with_sink`] with no shutdown flag and no stats collection.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
+/// Run a summary scenario to completion at the configured rate.
 pub async fn run(config: &SummaryScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, None).await?;
-    run_with_sink(config, &mut sink, None, None).await
+    let cancel = CancellationToken::new();
+    run_with_sink(config, &mut sink, &cancel, None).await
 }
 
-/// Run a summary scenario to completion, writing encoded events into the
-/// provided sink.
-///
-/// Builds the summary generator, encoder, and label sets from the config,
-/// then delegates to the shared schedule loop. The per-tick closure generates
-/// multiple `MetricEvent`s per tick (one per quantile + `_count` + `_sum`).
-///
-/// # Parameters
-///
-/// * `config` — the summary scenario configuration.
-/// * `sink` — the destination for encoded metric events.
-/// * `shutdown` — optional atomic flag for clean shutdown.
-/// * `stats` — optional shared stats for live telemetry.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run_with_sink(
     config: &SummaryScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_with_sink_gated(config, sink, shutdown, stats, None).await
-}
-
-/// Run a summary scenario with optional `while:` / `after:` gating.
-///
-/// Summaries cannot be `while:` upstreams (compile-time
-/// `NonMetricsTarget`), but they can be `while:`-gated downstreams.
-pub fn run_with_sink_gated_blocking(
-    config: &SummaryScenarioConfig,
-    shutdown: Option<&AtomicBool>,
-    stats: Option<Arc<RwLock<ScenarioStats>>>,
-    gate_ctx: Option<GateContext>,
-) -> Result<(), SondaError> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
-    rt.block_on(async {
-        let mut sink = create_sink(&config.sink, None).await?;
-        run_with_sink_gated(config, &mut sink, shutdown, stats, gate_ctx).await
-    })
+    run_with_sink_gated(config, sink, cancel, stats, None).await
 }
 
 pub async fn run_with_sink_gated(
     config: &SummaryScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
 ) -> Result<(), SondaError> {
@@ -255,21 +198,14 @@ pub async fn run_with_sink_gated(
 
     match gate_ctx {
         None => {
-            core_loop::run_schedule_loop(
-                &schedule,
-                config.rate,
-                shutdown,
-                stats,
-                sink,
-                &mut tick_fn,
-            )
-            .await
+            core_loop::run_schedule_loop(&schedule, config.rate, cancel, stats, sink, &mut tick_fn)
+                .await
         }
         Some(ctx) => {
             core_loop::gated_loop(
                 &schedule,
                 config.rate,
-                shutdown,
+                cancel,
                 stats,
                 ctx,
                 sink,
@@ -285,6 +221,7 @@ mod tests {
     use std::sync::Mutex;
 
     use async_trait::async_trait;
+    use tokio_util::sync::CancellationToken;
 
     use crate::config::{BaseScheduleConfig, DistributionConfig, SummaryScenarioConfig};
     use crate::encoder::EncoderConfig;
@@ -360,7 +297,7 @@ mod tests {
     async fn run_completes_for_short_duration() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("summary run must succeed");
         assert!(
@@ -375,7 +312,7 @@ mod tests {
     async fn output_contains_quantile_count_sum_series() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -402,7 +339,7 @@ mod tests {
     async fn quantile_events_have_quantile_label() {
         let config = make_config(50.0, "100ms", Some(vec![0.5, 0.99]));
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -430,7 +367,7 @@ mod tests {
         });
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -450,7 +387,7 @@ mod tests {
         config.base.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 

--- a/sonda-core/tests/common/mod.rs
+++ b/sonda-core/tests/common/mod.rs
@@ -19,9 +19,9 @@
 #![cfg(feature = "config")]
 #![allow(dead_code)]
 
+use sonda_core::CancellationToken;
 use std::collections::BTreeSet;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -178,54 +178,9 @@ impl Sink for CapturingSink {
     }
 }
 
-/// Run every entry in `entries` to completion against an in-memory sink,
-/// returning the raw concatenated stdout-equivalent bytes.
-///
-/// The harness mirrors a trimmed-down version of `launch_scenario`:
-///
-/// 1. `prepare_entries` expands csv_replay, desugars aliases, validates
-///    every entry, and resolves each entry's `phase_offset` into a
-///    `start_delay: Option<Duration>` — exactly the same preparation the
-///    production launcher does.
-/// 2. Each prepared entry runs on its own OS thread with a
-///    [`CapturingSink`] substituted for the user-configured sink. The
-///    shared `Arc<Mutex<Vec<u8>>>` is cloned into the thread so the parent
-///    can drain bytes after the thread joins.
-/// 3. Each thread honors its `start_delay` via `thread::sleep` (no shared
-///    shutdown signal — the scenario's own `duration:` field bounds the
-///    run, which must be set on every entry this harness sees).
-///
-/// The returned `Vec<u8>` is the raw byte stream a real stdout sink would
-/// have produced. Callers choose `assert_eq!` or a line-multiset comparison
-/// depending on whether order is deterministic for their scenario.
-///
-/// # Panics
-///
-/// Panics if `prepare_entries` fails, if a runner thread panics, or if a
-/// runner returns an error. For parity tests these are all bugs, not
-/// legitimate test outcomes.
-///
-/// # Determinism
-///
-/// All seeds, jitter seeds, and `seed:` fields must be pinned by the
-/// caller's configuration. The harness does not inject any randomness.
-/// Multi-entry output order is **not** deterministic — concurrent threads
-/// interleave writes at byte granularity. For multi-signal parity tests,
-/// compare via [`assert_line_multisets_equal`].
-///
-/// # Shutdown caveat
-///
-/// Unlike production
-/// [`launch_scenario`][sonda_core::schedule::launch::launch_scenario]
-/// — which polls a shared `Arc<AtomicBool>` every 50 ms during the
-/// `start_delay` window so an external stop signal can short-circuit the
-/// pre-roll — this harness only sleeps until the deadline elapses. It
-/// does **not** honor a shutdown signal during `start_delay`, and the
-/// runner threads are driven with `shutdown: None` thereafter. Every
-/// current call site is bounded by the scenario's own `duration:` field
-/// and never needs cancellation, so this is safe today; future callers
-/// that need cooperative cancellation must extend the harness rather
-/// than rely on it.
+/// Run every entry in `entries` to completion against an in-memory sink and
+/// return the concatenated stdout-equivalent bytes. Each entry must declare a
+/// `duration:` — the harness does not honor an external cancel signal.
 pub fn run_and_capture_stdout(entries: Vec<ScenarioEntry>) -> Vec<u8> {
     let prepared =
         prepare_entries(entries).expect("run_and_capture_stdout: prepare_entries must succeed");
@@ -342,40 +297,26 @@ pub fn normalize_timestamps(bytes: &[u8]) -> Vec<u8> {
     out
 }
 
-/// Dispatch a single `ScenarioEntry` to the runner matching its variant.
-///
-/// The runner is driven with `shutdown: None` (the scenario's own
-/// `duration:` field bounds the run) and `stats: None` (parity tests do
-/// not inspect stats). The async runner is driven from a per-call
-/// `current_thread` Tokio runtime so callers stay sync.
+/// Dispatch a single `ScenarioEntry` to the matching runner.
 fn run_entry_with_sink(entry: &ScenarioEntry, sink: &mut Box<dyn Sink>) -> Result<(), SondaError> {
-    const NONE_ATOMIC: Option<&AtomicBool> = None;
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .expect("tokio runtime for test runner must build");
+    let cancel = CancellationToken::new();
     match entry {
         ScenarioEntry::Metrics(config) => {
-            rt.block_on(runner::run_with_sink(config, sink, NONE_ATOMIC, None))
+            rt.block_on(runner::run_with_sink(config, sink, &cancel, None))
         }
-        ScenarioEntry::Logs(config) => rt.block_on(log_runner::run_logs_with_sink(
-            config,
-            sink,
-            NONE_ATOMIC,
-            None,
-        )),
-        ScenarioEntry::Histogram(config) => rt.block_on(histogram_runner::run_with_sink(
-            config,
-            sink,
-            NONE_ATOMIC,
-            None,
-        )),
-        ScenarioEntry::Summary(config) => rt.block_on(summary_runner::run_with_sink(
-            config,
-            sink,
-            NONE_ATOMIC,
-            None,
-        )),
+        ScenarioEntry::Logs(config) => {
+            rt.block_on(log_runner::run_logs_with_sink(config, sink, &cancel, None))
+        }
+        ScenarioEntry::Histogram(config) => {
+            rt.block_on(histogram_runner::run_with_sink(config, sink, &cancel, None))
+        }
+        ScenarioEntry::Summary(config) => {
+            rt.block_on(summary_runner::run_with_sink(config, sink, &cancel, None))
+        }
         // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary
         // (integration tests are a separate crate), so a wildcard arm is
         // required. A future signal variant has no runner wired in here yet.

--- a/sonda-core/tests/sink_error_policy.rs
+++ b/sonda-core/tests/sink_error_policy.rs
@@ -13,6 +13,8 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+
+use sonda_core::CancellationToken;
 use std::thread;
 use std::time::Duration;
 
@@ -124,15 +126,10 @@ async fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
         OnSinkError::Warn,
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handle = launch_scenario(
-        "warn-persistent".to_string(),
-        entry,
-        Arc::clone(&shutdown),
-        None,
-    )
-    .await
-    .expect("launch must succeed");
+    let cancel = CancellationToken::new();
+    let mut handle = launch_scenario("warn-persistent".to_string(), entry, cancel.clone(), None)
+        .await
+        .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(800));
     let snap_mid = handle.stats_snapshot();
@@ -189,15 +186,10 @@ async fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
         OnSinkError::Warn,
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handle = launch_scenario(
-        "warn-dead-url".to_string(),
-        entry,
-        Arc::clone(&shutdown),
-        None,
-    )
-    .await
-    .expect("launch must succeed");
+    let cancel = CancellationToken::new();
+    let mut handle = launch_scenario("warn-dead-url".to_string(), entry, cancel.clone(), None)
+        .await
+        .expect("launch must succeed");
 
     handle.join(Some(Duration::from_secs(3))).expect("join Ok");
 
@@ -239,15 +231,10 @@ async fn fail_policy_exits_thread_with_sink_error() {
         OnSinkError::Fail,
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handle = launch_scenario(
-        "fail-propagates".to_string(),
-        entry,
-        Arc::clone(&shutdown),
-        None,
-    )
-    .await
-    .expect("launch must succeed");
+    let cancel = CancellationToken::new();
+    let mut handle = launch_scenario("fail-propagates".to_string(), entry, cancel.clone(), None)
+        .await
+        .expect("launch must succeed");
 
     let join_result = handle.join(Some(Duration::from_secs(5)));
 

--- a/sonda-core/tests/start_time_shift.rs
+++ b/sonda-core/tests/start_time_shift.rs
@@ -3,8 +3,9 @@
 
 #![cfg(feature = "config")]
 
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, RwLock};
+
+use sonda_core::CancellationToken;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -111,7 +112,7 @@ async fn metric_absolute_past_start_time_anchors_first_event_at_exact_instant() 
     let config = metric_config("up", 5.0, "1s", Some("2026-05-08T14:00:00Z"));
 
     let (mut sink, buf) = probe_sink();
-    runner::run_with_sink(&config, &mut sink, None, None)
+    runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
 
@@ -167,7 +168,7 @@ async fn metric_relative_future_offset_shifts_events_ahead() {
     let config = metric_config("up", 10.0, "400ms", Some("+24h"));
 
     let (mut sink, buf) = probe_sink();
-    runner::run_with_sink(&config, &mut sink, None, None)
+    runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
     let after = now_ms();
@@ -194,7 +195,7 @@ async fn metric_relative_past_offset_shifts_events_back() {
     let config = metric_config("up", 10.0, "400ms", Some("-7d"));
 
     let (mut sink, buf) = probe_sink();
-    runner::run_with_sink(&config, &mut sink, None, None)
+    runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
     let after = now_ms();
@@ -226,7 +227,7 @@ async fn metric_without_start_time_emits_at_real_now() {
     let config = metric_config("up", 10.0, "400ms", None);
 
     let (mut sink, buf) = probe_sink();
-    runner::run_with_sink(&config, &mut sink, None, None)
+    runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
     let after = now_ms();
@@ -264,7 +265,7 @@ fn assert_all_in_past_window(timestamps: &[i128]) {
 async fn metric_signal_honours_absolute_past_shift() {
     let config = metric_config("up", 5.0, "600ms", Some(ANCHOR_RFC3339));
     let (mut sink, buf) = probe_sink();
-    runner::run_with_sink(&config, &mut sink, None, None)
+    runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
     let captured = buf.lock().unwrap();
@@ -287,7 +288,7 @@ async fn log_signal_honours_absolute_past_shift() {
     };
 
     let (mut sink, buf) = probe_sink();
-    log_runner::run_logs_with_sink(&config, &mut sink, None, None)
+    log_runner::run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
 
@@ -323,7 +324,7 @@ async fn histogram_signal_honours_absolute_past_shift() {
     };
 
     let (mut sink, buf) = probe_sink();
-    histogram_runner::run_with_sink(&config, &mut sink, None, None)
+    histogram_runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
     let captured = buf.lock().unwrap();
@@ -348,7 +349,7 @@ async fn summary_signal_honours_absolute_past_shift() {
     };
 
     let (mut sink, buf) = probe_sink();
-    summary_runner::run_with_sink(&config, &mut sink, None, None)
+    summary_runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
     let captured = buf.lock().unwrap();
@@ -385,7 +386,7 @@ fn gated_close_emit_marker_lands_in_shifted_window() {
 
     let runner_handle = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink = sink_init;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -394,7 +395,7 @@ fn gated_close_emit_marker_lands_in_shifted_window() {
         rt.block_on(runner::run_with_sink_gated(
             &config,
             &mut sink,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -15,8 +15,9 @@
 
 mod common;
 
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
+
+use sonda_core::CancellationToken;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -120,7 +121,7 @@ fn run_with_capture(
     // close the gate at the right moment.
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let gate_ctx = GateContext::new(rx, init)
             .with_delay(delay)
             .with_has_while(true);
@@ -132,7 +133,7 @@ fn run_with_capture(
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_runner),
             None,
             Some(gate_ctx),
@@ -338,7 +339,7 @@ fn non_remote_write_sink_no_close_marker_by_default() {
     let stats_for_thread = Arc::clone(&stats);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -347,7 +348,7 @@ fn non_remote_write_sink_no_close_marker_by_default() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -433,7 +434,7 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
     let stats_for_thread = Arc::clone(&stats);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -442,7 +443,7 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(
@@ -535,7 +536,7 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink_handle = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -544,7 +545,7 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(
@@ -639,7 +640,7 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink_handle = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -648,7 +649,7 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -726,7 +727,7 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -735,7 +736,7 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(
@@ -824,7 +825,7 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink_handle = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -833,7 +834,7 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(
@@ -921,7 +922,7 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink_handle = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -930,7 +931,7 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -1008,7 +1009,7 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink_handle = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -1017,7 +1018,7 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(
@@ -1074,7 +1075,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
 
     let config = ScenarioConfig {
         base: BaseScheduleConfig {
@@ -1108,7 +1109,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
 
     let stats_for_thread = Arc::clone(&stats);
     let bus_for_thread = Arc::clone(&bus);
-    let shutdown_for_thread = Arc::clone(&shutdown);
+    let cancel_for_thread = cancel.clone();
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let mut sink_handle = sink_for_thread;
@@ -1119,7 +1120,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown_for_thread.as_ref()),
+            &cancel_for_thread,
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -1128,7 +1129,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
     });
 
     thread::sleep(Duration::from_millis(150));
-    shutdown.store(false, std::sync::atomic::Ordering::SeqCst);
+    cancel.cancel();
     runner.join().expect("runner joined");
 
     let buf = capture.buf.lock().unwrap().clone();

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -8,7 +8,6 @@
 
 mod common;
 
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -22,6 +21,7 @@ use sonda_core::schedule::launch::launch_scenario_with_gates;
 use sonda_core::schedule::stats::ScenarioState;
 use sonda_core::schedule::GateContext;
 use sonda_core::sink::SinkConfig;
+use sonda_core::CancellationToken;
 
 fn metrics_entry(name: &str, rate: f64, duration_ms: u64) -> ScenarioEntry {
     ScenarioEntry::Metrics(ScenarioConfig {
@@ -101,7 +101,7 @@ async fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let gate_ctx = GateContext::new(rx, init).with_has_while(true);
 
     let entry = metrics_entry("downstream", 200.0, 600);
@@ -109,7 +109,7 @@ async fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
         "downstream".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(gate_ctx),
@@ -153,13 +153,13 @@ async fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subsc
     let (rx, init) = bus.subscribe(while_gt_zero());
     assert_eq!(init.while_gate_open, Some(true));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("d1", 100.0, 300);
     let mut handle = launch_scenario_with_gates(
         "d1".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -190,13 +190,13 @@ async fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
     let (rx, init) = bus.subscribe(while_gt_zero());
     assert_eq!(init.while_gate_open, Some(false));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("d2", 100.0, 300);
     let mut handle = launch_scenario_with_gates(
         "d2".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -222,13 +222,13 @@ async fn while_runtime_no_catch_up_burst_on_resume() {
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("d3", 100.0, 1500);
     let mut handle = launch_scenario_with_gates(
         "d3".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -309,7 +309,7 @@ async fn while_runtime_sequence_generator_preserves_position_across_pause() {
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let values = vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0];
     let entry = metrics_entry_with_generator(
         "seq_gated",
@@ -324,7 +324,7 @@ async fn while_runtime_sequence_generator_preserves_position_across_pause() {
         "seq_gated".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -379,7 +379,7 @@ async fn while_runtime_ramp_generator_slope_preserved_across_pause() {
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     // Sawtooth (saturation desugars to this): 0 → 100 over 4s at 50/s.
     let entry = metrics_entry_with_generator(
         "sat_gated",
@@ -395,7 +395,7 @@ async fn while_runtime_ramp_generator_slope_preserved_across_pause() {
         "sat_gated".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -448,13 +448,13 @@ async fn while_runtime_finished_state_after_duration_expires() {
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("d4", 50.0, 200);
     let mut handle = launch_scenario_with_gates(
         "d4".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -480,13 +480,13 @@ async fn while_runtime_multiple_downstreams_share_one_upstream() {
     let (rx_a, init_a) = bus.subscribe(while_gt_zero());
     let (rx_b, init_b) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
 
     let mut handle_a = launch_scenario_with_gates(
         "a".to_string(),
         None,
         metrics_entry("a", 100.0, 500),
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx_a, init_a).with_has_while(true)),
@@ -499,7 +499,7 @@ async fn while_runtime_multiple_downstreams_share_one_upstream() {
         "b".to_string(),
         None,
         metrics_entry("b", 100.0, 500),
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx_b, init_b).with_has_while(true)),
@@ -533,13 +533,13 @@ async fn while_runtime_logs_signal_can_be_gated_downstream() {
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = logs_entry("bgp_log", 200.0, 600);
     let mut handle = launch_scenario_with_gates(
         "bgp_log".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -590,13 +590,13 @@ async fn while_runtime_delay_open_debounces_pause_to_running_transition() {
         close_snap_to: None,
     };
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("debounced", 200.0, 1500);
     let mut handle = launch_scenario_with_gates(
         "debounced".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -649,13 +649,13 @@ async fn while_runtime_strict_lt_threshold_gating() {
     let (rx, init) = bus.subscribe(spec);
     assert_eq!(init.while_gate_open, Some(false));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("inv", 100.0, 500);
     let mut handle = launch_scenario_with_gates(
         "inv".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -685,13 +685,13 @@ async fn scenario_restart_does_not_leak_gate_bus() {
 
     for i in 0..20 {
         let (rx, init) = bus.subscribe(while_gt_zero());
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry(&format!("ephemeral_{i}"), 50.0, 80);
         let mut handle = launch_scenario_with_gates(
             format!("ephemeral_{i}"),
             None,
             entry,
-            shutdown,
+            cancel,
             None,
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -730,13 +730,13 @@ async fn while_runtime_delay_close_debounces_running_to_paused_transition() {
         close_snap_to: None,
     };
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("debounced_close", 200.0, 2000);
     let mut handle = launch_scenario_with_gates(
         "debounced_close".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -807,13 +807,13 @@ async fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
         "gate must be closed at value=1"
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("after_open", 100.0, 1000);
     let mut handle = launch_scenario_with_gates(
         "after_open".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -878,13 +878,13 @@ async fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
     assert!(!init.after_already_fired);
     assert_eq!(init.while_gate_open, Some(true));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("after_paused", 100.0, 1500);
     let mut handle = launch_scenario_with_gates(
         "after_paused".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -960,13 +960,13 @@ async fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
     assert!(!init.after_already_fired);
     assert_eq!(init.while_gate_open, Some(false));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("absorb", 100.0, 2000);
     let mut handle = launch_scenario_with_gates(
         "absorb".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -1038,13 +1038,13 @@ async fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() 
     assert!(!init.after_already_fired);
     assert_eq!(init.while_gate_open, Some(true));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("pending_upstream_gone", 100.0, 5000);
     let mut handle = launch_scenario_with_gates(
         "pending_upstream_gone".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -1098,12 +1098,12 @@ async fn while_runtime_steady_within_5pct_of_baseline() {
     // without `while:`. Both runs are short (300ms) to keep the test fast.
     async fn run_baseline() -> u64 {
         let entry = metrics_entry("baseline", 1000.0, 300);
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut handle = launch_scenario_with_gates(
             "baseline".to_string(),
             None,
             entry,
-            shutdown,
+            cancel,
             None,
             None,
             None,
@@ -1120,12 +1120,12 @@ async fn while_runtime_steady_within_5pct_of_baseline() {
         bus.tick(1.0);
         let (rx, init) = bus.subscribe(while_gt_zero());
         let entry = metrics_entry("gated", 1000.0, 300);
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut handle = launch_scenario_with_gates(
             "gated".to_string(),
             None,
             entry,
-            shutdown,
+            cancel,
             None,
             Some(Arc::clone(&bus)),
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -1262,13 +1262,13 @@ async fn nan_upstream_value_keeps_downstream_paused() {
         "NaN upstream must close the gate at subscription"
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("nan_paused", 200.0, 600);
     let mut handle = launch_scenario_with_gates(
         "nan_paused".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),

--- a/sonda-server/Cargo.toml
+++ b/sonda-server/Cargo.toml
@@ -27,6 +27,7 @@ path = "src/main.rs"
 sonda-core = { workspace = true }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }

--- a/sonda-server/src/gate_registry.rs
+++ b/sonda-server/src/gate_registry.rs
@@ -9,6 +9,7 @@ use sonda_core::schedule::gate_bus::{
     RegistryError, WhileSpec,
 };
 use sonda_core::schedule::stats::ScenarioStats;
+use sonda_core::ScenarioState;
 use sonda_core::UnresolvedBehavior;
 
 type BusKey = (String, String);
@@ -150,6 +151,23 @@ impl GateBusResolver for GateBusRegistry {
         let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
         let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
 
+        let stale_pending: Vec<String> = pending
+            .iter()
+            .filter(|(_, entry)| entry.scenario_name == scenario_name)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for handle_id in stale_pending {
+            let entry = pending.remove(&handle_id).expect("just snapshotted");
+            entry.edge_sender.send_replace(Some(GateEdge::UpstreamGone));
+            if let Some(stats_arc) = entry.stats.upgrade() {
+                if let Ok(mut s) = stats_arc.write() {
+                    if s.state != ScenarioState::Finished {
+                        s.transition_state(ScenarioState::Unresolved);
+                    }
+                }
+            }
+        }
+
         for key in removed_keys {
             let Some(refs) = subs.remove(&key) else {
                 continue;
@@ -224,6 +242,36 @@ impl GateBusResolver for GateBusRegistry {
         let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
         let (key, sub) = SubscriberRef::from_pending(pending);
         subs.entry(key).or_default().push(sub);
+    }
+
+    fn cancel_pending_for_upstream(
+        &self,
+        scenario_name: &str,
+        entry_id: &str,
+    ) -> Vec<RegistryError> {
+        let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
+        let matching: Vec<String> = pending
+            .iter()
+            .filter(|(_, p)| p.scenario_name == scenario_name && p.entry_id == entry_id)
+            .map(|(k, _)| k.clone())
+            .collect();
+        let mut errors = Vec::with_capacity(matching.len());
+        for handle_id in matching {
+            let entry = pending.remove(&handle_id).expect("just snapshotted");
+            entry.edge_sender.send_replace(Some(GateEdge::UpstreamGone));
+            if let Some(stats_arc) = entry.stats.upgrade() {
+                if let Ok(mut s) = stats_arc.write() {
+                    if s.state != ScenarioState::Finished {
+                        s.transition_state(ScenarioState::Unresolved);
+                    }
+                }
+            }
+            errors.push(RegistryError::UpstreamCancelled {
+                scenario_name: entry.scenario_name,
+                entry_id: entry.entry_id,
+            });
+        }
+        errors
     }
 }
 
@@ -431,6 +479,111 @@ mod tests {
             "no edge should be delivered for a dead-weak subscriber"
         );
         assert!(reg.pending_for_handle("h-dead").is_none());
+    }
+
+    #[test]
+    fn downstream_resolves_with_upstream_cancelled_error_when_upstream_cancels() {
+        let reg = GateBusRegistry::new();
+        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
+        let (alive, weak) = live_stats();
+        reg.insert_pending(make_pending(
+            "h-pending",
+            "post-upstream",
+            "metric_a",
+            weak,
+            tx,
+        ));
+        assert!(
+            reg.pending_for_handle("h-pending").is_some(),
+            "pending entry must be present before cancellation"
+        );
+
+        let errors = reg.cancel_pending_for_upstream("post-upstream", "metric_a");
+
+        assert_eq!(
+            errors.len(),
+            1,
+            "exactly one error must be returned for the cancelled pending entry"
+        );
+        assert!(
+            matches!(
+                &errors[0],
+                RegistryError::UpstreamCancelled { scenario_name, entry_id }
+                if scenario_name == "post-upstream" && entry_id == "metric_a"
+            ),
+            "error must be UpstreamCancelled for the matching upstream, got: {:?}",
+            errors[0]
+        );
+        assert!(
+            reg.pending_for_handle("h-pending").is_none(),
+            "pending entry must be removed after cancellation"
+        );
+        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
+            .expect("waiter must receive UpstreamGone within 200ms");
+        assert_eq!(edge, GateEdge::UpstreamGone);
+        drop(alive);
+    }
+
+    #[test]
+    fn cancel_pending_for_upstream_only_affects_matching_upstream() {
+        let reg = GateBusRegistry::new();
+        let (tx_a, mut rx_a) = watch::channel::<Option<GateEdge>>(None);
+        let (tx_b, mut rx_b) = watch::channel::<Option<GateEdge>>(None);
+        let (alive_a, weak_a) = live_stats();
+        let (alive_b, weak_b) = live_stats();
+        reg.insert_pending(make_pending(
+            "h-a",
+            "post-upstream",
+            "metric_a",
+            weak_a,
+            tx_a,
+        ));
+        reg.insert_pending(make_pending("h-b", "post-other", "metric_b", weak_b, tx_b));
+
+        let errors = reg.cancel_pending_for_upstream("post-upstream", "metric_a");
+        assert_eq!(errors.len(), 1);
+        assert!(
+            reg.pending_for_handle("h-a").is_none(),
+            "matching pending must be removed"
+        );
+        assert!(
+            reg.pending_for_handle("h-b").is_some(),
+            "non-matching pending must remain"
+        );
+        assert_eq!(
+            watch_recv_timeout(&mut rx_a, Duration::from_millis(200)),
+            Ok(GateEdge::UpstreamGone),
+            "matching waiter must receive UpstreamGone"
+        );
+        assert!(
+            watch_recv_timeout(&mut rx_b, Duration::from_millis(50)).is_err(),
+            "non-matching waiter must not receive any edge"
+        );
+        drop(alive_a);
+        drop(alive_b);
+    }
+
+    #[test]
+    fn unregister_signals_pending_downstreams_waiting_on_that_upstream() {
+        let reg = GateBusRegistry::new();
+        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
+        let (alive, weak) = live_stats();
+        reg.insert_pending(make_pending("h-pending", "nope", "entry-x", weak, tx));
+        assert!(
+            reg.pending_for_handle("h-pending").is_some(),
+            "pending entry must be present before unregister"
+        );
+
+        reg.unregister("nope");
+
+        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
+            .expect("waiter must receive UpstreamGone within 200ms");
+        assert_eq!(edge, GateEdge::UpstreamGone);
+        assert!(
+            reg.pending_for_handle("h-pending").is_none(),
+            "pending entry must be removed after unregister"
+        );
+        drop(alive);
     }
 
     #[test]

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -231,13 +231,17 @@ async fn shutdown_signal(state: AppState, #[cfg(unix)] mut sigterm: tokio::signa
         }
     }
 
-    // Write lock: join() consumes the inner JoinHandle.
+    // Write lock: join consumes the inner JoinHandle.
+    let mut ids_handles: Vec<(String, sonda_core::ScenarioHandle)> = Vec::new();
     if let Ok(mut scenarios) = state.scenarios.write() {
-        for (id, handle) in scenarios.iter_mut() {
-            match handle.join(Some(Duration::from_secs(5))) {
-                Ok(_) => info!(scenario = %id, "scenario thread joined"),
-                Err(e) => warn!(scenario = %id, error = %e, "scenario thread join failed"),
-            }
+        for (id, handle) in scenarios.drain() {
+            ids_handles.push((id, handle));
+        }
+    }
+    for (id, mut handle) in ids_handles {
+        match handle.join_async(Some(Duration::from_secs(5))).await {
+            Ok(_) => info!(scenario = %id, "scenario task joined"),
+            Err(e) => warn!(scenario = %id, error = %e, "scenario task join failed"),
         }
     }
 }

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -751,49 +751,34 @@ pub async fn delete_scenario(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, Response> {
-    // Acquire a write lock so we can mutate the handle (join requires &mut self).
-    let mut scenarios = state
-        .scenarios
-        .write()
-        .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
+    let (mut handle, scenario_name_to_unregister) = {
+        let mut scenarios = state
+            .scenarios
+            .write()
+            .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
+        let handle = scenarios
+            .remove(&id)
+            .ok_or_else(|| not_found(format!("scenario not found: {id}")))?;
+        handle
+            .cleaned_up
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let scenario_name_to_unregister = handle.scenario_name.clone();
+        handle.stop();
+        (handle, scenario_name_to_unregister)
+    };
 
-    let handle = scenarios
-        .get_mut(&id)
-        .ok_or_else(|| not_found(format!("scenario not found: {id}")))?;
-
-    // Pre-mark so the StateGuard skips its own unregister; Phase 1 owns it.
-    handle
-        .cleaned_up
-        .store(true, std::sync::atomic::Ordering::SeqCst);
-    let scenario_name_to_unregister = handle.scenario_name.clone();
-
-    // Signal the scenario to stop (idempotent — safe to call on already-stopped).
-    handle.stop();
-
-    // Wait for the thread to exit, with a 5-second timeout.
-    let was_running_before_join = handle.is_running();
-    if let Err(e) = handle.join(Some(Duration::from_secs(5))) {
-        warn!(id = %id, error = %e, "DELETE /scenarios/{id}: scenario thread returned an error");
+    if let Err(e) = handle.join_async(Some(Duration::from_secs(5))).await {
+        warn!(id = %id, error = %e, "DELETE /scenarios/{id}: scenario task returned an error");
     }
 
-    // Determine the final status based on whether the thread exited in time.
     let status = if handle.is_running() {
         warn!(id = %id, "DELETE /scenarios/{id}: join timed out after 5s, scenario force-stopped");
         "force_stopped".to_string()
-    } else if was_running_before_join {
-        "stopped".to_string()
     } else {
-        // Thread had already exited before DELETE was called.
         "stopped".to_string()
     };
 
-    // Read final stats before responding.
     let final_stats = handle.stats_snapshot();
-
-    // Remove the handle from the map to free resources (fixes memory leak).
-    scenarios.remove(&id);
-    // Lock order: scenarios then registry.
-    drop(scenarios);
 
     if let Some(name) = scenario_name_to_unregister {
         state.gate_bus_registry.unregister(&name);
@@ -1140,8 +1125,7 @@ mod tests {
     use axum::body::Body;
     use http_body_util::BodyExt;
     use hyper::{Request, StatusCode};
-    use sonda_core::ScenarioHandle;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use sonda_core::{CancellationToken, ScenarioHandle};
     use std::sync::{Arc, RwLock};
     use std::thread;
     use std::time::{Duration, Instant};
@@ -1149,39 +1133,33 @@ mod tests {
 
     // ---- Helpers ---------------------------------------------------------------
 
-    /// Build a ScenarioHandle with a background thread that increments stats.
-    ///
-    /// The thread emits `event_count` events at `interval` apart, incrementing
-    /// total_events and bytes_emitted on each tick.
+    /// Build a ScenarioHandle with a background task that increments stats.
     fn make_handle(id: &str, name: &str, event_count: u64, interval: Duration) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel_clone = cancel.clone();
         let stats_clone = Arc::clone(&stats);
 
-        let thread = thread::Builder::new()
-            .name(format!("test-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                for _ in 0..event_count {
-                    if !shutdown_clone.load(Ordering::SeqCst) {
-                        break;
-                    }
-                    thread::sleep(interval);
-                    if let Ok(mut st) = stats_clone.write() {
-                        st.total_events += 1;
-                        st.bytes_emitted += 64;
-                    }
+        let task = tokio::task::spawn(async move {
+            for _ in 0..event_count {
+                if cancel_clone.is_cancelled() {
+                    break;
                 }
-                Ok(())
-            })
-            .expect("thread must spawn");
+                tokio::time::sleep(interval).await;
+                if let Ok(mut st) = stats_clone.write() {
+                    st.total_events += 1;
+                    st.bytes_emitted += 64;
+                }
+            }
+            Ok::<_, sonda_core::SondaError>(())
+        });
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             100.0,
@@ -1195,30 +1173,22 @@ mod tests {
         )
     }
 
-    /// Build a ScenarioHandle that has already finished (thread exits immediately).
+    /// Build a ScenarioHandle whose task exits immediately.
     fn make_stopped_handle(id: &str, name: &str) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
+        cancel.cancel();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-        let shutdown_clone = Arc::clone(&shutdown);
 
-        let thread = thread::Builder::new()
-            .name(format!("test-stopped-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                // Check shutdown immediately and exit.
-                let _ = shutdown_clone.load(Ordering::SeqCst);
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async { Ok::<_, sonda_core::SondaError>(()) });
 
-        // Give thread time to finish.
         thread::sleep(Duration::from_millis(50));
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             100.0,
@@ -1643,7 +1613,7 @@ scenarios:
     // ---- GET /scenarios/{id}: stats.total_events > 0 after running ------------
 
     /// After running for a short time, stats.total_events > 0.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_stats_total_events_positive_after_running() {
         // Thread emits events every 10ms. After 200ms we should have ~20 events.
         let h = make_handle("id-events", "events_check", 500, Duration::from_millis(10));
@@ -2660,7 +2630,7 @@ scenarios:
     // ---- DELETE returns final stats (total_events) -------------------------
 
     /// DELETE returns total_events reflecting events emitted before stop.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_returns_final_stats_with_total_events() {
         // Thread emits events every 10ms. Wait 200ms so some events accumulate.
         let h = make_handle("id-del-stats", "del_stats", 1000, Duration::from_millis(10));
@@ -3019,34 +2989,19 @@ scenarios:
         initial_stats: ScenarioStats,
         running: bool,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(running));
+        let cancel = CancellationToken::new();
+        if !running {
+            cancel.cancel();
+        }
         let stats = Arc::new(RwLock::new(initial_stats));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel_clone = cancel.clone();
 
-        let thread = if running {
-            // Long-running thread that waits for shutdown.
-            thread::Builder::new()
-                .name(format!("test-stats-{name}"))
-                .spawn(move || -> Result<(), sonda_core::SondaError> {
-                    while shutdown_clone.load(Ordering::SeqCst) {
-                        thread::sleep(Duration::from_millis(10));
-                    }
-                    Ok(())
-                })
-                .expect("thread must spawn")
-        } else {
-            // Thread exits immediately.
-            thread::Builder::new()
-                .name(format!("test-stats-stopped-{name}"))
-                .spawn(move || -> Result<(), sonda_core::SondaError> {
-                    let _ = shutdown_clone.load(Ordering::SeqCst);
-                    Ok(())
-                })
-                .expect("thread must spawn")
-        };
+        let task = tokio::task::spawn(async move {
+            cancel_clone.cancelled().await;
+            Ok::<_, sonda_core::SondaError>(())
+        });
 
         if !running {
-            // Give the thread time to exit.
             thread::sleep(Duration::from_millis(50));
         }
 
@@ -3054,8 +3009,8 @@ scenarios:
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             target_rate,
@@ -3179,7 +3134,7 @@ scenarios:
     // ---- Fields update as scenario progresses --------------------------------
 
     /// Stats fields update as the scenario background thread emits events.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_fields_update_as_scenario_progresses() {
         // Thread emits events every 10ms.
         let h = make_handle(
@@ -3485,36 +3440,31 @@ scenarios:
         .expect("test metric name must be valid")
     }
 
-    /// Helper: build a ScenarioHandle with pre-populated metric events in the buffer.
+    /// Build a ScenarioHandle with pre-populated metric events in the buffer.
     fn make_handle_with_metrics(
         id: &str,
         name: &str,
         events: Vec<sonda_core::model::metric::MetricEvent>,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut stats = ScenarioStats::default();
         for event in events {
             stats.push_metric(event);
         }
         let stats = Arc::new(RwLock::new(stats));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel_clone = cancel.clone();
 
-        let thread = thread::Builder::new()
-            .name(format!("test-metrics-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                while shutdown_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async move {
+            cancel_clone.cancelled().await;
+            Ok::<_, sonda_core::SondaError>(())
+        });
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -3766,23 +3716,18 @@ scenarios:
         labels: Vec<(&str, &str)>,
         events: Vec<sonda_core::model::metric::MetricEvent>,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut stats = ScenarioStats::default();
         for event in events {
             stats.push_metric(event);
         }
         let stats = Arc::new(RwLock::new(stats));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel_clone = cancel.clone();
 
-        let thread = thread::Builder::new()
-            .name(format!("test-agg-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                while shutdown_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async move {
+            cancel_clone.cancelled().await;
+            Ok::<_, sonda_core::SondaError>(())
+        });
 
         let mut label_map = std::collections::HashMap::new();
         for (k, v) in labels {
@@ -3793,8 +3738,8 @@ scenarios:
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -4324,28 +4269,22 @@ scenarios:
 
     // ---- Helper: build a handle whose thread ignores the shutdown flag ------
 
-    /// Build a ScenarioHandle whose thread sleeps for a long time, ignoring
-    /// the shutdown flag. This simulates a scenario that cannot be stopped
-    /// gracefully within the join timeout.
+    /// Build a ScenarioHandle whose task sleeps for a long time, ignoring cancel.
     fn make_unjoinable_handle(id: &str, name: &str) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        let thread = thread::Builder::new()
-            .name(format!("test-unjoinable-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                // Ignore shutdown — sleep for a very long time.
-                thread::sleep(Duration::from_secs(300));
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async {
+            tokio::time::sleep(Duration::from_secs(300)).await;
+            Ok::<_, sonda_core::SondaError>(())
+        });
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             50.0,
@@ -4359,27 +4298,25 @@ scenarios:
         )
     }
 
-    /// Build a ScenarioHandle whose thread panics immediately.
+    /// Build a ScenarioHandle whose task panics immediately.
     fn make_panicking_handle(id: &str, name: &str) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        let thread = thread::Builder::new()
-            .name(format!("test-panic-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                panic!("intentional panic for testing");
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async {
+            panic!("intentional panic for testing");
+            #[allow(unreachable_code)]
+            Ok::<_, sonda_core::SondaError>(())
+        });
 
-        // Give the thread time to panic.
         thread::sleep(Duration::from_millis(50));
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -5278,28 +5215,23 @@ scenarios:
         meta: Option<sonda_core::PromMeta>,
         events: Vec<sonda_core::model::metric::MetricEvent>,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut stats = ScenarioStats::default();
         for event in events {
             stats.push_metric(event);
         }
         let stats = Arc::new(RwLock::new(stats));
-        let shutdown_clone = Arc::clone(&shutdown);
-        let thread = thread::Builder::new()
-            .name(format!("test-meta-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                while shutdown_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let cancel_clone = cancel.clone();
+        let task = tokio::task::spawn(async move {
+            cancel_clone.cancelled().await;
+            Ok::<_, sonda_core::SondaError>(())
+        });
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -5401,22 +5333,17 @@ scenarios:
         labels: Vec<(&str, &str)>,
         events: Vec<sonda_core::model::metric::MetricEvent>,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut stats = ScenarioStats::default();
         for event in events {
             stats.push_metric(event);
         }
         let stats = Arc::new(RwLock::new(stats));
-        let shutdown_clone = Arc::clone(&shutdown);
-        let thread = thread::Builder::new()
-            .name(format!("test-agg-meta-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                while shutdown_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let cancel_clone = cancel.clone();
+        let task = tokio::task::spawn(async move {
+            cancel_clone.cancelled().await;
+            Ok::<_, sonda_core::SondaError>(())
+        });
         let mut label_map = std::collections::HashMap::new();
         for (k, v) in labels {
             label_map.insert(k.to_string(), v.to_string());
@@ -5425,8 +5352,8 @@ scenarios:
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -5859,7 +5786,7 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn t18_get_scenario_for_unresolved_returns_pending_ref() {
         let (_, state) = test_router();
         let resp = post_with_query(
@@ -5909,7 +5836,7 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn t19_stats_endpoint_has_current_state_secs_and_cumulative_attempts() {
         let (_, state) = test_router();
         let resp = post_with_query(

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = { workspace = true }
 dialoguer = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio-util = { version = "0.7", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -10,13 +10,13 @@ mod sink_format;
 mod status;
 
 use std::process;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
 use clap::Parser;
 use owo_colors::OwoColorize;
 use owo_colors::Stream::Stderr;
+use sonda_core::CancellationToken;
 
 use cli::{Cli, Commands, Verbosity};
 use sonda_core::PreparedEntry;
@@ -43,11 +43,11 @@ fn run() -> anyhow::Result<()> {
         )
         .init();
 
-    let running = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     {
-        let r = Arc::clone(&running);
+        let c = cancel.clone();
         ctrlc::set_handler(move || {
-            r.store(false, Ordering::SeqCst);
+            c.cancel();
         })
         .expect("failed to register Ctrl+C handler");
     }
@@ -61,7 +61,7 @@ fn run() -> anyhow::Result<()> {
         .build()?;
 
     match cli.command {
-        Commands::Run(ref args) => run_scenario(&rt, args, &cli, catalog, verbosity, &running)?,
+        Commands::Run(ref args) => run_scenario(&rt, args, &cli, catalog, verbosity, &cancel)?,
         Commands::List(ref args) => list_catalog(args, catalog)?,
         Commands::Show(ref args) => show_entry(args, catalog)?,
         Commands::New(ref args) => new::run(args)?,
@@ -76,7 +76,7 @@ fn run_scenario(
     cli_opts: &Cli,
     catalog: Option<&std::path::Path>,
     verbosity: Verbosity,
-    running: &Arc<AtomicBool>,
+    cancel: &CancellationToken,
 ) -> anyhow::Result<()> {
     let mut compiled = scenario_loader::load_scenario_compiled(&args.scenario, catalog)?;
     config::apply_run_overrides_compiled(&mut compiled, args)?;
@@ -92,7 +92,7 @@ fn run_scenario(
         if verbosity == Verbosity::Verbose {
             status::print_version();
         }
-        run_compiled_with_progress(rt, compiled, running, verbosity)?;
+        run_compiled_with_progress(rt, compiled, cancel, verbosity)?;
         return Ok(());
     }
 
@@ -106,9 +106,9 @@ fn run_scenario(
 
     if prepared.len() == 1 {
         let p = prepared.into_iter().next().expect("len checked above");
-        run_single_scenario(rt, "cli-run".to_string(), p, running, verbosity)?;
+        run_single_scenario(rt, "cli-run".to_string(), p, cancel, verbosity)?;
     } else {
-        launch_and_join_prepared(rt, "cli-run", prepared, running, verbosity)?;
+        launch_and_join_prepared(rt, "cli-run", prepared, cancel, verbosity)?;
     }
     Ok(())
 }
@@ -204,7 +204,7 @@ fn run_single_scenario(
     rt: &tokio::runtime::Runtime,
     name: String,
     prepared: PreparedEntry,
-    running: &Arc<AtomicBool>,
+    cancel: &CancellationToken,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
     status::print_start(&prepared.entry, verbosity, None);
@@ -212,7 +212,7 @@ fn run_single_scenario(
         .block_on(sonda_core::launch_scenario(
             name,
             prepared.entry,
-            Arc::clone(running),
+            cancel.child_token(),
             prepared.start_delay,
         ))
         .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -278,7 +278,7 @@ fn launch_and_join_prepared(
     rt: &tokio::runtime::Runtime,
     id_prefix: &str,
     prepared: Vec<PreparedEntry>,
-    running: &Arc<AtomicBool>,
+    cancel: &CancellationToken,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
     let run_start = Instant::now();
@@ -298,7 +298,7 @@ fn launch_and_join_prepared(
             .block_on(sonda_core::launch_scenario(
                 id,
                 p.entry,
-                Arc::clone(running),
+                cancel.child_token(),
                 p.start_delay,
             ))
             .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -362,7 +362,7 @@ fn launch_and_join_prepared(
 fn run_compiled_with_progress(
     rt: &tokio::runtime::Runtime,
     compiled: sonda_core::compiler::compile_after::CompiledFile,
-    running: &Arc<AtomicBool>,
+    cancel: &CancellationToken,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
     let handles = rt
@@ -371,11 +371,14 @@ fn run_compiled_with_progress(
         ))
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    let per_handle_shutdowns: Vec<Arc<AtomicBool>> =
-        handles.iter().map(|h| Arc::clone(&h.shutdown)).collect();
-    let done = Arc::new(AtomicBool::new(false));
-    let watchdog =
-        spawn_ctrlc_watchdog(Arc::clone(running), per_handle_shutdowns, Arc::clone(&done));
+    let handle_cancels: Vec<CancellationToken> = handles.iter().map(|h| h.cancel.clone()).collect();
+    let cancel_watcher = cancel.clone();
+    let watcher = rt.spawn(async move {
+        cancel_watcher.cancelled().await;
+        for c in &handle_cancels {
+            c.cancel();
+        }
+    });
 
     let progress = maybe_start_progress_multi(&handles, verbosity);
 
@@ -386,8 +389,10 @@ fn run_compiled_with_progress(
         }
     }
 
-    done.store(true, Ordering::SeqCst);
-    let _ = watchdog.join();
+    watcher.abort();
+    rt.block_on(async {
+        let _ = watcher.await;
+    });
 
     if let Some(p) = progress {
         p.stop();
@@ -397,31 +402,6 @@ fn run_compiled_with_progress(
         return Err(anyhow::anyhow!("{}", errors.join("; ")));
     }
     Ok(())
-}
-
-fn spawn_ctrlc_watchdog(
-    master: Arc<AtomicBool>,
-    per_handle: Vec<Arc<AtomicBool>>,
-    done: Arc<AtomicBool>,
-) -> std::thread::JoinHandle<()> {
-    std::thread::Builder::new()
-        .name("sonda-cli-shutdown-watchdog".to_string())
-        .spawn(move || {
-            let poll = std::time::Duration::from_millis(100);
-            loop {
-                if done.load(Ordering::SeqCst) {
-                    return;
-                }
-                if !master.load(Ordering::SeqCst) {
-                    for flag in &per_handle {
-                        flag.store(false, Ordering::SeqCst);
-                    }
-                    return;
-                }
-                std::thread::sleep(poll);
-            }
-        })
-        .expect("watchdog thread must spawn")
 }
 
 fn stop_infos_for_groups(


### PR DESCRIPTION
## Summary

Replaces the std::thread-per-scenario model with bounded `tokio::task` spawning
and swaps `Arc<AtomicBool>` shutdown signalling for
`tokio_util::sync::CancellationToken`. Scenarios now spawn as tokio tasks on
the multi-thread runtime that the CLI builds in `main` (already in place from
the sink-layer refactor). Cancellation fans out from a parent token to
per-scenario child tokens; the dedicated watchdog task is gone. The
per-runner `_blocking` helpers that bridged sync `std::thread::spawn` to the
async sink trait are deleted — async runners run directly inside the spawned
tokio task.

## Changes

- **`ScenarioHandle`** now holds `cancel: CancellationToken` +
  `task: Option<tokio::task::JoinHandle<()>>`. New `join_async` API for async
  callers. Sync `join` builds a fresh `current_thread` runtime when called
  outside any ambient runtime; returns `RuntimeError::TaskAborted` when
  called from inside an ambient `current_thread` runtime (would deadlock).
- **`launch_scenario`** spawns each scenario via `tokio::task::spawn`. The
  runner future is wrapped in an outer biased `tokio::select!` with a
  `cancel.cancelled()` arm — combined with the inner cancel arms in
  `gated_loop_body`, an in-flight `tokio::time::sleep` (gap window or
  rate-control) is dropped on cancel and the scenario exits within
  milliseconds of `handle.stop()`.
- **`core_loop.rs`** rate-control and gap-window sleeps move from
  `std::thread::sleep` to `tokio::time::sleep` so worker threads stay
  cooperative under concurrent scenarios. Every former `shutdown_requested`
  poll becomes `cancel.is_cancelled()`; the four `recv_edge_timeout` sites
  are wrapped in `tokio::select!` with `cancel.cancelled()` arms.
- **New `GateBusResolver::cancel_pending_for_upstream`** trait method and
  `RegistryError::UpstreamCancelled` variant. `GateBusRegistry::unregister`
  drains pending waiters matching the removed `scenario_name` and signals
  `UpstreamGone`, closing the lifecycle gap where DELETE could leave
  downstream `while:` waiters blocked forever.
- **HTTP route** `delete_scenario` drops the `scenarios` RwLock before
  `join_async` to satisfy `clippy::await_holding_lock`. Server signal-handler
  shutdown follows the same pattern.
- **`sonda` CLI** threads a parent `CancellationToken` through
  `run_compiled_with_progress` and the per-scenario launch sites; the
  CTRL-C handler cancels the parent token, which cascades to all child
  scenarios via a tokio watcher task.
- **Per-runner `_blocking` helpers** in `runner.rs` / `log_runner.rs` /
  `histogram_runner.rs` / `summary_runner.rs` are deleted. Sink construction
  happens inline in `launch_scenario`'s async body now that the worker is
  a tokio task.
- **Watchdog** task and `spawn_shutdown_watchdog` are deleted.
- **`recv_edge_timeout`** in `gate_bus.rs` switches from an await-based watch
  receiver to a 2ms polling loop. The await variant deadlocked in the
  cross-POST late-subscription flow on a multi-thread runtime; the polling
  fix keeps every test green and is bounded above by the outer cancel
  `select!`. Tracked for a follow-up bug investigation.
- ~150 scenario- and registry-touching tests migrated to
  `#[tokio::test(flavor = "multi_thread")]`. Two new regression tests:
  `cancel_during_gap_sleep_exits_within_200ms` and
  `join_from_current_thread_runtime_returns_task_aborted_err`. One new
  cross-POST lifecycle regression test
  (`unregister_signals_pending_downstreams_waiting_on_that_upstream`)
  carried over from the prior Phase 3 attempt.

## Dependencies

- Adds `tokio-util = { version = "0.7", default-features = false }` to
  `sonda-core`, `sonda`, `sonda-server` (`CancellationToken`).
- Adds `rt-multi-thread` feature to `sonda-core`'s `tokio` dep (required
  for `block_in_place` in `handle.rs::join`'s multi-thread fallback).
- No new top-level crates.

## Semver

Stays `refactor(core):` despite public `ScenarioHandle` shape change and
new `GateBusResolver` trait method: no known external embedders.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace --all-features` — 2887 / 2887
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::await_holding_lock`
- [x] `cargo clippy -p sonda-core --no-default-features -- -D warnings`
- [x] `cargo test -p sonda-core --no-default-features --no-run`
- [x] `cargo fmt --all -- --check`
- [x] `cargo audit`
- [x] `cargo nextest run -p sonda-core --all-features --test while_close_workshop_repro` — 11 / 11, 0 skipped