### PR TITLE
feat(core): restore microsecond drift probe; cap default workers at 16

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,9 +124,9 @@ A schedule controls when events are emitted: their rate, duration, and any inten
 - **GapWindow** — a recurring silent period defined as `(gap_every, gap_for)`. During a gap, no events are emitted and the scheduler sleeps rather than busy-waiting.
 - **BurstWindow** — a recurring high-rate period defined as `(burst_every, burst_for, burst_multiplier)`. During a burst, the effective rate is multiplied.
 
-The scheduler uses `std::time::Instant` for elapsed tracking and `std::io::BufWriter` for output batching. A shared schedule loop (`core_loop.rs`) handles all rate control, gap/burst/spike window logic, and stats tracking for both metrics and logs. Signal-specific event construction is delegated to a per-signal callback, eliminating duplication between the metric and log runners. The loop is synchronous — tight sleep intervals are sufficient for the target rate range and avoid tokio overhead in the CLI path.
+The scheduler is async-native. A shared schedule loop (`core_loop.rs`) handles all rate control, gap/burst/spike window logic, and stats tracking for both metrics and logs; signal-specific event construction is delegated to a per-signal callback. `tokio::time::Interval` drives per-tick cadence with `MissedTickBehavior::Delay`, so a slow sink does not amplify into runaway catch-up emissions. Sinks call `.await` directly; the HTTP-family sinks bridge to blocking `ureq` via `tokio::task::spawn_blocking`.
 
-> **Concurrency (post-MVP):** Multiple concurrent scenarios will be supported in a future expansion. The plan is `std::thread` per scenario with `mpsc` channels feeding a shared sink, before introducing tokio. This keeps the core synchronous and avoids making tokio a core dependency.
+> **Concurrency.** Multiple concurrent scenarios run as `tokio::task::spawn` tasks on a shared multi-thread runtime. The CLI and the HTTP server both own one runtime and dispatch scenario launches into it via `launch_scenario`. The default tokio worker count is `min(available_parallelism(), 16)` — cgroup-aware on Linux containers, capped at 16 on larger hosts.
 
 ### 5.4 Encoders
 

--- a/sonda-core/benches/scheduler_baseline.rs
+++ b/sonda-core/benches/scheduler_baseline.rs
@@ -1,30 +1,23 @@
-//! Phase 0 baseline: measure the current thread-per-scenario scheduler at
-//! varying concurrent-scenario counts. Captures RSS, vsize, thread count,
-//! CPU%, tick-drift and dropped-tick percentage per N, and writes a markdown
-//! report alongside a stdout table.
+//! Multi-rate + multi-concurrency sweep of the async-scheduler. Captures RSS,
+//! vsize, thread count, CPU%, tick-drift (ms proxy + microsecond direct), and
+//! dropped-tick percentage per row, and writes a markdown report alongside a
+//! stdout table.
 
-use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
-use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex, RwLock};
-use std::thread;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use sonda_core::config::{BaseScheduleConfig, ScenarioConfig, ScenarioEntry};
 use sonda_core::encoder::EncoderConfig;
 use sonda_core::generator::GeneratorConfig;
 use sonda_core::schedule::handle::ScenarioHandle;
-use sonda_core::schedule::runner::run_with_sink;
-use sonda_core::schedule::stats::ScenarioStats;
-use sonda_core::sink::memory::{CapturedRing, MemorySink};
-use sonda_core::sink::{Sink, SinkConfig};
+use sonda_core::sink::memory::CapturedRing;
+use sonda_core::sink::SinkConfig;
 use sonda_core::{launch_scenario, prepare_entries, OnSinkError};
 use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System};
 
-const DEFAULT_SCENARIO_COUNTS: &[usize] = &[1, 10, 50, 100, 250, 500];
-const RATE_HZ: f64 = 100.0;
 const DEFAULT_WARMUP_SECS: u64 = 30;
 const DEFAULT_MEASURE_SECS: u64 = 60;
 const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
@@ -46,18 +39,70 @@ fn measure_secs() -> u64 {
         .unwrap_or(DEFAULT_MEASURE_SECS)
 }
 
