### PR TITLE
feat(server): bounded scheduler + --max-scenarios + /server/metrics self-instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2654,11 +2654,12 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
 ]
 

--- a/docs/site/docs/deploy/http-api.md
+++ b/docs/site/docs/deploy/http-api.md
@@ -37,17 +37,53 @@ For server-side setup (passing the flag, env var, Kubernetes Secret pattern), se
 
 ### Error response shape
 
-All error responses share the format `{"error": "<short_code>", "detail": "<message>"}`. Common short codes:
+Most error responses share the format `{"error": "<short_code>", "detail": "<message>"}`. The 408 and 413 capacity errors come from the request-handling layer and carry a status code with no JSON body; check the status, not the body. Common codes:
 
 | Status | Short code | When |
 |--------|------------|------|
 | 400 | (parser-specific) | Malformed body, missing `version: 2`, validation error |
 | 401 | `unauthorized` | Missing or invalid `Authorization: Bearer <key>` |
 | 404 | `not_found` | Unknown scenario ID |
+| 408 | (no JSON body) | Handler exceeded [`--request-timeout`](server.md#tuning-resource-limits). See [Capacity and resource errors](#capacity-and-resource-errors). |
 | 409 | (conflict-specific) | Duplicate `scenario_name` already running |
+| 413 | (no JSON body) | Body larger than [`--max-body-bytes`](server.md#tuning-resource-limits). See [Capacity and resource errors](#capacity-and-resource-errors). |
 | 422 | (validator-specific) | Runtime validation failure |
+| 429 | `capacity_exceeded` | Scenario row cap from [`--max-scenarios`](server.md#tuning-resource-limits) is full. See [Capacity and resource errors](#capacity-and-resource-errors). |
 | 502 | (sink-specific) | Sink push or flush returned an error |
 | 500 | (internal-specific) | Unexpected server error |
+
+### Capacity and resource errors
+
+Three status codes signal that a request was rejected by the server's resource-limit guards rather than by validation. They apply only to the control-plane sub-router (`POST /scenarios`, `DELETE /scenarios/{id}`, `POST /events`, list/inspect). The observability endpoints (`/server/metrics`, `/metrics`, `/scenarios/{id}/metrics`, `/scenarios/{id}/stats`, `/health`) are not subject to these limits and stay reachable under saturation. Every rejection is counted on [`sonda_server_requests_total{status="..."}`](server-metrics.md#sonda_server_requests_total).
+
+#### `429 Too Many Requests` — capacity_exceeded
+
+`POST /scenarios` returns 429 when [`--max-scenarios`](server.md#tuning-resource-limits) is set and the scenario row cap is full. The body identifies where the slots went so you know which scenarios to `DELETE`:
+
+```json title="Response (429 Too Many Requests)"
+{
+  "error": "capacity_exceeded",
+  "detail": "500 scenarios active (max 500); DELETE finished or stuck scenarios to free slots",
+  "by_state": {
+    "pending": 0,
+    "running": 312,
+    "paused": 0,
+    "held": 0,
+    "unresolved": 47,
+    "finished": 141
+  }
+}
+```
+
+`finished` rows still occupy slots. If the count is non-zero, your automation forgot to `DELETE /scenarios/{id}` after those scenarios completed; the cleanest fix is to delete them and re-POST. Alert on `rate(sonda_server_requests_total{status="429"}[5m]) > 0` to catch this before the next deploy.
+
+#### `408 Request Timeout`
+
+A control-plane request exceeded [`--request-timeout`](server.md#tuning-resource-limits) (default 30 seconds). Returned by the request-handling layer with no JSON body — clients should check the status code, not parse the response. The most common trigger is `POST /events` to a slow or unreachable sink; the handler builds the sink in-band and waits for the first connect to succeed.
+
+#### `413 Payload Too Large`
+
+The request body exceeded [`--max-body-bytes`](server.md#tuning-resource-limits) (default 1 MB). Returned by the request-handling layer with no JSON body. Either the caller is sending an oversized scenario file or the cap is set too tight for legitimate traffic. Catalog-resident scenarios are a better fit than inlining a 1 MB body — start the server with [`--catalog <DIR>`](server.md#server-flags) and reference packs by name.
 
 ### Sink URL gotchas
 
@@ -1010,11 +1046,13 @@ scrape_configs:
 | GET | `/scenarios/{id}/stats` | Live stats: rate, events, gap/burst state, sink-failure counters |
 | GET | `/scenarios/{id}/metrics` | Current per-series values for one scenario in Prometheus text format |
 | GET | `/metrics` | Aggregate Prometheus scrape across all running scenarios. Supports `?label=k:v` filtering |
+| GET | `/server/metrics` | Server-process RED and saturation telemetry. See [Server metrics](server-metrics.md). |
 | POST | `/events` | Emit one log or metric event synchronously |
 
 ## Where to next
 
 - [Deploy as a server](server.md) — install, configure, network, and operate the server itself.
+- [Server metrics](server-metrics.md) — the nine `/server/metrics` series and the alerts that matter.
 - [Scenario file format](../build/scenario-files.md) — what to put in the body of `POST /scenarios`.
 - [Encoders](../build/encoders.md) and [Sinks](../build/sinks.md) — every encoder/sink option you can declare in a posted body.
 - [Cross-POST `while:` refs (YAML schema)](../build/scenario-files.md#cross-post-while-refs) — the file-side counterpart to the HTTP cross-POST surface.

--- a/docs/site/docs/deploy/kubernetes.md
+++ b/docs/site/docs/deploy/kubernetes.md
@@ -151,20 +151,26 @@ instructions.
 
 ### ServiceMonitor
 
-A ServiceMonitor endpoint scrapes a single `path`. Two paths work for Sonda:
+A ServiceMonitor endpoint scrapes a single `path`. `sonda-server` exposes three Prometheus paths and they answer different questions — pick by the dashboard you are filling:
 
-- `/metrics` — an aggregate scrape across every running scenario, with optional `?label=k:v` filtering. This is the right choice for most installs. One ServiceMonitor covers every scenario the server runs, regardless of how it was launched.
-- `/scenarios/<scenario-id>/metrics` — a single-scenario snapshot. Use it when each scenario is its own logical target and you know its ID in advance. One example: a scenario loaded from the `scenarios` ConfigMap at a stable route.
+| Path | What it returns | When to scrape |
+|---|---|---|
+| `/server/metrics` | Server-process RED + saturation (`sonda_server_*` series). See [Server metrics](server-metrics.md). | Operational dashboards and alerts on the server itself. |
+| `/metrics` | Aggregate scenario data fused into one response. Supports `?label=k:v` filtering. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape). | A single scrape target covering every scenario, regardless of how it was launched. |
+| `/scenarios/<scenario-id>/metrics` | One scenario's series. | Per-scenario debugging or a stable URL per scenario loaded from the `scenarios` ConfigMap. |
 
-`serviceMonitor.path` has no default. If you set `serviceMonitor.enabled: true` without also setting `serviceMonitor.path`, `helm install` and `helm upgrade` fail with a clear error. The error tells you to set the path to a Prometheus-text endpoint such as `/metrics` or `/scenarios/<scenario-id>/metrics`. This prevents a ServiceMonitor that silently scrapes a non-metrics route.
+The chart defaults `serviceMonitor.path` to `/server/metrics` — the right choice for operational alerting on the server process. Switch it to `/metrics` when you also want one scrape job to cover every scenario the server is running.
 
 | Value | Default | Description |
 |-------|---------|-------------|
 | `serviceMonitor.enabled` | `false` | Enable Prometheus Operator ServiceMonitor |
 | `serviceMonitor.interval` | `30s` | Scrape interval |
 | `serviceMonitor.scrapeTimeout` | `10s` | Scrape timeout |
-| `serviceMonitor.path` | `""` (required when enabled) | Metrics endpoint path, e.g. `/metrics` or `/scenarios/<scenario-id>/metrics` |
+| `serviceMonitor.path` | `/server/metrics` | Metrics endpoint path. Switch to `/metrics` for aggregate scenario scraping, or `/scenarios/<scenario-id>/metrics` for a single scenario. |
 | `serviceMonitor.additionalLabels` | `{}` | Extra labels on the ServiceMonitor resource |
+
+!!! tip "One ServiceMonitor per path"
+    A ServiceMonitor endpoint scrapes a single path. To scrape both `/server/metrics` and `/metrics`, deploy two ServiceMonitor resources (or one with two `endpoints` entries — see the [manual ServiceMonitor example](#manual-servicemonitor) below).
 
 ### Scenarios (ConfigMap)
 
@@ -276,7 +282,15 @@ For example, a Prometheus instance in the same namespace can scrape
 
 ## Prometheus scraping
 
-`sonda-server` exposes two scrape endpoints. `GET /metrics` is the aggregate view. Every running scenario is fused into one response, with `?label=k:v` to slice the view by the labels you attached to each scenario. `GET /scenarios/{id}/metrics` is the per-scenario view. It carries the current value of every series for one scenario. Both endpoints are idempotent snapshots. They produce one sample per `(name, labels)` series with no timestamp, like a `node_exporter` scrape. For most Prometheus setups, the aggregate endpoint is the right choice. One job covers every scenario, and you do not need to know scenario IDs in advance. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape) for the full reference, including the `?label=k:v` AND-filter syntax.
+`sonda-server` exposes three scrape endpoints. Each answers a different question:
+
+| Endpoint | What it returns | When to scrape |
+|---|---|---|
+| `GET /scenarios/{id}/metrics` | One scenario's series | Per-scenario debugging |
+| `GET /metrics` | Aggregate scenario data | Per-process scenario view |
+| `GET /server/metrics` | Server-process RED + saturation | Operational dashboards and alerts |
+
+`GET /metrics` and `GET /scenarios/{id}/metrics` are idempotent snapshots — one sample per `(name, labels)` series with no timestamp, like a `node_exporter` scrape. `GET /server/metrics` returns the server's own RED and saturation telemetry — see [Server metrics](server-metrics.md) for the nine series and the alerts that go with them. Most Prometheus setups want a job per endpoint; the aggregate `/metrics` covers every scenario and you do not need to know scenario IDs in advance. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape) for the `?label=k:v` AND-filter syntax.
 
 ### Aggregate scrape config
 
@@ -319,7 +333,9 @@ helm install sonda ./helm/sonda --set serviceMonitor.enabled=true
 See the [ServiceMonitor](#servicemonitor) values reference for all options
 (`interval`, `scrapeTimeout`, `path`, `additionalLabels`).
 
-You can also apply a custom ServiceMonitor manually for full control:
+### Manual ServiceMonitor
+
+You can also apply a custom ServiceMonitor manually for full control. The example below scrapes the server's own RED metrics and the aggregate scenario view in one resource:
 
 ```yaml title="sonda-servicemonitor.yaml"
 apiVersion: monitoring.coreos.com/v1
@@ -335,17 +351,17 @@ spec:
   endpoints:
     - port: http
       interval: 15s
-      path: /scenarios/<SCENARIO_ID>/metrics
+      path: /server/metrics
+    - port: http
+      interval: 15s
+      path: /metrics
 ```
 
 ```bash
 kubectl apply -f sonda-servicemonitor.yaml
 ```
 
-The `port: http` field matches the named port on the Sonda Service.
-
-!!! warning "One path per endpoint"
-    Each ServiceMonitor endpoint scrapes a single `path`. For per-scenario scrapes, add one `endpoints` entry per scenario ID. To cover every scenario in one entry, point the endpoint at `/metrics` instead and use `?label=k:v` to slice the view.
+The `port: http` field matches the named port on the Sonda Service. Each `endpoints` entry scrapes a single path. For a per-scenario route, add one entry per scenario ID with `path: /scenarios/<SCENARIO_ID>/metrics`.
 
 ## API key authentication
 
@@ -428,16 +444,15 @@ curl http://localhost:8080/health
 
 ### Prometheus scraping with auth
 
-When authentication is enabled, both `/metrics` and `/scenarios/{id}/metrics` require a
-bearer token. Add the token to your Prometheus scrape config:
+When authentication is enabled, every scrape endpoint requires a bearer token: `/server/metrics`, `/metrics`, and `/scenarios/{id}/metrics`. Add the token to your Prometheus scrape config:
 
 === "Static scrape config"
 
     ```yaml title="prometheus-scrape.yaml"
     scrape_configs:
-      - job_name: sonda
+      - job_name: sonda-server
         scrape_interval: 15s
-        metrics_path: /scenarios/<SCENARIO_ID>/metrics
+        metrics_path: /server/metrics
         bearer_token: "your-secret-key-here"
         static_configs:
           - targets: ["sonda.default.svc:8080"]
@@ -447,9 +462,9 @@ bearer token. Add the token to your Prometheus scrape config:
 
     ```yaml title="prometheus-scrape.yaml"
     scrape_configs:
-      - job_name: sonda
+      - job_name: sonda-server
         scrape_interval: 15s
-        metrics_path: /scenarios/<SCENARIO_ID>/metrics
+        metrics_path: /server/metrics
         bearer_token_file: /etc/prometheus/sonda-token
         static_configs:
           - targets: ["sonda.default.svc:8080"]
@@ -471,11 +486,13 @@ spec:
   endpoints:
     - port: http
       interval: 15s
-      path: /scenarios/<SCENARIO_ID>/metrics
+      path: /server/metrics
       bearerTokenSecret:
         name: sonda-api-key
         key: api-key
 ```
+
+Add a second `endpoints` entry with the same `bearerTokenSecret` to also scrape `/metrics` or a per-scenario path. See [Authentication on Server metrics](server-metrics.md#authentication) for the full reference.
 
 !!! warning "Same Secret, same namespace"
     The `bearerTokenSecret` must reference a Secret in the **same namespace** as the
@@ -517,5 +534,6 @@ Add `-n <namespace>` if you installed into a non-default namespace.
 
 - [Synthetic Monitoring guide](../test/synthetic-monitoring.md) -- deploy Sonda on Kubernetes, submit long-running scenarios, scrape with Prometheus, and build Grafana dashboards
 - [Server API](server.md) -- full endpoint reference for `sonda-server`
+- [Server metrics](server-metrics.md) -- the nine `/server/metrics` series and the PromQL alerts that matter
 - [Docker](docker.md) -- Docker image and Compose stacks for local development
 - [Scenario Fields](../reference/scenario-fields.md) -- full YAML schema for scenario configuration

--- a/docs/site/docs/deploy/server-metrics.md
+++ b/docs/site/docs/deploy/server-metrics.md
@@ -1,0 +1,219 @@
+---
+title: Server metrics
+description: Three Prometheus endpoints on sonda-server, the nine /server/metrics series, and PromQL alerts for the load-bearing ones.
+---
+
+# Server metrics
+
+`sonda-server` exposes three Prometheus endpoints. Each one answers a different question. Point your scrape jobs and alerts at the right one — they are not interchangeable.
+
+| Endpoint | What it returns | When to scrape |
+|---|---|---|
+| `GET /scenarios/{id}/metrics` | One scenario's series | Per-scenario debugging |
+| `GET /metrics` | Aggregate scenario data | Per-process scenario view |
+| `GET /server/metrics` | Server-process RED + saturation | Operational dashboards and alerts |
+
+`/server/metrics` tells you whether the **server process** is healthy. `/metrics` and `/scenarios/{id}/metrics` tell you whether the **scenarios** are emitting the data you asked for. A saturated server can still serve metrics from a few healthy scenarios; a quiet `/metrics` while `/server/metrics` shows zero active scenarios is "no work in flight," not "server broken." Reading the right endpoint is the difference between paging on a real outage and chasing a healthy server.
+
+## `GET /server/metrics`
+
+Process-level RED (rate, errors, duration) plus saturation telemetry for the `sonda-server` process. The Helm chart's [ServiceMonitor scrapes this endpoint by default](kubernetes.md#servicemonitor).
+
+```bash
+curl http://localhost:8080/server/metrics
+```
+
+```text title="Response (text/plain; version=0.0.4; charset=utf-8)"
+# HELP sonda_server_active_scenarios Scenarios currently held in each operational state.
+# TYPE sonda_server_active_scenarios gauge
+sonda_server_active_scenarios{state="pending"} 0
+sonda_server_active_scenarios{state="running"} 3
+sonda_server_active_scenarios{state="paused"} 0
+sonda_server_active_scenarios{state="held"} 0
+sonda_server_active_scenarios{state="unresolved"} 0
+# HELP sonda_server_scenarios_finished_total Scenarios that have reached the Finished state and not yet been deleted.
+# TYPE sonda_server_scenarios_finished_total counter
+sonda_server_scenarios_finished_total 12
+# HELP sonda_server_worker_threads Configured tokio multi-thread worker count.
+# TYPE sonda_server_worker_threads gauge
+sonda_server_worker_threads 8
+# HELP sonda_server_max_scenarios Configured scenario row cap (0 means unlimited).
+# TYPE sonda_server_max_scenarios gauge
+sonda_server_max_scenarios 500
+# HELP sonda_server_requests_total HTTP requests served, per matched route, method, and status.
+# TYPE sonda_server_requests_total counter
+sonda_server_requests_total{route="/scenarios",method="POST",status="201"} 14
+sonda_server_requests_total{route="/scenarios/{id}/stats",method="GET",status="200"} 482
+# HELP sonda_server_request_duration_seconds HTTP request duration in seconds, per matched route and method.
+# TYPE sonda_server_request_duration_seconds histogram
+sonda_server_request_duration_seconds_bucket{route="/scenarios",method="POST",le="0.005"} 0
+sonda_server_request_duration_seconds_bucket{route="/scenarios",method="POST",le="+Inf"} 14
+sonda_server_request_duration_seconds_sum{route="/scenarios",method="POST"} 0.342
+sonda_server_request_duration_seconds_count{route="/scenarios",method="POST"} 14
+# HELP sonda_server_sink_errors_total Lifetime sink-write failures, summed across scenarios per sink_type.
+# TYPE sonda_server_sink_errors_total counter
+sonda_server_sink_errors_total{sink_type="loki"} 4
+# HELP sonda_server_uptime_seconds Seconds since the server process started.
+# TYPE sonda_server_uptime_seconds gauge
+sonda_server_uptime_seconds 18432.4
+# HELP sonda_server_build_info Build-time version and git SHA. Constant gauge always set to 1.
+# TYPE sonda_server_build_info gauge
+sonda_server_build_info{version="1.14.0",git_sha="58f288f47a2c2e91d8c3e8b4f1e6d8a9c2b5f3e7"} 1
+```
+
+The endpoint is idempotent — two back-to-back scrapes return logically equivalent bodies (counters increment, gauges may shift, but the shape and label sets stay stable).
+
+### Series reference
+
+Nine series. Operator-tense one-liners and the alerts that matter follow.
+
+#### `sonda_server_active_scenarios`
+
+Gauge. Scenarios currently held in each operational state. Always emits all five rows even when the value is zero, so Prometheus alerting stays continuous as scenarios come and go.
+
+| Label | Values |
+|---|---|
+| `state` | `pending` / `running` / `paused` / `held` / `unresolved` |
+
+`Finished` scenarios are tracked separately by [`sonda_server_scenarios_finished_total`](#sonda_server_scenarios_finished_total). They still consume a row against [`--max-scenarios`](server.md#tuning-resource-limits) until `DELETE /scenarios/{id}` removes them.
+
+```promql title="Alert: a scenario stuck waiting on a cross-POST upstream"
+sonda_server_active_scenarios{state="unresolved"} > 10
+```
+
+When this fires, the cross-POST resolver has more than 10 downstream scenarios queued without their upstream arriving. Inspect them with `GET /scenarios` and look at the `pending_ref` block on `GET /scenarios/{id}`.
+
+#### `sonda_server_scenarios_finished_total`
+
+Counter. Scenarios that have reached the `Finished` state and are still resident in the server. They consume a row against [`--max-scenarios`](server.md#tuning-resource-limits) until you `DELETE` them.
+
+```promql title="Alert: finished rows not being reaped"
+sonda_server_scenarios_finished_total > 100
+```
+
+If this counter climbs without a corresponding burst of new scenarios, your automation is forgetting to `DELETE /scenarios/{id}` after a scenario completes.
+
+#### `sonda_server_worker_threads`
+
+Gauge. The tokio multi-thread worker count configured at startup — that is, the value of [`--workers`](server.md#tuning-resource-limits) or the cgroup-aware default `std::thread::available_parallelism()`.
+
+#### `sonda_server_max_scenarios`
+
+Gauge. The configured value of [`--max-scenarios`](server.md#tuning-resource-limits). Reports `0` when the cap is disabled (unlimited).
+
+#### `sonda_server_requests_total`
+
+Counter. HTTP requests served by the protected sub-routers, labelled by the matched route template, method, and status.
+
+| Label | Values |
+|---|---|
+| `route` | The axum route template, e.g. `/scenarios/{id}/stats` — **not** the concrete URL with the UUID. |
+| `method` | `GET` / `POST` / `DELETE` / etc. |
+| `status` | The numeric status code as a string. |
+
+The `route` label uses the route template (with literal `{id}` braces), not the concrete request path. This keeps cardinality bounded regardless of how many unique scenario IDs hit the server.
+
+```promql title="Alert: control-plane saturation hitting the inflight cap"
+rate(sonda_server_requests_total{status="429"}[5m]) > 0
+```
+
+Sustained 429s mean either the server cap (`--max-scenarios`) is hit or the inflight-request cap (`--max-inflight-requests`) is. Cross-reference [`sonda_server_active_scenarios`](#sonda_server_active_scenarios) to tell which.
+
+```promql title="Alert: payload-size limit being hit"
+rate(sonda_server_requests_total{status="413"}[5m]) > 0
+```
+
+Some client is sending bodies larger than [`--max-body-bytes`](server.md#tuning-resource-limits). Either the limit is too tight for legitimate payloads or you have a misbehaving caller.
+
+#### `sonda_server_request_duration_seconds`
+
+Histogram. Request duration in seconds, labelled by matched route and method. Buckets are the Prometheus defaults: `0.005`, `0.01`, `0.025`, `0.05`, `0.1`, `0.25`, `0.5`, `1.0`, `2.5`, `5.0`, `10.0`, and `+Inf`.
+
+| Label | Values |
+|---|---|
+| `route` | Same matched-path template as `sonda_server_requests_total`. |
+| `method` | Same as `sonda_server_requests_total`. |
+| `le` | Cumulative bucket upper bound. |
+
+```promql title="Alert: control-plane P99 above 1 second"
+histogram_quantile(0.99,
+  sum by (le, route) (rate(sonda_server_request_duration_seconds_bucket[5m]))
+) > 1
+```
+
+Use this to catch back-pressure from `--max-inflight-requests`. `tower::limit::ConcurrencyLimitLayer` does not return explicit 503s; it back-pressures via `Service::poll_ready` and the listener queues requests, so the symptom is "P99 climbs" rather than "errors spike."
+
+#### `sonda_server_sink_errors_total`
+
+Counter. Lifetime sink-write failures across every active scenario, summed per `sink_type`.
+
+| Label | Values |
+|---|---|
+| `sink_type` | The sink kind, e.g. `loki`, `http_push`, `kafka`, `otlp_grpc`, `tcp`, `stdout`. |
+
+Computed at scrape time from each scenario's `total_sink_failures` counter on `GET /scenarios/{id}/stats`. The counter resets when scenarios are deleted, which is the intended behaviour — a deleted scenario is no longer your problem.
+
+```promql title="Alert: sink errors on any sink type in the last 5 minutes"
+rate(sonda_server_sink_errors_total[5m]) > 0
+```
+
+This is the single most important alert on the page. Sustained sink errors mean some backend is unreachable or rejecting writes. Drill into individual scenarios with `GET /scenarios` and look at the `degraded` field, then inspect the offenders with `GET /scenarios/{id}/stats` for `last_sink_error`.
+
+#### `sonda_server_uptime_seconds`
+
+Gauge. Seconds since the server process started. Drops to a small value on restart — useful as a crash-loop indicator.
+
+```promql title="Alert: server restarted in the last 5 minutes"
+sonda_server_uptime_seconds < 300
+```
+
+#### `sonda_server_build_info`
+
+Constant gauge, always `1`. Carries the build version and git SHA as labels.
+
+| Label | Values |
+|---|---|
+| `version` | Crate version from `Cargo.toml`. |
+| `git_sha` | Git SHA at build time, or `unknown` when `.git/` is absent (Docker source-tarball builds). |
+
+Use it to identify which build is running. Join it onto other queries with `group_left` to see whether a regression coincides with a deploy.
+
+### Authentication
+
+All three metrics endpoints inherit the same `SONDA_API_KEY` gate as `/scenarios/*` and `/events`. When the env var or `--api-key` flag is set, requests must include `Authorization: Bearer <key>`. When the key is unset, the endpoints are public. See [Authentication on Deploy as a server](server.md#authentication) for the full setup.
+
+```bash title="Scraping /server/metrics with auth"
+curl -H "Authorization: Bearer my-secret-key" http://localhost:8080/server/metrics
+```
+
+For Prometheus:
+
+```yaml title="prometheus.yml (with auth)"
+scrape_configs:
+  - job_name: sonda-server
+    scrape_interval: 15s
+    metrics_path: /server/metrics
+    bearer_token: my-secret-key
+    static_configs:
+      - targets: ["localhost:8080"]
+```
+
+For the Prometheus Operator, use a [`bearerTokenSecret` on the ServiceMonitor](kubernetes.md#prometheus-scraping-with-auth).
+
+### Scrape isolation under load
+
+The metrics endpoints sit on a separate sub-router from the control plane. `--max-inflight-requests`, `--request-timeout`, and `--max-body-bytes` do **not** apply to `/server/metrics`, `/metrics`, `/scenarios/{id}/metrics`, or `/scenarios/{id}/stats`. A saturated server still returns 200 on its observability endpoints, so alerting keeps firing when you need it most. The auth gate still applies.
+
+## `GET /metrics`
+
+Aggregate scenario data — every running scenario's series fused into one Prometheus text response. This is the right endpoint for a regular Prometheus or vmagent scrape job covering every scenario the server is running. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape) for the full reference, including the `?label=k:v` filter.
+
+## `GET /scenarios/{id}/metrics`
+
+One scenario's series in Prometheus text format. Use it when each scenario is its own logical target and you know the ID in advance — for example, a scenario loaded from a ConfigMap with a stable name. See [Per-scenario metrics](http-api.md#get-scenariosidmetrics) for the request shape and response semantics.
+
+## Where to next
+
+- [Deploy as a server](server.md) — flags and resource limits that shape `/server/metrics` values.
+- [HTTP API reference](http-api.md) — every endpoint and the 429 / 408 / 413 responses that `sonda_server_requests_total` counts.
+- [Kubernetes](kubernetes.md#servicemonitor) — ServiceMonitor configuration for the Prometheus Operator.

--- a/docs/site/docs/deploy/server.md
+++ b/docs/site/docs/deploy/server.md
@@ -220,7 +220,7 @@ The scenario runs in the background inside the server until its `duration` expir
 
 ## Server flags
 
-`sonda-server` accepts four flags: `--port <PORT>` (default `8080`), `--bind <ADDR>` (default `0.0.0.0`), `--api-key <KEY>` (or `SONDA_API_KEY`), and `--catalog <DIR>` (or `SONDA_CATALOG`). Use the `RUST_LOG` environment variable to control log verbosity (default `info`):
+`sonda-server` accepts nine flags. The first four are the network and addressing surface; the remaining five control resource limits and runtime sizing. Use the `RUST_LOG` environment variable to control log verbosity (default `info`):
 
 ```bash
 RUST_LOG=debug sonda-server --port 8080
@@ -230,12 +230,64 @@ RUST_LOG=debug sonda-server --port 8080
 |------|---------|---------|---------|
 | `--port <PORT>` | -- | `8080` | Port the server listens on |
 | `--bind <ADDR>` | -- | `0.0.0.0` | Bind address |
-| `--api-key <KEY>` | `SONDA_API_KEY` | (unset) | Bearer token for `/scenarios/*`, `/metrics`, and `/events`. See [Authentication](#authentication). |
+| `--api-key <KEY>` | `SONDA_API_KEY` | (unset) | Bearer token for `/scenarios/*`, `/events`, and metrics endpoints. See [Authentication](#authentication). |
 | `--catalog <DIR>` | `SONDA_CATALOG` | (unset) | Directory of scenario and pack YAML files. Lets `POST /scenarios` resolve `pack: <name>` references. See [Pack references over HTTP](http-api.md#pack-references-over-http). |
+| `--workers <N>` | -- | `available_parallelism()` | Tokio worker thread count. See [Tuning resource limits](#tuning-resource-limits). |
+| `--max-scenarios <N>` | -- | `0` (unlimited) | Maximum concurrent scenario rows. POSTs beyond the cap return [`429 capacity_exceeded`](http-api.md#capacity-and-resource-errors). |
+| `--max-inflight-requests <N>` | -- | `4 * workers` | Maximum concurrent in-flight control-plane HTTP requests. |
+| `--request-timeout <SECS>` | -- | `30` | Per-request timeout on control-plane routes. Returns [`408 request_timeout`](http-api.md#capacity-and-resource-errors) on expiry. |
+| `--max-body-bytes <N>` | -- | `1048576` (1 MB) | Maximum request body size on control-plane routes. Returns [`413 payload_too_large`](http-api.md#capacity-and-resource-errors) when exceeded. |
 
 When you pass `--catalog`, point it at a directory that holds your `kind: composable` pack YAML files. The path must exist. A missing directory makes the server fail at startup with a clear error.
 
 Press Ctrl+C for graceful shutdown. The server signals all running scenarios to stop before exiting.
+
+### Tuning resource limits
+
+The five resource-limit flags shape what the server accepts, how many scenarios it holds, and how it spends CPU. Their defaults work for a developer laptop. Production deployments should pick values per the guidance below.
+
+#### `--workers <N>`
+
+The size of the tokio multi-thread runtime. Bound: `N >= 1`. The default is `std::thread::available_parallelism()`, which respects cgroup CPU quotas — so the same binary picks 16 workers on a 16-core host and 2 workers on a Kubernetes pod with `cpu: 2000m` set. Override only when you want to deviate from the cgroup setting (for example, pin a workload to one worker to reduce context-switching noise during benchmarking).
+
+The configured value is exported on [`sonda_server_worker_threads`](server-metrics.md#sonda_server_worker_threads) — use it to confirm the runtime sees the value you expect.
+
+#### `--max-scenarios <N>`
+
+A **row cap**, not a CPU-task cap. Every entry in the server's scenario map consumes one slot, including scenarios in `pending`, `running`, `paused`, `held`, `unresolved`, and `finished` state. Reaching the cap returns `429 capacity_exceeded` with a `by_state` breakdown of where the slots went.
+
+Pick `N` from the memory you are willing to dedicate. Each scenario row holds runtime state plus a per-scenario stats buffer; an order-of-magnitude estimate is ~1 MB per scenario at moderate rates. Production deployments commonly use values in the `100` to `1000` range; CI runners often run with `--max-scenarios 50` so a runaway test cannot OOM the runner.
+
+`0` disables the cap entirely. The server emits a `WARN` log line at startup so the choice is visible:
+
+```text
+WARN sonda_server: --max-scenarios 0 — scenario row cap disabled (unlimited)
+```
+
+The cap is exported on [`sonda_server_max_scenarios`](server-metrics.md#sonda_server_max_scenarios). Live row usage is in [`sonda_server_active_scenarios`](server-metrics.md#sonda_server_active_scenarios) plus [`sonda_server_scenarios_finished_total`](server-metrics.md#sonda_server_scenarios_finished_total).
+
+!!! warning "Finished scenarios still occupy a slot"
+    A scenario in `finished` state holds its slot until `DELETE /scenarios/{id}` removes it. Automation that forgets to delete completed scenarios will fill the cap and start serving 429s on every new POST. Either DELETE after a scenario completes, or set `--max-scenarios` high enough to absorb the backlog you expect between cleanups.
+
+#### `--max-inflight-requests <N>`
+
+A global concurrency cap across the control-plane sub-router — `POST /scenarios`, `DELETE /scenarios/{id}`, `POST /events`, and the list/inspect routes. The default `4 * workers` keeps a healthy queue depth without overcommitting. Raise it when the server has CPU and memory headroom and you see request latency climbing under load. Lower it when control-plane work is starving scenario runners.
+
+The cap does **not** apply to the observability sub-router. `/server/metrics`, `/metrics`, `/scenarios/{id}/metrics`, and `/scenarios/{id}/stats` stay scrape-able under saturation — exactly when your alerts need them.
+
+Back-pressure is implicit. `tower::limit::ConcurrencyLimitLayer` does not return a 503; it back-pressures via the tokio runtime, and requests queue at the listener until a slot frees. The visible symptom is rising P99 on [`sonda_server_request_duration_seconds`](server-metrics.md#sonda_server_request_duration_seconds), not an error spike. Alert on the histogram, not on a status code.
+
+#### `--request-timeout <SECS>`
+
+Per-request handler bound on control-plane routes. Requests that exceed the limit return `408 request_timeout`. The default `30` covers the slowest legitimate POST (a large multi-scenario body with cross-POST `while:` resolution). Raise it when you regularly post bodies with many entries; lower it when you want a tighter SLO on the control plane.
+
+This is a handler-execution timeout, not a TCP read timeout — slow clients shipping a body bit-by-bit are not the trigger. The flag does not apply to the observability sub-router.
+
+#### `--max-body-bytes <N>`
+
+The maximum request body size on control-plane routes. Bodies above the limit return `413 payload_too_large`. The default 1 MB fits any realistic scenario YAML and most multi-scenario batches. Raise it when you post very large catalogs by-value (rare — prefer `--catalog <DIR>` for that). Lower it as a hardening measure on internet-facing deployments.
+
+The flag does not apply to the observability sub-router.
 
 ## Authentication
 
@@ -278,12 +330,13 @@ INFO sonda_server: API key authentication enabled for /scenarios/*, /events, and
 | `GET /scenarios/{id}/stats` | Yes |
 | `GET /scenarios/{id}/metrics` | Yes |
 | `GET /metrics` | Yes |
+| `GET /server/metrics` | Yes |
 | `POST /events` | Yes |
 
 See [Authentication conventions on HTTP API reference](http-api.md#authentication) for request shapes, header format, and 401 response bodies.
 
 !!! warning "Prometheus scraping with auth"
-    If you enable authentication, your Prometheus scrape config must include the bearer token for both `/metrics` and `/scenarios/{id}/metrics`. Add a `bearer_token` or `bearer_token_file` field to your `scrape_configs` entry. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape) for the scrape-config shape.
+    If you enable authentication, your Prometheus scrape config must include the bearer token for `/server/metrics`, `/metrics`, and `/scenarios/{id}/metrics`. Add a `bearer_token` or `bearer_token_file` field to your `scrape_configs` entry. See [Authentication on Server metrics](server-metrics.md#authentication) for the scrape-config shape.
 
 ??? tip "Kubernetes Secrets"
     In Kubernetes deployments, store the API key in a Secret and reference it as an environment variable in your Deployment spec:
@@ -318,6 +371,7 @@ See [Authentication conventions on HTTP API reference](http-api.md#authenticatio
 ## Where to next
 
 - [HTTP API reference](http-api.md) — every endpoint, request body, and response shape.
+- [Server metrics](server-metrics.md) — the nine `/server/metrics` series and the alerts that matter.
 - [Docker](docker.md) — Compose stacks and host-side `docker run` examples.
 - [Kubernetes](kubernetes.md) — Helm chart, Service DNS, cross-namespace access.
 - [Sinks](../build/sinks.md) — every sink type and its `url:` field.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -208,6 +208,7 @@ nav:
       - As a CLI: deploy/cli.md
       - As a server: deploy/server.md
       - HTTP API reference: deploy/http-api.md
+      - Server metrics: deploy/server-metrics.md
       - Docker: deploy/docker.md
       - Kubernetes: deploy/kubernetes.md
   - Reference:

--- a/helm/sonda/templates/servicemonitor.yaml
+++ b/helm/sonda/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
       {{- end }}
-      path: {{ required "serviceMonitor.enabled is true but serviceMonitor.path is empty — set it to a Prometheus-text endpoint such as /scenarios/<scenario-id>/metrics" .Values.serviceMonitor.path }}
+      path: {{ default "/server/metrics" .Values.serviceMonitor.path }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/helm/sonda/templates/servicemonitor.yaml
+++ b/helm/sonda/templates/servicemonitor.yaml
@@ -16,6 +16,13 @@ spec:
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
       {{- end }}
       path: {{ default "/server/metrics" .Values.serviceMonitor.path }}
+      {{- with .Values.serviceMonitor.bearerTokenSecret }}
+      {{- if and .name .key }}
+      bearerTokenSecret:
+        name: {{ .name }}
+        key: {{ .key }}
+      {{- end }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/helm/sonda/values.yaml
+++ b/helm/sonda/values.yaml
@@ -138,6 +138,12 @@ serviceMonitor:
   scrapeTimeout: 10s
   path: "/server/metrics"
   additionalLabels: {}
+  # When SONDA_API_KEY auth is enabled on the server, set both fields below to
+  # point at a Kubernetes Secret holding the bearer token. Prometheus Operator
+  # reads the secret from the same namespace as the ServiceMonitor.
+  bearerTokenSecret:
+    name: ""
+    key: ""
 
 # Node selector for pod scheduling.
 nodeSelector: {}

--- a/helm/sonda/values.yaml
+++ b/helm/sonda/values.yaml
@@ -127,16 +127,16 @@ ingress:
 
 # ServiceMonitor for Prometheus Operator.
 #
-# `path` must point at a Prometheus-text endpoint. sonda-server exposes
-# per-scenario metrics at /scenarios/<scenario-id>/metrics; choose the
-# scenario you want scraped and set `path` to that route. When enabled
-# without a path the chart install fails with a clear error rather than
-# silently scraping a non-metrics endpoint.
+# `path` should point at /server/metrics for server-process RED + saturation
+# metrics (recommended for operational dashboards and alerts). Per-scenario
+# metrics remain available at /scenarios/<scenario-id>/metrics, and aggregate
+# scenario data at /metrics, for ad-hoc scraping or workload-specific
+# ServiceMonitors.
 serviceMonitor:
   enabled: false
   interval: 30s
   scrapeTimeout: 10s
-  path: ""
+  path: "/server/metrics"
   additionalLabels: {}
 
 # Node selector for pod scheduling.

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
+use tokio::sync::OwnedSemaphorePermit;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -43,6 +44,10 @@ pub struct ScenarioHandle {
     pub labels: Arc<HashMap<String, String>>,
     pub prometheus_meta: Option<Arc<PromMeta>>,
     pub cleaned_up: Arc<AtomicBool>,
+    sink_type: &'static str,
+    // Drop order frees the permit last on natural completion; DELETE releases
+    // it explicitly via take_permit before joining so the cap is a row cap.
+    _permit: Option<OwnedSemaphorePermit>,
 }
 
 impl ScenarioHandle {
@@ -75,7 +80,30 @@ impl ScenarioHandle {
             labels,
             prometheus_meta,
             cleaned_up,
+            sink_type: "unknown",
+            _permit: None,
         }
+    }
+
+    /// Set the sink-type label this handle reports for `sonda_server_sink_errors_total`.
+    pub fn with_sink_type(mut self, sink_type: &'static str) -> Self {
+        self.sink_type = sink_type;
+        self
+    }
+
+    /// Stable label string identifying the sink kind for derive-at-scrape metrics.
+    pub fn sink_type(&self) -> &'static str {
+        self.sink_type
+    }
+
+    /// Attach an owned semaphore permit whose drop frees a server-side scenario slot.
+    pub fn attach_permit(&mut self, permit: OwnedSemaphorePermit) {
+        self._permit = Some(permit);
+    }
+
+    /// Take the attached semaphore permit, returning `None` if none was attached.
+    pub fn take_permit(&mut self) -> Option<OwnedSemaphorePermit> {
+        self._permit.take()
     }
 
     /// Signal this scenario to stop. Affects only this scenario.
@@ -564,6 +592,57 @@ mod tests {
         handle.join(None).expect("first join must succeed");
         let result = handle.join_timeout(Duration::from_millis(50));
         assert!(result.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sink_type_defaults_to_unknown() {
+        let handle = make_handle("st-1", "default_sink", 1, Duration::from_millis(1));
+        assert_eq!(handle.sink_type(), "unknown");
+        drop(handle);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn with_sink_type_overrides_default() {
+        let handle =
+            make_handle("st-2", "tagged_sink", 1, Duration::from_millis(1)).with_sink_type("loki");
+        assert_eq!(handle.sink_type(), "loki");
+        drop(handle);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn attach_permit_holds_permit_until_drop() {
+        let sem = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = Arc::clone(&sem).try_acquire_owned().expect("permit");
+        assert_eq!(sem.available_permits(), 0);
+
+        let mut handle = make_handle("st-3", "perm", 1, Duration::from_millis(1));
+        handle.attach_permit(permit);
+        assert_eq!(sem.available_permits(), 0);
+
+        handle.stop();
+        handle.join(Some(Duration::from_secs(2))).ok();
+        drop(handle);
+        assert_eq!(sem.available_permits(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn take_permit_releases_slot_without_dropping_handle() {
+        let sem = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = Arc::clone(&sem).try_acquire_owned().expect("permit");
+        assert_eq!(sem.available_permits(), 0);
+
+        let mut handle = make_handle("st-4", "take_perm", 1, Duration::from_millis(1));
+        handle.attach_permit(permit);
+        assert_eq!(sem.available_permits(), 0);
+
+        drop(handle.take_permit());
+        assert_eq!(sem.available_permits(), 1);
+        assert!(handle.take_permit().is_none());
+
+        handle.stop();
+        handle.join(Some(Duration::from_secs(2))).ok();
+        drop(handle);
+        assert_eq!(sem.available_permits(), 1);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -200,6 +200,7 @@ pub async fn launch_scenario_with_gates(
     };
     let labels = Arc::new(entry.base().labels.clone().unwrap_or_default());
     let prometheus_meta = derive_prometheus_meta(&entry);
+    let sink_type = sink_type_label(&entry.base().sink);
 
     let started_at = Instant::now();
 
@@ -327,7 +328,43 @@ pub async fn launch_scenario_with_gates(
         labels,
         prometheus_meta,
         cleaned_up,
-    ))
+    )
+    .with_sink_type(sink_type))
+}
+
+fn sink_type_label(sink: &crate::sink::SinkConfig) -> &'static str {
+    use crate::sink::SinkConfig;
+    // Catch-all guards against future #[non_exhaustive] variants; in-crate
+    // the match is exhaustive today.
+    #[allow(unreachable_patterns)]
+    match sink {
+        SinkConfig::Stdout => "stdout",
+        SinkConfig::File { .. } => "file",
+        SinkConfig::Tcp { .. } => "tcp",
+        SinkConfig::Udp { .. } => "udp",
+        SinkConfig::Memory { .. } => "memory",
+        #[cfg(feature = "http")]
+        SinkConfig::HttpPush { .. } => "http_push",
+        #[cfg(not(feature = "http"))]
+        SinkConfig::HttpPushDisabled {} => "http_push",
+        #[cfg(feature = "remote-write")]
+        SinkConfig::RemoteWrite { .. } => "remote_write",
+        #[cfg(not(feature = "remote-write"))]
+        SinkConfig::RemoteWriteDisabled {} => "remote_write",
+        #[cfg(feature = "kafka")]
+        SinkConfig::Kafka { .. } => "kafka",
+        #[cfg(not(feature = "kafka"))]
+        SinkConfig::KafkaDisabled {} => "kafka",
+        #[cfg(feature = "http")]
+        SinkConfig::Loki { .. } => "loki",
+        #[cfg(not(feature = "http"))]
+        SinkConfig::LokiDisabled {} => "loki",
+        #[cfg(feature = "otlp")]
+        SinkConfig::OtlpGrpc { .. } => "otlp_grpc",
+        #[cfg(not(feature = "otlp"))]
+        SinkConfig::OtlpGrpcDisabled {} => "otlp_grpc",
+        _ => "unknown",
+    }
 }
 
 fn derive_prometheus_meta(entry: &ScenarioEntry) -> Option<Arc<PromMeta>> {

--- a/sonda-core/src/schedule/stats.rs
+++ b/sonda-core/src/schedule/stats.rs
@@ -40,6 +40,35 @@ pub enum ScenarioState {
     Finished,
 }
 
+impl ScenarioState {
+    /// Operational states surfaced as separate gauge rows by the server metrics emitter.
+    pub fn operational_states() -> &'static [ScenarioState] {
+        &[
+            ScenarioState::Pending,
+            ScenarioState::Running,
+            ScenarioState::Paused,
+            ScenarioState::Held,
+            ScenarioState::Unresolved,
+        ]
+    }
+
+    /// Stable lowercase label text for Prometheus exposition.
+    pub fn as_label(&self) -> &'static str {
+        // Catch-all guards against future #[non_exhaustive] variants added by
+        // Phase 5; in-crate the match is exhaustive today.
+        #[allow(unreachable_patterns)]
+        match self {
+            ScenarioState::Pending => "pending",
+            ScenarioState::Running => "running",
+            ScenarioState::Paused => "paused",
+            ScenarioState::Held => "held",
+            ScenarioState::Unresolved => "unresolved",
+            ScenarioState::Finished => "finished",
+            _ => "unknown",
+        }
+    }
+}
+
 /// Live statistics for a running scenario, updated by the runner each tick.
 ///
 /// These counters are written by the scenario thread and read by callers
@@ -643,5 +672,52 @@ mod tests {
             ..Default::default()
         };
         assert!(!s.is_degraded(last - 1_000_000_000));
+    }
+
+    #[test]
+    fn operational_states_returns_five_states_in_documented_order() {
+        let states = ScenarioState::operational_states();
+        assert_eq!(states.len(), 5);
+        assert_eq!(states[0], ScenarioState::Pending);
+        assert_eq!(states[1], ScenarioState::Running);
+        assert_eq!(states[2], ScenarioState::Paused);
+        assert_eq!(states[3], ScenarioState::Held);
+        assert_eq!(states[4], ScenarioState::Unresolved);
+    }
+
+    #[test]
+    fn operational_states_excludes_finished() {
+        let states = ScenarioState::operational_states();
+        assert!(!states.contains(&ScenarioState::Finished));
+    }
+
+    #[test]
+    fn as_label_maps_every_variant_to_lowercase_text() {
+        assert_eq!(ScenarioState::Pending.as_label(), "pending");
+        assert_eq!(ScenarioState::Running.as_label(), "running");
+        assert_eq!(ScenarioState::Paused.as_label(), "paused");
+        assert_eq!(ScenarioState::Held.as_label(), "held");
+        assert_eq!(ScenarioState::Unresolved.as_label(), "unresolved");
+        assert_eq!(ScenarioState::Finished.as_label(), "finished");
+    }
+
+    #[test]
+    fn as_label_matches_serde_lowercase_rename() {
+        for state in [
+            ScenarioState::Pending,
+            ScenarioState::Running,
+            ScenarioState::Paused,
+            ScenarioState::Held,
+            ScenarioState::Unresolved,
+            ScenarioState::Finished,
+        ] {
+            let json = serde_json::to_string(&state).unwrap();
+            let serialized = json.trim_matches('"').to_string();
+            assert_eq!(
+                serialized,
+                state.as_label(),
+                "as_label must match serde rename for {state:?}"
+            );
+        }
     }
 }

--- a/sonda-server/Cargo.toml
+++ b/sonda-server/Cargo.toml
@@ -33,14 +33,14 @@ serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["env"] }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["timeout", "limit"] }
+tower = { version = "0.5", features = ["limit"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 subtle = "2"
 
 [dev-dependencies]
-tower = "0.5"
 http-body-util = "0.1"
 hyper = "1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls"] }

--- a/sonda-server/build.rs
+++ b/sonda-server/build.rs
@@ -1,0 +1,41 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    let sha = git_head_sha().unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=SONDA_GIT_SHA={sha}");
+
+    if let Some(head) = git_head_path() {
+        println!("cargo:rerun-if-changed={}", head.display());
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn git_head_sha() -> Option<String> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&manifest_dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(output.stdout).ok()?;
+    let trimmed = sha.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn git_head_path() -> Option<PathBuf> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let candidate = PathBuf::from(manifest_dir).join("../.git/HEAD");
+    if candidate.exists() {
+        Some(candidate)
+    } else {
+        None
+    }
+}

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -5,22 +5,27 @@
 
 mod auth;
 mod gate_registry;
+mod middleware;
 mod routes;
 mod state;
 
+use std::collections::HashMap;
 use std::env;
 use std::io::Write;
 use std::net::SocketAddr;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{exit, Command};
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use clap::Parser;
+use tokio::sync::Semaphore;
 use tracing::{info, warn};
 
+use crate::routes::RouterConfig;
 use crate::state::AppState;
 
 /// Subcommands the dispatch shim forwards to the sibling `sonda` binary.
@@ -58,6 +63,26 @@ struct Args {
     /// Can also be set via the `SONDA_CATALOG` environment variable.
     #[arg(long, env = "SONDA_CATALOG")]
     catalog: Option<PathBuf>,
+
+    /// Tokio worker thread count. Defaults to `std::thread::available_parallelism()`.
+    #[arg(long, value_parser = clap::builder::RangedU64ValueParser::<u64>::new().range(1..))]
+    workers: Option<u64>,
+
+    /// Maximum concurrent scenario rows in `AppState`. `0` means unlimited.
+    #[arg(long, default_value_t = 0)]
+    max_scenarios: usize,
+
+    /// Maximum concurrent in-flight control-plane HTTP requests. Defaults to `4 * workers`.
+    #[arg(long)]
+    max_inflight_requests: Option<usize>,
+
+    /// Per-request timeout in seconds applied to control-plane routes. Returns 408 on expiry.
+    #[arg(long, default_value_t = 30)]
+    request_timeout: u64,
+
+    /// Maximum request body size in bytes accepted by control-plane routes. Returns 413 when exceeded.
+    #[arg(long, default_value_t = 1_048_576)]
+    max_body_bytes: usize,
 }
 
 impl std::fmt::Debug for Args {
@@ -67,15 +92,36 @@ impl std::fmt::Debug for Args {
             .field("bind", &self.bind)
             .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
             .field("catalog", &self.catalog)
+            .field("workers", &self.workers)
+            .field("max_scenarios", &self.max_scenarios)
+            .field("max_inflight_requests", &self.max_inflight_requests)
+            .field("request_timeout", &self.request_timeout)
+            .field("max_body_bytes", &self.max_body_bytes)
             .finish()
     }
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     maybe_dispatch_to_sonda_cli();
 
-    // Tracing on stderr — stdout is reserved for the bound-port announce.
+    let args = Args::parse();
+    let workers = args.workers.map(|n| n as usize).unwrap_or_else(|| {
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1)
+    });
+    let max_inflight_requests = args.max_inflight_requests.unwrap_or(workers * 4);
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(workers)
+        .enable_all()
+        .build()
+        .context("failed to build tokio runtime")?;
+
+    runtime.block_on(async move { run(args, workers, max_inflight_requests).await })
+}
+
+async fn run(args: Args, workers: usize, max_inflight_requests: usize) -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -83,8 +129,6 @@ async fn main() -> anyhow::Result<()> {
         )
         .with_writer(std::io::stderr)
         .init();
-
-    let args = Args::parse();
 
     let bind_addr: SocketAddr = format!("{}:{}", args.bind, args.port)
         .parse()
@@ -116,9 +160,35 @@ async fn main() -> anyhow::Result<()> {
         info!(catalog = %dir.display(), "pack catalog enabled for POST /scenarios");
     }
 
-    let mut state = AppState::with_api_key(api_key);
-    state.catalog_dir = args.catalog.map(Arc::new);
-    let app = routes::router(state.clone());
+    let permits = if args.max_scenarios == 0 {
+        warn!("--max-scenarios 0 — scenario row cap disabled (unlimited)");
+        Semaphore::new(Semaphore::MAX_PERMITS)
+    } else {
+        Semaphore::new(args.max_scenarios)
+    };
+
+    let state = AppState {
+        scenarios: Arc::new(RwLock::new(HashMap::new())),
+        api_key: api_key.map(Arc::new),
+        catalog_dir: args.catalog.clone().map(Arc::new),
+        gate_bus_registry: Arc::new(crate::gate_registry::GateBusRegistry::new()),
+        scenario_permits: Arc::new(permits),
+        started_at: Instant::now(),
+        worker_threads: workers,
+        max_scenarios: args.max_scenarios,
+        request_counters: Arc::new(RwLock::new(
+            HashMap::<crate::state::RouteKey, AtomicU64>::new(),
+        )),
+        request_histograms: Arc::new(RwLock::new(HashMap::new())),
+    };
+
+    let inflight_semaphore = Arc::new(Semaphore::new(max_inflight_requests));
+    let router_cfg = RouterConfig {
+        request_timeout: Duration::from_secs(args.request_timeout),
+        max_body_bytes: args.max_body_bytes,
+        inflight_semaphore,
+    };
+    let app = routes::router_with_config(state.clone(), router_cfg);
 
     let listener = tokio::net::TcpListener::bind(bind_addr)
         .await
@@ -134,7 +204,7 @@ async fn main() -> anyhow::Result<()> {
 
     announce_bound_port(bound_addr.port())?;
 
-    info!(addr = %bound_addr, "sonda-server listening");
+    info!(addr = %bound_addr, workers, "sonda-server listening");
 
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(
@@ -290,6 +360,15 @@ mod tests {
             len_before,
             sorted.len(),
             "SONDA_SUBCOMMANDS contains duplicates"
+        );
+    }
+
+    #[test]
+    fn sonda_git_sha_env_is_injected_by_build_rs() {
+        let sha = env!("SONDA_GIT_SHA");
+        assert!(
+            !sha.is_empty(),
+            "SONDA_GIT_SHA must be injected (either a git rev or the 'unknown' fallback)"
         );
     }
 }

--- a/sonda-server/src/middleware/metrics.rs
+++ b/sonda-server/src/middleware/metrics.rs
@@ -1,0 +1,77 @@
+//! RED-metric instrumentation middleware.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use axum::extract::{MatchedPath, Request, State};
+use axum::middleware::Next;
+use axum::response::Response;
+
+use crate::state::AppState;
+
+pub async fn record_request_metrics(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|p| p.as_str().to_string())
+        .unwrap_or_else(|| "<unmatched>".to_string());
+    let method = request.method().as_str().to_string();
+    let started = Instant::now();
+
+    let response = next.run(request).await;
+
+    let status = response.status().as_u16();
+    let elapsed = started.elapsed().as_secs_f64();
+
+    increment_counter(&state, route.clone(), method.clone(), status);
+    observe_histogram(&state, route, method, elapsed);
+
+    response
+}
+
+fn increment_counter(state: &AppState, route: String, method: String, status: u16) {
+    let key = (route, method, status);
+    {
+        let guard = state
+            .request_counters
+            .read()
+            .expect("request_counters lock poisoned");
+        if let Some(counter) = guard.get(&key) {
+            counter.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+    }
+    // Slow path: another writer may have created the entry between the read
+    // drop and the write acquire — entry().or_insert_with handles both cases.
+    let mut guard = state
+        .request_counters
+        .write()
+        .expect("request_counters lock poisoned");
+    guard
+        .entry(key)
+        .or_insert_with(|| AtomicU64::new(0))
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+fn observe_histogram(state: &AppState, route: String, method: String, seconds: f64) {
+    let key = (route, method);
+    {
+        let guard = state
+            .request_histograms
+            .read()
+            .expect("request_histograms lock poisoned");
+        if let Some(shard) = guard.get(&key) {
+            shard.observe(seconds);
+            return;
+        }
+    }
+    let mut guard = state
+        .request_histograms
+        .write()
+        .expect("request_histograms lock poisoned");
+    guard.entry(key).or_default().observe(seconds);
+}

--- a/sonda-server/src/middleware/mod.rs
+++ b/sonda-server/src/middleware/mod.rs
@@ -1,0 +1,3 @@
+//! HTTP middleware for sonda-server.
+
+pub mod metrics;

--- a/sonda-server/src/routes/mod.rs
+++ b/sonda-server/src/routes/mod.rs
@@ -1,40 +1,86 @@
 //! HTTP route definitions for sonda-server.
-//!
-//! Routes are split into two sub-routers:
-//! - **Public**: `/health` — always accessible, no authentication required.
-//! - **Protected**: `/scenarios/*` — guarded by the [`require_api_key`] middleware
-//!   when an API key is configured. When no key is configured, these routes are
-//!   also publicly accessible (backwards compatible).
-//!
-//! The `route_layer` approach ensures that only matched routes run through the
-//! auth middleware. Unmatched paths get a plain 404 from the router, not a 401.
 
 pub mod events;
 pub mod health;
 pub mod scenarios;
+pub mod server_metrics;
 pub mod sink_warnings;
 
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::http::StatusCode;
 use axum::middleware;
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
+use tokio::sync::Semaphore;
+use tower::limit::GlobalConcurrencyLimitLayer;
+use tower::ServiceBuilder;
+use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::timeout::TimeoutLayer;
 
 use crate::auth::require_api_key;
+use crate::middleware::metrics::record_request_metrics;
 use crate::state::AppState;
 
-/// Build the application router with all routes wired up.
-///
-/// The returned [`Router`] is ready to be handed to the axum server. State is
-/// injected via [`axum::extract::State`] in each handler.
-///
-/// The router is composed of two sub-trees:
-/// - A **public** router for endpoints that must always be accessible (health
-///   checks, readiness probes).
-/// - A **protected** router for scenario management endpoints, guarded by
-///   bearer-token authentication when an API key is configured.
+#[derive(Clone)]
+pub struct RouterConfig {
+    pub request_timeout: Duration,
+    pub max_body_bytes: usize,
+    pub inflight_semaphore: Arc<Semaphore>,
+}
+
+impl RouterConfig {
+    #[allow(dead_code)]
+    pub fn test_defaults() -> Self {
+        Self {
+            request_timeout: Duration::from_secs(30),
+            max_body_bytes: 1_048_576,
+            inflight_semaphore: Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
+        }
+    }
+}
+
+#[allow(dead_code)]
 pub fn router(state: AppState) -> Router {
+    router_with_config(state, RouterConfig::test_defaults())
+}
+
+pub fn router_with_config(state: AppState, cfg: RouterConfig) -> Router {
     let public = Router::new().route("/health", get(health::health));
 
-    let protected = Router::new()
+    let protected_observability = Router::new()
+        .route("/scenarios/{id}/stats", get(scenarios::get_scenario_stats))
+        .route(
+            "/scenarios/{id}/metrics",
+            get(scenarios::get_scenario_metrics),
+        )
+        .route("/metrics", get(scenarios::get_aggregate_metrics))
+        .route("/server/metrics", get(server_metrics::get_server_metrics))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            record_request_metrics,
+        ))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_api_key,
+        ));
+
+    // RequestBodyLimit must wrap a service whose response body is
+    // axum::body::Body; Timeout wraps the response into a type that
+    // RequestBodyLimitLayer's downstream bound rejects, so timeout goes
+    // inside the body limit at the layer-application level.
+    let control_stack = ServiceBuilder::new()
+        .layer(RequestBodyLimitLayer::new(cfg.max_body_bytes))
+        .layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            cfg.request_timeout,
+        ))
+        .layer(GlobalConcurrencyLimitLayer::with_semaphore(
+            cfg.inflight_semaphore.clone(),
+        ));
+
+    let protected_control = Router::new()
         .route(
             "/scenarios",
             get(scenarios::list_scenarios).post(scenarios::post_scenario),
@@ -43,19 +89,21 @@ pub fn router(state: AppState) -> Router {
             "/scenarios/{id}",
             get(scenarios::get_scenario).delete(scenarios::delete_scenario),
         )
-        .route("/scenarios/{id}/stats", get(scenarios::get_scenario_stats))
-        .route(
-            "/scenarios/{id}/metrics",
-            get(scenarios::get_scenario_metrics),
-        )
-        .route("/metrics", get(scenarios::get_aggregate_metrics))
-        .route("/events", axum::routing::post(events::post_events))
+        .route("/events", post(events::post_events))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            record_request_metrics,
+        ))
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             require_api_key,
-        ));
+        ))
+        .layer(control_stack);
 
-    public.merge(protected).with_state(state)
+    public
+        .merge(protected_observability)
+        .merge(protected_control)
+        .with_state(state)
 }
 
 #[cfg(test)]

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -30,6 +30,7 @@ use sonda_core::compiler::parse::detect_version;
 use sonda_core::encoder::prometheus::PrometheusText;
 use sonda_core::encoder::Encoder;
 use sonda_core::{GateBusResolver, ScenarioState, ScenarioStats};
+use tokio::sync::{OwnedSemaphorePermit, TryAcquireError};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -585,16 +586,78 @@ pub async fn post_scenario(
     log_warnings("POST /scenarios", &warnings);
     drop(warning_entries);
 
-    launch_compiled(state, *compiled, warnings).await
+    let needed = compiled.entries.len();
+    let permits = match acquire_permits(&state, needed) {
+        Ok(p) => p,
+        Err(PermitError::CapacityExceeded) => {
+            warn!(
+                needed,
+                "POST /scenarios: scenario cap reached, returning 429"
+            );
+            return Err(capacity_exceeded_response(&state, needed));
+        }
+        Err(PermitError::SemaphoreClosed) => {
+            warn!("POST /scenarios: scenario_permits semaphore is closed");
+            return Err(internal_error("scenario permit semaphore is closed"));
+        }
+    };
+
+    launch_compiled(state, *compiled, warnings, permits).await
 }
 
-/// Launch every entry in `compiled` through the gated multi-runner and store
-/// the resulting handles in [`AppState`]. Single-vs-multi response shape is
-/// decided post-launch from the count of returned handles.
+enum PermitError {
+    CapacityExceeded,
+    SemaphoreClosed,
+}
+
+fn acquire_permits(
+    state: &AppState,
+    needed: usize,
+) -> Result<Vec<OwnedSemaphorePermit>, PermitError> {
+    let mut permits = Vec::with_capacity(needed);
+    for _ in 0..needed {
+        match state.scenario_permits.clone().try_acquire_owned() {
+            Ok(p) => permits.push(p),
+            Err(TryAcquireError::NoPermits) => return Err(PermitError::CapacityExceeded),
+            Err(TryAcquireError::Closed) => return Err(PermitError::SemaphoreClosed),
+        }
+    }
+    Ok(permits)
+}
+
+fn capacity_exceeded_response(state: &AppState, _needed: usize) -> Response {
+    let mut by_state = serde_json::Map::new();
+    for op in ScenarioState::operational_states() {
+        by_state.insert(op.as_label().to_string(), json!(0));
+    }
+    by_state.insert(ScenarioState::Finished.as_label().to_string(), json!(0));
+    let mut total = 0u64;
+    if let Ok(scenarios) = state.scenarios.read() {
+        for handle in scenarios.values() {
+            total += 1;
+            let label = handle.stats_snapshot().state.as_label();
+            if let Some(v) = by_state.get_mut(label) {
+                *v = json!(v.as_u64().unwrap_or(0) + 1);
+            }
+        }
+    }
+    let max = state.max_scenarios;
+    let detail = format!(
+        "{total} scenarios active (max {max}); DELETE finished or stuck scenarios to free slots"
+    );
+    let body = json!({
+        "error": "capacity_exceeded",
+        "detail": detail,
+        "by_state": by_state,
+    });
+    (StatusCode::TOO_MANY_REQUESTS, Json(body)).into_response()
+}
+
 async fn launch_compiled(
     state: AppState,
     compiled: CompiledFile,
     warnings: Vec<String>,
+    mut permits: Vec<OwnedSemaphorePermit>,
 ) -> Result<Response, Response> {
     let resolver: Arc<dyn sonda_core::GateBusResolver> = state.gate_bus_registry.clone();
     let mut handles = launch_multi_compiled(compiled, Some(resolver))
@@ -622,6 +685,9 @@ async fn launch_compiled(
         let name = handle.name.clone();
         let state_str = state_string(&handle.stats_snapshot()).to_string();
         info!(id = %new_id, name = %name, state = %state_str, "scenario launched");
+        if let Some(permit) = permits.pop() {
+            handle.attach_permit(permit);
+        }
         created.push(CreatedScenario {
             id: new_id,
             name,
@@ -766,6 +832,9 @@ pub async fn delete_scenario(
         handle.stop();
         (handle, scenario_name_to_unregister)
     };
+
+    // Release the slot before the join window — row cap, not task-CPU cap.
+    drop(handle.take_permit());
 
     if let Err(e) = handle.join_async(Some(Duration::from_secs(5))).await {
         warn!(id = %id, error = %e, "DELETE /scenarios/{id}: scenario task returned an error");

--- a/sonda-server/src/routes/server_metrics.rs
+++ b/sonda-server/src/routes/server_metrics.rs
@@ -1,0 +1,276 @@
+//! `GET /server/metrics` — process-level RED and saturation telemetry.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::sync::atomic::Ordering;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use sonda_core::ScenarioState;
+
+use crate::state::{AppState, HistogramShard};
+
+const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+pub async fn get_server_metrics(State(state): State<AppState>) -> Result<Response, Response> {
+    let mut buf = String::with_capacity(4096);
+
+    write_active_scenarios(&state, &mut buf).map_err(internal)?;
+    write_scenarios_finished_total(&state, &mut buf).map_err(internal)?;
+    write_worker_threads(&state, &mut buf).map_err(internal)?;
+    write_max_scenarios(&state, &mut buf).map_err(internal)?;
+    write_requests_total(&state, &mut buf).map_err(internal)?;
+    write_request_duration_seconds(&state, &mut buf).map_err(internal)?;
+    write_sink_errors_total(&state, &mut buf).map_err(internal)?;
+    write_uptime_seconds(&state, &mut buf).map_err(internal)?;
+    write_build_info(&mut buf).map_err(internal)?;
+
+    Ok((
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, PROMETHEUS_CONTENT_TYPE)],
+        buf,
+    )
+        .into_response())
+}
+
+fn internal(_: std::fmt::Error) -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "failed to emit server metrics",
+    )
+        .into_response()
+}
+
+fn write_active_scenarios(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    let mut by_state: BTreeMap<&'static str, u64> = BTreeMap::new();
+    for op in ScenarioState::operational_states() {
+        by_state.insert(op.as_label(), 0);
+    }
+    {
+        let scenarios = match state.scenarios.read() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        for handle in scenarios.values() {
+            let snap = handle.stats_snapshot();
+            if snap.state == ScenarioState::Finished {
+                continue;
+            }
+            let label = snap.state.as_label();
+            *by_state.entry(label).or_insert(0) += 1;
+        }
+    }
+
+    writeln!(
+        buf,
+        "# HELP sonda_server_active_scenarios Scenarios currently held in each operational state."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_active_scenarios gauge")?;
+    for op in ScenarioState::operational_states() {
+        let label = op.as_label();
+        let value = by_state.get(label).copied().unwrap_or(0);
+        writeln!(
+            buf,
+            "sonda_server_active_scenarios{{state=\"{label}\"}} {value}"
+        )?;
+    }
+    Ok(())
+}
+
+fn write_scenarios_finished_total(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    let mut finished: u64 = 0;
+    {
+        let scenarios = match state.scenarios.read() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        for handle in scenarios.values() {
+            if handle.stats_snapshot().state == ScenarioState::Finished {
+                finished += 1;
+            }
+        }
+    }
+    writeln!(
+        buf,
+        "# HELP sonda_server_scenarios_finished_total Scenarios that have reached the Finished state and not yet been deleted."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_scenarios_finished_total counter")?;
+    writeln!(buf, "sonda_server_scenarios_finished_total {finished}")
+}
+
+fn write_worker_threads(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    writeln!(
+        buf,
+        "# HELP sonda_server_worker_threads Configured tokio multi-thread worker count."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_worker_threads gauge")?;
+    writeln!(buf, "sonda_server_worker_threads {}", state.worker_threads)
+}
+
+fn write_max_scenarios(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    writeln!(
+        buf,
+        "# HELP sonda_server_max_scenarios Configured scenario row cap (0 means unlimited)."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_max_scenarios gauge")?;
+    writeln!(buf, "sonda_server_max_scenarios {}", state.max_scenarios)
+}
+
+fn write_requests_total(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    writeln!(
+        buf,
+        "# HELP sonda_server_requests_total HTTP requests served, per matched route, method, and status."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_requests_total counter")?;
+    let snapshot: Vec<((String, String, u16), u64)> = {
+        let guard = match state.request_counters.read() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let mut rows: Vec<_> = guard
+            .iter()
+            .map(|((r, m, s), c)| ((r.clone(), m.clone(), *s), c.load(Ordering::Relaxed)))
+            .collect();
+        rows.sort_by(|a, b| a.0.cmp(&b.0));
+        rows
+    };
+    for ((route, method, status), value) in &snapshot {
+        writeln!(
+            buf,
+            "sonda_server_requests_total{{route=\"{}\",method=\"{}\",status=\"{}\"}} {}",
+            escape_label(route),
+            escape_label(method),
+            status,
+            value
+        )?;
+    }
+    Ok(())
+}
+
+fn write_request_duration_seconds(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    writeln!(
+        buf,
+        "# HELP sonda_server_request_duration_seconds HTTP request duration in seconds, per matched route and method."
+    )?;
+    writeln!(
+        buf,
+        "# TYPE sonda_server_request_duration_seconds histogram"
+    )?;
+    let snapshots: Vec<((String, String), _)> = {
+        let guard = match state.request_histograms.read() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let mut rows: Vec<_> = guard
+            .iter()
+            .map(|(k, shard)| (k.clone(), shard.snapshot()))
+            .collect();
+        rows.sort_by(|a, b| a.0.cmp(&b.0));
+        rows
+    };
+    for ((route, method), snap) in &snapshots {
+        let route_esc = escape_label(route);
+        let method_esc = escape_label(method);
+        for (i, bound) in HistogramShard::BUCKET_BOUNDS.iter().enumerate() {
+            writeln!(
+                buf,
+                "sonda_server_request_duration_seconds_bucket{{route=\"{route_esc}\",method=\"{method_esc}\",le=\"{bound}\"}} {}",
+                snap.buckets[i]
+            )?;
+        }
+        writeln!(
+            buf,
+            "sonda_server_request_duration_seconds_bucket{{route=\"{route_esc}\",method=\"{method_esc}\",le=\"+Inf\"}} {}",
+            snap.plus_inf
+        )?;
+        writeln!(
+            buf,
+            "sonda_server_request_duration_seconds_sum{{route=\"{route_esc}\",method=\"{method_esc}\"}} {}",
+            snap.sum
+        )?;
+        writeln!(
+            buf,
+            "sonda_server_request_duration_seconds_count{{route=\"{route_esc}\",method=\"{method_esc}\"}} {}",
+            snap.count
+        )?;
+    }
+    Ok(())
+}
+
+fn write_sink_errors_total(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    writeln!(
+        buf,
+        "# HELP sonda_server_sink_errors_total Lifetime sink-write failures, summed across scenarios per sink_type."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_sink_errors_total counter")?;
+    let mut totals: BTreeMap<&'static str, u64> = BTreeMap::new();
+    {
+        let scenarios = match state.scenarios.read() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        for handle in scenarios.values() {
+            let snap = handle.stats_snapshot();
+            *totals.entry(handle.sink_type()).or_insert(0) += snap.total_sink_failures;
+        }
+    }
+    for (sink_type, value) in totals {
+        writeln!(
+            buf,
+            "sonda_server_sink_errors_total{{sink_type=\"{sink_type}\"}} {value}"
+        )?;
+    }
+    Ok(())
+}
+
+fn write_uptime_seconds(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    let uptime = state.started_at.elapsed().as_secs_f64();
+    writeln!(
+        buf,
+        "# HELP sonda_server_uptime_seconds Seconds since the server process started."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_uptime_seconds gauge")?;
+    writeln!(buf, "sonda_server_uptime_seconds {uptime}")
+}
+
+fn write_build_info(buf: &mut String) -> std::fmt::Result {
+    let version = env!("CARGO_PKG_VERSION");
+    let git_sha = env!("SONDA_GIT_SHA");
+    writeln!(
+        buf,
+        "# HELP sonda_server_build_info Build-time version and git SHA. Constant gauge always set to 1."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_build_info gauge")?;
+    writeln!(
+        buf,
+        "sonda_server_build_info{{version=\"{}\",git_sha=\"{}\"}} 1",
+        escape_label(version),
+        escape_label(git_sha)
+    )
+}
+
+fn escape_label(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_label_handles_backslash_quote_and_newline() {
+        assert_eq!(escape_label(r#"a\b"c"#), r#"a\\b\"c"#);
+        assert_eq!(escape_label("line\nbreak"), "line\\nbreak");
+        assert_eq!(escape_label("plain"), "plain");
+    }
+}

--- a/sonda-server/src/state.rs
+++ b/sonda-server/src/state.rs
@@ -2,11 +2,99 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
 use sonda_core::ScenarioHandle;
+use tokio::sync::Semaphore;
 
 use crate::gate_registry::GateBusRegistry;
+
+pub type RouteKey = (String, String, u16);
+pub type HistogramKey = (String, String);
+
+pub struct HistogramShard {
+    pub buckets: [AtomicU64; 11],
+    pub plus_inf: AtomicU64,
+    pub sum_bits: AtomicU64,
+    pub count: AtomicU64,
+}
+
+impl HistogramShard {
+    pub const BUCKET_BOUNDS: [f64; 11] = [
+        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+    ];
+
+    pub fn new() -> Self {
+        Self {
+            buckets: [
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+            ],
+            plus_inf: AtomicU64::new(0),
+            sum_bits: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        }
+    }
+
+    pub fn observe(&self, seconds: f64) {
+        use std::sync::atomic::Ordering;
+        for (i, bound) in Self::BUCKET_BOUNDS.iter().enumerate() {
+            if seconds <= *bound {
+                self.buckets[i].fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        self.plus_inf.fetch_add(1, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+        // Atomic sum tracked as f64 bit-pattern via CAS loop.
+        let mut current = self.sum_bits.load(Ordering::Relaxed);
+        loop {
+            let updated = f64::from_bits(current) + seconds;
+            match self.sum_bits.compare_exchange_weak(
+                current,
+                updated.to_bits(),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    pub fn snapshot(&self) -> HistogramSnapshot {
+        use std::sync::atomic::Ordering;
+        HistogramSnapshot {
+            buckets: self.buckets.each_ref().map(|a| a.load(Ordering::Relaxed)),
+            plus_inf: self.plus_inf.load(Ordering::Relaxed),
+            sum: f64::from_bits(self.sum_bits.load(Ordering::Relaxed)),
+            count: self.count.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl Default for HistogramShard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct HistogramSnapshot {
+    pub buckets: [u64; 11],
+    pub plus_inf: u64,
+    pub sum: f64,
+    pub count: u64,
+}
 
 /// Shared application state for the HTTP server.
 ///
@@ -28,6 +116,18 @@ pub struct AppState {
     pub catalog_dir: Option<Arc<PathBuf>>,
     /// Registry of cross-POST `while:` upstream buses.
     pub gate_bus_registry: Arc<GateBusRegistry>,
+    /// Permits gating the `--max-scenarios` row cap.
+    pub scenario_permits: Arc<Semaphore>,
+    /// Process start time for `sonda_server_uptime_seconds`.
+    pub started_at: Instant,
+    /// Configured tokio worker thread count exposed via `sonda_server_worker_threads`.
+    pub worker_threads: usize,
+    /// Configured `--max-scenarios` value exposed via `sonda_server_max_scenarios`.
+    pub max_scenarios: usize,
+    /// Per-`(route, method, status)` request counters.
+    pub request_counters: Arc<RwLock<HashMap<RouteKey, AtomicU64>>>,
+    /// Per-`(route, method)` duration histograms.
+    pub request_histograms: Arc<RwLock<HashMap<HistogramKey, HistogramShard>>>,
 }
 
 impl AppState {
@@ -38,16 +138,29 @@ impl AppState {
             api_key: None,
             catalog_dir: None,
             gate_bus_registry: Arc::new(GateBusRegistry::new()),
+            scenario_permits: Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
+            started_at: Instant::now(),
+            worker_threads: 1,
+            max_scenarios: 0,
+            request_counters: Arc::new(RwLock::new(HashMap::new())),
+            request_histograms: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
     /// Create a new, empty application state with an optional API key.
+    #[allow(dead_code)]
     pub fn with_api_key(api_key: Option<String>) -> Self {
         Self {
             scenarios: Arc::new(RwLock::new(HashMap::new())),
             api_key: api_key.map(Arc::new),
             catalog_dir: None,
             gate_bus_registry: Arc::new(GateBusRegistry::new()),
+            scenario_permits: Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
+            started_at: Instant::now(),
+            worker_threads: 1,
+            max_scenarios: 0,
+            request_counters: Arc::new(RwLock::new(HashMap::new())),
+            request_histograms: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }
@@ -191,5 +304,40 @@ mod tests {
     fn app_state_is_clone() {
         fn assert_clone<T: Clone>() {}
         assert_clone::<AppState>();
+    }
+
+    #[test]
+    fn new_defaults_semaphore_to_max_permits() {
+        let state = AppState::new();
+        assert_eq!(
+            state.scenario_permits.available_permits(),
+            Semaphore::MAX_PERMITS
+        );
+        assert_eq!(state.max_scenarios, 0);
+        assert_eq!(state.worker_threads, 1);
+    }
+
+    #[test]
+    fn started_at_is_recorded_on_construction() {
+        let before = Instant::now();
+        let state = AppState::new();
+        let after = Instant::now();
+        assert!(state.started_at >= before);
+        assert!(state.started_at <= after);
+    }
+
+    #[test]
+    fn histogram_shard_observe_records_bucket_count_and_sum() {
+        let shard = HistogramShard::new();
+        shard.observe(0.004);
+        shard.observe(0.5);
+        let snap = shard.snapshot();
+        assert_eq!(snap.count, 2);
+        assert_eq!(snap.plus_inf, 2);
+        assert!((snap.sum - 0.504).abs() < 1e-9);
+        // 0.004 falls in the 0.005 bucket and every higher bucket.
+        assert_eq!(snap.buckets[0], 1);
+        // 0.5 also falls in 0.5 bucket and above.
+        assert_eq!(snap.buckets[6], 2);
     }
 }

--- a/sonda-server/tests/bounded_scheduler.rs
+++ b/sonda-server/tests/bounded_scheduler.rs
@@ -1,0 +1,695 @@
+//! End-to-end integration tests for the bounded scheduler and /server/metrics endpoint.
+
+mod common;
+
+use std::io::{BufRead, BufReader};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+const LONG_RUNNING_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: cap_test
+    signal_type: metrics
+    name: cap_test
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+const SHORT_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 200ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: short_scn
+    signal_type: metrics
+    name: short_scn
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+fn unique_yaml(template: &str, name: &str) -> String {
+    template
+        .replace("id: cap_test", &format!("id: {name}"))
+        .replace("name: cap_test", &format!("name: {name}"))
+        .replace("id: short_scn", &format!("id: {name}"))
+        .replace("name: short_scn", &format!("name: {name}"))
+}
+
+#[test]
+fn delete_frees_slot_before_join_window_elapses() {
+    let (port, _guard) = common::start_server_with(&["--max-scenarios", "1"], &[]);
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let body = unique_yaml(LONG_RUNNING_YAML, "slot_first");
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(body)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(resp.status().as_u16(), 201);
+    let json: serde_json::Value = resp.json().expect("JSON");
+    let id = json["id"].as_str().expect("id").to_string();
+
+    let delete_url = format!("{base}/scenarios/{id}");
+    let delete_client = client.clone();
+    let delete_started = Instant::now();
+    let delete_join = thread::spawn(move || {
+        delete_client
+            .delete(delete_url)
+            .send()
+            .expect("DELETE must succeed")
+            .status()
+            .as_u16()
+    });
+
+    // Give DELETE 50ms to remove the row + drop the permit.
+    thread::sleep(Duration::from_millis(50));
+
+    let second_body = unique_yaml(LONG_RUNNING_YAML, "slot_second");
+    let second_post_started = Instant::now();
+    let second_resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(second_body)
+        .send()
+        .expect("second POST must succeed");
+    let second_elapsed = second_post_started.elapsed();
+
+    assert_eq!(
+        second_resp.status().as_u16(),
+        201,
+        "second POST must succeed after DELETE removes the row, not 5s later (DELETE wall {:?})",
+        delete_started.elapsed(),
+    );
+    assert!(
+        second_elapsed < Duration::from_millis(500),
+        "second POST returned in {second_elapsed:?}; expected < 500ms after slot release",
+    );
+
+    let delete_status = delete_join.join().expect("DELETE thread joined");
+    assert_eq!(delete_status, 200, "DELETE must return 200");
+}
+
+#[test]
+fn sixth_scenario_returns_429_when_max_scenarios_is_five() {
+    let (port, _guard) = common::start_server_with(&["--max-scenarios", "5"], &[]);
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    for i in 0..5 {
+        let body = unique_yaml(LONG_RUNNING_YAML, &format!("cap_scn_{i}"));
+        let resp = client
+            .post(format!("{base}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(body)
+            .send()
+            .expect("POST must succeed");
+        assert_eq!(resp.status().as_u16(), 201, "POST #{i} must return 201");
+    }
+
+    let body = unique_yaml(LONG_RUNNING_YAML, "cap_scn_overflow");
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(body)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(
+        resp.status().as_u16(),
+        429,
+        "6th POST must return 429 Too Many Requests"
+    );
+
+    let body: serde_json::Value = resp.json().expect("JSON body");
+    assert_eq!(body["error"], "capacity_exceeded");
+    assert!(body["detail"].as_str().unwrap().contains("max 5"));
+    let by_state = &body["by_state"];
+    assert!(by_state.is_object(), "by_state must be an object");
+    for label in [
+        "pending",
+        "running",
+        "paused",
+        "held",
+        "unresolved",
+        "finished",
+    ] {
+        assert!(
+            by_state.get(label).is_some(),
+            "by_state must contain '{label}'"
+        );
+    }
+}
+
+#[test]
+fn finished_scenarios_count_against_cap() {
+    let (port, _guard) = common::start_server_with(&["--max-scenarios", "5"], &[]);
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    for i in 0..5 {
+        let body = unique_yaml(SHORT_YAML, &format!("done_{i}"));
+        let resp = client
+            .post(format!("{base}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(body)
+            .send()
+            .expect("POST must succeed");
+        assert_eq!(resp.status().as_u16(), 201);
+    }
+
+    // Allow the short scenarios to finish.
+    thread::sleep(Duration::from_millis(800));
+
+    let body = unique_yaml(SHORT_YAML, "done_overflow");
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(body)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(
+        resp.status().as_u16(),
+        429,
+        "Finished rows still consume slots"
+    );
+    let json: serde_json::Value = resp.json().expect("JSON");
+    let finished = json["by_state"]["finished"].as_u64().unwrap_or(0);
+    assert_eq!(finished, 5, "all 5 should be in Finished state");
+
+    let metrics = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET /server/metrics must succeed");
+    assert_eq!(metrics.status().as_u16(), 200);
+    let text = metrics.text().expect("body");
+    assert!(
+        !text.contains("sonda_server_active_scenarios{state=\"finished\"}"),
+        "Finished scenarios must NOT appear in active_scenarios gauge. Got:\n{text}"
+    );
+    assert!(
+        text.contains("sonda_server_scenarios_finished_total 5"),
+        "scenarios_finished_total must report 5 after all rows reach Finished. Got:\n{text}"
+    );
+}
+
+#[test]
+fn max_scenarios_zero_allows_unlimited_posts() {
+    let (port, mut child) = common::spawn_server_with(&["--max-scenarios", "0"], &[]);
+    let stderr = child.stderr.take().expect("child stderr must be piped");
+    let (tx, rx) = mpsc::channel::<String>();
+    let stderr_thread = thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            let _ = tx.send(line);
+        }
+    });
+
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    for i in 0..10 {
+        let body = unique_yaml(LONG_RUNNING_YAML, &format!("unl_{i}"));
+        let resp = client
+            .post(format!("{base}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(body)
+            .send()
+            .expect("POST must succeed");
+        assert_eq!(resp.status().as_u16(), 201, "POST #{i} must return 201");
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let mut saw_warn = false;
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(200)) {
+            Ok(line) => {
+                if line.contains("scenario row cap disabled") || line.contains("max-scenarios 0") {
+                    saw_warn = true;
+                    break;
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+
+    child.kill().ok();
+    child.wait().ok();
+    let _ = stderr_thread.join();
+
+    assert!(
+        saw_warn,
+        "expected --max-scenarios 0 WARN line on stderr; none captured before timeout"
+    );
+}
+
+#[test]
+fn server_metrics_emits_all_nine_series_with_zero_state_rows() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let resp = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET must succeed");
+    assert_eq!(resp.status().as_u16(), 200);
+    let text = resp.text().expect("body");
+
+    for series in [
+        "sonda_server_active_scenarios",
+        "sonda_server_scenarios_finished_total",
+        "sonda_server_worker_threads",
+        "sonda_server_max_scenarios",
+        "sonda_server_requests_total",
+        "sonda_server_request_duration_seconds",
+        "sonda_server_sink_errors_total",
+        "sonda_server_uptime_seconds",
+        "sonda_server_build_info",
+    ] {
+        assert!(
+            text.contains(series),
+            "/server/metrics must contain `{series}`. Got:\n{text}"
+        );
+    }
+
+    for label in ["pending", "running", "paused", "held", "unresolved"] {
+        let needle = format!("sonda_server_active_scenarios{{state=\"{label}\"}} 0");
+        assert!(
+            text.contains(&needle),
+            "expected zero-row `{needle}`. Got:\n{text}"
+        );
+    }
+}
+
+#[test]
+fn server_metrics_requires_bearer_token_when_api_key_set() {
+    let (port, _guard) = common::start_server_with(&[], &[("SONDA_API_KEY", "topsecret")]);
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let resp = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET must succeed");
+    assert_eq!(
+        resp.status().as_u16(),
+        401,
+        "GET /server/metrics without auth must return 401"
+    );
+
+    let resp = client
+        .get(format!("{base}/server/metrics"))
+        .header("authorization", "Bearer topsecret")
+        .send()
+        .expect("GET must succeed");
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+#[test]
+fn requests_total_uses_matched_path_for_route_label() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let body = unique_yaml(LONG_RUNNING_YAML, "route_lbl");
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(body)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(resp.status().as_u16(), 201);
+    let json: serde_json::Value = resp.json().expect("JSON");
+    let id = json["id"].as_str().expect("id").to_string();
+
+    let _ = client
+        .get(format!("{base}/scenarios/{id}/stats"))
+        .send()
+        .expect("GET stats must succeed");
+
+    let resp = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET /server/metrics must succeed");
+    let text = resp.text().expect("body");
+
+    let needle = "route=\"/scenarios/{id}/stats\"";
+    assert!(
+        text.contains(needle),
+        "route label must be the matched-path template `{needle}`, NOT the concrete UUID. Got:\n{text}"
+    );
+    assert!(
+        !text.contains(&format!("route=\"/scenarios/{id}/stats\"")),
+        "route label MUST NOT include the concrete UUID"
+    );
+}
+
+#[test]
+fn body_limit_returns_413_with_structured_error() {
+    let (port, _guard) = common::start_server_with(&["--max-body-bytes", "1024"], &[]);
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let huge_body = "x".repeat(8 * 1024);
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(huge_body)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(
+        resp.status().as_u16(),
+        413,
+        "oversized body must return 413 Payload Too Large"
+    );
+}
+
+#[test]
+fn request_timeout_returns_408_with_structured_error() {
+    let (port, _guard) = common::start_server_with(&["--request-timeout", "1"], &[]);
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .build()
+        .expect("HTTP client");
+    let base = format!("http://127.0.0.1:{port}");
+
+    // /events builds the sink in the handler; TEST-NET-1 drops SYNs so the
+    // TCP connect hangs past `--request-timeout 1`.
+    let body = serde_json::json!({
+        "signal_type": "logs",
+        "log": {"severity": "info", "message": "x"},
+        "encoder": {"type": "json_lines"},
+        "sink": {
+            "type": "tcp",
+            "address": "192.0.2.1:1"
+        },
+    });
+
+    let resp = client
+        .post(format!("{base}/events"))
+        .header("content-type", "application/json")
+        .body(body.to_string())
+        .send()
+        .expect("POST must succeed");
+
+    assert_eq!(
+        resp.status().as_u16(),
+        408,
+        "request awaiting beyond --request-timeout must return 408 Request Timeout"
+    );
+}
+
+#[test]
+fn single_worker_runtime_drains_three_scenarios_on_sigterm() {
+    let (port, mut child) =
+        common::spawn_server_with(&["--workers", "1", "--max-scenarios", "10"], &[]);
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    for i in 0..3 {
+        let body = unique_yaml(LONG_RUNNING_YAML, &format!("workers1_{i}"));
+        let resp = client
+            .post(format!("{base}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(body)
+            .send()
+            .expect("POST must succeed");
+        assert_eq!(resp.status().as_u16(), 201, "POST #{i} must return 201");
+    }
+
+    // Sanity-check the process is still alive before signalling.
+    let health = client
+        .get(format!("{base}/health"))
+        .send()
+        .expect("GET /health must succeed");
+    assert_eq!(health.status().as_u16(), 200);
+
+    let started = Instant::now();
+    unsafe {
+        libc::kill(child.id() as i32, libc::SIGTERM);
+    }
+    let status = child.wait().expect("must wait for child");
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed <= Duration::from_secs(6),
+        "single-worker runtime must drain 3 scenarios within 6s of SIGTERM; took {elapsed:?}"
+    );
+    assert!(
+        status.success(),
+        "SIGTERM must produce a clean exit, got {status:?}"
+    );
+}
+
+#[test]
+fn health_remains_responsive_when_control_plane_is_saturated() {
+    let (port, _guard) = common::start_server_with(&["--max-inflight-requests", "1"], &[]);
+    let base = format!("http://127.0.0.1:{port}");
+
+    // Hold the /events permit open via a TCP connect to TEST-NET-1 (drops SYNs).
+    let saturator_base = base.clone();
+    let (started_tx, started_rx) = mpsc::channel::<()>();
+    let saturator = thread::spawn(move || {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("HTTP client");
+        let body = serde_json::json!({
+            "signal_type": "logs",
+            "log": {"severity": "info", "message": "saturator"},
+            "encoder": {"type": "json_lines"},
+            "sink": {
+                "type": "tcp",
+                "address": "192.0.2.1:1"
+            },
+        });
+        let req = client
+            .post(format!("{saturator_base}/events"))
+            .header("content-type", "application/json")
+            .body(body.to_string());
+        started_tx.send(()).ok();
+        req.send().ok();
+    });
+
+    started_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("saturator thread did not start");
+    // Allow the saturator's send() to reach the server and await the TCP connect.
+    thread::sleep(Duration::from_millis(500));
+
+    let client = common::http_client();
+    let health = client
+        .get(format!("{base}/health"))
+        .send()
+        .expect("GET /health must succeed");
+    assert_eq!(
+        health.status().as_u16(),
+        200,
+        "/health must stay reachable while POST holds the concurrency permit"
+    );
+
+    let server_metrics = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET /server/metrics must succeed");
+    assert_eq!(
+        server_metrics.status().as_u16(),
+        200,
+        "/server/metrics must stay reachable while POST holds the concurrency permit"
+    );
+
+    // A second POST on the same route must be queued behind the saturator's permit.
+    let gated_client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_millis(800))
+        .build()
+        .expect("HTTP client");
+    let gated_body = serde_json::json!({
+        "signal_type": "logs",
+        "log": {"severity": "info", "message": "gated"},
+        "encoder": {"type": "json_lines"},
+        "sink": {
+            "type": "tcp",
+            "address": "192.0.2.1:1"
+        },
+    });
+    let gated_started = Instant::now();
+    let gated_result = gated_client
+        .post(format!("{base}/events"))
+        .header("content-type", "application/json")
+        .body(gated_body.to_string())
+        .send();
+    let gated_elapsed = gated_started.elapsed();
+
+    assert!(
+        gated_elapsed >= Duration::from_millis(500),
+        "second POST on the saturated route should have been queued; elapsed {gated_elapsed:?} (result: {gated_result:?})"
+    );
+
+    drop(saturator);
+}
+
+#[test]
+fn global_inflight_limit_gates_across_routes() {
+    let (port, _guard) = common::start_server_with(&["--max-inflight-requests", "1"], &[]);
+    let base = format!("http://127.0.0.1:{port}");
+
+    // Hold the only permit on /events via a TCP connect to TEST-NET-1 (drops SYNs).
+    let saturator_base = base.clone();
+    let (started_tx, started_rx) = mpsc::channel::<()>();
+    let saturator = thread::spawn(move || {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("HTTP client");
+        let body = serde_json::json!({
+            "signal_type": "logs",
+            "log": {"severity": "info", "message": "saturator"},
+            "encoder": {"type": "json_lines"},
+            "sink": {
+                "type": "tcp",
+                "address": "192.0.2.1:1"
+            },
+        });
+        let req = client
+            .post(format!("{saturator_base}/events"))
+            .header("content-type", "application/json")
+            .body(body.to_string());
+        started_tx.send(()).ok();
+        req.send().ok();
+    });
+
+    started_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("saturator thread did not start");
+    // Allow the saturator's send() to reach the server and await the TCP connect.
+    thread::sleep(Duration::from_millis(500));
+
+    // POST /scenarios must be gated by the same global permit even though it is
+    // a different route than /events.
+    let gated_client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_millis(1500))
+        .build()
+        .expect("HTTP client");
+    let gated_body = unique_yaml(LONG_RUNNING_YAML, "cross_route");
+    let gated_started = Instant::now();
+    let gated_result = gated_client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(gated_body)
+        .send();
+    let gated_elapsed = gated_started.elapsed();
+
+    assert!(
+        gated_elapsed >= Duration::from_millis(500),
+        "POST /scenarios should have been queued behind the /events permit; elapsed {gated_elapsed:?} (result: {gated_result:?})"
+    );
+
+    drop(saturator);
+}
+
+#[test]
+fn observability_endpoints_reachable_under_concurrent_post_saturation() {
+    let (port, _guard) = common::start_server_with(&["--max-inflight-requests", "1"], &[]);
+    let base = format!("http://127.0.0.1:{port}");
+
+    // First, register a scenario so /scenarios/{id}/metrics has a real id to hit.
+    let client = common::http_client();
+    let body = unique_yaml(LONG_RUNNING_YAML, "sat_obs");
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(body)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(resp.status().as_u16(), 201);
+    let json: serde_json::Value = resp.json().expect("JSON");
+    let id = json["id"].as_str().expect("id").to_string();
+
+    let saturator_base = base.clone();
+    let (started_tx, started_rx) = mpsc::channel::<()>();
+    let saturator = thread::spawn(move || {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("HTTP client");
+        let body = serde_json::json!({
+            "signal_type": "logs",
+            "log": {"severity": "info", "message": "saturator"},
+            "encoder": {"type": "json_lines"},
+            "sink": {
+                "type": "tcp",
+                "address": "192.0.2.1:1"
+            },
+        });
+        let req = client
+            .post(format!("{saturator_base}/events"))
+            .header("content-type", "application/json")
+            .body(body.to_string());
+        started_tx.send(()).ok();
+        req.send().ok();
+    });
+
+    started_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("saturator thread did not start");
+    thread::sleep(Duration::from_millis(500));
+
+    let health = client
+        .get(format!("{base}/health"))
+        .send()
+        .expect("GET /health");
+    assert_eq!(health.status().as_u16(), 200);
+
+    let server_metrics = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET /server/metrics");
+    assert_eq!(server_metrics.status().as_u16(), 200);
+
+    let scenario_metrics = client
+        .get(format!("{base}/scenarios/{id}/metrics"))
+        .send()
+        .expect("GET /scenarios/{id}/metrics");
+    assert_eq!(
+        scenario_metrics.status().as_u16(),
+        200,
+        "scenario scrape must stay reachable while control-plane POST holds the permit"
+    );
+
+    drop(saturator);
+}
+
+#[test]
+fn build_info_exposes_version_and_git_sha() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let resp = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET must succeed");
+    let text = resp.text().expect("body");
+    assert!(text.contains("sonda_server_build_info{version="));
+    assert!(text.contains("git_sha="));
+}

--- a/sonda-server/tests/build_info.rs
+++ b/sonda-server/tests/build_info.rs
@@ -1,0 +1,34 @@
+//! Verifies `build.rs` SHA injection and its no-git fallback contract.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn sonda_git_sha_is_injected_at_compile_time() {
+    let sha = env!("SONDA_GIT_SHA");
+    assert!(!sha.is_empty());
+    assert!(
+        sha == "unknown" || (sha.len() >= 7 && sha.chars().all(|c| c.is_ascii_hexdigit())),
+        "SONDA_GIT_SHA must be 'unknown' or a hex SHA, got: {sha:?}"
+    );
+}
+
+#[test]
+fn build_rs_fallback_returns_unknown_when_git_directory_is_absent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let no_git_dir: PathBuf = dir.path().into();
+    let result = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&no_git_dir)
+        .output();
+    match result {
+        Ok(out) => assert!(
+            !out.status.success(),
+            "git rev-parse HEAD in a non-git directory must fail; build.rs falls back to 'unknown' on this path"
+        ),
+        Err(_) => {
+            // git binary not present at all — the build.rs path still
+            // catches the spawn error and falls back to 'unknown'.
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds operator surface for production deployments: configurable tokio runtime
worker count, bounded concurrent scenario row cap, global inflight-request
limit, per-request timeout, body-size limit, and a Prometheus self-
instrumentation endpoint exposing RED + saturation metrics. Closes
adoption-review Gap #1 (resource limits) and Gap #2 (server self-telemetry).

## New CLI flags on `sonda-server`

- **`--workers N`** — configures the tokio multi-thread runtime. Defaults to
  `std::thread::available_parallelism()` so cgroup CPU quotas are honored in
  containers. Replaces the implicit `#[tokio::main]` default.
- **`--max-scenarios N`** — caps concurrent scenario rows in `AppState.scenarios`
  via `Arc<Semaphore>`. `0` means unlimited and emits a startup WARN. Permit
  lives on `ScenarioHandle`; `DELETE` releases it on row removal so the slot
  is freed promptly (row cap, not task-CPU cap).
- **`--max-inflight-requests N`** — gates the protected control sub-router via
  `tower::limit::GlobalConcurrencyLimitLayer` with a shared `Arc<Semaphore>`.
  Applies across all control routes — true global cap.
- **`--request-timeout SECS`** (default 30) — handler-execution bound returning
  HTTP 408 on expiry.
- **`--max-body-bytes N`** (default 1 MiB) — request body cap returning HTTP 413
  on oversize.

## New endpoint `GET /server/metrics`

Prometheus text exposition. Nine series:

| Series | Type | Labels |
|---|---|---|
| `sonda_server_active_scenarios` | gauge (5 rows always) | `state` |
| `sonda_server_scenarios_finished_total` | counter | — |
| `sonda_server_worker_threads` | gauge | — |
| `sonda_server_max_scenarios` | gauge | — |
| `sonda_server_requests_total` | counter | `route, method, status` |
| `sonda_server_request_duration_seconds` | histogram | `route, method, le` |
| `sonda_server_sink_errors_total` | counter | `sink_type` |
| `sonda_server_uptime_seconds` | gauge | — |
| `sonda_server_build_info` | gauge=1 | `version, git_sha` |

Hand-rolled emitter consistent with the existing `/scenarios/{id}/metrics`
and `/metrics` emitters. `route` label uses `axum::extract::MatchedPath`
(route template) not the resolved URI — bounded TSDB cardinality.
`sink_errors_total` is derived at scrape time from `ScenarioStats`; no
core-side counter mutation.

## Router restructure

Three sub-routers:

- **`public`** — no auth, no Tower stack. Hosts `/health` so kubelet probes
  never block on saturation.
- **`protected_observability`** — auth-gated, no Tower load-control. Hosts
  `/server/metrics`, `/metrics`, `/scenarios/{id}/metrics`,
  `/scenarios/{id}/stats` so Prometheus scrapes stay green during saturation.
- **`protected_control`** — auth-gated, full Tower stack
  (`body-limit → timeout → concurrency-limit`). Tower stack wraps outside
  `record_request_metrics` so 408/413/429 responses are still counted.

## Public API additions (sonda-core)

All on `#[non_exhaustive]` types:

- `ScenarioHandle::attach_permit`, `take_permit`, `sink_type`, `with_sink_type`.
- `ScenarioState::operational_states`, `as_label` — single source of truth
  for the operational gauge label set and the `capacity_exceeded_response`
  JSON `by_state` map.

## Helm

`ServiceMonitor` defaults to scraping `/server/metrics`.

## Build

`sonda-server/build.rs` injects `SONDA_GIT_SHA` from `git rev-parse HEAD`
with `"unknown"` fallback for Docker tarball builds.

## Deps

- `tower` promoted from `[dev-dependencies]` to `[dependencies]` with
  `features = ["limit"]`.
- `tower-http` features changed from `{cors, trace}` to `{timeout, limit}`.
- No new top-level crates.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace --all-features` — 2916 / 2916
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::await_holding_lock`
- [x] `cargo clippy -p sonda-core --no-default-features -- -D warnings`
- [x] `cargo test -p sonda-core --no-default-features --no-run`
- [x] `cargo fmt --all -- --check`
- [x] `cargo audit`
- [x] `cargo nextest run -p sonda-core --all-features --test while_close_workshop_repro` — 11 / 11, 0 skipped
- [x] `global_inflight_limit_gates_across_routes` proves cross-route concurrency cap
- [x] `delete_frees_slot_before_join_window_elapses` proves R6 row-cap semantic
- [x] `request_timeout_returns_408_with_structured_error` proves 408 path
- [x] `single_worker_runtime_drains_three_scenarios_on_sigterm` proves `--workers 1` SIGTERM grace

Refs adoption-review Gap #1, #2.