-fn scenario_counts() -> Vec<usize> {
-    match std::env::var("SONDA_BENCH_COUNTS").ok() {
-        Some(s) => s
-            .split(',')
-            .filter_map(|p| p.trim().parse::<usize>().ok())
-            .collect(),
-        None => DEFAULT_SCENARIO_COUNTS.to_vec(),
-    }
+#[derive(Clone, Copy)]
+struct SweepRow {
+    n: usize,
+    rate_hz: f64,
+    label: &'static str,
 }
 
+const DEFAULT_SWEEP: &[SweepRow] = &[
+    SweepRow {
+        n: 10,
+        rate_hz: 100.0,
+        label: "rate@10:100Hz",
+    },
+    SweepRow {
+        n: 10,
+        rate_hz: 1_000.0,
+        label: "rate@10:1kHz",
+    },
+    SweepRow {
+        n: 10,
+        rate_hz: 10_000.0,
+        label: "rate@10:10kHz",
+    },
+    SweepRow {
+        n: 1,
+        rate_hz: 100.0,
+        label: "conc:1@100Hz",
+    },
+    SweepRow {
+        n: 10,
+        rate_hz: 100.0,
+        label: "conc:10@100Hz",
+    },
+    SweepRow {
+        n: 100,
+        rate_hz: 100.0,
+        label: "conc:100@100Hz",
+    },
+    SweepRow {
+        n: 500,
+        rate_hz: 100.0,
+        label: "conc:500@100Hz",
+    },
+    SweepRow {
+        n: 1000,
+        rate_hz: 100.0,
+        label: "conc:1000@100Hz",
+    },
+    SweepRow {
+        n: 1000,
+        rate_hz: 100.0,
+        label: "production:1000x100Hz",
+    },
+    SweepRow {
+        n: 100,
+        rate_hz: 1_000.0,
+        label: "stress:100x1kHz",
+    },
+];
+
 struct RowResult {
+    label: &'static str,
     n: usize,
+    rate_hz: f64,
     rss_mb: f64,
     vsize_mb: f64,
     threads: usize,
@@ -79,11 +124,11 @@ struct Sample {
     per_scenario_events: Vec<u64>,
 }
 
-fn metrics_entry(name: String, rate: f64, sink: SinkConfig) -> ScenarioEntry {
+fn metrics_entry(name: String, rate_hz: f64, sink: SinkConfig) -> ScenarioEntry {
     ScenarioEntry::Metrics(ScenarioConfig {
         base: BaseScheduleConfig {
             name,
-            rate,
+            rate: rate_hz,
             duration: None,
             gaps: None,
             bursts: None,
@@ -104,36 +149,6 @@ fn metrics_entry(name: String, rate: f64, sink: SinkConfig) -> ScenarioEntry {
         metric_type: None,
         help: None,
     })
-}
-
-fn metrics_config_for_capture(name: String, rate: f64) -> ScenarioConfig {
-    ScenarioConfig {
-        base: BaseScheduleConfig {
-            name,
-            rate,
-            duration: None,
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            dynamic_labels: None,
-            labels: None,
-            sink: SinkConfig::Memory {
-                capture: true,
-                max_events: Some(CAPTURE_RING_SIZE),
-            },
-            phase_offset: None,
-            clock_group: None,
-            clock_group_is_auto: None,
-            start_time: None,
-            jitter: None,
-            jitter_seed: None,
-            on_sink_error: OnSinkError::Warn,
-        },
-        generator: GeneratorConfig::Constant { value: 1.0 },
-        encoder: EncoderConfig::PrometheusText { precision: None },
-        metric_type: None,
-        help: None,
-    }
 }
 
 struct DriftStats {
@@ -176,108 +191,47 @@ fn compute_drift_stats(timestamps: &[Instant], rate_hz: f64) -> DriftStats {
     }
 }
 
-fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
+async fn launch_n(n: usize, rate_hz: f64) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
     assert!(n >= 1, "launch_n requires at least one scenario");
     let capture_handle = Arc::new(Mutex::new(CapturedRing::new(CAPTURE_RING_SIZE)));
 
-    let rt: &'static tokio::runtime::Runtime = Box::leak(Box::new(
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .expect("tokio runtime must build"),
-    ));
-    let mut handles = Vec::with_capacity(n);
-    handles.push(launch_capturing_scenario(
-        rt,
-        "bench_0".to_string(),
-        Arc::clone(&capture_handle),
-    ));
+    let entries: Vec<ScenarioEntry> = (0..n)
+        .map(|i| {
+            let sink = if i == 0 {
+                SinkConfig::Memory {
+                    capture: false,
+                    max_events: None,
+                    capture_handle: Some(Arc::clone(&capture_handle)),
+                }
+            } else {
+                SinkConfig::Memory {
+                    capture: false,
+                    max_events: None,
+                    capture_handle: None,
+                }
+            };
+            metrics_entry(format!("bench_{i}"), rate_hz, sink)
+        })
+        .collect();
 
-    if n > 1 {
-        let entries: Vec<ScenarioEntry> = (1..n)
-            .map(|i| {
-                metrics_entry(
-                    format!("bench_{i}"),
-                    RATE_HZ,
-                    SinkConfig::Memory {
-                        capture: false,
-                        max_events: None,
-                    },
-                )
-            })
-            .collect();
-        let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
-        for (offset, p) in prepared.into_iter().enumerate() {
-            let i = offset + 1;
-            let cancel = sonda_core::CancellationToken::new();
-            let handle = rt
-                .block_on(launch_scenario(
-                    format!("bench_{i}"),
-                    p.entry,
-                    cancel,
-                    p.start_delay,
-                ))
-                .expect("launch_scenario must succeed");
-            handles.push(handle);
-        }
+    let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
+    let mut handles = Vec::with_capacity(n);
+    for (offset, p) in prepared.into_iter().enumerate() {
+        let cancel = sonda_core::CancellationToken::new();
+        let handle = launch_scenario(format!("bench_{offset}"), p.entry, cancel, p.start_delay)
+            .await
+            .expect("launch_scenario must succeed");
+        handles.push(handle);
     }
     (handles, capture_handle)
 }
 
-// Mirrors launch_scenario for the shared-capture path; bench-local replica.
-fn launch_capturing_scenario(
-    rt: &tokio::runtime::Runtime,
-    id: String,
-    capture_handle: Arc<Mutex<CapturedRing>>,
-) -> ScenarioHandle {
-    let config = metrics_config_for_capture(id.clone(), RATE_HZ);
-    let name = config.base.name.clone();
-    let cancel = sonda_core::CancellationToken::new();
-    let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-    let alive = Arc::new(AtomicBool::new(true));
-    let cleaned_up = Arc::new(AtomicBool::new(true));
-    let labels: Arc<HashMap<String, String>> = Arc::new(HashMap::new());
-
-    let cancel_for_task = cancel.clone();
-    let stats_for_task = Arc::clone(&stats);
-    let alive_for_task = Arc::clone(&alive);
-
-    let task = rt.spawn(async move {
-        struct AliveGuard(Arc<AtomicBool>);
-        impl Drop for AliveGuard {
-            fn drop(&mut self) {
-                self.0.store(false, std::sync::atomic::Ordering::SeqCst);
-            }
-        }
-        let _guard = AliveGuard(alive_for_task);
-
-        let sink_inner = MemorySink::with_shared_capture(capture_handle);
-        let mut sink: Box<dyn Sink> = Box::new(sink_inner);
-        run_with_sink(&config, &mut sink, &cancel_for_task, Some(stats_for_task)).await
-    });
-
-    ScenarioHandle::new(
-        id,
-        name,
-        None,
-        cancel,
-        Some(task),
-        Instant::now(),
-        stats,
-        RATE_HZ,
-        alive,
-        labels,
-        None,
-        cleaned_up,
-    )
-}
-
-fn stop_all(handles: &mut [ScenarioHandle]) {
+async fn stop_all(handles: &mut [ScenarioHandle]) {
     for h in handles.iter() {
         h.stop();
     }
     for h in handles.iter_mut() {
-        let _ = h.join(Some(Duration::from_secs(5)));
+        let _ = h.join_async(Some(Duration::from_secs(5))).await;
     }
 }
 
@@ -339,15 +293,21 @@ fn current_thread_count() -> Option<usize> {
     None
 }
 
-fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
+async fn run_row(
+    runtime: &tokio::runtime::Handle,
+    row: SweepRow,
+    warmup: u64,
+    measure: u64,
+) -> RowResult {
+    let SweepRow { n, rate_hz, label } = row;
     eprintln!(
-        "[bench] N={n}: launching scenarios at {RATE_HZ:.0} Hz \
+        "[bench] {label}: N={n} rate={rate_hz:.0}Hz \
          (warmup {warmup}s, measure {measure}s)"
     );
 
-    let (mut handles, capture_handle) = launch_n(n);
+    let (mut handles, capture_handle) = launch_n(n, rate_hz).await;
 
-    thread::sleep(Duration::from_secs(warmup));
+    tokio::time::sleep(Duration::from_secs(warmup)).await;
 
     let pid = Pid::from_u32(std::process::id());
     let mut system = System::new_with_specifics(
@@ -365,7 +325,7 @@ fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
     let measure_end = Instant::now() + Duration::from_secs(measure);
 
     while Instant::now() < measure_end {
-        thread::sleep(SAMPLE_INTERVAL);
+        tokio::time::sleep(SAMPLE_INTERVAL).await;
         if let Some(s) = sample_process(&mut system, pid, &handles) {
             samples.push(s);
         }
@@ -376,29 +336,35 @@ fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
     let threads = samples.iter().map(|s| s.threads).max().unwrap_or(0);
     let cpu_pct = mean(samples.iter().map(|s| s.cpu_pct));
 
-    let drift_samples_ms = compute_drift_ms(&samples, &initial_events);
+    let drift_samples_ms = compute_drift_ms(&samples, &initial_events, rate_hz);
     let drift_mean_ms = mean(drift_samples_ms.iter().copied());
     let drift_p99_ms = percentile(&drift_samples_ms, 99.0);
-    let dropped_pct = compute_dropped_pct(&samples, &initial_events);
+    let dropped_pct = compute_dropped_pct(&samples, &initial_events, rate_hz);
 
     let captured_timestamps: Vec<Instant> = {
         let guard = capture_handle.lock().expect("capture handle poisoned");
         guard.events().iter().map(|(ts, _)| *ts).collect()
     };
-    let drift = compute_drift_stats(&captured_timestamps, RATE_HZ);
+    let drift = compute_drift_stats(&captured_timestamps, rate_hz);
 
     eprintln!(
-        "[bench] N={n}: rss={rss_mb:.1}MB vsize={vsize_mb:.0}MB threads={threads} \
+        "[bench] {label}: rss={rss_mb:.1}MB vsize={vsize_mb:.0}MB threads={threads} \
          cpu={cpu_pct:.1}% drift_mean={drift_mean_ms:.2}ms drift_p99={drift_p99_ms:.2}ms \
          drift_us p50={:.1} p90={:.1} p99={:.1} max={:.1} \
          dropped={dropped_pct:.2}%",
         drift.p50_us, drift.p90_us, drift.p99_us, drift.max_us
     );
 
-    stop_all(&mut handles);
+    stop_all(&mut handles).await;
+    drop(handles);
+    tokio::task::yield_now().await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let _ = runtime;
 
     RowResult {
+        label,
         n,
+        rate_hz,
         rss_mb,
         vsize_mb,
         threads,
@@ -413,11 +379,11 @@ fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
     }
 }
 
-fn compute_drift_ms(samples: &[Sample], initial_events: &[u64]) -> Vec<f64> {
+fn compute_drift_ms(samples: &[Sample], initial_events: &[u64], rate_hz: f64) -> Vec<f64> {
     let mut out = Vec::new();
     let mut prev = initial_events.to_vec();
-    let expected_per_sample = RATE_HZ * SAMPLE_INTERVAL.as_secs_f64();
-    let ms_per_tick = 1000.0 / RATE_HZ;
+    let expected_per_sample = rate_hz * SAMPLE_INTERVAL.as_secs_f64();
+    let ms_per_tick = 1000.0 / rate_hz;
     for s in samples {
         for (i, &observed) in s.per_scenario_events.iter().enumerate() {
             let prev_v = *prev.get(i).unwrap_or(&0);
@@ -430,8 +396,8 @@ fn compute_drift_ms(samples: &[Sample], initial_events: &[u64]) -> Vec<f64> {
     out
 }
 
-fn compute_dropped_pct(samples: &[Sample], initial_events: &[u64]) -> f64 {
-    let expected_per_sample = RATE_HZ * SAMPLE_INTERVAL.as_secs_f64();
+fn compute_dropped_pct(samples: &[Sample], initial_events: &[u64], rate_hz: f64) -> f64 {
+    let expected_per_sample = rate_hz * SAMPLE_INTERVAL.as_secs_f64();
     let mut prev = initial_events.to_vec();
     let mut dropped_buckets = 0u64;
     let mut total_buckets = 0u64;
@@ -489,8 +455,10 @@ fn percentile(values: &[f64], p: f64) -> f64 {
 fn print_table(rows: &[RowResult]) {
     println!();
     println!(
-        "| {:>5} | {:>9} | {:>11} | {:>7} | {:>5} | {:>20} | {:>19} | {:>12} | {:>12} | {:>12} | {:>11} | {:>14} |",
+        "| {:<24} | {:>5} | {:>8} | {:>9} | {:>11} | {:>7} | {:>5} | {:>20} | {:>19} | {:>12} | {:>12} | {:>12} | {:>11} | {:>14} |",
+        "Row",
         "N",
+        "Rate Hz",
         "RSS (MB)",
         "VSize (MB)",
         "Threads",
@@ -504,13 +472,15 @@ fn print_table(rows: &[RowResult]) {
         "Dropped-tick %"
     );
     println!(
-        "|{:-<7}|{:-<11}|{:-<13}|{:-<9}|{:-<7}|{:-<22}|{:-<21}|{:-<14}|{:-<14}|{:-<14}|{:-<13}|{:-<16}|",
-        "", "", "", "", "", "", "", "", "", "", "", ""
+        "|{:-<26}|{:-<7}|{:-<10}|{:-<11}|{:-<13}|{:-<9}|{:-<7}|{:-<22}|{:-<21}|{:-<14}|{:-<14}|{:-<14}|{:-<13}|{:-<16}|",
+        "", "", "", "", "", "", "", "", "", "", "", "", "", ""
     );
     for r in rows {
         println!(
-            "| {:>5} | {:>9.1} | {:>11.1} | {:>7} | {:>5.1} | {:>20.2} | {:>19.2} | {:>12.1} | {:>12.1} | {:>12.1} | {:>11.1} | {:>14.2} |",
+            "| {:<24} | {:>5} | {:>8.0} | {:>9.1} | {:>11.1} | {:>7} | {:>5.1} | {:>20.2} | {:>19.2} | {:>12.1} | {:>12.1} | {:>12.1} | {:>11.1} | {:>14.2} |",
+            r.label,
             r.n,
+            r.rate_hz,
             r.rss_mb,
             r.vsize_mb,
             r.threads,
@@ -533,38 +503,44 @@ fn render_markdown(rows: &[RowResult], warmup: u64, measure: u64) -> String {
     let commit = git_head_sha().unwrap_or_else(|| "unknown".to_string());
 
     let mut out = String::new();
-    out.push_str("# Async-Scheduler Baseline Numbers (BEFORE — thread-per-scenario)\n\n");
+    out.push_str("# Async-Scheduler Sweep — sweep matrix\n\n");
     out.push_str(&format!("**Captured**: {ts}\n"));
     out.push_str(&format!("**Host**: {host}\n"));
     out.push_str(&format!("**Sonda commit**: {commit}\n"));
     out.push_str("**Harness**: sonda-core/benches/scheduler_baseline.rs\n\n");
     out.push_str("## Methodology\n\n");
     out.push_str(&format!(
-        "Each row is N concurrent scenarios, each emitting at 100 events/sec via the \
-         Prometheus text encoder into a `memory` sink (no I/O — measures the scheduler, \
-         not the sink). {warmup}s warm-up + {measure}s measurement window. RSS / VSize / \
-         thread count / CPU% sampled every ~1s via the `sysinfo` crate. \
-         Tick drift is reported two ways: \n\
+        "Each row is N concurrent scenarios at the given rate via the Prometheus text encoder \
+         into a `memory` sink (no I/O — measures the scheduler, not the sink). \
+         {warmup}s warm-up + {measure}s measurement window. RSS / VSize / thread count / CPU% \
+         sampled every ~1s via the `sysinfo` crate. Tick drift is reported two ways: \n\
          \n\
          - **ms-level proxy** — `total_events` deltas between consecutive 1s samples. A bucket \
          is counted as `dropped` when the observed events in the 1s window deviate from the \
          expected count (`rate * dt`) by more than ±10%. \n\
-         - **microsecond-level direct** — the first of the N main scenarios writes through a \
-         `memory` sink with `capture: true`, retaining `(Instant, bytes)` per event across the \
-         full warm-up and measurement window. All N scenarios share the same scheduler, so the \
-         captured cadence reflects the load every scenario experiences at this N. Per-event \
-         drift is computed as `(t[i+1] - t[i]) - (1_000_000us / rate_hz)`; the first 10% of \
-         samples are dropped as warm-up jitter; p50/p90/p99/max are reported in microseconds. \n\n"
+         - **microsecond-level direct** — the first of the N scenarios writes through a \
+         `memory` sink with `capture_handle: Some(arc)`, retaining `(Instant, bytes)` per event \
+         across the full warm-up and measurement window via the shared `CapturedRing`. All N \
+         scenarios share the same tokio runtime, so the captured cadence reflects the load \
+         every scenario experiences at this N. Per-event drift is computed as \
+         `(t[i+1] - t[i]) - (1_000_000us / rate_hz)`; the first 10% of samples are dropped as \
+         warm-up jitter; p50/p90/p99/max are reported in microseconds. \n\
+         \n\
+         **Sink boundary footnote**: this bench exercises the MemorySink path only. The \
+         `spawn_blocking` boundary used by HTTP-family sinks is exercised in the end-to-end \
+         integration run against the autocon5 stack, not here.\n\n"
     ));
     out.push_str("## Results\n\n");
     out.push_str(
-        "| N scenarios | RSS (MB) | VSize (MB) | Threads | CPU % | Tick drift mean (ms) | Tick drift p99 (ms) | Drift p50 (us) | Drift p90 (us) | Drift p99 (us) | Drift max (us) | Dropped-tick % |\n",
+        "| Row | N | Rate Hz | RSS (MB) | VSize (MB) | Threads | CPU % | Tick drift mean (ms) | Tick drift p99 (ms) | Drift p50 (us) | Drift p90 (us) | Drift p99 (us) | Drift max (us) | Dropped-tick % |\n",
     );
-    out.push_str("|---|---|---|---|---|---|---|---|---|---|---|---|\n");
+    out.push_str("|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n");
     for r in rows {
         out.push_str(&format!(
-            "| {} | {:.1} | {:.1} | {} | {:.1} | {:.2} | {:.2} | {:.1} | {:.1} | {:.1} | {:.1} | {:.2} |\n",
+            "| {} | {} | {:.0} | {:.1} | {:.1} | {} | {:.1} | {:.2} | {:.2} | {:.1} | {:.1} | {:.1} | {:.1} | {:.2} |\n",
+            r.label,
             r.n,
+            r.rate_hz,
             r.rss_mb,
             r.vsize_mb,
             r.threads,
@@ -578,49 +554,25 @@ fn render_markdown(rows: &[RowResult], warmup: u64, measure: u64) -> String {
             r.dropped_pct
         ));
     }
-    out.push_str("\n## Inflection point analysis\n\n");
-    out.push_str(&inflection_paragraph(rows));
-    out.push_str("\n\n## Notes\n\n");
+    out.push_str("\n## Notes\n\n");
     out.push_str(&notes_paragraph(rows));
     out.push('\n');
     out
 }
 
-fn inflection_paragraph(rows: &[RowResult]) -> String {
-    let max_threads = rows.iter().map(|r| r.threads).max().unwrap_or(0);
-    let max_rss = rows.iter().map(|r| r.rss_mb).fold(0.0f64, f64::max);
-    let max_drift_p99 = rows.iter().map(|r| r.drift_p99_ms).fold(0.0f64, f64::max);
-    let max_drift_p99_us = rows.iter().map(|r| r.drift_p99_us).fold(0.0f64, f64::max);
-    let max_dropped = rows.iter().map(|r| r.dropped_pct).fold(0.0f64, f64::max);
-    format!(
-        "Thread count grows linearly with N (peak observed: {max_threads}); RSS scales with \
-         the per-thread stack reservation (peak observed: {max_rss:.1} MB). The earliest \
-         metric to break under this scheduler is whichever among tick-drift p99 (peak \
-         observed: {max_drift_p99:.2} ms proxy / {max_drift_p99_us:.1} us direct), \
-         dropped-tick percentage (peak observed: {max_dropped:.2}%), and CPU% saturates \
-         first as N climbs. Read the row-to-row deltas above to identify where the curve \
-         bends — the linear-thread, linear-stack growth itself is the canary for this \
-         baseline."
-    )
-}
-
 fn notes_paragraph(rows: &[RowResult]) -> String {
     let mut notes = String::new();
-    let failed_rows: Vec<usize> = rows
+    let failed_rows: Vec<&str> = rows
         .iter()
         .filter(|r| r.dropped_pct > 50.0)
-        .map(|r| r.n)
+        .map(|r| r.label)
         .collect();
     if !failed_rows.is_empty() {
         notes.push_str(&format!(
-            "- High dropped-tick percentage (> 50%) observed at N = {failed_rows:?}; the \
-             scheduler could not sustain the 100 Hz target for these scenarios.\n"
+            "- High dropped-tick percentage (> 50%) observed at rows = {failed_rows:?}; the \
+             scheduler could not sustain the target rate for these configurations.\n"
         ));
     }
-    #[cfg(target_os = "macos")]
-    notes.push_str(
-        "- Context-switches/sec is Linux-only via `/proc/<pid>/status`; not collected on macOS.\n",
-    );
     if notes.is_empty() {
         notes.push_str("None.");
     }
@@ -683,18 +635,30 @@ fn epoch_to_ymdhms(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
 }
 
 fn main() {
-    let counts = scenario_counts();
     let warmup = warmup_secs();
     let measure = measure_secs();
-    eprintln!("[bench] sonda scheduler baseline harness");
+    let sweep: Vec<SweepRow> = DEFAULT_SWEEP.to_vec();
+
+    eprintln!("[bench] sonda scheduler sweep harness");
     eprintln!(
-        "[bench] N values: {counts:?}; rate {RATE_HZ:.0} Hz; \
-         warmup {warmup}s; measure {measure}s"
+        "[bench] {} rows; warmup {warmup}s; measure {measure}s",
+        sweep.len()
     );
-    let mut rows = Vec::with_capacity(counts.len());
-    for &n in &counts {
-        rows.push(run_row(n, warmup, measure));
-    }
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime must build");
+    let handle = runtime.handle().clone();
+
+    let rows = runtime.block_on(async move {
+        let mut rows = Vec::with_capacity(sweep.len());
+        for row in sweep {
+            rows.push(run_row(&handle, row, warmup, measure).await);
+        }
+        rows
+    });
+
     print_table(&rows);
     let md = render_markdown(&rows, warmup, measure);
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -412,7 +412,7 @@ impl Drop for StateGuard {
                 st.transition_state(ScenarioState::Finished);
             }
         }
-        // Skip when Phase 1 (delete_scenario) already ran; ensure exactly once.
+        // delete_scenario sets cleaned_up first; skip duplicate unregister.
         if self.cleaned_up.swap(true, Ordering::SeqCst) {
             return;
         }

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -22,10 +22,12 @@ pub mod udp;
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
 use crate::model::log::LogEvent;
+use crate::sink::memory::CapturedRing;
 use crate::SondaError;
 
 /// A sink consumes encoded bytes and delivers them to a destination.
@@ -157,6 +159,9 @@ pub enum SinkConfig {
     /// When `capture` is `true`, each write records its `Instant` alongside
     /// the bytes, bounded to the most recent `max_events` entries. When
     /// `capture` is `false`, the sink only accumulates bytes in its buffer.
+    /// Programmatic embedders can pass `capture_handle: Some(arc)` to mirror
+    /// writes into an externally-owned ring; YAML scenarios always leave it
+    /// `None` because the field is `serde(skip)`.
     #[cfg_attr(feature = "config", serde(rename = "memory"))]
     Memory {
         /// Whether to record `(Instant, bytes)` on every write.
@@ -167,6 +172,10 @@ pub enum SinkConfig {
         /// `capture` is `true` and the field is omitted.
         #[cfg_attr(feature = "config", serde(default))]
         max_events: Option<usize>,
+
+        /// Programmatic capture handle for embedders. `None` for YAML.
+        #[cfg_attr(feature = "config", serde(skip))]
+        capture_handle: Option<Arc<Mutex<CapturedRing>>>,
     },
 
     /// Batch encoded events and deliver them via HTTP POST.
@@ -413,8 +422,13 @@ pub async fn create_sink(
         SinkConfig::Memory {
             capture,
             max_events,
+            capture_handle,
         } => {
-            if *capture {
+            if let Some(handle) = capture_handle {
+                Ok(Box::new(memory::MemorySink::with_shared_capture(
+                    Arc::clone(handle),
+                )))
+            } else if *capture {
                 let max = max_events.unwrap_or(1_000_000);
                 Ok(Box::new(memory::MemorySink::with_capture(max)))
             } else {
@@ -1415,6 +1429,7 @@ retry:
         let cfg = SinkConfig::Memory {
             capture: false,
             max_events: None,
+            capture_handle: None,
         };
         let mut sink = create_sink(&cfg, None).await.unwrap();
         sink.write(b"hello").await.unwrap();
@@ -1426,11 +1441,42 @@ retry:
         let cfg = SinkConfig::Memory {
             capture: true,
             max_events: Some(8),
+            capture_handle: None,
         };
         let mut sink = create_sink(&cfg, None).await.unwrap();
         sink.write(b"one").await.unwrap();
         sink.write(b"two").await.unwrap();
         sink.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_sink_memory_with_shared_capture_handle_mirrors_writes() {
+        let ring = Arc::new(Mutex::new(memory::CapturedRing::new(8)));
+        let cfg = SinkConfig::Memory {
+            capture: false,
+            max_events: None,
+            capture_handle: Some(Arc::clone(&ring)),
+        };
+        let mut sink = create_sink(&cfg, None).await.unwrap();
+        sink.write(b"one").await.unwrap();
+        sink.write(b"two").await.unwrap();
+        let guard = ring.lock().unwrap();
+        assert_eq!(guard.len(), 2);
+        assert_eq!(guard.events()[0].1, b"one");
+        assert_eq!(guard.events()[1].1, b"two");
+    }
+
+    #[tokio::test]
+    async fn create_sink_memory_capture_handle_takes_precedence_over_capture_flag() {
+        let ring = Arc::new(Mutex::new(memory::CapturedRing::new(4)));
+        let cfg = SinkConfig::Memory {
+            capture: true,
+            max_events: Some(1_000_000),
+            capture_handle: Some(Arc::clone(&ring)),
+        };
+        let mut sink = create_sink(&cfg, None).await.unwrap();
+        sink.write(b"shared").await.unwrap();
+        assert_eq!(ring.lock().unwrap().len(), 1);
     }
 
     #[cfg(feature = "config")]
@@ -1442,7 +1488,8 @@ retry:
             config,
             SinkConfig::Memory {
                 capture: true,
-                max_events: Some(64)
+                max_events: Some(64),
+                capture_handle: None,
             }
         ));
     }
@@ -1456,7 +1503,23 @@ retry:
             config,
             SinkConfig::Memory {
                 capture: false,
-                max_events: None
+                max_events: None,
+                capture_handle: None,
+            }
+        ));
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_memory_capture_handle_is_skipped_in_yaml() {
+        let yaml = "type: memory\ncapture: true\nmax_events: 4\ncapture_handle: anything";
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(matches!(
+            config,
+            SinkConfig::Memory {
+                capture: true,
+                max_events: Some(4),
+                capture_handle: None,
             }
         ));
     }
@@ -1466,17 +1529,37 @@ retry:
         let cfg = SinkConfig::Memory {
             capture: true,
             max_events: Some(16),
+            capture_handle: None,
         };
         let cloned = cfg.clone();
         assert!(matches!(
             cloned,
             SinkConfig::Memory {
                 capture: true,
-                max_events: Some(16)
+                max_events: Some(16),
+                capture_handle: None,
             }
         ));
         let s = format!("{cfg:?}");
         assert!(s.contains("Memory"));
+    }
+
+    #[test]
+    fn sink_config_memory_with_handle_is_cloneable_and_shares_ring() {
+        let ring = Arc::new(Mutex::new(memory::CapturedRing::new(2)));
+        let cfg = SinkConfig::Memory {
+            capture: false,
+            max_events: None,
+            capture_handle: Some(Arc::clone(&ring)),
+        };
+        let cloned = cfg.clone();
+        match cloned {
+            SinkConfig::Memory {
+                capture_handle: Some(h),
+                ..
+            } => assert!(Arc::ptr_eq(&h, &ring)),
+            _ => panic!("cloned variant must preserve the handle"),
+        }
     }
 
     #[cfg(all(not(feature = "otlp"), feature = "config"))]

--- a/sonda-core/src/sink/remote_write.rs
+++ b/sonda-core/src/sink/remote_write.rs
@@ -230,18 +230,12 @@ fn do_send(
     body: &[u8],
     retry_policy: Option<&RetryPolicy>,
 ) -> Result<(), SondaError> {
-    let result = match retry_policy {
+    match retry_policy {
         Some(policy) => policy.execute(
             || RemoteWriteSink::do_post_checked_at(client, url, body),
             RemoteWriteSink::is_retryable,
         ),
         None => RemoteWriteSink::do_post_checked_at(client, url, body),
-    };
-    match &result {
-        Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
-            Ok(())
-        }
-        _ => result,
     }
 }
 
@@ -484,6 +478,41 @@ mod tests {
         sink.write(&encode_one("c", 3.0))
             .await
             .expect("partial write after a size flush must not time-flush immediately");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn http_4xx_propagates_as_sink_error() {
+        let (listener, url) = mock_server_listener();
+        let server = thread::spawn(move || accept_one_and_respond(&listener, 400));
+
+        let mut sink = RemoteWriteSink::new(&url, 1, None, Duration::ZERO).expect("construct sink");
+        let result = sink.write(&encode_one("cpu", 1.0)).await;
+        let _ = server.join();
+
+        match result {
+            Err(SondaError::Sink(io_err)) => {
+                assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidInput);
+                assert!(io_err.to_string().contains("HTTP 400"));
+            }
+            other => panic!("HTTP 4xx must surface as SondaError::Sink, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn http_5xx_propagates_as_sink_error() {
+        let (listener, url) = mock_server_listener();
+        let server = thread::spawn(move || accept_one_and_respond(&listener, 503));
+
+        let mut sink = RemoteWriteSink::new(&url, 1, None, Duration::ZERO).expect("construct sink");
+        let result = sink.write(&encode_one("cpu", 1.0)).await;
+        let _ = server.join();
+
+        match result {
+            Err(SondaError::Sink(io_err)) => {
+                assert!(io_err.to_string().contains("HTTP 503"));
+            }
+            other => panic!("HTTP 5xx must surface as SondaError::Sink, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/sonda-server/CLAUDE.md
+++ b/sonda-server/CLAUDE.md
@@ -21,8 +21,12 @@ src/
 ├── auth.rs             ← require_api_key middleware (Bearer token), unauthorized() helper,
 │                         extract_bearer_token(), constant-time key comparison via subtle
 ├── routes/
-│   ├── mod.rs          ← router() function: splits public (/health) and protected (/scenarios/*,
-│                         /events) sub-routers; applies auth middleware via route_layer on protected routes
+│   ├── mod.rs          ← router_with_config() function: splits three sub-routers — public (/health),
+│                         protected observability (/scenarios/{id}/stats, /scenarios/{id}/metrics,
+│                         /metrics, /server/metrics), and protected control (/scenarios POST/GET,
+│                         /scenarios/{id} GET/DELETE, /events). Auth + request-metrics middleware
+│                         applied per protected sub-router; the control sub-router additionally
+│                         carries the timeout + body-limit + global-concurrency tower stack.
 │   ├── health.rs       ← GET /health → {"status": "ok"}
 │   ├── events.rs       ← POST /events: synchronous single-event emission. Tagged-enum
 │                         request body, dispatches on signal_type, builds LogEvent/MetricEvent,
@@ -88,9 +92,15 @@ Server Error` with a JSON error body instead of panicking. The per-scenario stat
 
 ## Concurrency Model
 
-Each scenario runs on a dedicated thread (spawned by `sonda_core::schedule::launch::launch_scenario`).
-The axum handler stores and queries `ScenarioHandle` instances from sonda-core. This keeps sonda-core
-synchronous while the server handles HTTP I/O asynchronously via tokio.
+Scenarios run as tokio tasks on the shared multi-thread runtime that hosts the axum HTTP layer
+(spawned by `sonda_core::schedule::launch::launch_scenario`). sonda-core is async-native: the
+runner loop, the encoder layer, and every sink share the same runtime as the HTTP handlers. The
+axum handler stores `ScenarioHandle` instances in `AppState` and queries them via the lock-free
+`stats_snapshot()` path. Per-request bounding is provided by `--max-inflight-requests` (a
+`tower::limit::GlobalConcurrencyLimitLayer` over an `Arc<Semaphore>`); per-scenario bounding is
+provided by `--max-scenarios`. Worker count defaults to `min(available_parallelism(), 16)` —
+host-CPU- and cgroup-aware, with a hard ceiling so a 64-core production host doesn't spawn 64
+worker threads.
 
 ## Authentication
 
@@ -135,7 +145,7 @@ Keep `SONDA_SUBCOMMANDS` in sync with `sonda`'s clap definitions.
 | `serde` + `serde_json` + `serde_yaml_ng` | Request/response serialization       |
 | `anyhow`           | Error handling in binary code                             |
 | `clap`             | CLI argument parsing                                      |
-| `tower-http`       | CORS and trace middleware                                 |
+| `tower-http`       | Timeout + request-body limit middleware for control routes |
 | `tracing` + `tracing-subscriber` | Structured logging                      |
 | `subtle`           | Constant-time byte comparison for API key auth            |
 | `uuid`             | Generating scenario IDs                                   |

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -64,7 +64,7 @@ struct Args {
     #[arg(long, env = "SONDA_CATALOG")]
     catalog: Option<PathBuf>,
 
-    /// Tokio worker thread count. Defaults to `std::thread::available_parallelism()`.
+    /// Tokio worker thread count. Defaults to min(available_parallelism(), 16).
     #[arg(long, value_parser = clap::builder::RangedU64ValueParser::<u64>::new().range(1..))]
     workers: Option<u64>,
 
@@ -77,7 +77,8 @@ struct Args {
     max_inflight_requests: Option<usize>,
 
     /// Per-request timeout in seconds applied to control-plane routes. Returns 408 on expiry.
-    #[arg(long, default_value_t = 30)]
+    #[arg(long, default_value_t = 30,
+          value_parser = clap::builder::RangedU64ValueParser::<u64>::new().range(1..))]
     request_timeout: u64,
 
     /// Maximum request body size in bytes accepted by control-plane routes. Returns 413 when exceeded.
@@ -109,6 +110,7 @@ fn main() -> anyhow::Result<()> {
         std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(1)
+            .min(16)
     });
     let max_inflight_requests = args.max_inflight_requests.unwrap_or(workers * 4);
 

--- a/sonda-server/tests/bounded_scheduler.rs
+++ b/sonda-server/tests/bounded_scheduler.rs
@@ -385,6 +385,37 @@ fn body_limit_returns_413_with_structured_error() {
 }
 
 #[test]
+fn request_timeout_zero_is_rejected_at_parse_time() {
+    use std::process::{Command, Stdio};
+
+    let binary = env!("CARGO_BIN_EXE_sonda-server");
+    let out = Command::new(binary)
+        .args([
+            "--port",
+            "0",
+            "--bind",
+            "127.0.0.1",
+            "--request-timeout",
+            "0",
+        ])
+        .env_remove("SONDA_API_KEY")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("must spawn sonda-server");
+    assert!(
+        !out.status.success(),
+        "--request-timeout 0 must exit non-zero, got status {:?}",
+        out.status
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("request-timeout") || stderr.contains("request_timeout"),
+        "clap rejection must mention the flag, got stderr: {stderr}"
+    );
+}
+
+#[test]
 fn request_timeout_returns_408_with_structured_error() {
     let (port, _guard) = common::start_server_with(&["--request-timeout", "1"], &[]);
     let client = reqwest::blocking::Client::builder()

--- a/sonda/src/sink_format.rs
+++ b/sonda/src/sink_format.rs
@@ -46,6 +46,7 @@ pub fn sink_display(sink: &SinkConfig) -> String {
         SinkConfig::Memory {
             capture,
             max_events,
+            ..
         } => {
             if *capture {
                 let cap = max_events.unwrap_or(1_000_000);
@@ -119,6 +120,7 @@ mod tests {
         let s = SinkConfig::Memory {
             capture: false,
             max_events: None,
+            capture_handle: None,
         };
         assert_eq!(sink_display(&s), "memory");
     }
@@ -128,6 +130,7 @@ mod tests {
         let s = SinkConfig::Memory {
             capture: true,
             max_events: Some(2048),
+            capture_handle: None,
         };
         assert_eq!(sink_display(&s), "memory (capture, max_events=2048)");
     }


### PR DESCRIPTION
## Summary

Closes out the async-scheduler initiative. Extends `SinkConfig::Memory` with a
programmatic-only `capture_handle` field, restoring per-event timestamp capture
in the scheduler benchmark. Caps the default tokio worker count at 16 on hosts
with >16 cores. Restructures the bench harness around the public
`launch_scenario` API and a single global tokio runtime.

After this lands on `feat/async-scheduler-landing`, the landing branch squashes
to `main` as a single atomic commit.

## Highlight: architectural validation

End-to-end measurement against the Phase 0 thread-per-scenario baseline on
identical hardware:

| | macOS M3 Pro (11-core) | Linux container (--cpus=4 --memory=4g) |
|---|---|---|
| Threads at N=1000 | 12 (`min(11,16)+main`) | 5 (`min(4,16)+main`) |
| RSS at N=1000 | 410.5 MB | 331.5 MB |
| Drift mean (ms-proxy) | 16.5 ms | 3.06 ms |
| Dropped-tick % | 0.00% | 0.00% |
| Phase 0 capable? | yes (1001 threads) | **no** (1000 × 8 MB stack > 4 GB) |

The production-target row (N=1000 × 100 Hz on a 4-core / 4 GB Linux container)
is **structurally impossible** on the Phase 0 thread-per-scenario design. The
async-scheduler initiative makes it routine.

## Highlight: north-star integration

Validated against the current `autocon5/sonda` workshops stack (pinned at
`github.com/network-observability/workshops` @
`5fbdafa2e64c48aaa620a6d379ed57021136f406`):

| Assertion | Result |
|---|---|
| Prometheus: `bgp_oper_state` flows with Telegraf-normalized labels | PASS — 6 series across srl1+srl2 |
| Alertmanager: `BgpSessionNotUp` fires for synthetic-down peer | PASS — active on srl2/10.1.11.1 |
| Loki: sonda log streams ingested via `{pipeline="direct"}` | PASS — 3 streams, real BGP / config content |

In autocon5, Telegraf scrapes sonda-server and rewrites raw exposition to
canonical schema before Prometheus scrape. Schema parity holds out-of-the-box
— no scenario YAML edits required to drive the existing alert rules.

## Changes

- `SinkConfig::Memory.capture_handle: Option<Arc<Mutex<CapturedRing>>>` with
  `#[serde(skip)]`. Architectural-class addition on a `pub`-re-exported core
  type. Factory routes `Some(handle)` to `MemorySink::with_shared_capture`;
  `None` falls through to the existing default path. Forward-compat patterns
  (`..` rest match, explicit `None`) used at the affected call sites.
- `sonda-server/src/main.rs:113` — `.min(16)` added to the `--workers` default
  computation. Runtime behavior change on hosts with >16 cores. The `--help`
  text already advertised the cap; this edit closes the docs/runtime gap.
- `--request-timeout` clap range validator added (mirrors `--workers`).
- `sonda-core/src/sink/remote_write.rs::do_send` no longer swallows HTTP 4xx
  errors. The `total_sink_failures` counter now reflects both 4xx and 5xx.
  Two new regression tests.
- Bench harness restructured: 10-row sweep matrix, single global tokio runtime,
  parallel launch path deleted, µs-direct drift probe restored.
- Stale phase-narration comment in `launch.rs` rewritten to describe the
  invariant locally.
- `sonda-server/CLAUDE.md` Router-shape, tower-http purpose, and
  Concurrency-Model sections refreshed.
- `docs/architecture.md` Concurrency block rewritten.

## Deferred to post-squash PRs

- `cleanup_scenarios` `join_async` migration (~103 current_thread tests;
  race-sensitive).
- `/metrics` → `/scenarios/metrics` rename + 308 redirect (user-visible
  behavior change deserving its own deprecation cycle).

## Deferred to separate research issue

- `gate_bus` polling fallback redesign — Notify+AtomicU8 alternative
  documented at #465. The 2 ms `try_recv` loop in `recv_edge_timeout` stays
  in place until a stress-tested replacement lands.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace --all-features` — 2923 / 2923 passed
- [x] `cargo test --workspace --doc` — 4 / 4
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::await_holding_lock`
- [x] `cargo clippy -p sonda-core --no-default-features -- -D warnings`
- [x] `cargo nextest run -p sonda-core --no-default-features` — 1299 / 1299 (new 10th gate, runs the no-default-features tests rather than just building them)
- [x] `cargo fmt --all -- --check`
- [x] `cargo audit`
- [x] `cargo nextest run -p sonda-core --all-features --test while_close_workshop_repro` — 11 / 11, 0 skipped
- [x] `mkdocs build --strict`
- [x] Phase 5 bench sweep (10 rows) on landing tip
- [x] Phase 0 freshness sweep on the bench-introduction commit `3f3de69` (the original baseline doc cited `d5c8f5f8` which predates the bench harness — correctness note)
- [x] Linux container production row (`--cpus=4 --memory=4g`)
- [x] autocon5/sonda real-stack end-to-end against a locally-built `sonda:phase5-validation` image

Refs adoption-review performance + north-star promise. Refs #465.