### PR TITLE
feat: async-native scheduler — bounded operator surface + /server/metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Full design rationale is in `docs/architecture.md`. Key decisions:
 - Cargo workspace for parallel compilation and clean dep isolation.
 - Trait objects (`Box<dyn Trait>`) for generators, encoders, sinks — extensible without dispatch changes.
 - YAML for all scenario config; CLI flags and `SONDA_*` env vars override.
-- Sync-first (std::thread + mpsc). Tokio only in sonda-server.
+- Tokio-first: scenarios run as `tokio::task::spawn` tasks on a shared multi-thread runtime.
 - Static binary (musl). Pure-Rust deps only (rustls, not openssl).
 
 ## Extension Points

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,10 +1352,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "once_cell"
@@ -2232,6 +2260,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "snap",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2346,6 +2375,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.39.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -3040,6 +3083,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,6 +3114,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3079,6 +3154,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3180,6 +3265,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2250,7 @@ dependencies = [
  "serde_yaml_ng",
  "sonda-core",
  "tempfile",
+ "tokio",
  "tracing-subscriber",
 ]
 
@@ -2246,6 +2258,7 @@ dependencies = [
 name = "sonda-core"
 version = "1.14.0"
 dependencies = [
+ "async-trait",
  "bytes",
  "chrono",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,6 +2251,7 @@ dependencies = [
  "sonda-core",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing-subscriber",
 ]
 
@@ -2277,6 +2278,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tonic",
  "tracing",
  "tracing-test",
@@ -2304,6 +2306,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2654,11 +2654,12 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,7 @@ clap = { version = "4", features = ["derive"] }
 ureq = { version = "2", default-features = false, features = ["tls"] }
 insta = { version = "1.40", features = ["json", "yaml"] }
 rstest = "0.26"
+
+[workspace.lints.clippy]
+# Holding a std::sync lock across an .await deadlocks the runtime.
+await_holding_lock = "deny"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,9 +124,9 @@ A schedule controls when events are emitted: their rate, duration, and any inten
 - **GapWindow** — a recurring silent period defined as `(gap_every, gap_for)`. During a gap, no events are emitted and the scheduler sleeps rather than busy-waiting.
 - **BurstWindow** — a recurring high-rate period defined as `(burst_every, burst_for, burst_multiplier)`. During a burst, the effective rate is multiplied.
 
-The scheduler uses `std::time::Instant` for elapsed tracking and `std::io::BufWriter` for output batching. A shared schedule loop (`core_loop.rs`) handles all rate control, gap/burst/spike window logic, and stats tracking for both metrics and logs. Signal-specific event construction is delegated to a per-signal callback, eliminating duplication between the metric and log runners. The loop is synchronous — tight sleep intervals are sufficient for the target rate range and avoid tokio overhead in the CLI path.
+The scheduler is async-native. A shared schedule loop (`core_loop.rs`) handles all rate control, gap/burst/spike window logic, and stats tracking for both metrics and logs; signal-specific event construction is delegated to a per-signal callback. `tokio::time::Interval` drives per-tick cadence with `MissedTickBehavior::Delay`, so a slow sink does not amplify into runaway catch-up emissions. Sinks call `.await` directly; the HTTP-family sinks bridge to blocking `ureq` via `tokio::task::spawn_blocking`.
 
-> **Concurrency (post-MVP):** Multiple concurrent scenarios will be supported in a future expansion. The plan is `std::thread` per scenario with `mpsc` channels feeding a shared sink, before introducing tokio. This keeps the core synchronous and avoids making tokio a core dependency.
+> **Concurrency.** Multiple concurrent scenarios run as `tokio::task::spawn` tasks on a shared multi-thread runtime. The CLI and the HTTP server both own one runtime and dispatch scenario launches into it via `launch_scenario`. The default tokio worker count is `min(available_parallelism(), 16)` — cgroup-aware on Linux containers, capped at 16 on larger hosts.
 
 ### 5.4 Encoders
 

--- a/docs/site/docs/build/sinks.md
+++ b/docs/site/docs/build/sinks.md
@@ -66,6 +66,32 @@ sink:
   address: "127.0.0.1:9999"
 ```
 
+## memory
+
+In-process buffer sink for tests and benchmarks. Encoded bytes accumulate in a `Vec<u8>` inside the running process; no I/O happens, no destination is contacted. Use this when you want to drive a scenario through Sonda's pipeline (generator → encoder → sink) and either ignore the output or inspect it from a test harness that holds a `MemorySink` directly.
+
+When `capture: true`, each write records the `Instant` it landed alongside the bytes, keeping a ring of the most recent `max_events` entries (default `1_000_000`). The ring drops the oldest entry on overflow, so a benchmark that runs longer than the cap allows still ends up with the latest events for drift or rate analysis.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `capture` | boolean | no | `false` | Record `(Instant, bytes)` per write. |
+| `max_events` | integer | no | `1_000_000` | Cap on retained captured events when `capture: true`. |
+
+```yaml title="Memory sink (capture disabled)"
+sink:
+  type: memory
+```
+
+```yaml title="Memory sink with capture for drift measurement"
+sink:
+  type: memory
+  capture: true
+  max_events: 100000
+```
+
+!!! warning
+    This sink is for in-process inspection only — there is no destination to deliver to, so it should never be used in production scenarios. Pair it with a Rust test or benchmark harness that holds the `MemorySink` instance and reads `MemorySink::captured()` after the run.
+
 ## http_push
 
 !!! note

--- a/docs/site/docs/deploy/http-api.md
+++ b/docs/site/docs/deploy/http-api.md
@@ -37,17 +37,53 @@ For server-side setup (passing the flag, env var, Kubernetes Secret pattern), se
 
 ### Error response shape
 
-All error responses share the format `{"error": "<short_code>", "detail": "<message>"}`. Common short codes:
+Most error responses share the format `{"error": "<short_code>", "detail": "<message>"}`. The 408 and 413 capacity errors come from the request-handling layer and carry a status code with no JSON body; check the status, not the body. Common codes:
 
 | Status | Short code | When |
 |--------|------------|------|
 | 400 | (parser-specific) | Malformed body, missing `version: 2`, validation error |
 | 401 | `unauthorized` | Missing or invalid `Authorization: Bearer <key>` |
 | 404 | `not_found` | Unknown scenario ID |
+| 408 | (no JSON body) | Handler exceeded [`--request-timeout`](server.md#tuning-resource-limits). See [Capacity and resource errors](#capacity-and-resource-errors). |
 | 409 | (conflict-specific) | Duplicate `scenario_name` already running |
+| 413 | (no JSON body) | Body larger than [`--max-body-bytes`](server.md#tuning-resource-limits). See [Capacity and resource errors](#capacity-and-resource-errors). |
 | 422 | (validator-specific) | Runtime validation failure |
+| 429 | `capacity_exceeded` | Scenario row cap from [`--max-scenarios`](server.md#tuning-resource-limits) is full. See [Capacity and resource errors](#capacity-and-resource-errors). |
 | 502 | (sink-specific) | Sink push or flush returned an error |
 | 500 | (internal-specific) | Unexpected server error |
+
+### Capacity and resource errors
+
+Three status codes signal that a request was rejected by the server's resource-limit guards rather than by validation. They apply only to the control-plane sub-router (`POST /scenarios`, `DELETE /scenarios/{id}`, `POST /events`, list/inspect). The observability endpoints (`/server/metrics`, `/metrics`, `/scenarios/{id}/metrics`, `/scenarios/{id}/stats`, `/health`) are not subject to these limits and stay reachable under saturation. Every rejection is counted on [`sonda_server_requests_total{status="..."}`](server-metrics.md#sonda_server_requests_total).
+
+#### `429 Too Many Requests` — capacity_exceeded
+
+`POST /scenarios` returns 429 when [`--max-scenarios`](server.md#tuning-resource-limits) is set and the scenario row cap is full. The body identifies where the slots went so you know which scenarios to `DELETE`:
+
+```json title="Response (429 Too Many Requests)"
+{
+  "error": "capacity_exceeded",
+  "detail": "500 scenarios active (max 500); DELETE finished or stuck scenarios to free slots",
+  "by_state": {
+    "pending": 0,
+    "running": 312,
+    "paused": 0,
+    "held": 0,
+    "unresolved": 47,
+    "finished": 141
+  }
+}
+```
+
+`finished` rows still occupy slots. If the count is non-zero, your automation forgot to `DELETE /scenarios/{id}` after those scenarios completed; the cleanest fix is to delete them and re-POST. Alert on `rate(sonda_server_requests_total{status="429"}[5m]) > 0` to catch this before the next deploy.
+
+#### `408 Request Timeout`
+
+A control-plane request exceeded [`--request-timeout`](server.md#tuning-resource-limits) (default 30 seconds). Returned by the request-handling layer with no JSON body — clients should check the status code, not parse the response. The most common trigger is `POST /events` to a slow or unreachable sink; the handler builds the sink in-band and waits for the first connect to succeed.
+
+#### `413 Payload Too Large`
+
+The request body exceeded [`--max-body-bytes`](server.md#tuning-resource-limits) (default 1 MB). Returned by the request-handling layer with no JSON body. Either the caller is sending an oversized scenario file or the cap is set too tight for legitimate traffic. Catalog-resident scenarios are a better fit than inlining a 1 MB body — start the server with [`--catalog <DIR>`](server.md#server-flags) and reference packs by name.
 
 ### Sink URL gotchas
 
@@ -1010,11 +1046,13 @@ scrape_configs:
 | GET | `/scenarios/{id}/stats` | Live stats: rate, events, gap/burst state, sink-failure counters |
 | GET | `/scenarios/{id}/metrics` | Current per-series values for one scenario in Prometheus text format |
 | GET | `/metrics` | Aggregate Prometheus scrape across all running scenarios. Supports `?label=k:v` filtering |
+| GET | `/server/metrics` | Server-process RED and saturation telemetry. See [Server metrics](server-metrics.md). |
 | POST | `/events` | Emit one log or metric event synchronously |
 
 ## Where to next
 
 - [Deploy as a server](server.md) — install, configure, network, and operate the server itself.
+- [Server metrics](server-metrics.md) — the nine `/server/metrics` series and the alerts that matter.
 - [Scenario file format](../build/scenario-files.md) — what to put in the body of `POST /scenarios`.
 - [Encoders](../build/encoders.md) and [Sinks](../build/sinks.md) — every encoder/sink option you can declare in a posted body.
 - [Cross-POST `while:` refs (YAML schema)](../build/scenario-files.md#cross-post-while-refs) — the file-side counterpart to the HTTP cross-POST surface.

--- a/docs/site/docs/deploy/kubernetes.md
+++ b/docs/site/docs/deploy/kubernetes.md
@@ -151,20 +151,26 @@ instructions.
 
 ### ServiceMonitor
 
-A ServiceMonitor endpoint scrapes a single `path`. Two paths work for Sonda:
+A ServiceMonitor endpoint scrapes a single `path`. `sonda-server` exposes three Prometheus paths and they answer different questions — pick by the dashboard you are filling:
 
-- `/metrics` — an aggregate scrape across every running scenario, with optional `?label=k:v` filtering. This is the right choice for most installs. One ServiceMonitor covers every scenario the server runs, regardless of how it was launched.
-- `/scenarios/<scenario-id>/metrics` — a single-scenario snapshot. Use it when each scenario is its own logical target and you know its ID in advance. One example: a scenario loaded from the `scenarios` ConfigMap at a stable route.
+| Path | What it returns | When to scrape |
+|---|---|---|
+| `/server/metrics` | Server-process RED + saturation (`sonda_server_*` series). See [Server metrics](server-metrics.md). | Operational dashboards and alerts on the server itself. |
+| `/metrics` | Aggregate scenario data fused into one response. Supports `?label=k:v` filtering. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape). | A single scrape target covering every scenario, regardless of how it was launched. |
+| `/scenarios/<scenario-id>/metrics` | One scenario's series. | Per-scenario debugging or a stable URL per scenario loaded from the `scenarios` ConfigMap. |
 
-`serviceMonitor.path` has no default. If you set `serviceMonitor.enabled: true` without also setting `serviceMonitor.path`, `helm install` and `helm upgrade` fail with a clear error. The error tells you to set the path to a Prometheus-text endpoint such as `/metrics` or `/scenarios/<scenario-id>/metrics`. This prevents a ServiceMonitor that silently scrapes a non-metrics route.
+The chart defaults `serviceMonitor.path` to `/server/metrics` — the right choice for operational alerting on the server process. Switch it to `/metrics` when you also want one scrape job to cover every scenario the server is running.
 
 | Value | Default | Description |
 |-------|---------|-------------|
 | `serviceMonitor.enabled` | `false` | Enable Prometheus Operator ServiceMonitor |
 | `serviceMonitor.interval` | `30s` | Scrape interval |
 | `serviceMonitor.scrapeTimeout` | `10s` | Scrape timeout |
-| `serviceMonitor.path` | `""` (required when enabled) | Metrics endpoint path, e.g. `/metrics` or `/scenarios/<scenario-id>/metrics` |
+| `serviceMonitor.path` | `/server/metrics` | Metrics endpoint path. Switch to `/metrics` for aggregate scenario scraping, or `/scenarios/<scenario-id>/metrics` for a single scenario. |
 | `serviceMonitor.additionalLabels` | `{}` | Extra labels on the ServiceMonitor resource |
+
+!!! tip "One ServiceMonitor per path"
+    A ServiceMonitor endpoint scrapes a single path. To scrape both `/server/metrics` and `/metrics`, deploy two ServiceMonitor resources (or one with two `endpoints` entries — see the [manual ServiceMonitor example](#manual-servicemonitor) below).
 
 ### Scenarios (ConfigMap)
 
@@ -276,7 +282,15 @@ For example, a Prometheus instance in the same namespace can scrape
 
 ## Prometheus scraping
 
-`sonda-server` exposes two scrape endpoints. `GET /metrics` is the aggregate view. Every running scenario is fused into one response, with `?label=k:v` to slice the view by the labels you attached to each scenario. `GET /scenarios/{id}/metrics` is the per-scenario view. It carries the current value of every series for one scenario. Both endpoints are idempotent snapshots. They produce one sample per `(name, labels)` series with no timestamp, like a `node_exporter` scrape. For most Prometheus setups, the aggregate endpoint is the right choice. One job covers every scenario, and you do not need to know scenario IDs in advance. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape) for the full reference, including the `?label=k:v` AND-filter syntax.
+`sonda-server` exposes three scrape endpoints. Each answers a different question:
+
+| Endpoint | What it returns | When to scrape |
+|---|---|---|
+| `GET /scenarios/{id}/metrics` | One scenario's series | Per-scenario debugging |
+| `GET /metrics` | Aggregate scenario data | Per-process scenario view |
+| `GET /server/metrics` | Server-process RED + saturation | Operational dashboards and alerts |
+
+`GET /metrics` and `GET /scenarios/{id}/metrics` are idempotent snapshots — one sample per `(name, labels)` series with no timestamp, like a `node_exporter` scrape. `GET /server/metrics` returns the server's own RED and saturation telemetry — see [Server metrics](server-metrics.md) for the nine series and the alerts that go with them. Most Prometheus setups want a job per endpoint; the aggregate `/metrics` covers every scenario and you do not need to know scenario IDs in advance. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape) for the `?label=k:v` AND-filter syntax.
 
 ### Aggregate scrape config
 
@@ -319,7 +333,9 @@ helm install sonda ./helm/sonda --set serviceMonitor.enabled=true
 See the [ServiceMonitor](#servicemonitor) values reference for all options
 (`interval`, `scrapeTimeout`, `path`, `additionalLabels`).
 
-You can also apply a custom ServiceMonitor manually for full control:
+### Manual ServiceMonitor
+
+You can also apply a custom ServiceMonitor manually for full control. The example below scrapes the server's own RED metrics and the aggregate scenario view in one resource:
 
 ```yaml title="sonda-servicemonitor.yaml"
 apiVersion: monitoring.coreos.com/v1
@@ -335,17 +351,17 @@ spec:
   endpoints:
     - port: http
       interval: 15s
-      path: /scenarios/<SCENARIO_ID>/metrics
+      path: /server/metrics
+    - port: http
+      interval: 15s
+      path: /metrics
 ```
 
 ```bash
 kubectl apply -f sonda-servicemonitor.yaml
 ```
 
-The `port: http` field matches the named port on the Sonda Service.
-
-!!! warning "One path per endpoint"
-    Each ServiceMonitor endpoint scrapes a single `path`. For per-scenario scrapes, add one `endpoints` entry per scenario ID. To cover every scenario in one entry, point the endpoint at `/metrics` instead and use `?label=k:v` to slice the view.
+The `port: http` field matches the named port on the Sonda Service. Each `endpoints` entry scrapes a single path. For a per-scenario route, add one entry per scenario ID with `path: /scenarios/<SCENARIO_ID>/metrics`.
 
 ## API key authentication
 
@@ -428,16 +444,15 @@ curl http://localhost:8080/health
 
 ### Prometheus scraping with auth
 
-When authentication is enabled, both `/metrics` and `/scenarios/{id}/metrics` require a
-bearer token. Add the token to your Prometheus scrape config:
+When authentication is enabled, every scrape endpoint requires a bearer token: `/server/metrics`, `/metrics`, and `/scenarios/{id}/metrics`. Add the token to your Prometheus scrape config:
 
 === "Static scrape config"
 
     ```yaml title="prometheus-scrape.yaml"
     scrape_configs:
-      - job_name: sonda
+      - job_name: sonda-server
         scrape_interval: 15s
-        metrics_path: /scenarios/<SCENARIO_ID>/metrics
+        metrics_path: /server/metrics
         bearer_token: "your-secret-key-here"
         static_configs:
           - targets: ["sonda.default.svc:8080"]
@@ -447,9 +462,9 @@ bearer token. Add the token to your Prometheus scrape config:
 
     ```yaml title="prometheus-scrape.yaml"
     scrape_configs:
-      - job_name: sonda
+      - job_name: sonda-server
         scrape_interval: 15s
-        metrics_path: /scenarios/<SCENARIO_ID>/metrics
+        metrics_path: /server/metrics
         bearer_token_file: /etc/prometheus/sonda-token
         static_configs:
           - targets: ["sonda.default.svc:8080"]
@@ -471,11 +486,13 @@ spec:
   endpoints:
     - port: http
       interval: 15s
-      path: /scenarios/<SCENARIO_ID>/metrics
+      path: /server/metrics
       bearerTokenSecret:
         name: sonda-api-key
         key: api-key
 ```
+
+Add a second `endpoints` entry with the same `bearerTokenSecret` to also scrape `/metrics` or a per-scenario path. See [Authentication on Server metrics](server-metrics.md#authentication) for the full reference.
 
 !!! warning "Same Secret, same namespace"
     The `bearerTokenSecret` must reference a Secret in the **same namespace** as the
@@ -517,5 +534,6 @@ Add `-n <namespace>` if you installed into a non-default namespace.
 
 - [Synthetic Monitoring guide](../test/synthetic-monitoring.md) -- deploy Sonda on Kubernetes, submit long-running scenarios, scrape with Prometheus, and build Grafana dashboards
 - [Server API](server.md) -- full endpoint reference for `sonda-server`
+- [Server metrics](server-metrics.md) -- the nine `/server/metrics` series and the PromQL alerts that matter
 - [Docker](docker.md) -- Docker image and Compose stacks for local development
 - [Scenario Fields](../reference/scenario-fields.md) -- full YAML schema for scenario configuration

--- a/docs/site/docs/deploy/server-metrics.md
+++ b/docs/site/docs/deploy/server-metrics.md
@@ -1,0 +1,219 @@
+---
+title: Server metrics
+description: Three Prometheus endpoints on sonda-server, the nine /server/metrics series, and PromQL alerts for the load-bearing ones.
+---
+
+# Server metrics
+
+`sonda-server` exposes three Prometheus endpoints. Each one answers a different question. Point your scrape jobs and alerts at the right one — they are not interchangeable.
+
+| Endpoint | What it returns | When to scrape |
+|---|---|---|
+| `GET /scenarios/{id}/metrics` | One scenario's series | Per-scenario debugging |
+| `GET /metrics` | Aggregate scenario data | Per-process scenario view |
+| `GET /server/metrics` | Server-process RED + saturation | Operational dashboards and alerts |
+
+`/server/metrics` tells you whether the **server process** is healthy. `/metrics` and `/scenarios/{id}/metrics` tell you whether the **scenarios** are emitting the data you asked for. A saturated server can still serve metrics from a few healthy scenarios; a quiet `/metrics` while `/server/metrics` shows zero active scenarios is "no work in flight," not "server broken." Reading the right endpoint is the difference between paging on a real outage and chasing a healthy server.
+
+## `GET /server/metrics`
+
+Process-level RED (rate, errors, duration) plus saturation telemetry for the `sonda-server` process. The Helm chart's [ServiceMonitor scrapes this endpoint by default](kubernetes.md#servicemonitor).
+
+```bash
+curl http://localhost:8080/server/metrics
+```
+
+```text title="Response (text/plain; version=0.0.4; charset=utf-8)"
+# HELP sonda_server_active_scenarios Scenarios currently held in each operational state.
+# TYPE sonda_server_active_scenarios gauge
+sonda_server_active_scenarios{state="pending"} 0
+sonda_server_active_scenarios{state="running"} 3
+sonda_server_active_scenarios{state="paused"} 0
+sonda_server_active_scenarios{state="held"} 0
+sonda_server_active_scenarios{state="unresolved"} 0
+# HELP sonda_server_scenarios_finished_total Scenarios that have reached the Finished state and not yet been deleted.
+# TYPE sonda_server_scenarios_finished_total counter
+sonda_server_scenarios_finished_total 12
+# HELP sonda_server_worker_threads Configured tokio multi-thread worker count.
+# TYPE sonda_server_worker_threads gauge
+sonda_server_worker_threads 8
+# HELP sonda_server_max_scenarios Configured scenario row cap (0 means unlimited).
+# TYPE sonda_server_max_scenarios gauge
+sonda_server_max_scenarios 500
+# HELP sonda_server_requests_total HTTP requests served, per matched route, method, and status.
+# TYPE sonda_server_requests_total counter
+sonda_server_requests_total{route="/scenarios",method="POST",status="201"} 14
+sonda_server_requests_total{route="/scenarios/{id}/stats",method="GET",status="200"} 482
+# HELP sonda_server_request_duration_seconds HTTP request duration in seconds, per matched route and method.
+# TYPE sonda_server_request_duration_seconds histogram
+sonda_server_request_duration_seconds_bucket{route="/scenarios",method="POST",le="0.005"} 0
+sonda_server_request_duration_seconds_bucket{route="/scenarios",method="POST",le="+Inf"} 14
+sonda_server_request_duration_seconds_sum{route="/scenarios",method="POST"} 0.342
+sonda_server_request_duration_seconds_count{route="/scenarios",method="POST"} 14
+# HELP sonda_server_sink_errors_total Lifetime sink-write failures, summed across scenarios per sink_type.
+# TYPE sonda_server_sink_errors_total counter
+sonda_server_sink_errors_total{sink_type="loki"} 4
+# HELP sonda_server_uptime_seconds Seconds since the server process started.
+# TYPE sonda_server_uptime_seconds gauge
+sonda_server_uptime_seconds 18432.4
+# HELP sonda_server_build_info Build-time version and git SHA. Constant gauge always set to 1.
+# TYPE sonda_server_build_info gauge
+sonda_server_build_info{version="1.14.0",git_sha="58f288f47a2c2e91d8c3e8b4f1e6d8a9c2b5f3e7"} 1
+```
+
+The endpoint is idempotent — two back-to-back scrapes return logically equivalent bodies (counters increment, gauges may shift, but the shape and label sets stay stable).
+
+### Series reference
+
+Nine series. Operator-tense one-liners and the alerts that matter follow.
+
+#### `sonda_server_active_scenarios`
+
+Gauge. Scenarios currently held in each operational state. Always emits all five rows even when the value is zero, so Prometheus alerting stays continuous as scenarios come and go.
+
+| Label | Values |
+|---|---|
+| `state` | `pending` / `running` / `paused` / `held` / `unresolved` |
+
+`Finished` scenarios are tracked separately by [`sonda_server_scenarios_finished_total`](#sonda_server_scenarios_finished_total). They still consume a row against [`--max-scenarios`](server.md#tuning-resource-limits) until `DELETE /scenarios/{id}` removes them.
+
+```promql title="Alert: a scenario stuck waiting on a cross-POST upstream"
+sonda_server_active_scenarios{state="unresolved"} > 10
+```
+
+When this fires, the cross-POST resolver has more than 10 downstream scenarios queued without their upstream arriving. Inspect them with `GET /scenarios` and look at the `pending_ref` block on `GET /scenarios/{id}`.
+
+#### `sonda_server_scenarios_finished_total`
+
+Counter. Scenarios that have reached the `Finished` state and are still resident in the server. They consume a row against [`--max-scenarios`](server.md#tuning-resource-limits) until you `DELETE` them.
+
+```promql title="Alert: finished rows not being reaped"
+sonda_server_scenarios_finished_total > 100
+```
+
+If this counter climbs without a corresponding burst of new scenarios, your automation is forgetting to `DELETE /scenarios/{id}` after a scenario completes.
+
+#### `sonda_server_worker_threads`
+
+Gauge. The tokio multi-thread worker count configured at startup — that is, the value of [`--workers`](server.md#tuning-resource-limits) or the cgroup-aware default `std::thread::available_parallelism()`.
+
+#### `sonda_server_max_scenarios`
+
+Gauge. The configured value of [`--max-scenarios`](server.md#tuning-resource-limits). Reports `0` when the cap is disabled (unlimited).
+
+#### `sonda_server_requests_total`
+
+Counter. HTTP requests served by the protected sub-routers, labelled by the matched route template, method, and status.
+
+| Label | Values |
+|---|---|
+| `route` | The axum route template, e.g. `/scenarios/{id}/stats` — **not** the concrete URL with the UUID. |
+| `method` | `GET` / `POST` / `DELETE` / etc. |
+| `status` | The numeric status code as a string. |
+
+The `route` label uses the route template (with literal `{id}` braces), not the concrete request path. This keeps cardinality bounded regardless of how many unique scenario IDs hit the server.
+
+```promql title="Alert: control-plane saturation hitting the inflight cap"
+rate(sonda_server_requests_total{status="429"}[5m]) > 0
+```
+
+Sustained 429s mean either the server cap (`--max-scenarios`) is hit or the inflight-request cap (`--max-inflight-requests`) is. Cross-reference [`sonda_server_active_scenarios`](#sonda_server_active_scenarios) to tell which.
+
+```promql title="Alert: payload-size limit being hit"
+rate(sonda_server_requests_total{status="413"}[5m]) > 0
+```
+
+Some client is sending bodies larger than [`--max-body-bytes`](server.md#tuning-resource-limits). Either the limit is too tight for legitimate payloads or you have a misbehaving caller.
+
+#### `sonda_server_request_duration_seconds`
+
+Histogram. Request duration in seconds, labelled by matched route and method. Buckets are the Prometheus defaults: `0.005`, `0.01`, `0.025`, `0.05`, `0.1`, `0.25`, `0.5`, `1.0`, `2.5`, `5.0`, `10.0`, and `+Inf`.
+
+| Label | Values |
+|---|---|
+| `route` | Same matched-path template as `sonda_server_requests_total`. |
+| `method` | Same as `sonda_server_requests_total`. |
+| `le` | Cumulative bucket upper bound. |
+
+```promql title="Alert: control-plane P99 above 1 second"
+histogram_quantile(0.99,
+  sum by (le, route) (rate(sonda_server_request_duration_seconds_bucket[5m]))
+) > 1
+```
+
+Use this to catch back-pressure from `--max-inflight-requests`. `tower::limit::ConcurrencyLimitLayer` does not return explicit 503s; it back-pressures via `Service::poll_ready` and the listener queues requests, so the symptom is "P99 climbs" rather than "errors spike."
+
+#### `sonda_server_sink_errors_total`
+
+Counter. Lifetime sink-write failures across every active scenario, summed per `sink_type`.
+
+| Label | Values |
+|---|---|
+| `sink_type` | The sink kind, e.g. `loki`, `http_push`, `kafka`, `otlp_grpc`, `tcp`, `stdout`. |
+
+Computed at scrape time from each scenario's `total_sink_failures` counter on `GET /scenarios/{id}/stats`. The counter resets when scenarios are deleted, which is the intended behaviour — a deleted scenario is no longer your problem.
+
+```promql title="Alert: sink errors on any sink type in the last 5 minutes"
+rate(sonda_server_sink_errors_total[5m]) > 0
+```
+
+This is the single most important alert on the page. Sustained sink errors mean some backend is unreachable or rejecting writes. Drill into individual scenarios with `GET /scenarios` and look at the `degraded` field, then inspect the offenders with `GET /scenarios/{id}/stats` for `last_sink_error`.
+
+#### `sonda_server_uptime_seconds`
+
+Gauge. Seconds since the server process started. Drops to a small value on restart — useful as a crash-loop indicator.
+
+```promql title="Alert: server restarted in the last 5 minutes"
+sonda_server_uptime_seconds < 300
+```
+
+#### `sonda_server_build_info`
+
+Constant gauge, always `1`. Carries the build version and git SHA as labels.
+
+| Label | Values |
+|---|---|
+| `version` | Crate version from `Cargo.toml`. |
+| `git_sha` | Git SHA at build time, or `unknown` when `.git/` is absent (Docker source-tarball builds). |
+
+Use it to identify which build is running. Join it onto other queries with `group_left` to see whether a regression coincides with a deploy.
+
+### Authentication
+
+All three metrics endpoints inherit the same `SONDA_API_KEY` gate as `/scenarios/*` and `/events`. When the env var or `--api-key` flag is set, requests must include `Authorization: Bearer <key>`. When the key is unset, the endpoints are public. See [Authentication on Deploy as a server](server.md#authentication) for the full setup.
+
+```bash title="Scraping /server/metrics with auth"
+curl -H "Authorization: Bearer my-secret-key" http://localhost:8080/server/metrics
+```
+
+For Prometheus:
+
+```yaml title="prometheus.yml (with auth)"
+scrape_configs:
+  - job_name: sonda-server
+    scrape_interval: 15s
+    metrics_path: /server/metrics
+    bearer_token: my-secret-key
+    static_configs:
+      - targets: ["localhost:8080"]
+```
+
+For the Prometheus Operator, use a [`bearerTokenSecret` on the ServiceMonitor](kubernetes.md#prometheus-scraping-with-auth).
+
+### Scrape isolation under load
+
+The metrics endpoints sit on a separate sub-router from the control plane. `--max-inflight-requests`, `--request-timeout`, and `--max-body-bytes` do **not** apply to `/server/metrics`, `/metrics`, `/scenarios/{id}/metrics`, or `/scenarios/{id}/stats`. A saturated server still returns 200 on its observability endpoints, so alerting keeps firing when you need it most. The auth gate still applies.
+
+## `GET /metrics`
+
+Aggregate scenario data — every running scenario's series fused into one Prometheus text response. This is the right endpoint for a regular Prometheus or vmagent scrape job covering every scenario the server is running. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape) for the full reference, including the `?label=k:v` filter.
+
+## `GET /scenarios/{id}/metrics`
+
+One scenario's series in Prometheus text format. Use it when each scenario is its own logical target and you know the ID in advance — for example, a scenario loaded from a ConfigMap with a stable name. See [Per-scenario metrics](http-api.md#get-scenariosidmetrics) for the request shape and response semantics.
+
+## Where to next
+
+- [Deploy as a server](server.md) — flags and resource limits that shape `/server/metrics` values.
+- [HTTP API reference](http-api.md) — every endpoint and the 429 / 408 / 413 responses that `sonda_server_requests_total` counts.
+- [Kubernetes](kubernetes.md#servicemonitor) — ServiceMonitor configuration for the Prometheus Operator.

--- a/docs/site/docs/deploy/server.md
+++ b/docs/site/docs/deploy/server.md
@@ -220,7 +220,7 @@ The scenario runs in the background inside the server until its `duration` expir
 
 ## Server flags
 
-`sonda-server` accepts four flags: `--port <PORT>` (default `8080`), `--bind <ADDR>` (default `0.0.0.0`), `--api-key <KEY>` (or `SONDA_API_KEY`), and `--catalog <DIR>` (or `SONDA_CATALOG`). Use the `RUST_LOG` environment variable to control log verbosity (default `info`):
+`sonda-server` accepts nine flags. The first four are the network and addressing surface; the remaining five control resource limits and runtime sizing. Use the `RUST_LOG` environment variable to control log verbosity (default `info`):
 
 ```bash
 RUST_LOG=debug sonda-server --port 8080
@@ -230,12 +230,64 @@ RUST_LOG=debug sonda-server --port 8080
 |------|---------|---------|---------|
 | `--port <PORT>` | -- | `8080` | Port the server listens on |
 | `--bind <ADDR>` | -- | `0.0.0.0` | Bind address |
-| `--api-key <KEY>` | `SONDA_API_KEY` | (unset) | Bearer token for `/scenarios/*`, `/metrics`, and `/events`. See [Authentication](#authentication). |
+| `--api-key <KEY>` | `SONDA_API_KEY` | (unset) | Bearer token for `/scenarios/*`, `/events`, and metrics endpoints. See [Authentication](#authentication). |
 | `--catalog <DIR>` | `SONDA_CATALOG` | (unset) | Directory of scenario and pack YAML files. Lets `POST /scenarios` resolve `pack: <name>` references. See [Pack references over HTTP](http-api.md#pack-references-over-http). |
+| `--workers <N>` | -- | `available_parallelism()` | Tokio worker thread count. See [Tuning resource limits](#tuning-resource-limits). |
+| `--max-scenarios <N>` | -- | `0` (unlimited) | Maximum concurrent scenario rows. POSTs beyond the cap return [`429 capacity_exceeded`](http-api.md#capacity-and-resource-errors). |
+| `--max-inflight-requests <N>` | -- | `4 * workers` | Maximum concurrent in-flight control-plane HTTP requests. |
+| `--request-timeout <SECS>` | -- | `30` | Per-request timeout on control-plane routes. Returns [`408 request_timeout`](http-api.md#capacity-and-resource-errors) on expiry. |
+| `--max-body-bytes <N>` | -- | `1048576` (1 MB) | Maximum request body size on control-plane routes. Returns [`413 payload_too_large`](http-api.md#capacity-and-resource-errors) when exceeded. |
 
 When you pass `--catalog`, point it at a directory that holds your `kind: composable` pack YAML files. The path must exist. A missing directory makes the server fail at startup with a clear error.
 
 Press Ctrl+C for graceful shutdown. The server signals all running scenarios to stop before exiting.
+
+### Tuning resource limits
+
+The five resource-limit flags shape what the server accepts, how many scenarios it holds, and how it spends CPU. Their defaults work for a developer laptop. Production deployments should pick values per the guidance below.
+
+#### `--workers <N>`
+
+The size of the tokio multi-thread runtime. Bound: `N >= 1`. The default is `std::thread::available_parallelism()`, which respects cgroup CPU quotas — so the same binary picks 16 workers on a 16-core host and 2 workers on a Kubernetes pod with `cpu: 2000m` set. Override only when you want to deviate from the cgroup setting (for example, pin a workload to one worker to reduce context-switching noise during benchmarking).
+
+The configured value is exported on [`sonda_server_worker_threads`](server-metrics.md#sonda_server_worker_threads) — use it to confirm the runtime sees the value you expect.
+
+#### `--max-scenarios <N>`
+
+A **row cap**, not a CPU-task cap. Every entry in the server's scenario map consumes one slot, including scenarios in `pending`, `running`, `paused`, `held`, `unresolved`, and `finished` state. Reaching the cap returns `429 capacity_exceeded` with a `by_state` breakdown of where the slots went.
+
+Pick `N` from the memory you are willing to dedicate. Each scenario row holds runtime state plus a per-scenario stats buffer; an order-of-magnitude estimate is ~1 MB per scenario at moderate rates. Production deployments commonly use values in the `100` to `1000` range; CI runners often run with `--max-scenarios 50` so a runaway test cannot OOM the runner.
+
+`0` disables the cap entirely. The server emits a `WARN` log line at startup so the choice is visible:
+
+```text
+WARN sonda_server: --max-scenarios 0 — scenario row cap disabled (unlimited)
+```
+
+The cap is exported on [`sonda_server_max_scenarios`](server-metrics.md#sonda_server_max_scenarios). Live row usage is in [`sonda_server_active_scenarios`](server-metrics.md#sonda_server_active_scenarios) plus [`sonda_server_scenarios_finished_total`](server-metrics.md#sonda_server_scenarios_finished_total).
+
+!!! warning "Finished scenarios still occupy a slot"
+    A scenario in `finished` state holds its slot until `DELETE /scenarios/{id}` removes it. Automation that forgets to delete completed scenarios will fill the cap and start serving 429s on every new POST. Either DELETE after a scenario completes, or set `--max-scenarios` high enough to absorb the backlog you expect between cleanups.
+
+#### `--max-inflight-requests <N>`
+
+A global concurrency cap across the control-plane sub-router — `POST /scenarios`, `DELETE /scenarios/{id}`, `POST /events`, and the list/inspect routes. The default `4 * workers` keeps a healthy queue depth without overcommitting. Raise it when the server has CPU and memory headroom and you see request latency climbing under load. Lower it when control-plane work is starving scenario runners.
+
+The cap does **not** apply to the observability sub-router. `/server/metrics`, `/metrics`, `/scenarios/{id}/metrics`, and `/scenarios/{id}/stats` stay scrape-able under saturation — exactly when your alerts need them.
+
+Back-pressure is implicit. `tower::limit::ConcurrencyLimitLayer` does not return a 503; it back-pressures via the tokio runtime, and requests queue at the listener until a slot frees. The visible symptom is rising P99 on [`sonda_server_request_duration_seconds`](server-metrics.md#sonda_server_request_duration_seconds), not an error spike. Alert on the histogram, not on a status code.
+
+#### `--request-timeout <SECS>`
+
+Per-request handler bound on control-plane routes. Requests that exceed the limit return `408 request_timeout`. The default `30` covers the slowest legitimate POST (a large multi-scenario body with cross-POST `while:` resolution). Raise it when you regularly post bodies with many entries; lower it when you want a tighter SLO on the control plane.
+
+This is a handler-execution timeout, not a TCP read timeout — slow clients shipping a body bit-by-bit are not the trigger. The flag does not apply to the observability sub-router.
+
+#### `--max-body-bytes <N>`
+
+The maximum request body size on control-plane routes. Bodies above the limit return `413 payload_too_large`. The default 1 MB fits any realistic scenario YAML and most multi-scenario batches. Raise it when you post very large catalogs by-value (rare — prefer `--catalog <DIR>` for that). Lower it as a hardening measure on internet-facing deployments.
+
+The flag does not apply to the observability sub-router.
 
 ## Authentication
 
@@ -278,12 +330,13 @@ INFO sonda_server: API key authentication enabled for /scenarios/*, /events, and
 | `GET /scenarios/{id}/stats` | Yes |
 | `GET /scenarios/{id}/metrics` | Yes |
 | `GET /metrics` | Yes |
+| `GET /server/metrics` | Yes |
 | `POST /events` | Yes |
 
 See [Authentication conventions on HTTP API reference](http-api.md#authentication) for request shapes, header format, and 401 response bodies.
 
 !!! warning "Prometheus scraping with auth"
-    If you enable authentication, your Prometheus scrape config must include the bearer token for both `/metrics` and `/scenarios/{id}/metrics`. Add a `bearer_token` or `bearer_token_file` field to your `scrape_configs` entry. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape) for the scrape-config shape.
+    If you enable authentication, your Prometheus scrape config must include the bearer token for `/server/metrics`, `/metrics`, and `/scenarios/{id}/metrics`. Add a `bearer_token` or `bearer_token_file` field to your `scrape_configs` entry. See [Authentication on Server metrics](server-metrics.md#authentication) for the scrape-config shape.
 
 ??? tip "Kubernetes Secrets"
     In Kubernetes deployments, store the API key in a Secret and reference it as an environment variable in your Deployment spec:
@@ -318,6 +371,7 @@ See [Authentication conventions on HTTP API reference](http-api.md#authenticatio
 ## Where to next
 
 - [HTTP API reference](http-api.md) — every endpoint, request body, and response shape.
+- [Server metrics](server-metrics.md) — the nine `/server/metrics` series and the alerts that matter.
 - [Docker](docker.md) — Compose stacks and host-side `docker run` examples.
 - [Kubernetes](kubernetes.md) — Helm chart, Service DNS, cross-namespace access.
 - [Sinks](../build/sinks.md) — every sink type and its `url:` field.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -208,6 +208,7 @@ nav:
       - As a CLI: deploy/cli.md
       - As a server: deploy/server.md
       - HTTP API reference: deploy/http-api.md
+      - Server metrics: deploy/server-metrics.md
       - Docker: deploy/docker.md
       - Kubernetes: deploy/kubernetes.md
   - Reference:

--- a/helm/sonda/templates/servicemonitor.yaml
+++ b/helm/sonda/templates/servicemonitor.yaml
@@ -15,7 +15,14 @@ spec:
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
       {{- end }}
-      path: {{ required "serviceMonitor.enabled is true but serviceMonitor.path is empty — set it to a Prometheus-text endpoint such as /scenarios/<scenario-id>/metrics" .Values.serviceMonitor.path }}
+      path: {{ default "/server/metrics" .Values.serviceMonitor.path }}
+      {{- with .Values.serviceMonitor.bearerTokenSecret }}
+      {{- if and .name .key }}
+      bearerTokenSecret:
+        name: {{ .name }}
+        key: {{ .key }}
+      {{- end }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/helm/sonda/values.yaml
+++ b/helm/sonda/values.yaml
@@ -127,17 +127,23 @@ ingress:
 
 # ServiceMonitor for Prometheus Operator.
 #
-# `path` must point at a Prometheus-text endpoint. sonda-server exposes
-# per-scenario metrics at /scenarios/<scenario-id>/metrics; choose the
-# scenario you want scraped and set `path` to that route. When enabled
-# without a path the chart install fails with a clear error rather than
-# silently scraping a non-metrics endpoint.
+# `path` should point at /server/metrics for server-process RED + saturation
+# metrics (recommended for operational dashboards and alerts). Per-scenario
+# metrics remain available at /scenarios/<scenario-id>/metrics, and aggregate
+# scenario data at /metrics, for ad-hoc scraping or workload-specific
+# ServiceMonitors.
 serviceMonitor:
   enabled: false
   interval: 30s
   scrapeTimeout: 10s
-  path: ""
+  path: "/server/metrics"
   additionalLabels: {}
+  # When SONDA_API_KEY auth is enabled on the server, set both fields below to
+  # point at a Kubernetes Secret holding the bearer token. Prometheus Operator
+  # reads the secret from the same namespace as the ServiceMonitor.
+  bearerTokenSecret:
+    name: ""
+    key: ""
 
 # Node selector for pod scheduling.
 nodeSelector: {}

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -25,9 +25,10 @@ serde_yaml_ng = { workspace = true, optional = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = "0.1"
+async-trait = "0.1"
 ureq = { workspace = true, optional = true }
 rskafka = { version = "0.6.0", default-features = false, features = ["transport-tls"], optional = true }
-tokio = { version = "1", features = ["rt", "sync", "net", "time", "macros"] }
+tokio = { version = "1", features = ["rt", "sync", "net", "time", "macros", "fs", "io-std", "io-util"] }
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"], optional = true }
 rustls-pki-types = { version = "1", features = ["std"], optional = true }
@@ -45,6 +46,7 @@ rstest = { workspace = true }
 criterion = { version = "0.8", default-features = false }
 sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 tracing-test = "0.2"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [[bench]]
 name = "while_steady_state"

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -15,9 +15,9 @@ readme = "../README.md"
 default = ["config"]
 config = ["dep:serde_yaml_ng", "dep:chrono", "chrono/serde"]
 http = ["dep:ureq"]
-kafka = ["dep:rskafka", "dep:tokio", "dep:chrono", "chrono/clock", "dep:rustls", "dep:rustls-pki-types", "dep:webpki-roots"]
+kafka = ["dep:rskafka", "dep:chrono", "chrono/clock", "dep:rustls", "dep:rustls-pki-types", "dep:webpki-roots"]
 remote-write = ["dep:prost", "dep:snap", "dep:ureq"]
-otlp = ["dep:tonic", "dep:prost", "dep:tokio", "dep:bytes", "dep:http"]
+otlp = ["dep:tonic", "dep:prost", "dep:bytes", "dep:http"]
 
 [dependencies]
 serde = { workspace = true }
@@ -27,7 +27,7 @@ thiserror = { workspace = true }
 tracing = "0.1"
 ureq = { workspace = true, optional = true }
 rskafka = { version = "0.6.0", default-features = false, features = ["transport-tls"], optional = true }
-tokio = { version = "1", features = ["rt", "net", "time", "macros"], optional = true }
+tokio = { version = "1", features = ["rt", "sync", "net", "time", "macros"] }
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"], optional = true }
 rustls-pki-types = { version = "1", features = ["std"], optional = true }

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -53,3 +53,6 @@ harness = false
 [[bench]]
 name = "scheduler_baseline"
 harness = false
+
+[lints]
+workspace = true

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -43,8 +43,13 @@ tempfile = "3"
 insta = { workspace = true, features = ["filters"] }
 rstest = { workspace = true }
 criterion = { version = "0.8", default-features = false }
+sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 tracing-test = "0.2"
 
 [[bench]]
 name = "while_steady_state"
+harness = false
+
+[[bench]]
+name = "scheduler_baseline"
 harness = false

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -28,7 +28,8 @@ tracing = "0.1"
 async-trait = "0.1"
 ureq = { workspace = true, optional = true }
 rskafka = { version = "0.6.0", default-features = false, features = ["transport-tls"], optional = true }
-tokio = { version = "1", features = ["rt", "sync", "net", "time", "macros", "fs", "io-std", "io-util"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "net", "time", "macros", "fs", "io-std", "io-util"] }
+tokio-util = { version = "0.7", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"], optional = true }
 rustls-pki-types = { version = "1", features = ["std"], optional = true }

--- a/sonda-core/benches/scheduler_baseline.rs
+++ b/sonda-core/benches/scheduler_baseline.rs
@@ -200,10 +200,20 @@ fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
             })
             .collect();
         let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
         for (offset, p) in prepared.into_iter().enumerate() {
             let i = offset + 1;
             let shutdown = Arc::new(AtomicBool::new(true));
-            let handle = launch_scenario(format!("bench_{i}"), p.entry, shutdown, p.start_delay)
+            let handle = rt
+                .block_on(launch_scenario(
+                    format!("bench_{i}"),
+                    p.entry,
+                    shutdown,
+                    p.start_delay,
+                ))
                 .expect("launch_scenario must succeed");
             handles.push(handle);
         }

--- a/sonda-core/benches/scheduler_baseline.rs
+++ b/sonda-core/benches/scheduler_baseline.rs
@@ -1,30 +1,23 @@
-//! Phase 0 baseline: measure the current thread-per-scenario scheduler at
-//! varying concurrent-scenario counts. Captures RSS, vsize, thread count,
-//! CPU%, tick-drift and dropped-tick percentage per N, and writes a markdown
-//! report alongside a stdout table.
+//! Multi-rate + multi-concurrency sweep of the async-scheduler. Captures RSS,
+//! vsize, thread count, CPU%, tick-drift (ms proxy + microsecond direct), and
+//! dropped-tick percentage per row, and writes a markdown report alongside a
+//! stdout table.
 
-use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
-use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex, RwLock};
-use std::thread;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use sonda_core::config::{BaseScheduleConfig, ScenarioConfig, ScenarioEntry};
 use sonda_core::encoder::EncoderConfig;
 use sonda_core::generator::GeneratorConfig;
 use sonda_core::schedule::handle::ScenarioHandle;
-use sonda_core::schedule::runner::run_with_sink;
-use sonda_core::schedule::stats::ScenarioStats;
-use sonda_core::sink::memory::{CapturedRing, MemorySink};
-use sonda_core::sink::{Sink, SinkConfig};
+use sonda_core::sink::memory::CapturedRing;
+use sonda_core::sink::SinkConfig;
 use sonda_core::{launch_scenario, prepare_entries, OnSinkError};
 use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System};
 
-const DEFAULT_SCENARIO_COUNTS: &[usize] = &[1, 10, 50, 100, 250, 500];
-const RATE_HZ: f64 = 100.0;
 const DEFAULT_WARMUP_SECS: u64 = 30;
 const DEFAULT_MEASURE_SECS: u64 = 60;
 const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
@@ -46,18 +39,70 @@ fn measure_secs() -> u64 {
         .unwrap_or(DEFAULT_MEASURE_SECS)
 }
 
-fn scenario_counts() -> Vec<usize> {
-    match std::env::var("SONDA_BENCH_COUNTS").ok() {
-        Some(s) => s
-            .split(',')
-            .filter_map(|p| p.trim().parse::<usize>().ok())
-            .collect(),
-        None => DEFAULT_SCENARIO_COUNTS.to_vec(),
-    }
+#[derive(Clone, Copy)]
+struct SweepRow {
+    n: usize,
+    rate_hz: f64,
+    label: &'static str,
 }
 
+const DEFAULT_SWEEP: &[SweepRow] = &[
+    SweepRow {
+        n: 10,
+        rate_hz: 100.0,
+        label: "rate@10:100Hz",
+    },
+    SweepRow {
+        n: 10,
+        rate_hz: 1_000.0,
+        label: "rate@10:1kHz",
+    },
+    SweepRow {
+        n: 10,
+        rate_hz: 10_000.0,
+        label: "rate@10:10kHz",
+    },
+    SweepRow {
+        n: 1,
+        rate_hz: 100.0,
+        label: "conc:1@100Hz",
+    },
+    SweepRow {
+        n: 10,
+        rate_hz: 100.0,
+        label: "conc:10@100Hz",
+    },
+    SweepRow {
+        n: 100,
+        rate_hz: 100.0,
+        label: "conc:100@100Hz",
+    },
+    SweepRow {
+        n: 500,
+        rate_hz: 100.0,
+        label: "conc:500@100Hz",
+    },
+    SweepRow {
+        n: 1000,
+        rate_hz: 100.0,
+        label: "conc:1000@100Hz",
+    },
+    SweepRow {
+        n: 1000,
+        rate_hz: 100.0,
+        label: "production:1000x100Hz",
+    },
+    SweepRow {
+        n: 100,
+        rate_hz: 1_000.0,
+        label: "stress:100x1kHz",
+    },
+];
+
 struct RowResult {
+    label: &'static str,
     n: usize,
+    rate_hz: f64,
     rss_mb: f64,
     vsize_mb: f64,
     threads: usize,
@@ -79,11 +124,11 @@ struct Sample {
     per_scenario_events: Vec<u64>,
 }
 
-fn metrics_entry(name: String, rate: f64, sink: SinkConfig) -> ScenarioEntry {
+fn metrics_entry(name: String, rate_hz: f64, sink: SinkConfig) -> ScenarioEntry {
     ScenarioEntry::Metrics(ScenarioConfig {
         base: BaseScheduleConfig {
             name,
-            rate,
+            rate: rate_hz,
             duration: None,
             gaps: None,
             bursts: None,
@@ -104,36 +149,6 @@ fn metrics_entry(name: String, rate: f64, sink: SinkConfig) -> ScenarioEntry {
         metric_type: None,
         help: None,
     })
-}
-
-fn metrics_config_for_capture(name: String, rate: f64) -> ScenarioConfig {
-    ScenarioConfig {
-        base: BaseScheduleConfig {
-            name,
-            rate,
-            duration: None,
-            gaps: None,
-            bursts: None,
-            cardinality_spikes: None,
-            dynamic_labels: None,
-            labels: None,
-            sink: SinkConfig::Memory {
-                capture: true,
-                max_events: Some(CAPTURE_RING_SIZE),
-            },
-            phase_offset: None,
-            clock_group: None,
-            clock_group_is_auto: None,
-            start_time: None,
-            jitter: None,
-            jitter_seed: None,
-            on_sink_error: OnSinkError::Warn,
-        },
-        generator: GeneratorConfig::Constant { value: 1.0 },
-        encoder: EncoderConfig::PrometheusText { precision: None },
-        metric_type: None,
-        help: None,
-    }
 }
 
 struct DriftStats {
@@ -176,108 +191,47 @@ fn compute_drift_stats(timestamps: &[Instant], rate_hz: f64) -> DriftStats {
     }
 }
 
-fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
+async fn launch_n(n: usize, rate_hz: f64) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
     assert!(n >= 1, "launch_n requires at least one scenario");
     let capture_handle = Arc::new(Mutex::new(CapturedRing::new(CAPTURE_RING_SIZE)));
 
-    let rt: &'static tokio::runtime::Runtime = Box::leak(Box::new(
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .expect("tokio runtime must build"),
-    ));
-    let mut handles = Vec::with_capacity(n);
-    handles.push(launch_capturing_scenario(
-        rt,
-        "bench_0".to_string(),
-        Arc::clone(&capture_handle),
-    ));
+    let entries: Vec<ScenarioEntry> = (0..n)
+        .map(|i| {
+            let sink = if i == 0 {
+                SinkConfig::Memory {
+                    capture: false,
+                    max_events: None,
+                    capture_handle: Some(Arc::clone(&capture_handle)),
+                }
+            } else {
+                SinkConfig::Memory {
+                    capture: false,
+                    max_events: None,
+                    capture_handle: None,
+                }
+            };
+            metrics_entry(format!("bench_{i}"), rate_hz, sink)
+        })
+        .collect();
 
-    if n > 1 {
-        let entries: Vec<ScenarioEntry> = (1..n)
-            .map(|i| {
-                metrics_entry(
-                    format!("bench_{i}"),
-                    RATE_HZ,
-                    SinkConfig::Memory {
-                        capture: false,
-                        max_events: None,
-                    },
-                )
-            })
-            .collect();
-        let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
-        for (offset, p) in prepared.into_iter().enumerate() {
-            let i = offset + 1;
-            let cancel = sonda_core::CancellationToken::new();
-            let handle = rt
-                .block_on(launch_scenario(
-                    format!("bench_{i}"),
-                    p.entry,
-                    cancel,
-                    p.start_delay,
-                ))
-                .expect("launch_scenario must succeed");
-            handles.push(handle);
-        }
+    let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
+    let mut handles = Vec::with_capacity(n);
+    for (offset, p) in prepared.into_iter().enumerate() {
+        let cancel = sonda_core::CancellationToken::new();
+        let handle = launch_scenario(format!("bench_{offset}"), p.entry, cancel, p.start_delay)
+            .await
+            .expect("launch_scenario must succeed");
+        handles.push(handle);
     }
     (handles, capture_handle)
 }
 
-// Mirrors launch_scenario for the shared-capture path; bench-local replica.
-fn launch_capturing_scenario(
-    rt: &tokio::runtime::Runtime,
-    id: String,
-    capture_handle: Arc<Mutex<CapturedRing>>,
-) -> ScenarioHandle {
-    let config = metrics_config_for_capture(id.clone(), RATE_HZ);
-    let name = config.base.name.clone();
-    let cancel = sonda_core::CancellationToken::new();
-    let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-    let alive = Arc::new(AtomicBool::new(true));
-    let cleaned_up = Arc::new(AtomicBool::new(true));
-    let labels: Arc<HashMap<String, String>> = Arc::new(HashMap::new());
-
-    let cancel_for_task = cancel.clone();
-    let stats_for_task = Arc::clone(&stats);
-    let alive_for_task = Arc::clone(&alive);
-
-    let task = rt.spawn(async move {
-        struct AliveGuard(Arc<AtomicBool>);
-        impl Drop for AliveGuard {
-            fn drop(&mut self) {
-                self.0.store(false, std::sync::atomic::Ordering::SeqCst);
-            }
-        }
-        let _guard = AliveGuard(alive_for_task);
-
-        let sink_inner = MemorySink::with_shared_capture(capture_handle);
-        let mut sink: Box<dyn Sink> = Box::new(sink_inner);
-        run_with_sink(&config, &mut sink, &cancel_for_task, Some(stats_for_task)).await
-    });
-
-    ScenarioHandle::new(
-        id,
-        name,
-        None,
-        cancel,
-        Some(task),
-        Instant::now(),
-        stats,
-        RATE_HZ,
-        alive,
-        labels,
-        None,
-        cleaned_up,
-    )
-}
-
-fn stop_all(handles: &mut [ScenarioHandle]) {
+async fn stop_all(handles: &mut [ScenarioHandle]) {
     for h in handles.iter() {
         h.stop();
     }
     for h in handles.iter_mut() {
-        let _ = h.join(Some(Duration::from_secs(5)));
+        let _ = h.join_async(Some(Duration::from_secs(5))).await;
     }
 }
 
@@ -339,15 +293,21 @@ fn current_thread_count() -> Option<usize> {
     None
 }
 
-fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
+async fn run_row(
+    runtime: &tokio::runtime::Handle,
+    row: SweepRow,
+    warmup: u64,
+    measure: u64,
+) -> RowResult {
+    let SweepRow { n, rate_hz, label } = row;
     eprintln!(
-        "[bench] N={n}: launching scenarios at {RATE_HZ:.0} Hz \
+        "[bench] {label}: N={n} rate={rate_hz:.0}Hz \
          (warmup {warmup}s, measure {measure}s)"
     );
 
-    let (mut handles, capture_handle) = launch_n(n);
+    let (mut handles, capture_handle) = launch_n(n, rate_hz).await;
 
-    thread::sleep(Duration::from_secs(warmup));
+    tokio::time::sleep(Duration::from_secs(warmup)).await;
 
     let pid = Pid::from_u32(std::process::id());
     let mut system = System::new_with_specifics(
@@ -365,7 +325,7 @@ fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
     let measure_end = Instant::now() + Duration::from_secs(measure);
 
     while Instant::now() < measure_end {
-        thread::sleep(SAMPLE_INTERVAL);
+        tokio::time::sleep(SAMPLE_INTERVAL).await;
         if let Some(s) = sample_process(&mut system, pid, &handles) {
             samples.push(s);
         }
@@ -376,29 +336,35 @@ fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
     let threads = samples.iter().map(|s| s.threads).max().unwrap_or(0);
     let cpu_pct = mean(samples.iter().map(|s| s.cpu_pct));
 
-    let drift_samples_ms = compute_drift_ms(&samples, &initial_events);
+    let drift_samples_ms = compute_drift_ms(&samples, &initial_events, rate_hz);
     let drift_mean_ms = mean(drift_samples_ms.iter().copied());
     let drift_p99_ms = percentile(&drift_samples_ms, 99.0);
-    let dropped_pct = compute_dropped_pct(&samples, &initial_events);
+    let dropped_pct = compute_dropped_pct(&samples, &initial_events, rate_hz);
 
     let captured_timestamps: Vec<Instant> = {
         let guard = capture_handle.lock().expect("capture handle poisoned");
         guard.events().iter().map(|(ts, _)| *ts).collect()
     };
-    let drift = compute_drift_stats(&captured_timestamps, RATE_HZ);
+    let drift = compute_drift_stats(&captured_timestamps, rate_hz);
 
     eprintln!(
-        "[bench] N={n}: rss={rss_mb:.1}MB vsize={vsize_mb:.0}MB threads={threads} \
+        "[bench] {label}: rss={rss_mb:.1}MB vsize={vsize_mb:.0}MB threads={threads} \
          cpu={cpu_pct:.1}% drift_mean={drift_mean_ms:.2}ms drift_p99={drift_p99_ms:.2}ms \
          drift_us p50={:.1} p90={:.1} p99={:.1} max={:.1} \
          dropped={dropped_pct:.2}%",
         drift.p50_us, drift.p90_us, drift.p99_us, drift.max_us
     );
 
-    stop_all(&mut handles);
+    stop_all(&mut handles).await;
+    drop(handles);
+    tokio::task::yield_now().await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let _ = runtime;
 
     RowResult {
+        label,
         n,
+        rate_hz,
         rss_mb,
         vsize_mb,
         threads,
@@ -413,11 +379,11 @@ fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
     }
 }
 
-fn compute_drift_ms(samples: &[Sample], initial_events: &[u64]) -> Vec<f64> {
+fn compute_drift_ms(samples: &[Sample], initial_events: &[u64], rate_hz: f64) -> Vec<f64> {
     let mut out = Vec::new();
     let mut prev = initial_events.to_vec();
-    let expected_per_sample = RATE_HZ * SAMPLE_INTERVAL.as_secs_f64();
-    let ms_per_tick = 1000.0 / RATE_HZ;
+    let expected_per_sample = rate_hz * SAMPLE_INTERVAL.as_secs_f64();
+    let ms_per_tick = 1000.0 / rate_hz;
     for s in samples {
         for (i, &observed) in s.per_scenario_events.iter().enumerate() {
             let prev_v = *prev.get(i).unwrap_or(&0);
@@ -430,8 +396,8 @@ fn compute_drift_ms(samples: &[Sample], initial_events: &[u64]) -> Vec<f64> {
     out
 }
 
-fn compute_dropped_pct(samples: &[Sample], initial_events: &[u64]) -> f64 {
-    let expected_per_sample = RATE_HZ * SAMPLE_INTERVAL.as_secs_f64();
+fn compute_dropped_pct(samples: &[Sample], initial_events: &[u64], rate_hz: f64) -> f64 {
+    let expected_per_sample = rate_hz * SAMPLE_INTERVAL.as_secs_f64();
     let mut prev = initial_events.to_vec();
     let mut dropped_buckets = 0u64;
     let mut total_buckets = 0u64;
@@ -489,8 +455,10 @@ fn percentile(values: &[f64], p: f64) -> f64 {
 fn print_table(rows: &[RowResult]) {
     println!();
     println!(
-        "| {:>5} | {:>9} | {:>11} | {:>7} | {:>5} | {:>20} | {:>19} | {:>12} | {:>12} | {:>12} | {:>11} | {:>14} |",
+        "| {:<24} | {:>5} | {:>8} | {:>9} | {:>11} | {:>7} | {:>5} | {:>20} | {:>19} | {:>12} | {:>12} | {:>12} | {:>11} | {:>14} |",
+        "Row",
         "N",
+        "Rate Hz",
         "RSS (MB)",
         "VSize (MB)",
         "Threads",
@@ -504,13 +472,15 @@ fn print_table(rows: &[RowResult]) {
         "Dropped-tick %"
     );
     println!(
-        "|{:-<7}|{:-<11}|{:-<13}|{:-<9}|{:-<7}|{:-<22}|{:-<21}|{:-<14}|{:-<14}|{:-<14}|{:-<13}|{:-<16}|",
-        "", "", "", "", "", "", "", "", "", "", "", ""
+        "|{:-<26}|{:-<7}|{:-<10}|{:-<11}|{:-<13}|{:-<9}|{:-<7}|{:-<22}|{:-<21}|{:-<14}|{:-<14}|{:-<14}|{:-<13}|{:-<16}|",
+        "", "", "", "", "", "", "", "", "", "", "", "", "", ""
     );
     for r in rows {
         println!(
-            "| {:>5} | {:>9.1} | {:>11.1} | {:>7} | {:>5.1} | {:>20.2} | {:>19.2} | {:>12.1} | {:>12.1} | {:>12.1} | {:>11.1} | {:>14.2} |",
+            "| {:<24} | {:>5} | {:>8.0} | {:>9.1} | {:>11.1} | {:>7} | {:>5.1} | {:>20.2} | {:>19.2} | {:>12.1} | {:>12.1} | {:>12.1} | {:>11.1} | {:>14.2} |",
+            r.label,
             r.n,
+            r.rate_hz,
             r.rss_mb,
             r.vsize_mb,
             r.threads,
@@ -533,38 +503,44 @@ fn render_markdown(rows: &[RowResult], warmup: u64, measure: u64) -> String {
     let commit = git_head_sha().unwrap_or_else(|| "unknown".to_string());
 
     let mut out = String::new();
-    out.push_str("# Async-Scheduler Baseline Numbers (BEFORE — thread-per-scenario)\n\n");
+    out.push_str("# Async-Scheduler Sweep — sweep matrix\n\n");
     out.push_str(&format!("**Captured**: {ts}\n"));
     out.push_str(&format!("**Host**: {host}\n"));
     out.push_str(&format!("**Sonda commit**: {commit}\n"));
     out.push_str("**Harness**: sonda-core/benches/scheduler_baseline.rs\n\n");
     out.push_str("## Methodology\n\n");
     out.push_str(&format!(
-        "Each row is N concurrent scenarios, each emitting at 100 events/sec via the \
-         Prometheus text encoder into a `memory` sink (no I/O — measures the scheduler, \
-         not the sink). {warmup}s warm-up + {measure}s measurement window. RSS / VSize / \
-         thread count / CPU% sampled every ~1s via the `sysinfo` crate. \
-         Tick drift is reported two ways: \n\
+        "Each row is N concurrent scenarios at the given rate via the Prometheus text encoder \
+         into a `memory` sink (no I/O — measures the scheduler, not the sink). \
+         {warmup}s warm-up + {measure}s measurement window. RSS / VSize / thread count / CPU% \
+         sampled every ~1s via the `sysinfo` crate. Tick drift is reported two ways: \n\
          \n\
          - **ms-level proxy** — `total_events` deltas between consecutive 1s samples. A bucket \
          is counted as `dropped` when the observed events in the 1s window deviate from the \
          expected count (`rate * dt`) by more than ±10%. \n\
-         - **microsecond-level direct** — the first of the N main scenarios writes through a \
-         `memory` sink with `capture: true`, retaining `(Instant, bytes)` per event across the \
-         full warm-up and measurement window. All N scenarios share the same scheduler, so the \
-         captured cadence reflects the load every scenario experiences at this N. Per-event \
-         drift is computed as `(t[i+1] - t[i]) - (1_000_000us / rate_hz)`; the first 10% of \
-         samples are dropped as warm-up jitter; p50/p90/p99/max are reported in microseconds. \n\n"
+         - **microsecond-level direct** — the first of the N scenarios writes through a \
+         `memory` sink with `capture_handle: Some(arc)`, retaining `(Instant, bytes)` per event \
+         across the full warm-up and measurement window via the shared `CapturedRing`. All N \
+         scenarios share the same tokio runtime, so the captured cadence reflects the load \
+         every scenario experiences at this N. Per-event drift is computed as \
+         `(t[i+1] - t[i]) - (1_000_000us / rate_hz)`; the first 10% of samples are dropped as \
+         warm-up jitter; p50/p90/p99/max are reported in microseconds. \n\
+         \n\
+         **Sink boundary footnote**: this bench exercises the MemorySink path only. The \
+         `spawn_blocking` boundary used by HTTP-family sinks is exercised in the end-to-end \
+         integration run against the autocon5 stack, not here.\n\n"
     ));
     out.push_str("## Results\n\n");
     out.push_str(
-        "| N scenarios | RSS (MB) | VSize (MB) | Threads | CPU % | Tick drift mean (ms) | Tick drift p99 (ms) | Drift p50 (us) | Drift p90 (us) | Drift p99 (us) | Drift max (us) | Dropped-tick % |\n",
+        "| Row | N | Rate Hz | RSS (MB) | VSize (MB) | Threads | CPU % | Tick drift mean (ms) | Tick drift p99 (ms) | Drift p50 (us) | Drift p90 (us) | Drift p99 (us) | Drift max (us) | Dropped-tick % |\n",
     );
-    out.push_str("|---|---|---|---|---|---|---|---|---|---|---|---|\n");
+    out.push_str("|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n");
     for r in rows {
         out.push_str(&format!(
-            "| {} | {:.1} | {:.1} | {} | {:.1} | {:.2} | {:.2} | {:.1} | {:.1} | {:.1} | {:.1} | {:.2} |\n",
+            "| {} | {} | {:.0} | {:.1} | {:.1} | {} | {:.1} | {:.2} | {:.2} | {:.1} | {:.1} | {:.1} | {:.1} | {:.2} |\n",
+            r.label,
             r.n,
+            r.rate_hz,
             r.rss_mb,
             r.vsize_mb,
             r.threads,
@@ -578,49 +554,25 @@ fn render_markdown(rows: &[RowResult], warmup: u64, measure: u64) -> String {
             r.dropped_pct
         ));
     }
-    out.push_str("\n## Inflection point analysis\n\n");
-    out.push_str(&inflection_paragraph(rows));
-    out.push_str("\n\n## Notes\n\n");
+    out.push_str("\n## Notes\n\n");
     out.push_str(&notes_paragraph(rows));
     out.push('\n');
     out
 }
 
-fn inflection_paragraph(rows: &[RowResult]) -> String {
-    let max_threads = rows.iter().map(|r| r.threads).max().unwrap_or(0);
-    let max_rss = rows.iter().map(|r| r.rss_mb).fold(0.0f64, f64::max);
-    let max_drift_p99 = rows.iter().map(|r| r.drift_p99_ms).fold(0.0f64, f64::max);
-    let max_drift_p99_us = rows.iter().map(|r| r.drift_p99_us).fold(0.0f64, f64::max);
-    let max_dropped = rows.iter().map(|r| r.dropped_pct).fold(0.0f64, f64::max);
-    format!(
-        "Thread count grows linearly with N (peak observed: {max_threads}); RSS scales with \
-         the per-thread stack reservation (peak observed: {max_rss:.1} MB). The earliest \
-         metric to break under this scheduler is whichever among tick-drift p99 (peak \
-         observed: {max_drift_p99:.2} ms proxy / {max_drift_p99_us:.1} us direct), \
-         dropped-tick percentage (peak observed: {max_dropped:.2}%), and CPU% saturates \
-         first as N climbs. Read the row-to-row deltas above to identify where the curve \
-         bends — the linear-thread, linear-stack growth itself is the canary for this \
-         baseline."
-    )
-}
-
 fn notes_paragraph(rows: &[RowResult]) -> String {
     let mut notes = String::new();
-    let failed_rows: Vec<usize> = rows
+    let failed_rows: Vec<&str> = rows
         .iter()
         .filter(|r| r.dropped_pct > 50.0)
-        .map(|r| r.n)
+        .map(|r| r.label)
         .collect();
     if !failed_rows.is_empty() {
         notes.push_str(&format!(
-            "- High dropped-tick percentage (> 50%) observed at N = {failed_rows:?}; the \
-             scheduler could not sustain the 100 Hz target for these scenarios.\n"
+            "- High dropped-tick percentage (> 50%) observed at rows = {failed_rows:?}; the \
+             scheduler could not sustain the target rate for these configurations.\n"
         ));
     }
-    #[cfg(target_os = "macos")]
-    notes.push_str(
-        "- Context-switches/sec is Linux-only via `/proc/<pid>/status`; not collected on macOS.\n",
-    );
     if notes.is_empty() {
         notes.push_str("None.");
     }
@@ -683,18 +635,30 @@ fn epoch_to_ymdhms(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
 }
 
 fn main() {
-    let counts = scenario_counts();
     let warmup = warmup_secs();
     let measure = measure_secs();
-    eprintln!("[bench] sonda scheduler baseline harness");
+    let sweep: Vec<SweepRow> = DEFAULT_SWEEP.to_vec();
+
+    eprintln!("[bench] sonda scheduler sweep harness");
     eprintln!(
-        "[bench] N values: {counts:?}; rate {RATE_HZ:.0} Hz; \
-         warmup {warmup}s; measure {measure}s"
+        "[bench] {} rows; warmup {warmup}s; measure {measure}s",
+        sweep.len()
     );
-    let mut rows = Vec::with_capacity(counts.len());
-    for &n in &counts {
-        rows.push(run_row(n, warmup, measure));
-    }
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime must build");
+    let handle = runtime.handle().clone();
+
+    let rows = runtime.block_on(async move {
+        let mut rows = Vec::with_capacity(sweep.len());
+        for row in sweep {
+            rows.push(run_row(&handle, row, warmup, measure).await);
+        }
+        rows
+    });
+
     print_table(&rows);
     let md = render_markdown(&rows, warmup, measure);
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/sonda-core/benches/scheduler_baseline.rs
+++ b/sonda-core/benches/scheduler_baseline.rs
@@ -20,7 +20,7 @@ use sonda_core::schedule::runner::run_with_sink;
 use sonda_core::schedule::stats::ScenarioStats;
 use sonda_core::sink::memory::{CapturedRing, MemorySink};
 use sonda_core::sink::{Sink, SinkConfig};
-use sonda_core::{launch_scenario, prepare_entries, OnSinkError, RuntimeError, SondaError};
+use sonda_core::{launch_scenario, prepare_entries, OnSinkError};
 use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System};
 
 const DEFAULT_SCENARIO_COUNTS: &[usize] = &[1, 10, 50, 100, 250, 500];
@@ -180,8 +180,15 @@ fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
     assert!(n >= 1, "launch_n requires at least one scenario");
     let capture_handle = Arc::new(Mutex::new(CapturedRing::new(CAPTURE_RING_SIZE)));
 
+    let rt: &'static tokio::runtime::Runtime = Box::leak(Box::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build"),
+    ));
     let mut handles = Vec::with_capacity(n);
     handles.push(launch_capturing_scenario(
+        rt,
         "bench_0".to_string(),
         Arc::clone(&capture_handle),
     ));
@@ -200,18 +207,14 @@ fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
             })
             .collect();
         let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .expect("tokio runtime must build");
         for (offset, p) in prepared.into_iter().enumerate() {
             let i = offset + 1;
-            let shutdown = Arc::new(AtomicBool::new(true));
+            let cancel = sonda_core::CancellationToken::new();
             let handle = rt
                 .block_on(launch_scenario(
                     format!("bench_{i}"),
                     p.entry,
-                    shutdown,
+                    cancel,
                     p.start_delay,
                 ))
                 .expect("launch_scenario must succeed");
@@ -223,53 +226,42 @@ fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
 
 // Mirrors launch_scenario for the shared-capture path; bench-local replica.
 fn launch_capturing_scenario(
+    rt: &tokio::runtime::Runtime,
     id: String,
     capture_handle: Arc<Mutex<CapturedRing>>,
 ) -> ScenarioHandle {
     let config = metrics_config_for_capture(id.clone(), RATE_HZ);
     let name = config.base.name.clone();
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = sonda_core::CancellationToken::new();
     let stats = Arc::new(RwLock::new(ScenarioStats::default()));
     let alive = Arc::new(AtomicBool::new(true));
     let cleaned_up = Arc::new(AtomicBool::new(true));
     let labels: Arc<HashMap<String, String>> = Arc::new(HashMap::new());
 
-    let shutdown_for_thread = Arc::clone(&shutdown);
-    let stats_for_thread = Arc::clone(&stats);
-    let alive_for_thread = Arc::clone(&alive);
+    let cancel_for_task = cancel.clone();
+    let stats_for_task = Arc::clone(&stats);
+    let alive_for_task = Arc::clone(&alive);
 
-    let thread = std::thread::Builder::new()
-        .name(format!("sonda-{name}"))
-        .spawn(move || -> Result<(), SondaError> {
-            struct AliveGuard(Arc<AtomicBool>);
-            impl Drop for AliveGuard {
-                fn drop(&mut self) {
-                    self.0.store(false, std::sync::atomic::Ordering::SeqCst);
-                }
+    let task = rt.spawn(async move {
+        struct AliveGuard(Arc<AtomicBool>);
+        impl Drop for AliveGuard {
+            fn drop(&mut self) {
+                self.0.store(false, std::sync::atomic::Ordering::SeqCst);
             }
-            let _guard = AliveGuard(alive_for_thread);
+        }
+        let _guard = AliveGuard(alive_for_task);
 
-            let sink_inner = MemorySink::with_shared_capture(capture_handle);
-            let mut sink: Box<dyn Sink> = Box::new(sink_inner);
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
-            rt.block_on(run_with_sink(
-                &config,
-                &mut sink,
-                Some(shutdown_for_thread.as_ref()),
-                Some(stats_for_thread),
-            ))
-        })
-        .expect("scenario thread must spawn");
+        let sink_inner = MemorySink::with_shared_capture(capture_handle);
+        let mut sink: Box<dyn Sink> = Box::new(sink_inner);
+        run_with_sink(&config, &mut sink, &cancel_for_task, Some(stats_for_task)).await
+    });
 
     ScenarioHandle::new(
         id,
         name,
         None,
-        shutdown,
-        Some(thread),
+        cancel,
+        Some(task),
         Instant::now(),
         stats,
         RATE_HZ,

--- a/sonda-core/benches/scheduler_baseline.rs
+++ b/sonda-core/benches/scheduler_baseline.rs
@@ -1,0 +1,520 @@
+//! Phase 0 baseline: measure the current thread-per-scenario scheduler at
+//! varying concurrent-scenario counts. Captures RSS, vsize, thread count,
+//! CPU%, tick-drift and dropped-tick percentage per N, and writes a markdown
+//! report alongside a stdout table.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use sonda_core::config::{BaseScheduleConfig, ScenarioConfig, ScenarioEntry};
+use sonda_core::encoder::EncoderConfig;
+use sonda_core::generator::GeneratorConfig;
+use sonda_core::schedule::handle::ScenarioHandle;
+use sonda_core::sink::SinkConfig;
+use sonda_core::{launch_scenario, prepare_entries, OnSinkError};
+use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System};
+
+const DEFAULT_SCENARIO_COUNTS: &[usize] = &[1, 10, 50, 100, 250, 500];
+const RATE_HZ: f64 = 100.0;
+const DEFAULT_WARMUP_SECS: u64 = 30;
+const DEFAULT_MEASURE_SECS: u64 = 60;
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+const DROPPED_TICK_TOLERANCE: f64 = 0.10;
+const NULL_SINK_PATH: &str = "/dev/null";
+
+fn warmup_secs() -> u64 {
+    std::env::var("SONDA_BENCH_WARMUP_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_WARMUP_SECS)
+}
+
+fn measure_secs() -> u64 {
+    std::env::var("SONDA_BENCH_MEASURE_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_MEASURE_SECS)
+}
+
+fn scenario_counts() -> Vec<usize> {
+    match std::env::var("SONDA_BENCH_COUNTS").ok() {
+        Some(s) => s
+            .split(',')
+            .filter_map(|p| p.trim().parse::<usize>().ok())
+            .collect(),
+        None => DEFAULT_SCENARIO_COUNTS.to_vec(),
+    }
+}
+
+struct RowResult {
+    n: usize,
+    rss_mb: f64,
+    vsize_mb: f64,
+    threads: usize,
+    cpu_pct: f64,
+    drift_mean_ms: f64,
+    drift_p99_ms: f64,
+    dropped_pct: f64,
+}
+
+struct Sample {
+    rss_bytes: u64,
+    vsize_bytes: u64,
+    threads: usize,
+    cpu_pct: f64,
+    per_scenario_events: Vec<u64>,
+}
+
+fn metrics_entry(name: String, rate: f64) -> ScenarioEntry {
+    ScenarioEntry::Metrics(ScenarioConfig {
+        base: BaseScheduleConfig {
+            name,
+            rate,
+            duration: None,
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            dynamic_labels: None,
+            labels: None,
+            sink: SinkConfig::File {
+                path: NULL_SINK_PATH.to_string(),
+            },
+            phase_offset: None,
+            clock_group: None,
+            clock_group_is_auto: None,
+            start_time: None,
+            jitter: None,
+            jitter_seed: None,
+            on_sink_error: OnSinkError::Warn,
+        },
+        generator: GeneratorConfig::Constant { value: 1.0 },
+        encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
+    })
+}
+
+fn launch_n(n: usize) -> Vec<ScenarioHandle> {
+    let entries: Vec<ScenarioEntry> = (0..n)
+        .map(|i| metrics_entry(format!("bench_{i}"), RATE_HZ))
+        .collect();
+    let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
+    let mut handles = Vec::with_capacity(prepared.len());
+    for (i, p) in prepared.into_iter().enumerate() {
+        let shutdown = Arc::new(AtomicBool::new(true));
+        let handle = launch_scenario(format!("bench_{i}"), p.entry, shutdown, p.start_delay)
+            .expect("launch_scenario must succeed");
+        handles.push(handle);
+    }
+    handles
+}
+
+fn stop_all(handles: &mut [ScenarioHandle]) {
+    for h in handles.iter() {
+        h.stop();
+    }
+    for h in handles.iter_mut() {
+        let _ = h.join(Some(Duration::from_secs(5)));
+    }
+}
+
+fn sample_process(system: &mut System, pid: Pid, handles: &[ScenarioHandle]) -> Option<Sample> {
+    system.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::Some(&[pid]),
+        true,
+        ProcessRefreshKind::nothing().with_cpu().with_memory(),
+    );
+    let proc = system.process(pid)?;
+    let rss_bytes = proc.memory();
+    let vsize_bytes = proc.virtual_memory();
+    let cpu_pct = proc.cpu_usage() as f64;
+    let threads = current_thread_count().unwrap_or(0);
+    let per_scenario_events: Vec<u64> = handles
+        .iter()
+        .map(|h| h.stats_snapshot().total_events)
+        .collect();
+    Some(Sample {
+        rss_bytes,
+        vsize_bytes,
+        threads,
+        cpu_pct,
+        per_scenario_events,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn current_thread_count() -> Option<usize> {
+    let s = fs::read_to_string("/proc/self/status").ok()?;
+    for line in s.lines() {
+        if let Some(rest) = line.strip_prefix("Threads:") {
+            return rest.trim().parse::<usize>().ok();
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn current_thread_count() -> Option<usize> {
+    let pid = std::process::id();
+    let out = Command::new("ps")
+        .args(["-M", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let lines = String::from_utf8_lossy(&out.stdout).lines().count();
+    if lines > 1 {
+        Some(lines - 1)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn current_thread_count() -> Option<usize> {
+    None
+}
+
+fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
+    eprintln!(
+        "[bench] N={n}: launching scenarios at {RATE_HZ:.0} Hz \
+         (warmup {warmup}s, measure {measure}s)"
+    );
+    let mut handles = launch_n(n);
+
+    thread::sleep(Duration::from_secs(warmup));
+
+    let pid = Pid::from_u32(std::process::id());
+    let mut system = System::new_with_specifics(
+        RefreshKind::nothing()
+            .with_processes(ProcessRefreshKind::nothing().with_cpu().with_memory()),
+    );
+    let _ = sample_process(&mut system, pid, &handles);
+
+    let initial_events: Vec<u64> = handles
+        .iter()
+        .map(|h| h.stats_snapshot().total_events)
+        .collect();
+
+    let mut samples: Vec<Sample> = Vec::with_capacity(measure as usize);
+    let measure_end = Instant::now() + Duration::from_secs(measure);
+
+    while Instant::now() < measure_end {
+        thread::sleep(SAMPLE_INTERVAL);
+        if let Some(s) = sample_process(&mut system, pid, &handles) {
+            samples.push(s);
+        }
+    }
+
+    let rss_mb = mean(samples.iter().map(|s| s.rss_bytes as f64)) / (1024.0 * 1024.0);
+    let vsize_mb = mean(samples.iter().map(|s| s.vsize_bytes as f64)) / (1024.0 * 1024.0);
+    let threads = samples.iter().map(|s| s.threads).max().unwrap_or(0);
+    let cpu_pct = mean(samples.iter().map(|s| s.cpu_pct));
+
+    let drift_samples_ms = compute_drift_ms(&samples, &initial_events);
+    let drift_mean_ms = mean(drift_samples_ms.iter().copied());
+    let drift_p99_ms = percentile(&drift_samples_ms, 99.0);
+    let dropped_pct = compute_dropped_pct(&samples, &initial_events);
+
+    eprintln!(
+        "[bench] N={n}: rss={rss_mb:.1}MB vsize={vsize_mb:.0}MB threads={threads} \
+         cpu={cpu_pct:.1}% drift_mean={drift_mean_ms:.2}ms drift_p99={drift_p99_ms:.2}ms \
+         dropped={dropped_pct:.2}%"
+    );
+
+    stop_all(&mut handles);
+
+    RowResult {
+        n,
+        rss_mb,
+        vsize_mb,
+        threads,
+        cpu_pct,
+        drift_mean_ms,
+        drift_p99_ms,
+        dropped_pct,
+    }
+}
+
+fn compute_drift_ms(samples: &[Sample], initial_events: &[u64]) -> Vec<f64> {
+    let mut out = Vec::new();
+    let mut prev = initial_events.to_vec();
+    let expected_per_sample = RATE_HZ * SAMPLE_INTERVAL.as_secs_f64();
+    let ms_per_tick = 1000.0 / RATE_HZ;
+    for s in samples {
+        for (i, &observed) in s.per_scenario_events.iter().enumerate() {
+            let prev_v = *prev.get(i).unwrap_or(&0);
+            let delta = observed.saturating_sub(prev_v) as f64;
+            let drift_ticks = (expected_per_sample - delta).abs();
+            out.push(drift_ticks * ms_per_tick);
+        }
+        prev = s.per_scenario_events.clone();
+    }
+    out
+}
+
+fn compute_dropped_pct(samples: &[Sample], initial_events: &[u64]) -> f64 {
+    let expected_per_sample = RATE_HZ * SAMPLE_INTERVAL.as_secs_f64();
+    let mut prev = initial_events.to_vec();
+    let mut dropped_buckets = 0u64;
+    let mut total_buckets = 0u64;
+    for s in samples {
+        for (i, &observed) in s.per_scenario_events.iter().enumerate() {
+            let prev_v = *prev.get(i).unwrap_or(&0);
+            let delta = observed.saturating_sub(prev_v) as f64;
+            let lo = expected_per_sample * (1.0 - DROPPED_TICK_TOLERANCE);
+            let hi = expected_per_sample * (1.0 + DROPPED_TICK_TOLERANCE);
+            if delta < lo || delta > hi {
+                dropped_buckets += 1;
+            }
+            total_buckets += 1;
+        }
+        prev = s.per_scenario_events.clone();
+    }
+    if total_buckets == 0 {
+        0.0
+    } else {
+        100.0 * (dropped_buckets as f64) / (total_buckets as f64)
+    }
+}
+
+fn mean<I: Iterator<Item = f64>>(iter: I) -> f64 {
+    let mut sum = 0.0;
+    let mut n = 0usize;
+    for v in iter {
+        sum += v;
+        n += 1;
+    }
+    if n == 0 {
+        0.0
+    } else {
+        sum / (n as f64)
+    }
+}
+
+fn percentile(values: &[f64], p: f64) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted: Vec<f64> = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let rank = (p / 100.0) * ((sorted.len() - 1) as f64);
+    let lo = rank.floor() as usize;
+    let hi = rank.ceil() as usize;
+    if lo == hi {
+        sorted[lo]
+    } else {
+        let frac = rank - (lo as f64);
+        sorted[lo] * (1.0 - frac) + sorted[hi] * frac
+    }
+}
+
+fn print_table(rows: &[RowResult]) {
+    println!();
+    println!(
+        "| {:>5} | {:>9} | {:>11} | {:>7} | {:>5} | {:>20} | {:>19} | {:>14} |",
+        "N",
+        "RSS (MB)",
+        "VSize (MB)",
+        "Threads",
+        "CPU %",
+        "Tick drift mean (ms)",
+        "Tick drift p99 (ms)",
+        "Dropped-tick %"
+    );
+    println!(
+        "|{:-<7}|{:-<11}|{:-<13}|{:-<9}|{:-<7}|{:-<22}|{:-<21}|{:-<16}|",
+        "", "", "", "", "", "", "", ""
+    );
+    for r in rows {
+        println!(
+            "| {:>5} | {:>9.1} | {:>11.1} | {:>7} | {:>5.1} | {:>20.2} | {:>19.2} | {:>14.2} |",
+            r.n,
+            r.rss_mb,
+            r.vsize_mb,
+            r.threads,
+            r.cpu_pct,
+            r.drift_mean_ms,
+            r.drift_p99_ms,
+            r.dropped_pct
+        );
+    }
+    println!();
+}
+
+fn render_markdown(rows: &[RowResult], warmup: u64, measure: u64) -> String {
+    let ts = chrono_ish_utc_now();
+    let host = host_descriptor();
+    let commit = git_head_sha().unwrap_or_else(|| "unknown".to_string());
+
+    let mut out = String::new();
+    out.push_str("# Async-Scheduler Baseline Numbers (BEFORE — thread-per-scenario)\n\n");
+    out.push_str(&format!("**Captured**: {ts}\n"));
+    out.push_str(&format!("**Host**: {host}\n"));
+    out.push_str(&format!("**Sonda commit**: {commit}\n"));
+    out.push_str("**Harness**: sonda-core/benches/scheduler_baseline.rs\n\n");
+    out.push_str("## Methodology\n\n");
+    out.push_str(&format!(
+        "Each row is N concurrent scenarios, each emitting at 100 events/sec via the \
+         Prometheus text encoder to a `file:/dev/null` sink (no real I/O — measures the \
+         scheduler, not the sink). {warmup}s warm-up + {measure}s measurement window. \
+         RSS / VSize / thread count / CPU% sampled every ~1s via the `sysinfo` crate; \
+         tick drift and dropped-tick rate computed from per-scenario \
+         `ScenarioStats::total_events` deltas between consecutive 1s samples (the \
+         production sinks do not expose per-event timestamps to the harness without a \
+         production-code change, so per-sample event-rate deviation is used as the \
+         scheduler-fidelity proxy). A bucket is counted as `dropped` when the observed \
+         events in the 1s window deviate from the expected count (`rate * dt`) by more \
+         than ±10%.\n\n"
+    ));
+    out.push_str("## Results\n\n");
+    out.push_str(
+        "| N scenarios | RSS (MB) | VSize (MB) | Threads | CPU % | Tick drift mean (ms) | Tick drift p99 (ms) | Dropped-tick % |\n",
+    );
+    out.push_str("|---|---|---|---|---|---|---|---|\n");
+    for r in rows {
+        out.push_str(&format!(
+            "| {} | {:.1} | {:.1} | {} | {:.1} | {:.2} | {:.2} | {:.2} |\n",
+            r.n,
+            r.rss_mb,
+            r.vsize_mb,
+            r.threads,
+            r.cpu_pct,
+            r.drift_mean_ms,
+            r.drift_p99_ms,
+            r.dropped_pct
+        ));
+    }
+    out.push_str("\n## Inflection point analysis\n\n");
+    out.push_str(&inflection_paragraph(rows));
+    out.push_str("\n\n## Notes\n\n");
+    out.push_str(&notes_paragraph(rows));
+    out.push('\n');
+    out
+}
+
+fn inflection_paragraph(rows: &[RowResult]) -> String {
+    let max_threads = rows.iter().map(|r| r.threads).max().unwrap_or(0);
+    let max_rss = rows.iter().map(|r| r.rss_mb).fold(0.0f64, f64::max);
+    let max_drift_p99 = rows.iter().map(|r| r.drift_p99_ms).fold(0.0f64, f64::max);
+    let max_dropped = rows.iter().map(|r| r.dropped_pct).fold(0.0f64, f64::max);
+    format!(
+        "Thread count grows linearly with N (peak observed: {max_threads}); RSS scales with \
+         the per-thread stack reservation (peak observed: {max_rss:.1} MB). The earliest \
+         metric to break under this scheduler is whichever among tick-drift p99 (peak \
+         observed: {max_drift_p99:.2} ms), dropped-tick percentage (peak observed: \
+         {max_dropped:.2}%), and CPU% saturates first as N climbs. Read the row-to-row \
+         deltas above to identify where the curve bends — the linear-thread, linear-stack \
+         growth itself is the canary for this baseline."
+    )
+}
+
+fn notes_paragraph(rows: &[RowResult]) -> String {
+    let mut notes = String::new();
+    let failed_rows: Vec<usize> = rows
+        .iter()
+        .filter(|r| r.dropped_pct > 50.0)
+        .map(|r| r.n)
+        .collect();
+    if !failed_rows.is_empty() {
+        notes.push_str(&format!(
+            "- High dropped-tick percentage (> 50%) observed at N = {failed_rows:?}; the \
+             scheduler could not sustain the 100 Hz target for these scenarios.\n"
+        ));
+    }
+    #[cfg(target_os = "macos")]
+    notes.push_str(
+        "- Context-switches/sec is Linux-only via `/proc/<pid>/status`; not collected on macOS.\n",
+    );
+    if notes.is_empty() {
+        notes.push_str("None.");
+    }
+    notes
+}
+
+fn host_descriptor() -> String {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+    let mut sys = System::new_all();
+    sys.refresh_all();
+    let cpu_brand = sys
+        .cpus()
+        .first()
+        .map(|c| c.brand().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let cores = sys.cpus().len();
+    let total_ram_gb = (sys.total_memory() as f64) / (1024.0 * 1024.0 * 1024.0);
+    format!("{os}/{arch}, {cpu_brand}, {cores} cores, {total_ram_gb:.1} GB RAM")
+}
+
+fn git_head_sha() -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?;
+    Some(s.trim().to_string())
+}
+
+fn chrono_ish_utc_now() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = now.as_secs();
+    let (year, month, day, hh, mm, ss) = epoch_to_ymdhms(secs);
+    format!("{year:04}-{month:02}-{day:02}T{hh:02}:{mm:02}:{ss:02}Z")
+}
+
+fn epoch_to_ymdhms(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
+    let days = (secs / 86400) as i64;
+    let rem = (secs % 86400) as u32;
+    let hh = rem / 3600;
+    let mm = (rem % 3600) / 60;
+    let ss = rem % 60;
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    let year = if m <= 2 { y + 1 } else { y };
+    (year as i32, m, d, hh, mm, ss)
+}
+
+fn main() {
+    let counts = scenario_counts();
+    let warmup = warmup_secs();
+    let measure = measure_secs();
+    eprintln!("[bench] sonda scheduler baseline harness");
+    eprintln!(
+        "[bench] N values: {counts:?}; rate {RATE_HZ:.0} Hz; \
+         warmup {warmup}s; measure {measure}s"
+    );
+    let mut rows = Vec::with_capacity(counts.len());
+    for &n in &counts {
+        rows.push(run_row(n, warmup, measure));
+    }
+    print_table(&rows);
+    let md = render_markdown(&rows, warmup, measure);
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate dir must have a parent (workspace root)");
+    let out_path = workspace_root.join("target/bench-output/scheduler-baseline.md");
+    if let Some(parent) = out_path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    fs::write(&out_path, md).expect("must write markdown report");
+    eprintln!("[bench] wrote {}", out_path.display());
+}

--- a/sonda-core/benches/scheduler_baseline.rs
+++ b/sonda-core/benches/scheduler_baseline.rs
@@ -3,11 +3,12 @@
 //! CPU%, tick-drift and dropped-tick percentage per N, and writes a markdown
 //! report alongside a stdout table.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -15,8 +16,11 @@ use sonda_core::config::{BaseScheduleConfig, ScenarioConfig, ScenarioEntry};
 use sonda_core::encoder::EncoderConfig;
 use sonda_core::generator::GeneratorConfig;
 use sonda_core::schedule::handle::ScenarioHandle;
-use sonda_core::sink::SinkConfig;
-use sonda_core::{launch_scenario, prepare_entries, OnSinkError};
+use sonda_core::schedule::runner::run_with_sink;
+use sonda_core::schedule::stats::ScenarioStats;
+use sonda_core::sink::memory::{CapturedRing, MemorySink};
+use sonda_core::sink::{Sink, SinkConfig};
+use sonda_core::{launch_scenario, prepare_entries, OnSinkError, RuntimeError, SondaError};
 use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System};
 
 const DEFAULT_SCENARIO_COUNTS: &[usize] = &[1, 10, 50, 100, 250, 500];
@@ -25,7 +29,8 @@ const DEFAULT_WARMUP_SECS: u64 = 30;
 const DEFAULT_MEASURE_SECS: u64 = 60;
 const SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
 const DROPPED_TICK_TOLERANCE: f64 = 0.10;
-const NULL_SINK_PATH: &str = "/dev/null";
+const CAPTURE_RING_SIZE: usize = 1_000_000;
+const DRIFT_WARMUP_FRACTION: f64 = 0.10;
 
 fn warmup_secs() -> u64 {
     std::env::var("SONDA_BENCH_WARMUP_SECS")
@@ -59,6 +64,10 @@ struct RowResult {
     cpu_pct: f64,
     drift_mean_ms: f64,
     drift_p99_ms: f64,
+    drift_p50_us: f64,
+    drift_p90_us: f64,
+    drift_p99_us: f64,
+    drift_max_us: f64,
     dropped_pct: f64,
 }
 
@@ -70,7 +79,7 @@ struct Sample {
     per_scenario_events: Vec<u64>,
 }
 
-fn metrics_entry(name: String, rate: f64) -> ScenarioEntry {
+fn metrics_entry(name: String, rate: f64, sink: SinkConfig) -> ScenarioEntry {
     ScenarioEntry::Metrics(ScenarioConfig {
         base: BaseScheduleConfig {
             name,
@@ -81,9 +90,7 @@ fn metrics_entry(name: String, rate: f64) -> ScenarioEntry {
             cardinality_spikes: None,
             dynamic_labels: None,
             labels: None,
-            sink: SinkConfig::File {
-                path: NULL_SINK_PATH.to_string(),
-            },
+            sink,
             phase_offset: None,
             clock_group: None,
             clock_group_is_auto: None,
@@ -99,19 +106,168 @@ fn metrics_entry(name: String, rate: f64) -> ScenarioEntry {
     })
 }
 
-fn launch_n(n: usize) -> Vec<ScenarioHandle> {
-    let entries: Vec<ScenarioEntry> = (0..n)
-        .map(|i| metrics_entry(format!("bench_{i}"), RATE_HZ))
-        .collect();
-    let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
-    let mut handles = Vec::with_capacity(prepared.len());
-    for (i, p) in prepared.into_iter().enumerate() {
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let handle = launch_scenario(format!("bench_{i}"), p.entry, shutdown, p.start_delay)
-            .expect("launch_scenario must succeed");
-        handles.push(handle);
+fn metrics_config_for_capture(name: String, rate: f64) -> ScenarioConfig {
+    ScenarioConfig {
+        base: BaseScheduleConfig {
+            name,
+            rate,
+            duration: None,
+            gaps: None,
+            bursts: None,
+            cardinality_spikes: None,
+            dynamic_labels: None,
+            labels: None,
+            sink: SinkConfig::Memory {
+                capture: true,
+                max_events: Some(CAPTURE_RING_SIZE),
+            },
+            phase_offset: None,
+            clock_group: None,
+            clock_group_is_auto: None,
+            start_time: None,
+            jitter: None,
+            jitter_seed: None,
+            on_sink_error: OnSinkError::Warn,
+        },
+        generator: GeneratorConfig::Constant { value: 1.0 },
+        encoder: EncoderConfig::PrometheusText { precision: None },
+        metric_type: None,
+        help: None,
     }
-    handles
+}
+
+struct DriftStats {
+    p50_us: f64,
+    p90_us: f64,
+    p99_us: f64,
+    max_us: f64,
+}
+
+fn compute_drift_stats(timestamps: &[Instant], rate_hz: f64) -> DriftStats {
+    if timestamps.len() < 2 {
+        return DriftStats {
+            p50_us: 0.0,
+            p90_us: 0.0,
+            p99_us: 0.0,
+            max_us: 0.0,
+        };
+    }
+    let expected_interval_us = 1_000_000.0 / rate_hz;
+    let skip = ((timestamps.len() as f64) * DRIFT_WARMUP_FRACTION).floor() as usize;
+    let trimmed = &timestamps[skip..];
+    if trimmed.len() < 2 {
+        return DriftStats {
+            p50_us: 0.0,
+            p90_us: 0.0,
+            p99_us: 0.0,
+            max_us: 0.0,
+        };
+    }
+    let mut deltas_us: Vec<f64> = Vec::with_capacity(trimmed.len() - 1);
+    for pair in trimmed.windows(2) {
+        let dt_us = pair[1].duration_since(pair[0]).as_micros() as f64;
+        deltas_us.push((dt_us - expected_interval_us).abs());
+    }
+    DriftStats {
+        p50_us: percentile(&deltas_us, 50.0),
+        p90_us: percentile(&deltas_us, 90.0),
+        p99_us: percentile(&deltas_us, 99.0),
+        max_us: deltas_us.iter().copied().fold(0.0f64, f64::max),
+    }
+}
+
+fn launch_n(n: usize) -> (Vec<ScenarioHandle>, Arc<Mutex<CapturedRing>>) {
+    assert!(n >= 1, "launch_n requires at least one scenario");
+    let capture_handle = Arc::new(Mutex::new(CapturedRing::new(CAPTURE_RING_SIZE)));
+
+    let mut handles = Vec::with_capacity(n);
+    handles.push(launch_capturing_scenario(
+        "bench_0".to_string(),
+        Arc::clone(&capture_handle),
+    ));
+
+    if n > 1 {
+        let entries: Vec<ScenarioEntry> = (1..n)
+            .map(|i| {
+                metrics_entry(
+                    format!("bench_{i}"),
+                    RATE_HZ,
+                    SinkConfig::Memory {
+                        capture: false,
+                        max_events: None,
+                    },
+                )
+            })
+            .collect();
+        let prepared = prepare_entries(entries).expect("prepare_entries must succeed");
+        for (offset, p) in prepared.into_iter().enumerate() {
+            let i = offset + 1;
+            let shutdown = Arc::new(AtomicBool::new(true));
+            let handle = launch_scenario(format!("bench_{i}"), p.entry, shutdown, p.start_delay)
+                .expect("launch_scenario must succeed");
+            handles.push(handle);
+        }
+    }
+    (handles, capture_handle)
+}
+
+// Mirrors launch_scenario for the shared-capture path; bench-local replica.
+fn launch_capturing_scenario(
+    id: String,
+    capture_handle: Arc<Mutex<CapturedRing>>,
+) -> ScenarioHandle {
+    let config = metrics_config_for_capture(id.clone(), RATE_HZ);
+    let name = config.base.name.clone();
+    let shutdown = Arc::new(AtomicBool::new(true));
+    let stats = Arc::new(RwLock::new(ScenarioStats::default()));
+    let alive = Arc::new(AtomicBool::new(true));
+    let cleaned_up = Arc::new(AtomicBool::new(true));
+    let labels: Arc<HashMap<String, String>> = Arc::new(HashMap::new());
+
+    let shutdown_for_thread = Arc::clone(&shutdown);
+    let stats_for_thread = Arc::clone(&stats);
+    let alive_for_thread = Arc::clone(&alive);
+
+    let thread = std::thread::Builder::new()
+        .name(format!("sonda-{name}"))
+        .spawn(move || -> Result<(), SondaError> {
+            struct AliveGuard(Arc<AtomicBool>);
+            impl Drop for AliveGuard {
+                fn drop(&mut self) {
+                    self.0.store(false, std::sync::atomic::Ordering::SeqCst);
+                }
+            }
+            let _guard = AliveGuard(alive_for_thread);
+
+            let sink_inner = MemorySink::with_shared_capture(capture_handle);
+            let mut sink: Box<dyn Sink> = Box::new(sink_inner);
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
+            rt.block_on(run_with_sink(
+                &config,
+                &mut sink,
+                Some(shutdown_for_thread.as_ref()),
+                Some(stats_for_thread),
+            ))
+        })
+        .expect("scenario thread must spawn");
+
+    ScenarioHandle::new(
+        id,
+        name,
+        None,
+        shutdown,
+        Some(thread),
+        Instant::now(),
+        stats,
+        RATE_HZ,
+        alive,
+        labels,
+        None,
+        cleaned_up,
+    )
 }
 
 fn stop_all(handles: &mut [ScenarioHandle]) {
@@ -186,7 +342,8 @@ fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
         "[bench] N={n}: launching scenarios at {RATE_HZ:.0} Hz \
          (warmup {warmup}s, measure {measure}s)"
     );
-    let mut handles = launch_n(n);
+
+    let (mut handles, capture_handle) = launch_n(n);
 
     thread::sleep(Duration::from_secs(warmup));
 
@@ -222,10 +379,18 @@ fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
     let drift_p99_ms = percentile(&drift_samples_ms, 99.0);
     let dropped_pct = compute_dropped_pct(&samples, &initial_events);
 
+    let captured_timestamps: Vec<Instant> = {
+        let guard = capture_handle.lock().expect("capture handle poisoned");
+        guard.events().iter().map(|(ts, _)| *ts).collect()
+    };
+    let drift = compute_drift_stats(&captured_timestamps, RATE_HZ);
+
     eprintln!(
         "[bench] N={n}: rss={rss_mb:.1}MB vsize={vsize_mb:.0}MB threads={threads} \
          cpu={cpu_pct:.1}% drift_mean={drift_mean_ms:.2}ms drift_p99={drift_p99_ms:.2}ms \
-         dropped={dropped_pct:.2}%"
+         drift_us p50={:.1} p90={:.1} p99={:.1} max={:.1} \
+         dropped={dropped_pct:.2}%",
+        drift.p50_us, drift.p90_us, drift.p99_us, drift.max_us
     );
 
     stop_all(&mut handles);
@@ -238,6 +403,10 @@ fn run_row(n: usize, warmup: u64, measure: u64) -> RowResult {
         cpu_pct,
         drift_mean_ms,
         drift_p99_ms,
+        drift_p50_us: drift.p50_us,
+        drift_p90_us: drift.p90_us,
+        drift_p99_us: drift.p99_us,
+        drift_max_us: drift.max_us,
         dropped_pct,
     }
 }
@@ -318,7 +487,7 @@ fn percentile(values: &[f64], p: f64) -> f64 {
 fn print_table(rows: &[RowResult]) {
     println!();
     println!(
-        "| {:>5} | {:>9} | {:>11} | {:>7} | {:>5} | {:>20} | {:>19} | {:>14} |",
+        "| {:>5} | {:>9} | {:>11} | {:>7} | {:>5} | {:>20} | {:>19} | {:>12} | {:>12} | {:>12} | {:>11} | {:>14} |",
         "N",
         "RSS (MB)",
         "VSize (MB)",
@@ -326,15 +495,19 @@ fn print_table(rows: &[RowResult]) {
         "CPU %",
         "Tick drift mean (ms)",
         "Tick drift p99 (ms)",
+        "Drift p50 us",
+        "Drift p90 us",
+        "Drift p99 us",
+        "Drift max us",
         "Dropped-tick %"
     );
     println!(
-        "|{:-<7}|{:-<11}|{:-<13}|{:-<9}|{:-<7}|{:-<22}|{:-<21}|{:-<16}|",
-        "", "", "", "", "", "", "", ""
+        "|{:-<7}|{:-<11}|{:-<13}|{:-<9}|{:-<7}|{:-<22}|{:-<21}|{:-<14}|{:-<14}|{:-<14}|{:-<13}|{:-<16}|",
+        "", "", "", "", "", "", "", "", "", "", "", ""
     );
     for r in rows {
         println!(
-            "| {:>5} | {:>9.1} | {:>11.1} | {:>7} | {:>5.1} | {:>20.2} | {:>19.2} | {:>14.2} |",
+            "| {:>5} | {:>9.1} | {:>11.1} | {:>7} | {:>5.1} | {:>20.2} | {:>19.2} | {:>12.1} | {:>12.1} | {:>12.1} | {:>11.1} | {:>14.2} |",
             r.n,
             r.rss_mb,
             r.vsize_mb,
@@ -342,6 +515,10 @@ fn print_table(rows: &[RowResult]) {
             r.cpu_pct,
             r.drift_mean_ms,
             r.drift_p99_ms,
+            r.drift_p50_us,
+            r.drift_p90_us,
+            r.drift_p99_us,
+            r.drift_max_us,
             r.dropped_pct
         );
     }
@@ -362,25 +539,29 @@ fn render_markdown(rows: &[RowResult], warmup: u64, measure: u64) -> String {
     out.push_str("## Methodology\n\n");
     out.push_str(&format!(
         "Each row is N concurrent scenarios, each emitting at 100 events/sec via the \
-         Prometheus text encoder to a `file:/dev/null` sink (no real I/O — measures the \
-         scheduler, not the sink). {warmup}s warm-up + {measure}s measurement window. \
-         RSS / VSize / thread count / CPU% sampled every ~1s via the `sysinfo` crate; \
-         tick drift and dropped-tick rate computed from per-scenario \
-         `ScenarioStats::total_events` deltas between consecutive 1s samples (the \
-         production sinks do not expose per-event timestamps to the harness without a \
-         production-code change, so per-sample event-rate deviation is used as the \
-         scheduler-fidelity proxy). A bucket is counted as `dropped` when the observed \
-         events in the 1s window deviate from the expected count (`rate * dt`) by more \
-         than ±10%.\n\n"
+         Prometheus text encoder into a `memory` sink (no I/O — measures the scheduler, \
+         not the sink). {warmup}s warm-up + {measure}s measurement window. RSS / VSize / \
+         thread count / CPU% sampled every ~1s via the `sysinfo` crate. \
+         Tick drift is reported two ways: \n\
+         \n\
+         - **ms-level proxy** — `total_events` deltas between consecutive 1s samples. A bucket \
+         is counted as `dropped` when the observed events in the 1s window deviate from the \
+         expected count (`rate * dt`) by more than ±10%. \n\
+         - **microsecond-level direct** — the first of the N main scenarios writes through a \
+         `memory` sink with `capture: true`, retaining `(Instant, bytes)` per event across the \
+         full warm-up and measurement window. All N scenarios share the same scheduler, so the \
+         captured cadence reflects the load every scenario experiences at this N. Per-event \
+         drift is computed as `(t[i+1] - t[i]) - (1_000_000us / rate_hz)`; the first 10% of \
+         samples are dropped as warm-up jitter; p50/p90/p99/max are reported in microseconds. \n\n"
     ));
     out.push_str("## Results\n\n");
     out.push_str(
-        "| N scenarios | RSS (MB) | VSize (MB) | Threads | CPU % | Tick drift mean (ms) | Tick drift p99 (ms) | Dropped-tick % |\n",
+        "| N scenarios | RSS (MB) | VSize (MB) | Threads | CPU % | Tick drift mean (ms) | Tick drift p99 (ms) | Drift p50 (us) | Drift p90 (us) | Drift p99 (us) | Drift max (us) | Dropped-tick % |\n",
     );
-    out.push_str("|---|---|---|---|---|---|---|---|\n");
+    out.push_str("|---|---|---|---|---|---|---|---|---|---|---|---|\n");
     for r in rows {
         out.push_str(&format!(
-            "| {} | {:.1} | {:.1} | {} | {:.1} | {:.2} | {:.2} | {:.2} |\n",
+            "| {} | {:.1} | {:.1} | {} | {:.1} | {:.2} | {:.2} | {:.1} | {:.1} | {:.1} | {:.1} | {:.2} |\n",
             r.n,
             r.rss_mb,
             r.vsize_mb,
@@ -388,6 +569,10 @@ fn render_markdown(rows: &[RowResult], warmup: u64, measure: u64) -> String {
             r.cpu_pct,
             r.drift_mean_ms,
             r.drift_p99_ms,
+            r.drift_p50_us,
+            r.drift_p90_us,
+            r.drift_p99_us,
+            r.drift_max_us,
             r.dropped_pct
         ));
     }
@@ -403,15 +588,17 @@ fn inflection_paragraph(rows: &[RowResult]) -> String {
     let max_threads = rows.iter().map(|r| r.threads).max().unwrap_or(0);
     let max_rss = rows.iter().map(|r| r.rss_mb).fold(0.0f64, f64::max);
     let max_drift_p99 = rows.iter().map(|r| r.drift_p99_ms).fold(0.0f64, f64::max);
+    let max_drift_p99_us = rows.iter().map(|r| r.drift_p99_us).fold(0.0f64, f64::max);
     let max_dropped = rows.iter().map(|r| r.dropped_pct).fold(0.0f64, f64::max);
     format!(
         "Thread count grows linearly with N (peak observed: {max_threads}); RSS scales with \
          the per-thread stack reservation (peak observed: {max_rss:.1} MB). The earliest \
          metric to break under this scheduler is whichever among tick-drift p99 (peak \
-         observed: {max_drift_p99:.2} ms), dropped-tick percentage (peak observed: \
-         {max_dropped:.2}%), and CPU% saturates first as N climbs. Read the row-to-row \
-         deltas above to identify where the curve bends — the linear-thread, linear-stack \
-         growth itself is the canary for this baseline."
+         observed: {max_drift_p99:.2} ms proxy / {max_drift_p99_us:.1} us direct), \
+         dropped-tick percentage (peak observed: {max_dropped:.2}%), and CPU% saturates \
+         first as N climbs. Read the row-to-row deltas above to identify where the curve \
+         bends — the linear-thread, linear-stack growth itself is the canary for this \
+         baseline."
     )
 }
 

--- a/sonda-core/benches/while_steady_state.rs
+++ b/sonda-core/benches/while_steady_state.rs
@@ -47,27 +47,36 @@ fn metrics_entry(name: &str, rate: f64, duration_ms: u64) -> ScenarioEntry {
 }
 
 fn bench_baseline_ungated(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime must build");
     c.bench_function("baseline_ungated_300ms_at_1khz", |b| {
         b.iter(|| {
             let entry = metrics_entry("bench", 1000.0, 300);
             let shutdown = Arc::new(AtomicBool::new(true));
-            let mut handle = launch_scenario_with_gates(
-                "bench".to_string(),
-                None,
-                entry,
-                shutdown,
-                None,
-                None,
-                None,
-                None,
-            )
-            .unwrap();
+            let mut handle = rt
+                .block_on(launch_scenario_with_gates(
+                    "bench".to_string(),
+                    None,
+                    entry,
+                    shutdown,
+                    None,
+                    None,
+                    None,
+                    None,
+                ))
+                .unwrap();
             handle.join(Some(Duration::from_secs(2))).unwrap();
         });
     });
 }
 
 fn bench_gated_open(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime must build");
     c.bench_function("gated_open_300ms_at_1khz", |b| {
         b.iter(|| {
             let bus = Arc::new(GateBus::new());
@@ -81,17 +90,18 @@ fn bench_gated_open(c: &mut Criterion) {
             });
             let entry = metrics_entry("gated", 1000.0, 300);
             let shutdown = Arc::new(AtomicBool::new(true));
-            let mut handle = launch_scenario_with_gates(
-                "gated".to_string(),
-                None,
-                entry,
-                shutdown,
-                None,
-                Some(Arc::clone(&bus)),
-                Some(GateContext::new(rx, init).with_has_while(true)),
-                None,
-            )
-            .unwrap();
+            let mut handle = rt
+                .block_on(launch_scenario_with_gates(
+                    "gated".to_string(),
+                    None,
+                    entry,
+                    shutdown,
+                    None,
+                    Some(Arc::clone(&bus)),
+                    Some(GateContext::new(rx, init).with_has_while(true)),
+                    None,
+                ))
+                .unwrap();
             handle.join(Some(Duration::from_secs(2))).unwrap();
         });
     });

--- a/sonda-core/benches/while_steady_state.rs
+++ b/sonda-core/benches/while_steady_state.rs
@@ -5,7 +5,6 @@
 //! lives separately as a `#[test] fn` in `tests/while_runtime.rs`; this
 //! bench is the developer-facing profiler.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -54,13 +53,13 @@ fn bench_baseline_ungated(c: &mut Criterion) {
     c.bench_function("baseline_ungated_300ms_at_1khz", |b| {
         b.iter(|| {
             let entry = metrics_entry("bench", 1000.0, 300);
-            let shutdown = Arc::new(AtomicBool::new(true));
+            let cancel = sonda_core::CancellationToken::new();
             let mut handle = rt
                 .block_on(launch_scenario_with_gates(
                     "bench".to_string(),
                     None,
                     entry,
-                    shutdown,
+                    cancel,
                     None,
                     None,
                     None,
@@ -89,13 +88,13 @@ fn bench_gated_open(c: &mut Criterion) {
                 }),
             });
             let entry = metrics_entry("gated", 1000.0, 300);
-            let shutdown = Arc::new(AtomicBool::new(true));
+            let cancel = sonda_core::CancellationToken::new();
             let mut handle = rt
                 .block_on(launch_scenario_with_gates(
                     "gated".to_string(),
                     None,
                     entry,
-                    shutdown,
+                    cancel,
                     None,
                     Some(Arc::clone(&bus)),
                     Some(GateContext::new(rx, init).with_has_while(true)),

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -584,6 +584,7 @@ fn sink_kind_str(sink: &SinkConfig) -> &'static str {
         SinkConfig::File { .. } => "file",
         SinkConfig::Tcp { .. } => "tcp",
         SinkConfig::Udp { .. } => "udp",
+        SinkConfig::Memory { .. } => "memory",
         #[cfg(feature = "http")]
         SinkConfig::HttpPush { .. } => "http_push",
         #[cfg(not(feature = "http"))]

--- a/sonda-core/src/config/validate.rs
+++ b/sonda-core/src/config/validate.rs
@@ -1551,8 +1551,8 @@ sink:
     // ---- Round-trip: deserialize -> validate -> create factories -------------
 
     #[cfg(feature = "config")]
-    #[test]
-    fn round_trip_creates_generator_encoder_sink_successfully() {
+    #[tokio::test]
+    async fn round_trip_creates_generator_encoder_sink_successfully() {
         use crate::encoder::create_encoder;
         use crate::generator::create_generator;
         use crate::sink::create_sink;
@@ -1587,7 +1587,7 @@ sink:
         // Encoder must exist (just check it does not panic on creation)
         drop(encoder);
 
-        let sink = create_sink(&config.sink, None);
+        let sink = create_sink(&config.sink, None).await;
         assert!(sink.is_ok(), "sink must be created without error");
     }
 

--- a/sonda-core/src/config/validate.rs
+++ b/sonda-core/src/config/validate.rs
@@ -761,7 +761,10 @@ pub fn validate_summary_config(config: &SummaryScenarioConfig) -> Result<(), Son
 /// validation time, not at factory time.
 pub fn validate_sink_config(sink: &SinkConfig) -> Result<(), SondaError> {
     match sink {
-        SinkConfig::Stdout | SinkConfig::File { .. } | SinkConfig::Udp { .. } => Ok(()),
+        SinkConfig::Stdout
+        | SinkConfig::File { .. }
+        | SinkConfig::Udp { .. }
+        | SinkConfig::Memory { .. } => Ok(()),
         SinkConfig::Tcp { retry, .. } => validate_retry_config_opt(retry.as_ref()),
         #[cfg(feature = "http")]
         SinkConfig::HttpPush {

--- a/sonda-core/src/emit.rs
+++ b/sonda-core/src/emit.rs
@@ -1,4 +1,4 @@
-//! Synchronous single-event emission.
+//! Single-event emission helpers.
 
 use std::collections::HashMap;
 
@@ -9,33 +9,33 @@ use crate::sink::{create_sink, SinkConfig};
 use crate::SondaError;
 
 /// Encode a [`LogEvent`] and deliver it through a one-shot sink.
-pub fn emit_log(
+pub async fn emit_log(
     event: &LogEvent,
     encoder: &EncoderConfig,
     sink: &SinkConfig,
     labels: Option<&HashMap<String, String>>,
 ) -> Result<(), SondaError> {
     let encoder = create_encoder(encoder)?;
-    let mut sink = create_sink(sink, labels)?;
+    let mut sink = create_sink(sink, labels).await?;
     let mut buf: Vec<u8> = Vec::new();
     encoder.encode_log(event, &mut buf)?;
-    sink.write_log_event(event, &buf)?;
-    sink.flush()
+    sink.write_log_event(event, &buf).await?;
+    sink.flush().await
 }
 
 /// Encode a [`MetricEvent`] and deliver it through a one-shot sink.
-pub fn emit_metric(
+pub async fn emit_metric(
     event: &MetricEvent,
     encoder: &EncoderConfig,
     sink: &SinkConfig,
     labels: Option<&HashMap<String, String>>,
 ) -> Result<(), SondaError> {
     let encoder = create_encoder(encoder)?;
-    let mut sink = create_sink(sink, labels)?;
+    let mut sink = create_sink(sink, labels).await?;
     let mut buf: Vec<u8> = Vec::new();
     encoder.encode_metric(event, &mut buf)?;
-    sink.write(&buf)?;
-    sink.flush()
+    sink.write(&buf).await?;
+    sink.flush().await
 }
 
 #[cfg(test)]
@@ -58,8 +58,8 @@ mod tests {
         p
     }
 
-    #[test]
-    fn emit_log_writes_encoded_line_to_sink() {
+    #[tokio::test]
+    async fn emit_log_writes_encoded_line_to_sink() {
         let path = temp_path("emit_log_writes");
         let _ = std::fs::remove_file(&path);
 
@@ -78,6 +78,7 @@ mod tests {
             },
             None,
         )
+        .await
         .expect("emit_log must succeed");
 
         let contents = std::fs::read_to_string(&path).expect("read written file");
@@ -97,8 +98,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn emit_metric_writes_encoded_line_to_sink() {
+    #[tokio::test]
+    async fn emit_metric_writes_encoded_line_to_sink() {
         let path = temp_path("emit_metric_writes");
         let _ = std::fs::remove_file(&path);
 
@@ -117,6 +118,7 @@ mod tests {
             },
             None,
         )
+        .await
         .expect("emit_metric must succeed");
 
         let contents = std::fs::read_to_string(&path).expect("read written file");
@@ -132,8 +134,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn emit_log_propagates_config_error_for_invalid_sink_config() {
+    #[tokio::test]
+    async fn emit_log_propagates_config_error_for_invalid_sink_config() {
         let event = LogEvent::new(
             Severity::Info,
             "msg".to_string(),
@@ -156,6 +158,7 @@ mod tests {
             &bad_sink,
             None,
         )
+        .await
         .expect_err("invalid retry config must fail sink construction");
 
         assert!(
@@ -165,8 +168,8 @@ mod tests {
     }
 
     #[cfg(feature = "http")]
-    #[test]
-    fn emit_log_routes_event_labels_to_loki_sink_stream() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn emit_log_routes_event_labels_to_loki_sink_stream() {
         use std::io::{BufRead, BufReader, Read, Write};
         use std::net::{TcpListener, TcpStream};
         use std::thread;
@@ -222,6 +225,7 @@ mod tests {
             },
             None,
         )
+        .await
         .expect("emit_log must succeed");
 
         let body_bytes = handle.join().expect("mock server");
@@ -238,8 +242,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn emit_metric_propagates_config_error_for_invalid_sink_config() {
+    #[tokio::test]
+    async fn emit_metric_propagates_config_error_for_invalid_sink_config() {
         let event =
             MetricEvent::new("test_metric".to_string(), 1.0, Labels::default()).expect("metric");
 
@@ -258,6 +262,7 @@ mod tests {
             &bad_sink,
             None,
         )
+        .await
         .expect_err("invalid retry config must fail sink construction");
 
         assert!(

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -241,6 +241,10 @@ pub enum RuntimeError {
     /// [`ConfigError`] when collected at the multi-runner level.
     #[error("{0}")]
     ScenariosFailed(String),
+
+    /// A `tokio::task::spawn_blocking` task panicked or was cancelled.
+    #[error("blocking task failed: {0}")]
+    TaskPanicked(String),
 }
 
 #[cfg(test)]

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -308,12 +308,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn sink_file_error_produces_sink_variant() {
-        // Opening a file at an invalid path must produce SondaError::Sink.
+    #[tokio::test]
+    async fn sink_file_error_produces_sink_variant() {
         let result = sink::file::FileSink::new(std::path::Path::new(
             "/nonexistent/deeply/nested/path/output.txt",
-        ));
+        ))
+        .await;
         match result {
             Err(ref err) => {
                 assert!(
@@ -622,9 +622,8 @@ generator:
     }
 
     /// EncoderConfig, SinkConfig, and GeneratorConfig are all constructible
-    /// without deserialization and can be passed to their respective factory functions.
-    #[test]
-    fn factory_functions_work_without_deserialization() {
+    #[tokio::test]
+    async fn factory_functions_work_without_deserialization() {
         use crate::encoder::{create_encoder, EncoderConfig};
         use crate::generator::{create_generator, GeneratorConfig};
         use crate::sink::{create_sink, SinkConfig};
@@ -637,7 +636,9 @@ generator:
         let _enc = create_encoder(&enc_config).expect("encoder factory must succeed");
 
         let sink_config = SinkConfig::Stdout;
-        let _sink = create_sink(&sink_config, None).expect("sink factory must succeed");
+        let _sink = create_sink(&sink_config, None)
+            .await
+            .expect("sink factory must succeed");
     }
 
     #[test]

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -63,6 +63,7 @@ pub use schedule::gate_bus::{
 pub use schedule::handle::ScenarioHandle;
 pub use schedule::launch::{launch_scenario, prepare_entries, validate_entry, PreparedEntry};
 pub use schedule::stats::{ScenarioState, ScenarioStats};
+pub use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "config")]
 pub use compiler::prepare::PrepareError;
@@ -245,6 +246,13 @@ pub enum RuntimeError {
     /// A `tokio::task::spawn_blocking` task panicked or was cancelled.
     #[error("blocking task failed: {0}")]
     TaskPanicked(String),
+
+    /// A scenario task could not be joined safely in the current runtime context.
+    #[error("scenario task aborted: {reason}")]
+    TaskAborted {
+        /// Why the task could not be joined (e.g., called from a current_thread runtime).
+        reason: &'static str,
+    },
 }
 
 #[cfg(test)]

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -13,7 +13,7 @@ use crate::schedule::gate_bus::{GateEdge, GateReceiver, InitialState};
 use crate::schedule::stats::{ScenarioState, ScenarioStats};
 use crate::schedule::{is_in_burst, is_in_gap, is_in_spike, time_until_gap_end};
 use crate::sink::Sink;
-use crate::SondaError;
+use crate::{RuntimeError, SondaError};
 
 use super::ParsedSchedule;
 
@@ -589,8 +589,8 @@ impl GateContext {
 /// pause continues from tick N on resume.
 ///
 /// On `WhileClose` the wrapper breaks out of the inner loop via a
-/// segment-scoped flag, transitions to `Paused`, and blocks on
-/// `recv_timeout` until either the gate reopens or shutdown arrives.
+/// segment-scoped flag, transitions to `Paused`, and awaits the next
+/// gate edge until either the gate reopens or shutdown arrives.
 ///
 /// Stats updates: `state` is written on every transition. While paused,
 /// `current_rate` is reset to 0.0 and `elapsed_secs` keeps wall-clocking
@@ -607,7 +607,7 @@ pub(crate) fn gated_loop(
 ) -> Result<(), SondaError> {
     let mut close_warn_limiter = SinkErrorRateLimiter::new();
 
-    let body_result = gated_loop_body(
+    let body_result = run_on_thread_runtime(gated_loop_body(
         schedule,
         rate,
         shutdown,
@@ -616,7 +616,7 @@ pub(crate) fn gated_loop(
         &mut close_warn_limiter,
         sink,
         tick_fn,
-    );
+    ))?;
 
     match body_result {
         Ok(LoopExit::Shutdown) => {
@@ -653,8 +653,16 @@ pub(crate) fn gated_loop(
     }
 }
 
+fn run_on_thread_runtime<F: std::future::Future>(fut: F) -> Result<F::Output, SondaError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
+    Ok(rt.block_on(fut))
+}
+
 #[allow(clippy::too_many_arguments)]
-fn gated_loop_body(
+async fn gated_loop_body(
     schedule: &ParsedSchedule,
     rate: f64,
     shutdown: Option<&AtomicBool>,
@@ -704,11 +712,8 @@ fn gated_loop_body(
         match state {
             ScenarioState::Pending => {
                 if !after_satisfied {
-                    match gate_ctx.gate_rx.recv_timeout(remaining_until(
-                        schedule,
-                        started_at,
-                        PAUSED_POLL_INTERVAL,
-                    )) {
+                    let wait = remaining_until(schedule, started_at, PAUSED_POLL_INTERVAL);
+                    match gate_ctx.gate_rx.recv_edge_timeout(wait).await {
                         Some(GateEdge::AfterFired) => {
                             after_satisfied = true;
                         }
@@ -794,6 +799,7 @@ fn gated_loop_body(
                     && !debounce_close_to_paused(
                         schedule, started_at, shutdown, gate_ctx, &debounce,
                     )
+                    .await
                 {
                     while_open = true;
                     continue;
@@ -823,7 +829,7 @@ fn gated_loop_body(
                     wakeup = wakeup.min(remaining);
                 }
 
-                let recv = gate_ctx.gate_rx.recv_timeout(wakeup);
+                let recv = gate_ctx.gate_rx.recv_edge_timeout(wakeup).await;
                 let now = Instant::now();
                 match recv {
                     Some(GateEdge::WhileOpen) => {
@@ -922,7 +928,7 @@ fn gated_loop_body(
                     }
                     UnresolvedBehavior::Closed | UnresolvedBehavior::Pending => {
                         let wakeup = remaining_until(schedule, started_at, PAUSED_POLL_INTERVAL);
-                        match gate_ctx.gate_rx.recv_timeout(wakeup) {
+                        match gate_ctx.gate_rx.recv_edge_timeout(wakeup).await {
                             Some(GateEdge::WhileOpen) => {
                                 while_open = true;
                                 state = ScenarioState::Pending;
@@ -1067,11 +1073,11 @@ enum LoopExit {
 /// debounce timer to fire (commit). Returns `true` when the transition
 /// to `Paused` should commit, `false` when the close was cancelled by a
 /// reopen within the debounce window.
-fn debounce_close_to_paused(
+async fn debounce_close_to_paused(
     schedule: &ParsedSchedule,
     started_at: Instant,
     shutdown: Option<&AtomicBool>,
-    gate_ctx: &GateContext,
+    gate_ctx: &mut GateContext,
     debounce: &DebounceState,
 ) -> bool {
     if debounce.delay_close.is_zero() {
@@ -1091,7 +1097,7 @@ fn debounce_close_to_paused(
         if let Some(remaining) = remaining_duration(schedule, started_at) {
             wait = wait.min(remaining);
         }
-        match gate_ctx.gate_rx.recv_timeout(wait) {
+        match gate_ctx.gate_rx.recv_edge_timeout(wait).await {
             Some(GateEdge::WhileOpen) => return false,
             Some(GateEdge::WhileClose) => {}
             Some(GateEdge::AfterFired) => {}
@@ -1115,7 +1121,7 @@ fn run_running_segment(
     rate: f64,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
-    gate_ctx: &GateContext,
+    gate_ctx: &mut GateContext,
     segment_running: &Arc<AtomicBool>,
     initial_tick: u64,
     last_tick: Arc<AtomicU64>,
@@ -1136,7 +1142,7 @@ fn run_running_segment(
     let saw_close_for_wrapper = Arc::clone(&saw_close);
     let saw_gone_for_wrapper = Arc::clone(&saw_gone);
     let saw_open_for_wrapper = Arc::clone(&saw_open);
-    let gate_rx = &gate_ctx.gate_rx;
+    let gate_rx = &mut gate_ctx.gate_rx;
 
     type WrappedTick<'a> = Box<
         dyn FnMut(

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -14,7 +14,7 @@ use crate::schedule::gate_bus::{GateEdge, GateReceiver, InitialState};
 use crate::schedule::stats::{ScenarioState, ScenarioStats};
 use crate::schedule::{is_in_burst, is_in_gap, is_in_spike, time_until_gap_end};
 use crate::sink::Sink;
-use crate::{RuntimeError, SondaError};
+use crate::SondaError;
 
 use super::ParsedSchedule;
 
@@ -205,26 +205,6 @@ pub(crate) async fn run_schedule_loop(
     finalize_sink(schedule, stats_for_flush.as_ref(), sink, loop_result).await
 }
 
-/// Placeholder sink swapped in for the brief window each `Box<dyn Sink>` is
-/// owned by a `spawn_blocking` task. Lives only inside `drain_writes` /
-/// `finalize_sink`; never reachable from user code. If either helper returns
-/// `Err`, the caller's `Box<dyn Sink>` may still hold this placeholder —
-/// do not retry sink operations after an error return, propagate it.
-struct NullSink;
-
-impl Sink for NullSink {
-    fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
-        Ok(())
-    }
-    fn flush(&mut self) -> Result<(), SondaError> {
-        Ok(())
-    }
-}
-
-fn take_sink(sink: &mut Box<dyn Sink>) -> Box<dyn Sink> {
-    std::mem::replace(sink, Box::new(NullSink) as Box<dyn Sink>)
-}
-
 async fn finalize_sink(
     schedule: &ParsedSchedule,
     stats: Option<&Arc<RwLock<ScenarioStats>>>,
@@ -233,22 +213,7 @@ async fn finalize_sink(
 ) -> Result<(), SondaError> {
     match loop_result {
         Ok(()) => {
-            let owned = take_sink(sink);
-            let join = tokio::task::spawn_blocking(move || {
-                let mut s = owned;
-                let r = s.flush();
-                (s, r)
-            })
-            .await;
-            let (returned_sink, flush_result) = match join {
-                Ok(pair) => pair,
-                Err(e) => {
-                    return Err(SondaError::Runtime(RuntimeError::TaskPanicked(
-                        e.to_string(),
-                    )))
-                }
-            };
-            *sink = returned_sink;
+            let flush_result = sink.flush().await;
             apply_flush_policy(schedule, stats, flush_result)
         }
         Err(e) => Err(e),
@@ -473,26 +438,10 @@ async fn drain_writes(
 ) -> Result<Option<bool>, SondaError> {
     let mut delivered: Option<bool> = None;
     for cmd in output.writes.drain(..) {
-        let owned = take_sink(sink);
-        let join = tokio::task::spawn_blocking(move || {
-            let mut s = owned;
-            let r = match cmd {
-                WriteCommand::Bytes(buf) => s.write(&buf),
-                WriteCommand::LogEvent { event, bytes } => s.write_log_event(&event, &bytes),
-            };
-            (s, r)
-        })
-        .await;
-        let (returned_sink, write_result) = match join {
-            Ok(pair) => pair,
-            Err(e) => {
-                return Err(SondaError::Runtime(RuntimeError::TaskPanicked(
-                    e.to_string(),
-                )))
-            }
-        };
-        *sink = returned_sink;
-        write_result?;
+        match cmd {
+            WriteCommand::Bytes(buf) => sink.write(&buf).await?,
+            WriteCommand::LogEvent { event, bytes } => sink.write_log_event(&event, &bytes).await?,
+        }
         delivered = Some(sink.last_write_delivered());
     }
     Ok(delivered)
@@ -593,22 +542,7 @@ async fn invoke_close_emit(
     };
     match outcome {
         Ok(()) => {
-            let owned = take_sink(sink);
-            let join = tokio::task::spawn_blocking(move || {
-                let mut s = owned;
-                let r = s.flush();
-                (s, r)
-            })
-            .await;
-            let (returned_sink, flush_result) = match join {
-                Ok(pair) => pair,
-                Err(e) => {
-                    return Err(SondaError::Runtime(RuntimeError::TaskPanicked(
-                        e.to_string(),
-                    )))
-                }
-            };
-            *sink = returned_sink;
+            let flush_result = sink.flush().await;
             apply_close_emit_policy_flush(schedule, stats, limiter, flush_result)?;
         }
         Err(e) => apply_close_emit_policy(schedule, stats, limiter, e)?,
@@ -1408,14 +1342,14 @@ impl DebounceState {
 mod tests {
     use std::sync::Mutex;
 
+    use async_trait::async_trait;
+
     use super::*;
     use crate::schedule::{BurstWindow, GapWindow};
 
     type WriteLog = Arc<Mutex<Vec<Vec<u8>>>>;
 
-    /// Shared-buffer test sink. Owns nothing; the `Arc<Mutex<...>>` handles
-    /// let tests inspect outcomes after the runner has moved the sink in
-    /// and out of `spawn_blocking`.
+    /// Shared-buffer test sink that lets tests inspect captured writes.
     struct SharedSink {
         writes: WriteLog,
         fail_at: Option<usize>,
@@ -1439,8 +1373,9 @@ mod tests {
         (Box::new(sink) as Box<dyn Sink>, writes)
     }
 
+    #[async_trait]
     impl Sink for SharedSink {
-        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
             let mut writes = self.writes.lock().expect("shared sink mutex poisoned");
             if let Some(n) = self.fail_at {
                 if writes.len() == n {
@@ -1452,7 +1387,19 @@ mod tests {
             writes.push(data.to_vec());
             Ok(())
         }
-        fn flush(&mut self) -> Result<(), SondaError> {
+        async fn flush(&mut self) -> Result<(), SondaError> {
+            Ok(())
+        }
+    }
+
+    struct NullSink;
+
+    #[async_trait]
+    impl Sink for NullSink {
+        async fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
+            Ok(())
+        }
+        async fn flush(&mut self) -> Result<(), SondaError> {
             Ok(())
         }
     }
@@ -1499,47 +1446,35 @@ mod tests {
         );
     }
 
-    /// A spawn_blocking task that panics surfaces as RuntimeError::TaskPanicked.
     struct PanicSink;
 
+    #[async_trait]
     impl Sink for PanicSink {
-        fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
+        async fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
             panic!("synthetic sink panic");
         }
-        fn flush(&mut self) -> Result<(), SondaError> {
+        async fn flush(&mut self) -> Result<(), SondaError> {
             panic!("synthetic flush panic");
         }
     }
 
     #[tokio::test]
-    async fn drain_writes_panic_in_sink_propagates_as_task_panicked() {
+    #[should_panic(expected = "synthetic sink panic")]
+    async fn drain_writes_panic_in_sink_propagates() {
         let mut sink: Box<dyn Sink> = Box::new(PanicSink);
         let mut output = TickOutput::default();
         output
             .writes
             .push(WriteCommand::Bytes(b"panic-me".to_vec()));
-        let result = drain_writes(&mut output, &mut sink).await;
-        assert!(
-            matches!(
-                result,
-                Err(SondaError::Runtime(RuntimeError::TaskPanicked(_)))
-            ),
-            "spawn_blocking panic must surface as TaskPanicked, got: {result:?}"
-        );
+        let _ = drain_writes(&mut output, &mut sink).await;
     }
 
     #[tokio::test]
-    async fn finalize_sink_panic_in_flush_propagates_as_task_panicked() {
+    #[should_panic(expected = "synthetic flush panic")]
+    async fn finalize_sink_panic_in_flush_propagates() {
         let mut sink: Box<dyn Sink> = Box::new(PanicSink);
         let schedule = minimal_schedule(None);
-        let result = finalize_sink(&schedule, None, &mut sink, Ok(())).await;
-        assert!(
-            matches!(
-                result,
-                Err(SondaError::Runtime(RuntimeError::TaskPanicked(_)))
-            ),
-            "flush panic must surface as TaskPanicked, got: {result:?}"
-        );
+        let _ = finalize_sink(&schedule, None, &mut sink, Ok(())).await;
     }
 
     #[test]

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use crate::compiler::{DelayClause, UnresolvedBehavior};
 use crate::config::validate::StartTime;
 use crate::config::OnSinkError;
+use crate::model::log::LogEvent;
 use crate::model::metric::MetricEvent;
 use crate::schedule::gate_bus::{GateEdge, GateReceiver, InitialState};
 use crate::schedule::stats::{ScenarioState, ScenarioStats};
@@ -105,14 +106,31 @@ pub(crate) struct TickContext<'a> {
     pub wall_clock: SystemTime,
 }
 
-/// A per-tick callback that performs signal-specific work.
-///
-/// Called once per scheduled tick with the sink threaded as a parameter so
-/// that gated runs can additionally invoke a separate close-emit closure on
-/// the same sink without a borrow split. The `events_buf` is pre-cleared by
-/// the loop before each call; the callback pushes any emitted metric events
-/// into it so the loop can drain them into stats without per-tick allocation.
-pub(crate) type TickFn<'a> = dyn FnMut(&TickContext<'_>, &mut dyn Sink, &mut Vec<MetricEvent>) -> Result<TickResult, SondaError>
+/// A pending sink write produced by a tick callback.
+pub enum WriteCommand {
+    Bytes(Vec<u8>),
+    LogEvent { event: LogEvent, bytes: Vec<u8> },
+}
+
+/// Buffer of pending sink writes emitted by a tick callback.
+#[derive(Default)]
+pub struct TickOutput {
+    pub writes: Vec<WriteCommand>,
+}
+
+impl TickOutput {
+    pub fn clear(&mut self) {
+        self.writes.clear();
+    }
+}
+
+/// A per-tick callback that encodes events into `output`; the loop drains the
+/// queue to the sink. The `events_buf` is pre-cleared before each call.
+pub(crate) type TickFn<'a> = dyn FnMut(
+        &TickContext<'_>,
+        &mut TickOutput,
+        &mut Vec<MetricEvent>,
+    ) -> Result<TickResult, SondaError>
     + 'a;
 
 /// Scenario-level wall-clock anchor: the resolved emission-time base plus the
@@ -166,33 +184,11 @@ pub enum CloseSignal {
 }
 
 /// Per-scenario callback invoked on every committed `running → paused`
-/// transition. Logs/histograms/summaries pass `None`. The [`CloseSignal`]
-/// (StaleMarker vs SnapTo) is captured at build time, so the closure takes
-/// only the sink to write into.
-pub type CloseEmitFn = Box<dyn FnMut(&mut dyn Sink) -> Result<(), SondaError> + Send>;
+/// transition. Closures push markers into the supplied [`TickOutput`].
+pub type CloseEmitFn = Box<dyn FnMut(&mut TickOutput) -> Result<(), SondaError> + Send>;
 
-/// Run the shared schedule loop until duration expires or shutdown is signalled.
-///
-/// This function owns the entire rate-control loop: shutdown detection, duration
-/// checking, gap window sleeping, burst window effective interval, deadline-based
-/// sleep, and stats updating. The signal-specific work (event generation,
-/// encoding, sink writing) is delegated to `tick_fn`.
-///
-/// The caller is responsible for flushing the sink after this function returns.
-/// This design avoids a double-borrow conflict: the tick closure already holds
-/// `&mut sink` for per-tick writes, so the loop cannot also own it for flushing.
-///
-/// # Parameters
-///
-/// * `schedule` — the parsed schedule configuration (duration, windows).
-/// * `rate` — target events per second.
-/// * `shutdown` — optional atomic flag; when cleared the loop exits cleanly.
-/// * `stats` — optional shared stats for live telemetry.
-/// * `tick_fn` — per-tick callback for signal-specific work.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if the tick callback fails.
+/// Run the shared schedule loop until duration expires or shutdown is
+/// signalled, then flush the sink and apply the sink-error policy.
 pub(crate) fn run_schedule_loop(
     schedule: &ParsedSchedule,
     rate: f64,
@@ -201,9 +197,26 @@ pub(crate) fn run_schedule_loop(
     sink: &mut dyn Sink,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<(), SondaError> {
-    run_schedule_loop_with_initial_tick(
+    let stats_for_flush = stats.clone();
+    let loop_result = run_schedule_loop_with_initial_tick(
         schedule, rate, shutdown, stats, 0, None, None, sink, tick_fn,
-    )
+    );
+    finalize_sink(schedule, stats_for_flush.as_ref(), sink, loop_result)
+}
+
+fn finalize_sink(
+    schedule: &ParsedSchedule,
+    stats: Option<&Arc<RwLock<ScenarioStats>>>,
+    sink: &mut dyn Sink,
+    loop_result: Result<(), SondaError>,
+) -> Result<(), SondaError> {
+    match loop_result {
+        Ok(()) => {
+            let flush_result = sink.flush();
+            apply_flush_policy(schedule, stats, flush_result)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// Run the schedule loop starting from `initial_tick`, optionally reporting the
@@ -241,6 +254,9 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
     // Sized to cover typical histogram (10 buckets + 3) and summary
     // (~6 quantiles + 2) without reallocating.
     let mut events_buf: Vec<MetricEvent> = Vec::with_capacity(16);
+    let mut tick_output = TickOutput {
+        writes: Vec::with_capacity(16),
+    };
 
     loop {
         // Check shutdown flag first — highest priority exit path.
@@ -319,7 +335,21 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
             wall_clock: wall.wall_at(start, elapsed),
         };
         events_buf.clear();
-        let tick_outcome = tick_fn(&ctx, sink, &mut events_buf);
+        tick_output.clear();
+        let tick_outcome = match tick_fn(&ctx, &mut tick_output, &mut events_buf) {
+            Ok(mut result) => match drain_writes(&mut tick_output, sink) {
+                Ok(Some(delivered)) => {
+                    result.delivered = delivered;
+                    Ok(result)
+                }
+                Ok(None) => Ok(result),
+                Err(e) => Err(e),
+            },
+            Err(e) => {
+                tick_output.clear();
+                Err(e)
+            }
+        };
 
         // Determine spike state for stats (check all spike windows).
         let currently_in_spike = schedule
@@ -399,6 +429,18 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
         out.store(tick, Ordering::SeqCst);
     }
     Ok(())
+}
+
+fn drain_writes(output: &mut TickOutput, sink: &mut dyn Sink) -> Result<Option<bool>, SondaError> {
+    let mut delivered: Option<bool> = None;
+    for cmd in output.writes.drain(..) {
+        match cmd {
+            WriteCommand::Bytes(buf) => sink.write(&buf)?,
+            WriteCommand::LogEvent { event, bytes } => sink.write_log_event(&event, &bytes)?,
+        }
+        delivered = Some(sink.last_write_delivered());
+    }
+    Ok(delivered)
 }
 
 /// Apply the scenario's sink-error policy to a flush call made at scenario
@@ -489,11 +531,17 @@ fn invoke_close_emit(
     let Some(emit) = close_emit else {
         return Ok(());
     };
-    if let Err(e) = emit(sink) {
-        apply_close_emit_policy(schedule, stats, limiter, e)?;
-    } else {
-        let flush = sink.flush();
-        apply_close_emit_policy_flush(schedule, stats, limiter, flush)?;
+    let mut output = TickOutput::default();
+    let outcome = emit(&mut output).and_then(|()| {
+        drain_writes(&mut output, sink)?;
+        Ok(())
+    });
+    match outcome {
+        Ok(()) => {
+            let flush = sink.flush();
+            apply_close_emit_policy_flush(schedule, stats, limiter, flush)?;
+        }
+        Err(e) => apply_close_emit_policy(schedule, stats, limiter, e)?,
     }
     Ok(())
 }
@@ -607,7 +655,8 @@ pub(crate) fn gated_loop(
 ) -> Result<(), SondaError> {
     let mut close_warn_limiter = SinkErrorRateLimiter::new();
 
-    let body_result = run_on_thread_runtime(gated_loop_body(
+    let stats_for_flush = stats.clone();
+    let gated_result = run_on_thread_runtime(gated_loop_body(
         schedule,
         rate,
         shutdown,
@@ -616,30 +665,9 @@ pub(crate) fn gated_loop(
         &mut close_warn_limiter,
         sink,
         tick_fn,
-    ))?;
-
-    match body_result {
-        Ok(LoopExit::Shutdown) => {
-            invoke_close_emit(
-                schedule,
-                stats.as_ref(),
-                &mut close_warn_limiter,
-                gate_ctx.close_emit.as_mut(),
-                sink,
-            )?;
-            finish(stats)
-        }
-        Ok(LoopExit::DurationExpired) => {
-            invoke_close_emit(
-                schedule,
-                stats.as_ref(),
-                &mut close_warn_limiter,
-                gate_ctx.close_emit.as_mut(),
-                sink,
-            )?;
-            finish(stats)
-        }
-        Ok(LoopExit::UpstreamFinished) => {
+    ))
+    .and_then(|body_result| match body_result {
+        Ok(LoopExit::Shutdown | LoopExit::DurationExpired | LoopExit::UpstreamFinished) => {
             invoke_close_emit(
                 schedule,
                 stats.as_ref(),
@@ -650,7 +678,9 @@ pub(crate) fn gated_loop(
             finish(stats)
         }
         Err(e) => Err(e),
-    }
+    });
+
+    finalize_sink(schedule, stats_for_flush.as_ref(), sink, gated_result)
 }
 
 fn run_on_thread_runtime<F: std::future::Future>(fut: F) -> Result<F::Output, SondaError> {
@@ -1147,17 +1177,17 @@ fn run_running_segment(
     type WrappedTick<'a> = Box<
         dyn FnMut(
                 &TickContext<'_>,
-                &mut dyn Sink,
+                &mut TickOutput,
                 &mut Vec<MetricEvent>,
             ) -> Result<TickResult, SondaError>
             + 'a,
     >;
     let mut wrapped: WrappedTick<'_> = Box::new(
         move |ctx: &TickContext<'_>,
-              s: &mut dyn Sink,
+              output: &mut TickOutput,
               events_buf: &mut Vec<MetricEvent>|
               -> Result<TickResult, SondaError> {
-            let outcome = tick_fn(ctx, s, events_buf);
+            let outcome = tick_fn(ctx, output, events_buf);
 
             // Poll for gate edges after the tick. On WhileClose, break out.
             while let Some(edge) = gate_rx.try_recv() {
@@ -1316,6 +1346,68 @@ mod tests {
         }
     }
 
+    struct CapturingSink {
+        writes: Vec<Vec<u8>>,
+        fail_at: Option<usize>,
+    }
+    impl Sink for CapturingSink {
+        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+            if let Some(n) = self.fail_at {
+                if self.writes.len() == n {
+                    return Err(SondaError::Sink(std::io::Error::other(
+                        "capturing sink test failure",
+                    )));
+                }
+            }
+            self.writes.push(data.to_vec());
+            Ok(())
+        }
+        fn flush(&mut self) -> Result<(), SondaError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn drain_writes_preserves_command_order() {
+        let mut sink = CapturingSink {
+            writes: Vec::new(),
+            fail_at: None,
+        };
+        let mut output = TickOutput::default();
+        output.writes.push(WriteCommand::Bytes(b"first".to_vec()));
+        output.writes.push(WriteCommand::Bytes(b"second".to_vec()));
+        output.writes.push(WriteCommand::Bytes(b"third".to_vec()));
+        let delivered = drain_writes(&mut output, &mut sink).expect("drain must succeed");
+        assert_eq!(
+            sink.writes,
+            vec![b"first".to_vec(), b"second".to_vec(), b"third".to_vec()]
+        );
+        assert!(output.writes.is_empty(), "queue must be empty after drain");
+        assert_eq!(delivered, Some(true));
+    }
+
+    #[test]
+    fn drain_writes_short_circuits_on_sink_error() {
+        let mut sink = CapturingSink {
+            writes: Vec::new(),
+            fail_at: Some(1),
+        };
+        let mut output = TickOutput::default();
+        output.writes.push(WriteCommand::Bytes(b"first".to_vec()));
+        output.writes.push(WriteCommand::Bytes(b"second".to_vec()));
+        output.writes.push(WriteCommand::Bytes(b"third".to_vec()));
+        let result = drain_writes(&mut output, &mut sink);
+        assert!(
+            result.is_err(),
+            "sink error must propagate from drain_writes"
+        );
+        assert_eq!(
+            sink.writes,
+            vec![b"first".to_vec()],
+            "only writes before the error must reach the sink"
+        );
+    }
+
     #[test]
     fn loop_exit_variants_are_exhaustive_for_clean_exits() {
         fn assert_clean_exit_match(le: LoopExit) {
@@ -1353,7 +1445,7 @@ mod tests {
 
         let mut event_count: u64 = 0;
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             event_count += 1;
@@ -1402,7 +1494,7 @@ mod tests {
         });
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             event_count += 1;
@@ -1451,7 +1543,7 @@ mod tests {
 
         let mut event_count: u64 = 0;
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             event_count += 1;
@@ -1493,7 +1585,7 @@ mod tests {
 
         let mut event_count: u64 = 0;
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             event_count += 1;
@@ -1522,7 +1614,7 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Ok(TickResult {
@@ -1565,7 +1657,7 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             let event = MetricEvent::new("test".to_string(), 1.0, Labels::default())
@@ -1623,7 +1715,7 @@ mod tests {
 
         let mut saw_spike_windows = false;
         let mut tick_fn = |ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             if !ctx.spike_windows.is_empty() {
@@ -1651,7 +1743,7 @@ mod tests {
         let schedule = minimal_schedule(Some(Duration::from_secs(10)));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Err(SondaError::Encoder(crate::EncoderError::NotSupported(
@@ -1673,7 +1765,7 @@ mod tests {
         schedule.on_sink_error = OnSinkError::Fail;
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Err(SondaError::Sink(std::io::Error::other("test error")))
@@ -1694,7 +1786,7 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Err(SondaError::Sink(std::io::Error::new(
@@ -1747,7 +1839,7 @@ mod tests {
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Err(SondaError::Sink(std::io::Error::other("transient")))
@@ -1767,7 +1859,7 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Err(SondaError::Sink(std::io::Error::new(
@@ -1810,7 +1902,7 @@ mod tests {
         let mut counter: u64 = 0;
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             counter += 1;
@@ -1851,7 +1943,7 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Ok(TickResult {
@@ -1895,7 +1987,7 @@ mod tests {
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Ok(TickResult {
@@ -1972,7 +2064,7 @@ mod tests {
         let mut schedule = minimal_schedule(Some(Duration::from_millis(150)));
         schedule.on_sink_error = policy;
 
-        let mut tick_fn = |_ctx: &TickContext<'_>, _sink: &mut dyn Sink, _events_buf: &mut Vec<MetricEvent>| -> Result<TickResult, SondaError> {
+        let mut tick_fn = |_ctx: &TickContext<'_>, _output: &mut TickOutput, _events_buf: &mut Vec<MetricEvent>| -> Result<TickResult, SondaError> {
             match err_kind {
                 ErrKind::Sink => Err(SondaError::Sink(std::io::Error::other(
                     "matrix",
@@ -2055,7 +2147,7 @@ mod tests {
         let observed_first = std::sync::Mutex::new(None::<u64>);
 
         let mut tick_fn = |ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             let mut g = observed_first.lock().unwrap();
@@ -2094,7 +2186,7 @@ mod tests {
         let last_tick = AtomicU64::new(0);
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            _events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             Ok(TickResult {
@@ -2144,7 +2236,7 @@ mod tests {
         let first_ptr: Cell<Option<usize>> = Cell::new(None);
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
-                           _sink: &mut dyn Sink,
+                           _output: &mut TickOutput,
                            events_buf: &mut Vec<MetricEvent>|
          -> Result<TickResult, SondaError> {
             let event =

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -189,30 +189,66 @@ pub type CloseEmitFn = Box<dyn FnMut(&mut TickOutput) -> Result<(), SondaError> 
 
 /// Run the shared schedule loop until duration expires or shutdown is
 /// signalled, then flush the sink and apply the sink-error policy.
-pub(crate) fn run_schedule_loop(
+pub(crate) async fn run_schedule_loop(
     schedule: &ParsedSchedule,
     rate: f64,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<(), SondaError> {
     let stats_for_flush = stats.clone();
     let loop_result = run_schedule_loop_with_initial_tick(
         schedule, rate, shutdown, stats, 0, None, None, sink, tick_fn,
-    );
-    finalize_sink(schedule, stats_for_flush.as_ref(), sink, loop_result)
+    )
+    .await;
+    finalize_sink(schedule, stats_for_flush.as_ref(), sink, loop_result).await
 }
 
-fn finalize_sink(
+/// Placeholder sink swapped in for the brief window each `Box<dyn Sink>` is
+/// owned by a `spawn_blocking` task. Lives only inside `drain_writes` /
+/// `finalize_sink`; never reachable from user code. If either helper returns
+/// `Err`, the caller's `Box<dyn Sink>` may still hold this placeholder —
+/// do not retry sink operations after an error return, propagate it.
+struct NullSink;
+
+impl Sink for NullSink {
+    fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
+        Ok(())
+    }
+    fn flush(&mut self) -> Result<(), SondaError> {
+        Ok(())
+    }
+}
+
+fn take_sink(sink: &mut Box<dyn Sink>) -> Box<dyn Sink> {
+    std::mem::replace(sink, Box::new(NullSink) as Box<dyn Sink>)
+}
+
+async fn finalize_sink(
     schedule: &ParsedSchedule,
     stats: Option<&Arc<RwLock<ScenarioStats>>>,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     loop_result: Result<(), SondaError>,
 ) -> Result<(), SondaError> {
     match loop_result {
         Ok(()) => {
-            let flush_result = sink.flush();
+            let owned = take_sink(sink);
+            let join = tokio::task::spawn_blocking(move || {
+                let mut s = owned;
+                let r = s.flush();
+                (s, r)
+            })
+            .await;
+            let (returned_sink, flush_result) = match join {
+                Ok(pair) => pair,
+                Err(e) => {
+                    return Err(SondaError::Runtime(RuntimeError::TaskPanicked(
+                        e.to_string(),
+                    )))
+                }
+            };
+            *sink = returned_sink;
             apply_flush_policy(schedule, stats, flush_result)
         }
         Err(e) => Err(e),
@@ -223,7 +259,7 @@ fn finalize_sink(
 /// last tick reached on exit through `last_tick_out`. Used by `gated_loop` to
 /// continue the tick counter across pause/resume instead of restarting at 0.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn run_schedule_loop_with_initial_tick(
+pub(crate) async fn run_schedule_loop_with_initial_tick(
     schedule: &ParsedSchedule,
     rate: f64,
     shutdown: Option<&AtomicBool>,
@@ -231,7 +267,7 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
     initial_tick: u64,
     last_tick_out: Option<&AtomicU64>,
     wall: Option<WallClock>,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<(), SondaError> {
     let base_interval = Duration::from_secs_f64(1.0 / rate);
@@ -337,7 +373,7 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
         events_buf.clear();
         tick_output.clear();
         let tick_outcome = match tick_fn(&ctx, &mut tick_output, &mut events_buf) {
-            Ok(mut result) => match drain_writes(&mut tick_output, sink) {
+            Ok(mut result) => match drain_writes(&mut tick_output, sink).await {
                 Ok(Some(delivered)) => {
                     result.delivered = delivered;
                     Ok(result)
@@ -431,13 +467,32 @@ pub(crate) fn run_schedule_loop_with_initial_tick(
     Ok(())
 }
 
-fn drain_writes(output: &mut TickOutput, sink: &mut dyn Sink) -> Result<Option<bool>, SondaError> {
+async fn drain_writes(
+    output: &mut TickOutput,
+    sink: &mut Box<dyn Sink>,
+) -> Result<Option<bool>, SondaError> {
     let mut delivered: Option<bool> = None;
     for cmd in output.writes.drain(..) {
-        match cmd {
-            WriteCommand::Bytes(buf) => sink.write(&buf)?,
-            WriteCommand::LogEvent { event, bytes } => sink.write_log_event(&event, &bytes)?,
-        }
+        let owned = take_sink(sink);
+        let join = tokio::task::spawn_blocking(move || {
+            let mut s = owned;
+            let r = match cmd {
+                WriteCommand::Bytes(buf) => s.write(&buf),
+                WriteCommand::LogEvent { event, bytes } => s.write_log_event(&event, &bytes),
+            };
+            (s, r)
+        })
+        .await;
+        let (returned_sink, write_result) = match join {
+            Ok(pair) => pair,
+            Err(e) => {
+                return Err(SondaError::Runtime(RuntimeError::TaskPanicked(
+                    e.to_string(),
+                )))
+            }
+        };
+        *sink = returned_sink;
+        write_result?;
         delivered = Some(sink.last_write_delivered());
     }
     Ok(delivered)
@@ -521,25 +576,40 @@ fn apply_close_emit_policy_flush(
 
 /// Called on every committed `running → paused` transition AND on the
 /// single tail exit of `gated_loop`.
-fn invoke_close_emit(
+async fn invoke_close_emit(
     schedule: &ParsedSchedule,
     stats: Option<&Arc<RwLock<ScenarioStats>>>,
     limiter: &mut SinkErrorRateLimiter,
     close_emit: Option<&mut CloseEmitFn>,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
 ) -> Result<(), SondaError> {
     let Some(emit) = close_emit else {
         return Ok(());
     };
     let mut output = TickOutput::default();
-    let outcome = emit(&mut output).and_then(|()| {
-        drain_writes(&mut output, sink)?;
-        Ok(())
-    });
+    let outcome = match emit(&mut output) {
+        Ok(()) => drain_writes(&mut output, sink).await.map(|_| ()),
+        Err(e) => Err(e),
+    };
     match outcome {
         Ok(()) => {
-            let flush = sink.flush();
-            apply_close_emit_policy_flush(schedule, stats, limiter, flush)?;
+            let owned = take_sink(sink);
+            let join = tokio::task::spawn_blocking(move || {
+                let mut s = owned;
+                let r = s.flush();
+                (s, r)
+            })
+            .await;
+            let (returned_sink, flush_result) = match join {
+                Ok(pair) => pair,
+                Err(e) => {
+                    return Err(SondaError::Runtime(RuntimeError::TaskPanicked(
+                        e.to_string(),
+                    )))
+                }
+            };
+            *sink = returned_sink;
+            apply_close_emit_policy_flush(schedule, stats, limiter, flush_result)?;
         }
         Err(e) => apply_close_emit_policy(schedule, stats, limiter, e)?,
     }
@@ -644,19 +714,19 @@ impl GateContext {
 /// `current_rate` is reset to 0.0 and `elapsed_secs` keeps wall-clocking
 /// (the underlying `started_at` Instant inside `ScenarioHandle` runs
 /// against wall time regardless of pause state).
-pub(crate) fn gated_loop(
+pub(crate) async fn gated_loop(
     schedule: &ParsedSchedule,
     rate: f64,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     mut gate_ctx: GateContext,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<(), SondaError> {
     let mut close_warn_limiter = SinkErrorRateLimiter::new();
 
     let stats_for_flush = stats.clone();
-    let gated_result = run_on_thread_runtime(gated_loop_body(
+    let body_result = gated_loop_body(
         schedule,
         rate,
         shutdown,
@@ -665,30 +735,27 @@ pub(crate) fn gated_loop(
         &mut close_warn_limiter,
         sink,
         tick_fn,
-    ))
-    .and_then(|body_result| match body_result {
+    )
+    .await;
+    let gated_result = match body_result {
         Ok(LoopExit::Shutdown | LoopExit::DurationExpired | LoopExit::UpstreamFinished) => {
-            invoke_close_emit(
+            match invoke_close_emit(
                 schedule,
                 stats.as_ref(),
                 &mut close_warn_limiter,
                 gate_ctx.close_emit.as_mut(),
                 sink,
-            )?;
-            finish(stats)
+            )
+            .await
+            {
+                Ok(()) => finish(stats),
+                Err(e) => Err(e),
+            }
         }
         Err(e) => Err(e),
-    });
+    };
 
-    finalize_sink(schedule, stats_for_flush.as_ref(), sink, gated_result)
-}
-
-fn run_on_thread_runtime<F: std::future::Future>(fut: F) -> Result<F::Output, SondaError> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
-    Ok(rt.block_on(fut))
+    finalize_sink(schedule, stats_for_flush.as_ref(), sink, gated_result).await
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -699,7 +766,7 @@ async fn gated_loop_body(
     stats: Option<&Arc<RwLock<ScenarioStats>>>,
     gate_ctx: &mut GateContext,
     close_warn_limiter: &mut SinkErrorRateLimiter,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<LoopExit, SondaError> {
     let started_at = Instant::now();
@@ -799,7 +866,8 @@ async fn gated_loop_body(
                     sink,
                     tick_fn,
                     false,
-                )?;
+                )
+                .await?;
                 next_tick = last_tick.load(Ordering::SeqCst);
 
                 if shutdown_requested(shutdown) {
@@ -818,7 +886,8 @@ async fn gated_loop_body(
                         close_warn_limiter,
                         gate_ctx.close_emit.as_mut(),
                         sink,
-                    )?;
+                    )
+                    .await?;
                     state = ScenarioState::Unresolved;
                     while_open = false;
                     write_state(stats, ScenarioState::Unresolved, true);
@@ -841,7 +910,8 @@ async fn gated_loop_body(
                         close_warn_limiter,
                         gate_ctx.close_emit.as_mut(),
                         sink,
-                    )?;
+                    )
+                    .await?;
                 }
                 let close_state = close_target_state(gate_ctx.holds_on_close, stats);
                 state = close_state;
@@ -919,7 +989,8 @@ async fn gated_loop_body(
                             sink,
                             tick_fn,
                             true,
-                        )?;
+                        )
+                        .await?;
                         next_tick = last_tick.load(Ordering::SeqCst);
 
                         if shutdown_requested(shutdown) {
@@ -936,7 +1007,8 @@ async fn gated_loop_body(
                                     close_warn_limiter,
                                     gate_ctx.close_emit.as_mut(),
                                     sink,
-                                )?;
+                                )
+                                .await?;
                                 let close_state =
                                     close_target_state(gate_ctx.holds_on_close, stats);
                                 state = close_state;
@@ -1146,7 +1218,7 @@ async fn debounce_close_to_paused(
 /// captures the next tick the inner loop would have fired so the next segment
 /// continues from there.
 #[allow(clippy::too_many_arguments)]
-fn run_running_segment(
+async fn run_running_segment(
     schedule: &ParsedSchedule,
     rate: f64,
     shutdown: Option<&AtomicBool>,
@@ -1156,7 +1228,7 @@ fn run_running_segment(
     initial_tick: u64,
     last_tick: Arc<AtomicU64>,
     wall: WallClock,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     tick_fn: &mut TickFn<'_>,
     exit_on_while_open: bool,
 ) -> Result<SegmentExit, SondaError> {
@@ -1233,7 +1305,8 @@ fn run_running_segment(
         Some(wall),
         sink,
         wrapped.as_mut(),
-    )?;
+    )
+    .await?;
 
     Ok(if saw_gone.load(Ordering::SeqCst) {
         SegmentExit::UpstreamGone
@@ -1333,33 +1406,50 @@ impl DebounceState {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
     use crate::schedule::{BurstWindow, GapWindow};
 
-    struct NullSink;
-    impl Sink for NullSink {
-        fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
-            Ok(())
-        }
-        fn flush(&mut self) -> Result<(), SondaError> {
-            Ok(())
-        }
-    }
+    type WriteLog = Arc<Mutex<Vec<Vec<u8>>>>;
 
-    struct CapturingSink {
-        writes: Vec<Vec<u8>>,
+    /// Shared-buffer test sink. Owns nothing; the `Arc<Mutex<...>>` handles
+    /// let tests inspect outcomes after the runner has moved the sink in
+    /// and out of `spawn_blocking`.
+    struct SharedSink {
+        writes: WriteLog,
         fail_at: Option<usize>,
     }
-    impl Sink for CapturingSink {
+
+    fn shared_sink() -> (Box<dyn Sink>, WriteLog) {
+        let writes: WriteLog = Arc::new(Mutex::new(Vec::new()));
+        let sink = SharedSink {
+            writes: Arc::clone(&writes),
+            fail_at: None,
+        };
+        (Box::new(sink) as Box<dyn Sink>, writes)
+    }
+
+    fn shared_sink_failing(fail_at: usize) -> (Box<dyn Sink>, WriteLog) {
+        let writes: WriteLog = Arc::new(Mutex::new(Vec::new()));
+        let sink = SharedSink {
+            writes: Arc::clone(&writes),
+            fail_at: Some(fail_at),
+        };
+        (Box::new(sink) as Box<dyn Sink>, writes)
+    }
+
+    impl Sink for SharedSink {
         fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+            let mut writes = self.writes.lock().expect("shared sink mutex poisoned");
             if let Some(n) = self.fail_at {
-                if self.writes.len() == n {
+                if writes.len() == n {
                     return Err(SondaError::Sink(std::io::Error::other(
                         "capturing sink test failure",
                     )));
                 }
             }
-            self.writes.push(data.to_vec());
+            writes.push(data.to_vec());
             Ok(())
         }
         fn flush(&mut self) -> Result<(), SondaError> {
@@ -1367,44 +1457,88 @@ mod tests {
         }
     }
 
-    #[test]
-    fn drain_writes_preserves_command_order() {
-        let mut sink = CapturingSink {
-            writes: Vec::new(),
-            fail_at: None,
-        };
+    fn null_sink() -> Box<dyn Sink> {
+        Box::new(NullSink) as Box<dyn Sink>
+    }
+
+    #[tokio::test]
+    async fn drain_writes_preserves_command_order() {
+        let (mut sink, writes) = shared_sink();
         let mut output = TickOutput::default();
         output.writes.push(WriteCommand::Bytes(b"first".to_vec()));
         output.writes.push(WriteCommand::Bytes(b"second".to_vec()));
         output.writes.push(WriteCommand::Bytes(b"third".to_vec()));
-        let delivered = drain_writes(&mut output, &mut sink).expect("drain must succeed");
+        let delivered = drain_writes(&mut output, &mut sink)
+            .await
+            .expect("drain must succeed");
+        let captured = writes.lock().unwrap().clone();
         assert_eq!(
-            sink.writes,
+            captured,
             vec![b"first".to_vec(), b"second".to_vec(), b"third".to_vec()]
         );
         assert!(output.writes.is_empty(), "queue must be empty after drain");
         assert_eq!(delivered, Some(true));
     }
 
-    #[test]
-    fn drain_writes_short_circuits_on_sink_error() {
-        let mut sink = CapturingSink {
-            writes: Vec::new(),
-            fail_at: Some(1),
-        };
+    #[tokio::test]
+    async fn drain_writes_short_circuits_on_sink_error() {
+        let (mut sink, writes) = shared_sink_failing(1);
         let mut output = TickOutput::default();
         output.writes.push(WriteCommand::Bytes(b"first".to_vec()));
         output.writes.push(WriteCommand::Bytes(b"second".to_vec()));
         output.writes.push(WriteCommand::Bytes(b"third".to_vec()));
-        let result = drain_writes(&mut output, &mut sink);
+        let result = drain_writes(&mut output, &mut sink).await;
         assert!(
             result.is_err(),
             "sink error must propagate from drain_writes"
         );
         assert_eq!(
-            sink.writes,
+            *writes.lock().unwrap(),
             vec![b"first".to_vec()],
             "only writes before the error must reach the sink"
+        );
+    }
+
+    /// A spawn_blocking task that panics surfaces as RuntimeError::TaskPanicked.
+    struct PanicSink;
+
+    impl Sink for PanicSink {
+        fn write(&mut self, _data: &[u8]) -> Result<(), SondaError> {
+            panic!("synthetic sink panic");
+        }
+        fn flush(&mut self) -> Result<(), SondaError> {
+            panic!("synthetic flush panic");
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_writes_panic_in_sink_propagates_as_task_panicked() {
+        let mut sink: Box<dyn Sink> = Box::new(PanicSink);
+        let mut output = TickOutput::default();
+        output
+            .writes
+            .push(WriteCommand::Bytes(b"panic-me".to_vec()));
+        let result = drain_writes(&mut output, &mut sink).await;
+        assert!(
+            matches!(
+                result,
+                Err(SondaError::Runtime(RuntimeError::TaskPanicked(_)))
+            ),
+            "spawn_blocking panic must surface as TaskPanicked, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalize_sink_panic_in_flush_propagates_as_task_panicked() {
+        let mut sink: Box<dyn Sink> = Box::new(PanicSink);
+        let schedule = minimal_schedule(None);
+        let result = finalize_sink(&schedule, None, &mut sink, Ok(())).await;
+        assert!(
+            matches!(
+                result,
+                Err(SondaError::Runtime(RuntimeError::TaskPanicked(_)))
+            ),
+            "flush panic must surface as TaskPanicked, got: {result:?}"
         );
     }
 
@@ -1439,8 +1573,8 @@ mod tests {
     // ---- Basic loop: runs for duration, emits events -------------------------
 
     /// The loop emits events at the configured rate for the configured duration.
-    #[test]
-    fn loop_emits_events_for_duration() {
+    #[tokio::test]
+    async fn loop_emits_events_for_duration() {
         let schedule = minimal_schedule(Some(Duration::from_millis(500)));
 
         let mut event_count: u64 = 0;
@@ -1455,14 +1589,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             20.0, // 20 events/sec for 500ms = ~10 events
             None,
             None,
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         assert!(
@@ -1478,8 +1614,8 @@ mod tests {
     // ---- Shutdown flag: stops the loop early --------------------------------
 
     /// Clearing the shutdown flag stops the loop before duration expires.
-    #[test]
-    fn loop_stops_on_shutdown_flag() {
+    #[tokio::test]
+    async fn loop_stops_on_shutdown_flag() {
         use std::sync::atomic::AtomicBool;
 
         let schedule = minimal_schedule(None); // indefinite
@@ -1504,14 +1640,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             Some(shutdown_arc.as_ref()),
             None,
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         handle.join().expect("thread must complete");
@@ -1525,8 +1663,8 @@ mod tests {
     // ---- Gap window: suppresses events during gap ---------------------------
 
     /// Events are suppressed during a gap window.
-    #[test]
-    fn loop_suppresses_events_during_gap() {
+    #[tokio::test]
+    async fn loop_suppresses_events_during_gap() {
         let schedule = ParsedSchedule {
             total_duration: Some(Duration::from_secs(2)),
             gap_window: Some(GapWindow {
@@ -1553,7 +1691,9 @@ mod tests {
             })
         };
 
-        run_schedule_loop(&schedule, 100.0, None, None, &mut NullSink, &mut tick_fn)
+        let mut sink = null_sink();
+        run_schedule_loop(&schedule, 100.0, None, None, &mut sink, &mut tick_fn)
+            .await
             .expect("loop must succeed");
 
         // Only ~100 events from the first 1s before the gap kicks in.
@@ -1566,8 +1706,8 @@ mod tests {
     // ---- Burst window: increases event rate ---------------------------------
 
     /// Burst window increases the effective rate.
-    #[test]
-    fn loop_increases_rate_during_burst() {
+    #[tokio::test]
+    async fn loop_increases_rate_during_burst() {
         let schedule = ParsedSchedule {
             total_duration: Some(Duration::from_secs(1)),
             gap_window: None,
@@ -1595,7 +1735,9 @@ mod tests {
             })
         };
 
-        run_schedule_loop(&schedule, 10.0, None, None, &mut NullSink, &mut tick_fn)
+        let mut sink = null_sink();
+        run_schedule_loop(&schedule, 10.0, None, None, &mut sink, &mut tick_fn)
+            .await
             .expect("loop must succeed");
 
         // Without burst: ~10 events. With 5x burst: ~50 events.
@@ -1608,8 +1750,8 @@ mod tests {
     // ---- Stats tracking: updates stats arc ----------------------------------
 
     /// Stats are updated correctly when a stats arc is provided.
-    #[test]
-    fn loop_updates_stats() {
+    #[tokio::test]
+    async fn loop_updates_stats() {
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
@@ -1623,14 +1765,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
@@ -1649,8 +1793,8 @@ mod tests {
     // ---- Stats tracking: metric events pushed to buffer ---------------------
 
     /// When the tick callback returns a MetricEvent, it is pushed to the stats buffer.
-    #[test]
-    fn loop_pushes_metric_events_to_stats_buffer() {
+    #[tokio::test]
+    async fn loop_pushes_metric_events_to_stats_buffer() {
         use crate::model::metric::{Labels, MetricEvent};
 
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
@@ -1669,14 +1813,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
@@ -1689,8 +1835,8 @@ mod tests {
     // ---- Tick context: spike windows are passed to callback -----------------
 
     /// The tick callback receives spike windows in the context.
-    #[test]
-    fn loop_passes_spike_windows_to_tick_fn() {
+    #[tokio::test]
+    async fn loop_passes_spike_windows_to_tick_fn() {
         use crate::config::SpikeStrategy;
         use crate::schedule::CardinalitySpikeWindow;
 
@@ -1727,7 +1873,9 @@ mod tests {
             })
         };
 
-        run_schedule_loop(&schedule, 100.0, None, None, &mut NullSink, &mut tick_fn)
+        let mut sink = null_sink();
+        run_schedule_loop(&schedule, 100.0, None, None, &mut sink, &mut tick_fn)
+            .await
             .expect("loop must succeed");
 
         assert!(
@@ -1738,8 +1886,8 @@ mod tests {
 
     // ---- Error propagation: encoder errors propagate regardless of policy ----
 
-    #[test]
-    fn loop_propagates_encoder_error_under_warn_policy() {
+    #[tokio::test]
+    async fn loop_propagates_encoder_error_under_warn_policy() {
         let schedule = minimal_schedule(Some(Duration::from_secs(10)));
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
@@ -1751,7 +1899,8 @@ mod tests {
             )))
         };
 
-        let result = run_schedule_loop(&schedule, 10.0, None, None, &mut NullSink, &mut tick_fn);
+        let mut sink = null_sink();
+        let result = run_schedule_loop(&schedule, 10.0, None, None, &mut sink, &mut tick_fn).await;
 
         assert!(
             matches!(result, Err(SondaError::Encoder(_))),
@@ -1759,8 +1908,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn loop_propagates_sink_error_under_fail_policy() {
+    #[tokio::test]
+    async fn loop_propagates_sink_error_under_fail_policy() {
         let mut schedule = minimal_schedule(Some(Duration::from_secs(10)));
         schedule.on_sink_error = OnSinkError::Fail;
 
@@ -1771,7 +1920,8 @@ mod tests {
             Err(SondaError::Sink(std::io::Error::other("test error")))
         };
 
-        let result = run_schedule_loop(&schedule, 10.0, None, None, &mut NullSink, &mut tick_fn);
+        let mut sink = null_sink();
+        let result = run_schedule_loop(&schedule, 10.0, None, None, &mut sink, &mut tick_fn).await;
 
         assert!(
             matches!(result, Err(SondaError::Sink(_))),
@@ -1779,8 +1929,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn fail_policy_records_stats_before_propagating() {
+    #[tokio::test]
+    async fn fail_policy_records_stats_before_propagating() {
         let mut schedule = minimal_schedule(Some(Duration::from_secs(10)));
         schedule.on_sink_error = OnSinkError::Fail;
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
@@ -1795,14 +1945,16 @@ mod tests {
             )))
         };
 
+        let mut sink = null_sink();
         let result = run_schedule_loop(
             &schedule,
             10.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
-        );
+        )
+        .await;
 
         assert!(
             matches!(result, Err(SondaError::Sink(_))),
@@ -1832,8 +1984,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn loop_swallows_sink_error_under_warn_policy_and_continues() {
+    #[tokio::test]
+    async fn loop_swallows_sink_error_under_warn_policy_and_continues() {
         // 200ms run with rate=50: ~10 ticks. All return sink errors. Loop
         // must complete without propagating.
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
@@ -1845,7 +1997,8 @@ mod tests {
             Err(SondaError::Sink(std::io::Error::other("transient")))
         };
 
-        let result = run_schedule_loop(&schedule, 50.0, None, None, &mut NullSink, &mut tick_fn);
+        let mut sink = null_sink();
+        let result = run_schedule_loop(&schedule, 50.0, None, None, &mut sink, &mut tick_fn).await;
 
         assert!(
             result.is_ok(),
@@ -1853,8 +2006,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn warn_policy_updates_sink_failure_stats() {
+    #[tokio::test]
+    async fn warn_policy_updates_sink_failure_stats() {
         let schedule = minimal_schedule(Some(Duration::from_millis(150)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
@@ -1868,14 +2021,16 @@ mod tests {
             )))
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("warn policy must complete");
 
         let st = stats.read().expect("stats lock");
@@ -1895,8 +2050,8 @@ mod tests {
         assert!(st.errors > 0, "errors counter must increment too");
     }
 
-    #[test]
-    fn alternating_ok_err_resets_consecutive_failures() {
+    #[tokio::test]
+    async fn alternating_ok_err_resets_consecutive_failures() {
         let schedule = minimal_schedule(Some(Duration::from_millis(300)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
         let mut counter: u64 = 0;
@@ -1916,14 +2071,16 @@ mod tests {
             }
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("warn must succeed");
 
         let st = stats.read().expect("stats lock");
@@ -1937,8 +2094,8 @@ mod tests {
         assert!(st.last_successful_write_at.is_some());
     }
 
-    #[test]
-    fn buffered_write_does_not_update_delivery_health_stats() {
+    #[tokio::test]
+    async fn buffered_write_does_not_update_delivery_health_stats() {
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
@@ -1952,14 +2109,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         let st = stats.read().expect("stats lock");
@@ -1981,8 +2140,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn delivered_write_updates_delivery_health_stats() {
+    #[tokio::test]
+    async fn delivered_write_updates_delivery_health_stats() {
         let schedule = minimal_schedule(Some(Duration::from_millis(200)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
@@ -1996,14 +2155,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         let st = stats.read().expect("stats lock");
@@ -2076,7 +2237,14 @@ mod tests {
             }
         };
 
-        let result = run_schedule_loop(&schedule, 30.0, None, None, &mut NullSink, &mut tick_fn);
+        let mut sink = null_sink();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(run_schedule_loop(
+            &schedule, 30.0, None, None, &mut sink, &mut tick_fn,
+        ));
 
         match expected {
             PolicyOutcome::Ok => assert!(result.is_ok(), "must complete: {result:?}"),
@@ -2141,8 +2309,8 @@ mod tests {
 
     // ---- Contract: TickResult fields ----------------------------------------
 
-    #[test]
-    fn run_schedule_loop_with_initial_tick_seeds_first_tick_value() {
+    #[tokio::test]
+    async fn run_schedule_loop_with_initial_tick_seeds_first_tick_value() {
         let schedule = minimal_schedule(Some(Duration::from_millis(150)));
         let observed_first = std::sync::Mutex::new(None::<u64>);
 
@@ -2160,6 +2328,7 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop_with_initial_tick(
             &schedule,
             50.0,
@@ -2168,9 +2337,10 @@ mod tests {
             30,
             None,
             None,
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         assert_eq!(
@@ -2180,8 +2350,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn run_schedule_loop_with_initial_tick_reports_last_tick() {
+    #[tokio::test]
+    async fn run_schedule_loop_with_initial_tick_reports_last_tick() {
         let schedule = minimal_schedule(Some(Duration::from_millis(150)));
         let last_tick = AtomicU64::new(0);
 
@@ -2195,6 +2365,7 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop_with_initial_tick(
             &schedule,
             50.0,
@@ -2203,9 +2374,10 @@ mod tests {
             10,
             Some(&last_tick),
             None,
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         let final_tick = last_tick.load(Ordering::SeqCst);
@@ -2226,8 +2398,8 @@ mod tests {
         assert!(result.delivered);
     }
 
-    #[test]
-    fn events_buf_capacity_does_not_grow_under_metrics_workload() {
+    #[tokio::test]
+    async fn events_buf_capacity_does_not_grow_under_metrics_workload() {
         use crate::model::metric::{Labels, MetricEvent};
         use std::cell::Cell;
 
@@ -2266,14 +2438,16 @@ mod tests {
             })
         };
 
+        let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
             50.0,
             None,
             Some(Arc::clone(&stats)),
-            &mut NullSink,
+            &mut sink,
             &mut tick_fn,
         )
+        .await
         .expect("loop must succeed");
 
         let st = stats.read().expect("lock");

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -1,9 +1,10 @@
 //! Shared schedule loop for metrics, logs, histograms, and summaries.
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, RwLock};
-use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use tokio_util::sync::CancellationToken;
 
 use crate::compiler::{DelayClause, UnresolvedBehavior};
 use crate::config::validate::StartTime;
@@ -131,6 +132,7 @@ pub(crate) type TickFn<'a> = dyn FnMut(
         &mut TickOutput,
         &mut Vec<MetricEvent>,
     ) -> Result<TickResult, SondaError>
+    + Send
     + 'a;
 
 /// Scenario-level wall-clock anchor: the resolved emission-time base plus the
@@ -187,19 +189,19 @@ pub enum CloseSignal {
 /// transition. Closures push markers into the supplied [`TickOutput`].
 pub type CloseEmitFn = Box<dyn FnMut(&mut TickOutput) -> Result<(), SondaError> + Send>;
 
-/// Run the shared schedule loop until duration expires or shutdown is
+/// Run the shared schedule loop until duration expires or cancellation is
 /// signalled, then flush the sink and apply the sink-error policy.
 pub(crate) async fn run_schedule_loop(
     schedule: &ParsedSchedule,
     rate: f64,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     sink: &mut Box<dyn Sink>,
     tick_fn: &mut TickFn<'_>,
 ) -> Result<(), SondaError> {
     let stats_for_flush = stats.clone();
     let loop_result = run_schedule_loop_with_initial_tick(
-        schedule, rate, shutdown, stats, 0, None, None, sink, tick_fn,
+        schedule, rate, cancel, stats, 0, None, None, sink, tick_fn,
     )
     .await;
     finalize_sink(schedule, stats_for_flush.as_ref(), sink, loop_result).await
@@ -227,7 +229,7 @@ async fn finalize_sink(
 pub(crate) async fn run_schedule_loop_with_initial_tick(
     schedule: &ParsedSchedule,
     rate: f64,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     initial_tick: u64,
     last_tick_out: Option<&AtomicU64>,
@@ -260,11 +262,8 @@ pub(crate) async fn run_schedule_loop_with_initial_tick(
     };
 
     loop {
-        // Check shutdown flag first — highest priority exit path.
-        if let Some(flag) = shutdown {
-            if !flag.load(Ordering::SeqCst) {
-                break;
-            }
+        if cancel.is_cancelled() {
+            break;
         }
 
         let elapsed = start.elapsed();
@@ -289,7 +288,7 @@ pub(crate) async fn run_schedule_loop_with_initial_tick(
                 }
                 let sleep_for = time_until_gap_end(elapsed, gap);
                 if sleep_for > Duration::ZERO {
-                    thread::sleep(sleep_for);
+                    tokio::time::sleep(sleep_for).await;
                 }
                 // After sleeping through the gap, reset the deadline so we
                 // don't try to catch up for suppressed events. Re-derive
@@ -324,7 +323,7 @@ pub(crate) async fn run_schedule_loop_with_initial_tick(
         // Deadline-based rate control.
         let now = Instant::now();
         if now < next_deadline {
-            thread::sleep(next_deadline - now);
+            tokio::time::sleep(next_deadline - now).await;
         }
 
         // Invoke the signal-specific tick callback.
@@ -651,7 +650,7 @@ impl GateContext {
 pub(crate) async fn gated_loop(
     schedule: &ParsedSchedule,
     rate: f64,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     mut gate_ctx: GateContext,
     sink: &mut Box<dyn Sink>,
@@ -663,7 +662,7 @@ pub(crate) async fn gated_loop(
     let body_result = gated_loop_body(
         schedule,
         rate,
-        shutdown,
+        cancel,
         stats.as_ref(),
         &mut gate_ctx,
         &mut close_warn_limiter,
@@ -696,7 +695,7 @@ pub(crate) async fn gated_loop(
 async fn gated_loop_body(
     schedule: &ParsedSchedule,
     rate: f64,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<&Arc<RwLock<ScenarioStats>>>,
     gate_ctx: &mut GateContext,
     close_warn_limiter: &mut SinkErrorRateLimiter,
@@ -733,7 +732,7 @@ async fn gated_loop_body(
     write_state(stats, state, paused_zero_rate);
 
     loop {
-        if shutdown_requested(shutdown) {
+        if cancel.is_cancelled() {
             return Ok(LoopExit::Shutdown);
         }
         if duration_expired(schedule, started_at) {
@@ -744,7 +743,14 @@ async fn gated_loop_body(
             ScenarioState::Pending => {
                 if !after_satisfied {
                     let wait = remaining_until(schedule, started_at, PAUSED_POLL_INTERVAL);
-                    match gate_ctx.gate_rx.recv_edge_timeout(wait).await {
+                    let edge = tokio::select! {
+                        biased;
+                        _ = cancel.cancelled() => {
+                            return Ok(LoopExit::Shutdown);
+                        }
+                        e = gate_ctx.gate_rx.recv_edge_timeout(wait) => e,
+                    };
+                    match edge {
                         Some(GateEdge::AfterFired) => {
                             after_satisfied = true;
                         }
@@ -785,15 +791,13 @@ async fn gated_loop_body(
                 }
             }
             ScenarioState::Running => {
-                let segment_running = Arc::new(AtomicBool::new(true));
                 let last_tick = Arc::new(AtomicU64::new(next_tick));
                 let exit = run_running_segment(
                     schedule,
                     rate,
-                    shutdown,
+                    cancel,
                     stats.cloned(),
                     gate_ctx,
-                    &segment_running,
                     next_tick,
                     Arc::clone(&last_tick),
                     wall,
@@ -804,7 +808,7 @@ async fn gated_loop_body(
                 .await?;
                 next_tick = last_tick.load(Ordering::SeqCst);
 
-                if shutdown_requested(shutdown) {
+                if cancel.is_cancelled() {
                     return Ok(LoopExit::Shutdown);
                 }
                 if duration_expired(schedule, started_at) {
@@ -829,10 +833,8 @@ async fn gated_loop_body(
                     continue;
                 }
                 if exit == SegmentExit::WhileClose
-                    && !debounce_close_to_paused(
-                        schedule, started_at, shutdown, gate_ctx, &debounce,
-                    )
-                    .await
+                    && !debounce_close_to_paused(schedule, started_at, cancel, gate_ctx, &debounce)
+                        .await
                 {
                     while_open = true;
                     continue;
@@ -863,7 +865,13 @@ async fn gated_loop_body(
                     wakeup = wakeup.min(remaining);
                 }
 
-                let recv = gate_ctx.gate_rx.recv_edge_timeout(wakeup).await;
+                let recv = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        return Ok(LoopExit::Shutdown);
+                    }
+                    r = gate_ctx.gate_rx.recv_edge_timeout(wakeup) => r,
+                };
                 let now = Instant::now();
                 match recv {
                     Some(GateEdge::WhileOpen) => {
@@ -908,15 +916,13 @@ async fn gated_loop_body(
                 let mode = gate_ctx.if_unresolved.unwrap_or_default();
                 match mode {
                     UnresolvedBehavior::Open => {
-                        let segment_running = Arc::new(AtomicBool::new(true));
                         let last_tick = Arc::new(AtomicU64::new(next_tick));
                         let exit = run_running_segment(
                             schedule,
                             rate,
-                            shutdown,
+                            cancel,
                             stats.cloned(),
                             gate_ctx,
-                            &segment_running,
                             next_tick,
                             Arc::clone(&last_tick),
                             wall,
@@ -927,7 +933,7 @@ async fn gated_loop_body(
                         .await?;
                         next_tick = last_tick.load(Ordering::SeqCst);
 
-                        if shutdown_requested(shutdown) {
+                        if cancel.is_cancelled() {
                             return Ok(LoopExit::Shutdown);
                         }
                         if duration_expired(schedule, started_at) {
@@ -964,7 +970,14 @@ async fn gated_loop_body(
                     }
                     UnresolvedBehavior::Closed | UnresolvedBehavior::Pending => {
                         let wakeup = remaining_until(schedule, started_at, PAUSED_POLL_INTERVAL);
-                        match gate_ctx.gate_rx.recv_edge_timeout(wakeup).await {
+                        let recv = tokio::select! {
+                            biased;
+                            _ = cancel.cancelled() => {
+                                return Ok(LoopExit::Shutdown);
+                            }
+                            r = gate_ctx.gate_rx.recv_edge_timeout(wakeup) => r,
+                        };
+                        match recv {
                             Some(GateEdge::WhileOpen) => {
                                 while_open = true;
                                 state = ScenarioState::Pending;
@@ -1011,10 +1024,6 @@ fn close_target_state(
     } else {
         ScenarioState::Paused
     }
-}
-
-fn shutdown_requested(shutdown: Option<&AtomicBool>) -> bool {
-    shutdown.map(|f| !f.load(Ordering::SeqCst)).unwrap_or(false)
 }
 
 fn duration_expired(schedule: &ParsedSchedule, started_at: Instant) -> bool {
@@ -1112,7 +1121,7 @@ enum LoopExit {
 async fn debounce_close_to_paused(
     schedule: &ParsedSchedule,
     started_at: Instant,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     gate_ctx: &mut GateContext,
     debounce: &DebounceState,
 ) -> bool {
@@ -1122,7 +1131,7 @@ async fn debounce_close_to_paused(
 
     let deadline = Instant::now() + debounce.delay_close;
     loop {
-        if shutdown_requested(shutdown) || duration_expired(schedule, started_at) {
+        if cancel.is_cancelled() || duration_expired(schedule, started_at) {
             return true;
         }
         let now = Instant::now();
@@ -1133,7 +1142,12 @@ async fn debounce_close_to_paused(
         if let Some(remaining) = remaining_duration(schedule, started_at) {
             wait = wait.min(remaining);
         }
-        match gate_ctx.gate_rx.recv_edge_timeout(wait).await {
+        let recv = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return true,
+            r = gate_ctx.gate_rx.recv_edge_timeout(wait) => r,
+        };
+        match recv {
             Some(GateEdge::WhileOpen) => return false,
             Some(GateEdge::WhileClose) => {}
             Some(GateEdge::AfterFired) => {}
@@ -1145,7 +1159,7 @@ async fn debounce_close_to_paused(
 
 /// Run one `Running` segment: a fresh `run_schedule_loop` with a wrapped
 /// `tick_fn` that polls the gate channel after every successful tick.
-/// On `WhileClose` the segment_running flag is cleared so the inner loop
+/// On `WhileClose` the segment cancellation token fires so the inner loop
 /// exits at its top-of-loop shutdown check.
 ///
 /// `initial_tick` seeds the inner loop's tick counter on resume; `last_tick`
@@ -1155,10 +1169,9 @@ async fn debounce_close_to_paused(
 async fn run_running_segment(
     schedule: &ParsedSchedule,
     rate: f64,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: &mut GateContext,
-    segment_running: &Arc<AtomicBool>,
     initial_tick: u64,
     last_tick: Arc<AtomicU64>,
     wall: WallClock,
@@ -1166,18 +1179,11 @@ async fn run_running_segment(
     tick_fn: &mut TickFn<'_>,
     exit_on_while_open: bool,
 ) -> Result<SegmentExit, SondaError> {
-    let saw_close = Arc::new(AtomicBool::new(false));
-    let saw_gone = Arc::new(AtomicBool::new(false));
-    let saw_open = Arc::new(AtomicBool::new(false));
+    let segment_cancel = cancel.child_token();
+    let observed: Arc<AtomicU8> = Arc::new(AtomicU8::new(SEGMENT_EXIT_NONE));
 
-    // The inner loop's `shutdown` parameter wants "true = keep running."
-    // We pass our segment flag, and we additionally drain the user
-    // shutdown into the segment flag inside the wrapped tick.
-    let user_shutdown_for_wrapper = shutdown;
-    let segment_for_wrapper = Arc::clone(segment_running);
-    let saw_close_for_wrapper = Arc::clone(&saw_close);
-    let saw_gone_for_wrapper = Arc::clone(&saw_gone);
-    let saw_open_for_wrapper = Arc::clone(&saw_open);
+    let segment_for_wrapper = segment_cancel.clone();
+    let observed_for_wrapper = Arc::clone(&observed);
     let gate_rx = &mut gate_ctx.gate_rx;
 
     type WrappedTick<'a> = Box<
@@ -1186,6 +1192,7 @@ async fn run_running_segment(
                 &mut TickOutput,
                 &mut Vec<MetricEvent>,
             ) -> Result<TickResult, SondaError>
+            + Send
             + 'a,
     >;
     let mut wrapped: WrappedTick<'_> = Box::new(
@@ -1195,33 +1202,23 @@ async fn run_running_segment(
               -> Result<TickResult, SondaError> {
             let outcome = tick_fn(ctx, output, events_buf);
 
-            // Poll for gate edges after the tick. On WhileClose, break out.
             while let Some(edge) = gate_rx.try_recv() {
                 match edge {
                     GateEdge::WhileClose => {
-                        saw_close_for_wrapper.store(true, Ordering::SeqCst);
-                        segment_for_wrapper.store(false, Ordering::SeqCst);
+                        observed_for_wrapper.store(SEGMENT_EXIT_WHILE_CLOSE, Ordering::SeqCst);
+                        segment_for_wrapper.cancel();
                     }
                     GateEdge::WhileOpen => {
                         if exit_on_while_open {
-                            saw_open_for_wrapper.store(true, Ordering::SeqCst);
-                            segment_for_wrapper.store(false, Ordering::SeqCst);
+                            observed_for_wrapper.store(SEGMENT_EXIT_WHILE_OPEN, Ordering::SeqCst);
+                            segment_for_wrapper.cancel();
                         }
                     }
-                    GateEdge::AfterFired => {
-                        // Already past the after gate.
-                    }
+                    GateEdge::AfterFired => {}
                     GateEdge::UpstreamGone => {
-                        saw_gone_for_wrapper.store(true, Ordering::SeqCst);
-                        segment_for_wrapper.store(false, Ordering::SeqCst);
+                        observed_for_wrapper.store(SEGMENT_EXIT_UPSTREAM_GONE, Ordering::SeqCst);
+                        segment_for_wrapper.cancel();
                     }
-                }
-            }
-
-            // Honor user shutdown immediately (don't wait for next loop iter).
-            if let Some(user) = user_shutdown_for_wrapper {
-                if !user.load(Ordering::SeqCst) {
-                    segment_for_wrapper.store(false, Ordering::SeqCst);
                 }
             }
 
@@ -1232,7 +1229,7 @@ async fn run_running_segment(
     run_schedule_loop_with_initial_tick(
         schedule,
         rate,
-        Some(segment_running.as_ref()),
+        &segment_cancel,
         stats,
         initial_tick,
         Some(last_tick.as_ref()),
@@ -1242,15 +1239,21 @@ async fn run_running_segment(
     )
     .await?;
 
-    Ok(if saw_gone.load(Ordering::SeqCst) {
-        SegmentExit::UpstreamGone
-    } else if saw_close.load(Ordering::SeqCst) {
-        SegmentExit::WhileClose
-    } else if saw_open.load(Ordering::SeqCst) {
-        SegmentExit::WhileOpen
-    } else {
-        SegmentExit::ShutdownOrDuration
-    })
+    Ok(decode_segment_exit(observed.load(Ordering::SeqCst)))
+}
+
+const SEGMENT_EXIT_NONE: u8 = 0;
+const SEGMENT_EXIT_WHILE_CLOSE: u8 = 1;
+const SEGMENT_EXIT_UPSTREAM_GONE: u8 = 2;
+const SEGMENT_EXIT_WHILE_OPEN: u8 = 3;
+
+fn decode_segment_exit(code: u8) -> SegmentExit {
+    match code {
+        SEGMENT_EXIT_UPSTREAM_GONE => SegmentExit::UpstreamGone,
+        SEGMENT_EXIT_WHILE_CLOSE => SegmentExit::WhileClose,
+        SEGMENT_EXIT_WHILE_OPEN => SegmentExit::WhileOpen,
+        _ => SegmentExit::ShutdownOrDuration,
+    }
 }
 
 /// Open / close debounce timers for `while:` transitions.
@@ -1527,8 +1530,8 @@ mod tests {
         let mut sink = null_sink();
         run_schedule_loop(
             &schedule,
-            20.0, // 20 events/sec for 500ms = ~10 events
-            None,
+            20.0,
+            &CancellationToken::new(),
             None,
             &mut sink,
             &mut tick_fn,
@@ -1548,20 +1551,17 @@ mod tests {
 
     // ---- Shutdown flag: stops the loop early --------------------------------
 
-    /// Clearing the shutdown flag stops the loop before duration expires.
+    /// Cancelling the token stops the loop before duration expires.
     #[tokio::test]
-    async fn loop_stops_on_shutdown_flag() {
-        use std::sync::atomic::AtomicBool;
-
-        let schedule = minimal_schedule(None); // indefinite
+    async fn loop_stops_on_cancel() {
+        let schedule = minimal_schedule(None);
         let mut event_count: u64 = 0;
 
-        // Spawn a thread to clear the flag after 200ms.
-        let shutdown_arc = Arc::new(AtomicBool::new(true));
-        let flag_clone = Arc::clone(&shutdown_arc);
+        let cancel = CancellationToken::new();
+        let cancel_for_thread = cancel.clone();
         let handle = std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(200));
-            flag_clone.store(false, Ordering::SeqCst);
+            cancel_for_thread.cancel();
         });
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
@@ -1576,23 +1576,13 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        run_schedule_loop(
-            &schedule,
-            50.0,
-            Some(shutdown_arc.as_ref()),
-            None,
-            &mut sink,
-            &mut tick_fn,
-        )
-        .await
-        .expect("loop must succeed");
+        run_schedule_loop(&schedule, 50.0, &cancel, None, &mut sink, &mut tick_fn)
+            .await
+            .expect("loop must succeed");
 
         handle.join().expect("thread must complete");
 
-        assert!(
-            event_count > 0,
-            "some events should have been emitted before shutdown"
-        );
+        assert!(event_count > 0);
     }
 
     // ---- Gap window: suppresses events during gap ---------------------------
@@ -1627,9 +1617,16 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        run_schedule_loop(&schedule, 100.0, None, None, &mut sink, &mut tick_fn)
-            .await
-            .expect("loop must succeed");
+        run_schedule_loop(
+            &schedule,
+            100.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
+        )
+        .await
+        .expect("loop must succeed");
 
         // Only ~100 events from the first 1s before the gap kicks in.
         assert!(
@@ -1671,9 +1668,16 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        run_schedule_loop(&schedule, 10.0, None, None, &mut sink, &mut tick_fn)
-            .await
-            .expect("loop must succeed");
+        run_schedule_loop(
+            &schedule,
+            10.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
+        )
+        .await
+        .expect("loop must succeed");
 
         // Without burst: ~10 events. With 5x burst: ~50 events.
         assert!(
@@ -1704,7 +1708,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -1752,7 +1756,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -1809,9 +1813,16 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        run_schedule_loop(&schedule, 100.0, None, None, &mut sink, &mut tick_fn)
-            .await
-            .expect("loop must succeed");
+        run_schedule_loop(
+            &schedule,
+            100.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
+        )
+        .await
+        .expect("loop must succeed");
 
         assert!(
             saw_spike_windows,
@@ -1835,7 +1846,15 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        let result = run_schedule_loop(&schedule, 10.0, None, None, &mut sink, &mut tick_fn).await;
+        let result = run_schedule_loop(
+            &schedule,
+            10.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
+        )
+        .await;
 
         assert!(
             matches!(result, Err(SondaError::Encoder(_))),
@@ -1856,7 +1875,15 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        let result = run_schedule_loop(&schedule, 10.0, None, None, &mut sink, &mut tick_fn).await;
+        let result = run_schedule_loop(
+            &schedule,
+            10.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
+        )
+        .await;
 
         assert!(
             matches!(result, Err(SondaError::Sink(_))),
@@ -1884,7 +1911,7 @@ mod tests {
         let result = run_schedule_loop(
             &schedule,
             10.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -1933,7 +1960,15 @@ mod tests {
         };
 
         let mut sink = null_sink();
-        let result = run_schedule_loop(&schedule, 50.0, None, None, &mut sink, &mut tick_fn).await;
+        let result = run_schedule_loop(
+            &schedule,
+            50.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
+        )
+        .await;
 
         assert!(
             result.is_ok(),
@@ -1960,7 +1995,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -2010,7 +2045,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -2048,7 +2083,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -2094,7 +2129,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -2178,7 +2213,12 @@ mod tests {
             .build()
             .unwrap();
         let result = rt.block_on(run_schedule_loop(
-            &schedule, 30.0, None, None, &mut sink, &mut tick_fn,
+            &schedule,
+            30.0,
+            &CancellationToken::new(),
+            None,
+            &mut sink,
+            &mut tick_fn,
         ));
 
         match expected {
@@ -2267,7 +2307,7 @@ mod tests {
         run_schedule_loop_with_initial_tick(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             None,
             30,
             None,
@@ -2304,7 +2344,7 @@ mod tests {
         run_schedule_loop_with_initial_tick(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             None,
             10,
             Some(&last_tick),
@@ -2336,11 +2376,10 @@ mod tests {
     #[tokio::test]
     async fn events_buf_capacity_does_not_grow_under_metrics_workload() {
         use crate::model::metric::{Labels, MetricEvent};
-        use std::cell::Cell;
 
         let schedule = minimal_schedule(Some(Duration::from_millis(500)));
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-        let first_ptr: Cell<Option<usize>> = Cell::new(None);
+        let mut first_ptr: Option<usize> = None;
 
         let mut tick_fn = |_ctx: &TickContext<'_>,
                            _output: &mut TickOutput,
@@ -2348,23 +2387,12 @@ mod tests {
          -> Result<TickResult, SondaError> {
             let event =
                 MetricEvent::new("test".to_string(), 1.0, Labels::default()).expect("valid name");
-            assert_eq!(
-                events_buf.len(),
-                0,
-                "events_buf must be cleared by the loop before each tick"
-            );
-            assert_eq!(
-                events_buf.capacity(),
-                16,
-                "events_buf capacity must stay at the pre-allocated 16 for a 1-event-per-tick workload"
-            );
+            assert_eq!(events_buf.len(), 0);
+            assert_eq!(events_buf.capacity(), 16);
             let ptr = events_buf.as_ptr() as usize;
-            match first_ptr.get() {
-                None => first_ptr.set(Some(ptr)),
-                Some(p) => assert_eq!(
-                    ptr, p,
-                    "events_buf backing allocation must be reused across ticks"
-                ),
+            match first_ptr {
+                None => first_ptr = Some(ptr),
+                Some(p) => assert_eq!(ptr, p, "events_buf backing allocation must be reused"),
             }
             events_buf.push(event);
             Ok(TickResult {
@@ -2377,7 +2405,7 @@ mod tests {
         run_schedule_loop(
             &schedule,
             50.0,
-            None,
+            &CancellationToken::new(),
             Some(Arc::clone(&stats)),
             &mut sink,
             &mut tick_fn,
@@ -2390,10 +2418,7 @@ mod tests {
             st.total_events > 1,
             "loop must have executed multiple ticks to exercise the buffer reuse"
         );
-        assert!(
-            first_ptr.get().is_some(),
-            "tick_fn must have observed at least one events_buf pointer"
-        );
+        assert!(first_ptr.is_some());
     }
 
     #[test]

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -3,19 +3,22 @@
 //! Upstream metric runners publish per-tick values via [`GateBus::tick`].
 //! Downstream scenarios subscribe with a [`SubscriptionSpec`] and receive
 //! [`GateEdge`] events on every gate-state crossing. Each kind (`after`,
-//! `while`) gets its own `mpsc::sync_channel(1)` with replace-on-full
-//! semantics — a paused downstream's stale edge is overwritten by the
-//! latest, keeping memory flat regardless of upstream chatter.
+//! `while`) gets its own `tokio::sync::watch` channel — the latest edge
+//! always wins, keeping memory flat regardless of upstream chatter.
 
-use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::cell::RefCell;
 use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::{Duration, Instant};
+
+use tokio::sync::watch;
 
 use crate::compiler::{UnresolvedBehavior, WhileOp};
 use crate::schedule::stats::ScenarioStats;
 
 /// Sender end of a per-subscriber gate-edge channel.
-pub type GateEdgeSender = SyncSender<GateEdge>;
+pub type GateEdgeSender = watch::Sender<Option<GateEdge>>;
+
+type GateEdgeReceiver = watch::Receiver<Option<GateEdge>>;
 
 /// Direction of a strict comparison used by an `after:` clause.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,32 +70,46 @@ pub struct InitialState {
 
 /// Receive end of a subscription.
 ///
-/// Carries up to two `mpsc::sync_channel(1)` receivers (one per edge
-/// kind). Both receivers are polled by `try_recv` / `recv_timeout`; per
-/// kind, only the latest edge is buffered.
+/// Carries up to two `tokio::sync::watch` receivers (one per edge kind).
+/// Both receivers are polled by `try_recv` / `recv_timeout`; per kind, only
+/// the latest edge is buffered.
 pub struct GateReceiver {
-    after_rx: Option<Receiver<GateEdge>>,
-    while_rx: Option<Receiver<GateEdge>>,
+    after_rx: Option<Mutex<EdgeSlot>>,
+    while_rx: Option<Mutex<EdgeSlot>>,
+}
+
+struct EdgeSlot {
+    rx: GateEdgeReceiver,
+    drained_after_close: bool,
+}
+
+impl EdgeSlot {
+    fn new(rx: GateEdgeReceiver) -> Self {
+        Self {
+            rx,
+            drained_after_close: false,
+        }
+    }
 }
 
 impl GateReceiver {
     #[cfg(feature = "config")]
-    pub(crate) fn from_while_rx(rx: Receiver<GateEdge>) -> Self {
+    pub(crate) fn from_while_rx(rx: GateEdgeReceiver) -> Self {
         Self {
             after_rx: None,
-            while_rx: Some(rx),
+            while_rx: Some(Mutex::new(EdgeSlot::new(rx))),
         }
     }
 
     /// Poll both per-kind channels in priority order: after, then while.
     pub fn try_recv(&self) -> Option<GateEdge> {
-        if let Some(ref rx) = self.after_rx {
-            if let Ok(edge) = rx.try_recv() {
+        if let Some(ref m) = self.after_rx {
+            if let Some(edge) = poll_one(m) {
                 return Some(edge);
             }
         }
-        if let Some(ref rx) = self.while_rx {
-            if let Ok(edge) = rx.try_recv() {
+        if let Some(ref m) = self.while_rx {
+            if let Some(edge) = poll_one(m) {
                 return Some(edge);
             }
         }
@@ -100,25 +117,86 @@ impl GateReceiver {
     }
 
     /// Block until an edge arrives or the timeout expires.
-    ///
-    /// Polls both channels with a short interval. Returns `None` on
-    /// timeout. The polling interval is bounded by `min(timeout, 25ms)`
-    /// so the caller wakes promptly under shutdown / debounce timers.
     pub fn recv_timeout(&self, timeout: Duration) -> Option<GateEdge> {
-        let deadline = Instant::now() + timeout;
-        let poll_interval = Duration::from_millis(25);
-        loop {
-            if let Some(edge) = self.try_recv() {
-                return Some(edge);
+        if let Some(edge) = self.try_recv() {
+            return Some(edge);
+        }
+        with_thread_runtime(|rt| match rt {
+            Some(rt) => rt.block_on(self.wait_for_edge(timeout)),
+            None => std::thread::sleep(timeout),
+        });
+        self.try_recv()
+    }
+
+    async fn wait_for_edge(&self, timeout: Duration) {
+        match (self.after_rx.as_ref(), self.while_rx.as_ref()) {
+            (None, None) => tokio::time::sleep(timeout).await,
+            (Some(a), None) => {
+                let _ = tokio::time::timeout(timeout, changed_future(a)).await;
             }
-            let now = Instant::now();
-            if now >= deadline {
-                return None;
+            (None, Some(w)) => {
+                let _ = tokio::time::timeout(timeout, changed_future(w)).await;
             }
-            let chunk = (deadline - now).min(poll_interval);
-            std::thread::sleep(chunk);
+            (Some(a), Some(w)) => {
+                let _ = tokio::time::timeout(timeout, async {
+                    tokio::select! {
+                        _ = changed_future(a) => {}
+                        _ = changed_future(w) => {}
+                    }
+                })
+                .await;
+            }
         }
     }
+}
+
+fn poll_one(slot: &Mutex<EdgeSlot>) -> Option<GateEdge> {
+    let mut guard = slot.lock().unwrap_or_else(|p| p.into_inner());
+    match guard.rx.has_changed() {
+        Ok(true) => *guard.rx.borrow_and_update(),
+        Ok(false) => None,
+        Err(_) => {
+            if guard.drained_after_close {
+                return None;
+            }
+            guard.drained_after_close = true;
+            let cached = *guard.rx.borrow_and_update();
+            cached.or(Some(GateEdge::UpstreamGone))
+        }
+    }
+}
+
+async fn changed_future(rx: &Mutex<EdgeSlot>) {
+    let mut clone = {
+        let guard = rx.lock().unwrap_or_else(|p| p.into_inner());
+        guard.rx.clone()
+    };
+    let _ = clone.changed().await;
+}
+
+thread_local! {
+    static GATE_RUNTIME: RefCell<Option<tokio::runtime::Runtime>> = const { RefCell::new(None) };
+}
+
+/// Install a per-thread `current_thread` tokio runtime used by [`GateReceiver::recv_timeout`].
+pub fn install_thread_runtime() -> std::io::Result<()> {
+    GATE_RUNTIME.with(|cell| {
+        if cell.borrow().is_some() {
+            return Ok(());
+        }
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        *cell.borrow_mut() = Some(rt);
+        Ok(())
+    })
+}
+
+fn with_thread_runtime<R>(f: impl FnOnce(Option<&tokio::runtime::Runtime>) -> R) -> R {
+    GATE_RUNTIME.with(|cell| {
+        let borrow = cell.borrow();
+        f(borrow.as_ref())
+    })
 }
 
 /// Strict comparison evaluator. NaN fails closed (returns `false`).
@@ -144,8 +222,8 @@ fn after_eval(value: f64, op: AfterOpDir, threshold: f64) -> bool {
 
 struct Subscription {
     spec: SubscriptionSpec,
-    after_tx: Option<SyncSender<GateEdge>>,
-    while_tx: Option<SyncSender<GateEdge>>,
+    after_tx: Option<GateEdgeSender>,
+    while_tx: Option<GateEdgeSender>,
     after_fired: bool,
     prev_while_open: Option<bool>,
 }
@@ -192,14 +270,14 @@ impl GateBus {
         };
 
         let (after_tx, after_rx) = if spec.after.is_some() {
-            let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
-            (Some(tx), Some(rx))
+            let (tx, rx) = watch::channel::<Option<GateEdge>>(None);
+            (Some(tx), Some(Mutex::new(EdgeSlot::new(rx))))
         } else {
             (None, None)
         };
         let (while_tx, while_rx) = if spec.while_.is_some() {
-            let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
-            (Some(tx), Some(rx))
+            let (tx, rx) = watch::channel::<Option<GateEdge>>(None);
+            (Some(tx), Some(Mutex::new(EdgeSlot::new(rx))))
         } else {
             (None, None)
         };
@@ -223,7 +301,7 @@ impl GateBus {
 
         if after_already_fired {
             if let Some(ref tx) = sub.after_tx {
-                let _ = tx.try_send(GateEdge::AfterFired);
+                tx.send_replace(Some(GateEdge::AfterFired));
             }
         }
 
@@ -258,7 +336,7 @@ impl GateBus {
             } else {
                 GateEdge::WhileClose
             };
-            let _ = while_tx.try_send(edge);
+            while_tx.send_replace(Some(edge));
             (v, Some(open))
         } else {
             (f64::NAN, None)
@@ -360,28 +438,8 @@ fn bit_eq(a: f64, b: f64) -> bool {
     a.to_bits() == b.to_bits()
 }
 
-/// Replace-on-full send for a per-kind bounded(1) channel: try once,
-/// drain the stale edge if full, retry. The single-slot channel makes
-/// "latest-wins" trivial — at most one edge is in flight per kind.
-fn replace_send(tx: &SyncSender<GateEdge>, edge: GateEdge) {
-    if tx.try_send(edge).is_ok() {
-        return;
-    }
-    // Full. The receiver is the only consumer; we cannot drain from the
-    // sender side. Instead, attempt a non-blocking send again — the
-    // bounded(1) channel may have just been drained by a concurrent
-    // recv_timeout. If still full, the queued edge is the previous edge
-    // of the same kind — replacing it is the goal but std mpsc does not
-    // expose a "replace" primitive. Best-effort fallback: send blocking
-    // with a zero deadline equivalent — we drop the edge if the receiver
-    // is gone.
-    //
-    // Practically, "still full" only happens if the receiver is paused and
-    // hasn't drained — and on the next wakeup it will drain the now-stale
-    // edge anyway. The wrapper's state machine re-evaluates the gate from
-    // the bus's `last_value` on every running-segment entry, so a missed
-    // intermediate edge does not cause a permanent gate desync.
-    let _ = tx.try_send(edge);
+fn replace_send(tx: &GateEdgeSender, edge: GateEdge) {
+    tx.send_replace(Some(edge));
 }
 
 /// A downstream subscription waiting for the named upstream to register.
@@ -610,7 +668,7 @@ mod tests {
                 panic!("queue depth exceeded 1: replace-on-full broken");
             }
         }
-        assert!(count <= 1, "while: queue depth must stay ≤ 1, got {count}");
+        assert!(count <= 1, "while: queue depth must stay <= 1, got {count}");
     }
 
     #[test]
@@ -690,7 +748,22 @@ mod tests {
         check::<GateBus>();
     }
 
-    // ---- GateBusResolver: trait object-safety + no-op impl --------------------
+    #[test]
+    fn gate_receiver_is_send_and_sync() {
+        fn check<T: Send + Sync>() {}
+        check::<GateReceiver>();
+    }
+
+    #[test]
+    fn broadcast_upstream_gone_delivers_to_all_subscribers() {
+        let bus = GateBus::new();
+        bus.tick(0.0);
+        let (rx_a, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+        let (rx_b, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+        bus.broadcast_upstream_gone();
+        assert_eq!(rx_a.try_recv(), Some(GateEdge::UpstreamGone));
+        assert_eq!(rx_b.try_recv(), Some(GateEdge::UpstreamGone));
+    }
 
     struct NoOpResolver;
 

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -6,7 +6,6 @@
 //! `while`) gets its own `tokio::sync::watch` channel — the latest edge
 //! always wins, keeping memory flat regardless of upstream chatter.
 
-use std::cell::RefCell;
 use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -71,11 +70,11 @@ pub struct InitialState {
 /// Receive end of a subscription.
 ///
 /// Carries up to two `tokio::sync::watch` receivers (one per edge kind).
-/// Both receivers are polled by `try_recv` / `recv_timeout`; per kind, only
-/// the latest edge is buffered.
+/// Both receivers are polled by `try_recv` / `recv_edge_timeout`; per kind,
+/// only the latest edge is buffered.
 pub struct GateReceiver {
-    after_rx: Option<Mutex<EdgeSlot>>,
-    while_rx: Option<Mutex<EdgeSlot>>,
+    after_rx: Option<EdgeSlot>,
+    while_rx: Option<EdgeSlot>,
 }
 
 struct EdgeSlot {
@@ -90,6 +89,21 @@ impl EdgeSlot {
             drained_after_close: false,
         }
     }
+
+    fn poll(&mut self) -> Option<GateEdge> {
+        match self.rx.has_changed() {
+            Ok(true) => *self.rx.borrow_and_update(),
+            Ok(false) => None,
+            Err(_) => {
+                if self.drained_after_close {
+                    return None;
+                }
+                self.drained_after_close = true;
+                let cached = *self.rx.borrow_and_update();
+                cached.or(Some(GateEdge::UpstreamGone))
+            }
+        }
+    }
 }
 
 impl GateReceiver {
@@ -97,106 +111,64 @@ impl GateReceiver {
     pub(crate) fn from_while_rx(rx: GateEdgeReceiver) -> Self {
         Self {
             after_rx: None,
-            while_rx: Some(Mutex::new(EdgeSlot::new(rx))),
+            while_rx: Some(EdgeSlot::new(rx)),
         }
     }
 
     /// Poll both per-kind channels in priority order: after, then while.
-    pub fn try_recv(&self) -> Option<GateEdge> {
-        if let Some(ref m) = self.after_rx {
-            if let Some(edge) = poll_one(m) {
+    pub fn try_recv(&mut self) -> Option<GateEdge> {
+        if let Some(slot) = self.after_rx.as_mut() {
+            if let Some(edge) = slot.poll() {
                 return Some(edge);
             }
         }
-        if let Some(ref m) = self.while_rx {
-            if let Some(edge) = poll_one(m) {
+        if let Some(slot) = self.while_rx.as_mut() {
+            if let Some(edge) = slot.poll() {
                 return Some(edge);
             }
         }
         None
     }
 
-    /// Block until an edge arrives or the timeout expires.
-    pub fn recv_timeout(&self, timeout: Duration) -> Option<GateEdge> {
+    /// Await an edge from any subscribed channel, returning when one arrives.
+    pub async fn recv_edge(&mut self) -> Option<GateEdge> {
         if let Some(edge) = self.try_recv() {
             return Some(edge);
         }
-        with_thread_runtime(|rt| match rt {
-            Some(rt) => rt.block_on(self.wait_for_edge(timeout)),
-            None => std::thread::sleep(timeout),
-        });
+        self.wait_for_change().await;
         self.try_recv()
     }
 
-    async fn wait_for_edge(&self, timeout: Duration) {
-        match (self.after_rx.as_ref(), self.while_rx.as_ref()) {
-            (None, None) => tokio::time::sleep(timeout).await,
+    /// Await an edge until the timeout elapses; returns `None` on timeout.
+    pub async fn recv_edge_timeout(&mut self, timeout: Duration) -> Option<GateEdge> {
+        if let Some(edge) = self.try_recv() {
+            return Some(edge);
+        }
+        let _ = tokio::time::timeout(timeout, self.wait_for_change()).await;
+        self.try_recv()
+    }
+
+    async fn wait_for_change(&mut self) {
+        // Cloned watch receivers share the channel; observing a change here is
+        // visible to the owned slot's subsequent try_recv.
+        let mut after = self.after_rx.as_ref().map(|s| s.rx.clone());
+        let mut while_ = self.while_rx.as_ref().map(|s| s.rx.clone());
+        match (after.as_mut(), while_.as_mut()) {
+            (None, None) => std::future::pending::<()>().await,
             (Some(a), None) => {
-                let _ = tokio::time::timeout(timeout, changed_future(a)).await;
+                let _ = a.changed().await;
             }
             (None, Some(w)) => {
-                let _ = tokio::time::timeout(timeout, changed_future(w)).await;
+                let _ = w.changed().await;
             }
             (Some(a), Some(w)) => {
-                let _ = tokio::time::timeout(timeout, async {
-                    tokio::select! {
-                        _ = changed_future(a) => {}
-                        _ = changed_future(w) => {}
-                    }
-                })
-                .await;
+                tokio::select! {
+                    _ = a.changed() => {}
+                    _ = w.changed() => {}
+                }
             }
         }
     }
-}
-
-fn poll_one(slot: &Mutex<EdgeSlot>) -> Option<GateEdge> {
-    let mut guard = slot.lock().unwrap_or_else(|p| p.into_inner());
-    match guard.rx.has_changed() {
-        Ok(true) => *guard.rx.borrow_and_update(),
-        Ok(false) => None,
-        Err(_) => {
-            if guard.drained_after_close {
-                return None;
-            }
-            guard.drained_after_close = true;
-            let cached = *guard.rx.borrow_and_update();
-            cached.or(Some(GateEdge::UpstreamGone))
-        }
-    }
-}
-
-async fn changed_future(rx: &Mutex<EdgeSlot>) {
-    let mut clone = {
-        let guard = rx.lock().unwrap_or_else(|p| p.into_inner());
-        guard.rx.clone()
-    };
-    let _ = clone.changed().await;
-}
-
-thread_local! {
-    static GATE_RUNTIME: RefCell<Option<tokio::runtime::Runtime>> = const { RefCell::new(None) };
-}
-
-/// Install a per-thread `current_thread` tokio runtime used by [`GateReceiver::recv_timeout`].
-pub fn install_thread_runtime() -> std::io::Result<()> {
-    GATE_RUNTIME.with(|cell| {
-        if cell.borrow().is_some() {
-            return Ok(());
-        }
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()?;
-        *cell.borrow_mut() = Some(rt);
-        Ok(())
-    })
-}
-
-fn with_thread_runtime<R>(f: impl FnOnce(Option<&tokio::runtime::Runtime>) -> R) -> R {
-    GATE_RUNTIME.with(|cell| {
-        let borrow = cell.borrow();
-        f(borrow.as_ref())
-    })
 }
 
 /// Strict comparison evaluator. NaN fails closed (returns `false`).
@@ -271,13 +243,13 @@ impl GateBus {
 
         let (after_tx, after_rx) = if spec.after.is_some() {
             let (tx, rx) = watch::channel::<Option<GateEdge>>(None);
-            (Some(tx), Some(Mutex::new(EdgeSlot::new(rx))))
+            (Some(tx), Some(EdgeSlot::new(rx)))
         } else {
             (None, None)
         };
         let (while_tx, while_rx) = if spec.while_.is_some() {
             let (tx, rx) = watch::channel::<Option<GateEdge>>(None);
-            (Some(tx), Some(Mutex::new(EdgeSlot::new(rx))))
+            (Some(tx), Some(EdgeSlot::new(rx)))
         } else {
             (None, None)
         };
@@ -616,7 +588,7 @@ mod tests {
     fn while_gate_emits_open_then_close_edges() {
         let bus = GateBus::new();
         bus.tick(0.0);
-        let (rx, _init) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+        let (mut rx, _init) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
         assert!(rx.try_recv().is_none());
 
         bus.drive_value(1.0);
@@ -631,7 +603,7 @@ mod tests {
     fn after_fires_once_then_stays_silent() {
         let bus = GateBus::new();
         bus.tick(0.0);
-        let (rx, _init) = bus.subscribe(after_spec(AfterOpDir::GreaterThan, 1.0));
+        let (mut rx, _init) = bus.subscribe(after_spec(AfterOpDir::GreaterThan, 1.0));
         bus.drive_value(0.5);
         assert!(rx.try_recv().is_none());
         bus.drive_value(2.0);
@@ -647,7 +619,7 @@ mod tests {
     fn after_fires_immediately_when_threshold_already_crossed_at_subscription() {
         let bus = GateBus::new();
         bus.tick(5.0);
-        let (rx, init) = bus.subscribe(after_spec(AfterOpDir::GreaterThan, 1.0));
+        let (mut rx, init) = bus.subscribe(after_spec(AfterOpDir::GreaterThan, 1.0));
         assert!(init.after_already_fired);
         assert_eq!(rx.try_recv(), Some(GateEdge::AfterFired));
     }
@@ -656,7 +628,7 @@ mod tests {
     fn replace_on_full_keeps_only_latest_edge() {
         let bus = GateBus::new();
         bus.tick(0.0);
-        let (rx, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+        let (mut rx, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
         for i in 0..10 {
             bus.drive_value(if i % 2 == 0 { 1.0 } else { 0.0 });
         }
@@ -674,7 +646,7 @@ mod tests {
     #[test]
     fn unchanged_value_short_circuits() {
         let bus = GateBus::new();
-        let (rx, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+        let (mut rx, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
         bus.tick(1.0);
         let _ = rx.try_recv();
         for _ in 0..100 {
@@ -686,7 +658,7 @@ mod tests {
     #[test]
     fn nan_tick_does_not_open_gate() {
         let bus = GateBus::new();
-        let (rx, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+        let (mut rx, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
         bus.tick(f64::NAN);
         assert!(rx.try_recv().is_none());
     }
@@ -705,7 +677,7 @@ mod tests {
                 threshold: 0.0,
             }),
         };
-        let (rx, _init) = bus.subscribe(spec);
+        let (mut rx, _init) = bus.subscribe(spec);
 
         bus.drive_value(1.0);
         bus.drive_value(10.0);
@@ -719,19 +691,86 @@ mod tests {
     }
 
     #[test]
-    fn recv_timeout_returns_none_on_no_edge() {
-        let bus = GateBus::new();
-        let (rx, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
-        let r = rx.recv_timeout(Duration::from_millis(40));
-        assert!(r.is_none());
+    fn recv_edge_timeout_returns_none_when_no_edge_arrives() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let bus = GateBus::new();
+            let (mut rx, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+            let r = rx.recv_edge_timeout(Duration::from_millis(40)).await;
+            assert!(r.is_none());
+        });
+    }
+
+    #[test]
+    fn recv_edge_timeout_returns_edge_when_published_before_deadline() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let bus = Arc::new(GateBus::new());
+            bus.tick(0.0);
+            let (mut rx, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+            let bus_for_writer = Arc::clone(&bus);
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                bus_for_writer.drive_value(1.0);
+            });
+            let edge = rx.recv_edge_timeout(Duration::from_millis(200)).await;
+            assert_eq!(edge, Some(GateEdge::WhileOpen));
+        });
+    }
+
+    #[test]
+    fn drained_after_close_latch_drains_pending_then_returns_none() {
+        let (tx, watch_rx) = watch::channel::<Option<GateEdge>>(None);
+        tx.send_replace(Some(GateEdge::WhileOpen));
+        tx.send_replace(Some(GateEdge::WhileClose));
+        drop(tx);
+        let mut rx = GateReceiver {
+            after_rx: None,
+            while_rx: Some(EdgeSlot::new(watch_rx)),
+        };
+        assert_eq!(rx.try_recv(), Some(GateEdge::WhileClose));
+        assert!(rx.try_recv().is_none());
+        assert!(rx.try_recv().is_none());
+    }
+
+    #[test]
+    fn drained_after_close_latch_synthesises_upstream_gone_when_sender_drops_silent() {
+        let (tx, watch_rx) = watch::channel::<Option<GateEdge>>(None);
+        drop(tx);
+        let mut rx = GateReceiver {
+            after_rx: None,
+            while_rx: Some(EdgeSlot::new(watch_rx)),
+        };
+        assert_eq!(rx.try_recv(), Some(GateEdge::UpstreamGone));
+        assert!(rx.try_recv().is_none());
+    }
+
+    #[test]
+    fn drained_after_close_latch_returns_close_then_none_when_sender_drops_after_close() {
+        let (tx, watch_rx) = watch::channel::<Option<GateEdge>>(None);
+        tx.send_replace(Some(GateEdge::WhileClose));
+        drop(tx);
+        let mut rx = GateReceiver {
+            after_rx: None,
+            while_rx: Some(EdgeSlot::new(watch_rx)),
+        };
+        assert_eq!(rx.try_recv(), Some(GateEdge::WhileClose));
+        assert!(rx.try_recv().is_none());
+        assert!(rx.try_recv().is_none());
     }
 
     #[test]
     fn many_subscribers_receive_independently() {
         let bus = GateBus::new();
         bus.tick(0.0);
-        let (rx_a, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
-        let (rx_b, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 5.0));
+        let (mut rx_a, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+        let (mut rx_b, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 5.0));
 
         bus.drive_value(1.0);
         assert_eq!(rx_a.try_recv(), Some(GateEdge::WhileOpen));
@@ -758,8 +797,8 @@ mod tests {
     fn broadcast_upstream_gone_delivers_to_all_subscribers() {
         let bus = GateBus::new();
         bus.tick(0.0);
-        let (rx_a, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
-        let (rx_b, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+        let (mut rx_a, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+        let (mut rx_b, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
         bus.broadcast_upstream_gone();
         assert_eq!(rx_a.try_recv(), Some(GateEdge::UpstreamGone));
         assert_eq!(rx_b.try_recv(), Some(GateEdge::UpstreamGone));

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -144,8 +144,19 @@ impl GateReceiver {
         if let Some(edge) = self.try_recv() {
             return Some(edge);
         }
-        let _ = tokio::time::timeout(timeout, self.wait_for_change()).await;
-        self.try_recv()
+        let deadline = tokio::time::Instant::now() + timeout;
+        let poll_interval = std::time::Duration::from_millis(2);
+        loop {
+            if let Some(edge) = self.try_recv() {
+                return Some(edge);
+            }
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return None;
+            }
+            let sleep = (deadline - now).min(poll_interval);
+            tokio::time::sleep(sleep).await;
+        }
     }
 
     async fn wait_for_change(&mut self) {
@@ -494,6 +505,12 @@ impl PendingRef {
 pub enum RegistryError {
     #[error("scenario_name '{name}' is already in use by a running scenario")]
     DuplicateScenarioName { name: String },
+    /// The upstream scenario this resolution was waiting on was cancelled before it could register.
+    #[error("upstream '{scenario_name}/{entry_id}' was cancelled before resolving")]
+    UpstreamCancelled {
+        scenario_name: String,
+        entry_id: String,
+    },
 }
 
 /// Process-wide registry for cross-POST gate bus lookup.
@@ -532,6 +549,17 @@ pub trait GateBusResolver: Send + Sync {
     /// re-pend it for cross-POST re-resolution. Default impl is a no-op for
     /// resolvers that do not implement re-resolution tracking.
     fn track_subscriber(&self, _pending: PendingResolution) {}
+
+    /// Signal that an upstream scenario will not register; resolve any pending
+    /// waiters with [`RegistryError::UpstreamCancelled`] and notify them via
+    /// [`GateEdge::UpstreamGone`]. Default impl is a no-op.
+    fn cancel_pending_for_upstream(
+        &self,
+        _scenario_name: &str,
+        _entry_id: &str,
+    ) -> Vec<RegistryError> {
+        Vec::new()
+    }
 }
 
 #[cfg(test)]

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
+use tokio::sync::OwnedSemaphorePermit;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -43,6 +44,10 @@ pub struct ScenarioHandle {
     pub labels: Arc<HashMap<String, String>>,
     pub prometheus_meta: Option<Arc<PromMeta>>,
     pub cleaned_up: Arc<AtomicBool>,
+    sink_type: &'static str,
+    // Drop order frees the permit last on natural completion; DELETE releases
+    // it explicitly via take_permit before joining so the cap is a row cap.
+    _permit: Option<OwnedSemaphorePermit>,
 }
 
 impl ScenarioHandle {
@@ -75,7 +80,30 @@ impl ScenarioHandle {
             labels,
             prometheus_meta,
             cleaned_up,
+            sink_type: "unknown",
+            _permit: None,
         }
+    }
+
+    /// Set the sink-type label this handle reports for `sonda_server_sink_errors_total`.
+    pub fn with_sink_type(mut self, sink_type: &'static str) -> Self {
+        self.sink_type = sink_type;
+        self
+    }
+
+    /// Stable label string identifying the sink kind for derive-at-scrape metrics.
+    pub fn sink_type(&self) -> &'static str {
+        self.sink_type
+    }
+
+    /// Attach an owned semaphore permit whose drop frees a server-side scenario slot.
+    pub fn attach_permit(&mut self, permit: OwnedSemaphorePermit) {
+        self._permit = Some(permit);
+    }
+
+    /// Take the attached semaphore permit, returning `None` if none was attached.
+    pub fn take_permit(&mut self) -> Option<OwnedSemaphorePermit> {
+        self._permit.take()
     }
 
     /// Signal this scenario to stop. Affects only this scenario.
@@ -564,6 +592,57 @@ mod tests {
         handle.join(None).expect("first join must succeed");
         let result = handle.join_timeout(Duration::from_millis(50));
         assert!(result.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sink_type_defaults_to_unknown() {
+        let handle = make_handle("st-1", "default_sink", 1, Duration::from_millis(1));
+        assert_eq!(handle.sink_type(), "unknown");
+        drop(handle);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn with_sink_type_overrides_default() {
+        let handle =
+            make_handle("st-2", "tagged_sink", 1, Duration::from_millis(1)).with_sink_type("loki");
+        assert_eq!(handle.sink_type(), "loki");
+        drop(handle);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn attach_permit_holds_permit_until_drop() {
+        let sem = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = Arc::clone(&sem).try_acquire_owned().expect("permit");
+        assert_eq!(sem.available_permits(), 0);
+
+        let mut handle = make_handle("st-3", "perm", 1, Duration::from_millis(1));
+        handle.attach_permit(permit);
+        assert_eq!(sem.available_permits(), 0);
+
+        handle.stop();
+        handle.join(Some(Duration::from_secs(2))).ok();
+        drop(handle);
+        assert_eq!(sem.available_permits(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn take_permit_releases_slot_without_dropping_handle() {
+        let sem = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = Arc::clone(&sem).try_acquire_owned().expect("permit");
+        assert_eq!(sem.available_permits(), 0);
+
+        let mut handle = make_handle("st-4", "take_perm", 1, Duration::from_millis(1));
+        handle.attach_permit(permit);
+        assert_eq!(sem.available_permits(), 0);
+
+        drop(handle.take_permit());
+        assert_eq!(sem.available_permits(), 1);
+        assert!(handle.take_permit().is_none());
+
+        handle.stop();
+        handle.join(Some(Duration::from_secs(2))).ok();
+        drop(handle);
+        assert_eq!(sem.available_permits(), 1);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -3,65 +3,44 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
-use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
+
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::config::PromMeta;
 use crate::schedule::stats::ScenarioStats;
-use crate::{RuntimeError, SondaError};
+use crate::SondaError;
 
-/// Returned by [`ScenarioHandle::join_timeout`] when the thread did not finish
+/// Returned by [`ScenarioHandle::join_timeout`] when the task did not finish
 /// within the requested deadline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct JoinTimeout;
 
 impl std::fmt::Display for JoinTimeout {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("scenario thread did not exit within join_timeout")
+        f.write_str("scenario task did not exit within join_timeout")
     }
 }
 
 impl std::error::Error for JoinTimeout {}
 
 /// A running scenario's lifecycle handle.
-///
-/// Returned by [`crate::schedule::launch::launch_scenario`]. Provides shutdown,
-/// join, and stats access. Used identically by the CLI, multi_runner, and
-/// sonda-server.
-///
-/// The handle is `Send`: the `JoinHandle` is behind an `Option` and the other
-/// fields are all `Send`, so the handle can be stored in server state and
-/// moved across await points.
 #[non_exhaustive]
 pub struct ScenarioHandle {
-    /// Unique identifier for this scenario instance.
     pub id: String,
-    /// Human-readable scenario name (from config).
     pub name: String,
-    /// File-level `scenario_name` from the source YAML, when set. Read-only
-    /// after launch; every handle from the same POST shares this value.
     pub scenario_name: Option<String>,
-    /// Per-handle shutdown flag. `stop()` on one handle never affects another.
-    pub shutdown: Arc<AtomicBool>,
-    /// The OS thread running the scenario. `None` after [`ScenarioHandle::join`] consumes it.
-    pub thread: Option<JoinHandle<Result<(), SondaError>>>,
-    /// Wall-clock time when the scenario was launched.
+    /// Per-handle cancellation token. `stop()` on one handle never affects another.
+    pub cancel: CancellationToken,
+    /// The tokio task running the scenario. `None` after [`ScenarioHandle::join`] consumes it.
+    pub task: Option<JoinHandle<Result<(), SondaError>>>,
     pub started_at: Instant,
-    /// Live statistics updated by the runner thread on each tick.
     pub stats: Arc<RwLock<ScenarioStats>>,
-    /// The configured target rate (events per second) from the scenario config.
     pub target_rate: f64,
-    /// Lock-free liveness flag flipped to `false` when the runner thread exits.
-    ///
-    /// Set inside the spawned thread via a Drop guard so it is also cleared on
-    /// panic. External observers (e.g. the CLI progress display) read this
-    /// without acquiring `JoinHandle::is_finished()`.
+    /// Lock-free liveness flag flipped to `false` when the runner exits.
     pub alive: Arc<AtomicBool>,
-    /// Scenario-level labels.
     pub labels: Arc<HashMap<String, String>>,
-    /// Prometheus `# TYPE` / `# HELP` metadata derived at launch.
-    ///
-    /// `Some` for metrics, histogram, and summary scenarios; `None` for logs.
     pub prometheus_meta: Option<Arc<PromMeta>>,
     pub cleaned_up: Arc<AtomicBool>,
 }
@@ -73,8 +52,8 @@ impl ScenarioHandle {
         id: String,
         name: String,
         scenario_name: Option<String>,
-        shutdown: Arc<AtomicBool>,
-        thread: Option<JoinHandle<Result<(), SondaError>>>,
+        cancel: CancellationToken,
+        task: Option<JoinHandle<Result<(), SondaError>>>,
         started_at: Instant,
         stats: Arc<RwLock<ScenarioStats>>,
         target_rate: f64,
@@ -87,8 +66,8 @@ impl ScenarioHandle {
             id,
             name,
             scenario_name,
-            shutdown,
-            thread,
+            cancel,
+            task,
             started_at,
             stats,
             target_rate,
@@ -101,107 +80,134 @@ impl ScenarioHandle {
 
     /// Signal this scenario to stop. Affects only this scenario.
     pub fn stop(&self) {
-        self.shutdown.store(false, Ordering::SeqCst);
+        self.cancel.cancel();
     }
 
-    /// Check whether the scenario thread is still running.
-    ///
-    /// Returns `true` if the thread is still alive, `false` if it has exited
-    /// or if the handle has already been joined.
+    /// Check whether the scenario task is still running.
     pub fn is_running(&self) -> bool {
-        self.thread
+        self.task
             .as_ref()
             .map(|t| !t.is_finished())
             .unwrap_or(false)
     }
 
-    /// Lock-free check that the runner thread has not yet exited.
-    ///
-    /// Cheaper than [`Self::is_running`] in tight polling loops because it
-    /// reads an `AtomicBool` instead of probing the thread handle.
+    /// Lock-free check that the runner has not yet exited.
     pub fn is_alive(&self) -> bool {
         self.alive.load(Ordering::SeqCst)
     }
 
-    /// Join the scenario thread, consuming it.
-    ///
-    /// Blocks until the thread exits or the optional timeout expires. If a
-    /// timeout is provided and the thread does not exit within that time, this
-    /// method returns `Ok(())` without consuming the thread (the thread
-    /// continues running and the handle still owns it).
-    ///
-    /// **Orphaned thread trade-off:** When the join times out, the OS thread
-    /// continues running in the background with no way for the caller to
-    /// observe or control it further (the shutdown flag has already been set).
-    /// If the handle is subsequently dropped (e.g., removed from the server's
-    /// scenario map), the `JoinHandle` is dropped without joining, and the
-    /// thread becomes fully detached. This is an acceptable trade-off: the
-    /// thread will eventually exit on its own (it checks the shutdown flag
-    /// each tick), and blocking the HTTP handler indefinitely would be worse.
-    ///
-    /// Returns the thread's result on success, or a [`SondaError`] if the
-    /// thread panicked or returned an error.
-    pub fn join(&mut self, timeout: Option<Duration>) -> Result<(), SondaError> {
-        if self.thread.is_none() {
-            // Already joined.
+    /// Await the scenario task to completion within the optional timeout.
+    /// On timeout the handle still owns the task and the caller can retry.
+    pub async fn join_async(&mut self, timeout: Option<Duration>) -> Result<(), SondaError> {
+        if self.task.is_none() {
             return Ok(());
         }
 
-        // When a timeout is requested we poll with a short sleep, since
-        // `JoinHandle` does not expose a timed-join API on stable Rust.
-        if let Some(limit) = timeout {
-            let deadline = Instant::now() + limit;
-            while Instant::now() < deadline {
-                if self
-                    .thread
-                    .as_ref()
-                    .map(|t| t.is_finished())
-                    .unwrap_or(true)
-                {
+        if let Some(t) = timeout {
+            let deadline = Instant::now() + t;
+            loop {
+                if self.task.as_ref().map(|t| t.is_finished()).unwrap_or(true) {
                     break;
                 }
-                std::thread::sleep(Duration::from_millis(10));
-            }
-
-            // If still not finished, return without consuming the handle.
-            if !self
-                .thread
-                .as_ref()
-                .map(|t| t.is_finished())
-                .unwrap_or(true)
-            {
-                return Ok(());
+                let now = Instant::now();
+                if now >= deadline {
+                    return Ok(());
+                }
+                let remaining = deadline.saturating_duration_since(now);
+                tokio::time::sleep(remaining.min(Duration::from_millis(10))).await;
             }
         }
 
-        // Consume the JoinHandle.
-        let handle = self.thread.take().expect("checked above: thread is Some");
-        match handle.join() {
+        let task = self.task.take().expect("task present at this point");
+        match task.await {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => Err(e),
-            Err(_) => Err(SondaError::Runtime(RuntimeError::ThreadPanicked)),
+            Err(join_err) => {
+                if join_err.is_cancelled() {
+                    Ok(())
+                } else {
+                    Err(SondaError::Runtime(crate::RuntimeError::ThreadPanicked))
+                }
+            }
         }
     }
 
-    /// Best-effort timed join: poll the underlying thread until it finishes
-    /// or `timeout` elapses. On timeout the thread is left detached and
-    /// `Err(JoinTimeout)` is returned. On success the inner `JoinHandle`
-    /// is consumed.
+    /// Synchronously join the scenario task and return its result.
+    ///
+    /// Returns `Err(RuntimeError::TaskAborted)` if called from an ambient
+    /// current_thread runtime — blocking there would deadlock; use [`join_async`](Self::join_async).
+    pub fn join(&mut self, timeout: Option<Duration>) -> Result<(), SondaError> {
+        if self.task.is_none() {
+            return Ok(());
+        }
+
+        let deadline = timeout.map(|t| Instant::now() + t);
+        loop {
+            if self.task.as_ref().map(|t| t.is_finished()).unwrap_or(true) {
+                break;
+            }
+            match deadline {
+                Some(d) => {
+                    let now = Instant::now();
+                    if now >= d {
+                        return Ok(());
+                    }
+                    let remaining = d.saturating_duration_since(now);
+                    std::thread::sleep(remaining.min(Duration::from_millis(10)));
+                }
+                None => std::thread::sleep(Duration::from_millis(10)),
+            }
+        }
+
+        let task = self.task.take().expect("checked above: task is Some");
+        let result = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                if matches!(
+                    handle.runtime_flavor(),
+                    tokio::runtime::RuntimeFlavor::MultiThread
+                ) {
+                    tokio::task::block_in_place(|| handle.block_on(task))
+                } else {
+                    task.abort();
+                    return Err(SondaError::Runtime(crate::RuntimeError::TaskAborted {
+                        reason: "join() called from a current_thread tokio runtime; \
+                                 use join_async() instead",
+                    }));
+                }
+            }
+            Err(_) => {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
+                rt.block_on(task)
+            }
+        };
+        match result {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(e),
+            Err(join_err) => {
+                if join_err.is_cancelled() {
+                    Ok(())
+                } else {
+                    Err(SondaError::Runtime(crate::RuntimeError::ThreadPanicked))
+                }
+            }
+        }
+    }
+
+    /// Best-effort timed join: poll the underlying task until it finishes
+    /// or `timeout` elapses.
     pub fn join_timeout(&mut self, timeout: Duration) -> Result<(), JoinTimeout> {
-        if self.thread.is_none() {
+        if self.task.is_none() {
             return Ok(());
         }
         let deadline = Instant::now() + timeout;
         let poll_interval = Duration::from_millis(10);
         loop {
-            if self
-                .thread
-                .as_ref()
-                .map(|t| t.is_finished())
-                .unwrap_or(true)
-            {
-                if let Some(handle) = self.thread.take() {
-                    let _ = handle.join();
+            if self.task.as_ref().map(|t| t.is_finished()).unwrap_or(true) {
+                if let Some(task) = self.task.take() {
+                    task.abort();
                 }
                 return Ok(());
             }
@@ -214,22 +220,11 @@ impl ScenarioHandle {
     }
 
     /// Elapsed time since the scenario started.
-    ///
-    /// This is a real-time measurement based on the wall clock recorded at
-    /// launch. It continues to grow even after the scenario stops.
     pub fn elapsed(&self) -> Duration {
         self.started_at.elapsed()
     }
 
     /// Read the latest stats snapshot.
-    ///
-    /// Acquires the read lock briefly, clones the stats, and returns. Does not
-    /// block writers for longer than the clone operation.
-    ///
-    /// If the stats lock is poisoned (because a writer panicked), this method
-    /// recovers the data from the poisoned guard rather than propagating the
-    /// panic. The returned stats may be partially updated but will not cause
-    /// the caller to panic.
     pub fn stats_snapshot(&self) -> ScenarioStats {
         match self.stats.read() {
             Ok(guard) => guard.clone(),
@@ -266,53 +261,45 @@ impl Drop for ScenarioHandle {
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, RwLock};
-    use std::thread;
     use std::time::{Duration, Instant};
 
     use super::*;
     use crate::schedule::stats::ScenarioStats;
     use crate::SondaError;
 
-    // ---- Helper: build a ScenarioHandle backed by a trivial thread ----------
-
-    /// Build a `ScenarioHandle` whose thread counts to a limit, then exits.
-    ///
-    /// The thread increments `total_events` on the shared stats arc each
-    /// iteration so tests can observe live stat updates without involving
-    /// the full runner pipeline.
     fn make_handle(id: &str, name: &str, events: u64, interval: Duration) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-        let shutdown_thread = Arc::clone(&shutdown);
-        let stats_thread = Arc::clone(&stats);
+        let cancel_for_task = cancel.clone();
+        let stats_task = Arc::clone(&stats);
+        let alive = Arc::new(AtomicBool::new(true));
+        let alive_for_task = Arc::clone(&alive);
 
-        let thread = thread::Builder::new()
-            .name(format!("test-{name}"))
-            .spawn(move || -> Result<(), SondaError> {
-                for _ in 0..events {
-                    if !shutdown_thread.load(Ordering::SeqCst) {
-                        break;
-                    }
-                    thread::sleep(interval);
-                    if let Ok(mut st) = stats_thread.write() {
-                        st.total_events += 1;
-                        st.bytes_emitted += 64;
-                    }
+        let task = tokio::task::spawn(async move {
+            for _ in 0..events {
+                if cancel_for_task.is_cancelled() {
+                    break;
                 }
-                Ok(())
-            })
-            .expect("thread must spawn");
+                tokio::time::sleep(interval).await;
+                if let Ok(mut st) = stats_task.write() {
+                    st.total_events += 1;
+                    st.bytes_emitted += 64;
+                }
+            }
+            alive_for_task.store(false, Ordering::SeqCst);
+            Ok::<_, SondaError>(())
+        });
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             100.0,
-            Arc::new(AtomicBool::new(true)),
+            alive,
             Arc::new(HashMap::new()),
             Some(Arc::new(PromMeta::new(
                 crate::config::PromMetricType::Gauge,
@@ -322,146 +309,86 @@ mod tests {
         )
     }
 
-    // ---- is_running: true before stop, false after join ---------------------
-
-    /// A freshly spawned handle must report is_running() == true.
-    #[test]
-    fn is_running_returns_true_for_live_thread() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn is_running_returns_true_for_live_task() {
         let mut handle = make_handle("test-1", "live", 50, Duration::from_millis(10));
-        assert!(
-            handle.is_running(),
-            "is_running must return true for a live thread"
-        );
-        // Clean up.
+        assert!(handle.is_running());
         handle.stop();
         handle.join(Some(Duration::from_secs(2))).unwrap();
     }
 
-    /// After stop() + join(), is_running() must return false.
-    #[test]
-    fn is_running_returns_false_after_stop_and_join() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn is_running_returns_false_after_stop_and_join() {
         let mut handle = make_handle("test-2", "stopped", 1000, Duration::from_millis(5));
         handle.stop();
         handle
             .join(Some(Duration::from_secs(2)))
             .expect("join must succeed");
-        assert!(
-            !handle.is_running(),
-            "is_running must return false after the thread has been joined"
-        );
+        assert!(!handle.is_running());
     }
 
-    /// A handle whose JoinHandle has been consumed (None) returns false.
-    #[test]
-    fn is_running_returns_false_when_thread_is_none() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn is_running_returns_false_when_task_is_none() {
         let mut handle = make_handle("test-3", "none", 1, Duration::from_millis(1));
-        // Allow thread to finish naturally.
-        thread::sleep(Duration::from_millis(50));
-        // Consume the JoinHandle directly to mimic a post-join state.
-        handle.thread = None;
-        assert!(
-            !handle.is_running(),
-            "is_running must return false when thread is None"
-        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        handle.task = None;
+        assert!(!handle.is_running());
     }
 
-    // ---- stop(): sets the shutdown flag to false ----------------------------
-
-    /// stop() must store false in the shared AtomicBool.
-    #[test]
-    fn stop_sets_shutdown_flag_to_false() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stop_cancels_token() {
         let handle = make_handle("test-4", "stop_flag", 1000, Duration::from_millis(10));
-        assert!(
-            handle.shutdown.load(Ordering::SeqCst),
-            "shutdown flag must be true before stop"
-        );
+        assert!(!handle.cancel.is_cancelled());
         handle.stop();
-        assert!(
-            !handle.shutdown.load(Ordering::SeqCst),
-            "shutdown flag must be false after stop"
-        );
-        // Clean up the thread without consuming the handle.
+        assert!(handle.cancel.is_cancelled());
         drop(handle);
     }
 
-    // ---- join(): blocks until thread exits and returns Ok -------------------
-
-    /// join() with None timeout blocks until the thread finishes and returns Ok.
-    #[test]
-    fn join_none_timeout_waits_for_thread_and_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_none_timeout_waits_for_task_and_returns_ok() {
         let mut handle = make_handle("test-5", "join_none", 3, Duration::from_millis(10));
         let result = handle.join(None);
-        assert!(
-            result.is_ok(),
-            "join must return Ok when the thread succeeds: {result:?}"
-        );
+        assert!(result.is_ok(), "{result:?}");
     }
 
-    /// join() is idempotent: calling it a second time returns Ok immediately.
-    #[test]
-    fn join_is_idempotent_after_first_call() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_is_idempotent_after_first_call() {
         let mut handle = make_handle("test-6", "idempotent", 1, Duration::from_millis(1));
         handle.join(None).expect("first join must succeed");
         let result = handle.join(None);
-        assert!(
-            result.is_ok(),
-            "second join on an already-joined handle must return Ok: {result:?}"
-        );
+        assert!(result.is_ok(), "{result:?}");
     }
 
-    /// join() with a timeout that expires while thread is still running returns
-    /// Ok without consuming the thread (handle still owns it).
-    #[test]
-    fn join_with_short_timeout_returns_ok_without_consuming_thread() {
-        // Thread runs for 10 events × 50ms each = 500ms total.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_with_short_timeout_returns_ok_without_consuming_task() {
         let mut handle = make_handle("test-7", "timeout", 10, Duration::from_millis(50));
-        // Join with a very short timeout — thread will still be running.
         let result = handle.join(Some(Duration::from_millis(10)));
-        assert!(
-            result.is_ok(),
-            "join with expired timeout must still return Ok"
-        );
-        // The JoinHandle must NOT have been consumed — is_running may still be true.
-        assert!(
-            handle.thread.is_some(),
-            "thread must not be consumed when timeout expired before thread finished"
-        );
-        // Clean up.
+        assert!(result.is_ok());
+        assert!(handle.task.is_some());
         handle.stop();
         handle.join(None).ok();
     }
 
-    // ---- elapsed(): grows over time -----------------------------------------
-
-    /// elapsed() must return a positive Duration immediately after creation.
-    #[test]
-    fn elapsed_returns_positive_duration() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn elapsed_returns_positive_duration() {
         let handle = make_handle("test-8", "elapsed", 1, Duration::from_millis(1));
         let d = handle.elapsed();
-        // Even with scheduler jitter this should be at least 0 ns.
-        assert!(d >= Duration::ZERO, "elapsed must be non-negative: {d:?}");
+        assert!(d >= Duration::ZERO);
     }
 
-    /// elapsed() measured after a sleep must be greater than that sleep duration.
-    #[test]
-    fn elapsed_grows_monotonically_after_sleep() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn elapsed_grows_monotonically_after_sleep() {
         let mut handle = make_handle("test-9", "monotonic", 100, Duration::from_millis(5));
         let before = handle.elapsed();
-        thread::sleep(Duration::from_millis(100));
+        tokio::time::sleep(Duration::from_millis(100)).await;
         let after = handle.elapsed();
-        assert!(
-            after > before,
-            "elapsed must grow over time: before={before:?}, after={after:?}"
-        );
+        assert!(after > before);
         handle.stop();
         handle.join(None).ok();
     }
 
-    // ---- stats_snapshot(): returns the current stats atomically -------------
-
-    /// stats_snapshot() on a fresh handle returns all-zero stats.
-    #[test]
-    fn stats_snapshot_on_fresh_handle_returns_zeros() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_on_fresh_handle_returns_zeros() {
         let handle = make_handle("test-10", "fresh_stats", 0, Duration::ZERO);
         let snap = handle.stats_snapshot();
         assert_eq!(snap.total_events, 0);
@@ -469,24 +396,13 @@ mod tests {
         assert_eq!(snap.errors, 0);
     }
 
-    /// After the worker thread emits events, stats_snapshot() reflects the updates.
-    #[test]
-    fn stats_snapshot_returns_nonzero_total_events_after_running() {
-        // 5 events × 10ms each = ~50ms of work.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_returns_nonzero_total_events_after_running() {
         let mut handle = make_handle("test-11", "nonzero_stats", 5, Duration::from_millis(10));
-        // Wait long enough for all 5 events to fire.
-        thread::sleep(Duration::from_millis(200));
+        tokio::time::sleep(Duration::from_millis(200)).await;
         let snap = handle.stats_snapshot();
-        assert!(
-            snap.total_events > 0,
-            "stats_snapshot must reflect emitted events, got total_events={}",
-            snap.total_events
-        );
-        assert!(
-            snap.bytes_emitted > 0,
-            "stats_snapshot must reflect bytes_emitted > 0, got {}",
-            snap.bytes_emitted
-        );
+        assert!(snap.total_events > 0);
+        assert!(snap.bytes_emitted > 0);
         handle.join(None).ok();
     }
 
@@ -499,14 +415,14 @@ mod tests {
         .expect("test metric name must be valid")
     }
 
-    #[test]
-    fn recent_metrics_snapshot_on_fresh_handle_returns_empty() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recent_metrics_snapshot_on_fresh_handle_returns_empty() {
         let handle = make_handle("test-rm-1", "fresh", 0, Duration::ZERO);
         assert!(handle.recent_metrics_snapshot().is_empty());
     }
 
-    #[test]
-    fn recent_metrics_snapshot_returns_current_values_not_history() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recent_metrics_snapshot_returns_current_values_not_history() {
         let handle = make_handle("test-rm-2", "current", 0, Duration::ZERO);
         {
             let mut stats = handle.stats.write().expect("lock must not be poisoned");
@@ -515,12 +431,12 @@ mod tests {
             stats.push_metric(make_metric_event("up", 3.0));
         }
         let events = handle.recent_metrics_snapshot();
-        assert_eq!(events.len(), 1, "same series must collapse to one entry");
-        assert_eq!(events[0].value, 3.0, "latest value must win");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].value, 3.0);
     }
 
-    #[test]
-    fn recent_metrics_snapshot_is_idempotent() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recent_metrics_snapshot_is_idempotent() {
         let handle = make_handle("test-rm-3", "idempotent", 0, Duration::ZERO);
         {
             let mut stats = handle.stats.write().expect("lock must not be poisoned");
@@ -533,43 +449,32 @@ mod tests {
         assert_eq!(first[0].value, second[0].value);
     }
 
-    // ---- stats_snapshot: recovers from poisoned lock -------------------------
-
-    /// If the stats lock is poisoned, stats_snapshot recovers the data instead
-    /// of panicking.
-    #[test]
-    fn stats_snapshot_recovers_from_poisoned_lock() {
-        let shutdown = Arc::new(AtomicBool::new(false));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_recovers_from_poisoned_lock() {
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        // Set a known value before poisoning.
         {
             let mut guard = stats.write().expect("lock must not be poisoned");
             guard.total_events = 42;
         }
 
-        // Poison the lock by panicking inside a write guard.
         let stats_clone = Arc::clone(&stats);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _guard = stats_clone.write().expect("lock must not be poisoned");
             panic!("intentional panic to poison lock");
         }));
-        assert!(result.is_err(), "panic must have occurred");
+        assert!(result.is_err());
+        assert!(stats.read().is_err());
 
-        // Verify the lock is actually poisoned.
-        assert!(stats.read().is_err(), "lock must be poisoned after panic");
-
-        let thread = thread::Builder::new()
-            .name("test-poisoned-stats".to_string())
-            .spawn(|| -> Result<(), SondaError> { Ok(()) })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async { Ok::<_, SondaError>(()) });
 
         let handle = ScenarioHandle::new(
             "test-poisoned".to_string(),
             "poisoned".to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -582,17 +487,13 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
         );
 
-        // stats_snapshot must not panic — it recovers from the poisoned lock.
         let snap = handle.stats_snapshot();
-        assert_eq!(
-            snap.total_events, 42,
-            "stats_snapshot must recover data from poisoned lock"
-        );
+        assert_eq!(snap.total_events, 42);
     }
 
-    #[test]
-    fn recent_metrics_snapshot_recovers_from_poisoned_lock() {
-        let shutdown = Arc::new(AtomicBool::new(false));
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recent_metrics_snapshot_recovers_from_poisoned_lock() {
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
         {
@@ -605,19 +506,16 @@ mod tests {
             let _guard = stats_clone.write().expect("lock must not be poisoned");
             panic!("intentional panic to poison lock");
         }));
-        assert!(result.is_err(), "panic must have occurred");
+        assert!(result.is_err());
 
-        let thread = thread::Builder::new()
-            .name("test-poisoned-metrics".to_string())
-            .spawn(|| -> Result<(), SondaError> { Ok(()) })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async { Ok::<_, SondaError>(()) });
 
         let handle = ScenarioHandle::new(
             "test-poisoned-m".to_string(),
             "poisoned_metrics".to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -635,53 +533,52 @@ mod tests {
         assert_eq!(events[0].value, 99.0);
     }
 
-    // ---- Contract: ScenarioHandle is Send -----------------------------------
-
-    /// ScenarioHandle must be Send so it can be stored in server state and
-    /// moved across tokio await points.
     #[test]
     fn scenario_handle_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<ScenarioHandle>();
     }
 
-    #[test]
-    fn join_timeout_returns_ok_when_handle_exits_within_window() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_timeout_returns_ok_when_handle_exits_within_window() {
         let mut handle = make_handle("jt-1", "fast", 1, Duration::from_millis(5));
-        thread::sleep(Duration::from_millis(50));
+        tokio::time::sleep(Duration::from_millis(50)).await;
         let result = handle.join_timeout(Duration::from_millis(500));
-        assert!(
-            result.is_ok(),
-            "join_timeout must return Ok when thread already exited: {result:?}"
-        );
-        assert!(handle.thread.is_none(), "JoinHandle must be consumed on Ok");
+        assert!(result.is_ok(), "{result:?}");
+        assert!(handle.task.is_none());
     }
 
-    #[test]
-    fn join_timeout_returns_err_when_thread_still_running() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_timeout_returns_err_when_task_still_running() {
         let mut handle = make_handle("jt-2", "slow", 100, Duration::from_millis(50));
         let result = handle.join_timeout(Duration::from_millis(20));
-        assert!(
-            result.is_err(),
-            "join_timeout must return Err when timeout expires before exit"
-        );
-        assert!(
-            handle.thread.is_some(),
-            "JoinHandle must be retained on timeout"
-        );
-        // Clean up.
+        assert!(result.is_err());
+        assert!(handle.task.is_some());
         handle.stop();
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn join_timeout_is_idempotent_when_thread_already_consumed() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn join_timeout_is_idempotent_when_task_already_consumed() {
         let mut handle = make_handle("jt-3", "consumed", 1, Duration::from_millis(1));
         handle.join(None).expect("first join must succeed");
         let result = handle.join_timeout(Duration::from_millis(50));
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn join_from_current_thread_runtime_returns_task_aborted_err() {
+        let mut handle = make_handle("jt-ct", "current_thread", 1, Duration::from_millis(1));
+        // Let the task finish before the sync join polls it — `std::thread::sleep`
+        // inside join would otherwise starve the only current_thread worker.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let result = handle.join(None);
         assert!(
-            result.is_ok(),
-            "join_timeout on consumed handle must return Ok"
+            matches!(
+                result,
+                Err(SondaError::Runtime(crate::RuntimeError::TaskAborted { .. }))
+            ),
+            "join from current_thread runtime must return TaskAborted, got: {result:?}"
         );
     }
 }

--- a/sonda-core/src/schedule/histogram_runner.rs
+++ b/sonda-core/src/schedule/histogram_runner.rs
@@ -41,7 +41,7 @@ use crate::SondaError;
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run(config: &HistogramScenarioConfig) -> Result<(), SondaError> {
-    let mut sink = create_sink(&config.sink, None)?;
+    let mut sink = create_sink(&config.sink, None).await?;
     run_with_sink(config, &mut sink, None, None).await
 }
 
@@ -75,6 +75,22 @@ pub async fn run_with_sink(
 ///
 /// Histograms cannot be `while:` upstreams (compile-time
 /// `NonMetricsTarget`), but they can be `while:`-gated downstreams.
+pub fn run_with_sink_gated_blocking(
+    config: &HistogramScenarioConfig,
+    shutdown: Option<&AtomicBool>,
+    stats: Option<Arc<RwLock<ScenarioStats>>>,
+    gate_ctx: Option<GateContext>,
+) -> Result<(), SondaError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
+    rt.block_on(async {
+        let mut sink = create_sink(&config.sink, None).await?;
+        run_with_sink_gated(config, &mut sink, shutdown, stats, gate_ctx).await
+    })
+}
+
 pub async fn run_with_sink_gated(
     config: &HistogramScenarioConfig,
     sink: &mut Box<dyn Sink>,
@@ -320,6 +336,8 @@ fn format_le_value(bound: f64) -> String {
 mod tests {
     use std::sync::Mutex;
 
+    use async_trait::async_trait;
+
     use crate::config::{BaseScheduleConfig, DistributionConfig, HistogramScenarioConfig};
     use crate::encoder::EncoderConfig;
     use crate::sink::{Sink, SinkConfig};
@@ -329,15 +347,16 @@ mod tests {
 
     struct ProbeSink(SharedBuf);
 
+    #[async_trait]
     impl Sink for ProbeSink {
-        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
             self.0
                 .lock()
                 .expect("probe sink mutex poisoned")
                 .extend_from_slice(data);
             Ok(())
         }
-        fn flush(&mut self) -> Result<(), SondaError> {
+        async fn flush(&mut self) -> Result<(), SondaError> {
             Ok(())
         }
     }

--- a/sonda-core/src/schedule/histogram_runner.rs
+++ b/sonda-core/src/schedule/histogram_runner.rs
@@ -40,9 +40,9 @@ use crate::SondaError;
 /// # Errors
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-pub fn run(config: &HistogramScenarioConfig) -> Result<(), SondaError> {
+pub async fn run(config: &HistogramScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, None)?;
-    run_with_sink(config, sink.as_mut(), None, None)
+    run_with_sink(config, &mut sink, None, None).await
 }
 
 /// Run a histogram scenario to completion, writing encoded events into the
@@ -62,22 +62,22 @@ pub fn run(config: &HistogramScenarioConfig) -> Result<(), SondaError> {
 /// # Errors
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-pub fn run_with_sink(
+pub async fn run_with_sink(
     config: &HistogramScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_with_sink_gated(config, sink, shutdown, stats, None)
+    run_with_sink_gated(config, sink, shutdown, stats, None).await
 }
 
 /// Run a histogram scenario with optional `while:` / `after:` gating.
 ///
 /// Histograms cannot be `while:` upstreams (compile-time
 /// `NonMetricsTarget`), but they can be `while:`-gated downstreams.
-pub fn run_with_sink_gated(
+pub async fn run_with_sink_gated(
     config: &HistogramScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
@@ -277,23 +277,29 @@ pub fn run_with_sink_gated(
     };
 
     match gate_ctx {
-        None => core_loop::run_schedule_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            sink,
-            &mut tick_fn,
-        ),
-        Some(ctx) => core_loop::gated_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            ctx,
-            sink,
-            &mut tick_fn,
-        ),
+        None => {
+            core_loop::run_schedule_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
+        Some(ctx) => {
+            core_loop::gated_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                ctx,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
     }
 }
 
@@ -312,10 +318,35 @@ fn format_le_value(bound: f64) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use crate::config::{BaseScheduleConfig, DistributionConfig, HistogramScenarioConfig};
     use crate::encoder::EncoderConfig;
-    use crate::sink::memory::MemorySink;
-    use crate::sink::SinkConfig;
+    use crate::sink::{Sink, SinkConfig};
+    use crate::SondaError;
+
+    type SharedBuf = std::sync::Arc<Mutex<Vec<u8>>>;
+
+    struct ProbeSink(SharedBuf);
+
+    impl Sink for ProbeSink {
+        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+            self.0
+                .lock()
+                .expect("probe sink mutex poisoned")
+                .extend_from_slice(data);
+            Ok(())
+        }
+        fn flush(&mut self) -> Result<(), SondaError> {
+            Ok(())
+        }
+    }
+
+    fn probe_sink() -> (Box<dyn Sink>, SharedBuf) {
+        let buf: SharedBuf = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let sink: Box<dyn Sink> = Box::new(ProbeSink(SharedBuf::clone(&buf)));
+        (sink, buf)
+    }
 
     /// Build a minimal HistogramScenarioConfig for testing.
     fn make_config(
@@ -355,23 +386,31 @@ mod tests {
 
     // ---- Run completes without error ----------------------------------------
 
-    #[test]
-    fn run_completes_for_short_duration() {
+    #[tokio::test]
+    async fn run_completes_for_short_duration() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("histogram run must succeed");
-        assert!(!sink.buffer.is_empty(), "histogram run must produce output");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("histogram run must succeed");
+        assert!(
+            !buf.lock().unwrap().is_empty(),
+            "histogram run must produce output"
+        );
     }
 
     // ---- Output contains expected series names ------------------------------
 
-    #[test]
-    fn output_contains_bucket_count_sum_series() {
+    #[tokio::test]
+    async fn output_contains_bucket_count_sum_series() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
 
         assert!(
             output.contains("http_request_duration_seconds_bucket{"),
@@ -389,13 +428,16 @@ mod tests {
 
     // ---- le label present on bucket events -----------------------------------
 
-    #[test]
-    fn bucket_events_have_le_label() {
+    #[tokio::test]
+    async fn bucket_events_have_le_label() {
         let config = make_config(50.0, "100ms", Some(vec![0.1, 0.5, 1.0]));
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
 
         // Check for specific le values.
         assert!(
@@ -410,34 +452,39 @@ mod tests {
 
     // ---- Gap suppresses output -----------------------------------------------
 
-    #[test]
-    fn gap_suppresses_histogram_output() {
+    #[tokio::test]
+    async fn gap_suppresses_histogram_output() {
         let mut config = make_config(100.0, "2s", None);
         config.base.gaps = Some(crate::config::GapConfig {
             every: "1s".to_string(),
             r#for: "500ms".to_string(),
         });
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
         // With gaps, we should have less output than without.
         // Just verify it ran successfully and produced some output.
         assert!(
-            !sink.buffer.is_empty(),
+            !buf.lock().unwrap().is_empty(),
             "histogram with gaps must still produce some output"
         );
     }
 
     // ---- Custom buckets are used --------------------------------------------
 
-    #[test]
-    fn custom_buckets_appear_in_output() {
+    #[tokio::test]
+    async fn custom_buckets_appear_in_output() {
         let config = make_config(50.0, "100ms", Some(vec![1.0, 5.0, 10.0]));
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         // Should have events for le="1", le="5", le="10", and le="+Inf"
         assert!(output.contains("le=\"1\""), "expected le=\"1\" in output");
         assert!(
@@ -463,17 +510,20 @@ mod tests {
 
     // ---- Labels from config are included ------------------------------------
 
-    #[test]
-    fn config_labels_appear_in_output() {
+    #[tokio::test]
+    async fn config_labels_appear_in_output() {
         let mut config = make_config(50.0, "100ms", Some(vec![1.0]));
         let mut label_map = std::collections::HashMap::new();
         label_map.insert("method".to_string(), "GET".to_string());
         config.base.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         assert!(
             output.contains("method=\"GET\""),
             "config labels must appear in output"

--- a/sonda-core/src/schedule/histogram_runner.rs
+++ b/sonda-core/src/schedule/histogram_runner.rs
@@ -1,22 +1,8 @@
 //! The histogram scenario event loop.
-//!
-//! The histogram runner ties together the [`HistogramGenerator`], encoder, and
-//! sink with the shared schedule loop from
-//! [`core_loop::run_schedule_loop`](super::core_loop::run_schedule_loop).
-//!
-//! Each tick, the runner:
-//! 1. Advances the histogram generator to get a [`HistogramSample`].
-//! 2. For each bucket boundary, creates a `MetricEvent` with name
-//!    `{base}_bucket` and an `le="{bound}"` label.
-//! 3. Creates a `+Inf` bucket event (`le="+Inf"`, value = total count).
-//! 4. Creates `{base}_count` and `{base}_sum` events.
-//! 5. Encodes all events and writes them to the sink.
-//!
-//! The core loop is unchanged — all histogram-specific logic lives in the
-//! per-tick closure.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
+
+use tokio_util::sync::CancellationToken;
 
 use crate::config::HistogramScenarioConfig;
 use crate::encoder::create_encoder;
@@ -31,70 +17,26 @@ use crate::schedule::ParsedSchedule;
 use crate::sink::{create_sink, Sink};
 use crate::SondaError;
 
-/// Run a histogram scenario to completion, emitting encoded histogram events
-/// at the configured rate.
-///
-/// This is the primary entry point. It constructs a sink from the config and
-/// delegates to [`run_with_sink`] with no shutdown flag and no stats collection.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
+/// Run a histogram scenario to completion at the configured rate.
 pub async fn run(config: &HistogramScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, None).await?;
-    run_with_sink(config, &mut sink, None, None).await
+    let cancel = CancellationToken::new();
+    run_with_sink(config, &mut sink, &cancel, None).await
 }
 
-/// Run a histogram scenario to completion, writing encoded events into the
-/// provided sink.
-///
-/// Builds the histogram generator, encoder, and label sets from the config,
-/// then delegates to the shared schedule loop. The per-tick closure generates
-/// multiple `MetricEvent`s per tick (one per bucket + `+Inf` + `_count` + `_sum`).
-///
-/// # Parameters
-///
-/// * `config` — the histogram scenario configuration.
-/// * `sink` — the destination for encoded metric events.
-/// * `shutdown` — optional atomic flag for clean shutdown.
-/// * `stats` — optional shared stats for live telemetry.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run_with_sink(
     config: &HistogramScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_with_sink_gated(config, sink, shutdown, stats, None).await
-}
-
-/// Run a histogram scenario with optional `while:` / `after:` gating.
-///
-/// Histograms cannot be `while:` upstreams (compile-time
-/// `NonMetricsTarget`), but they can be `while:`-gated downstreams.
-pub fn run_with_sink_gated_blocking(
-    config: &HistogramScenarioConfig,
-    shutdown: Option<&AtomicBool>,
-    stats: Option<Arc<RwLock<ScenarioStats>>>,
-    gate_ctx: Option<GateContext>,
-) -> Result<(), SondaError> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
-    rt.block_on(async {
-        let mut sink = create_sink(&config.sink, None).await?;
-        run_with_sink_gated(config, &mut sink, shutdown, stats, gate_ctx).await
-    })
+    run_with_sink_gated(config, sink, cancel, stats, None).await
 }
 
 pub async fn run_with_sink_gated(
     config: &HistogramScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
 ) -> Result<(), SondaError> {
@@ -294,21 +236,14 @@ pub async fn run_with_sink_gated(
 
     match gate_ctx {
         None => {
-            core_loop::run_schedule_loop(
-                &schedule,
-                config.rate,
-                shutdown,
-                stats,
-                sink,
-                &mut tick_fn,
-            )
-            .await
+            core_loop::run_schedule_loop(&schedule, config.rate, cancel, stats, sink, &mut tick_fn)
+                .await
         }
         Some(ctx) => {
             core_loop::gated_loop(
                 &schedule,
                 config.rate,
-                shutdown,
+                cancel,
                 stats,
                 ctx,
                 sink,
@@ -337,6 +272,7 @@ mod tests {
     use std::sync::Mutex;
 
     use async_trait::async_trait;
+    use tokio_util::sync::CancellationToken;
 
     use crate::config::{BaseScheduleConfig, DistributionConfig, HistogramScenarioConfig};
     use crate::encoder::EncoderConfig;
@@ -409,7 +345,7 @@ mod tests {
     async fn run_completes_for_short_duration() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("histogram run must succeed");
         assert!(
@@ -424,7 +360,7 @@ mod tests {
     async fn output_contains_bucket_count_sum_series() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -451,7 +387,7 @@ mod tests {
     async fn bucket_events_have_le_label() {
         let config = make_config(50.0, "100ms", Some(vec![0.1, 0.5, 1.0]));
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -480,7 +416,7 @@ mod tests {
         });
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -498,7 +434,7 @@ mod tests {
     async fn custom_buckets_appear_in_output() {
         let config = make_config(50.0, "100ms", Some(vec![1.0, 5.0, 10.0]));
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -537,7 +473,7 @@ mod tests {
         config.base.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 

--- a/sonda-core/src/schedule/histogram_runner.rs
+++ b/sonda-core/src/schedule/histogram_runner.rs
@@ -22,7 +22,9 @@ use crate::config::HistogramScenarioConfig;
 use crate::encoder::create_encoder;
 use crate::generator::histogram::{to_distribution, HistogramGenerator, DEFAULT_HISTOGRAM_BUCKETS};
 use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
-use crate::schedule::core_loop::{self, GateContext, TickContext, TickResult};
+use crate::schedule::core_loop::{
+    self, GateContext, TickContext, TickOutput, TickResult, WriteCommand,
+};
 use crate::schedule::is_in_spike;
 use crate::schedule::stats::ScenarioStats;
 use crate::schedule::ParsedSchedule;
@@ -149,7 +151,7 @@ pub fn run_with_sink_gated(
     let mut buf: Vec<u8> = Vec::with_capacity(1024);
 
     let mut tick_fn = |ctx: &TickContext<'_>,
-                       sink: &mut dyn Sink,
+                       output: &mut TickOutput,
                        events_buf: &mut Vec<MetricEvent>|
      -> Result<TickResult, SondaError> {
         let wall_now = ctx.wall_clock;
@@ -189,7 +191,9 @@ pub fn run_with_sink_gated(
             buf.clear();
             encoder.encode_metric(&event, &mut buf)?;
             total_bytes += buf.len() as u64;
-            sink.write(&buf)?;
+            output
+                .writes
+                .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
             events_buf.push(event);
         }
 
@@ -217,7 +221,9 @@ pub fn run_with_sink_gated(
             buf.clear();
             encoder.encode_metric(&event, &mut buf)?;
             total_bytes += buf.len() as u64;
-            sink.write(&buf)?;
+            output
+                .writes
+                .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
             events_buf.push(event);
         }
 
@@ -245,7 +251,9 @@ pub fn run_with_sink_gated(
         buf.clear();
         encoder.encode_metric(&sum_event, &mut buf)?;
         total_bytes += buf.len() as u64;
-        sink.write(&buf)?;
+        output
+            .writes
+            .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
         events_buf.push(sum_event);
 
         let count_event = MetricEvent::from_parts(
@@ -257,19 +265,18 @@ pub fn run_with_sink_gated(
         buf.clear();
         encoder.encode_metric(&count_event, &mut buf)?;
         total_bytes += buf.len() as u64;
-        sink.write(&buf)?;
+        output
+            .writes
+            .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
         events_buf.push(count_event);
-
-        let delivered = sink.last_write_delivered();
 
         Ok(TickResult {
             bytes_written: total_bytes,
-            delivered,
+            delivered: true,
         })
     };
 
-    let stats_for_flush = stats.clone();
-    let loop_result = match gate_ctx {
+    match gate_ctx {
         None => core_loop::run_schedule_loop(
             &schedule,
             config.rate,
@@ -287,12 +294,6 @@ pub fn run_with_sink_gated(
             sink,
             &mut tick_fn,
         ),
-    };
-
-    let flush_result = sink.flush();
-    match loop_result {
-        Ok(()) => core_loop::apply_flush_policy(&schedule, stats_for_flush.as_ref(), flush_result),
-        Err(e) => Err(e),
     }
 }
 

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -200,6 +200,7 @@ pub async fn launch_scenario_with_gates(
     };
     let labels = Arc::new(entry.base().labels.clone().unwrap_or_default());
     let prometheus_meta = derive_prometheus_meta(&entry);
+    let sink_type = sink_type_label(&entry.base().sink);
 
     let started_at = Instant::now();
 
@@ -327,7 +328,43 @@ pub async fn launch_scenario_with_gates(
         labels,
         prometheus_meta,
         cleaned_up,
-    ))
+    )
+    .with_sink_type(sink_type))
+}
+
+fn sink_type_label(sink: &crate::sink::SinkConfig) -> &'static str {
+    use crate::sink::SinkConfig;
+    // Catch-all guards against future #[non_exhaustive] variants; in-crate
+    // the match is exhaustive today.
+    #[allow(unreachable_patterns)]
+    match sink {
+        SinkConfig::Stdout => "stdout",
+        SinkConfig::File { .. } => "file",
+        SinkConfig::Tcp { .. } => "tcp",
+        SinkConfig::Udp { .. } => "udp",
+        SinkConfig::Memory { .. } => "memory",
+        #[cfg(feature = "http")]
+        SinkConfig::HttpPush { .. } => "http_push",
+        #[cfg(not(feature = "http"))]
+        SinkConfig::HttpPushDisabled {} => "http_push",
+        #[cfg(feature = "remote-write")]
+        SinkConfig::RemoteWrite { .. } => "remote_write",
+        #[cfg(not(feature = "remote-write"))]
+        SinkConfig::RemoteWriteDisabled {} => "remote_write",
+        #[cfg(feature = "kafka")]
+        SinkConfig::Kafka { .. } => "kafka",
+        #[cfg(not(feature = "kafka"))]
+        SinkConfig::KafkaDisabled {} => "kafka",
+        #[cfg(feature = "http")]
+        SinkConfig::Loki { .. } => "loki",
+        #[cfg(not(feature = "http"))]
+        SinkConfig::LokiDisabled {} => "loki",
+        #[cfg(feature = "otlp")]
+        SinkConfig::OtlpGrpc { .. } => "otlp_grpc",
+        #[cfg(not(feature = "otlp"))]
+        SinkConfig::OtlpGrpcDisabled {} => "otlp_grpc",
+        _ => "unknown",
+    }
 }
 
 fn derive_prometheus_meta(entry: &ScenarioEntry) -> Option<Arc<PromMeta>> {

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -265,6 +265,9 @@ pub fn launch_scenario_with_gates(
     let thread = std::thread::Builder::new()
         .name(format!("sonda-{}", name))
         .spawn(move || -> Result<(), SondaError> {
+            crate::schedule::gate_bus::install_thread_runtime()
+                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
+
             // Drop guard clears the alive flag on every exit path, including
             // panics — observers polling `is_alive()` see a single clean
             // transition `true → false` regardless of how the thread terminates.

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -265,9 +265,6 @@ pub fn launch_scenario_with_gates(
     let thread = std::thread::Builder::new()
         .name(format!("sonda-{}", name))
         .spawn(move || -> Result<(), SondaError> {
-            crate::schedule::gate_bus::install_thread_runtime()
-                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
-
             // Drop guard clears the alive flag on every exit path, including
             // panics — observers polling `is_alive()` see a single clean
             // transition `true → false` regardless of how the thread terminates.

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -412,7 +412,7 @@ impl Drop for StateGuard {
                 st.transition_state(ScenarioState::Finished);
             }
         }
-        // Skip when Phase 1 (delete_scenario) already ran; ensure exactly once.
+        // delete_scenario sets cleaned_up first; skip duplicate unregister.
         if self.cleaned_up.swap(true, Ordering::SeqCst) {
             return;
         }

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -1,12 +1,10 @@
 //! Unified scenario launch API.
-//!
-//! This module is the single authoritative location for the "validate →
-//! create sink → spawn runner → manage lifecycle" pattern. Both the CLI and
-//! sonda-server call [`launch_scenario`]; neither duplicates this logic.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
+
+use tokio_util::sync::CancellationToken;
 
 use crate::compiler::{DelayClause, WhileClause};
 use crate::config::aliases::desugar_entry;
@@ -18,12 +16,13 @@ use crate::generator::GeneratorConfig;
 use crate::schedule::core_loop::GateContext;
 use crate::schedule::gate_bus::{GateBus, GateBusResolver};
 use crate::schedule::handle::ScenarioHandle;
-use crate::schedule::histogram_runner::run_with_sink_gated_blocking as run_histogram_with_sink_gated_blocking;
-use crate::schedule::log_runner::run_logs_with_sink_gated_blocking;
-use crate::schedule::runner::run_with_sink_gated_blocking;
+use crate::schedule::histogram_runner::run_with_sink_gated as run_histogram_with_sink_gated;
+use crate::schedule::log_runner::run_logs_with_sink_gated;
+use crate::schedule::runner::run_with_sink_gated;
 use crate::schedule::stats::{ScenarioState, ScenarioStats};
-use crate::schedule::summary_runner::run_with_sink_gated_blocking as run_summary_with_sink_gated_blocking;
-use crate::{ConfigError, RuntimeError, SondaError};
+use crate::schedule::summary_runner::run_with_sink_gated as run_summary_with_sink_gated;
+use crate::sink::create_sink;
+use crate::{ConfigError, SondaError};
 
 /// Extract the inner message from a [`SondaError`] for re-wrapping.
 ///
@@ -165,14 +164,14 @@ pub fn prepare_entries(entries: Vec<ScenarioEntry>) -> Result<Vec<PreparedEntry>
     Ok(prepared)
 }
 
-/// Launch a single scenario on a new OS thread.
+/// Launch a single scenario as a tokio task.
 pub async fn launch_scenario(
     id: String,
     entry: ScenarioEntry,
-    shutdown: Arc<AtomicBool>,
+    cancel: CancellationToken,
     start_delay: Option<Duration>,
 ) -> Result<ScenarioHandle, SondaError> {
-    launch_scenario_with_gates(id, None, entry, shutdown, start_delay, None, None, None).await
+    launch_scenario_with_gates(id, None, entry, cancel, start_delay, None, None, None).await
 }
 
 /// Launch a scenario with optional `while:` / `after:` gating wired in.
@@ -181,19 +180,18 @@ pub async fn launch_scenario_with_gates(
     id: String,
     scenario_name: Option<String>,
     entry: ScenarioEntry,
-    shutdown: Arc<AtomicBool>,
+    cancel: CancellationToken,
     start_delay: Option<Duration>,
     upstream_bus: Option<Arc<GateBus>>,
     gate_ctx: Option<GateContext>,
     resolver: Option<Arc<dyn GateBusResolver>>,
 ) -> Result<ScenarioHandle, SondaError> {
     let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-    let stats_for_thread = Arc::clone(&stats);
-    let shutdown_for_thread = Arc::clone(&shutdown);
+    let stats_for_task = Arc::clone(&stats);
     let alive = Arc::new(AtomicBool::new(true));
-    let alive_for_thread = Arc::clone(&alive);
+    let alive_for_task = Arc::clone(&alive);
+    let cancel_for_task = cancel.clone();
 
-    // Extract the name and target rate before moving `entry` into the thread closure.
     let (name, target_rate) = match &entry {
         ScenarioEntry::Metrics(c) => (c.name.clone(), c.rate),
         ScenarioEntry::Logs(c) => (c.name.clone(), c.rate),
@@ -205,114 +203,123 @@ pub async fn launch_scenario_with_gates(
 
     let started_at = Instant::now();
 
-    // Validate shutdown flag is currently set to `true` (running). The caller
-    // is responsible for ensuring this; we document the contract but do not
-    // enforce it here to avoid a redundant check on every launch.
-    //
-    // Ensure `running` ordering is visible from the new thread.
-    shutdown.store(true, Ordering::SeqCst);
-
     let stats_for_state = Arc::clone(&stats);
     let is_gated = gate_ctx.is_some();
     let cleaned_up = Arc::new(AtomicBool::new(false));
-    let cleaned_up_for_thread = Arc::clone(&cleaned_up);
-    let resolver_for_thread = resolver.clone();
-    let scenario_name_for_thread = scenario_name.clone();
+    let cleaned_up_for_task = Arc::clone(&cleaned_up);
+    let resolver_for_task = resolver.clone();
+    let scenario_name_for_task = scenario_name.clone();
 
     // Cross-POST scenarios broadcast via resolver.unregister; broadcasting
     // here too races the registry's subscriber migration.
-    let bus_for_finish_guard =
-        if scenario_name_for_thread.is_some() && resolver_for_thread.is_some() {
-            None
-        } else {
-            upstream_bus.as_ref().map(Arc::clone)
+    let bus_for_finish_guard = if scenario_name_for_task.is_some() && resolver_for_task.is_some() {
+        None
+    } else {
+        upstream_bus.as_ref().map(Arc::clone)
+    };
+
+    let task = tokio::task::spawn(async move {
+        // Drop guard clears the alive flag on every exit path, including
+        // panics — observers polling `is_alive()` see a single clean
+        // transition `true → false` regardless of how the task terminates.
+        let _alive_guard = AliveGuard {
+            flag: alive_for_task,
         };
 
-    let thread = std::thread::Builder::new()
-        .name(format!("sonda-{}", name))
-        .spawn(move || -> Result<(), SondaError> {
-            // Drop guard clears the alive flag on every exit path, including
-            // panics — observers polling `is_alive()` see a single clean
-            // transition `true → false` regardless of how the thread terminates.
-            let _guard = AliveGuard {
-                flag: alive_for_thread,
-            };
+        // Marks Finished on drop; unregisters when a resolver is wired.
+        let _state_guard = StateGuard {
+            stats: Arc::clone(&stats_for_state),
+            resolver: resolver_for_task,
+            scenario_name: scenario_name_for_task,
+            cleaned_up: cleaned_up_for_task,
+        };
 
-            // Marks Finished on drop; unregisters when a resolver is wired.
-            let _state_guard = StateGuard {
-                stats: Arc::clone(&stats_for_state),
-                resolver: resolver_for_thread,
-                scenario_name: scenario_name_for_thread,
-                cleaned_up: cleaned_up_for_thread,
-            };
+        // Drops before _state_guard so downstreams see UpstreamGone
+        // before the scenario flips to Finished.
+        let _bus_finish_guard = BusFinishGuard {
+            bus: bus_for_finish_guard,
+        };
 
-            // Drops before _state_guard so downstreams see UpstreamGone
-            // before the scenario flips to Finished.
-            let _bus_finish_guard = BusFinishGuard {
-                bus: bus_for_finish_guard,
-            };
-
-            // Sleep through the start_delay before entering the event loop.
-            // State stays `Pending` for the delay window so /stats reports
-            // `pending` until the first tick is actually due.
+        let cancel_for_outer = cancel_for_task.clone();
+        let runner = async move {
             if let Some(delay) = start_delay {
-                let deadline = std::time::Instant::now() + delay;
-                while std::time::Instant::now() < deadline {
-                    if !shutdown_for_thread.load(Ordering::SeqCst) {
-                        return Ok(());
+                tokio::select! {
+                    _ = cancel_for_task.cancelled() => {
+                        return Ok::<_, SondaError>(());
                     }
-                    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-                    let sleep_chunk = remaining.min(Duration::from_millis(50));
-                    if sleep_chunk > Duration::ZERO {
-                        std::thread::sleep(sleep_chunk);
-                    }
+                    _ = tokio::time::sleep(delay) => {}
                 }
             }
 
-            // gated_loop owns its own state transitions; non-gated runs
-            // need someone to mark Running once the start_delay has elapsed.
             if !is_gated {
                 if let Ok(mut st) = stats_for_state.write() {
                     st.transition_state(ScenarioState::Running);
                 }
             }
 
+            let sink_labels = entry.base().labels.clone();
+            let mut sink = create_sink(&entry.base().sink, sink_labels.as_ref()).await?;
+
             match entry {
-                ScenarioEntry::Metrics(config) => run_with_sink_gated_blocking(
-                    &config,
-                    Some(shutdown_for_thread.as_ref()),
-                    Some(Arc::clone(&stats_for_thread)),
-                    upstream_bus,
-                    gate_ctx,
-                ),
-                ScenarioEntry::Logs(config) => run_logs_with_sink_gated_blocking(
-                    &config,
-                    Some(shutdown_for_thread.as_ref()),
-                    Some(Arc::clone(&stats_for_thread)),
-                    gate_ctx,
-                ),
-                ScenarioEntry::Histogram(config) => run_histogram_with_sink_gated_blocking(
-                    &config,
-                    Some(shutdown_for_thread.as_ref()),
-                    Some(Arc::clone(&stats_for_thread)),
-                    gate_ctx,
-                ),
-                ScenarioEntry::Summary(config) => run_summary_with_sink_gated_blocking(
-                    &config,
-                    Some(shutdown_for_thread.as_ref()),
-                    Some(Arc::clone(&stats_for_thread)),
-                    gate_ctx,
-                ),
+                ScenarioEntry::Metrics(config) => {
+                    run_with_sink_gated(
+                        &config,
+                        &mut sink,
+                        &cancel_for_task,
+                        Some(Arc::clone(&stats_for_task)),
+                        upstream_bus,
+                        gate_ctx,
+                    )
+                    .await
+                }
+                ScenarioEntry::Logs(config) => {
+                    run_logs_with_sink_gated(
+                        &config,
+                        &mut sink,
+                        &cancel_for_task,
+                        Some(Arc::clone(&stats_for_task)),
+                        gate_ctx,
+                    )
+                    .await
+                }
+                ScenarioEntry::Histogram(config) => {
+                    run_histogram_with_sink_gated(
+                        &config,
+                        &mut sink,
+                        &cancel_for_task,
+                        Some(Arc::clone(&stats_for_task)),
+                        gate_ctx,
+                    )
+                    .await
+                }
+                ScenarioEntry::Summary(config) => {
+                    run_summary_with_sink_gated(
+                        &config,
+                        &mut sink,
+                        &cancel_for_task,
+                        Some(Arc::clone(&stats_for_task)),
+                        gate_ctx,
+                    )
+                    .await
+                }
             }
-        })
-        .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
+        };
+
+        // `biased` polls the cancel arm first, so an in-flight `tokio::time::sleep`
+        // inside the runner is dropped on cancel rather than awaited to completion.
+        tokio::select! {
+            biased;
+            _ = cancel_for_outer.cancelled() => Ok::<_, SondaError>(()),
+            result = runner => result,
+        }
+    });
 
     Ok(ScenarioHandle::new(
         id,
         name,
         scenario_name,
-        shutdown,
-        Some(thread),
+        cancel,
+        Some(task),
         started_at,
         stats,
         target_rate,
@@ -397,12 +404,12 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use super::*;
     use crate::config::{
-        BaseScheduleConfig, DistributionConfig, HistogramScenarioConfig, LogScenarioConfig,
-        ScenarioConfig, ScenarioEntry, SummaryScenarioConfig,
+        BaseScheduleConfig, DistributionConfig, GapConfig, HistogramScenarioConfig,
+        LogScenarioConfig, ScenarioConfig, ScenarioEntry, SummaryScenarioConfig,
     };
     use crate::encoder::EncoderConfig;
     use crate::generator::{GeneratorConfig, LogGeneratorConfig, TemplateConfig};
@@ -702,13 +709,12 @@ mod tests {
     /// launch_scenario with a metrics entry returns a handle whose thread is alive.
     #[tokio::test(flavor = "multi_thread")]
     async fn launch_scenario_metrics_returns_running_handle() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("launch_metrics");
 
-        let mut handle =
-            launch_scenario("test-id-1".to_string(), entry, Arc::clone(&shutdown), None)
-                .await
-                .expect("launch must succeed for valid metrics entry");
+        let mut handle = launch_scenario("test-id-1".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed for valid metrics entry");
 
         // The thread must be alive immediately after launch.
         assert!(
@@ -730,13 +736,12 @@ mod tests {
     /// launch_scenario with a logs entry returns a handle whose thread is alive.
     #[tokio::test(flavor = "multi_thread")]
     async fn launch_scenario_logs_returns_running_handle() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = logs_entry_indefinite("launch_logs");
 
-        let mut handle =
-            launch_scenario("test-id-2".to_string(), entry, Arc::clone(&shutdown), None)
-                .await
-                .expect("launch must succeed for valid logs entry");
+        let mut handle = launch_scenario("test-id-2".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed for valid logs entry");
 
         assert!(
             handle.is_running(),
@@ -755,9 +760,9 @@ mod tests {
     /// stop() followed by join() on a metrics scenario exits cleanly (Ok).
     #[tokio::test(flavor = "multi_thread")]
     async fn stop_then_join_metrics_scenario_returns_ok() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("stop_join_metrics");
-        let mut handle = launch_scenario("id-stop-1".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("id-stop-1".to_string(), entry, cancel, None)
             .await
             .expect("launch must succeed");
 
@@ -776,9 +781,9 @@ mod tests {
     /// stop() followed by join() on a logs scenario exits cleanly (Ok).
     #[tokio::test(flavor = "multi_thread")]
     async fn stop_then_join_logs_scenario_returns_ok() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = logs_entry_indefinite("stop_join_logs");
-        let mut handle = launch_scenario("id-stop-2".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("id-stop-2".to_string(), entry, cancel, None)
             .await
             .expect("launch must succeed");
 
@@ -793,9 +798,9 @@ mod tests {
     /// A finite-duration scenario exits on its own and join() returns Ok.
     #[tokio::test(flavor = "multi_thread")]
     async fn finite_duration_scenario_exits_naturally_and_join_returns_ok() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry("natural_exit");
-        let mut handle = launch_scenario("id-natural".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("id-natural".to_string(), entry, cancel, None)
             .await
             .expect("launch must succeed");
 
@@ -814,7 +819,7 @@ mod tests {
     async fn stats_snapshot_shows_nonzero_events_after_brief_run() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         // High rate so events accumulate quickly.
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
@@ -841,10 +846,9 @@ mod tests {
             help: None,
         });
 
-        let mut handle =
-            launch_scenario("id-stats".to_string(), entry, Arc::clone(&shutdown), None)
-                .await
-                .expect("launch must succeed");
+        let mut handle = launch_scenario("id-stats".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed");
 
         // Wait long enough for at least a few events to be emitted and stats updated.
         thread::sleep(Duration::from_millis(200));
@@ -870,7 +874,7 @@ mod tests {
     async fn stats_snapshot_shows_nonzero_events_for_logs_scenario() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
             base: BaseScheduleConfig {
                 name: "logs_stats_test".to_string(),
@@ -901,14 +905,9 @@ mod tests {
             encoder: EncoderConfig::JsonLines { precision: None },
         });
 
-        let mut handle = launch_scenario(
-            "id-log-stats".to_string(),
-            entry,
-            Arc::clone(&shutdown),
-            None,
-        )
-        .await
-        .expect("launch must succeed");
+        let mut handle = launch_scenario("id-log-stats".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed");
 
         thread::sleep(Duration::from_millis(200));
 
@@ -928,9 +927,9 @@ mod tests {
     /// elapsed() is positive immediately after launch.
     #[tokio::test(flavor = "multi_thread")]
     async fn elapsed_is_positive_after_launch() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("elapsed_test");
-        let mut handle = launch_scenario("id-elapsed".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("id-elapsed".to_string(), entry, cancel, None)
             .await
             .expect("launch must succeed");
 
@@ -944,29 +943,6 @@ mod tests {
         handle.join(None).ok();
     }
 
-    // ---- shutdown flag is set to true on launch -----------------------------
-
-    /// launch_scenario sets the shared shutdown flag to true (SeqCst), regardless
-    /// of what the caller set it to beforehand.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn launch_scenario_resets_shutdown_flag_to_true() {
-        // Intentionally start the flag as false to verify launch forces it true.
-        let shutdown = Arc::new(AtomicBool::new(false));
-        let entry = metrics_entry_indefinite("flag_reset");
-
-        let mut handle = launch_scenario("id-flag".to_string(), entry, Arc::clone(&shutdown), None)
-            .await
-            .expect("launch must succeed");
-
-        assert!(
-            shutdown.load(Ordering::SeqCst),
-            "launch_scenario must reset the shutdown flag to true"
-        );
-
-        handle.stop();
-        handle.join(None).ok();
-    }
-
     // ---- start_delay: None starts immediately -------------------------------
 
     /// launch_scenario with start_delay=None starts emitting events immediately.
@@ -974,7 +950,7 @@ mod tests {
     async fn launch_with_no_start_delay_emits_events_immediately() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "no_delay_test".to_string(),
@@ -1000,10 +976,9 @@ mod tests {
             help: None,
         });
 
-        let mut handle =
-            launch_scenario("id-nodelay".to_string(), entry, Arc::clone(&shutdown), None)
-                .await
-                .expect("launch must succeed");
+        let mut handle = launch_scenario("id-nodelay".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed");
 
         // Wait briefly and check events have already been emitted.
         thread::sleep(Duration::from_millis(200));
@@ -1026,7 +1001,7 @@ mod tests {
     async fn launch_with_start_delay_does_not_emit_during_delay() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "delay_test".to_string(),
@@ -1053,14 +1028,10 @@ mod tests {
         });
 
         let delay = Duration::from_millis(500);
-        let mut handle = launch_scenario(
-            "id-delay".to_string(),
-            entry,
-            Arc::clone(&shutdown),
-            Some(delay),
-        )
-        .await
-        .expect("launch must succeed");
+        let mut handle =
+            launch_scenario("id-delay".to_string(), entry, cancel.clone(), Some(delay))
+                .await
+                .expect("launch must succeed");
 
         // Check after 100ms — should still be in the delay period.
         thread::sleep(Duration::from_millis(100));
@@ -1093,7 +1064,7 @@ mod tests {
         use std::thread;
         use std::time::Instant;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("shutdown_delay");
 
         // Set a long delay (10 seconds) so we can verify the shutdown works.
@@ -1101,7 +1072,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-shutdown-delay".to_string(),
             entry,
-            Arc::clone(&shutdown),
+            cancel.clone(),
             Some(delay),
         )
         .await
@@ -1142,7 +1113,7 @@ mod tests {
     async fn launch_logs_with_start_delay_does_not_emit_during_delay() {
         use std::thread;
 
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = ScenarioEntry::Logs(LogScenarioConfig {
             base: BaseScheduleConfig {
                 name: "log_delay_test".to_string(),
@@ -1177,7 +1148,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-log-delay".to_string(),
             entry,
-            Arc::clone(&shutdown),
+            cancel.clone(),
             Some(delay),
         )
         .await
@@ -1279,16 +1250,11 @@ mod tests {
     /// A short histogram scenario launches, runs to completion, and join returns Ok.
     #[tokio::test(flavor = "multi_thread")]
     async fn launch_histogram_scenario_runs_to_completion() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = histogram_entry("launch_histogram");
-        let mut handle = launch_scenario(
-            "id-histogram".to_string(),
-            entry,
-            Arc::clone(&shutdown),
-            None,
-        )
-        .await
-        .expect("launch must succeed for valid histogram entry");
+        let mut handle = launch_scenario("id-histogram".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed for valid histogram entry");
 
         let result = handle.join(Some(Duration::from_secs(5)));
         assert!(
@@ -1302,12 +1268,11 @@ mod tests {
     /// A short summary scenario launches, runs to completion, and join returns Ok.
     #[tokio::test(flavor = "multi_thread")]
     async fn launch_summary_scenario_runs_to_completion() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = summary_entry("launch_summary");
-        let mut handle =
-            launch_scenario("id-summary".to_string(), entry, Arc::clone(&shutdown), None)
-                .await
-                .expect("launch must succeed for valid summary entry");
+        let mut handle = launch_scenario("id-summary".to_string(), entry, cancel.clone(), None)
+            .await
+            .expect("launch must succeed for valid summary entry");
 
         let result = handle.join(Some(Duration::from_secs(5)));
         assert!(
@@ -1611,12 +1576,12 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn state_remains_pending_during_start_delay_then_transitions_to_running() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry_indefinite("delayed_state");
         let mut handle = launch_scenario(
             "delayed-state-id".to_string(),
             entry,
-            Arc::clone(&shutdown),
+            cancel.clone(),
             Some(Duration::from_millis(200)),
         )
         .await
@@ -1642,9 +1607,9 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn launch_non_gated_scenario_state_transitions_through_running_to_finished() {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry("state_lifecycle");
-        let mut handle = launch_scenario("state-id".to_string(), entry, shutdown, None)
+        let mut handle = launch_scenario("state-id".to_string(), entry, cancel, None)
             .await
             .expect("launch must succeed");
 
@@ -1826,7 +1791,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-meta-gauge".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .await
@@ -1846,7 +1811,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-meta-step".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .await
@@ -1866,7 +1831,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-meta-hist".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .await
@@ -1885,7 +1850,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-meta-sum".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .await
@@ -1904,7 +1869,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-meta-explicit".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .await
@@ -1924,7 +1889,7 @@ mod tests {
         let mut handle = launch_scenario(
             "id-meta-logs".to_string(),
             entry,
-            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
             None,
         )
         .await
@@ -1935,5 +1900,62 @@ mod tests {
         );
         handle.stop();
         handle.join(Some(Duration::from_secs(2))).ok();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancel_during_gap_sleep_exits_within_200ms() {
+        let cancel = CancellationToken::new();
+        let entry = ScenarioEntry::Metrics(ScenarioConfig {
+            base: BaseScheduleConfig {
+                name: "cancel_during_gap_sleep".to_string(),
+                rate: 100.0,
+                duration: None,
+                gaps: Some(GapConfig {
+                    every: "3s".to_string(),
+                    r#for: "2900ms".to_string(),
+                }),
+                bursts: None,
+                cardinality_spikes: None,
+                dynamic_labels: None,
+                labels: None,
+                sink: SinkConfig::Stdout,
+                phase_offset: None,
+                clock_group: None,
+                clock_group_is_auto: None,
+                start_time: None,
+                jitter: None,
+                jitter_seed: None,
+                on_sink_error: crate::OnSinkError::Warn,
+            },
+            generator: GeneratorConfig::Constant { value: 1.0 },
+            encoder: EncoderConfig::PrometheusText { precision: None },
+            metric_type: None,
+            help: None,
+        });
+
+        let mut handle = launch_scenario(
+            "cancel-gap-sleep-id".to_string(),
+            entry,
+            cancel.clone(),
+            None,
+        )
+        .await
+        .expect("launch must succeed");
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let cancel_at = Instant::now();
+        handle.stop();
+        let join_result = handle.join_async(Some(Duration::from_millis(500))).await;
+        let exit_duration = cancel_at.elapsed();
+
+        assert!(
+            join_result.is_ok(),
+            "join_async must complete within 500ms; got {join_result:?}"
+        );
+        assert!(
+            exit_duration < Duration::from_millis(200),
+            "cancel-to-exit must be under 200ms; took {exit_duration:?}"
+        );
     }
 }

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -311,47 +311,56 @@ pub fn launch_scenario_with_gates(
                 }
             }
 
+            // Per-scenario current-thread Tokio runtime: drives the async
+            // runner from inside the std::thread::spawn'd scenario thread.
+            // One runtime per thread keeps the blocking-task pool local to
+            // this scenario.
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
+
             match entry {
                 ScenarioEntry::Metrics(config) => {
                     let mut sink = create_sink(&config.sink, None)?;
-                    run_with_sink_gated(
+                    rt.block_on(run_with_sink_gated(
                         &config,
-                        sink.as_mut(),
+                        &mut sink,
                         Some(shutdown_for_thread.as_ref()),
                         Some(Arc::clone(&stats_for_thread)),
                         upstream_bus,
                         gate_ctx,
-                    )
+                    ))
                 }
                 ScenarioEntry::Logs(config) => {
                     let mut sink = create_sink(&config.sink, config.labels.as_ref())?;
-                    run_logs_with_sink_gated(
+                    rt.block_on(run_logs_with_sink_gated(
                         &config,
-                        sink.as_mut(),
+                        &mut sink,
                         Some(shutdown_for_thread.as_ref()),
                         Some(Arc::clone(&stats_for_thread)),
                         gate_ctx,
-                    )
+                    ))
                 }
                 ScenarioEntry::Histogram(config) => {
                     let mut sink = create_sink(&config.sink, None)?;
-                    run_histogram_with_sink_gated(
+                    rt.block_on(run_histogram_with_sink_gated(
                         &config,
-                        sink.as_mut(),
+                        &mut sink,
                         Some(shutdown_for_thread.as_ref()),
                         Some(Arc::clone(&stats_for_thread)),
                         gate_ctx,
-                    )
+                    ))
                 }
                 ScenarioEntry::Summary(config) => {
                     let mut sink = create_sink(&config.sink, None)?;
-                    run_summary_with_sink_gated(
+                    rt.block_on(run_summary_with_sink_gated(
                         &config,
-                        sink.as_mut(),
+                        &mut sink,
                         Some(shutdown_for_thread.as_ref()),
                         Some(Arc::clone(&stats_for_thread)),
                         gate_ctx,
-                    )
+                    ))
                 }
             }
         })

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -18,12 +18,11 @@ use crate::generator::GeneratorConfig;
 use crate::schedule::core_loop::GateContext;
 use crate::schedule::gate_bus::{GateBus, GateBusResolver};
 use crate::schedule::handle::ScenarioHandle;
-use crate::schedule::histogram_runner::run_with_sink_gated as run_histogram_with_sink_gated;
-use crate::schedule::log_runner::run_logs_with_sink_gated;
-use crate::schedule::runner::run_with_sink_gated;
+use crate::schedule::histogram_runner::run_with_sink_gated_blocking as run_histogram_with_sink_gated_blocking;
+use crate::schedule::log_runner::run_logs_with_sink_gated_blocking;
+use crate::schedule::runner::run_with_sink_gated_blocking;
 use crate::schedule::stats::{ScenarioState, ScenarioStats};
-use crate::schedule::summary_runner::run_with_sink_gated as run_summary_with_sink_gated;
-use crate::sink::create_sink;
+use crate::schedule::summary_runner::run_with_sink_gated_blocking as run_summary_with_sink_gated_blocking;
 use crate::{ConfigError, RuntimeError, SondaError};
 
 /// Extract the inner message from a [`SondaError`] for re-wrapping.
@@ -167,51 +166,18 @@ pub fn prepare_entries(entries: Vec<ScenarioEntry>) -> Result<Vec<PreparedEntry>
 }
 
 /// Launch a single scenario on a new OS thread.
-///
-/// Creates the sink, wires up the shutdown flag and the stats arc, spawns the
-/// appropriate runner (metrics, logs, histogram, or summary), and returns a
-/// [`ScenarioHandle`] for lifecycle management.
-///
-/// This is the single function that both the CLI and sonda-server call to
-/// start a scenario. No scenario launch logic exists outside this function.
-///
-/// # Parameters
-///
-/// * `id` — unique identifier for this scenario instance (e.g. a UUID string).
-/// * `entry` — the scenario configuration. The `signal_type` field selects
-///   the runner.
-/// * `shutdown` — shared shutdown flag. Pass `Arc::new(AtomicBool::new(true))`
-///   for a new scenario. The handle's [`ScenarioHandle::stop`] method sets this
-///   to `false` to request a clean exit.
-/// * `start_delay` — optional delay before the scenario begins emitting events.
-///   When `Some`, the spawned thread sleeps for this duration before entering the
-///   event loop. This enables temporal correlation in multi-scenario mode: "metric
-///   A starts immediately, metric B starts 30s later". The sleep happens inside
-///   the spawned thread, so it does not block the caller.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if the sink cannot be created. Thread spawn failures
-/// are extremely rare on modern operating systems; if the OS refuses to spawn
-/// a thread it is treated as an unrecoverable condition.
-pub fn launch_scenario(
+pub async fn launch_scenario(
     id: String,
     entry: ScenarioEntry,
     shutdown: Arc<AtomicBool>,
     start_delay: Option<Duration>,
 ) -> Result<ScenarioHandle, SondaError> {
-    launch_scenario_with_gates(id, None, entry, shutdown, start_delay, None, None, None)
+    launch_scenario_with_gates(id, None, entry, shutdown, start_delay, None, None, None).await
 }
 
 /// Launch a scenario with optional `while:` / `after:` gating wired in.
-///
-/// `scenario_name` surfaces on [`ScenarioHandle::scenario_name`]; pass `None`
-/// for anonymous bodies. `upstream_bus` is the bus this scenario PUBLISHES
-/// into (for downstream gates to read). `gate_ctx` is what THIS scenario
-/// consumes from an upstream bus. When `resolver` is `Some` AND `scenario_name`
-/// is `Some`, natural-exit cleanup unregisters the upstream bus on thread exit.
 #[allow(clippy::too_many_arguments)]
-pub fn launch_scenario_with_gates(
+pub async fn launch_scenario_with_gates(
     id: String,
     scenario_name: Option<String>,
     entry: ScenarioEntry,
@@ -311,57 +277,32 @@ pub fn launch_scenario_with_gates(
                 }
             }
 
-            // Per-scenario current-thread Tokio runtime: drives the async
-            // runner from inside the std::thread::spawn'd scenario thread.
-            // One runtime per thread keeps the blocking-task pool local to
-            // this scenario.
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
-
             match entry {
-                ScenarioEntry::Metrics(config) => {
-                    let mut sink = create_sink(&config.sink, None)?;
-                    rt.block_on(run_with_sink_gated(
-                        &config,
-                        &mut sink,
-                        Some(shutdown_for_thread.as_ref()),
-                        Some(Arc::clone(&stats_for_thread)),
-                        upstream_bus,
-                        gate_ctx,
-                    ))
-                }
-                ScenarioEntry::Logs(config) => {
-                    let mut sink = create_sink(&config.sink, config.labels.as_ref())?;
-                    rt.block_on(run_logs_with_sink_gated(
-                        &config,
-                        &mut sink,
-                        Some(shutdown_for_thread.as_ref()),
-                        Some(Arc::clone(&stats_for_thread)),
-                        gate_ctx,
-                    ))
-                }
-                ScenarioEntry::Histogram(config) => {
-                    let mut sink = create_sink(&config.sink, None)?;
-                    rt.block_on(run_histogram_with_sink_gated(
-                        &config,
-                        &mut sink,
-                        Some(shutdown_for_thread.as_ref()),
-                        Some(Arc::clone(&stats_for_thread)),
-                        gate_ctx,
-                    ))
-                }
-                ScenarioEntry::Summary(config) => {
-                    let mut sink = create_sink(&config.sink, None)?;
-                    rt.block_on(run_summary_with_sink_gated(
-                        &config,
-                        &mut sink,
-                        Some(shutdown_for_thread.as_ref()),
-                        Some(Arc::clone(&stats_for_thread)),
-                        gate_ctx,
-                    ))
-                }
+                ScenarioEntry::Metrics(config) => run_with_sink_gated_blocking(
+                    &config,
+                    Some(shutdown_for_thread.as_ref()),
+                    Some(Arc::clone(&stats_for_thread)),
+                    upstream_bus,
+                    gate_ctx,
+                ),
+                ScenarioEntry::Logs(config) => run_logs_with_sink_gated_blocking(
+                    &config,
+                    Some(shutdown_for_thread.as_ref()),
+                    Some(Arc::clone(&stats_for_thread)),
+                    gate_ctx,
+                ),
+                ScenarioEntry::Histogram(config) => run_histogram_with_sink_gated_blocking(
+                    &config,
+                    Some(shutdown_for_thread.as_ref()),
+                    Some(Arc::clone(&stats_for_thread)),
+                    gate_ctx,
+                ),
+                ScenarioEntry::Summary(config) => run_summary_with_sink_gated_blocking(
+                    &config,
+                    Some(shutdown_for_thread.as_ref()),
+                    Some(Arc::clone(&stats_for_thread)),
+                    gate_ctx,
+                ),
             }
         })
         .map_err(|e| SondaError::Runtime(RuntimeError::SpawnFailed(e)))?;
@@ -759,13 +700,14 @@ mod tests {
     // ---- launch_scenario: returns a running handle --------------------------
 
     /// launch_scenario with a metrics entry returns a handle whose thread is alive.
-    #[test]
-    fn launch_scenario_metrics_returns_running_handle() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_scenario_metrics_returns_running_handle() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = metrics_entry_indefinite("launch_metrics");
 
         let mut handle =
             launch_scenario("test-id-1".to_string(), entry, Arc::clone(&shutdown), None)
+                .await
                 .expect("launch must succeed for valid metrics entry");
 
         // The thread must be alive immediately after launch.
@@ -786,13 +728,14 @@ mod tests {
     }
 
     /// launch_scenario with a logs entry returns a handle whose thread is alive.
-    #[test]
-    fn launch_scenario_logs_returns_running_handle() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_scenario_logs_returns_running_handle() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = logs_entry_indefinite("launch_logs");
 
         let mut handle =
             launch_scenario("test-id-2".to_string(), entry, Arc::clone(&shutdown), None)
+                .await
                 .expect("launch must succeed for valid logs entry");
 
         assert!(
@@ -810,11 +753,12 @@ mod tests {
     // ---- stop() + join() exits cleanly --------------------------------------
 
     /// stop() followed by join() on a metrics scenario exits cleanly (Ok).
-    #[test]
-    fn stop_then_join_metrics_scenario_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stop_then_join_metrics_scenario_returns_ok() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = metrics_entry_indefinite("stop_join_metrics");
         let mut handle = launch_scenario("id-stop-1".to_string(), entry, shutdown, None)
+            .await
             .expect("launch must succeed");
 
         handle.stop();
@@ -830,11 +774,12 @@ mod tests {
     }
 
     /// stop() followed by join() on a logs scenario exits cleanly (Ok).
-    #[test]
-    fn stop_then_join_logs_scenario_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stop_then_join_logs_scenario_returns_ok() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = logs_entry_indefinite("stop_join_logs");
         let mut handle = launch_scenario("id-stop-2".to_string(), entry, shutdown, None)
+            .await
             .expect("launch must succeed");
 
         handle.stop();
@@ -846,11 +791,12 @@ mod tests {
     }
 
     /// A finite-duration scenario exits on its own and join() returns Ok.
-    #[test]
-    fn finite_duration_scenario_exits_naturally_and_join_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn finite_duration_scenario_exits_naturally_and_join_returns_ok() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = metrics_entry("natural_exit");
         let mut handle = launch_scenario("id-natural".to_string(), entry, shutdown, None)
+            .await
             .expect("launch must succeed");
 
         // 200ms duration — wait for it to finish, then join.
@@ -864,8 +810,8 @@ mod tests {
     // ---- stats_snapshot(): non-zero total_events after brief run ------------
 
     /// After letting a launched scenario run briefly, stats show non-zero events.
-    #[test]
-    fn stats_snapshot_shows_nonzero_events_after_brief_run() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_shows_nonzero_events_after_brief_run() {
         use std::thread;
 
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -897,6 +843,7 @@ mod tests {
 
         let mut handle =
             launch_scenario("id-stats".to_string(), entry, Arc::clone(&shutdown), None)
+                .await
                 .expect("launch must succeed");
 
         // Wait long enough for at least a few events to be emitted and stats updated.
@@ -919,8 +866,8 @@ mod tests {
     }
 
     /// Stats are also tracked for logs scenarios.
-    #[test]
-    fn stats_snapshot_shows_nonzero_events_for_logs_scenario() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stats_snapshot_shows_nonzero_events_for_logs_scenario() {
         use std::thread;
 
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -960,6 +907,7 @@ mod tests {
             Arc::clone(&shutdown),
             None,
         )
+        .await
         .expect("launch must succeed");
 
         thread::sleep(Duration::from_millis(200));
@@ -978,11 +926,12 @@ mod tests {
     // ---- elapsed(): positive duration after launch --------------------------
 
     /// elapsed() is positive immediately after launch.
-    #[test]
-    fn elapsed_is_positive_after_launch() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn elapsed_is_positive_after_launch() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = metrics_entry_indefinite("elapsed_test");
         let mut handle = launch_scenario("id-elapsed".to_string(), entry, shutdown, None)
+            .await
             .expect("launch must succeed");
 
         let d = handle.elapsed();
@@ -999,13 +948,14 @@ mod tests {
 
     /// launch_scenario sets the shared shutdown flag to true (SeqCst), regardless
     /// of what the caller set it to beforehand.
-    #[test]
-    fn launch_scenario_resets_shutdown_flag_to_true() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_scenario_resets_shutdown_flag_to_true() {
         // Intentionally start the flag as false to verify launch forces it true.
         let shutdown = Arc::new(AtomicBool::new(false));
         let entry = metrics_entry_indefinite("flag_reset");
 
         let mut handle = launch_scenario("id-flag".to_string(), entry, Arc::clone(&shutdown), None)
+            .await
             .expect("launch must succeed");
 
         assert!(
@@ -1020,8 +970,8 @@ mod tests {
     // ---- start_delay: None starts immediately -------------------------------
 
     /// launch_scenario with start_delay=None starts emitting events immediately.
-    #[test]
-    fn launch_with_no_start_delay_emits_events_immediately() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_with_no_start_delay_emits_events_immediately() {
         use std::thread;
 
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -1052,6 +1002,7 @@ mod tests {
 
         let mut handle =
             launch_scenario("id-nodelay".to_string(), entry, Arc::clone(&shutdown), None)
+                .await
                 .expect("launch must succeed");
 
         // Wait briefly and check events have already been emitted.
@@ -1071,8 +1022,8 @@ mod tests {
 
     /// launch_scenario with start_delay=Some(500ms) does not emit events for
     /// the first ~400ms (allowing margin for thread scheduling).
-    #[test]
-    fn launch_with_start_delay_does_not_emit_during_delay() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_with_start_delay_does_not_emit_during_delay() {
         use std::thread;
 
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -1108,6 +1059,7 @@ mod tests {
             Arc::clone(&shutdown),
             Some(delay),
         )
+        .await
         .expect("launch must succeed");
 
         // Check after 100ms — should still be in the delay period.
@@ -1136,8 +1088,8 @@ mod tests {
 
     /// Sending shutdown during start_delay causes the thread to exit cleanly
     /// without hanging.
-    #[test]
-    fn shutdown_during_start_delay_exits_cleanly() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn shutdown_during_start_delay_exits_cleanly() {
         use std::thread;
         use std::time::Instant;
 
@@ -1152,6 +1104,7 @@ mod tests {
             Arc::clone(&shutdown),
             Some(delay),
         )
+        .await
         .expect("launch must succeed");
 
         // Wait 100ms then signal shutdown.
@@ -1185,8 +1138,8 @@ mod tests {
     // ---- start_delay with logs scenario -------------------------------------
 
     /// launch_scenario with start_delay works for logs scenarios too.
-    #[test]
-    fn launch_logs_with_start_delay_does_not_emit_during_delay() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_logs_with_start_delay_does_not_emit_during_delay() {
         use std::thread;
 
         let shutdown = Arc::new(AtomicBool::new(true));
@@ -1227,6 +1180,7 @@ mod tests {
             Arc::clone(&shutdown),
             Some(delay),
         )
+        .await
         .expect("launch must succeed");
 
         // Check during the delay.
@@ -1323,8 +1277,8 @@ mod tests {
     // ---- launch_scenario: histogram runs to completion ----------------------
 
     /// A short histogram scenario launches, runs to completion, and join returns Ok.
-    #[test]
-    fn launch_histogram_scenario_runs_to_completion() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_histogram_scenario_runs_to_completion() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = histogram_entry("launch_histogram");
         let mut handle = launch_scenario(
@@ -1333,6 +1287,7 @@ mod tests {
             Arc::clone(&shutdown),
             None,
         )
+        .await
         .expect("launch must succeed for valid histogram entry");
 
         let result = handle.join(Some(Duration::from_secs(5)));
@@ -1345,12 +1300,13 @@ mod tests {
     // ---- launch_scenario: summary runs to completion -----------------------
 
     /// A short summary scenario launches, runs to completion, and join returns Ok.
-    #[test]
-    fn launch_summary_scenario_runs_to_completion() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_summary_scenario_runs_to_completion() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = summary_entry("launch_summary");
         let mut handle =
             launch_scenario("id-summary".to_string(), entry, Arc::clone(&shutdown), None)
+                .await
                 .expect("launch must succeed for valid summary entry");
 
         let result = handle.join(Some(Duration::from_secs(5)));
@@ -1653,8 +1609,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn state_remains_pending_during_start_delay_then_transitions_to_running() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn state_remains_pending_during_start_delay_then_transitions_to_running() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = metrics_entry_indefinite("delayed_state");
         let mut handle = launch_scenario(
@@ -1663,6 +1619,7 @@ mod tests {
             Arc::clone(&shutdown),
             Some(Duration::from_millis(200)),
         )
+        .await
         .expect("launch must succeed");
 
         std::thread::sleep(Duration::from_millis(50));
@@ -1683,11 +1640,12 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_non_gated_scenario_state_transitions_through_running_to_finished() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_non_gated_scenario_state_transitions_through_running_to_finished() {
         let shutdown = Arc::new(AtomicBool::new(true));
         let entry = metrics_entry("state_lifecycle");
         let mut handle = launch_scenario("state-id".to_string(), entry, shutdown, None)
+            .await
             .expect("launch must succeed");
 
         let mut saw_running = false;
@@ -1862,8 +1820,8 @@ mod tests {
         })
     }
 
-    #[test]
-    fn launch_metrics_scenario_with_no_type_defaults_to_gauge() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_metrics_scenario_with_no_type_defaults_to_gauge() {
         let entry = entry_with_metric_type(None);
         let mut handle = launch_scenario(
             "id-meta-gauge".to_string(),
@@ -1871,6 +1829,7 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         let meta = handle
             .prometheus_meta
@@ -1881,8 +1840,8 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_metrics_scenario_with_step_generator_defaults_to_counter() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_metrics_scenario_with_step_generator_defaults_to_counter() {
         let entry = step_entry("step_counter");
         let mut handle = launch_scenario(
             "id-meta-step".to_string(),
@@ -1890,6 +1849,7 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         let meta = handle
             .prometheus_meta
@@ -1900,8 +1860,8 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_histogram_scenario_defaults_to_histogram() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_histogram_scenario_defaults_to_histogram() {
         let entry = histogram_entry("hist_default");
         let mut handle = launch_scenario(
             "id-meta-hist".to_string(),
@@ -1909,6 +1869,7 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         let meta = handle
             .prometheus_meta
@@ -1918,8 +1879,8 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_summary_scenario_defaults_to_summary() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_summary_scenario_defaults_to_summary() {
         let entry = summary_entry("summary_default");
         let mut handle = launch_scenario(
             "id-meta-sum".to_string(),
@@ -1927,6 +1888,7 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         let meta = handle
             .prometheus_meta
@@ -1936,8 +1898,8 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_scenario_explicit_metric_type_overrides_default() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_scenario_explicit_metric_type_overrides_default() {
         let entry = entry_with_metric_type(Some(PromMetricType::Counter));
         let mut handle = launch_scenario(
             "id-meta-explicit".to_string(),
@@ -1945,6 +1907,7 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         let meta = handle
             .prometheus_meta
@@ -1955,8 +1918,8 @@ mod tests {
         handle.join(Some(Duration::from_secs(2))).ok();
     }
 
-    #[test]
-    fn launch_log_scenario_has_no_prometheus_meta() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_log_scenario_has_no_prometheus_meta() {
         let entry = logs_entry("log_no_meta");
         let mut handle = launch_scenario(
             "id-meta-logs".to_string(),
@@ -1964,6 +1927,7 @@ mod tests {
             Arc::new(AtomicBool::new(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         assert!(
             handle.prometheus_meta.is_none(),

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -34,7 +34,7 @@ use crate::SondaError;
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run_logs(config: &LogScenarioConfig) -> Result<(), SondaError> {
-    let mut sink = create_sink(&config.sink, config.labels.as_ref())?;
+    let mut sink = create_sink(&config.sink, config.labels.as_ref()).await?;
     run_logs_with_sink(config, &mut sink, None, None).await
 }
 
@@ -77,6 +77,22 @@ pub async fn run_logs_with_sink(
 ///
 /// Logs cannot be `while:` upstreams (compile-time `NonMetricsTarget`),
 /// but they can be `while:`-gated downstreams.
+pub fn run_logs_with_sink_gated_blocking(
+    config: &LogScenarioConfig,
+    shutdown: Option<&AtomicBool>,
+    stats: Option<Arc<RwLock<ScenarioStats>>>,
+    gate_ctx: Option<GateContext>,
+) -> Result<(), SondaError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
+    rt.block_on(async {
+        let mut sink = create_sink(&config.sink, config.labels.as_ref()).await?;
+        run_logs_with_sink_gated(config, &mut sink, shutdown, stats, gate_ctx).await
+    })
+}
+
 pub async fn run_logs_with_sink_gated(
     config: &LogScenarioConfig,
     sink: &mut Box<dyn Sink>,
@@ -175,6 +191,8 @@ mod tests {
     use std::collections::{BTreeMap, HashMap};
     use std::sync::Mutex;
 
+    use async_trait::async_trait;
+
     use super::*;
     use crate::config::{BaseScheduleConfig, GapConfig, LogScenarioConfig};
     use crate::encoder::EncoderConfig;
@@ -185,15 +203,16 @@ mod tests {
 
     struct ProbeSink(SharedBuf);
 
+    #[async_trait]
     impl Sink for ProbeSink {
-        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
             self.0
                 .lock()
                 .expect("probe sink mutex poisoned")
                 .extend_from_slice(data);
             Ok(())
         }
-        fn flush(&mut self) -> Result<(), SondaError> {
+        async fn flush(&mut self) -> Result<(), SondaError> {
             Ok(())
         }
     }

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -13,7 +13,9 @@ use crate::config::LogScenarioConfig;
 use crate::encoder::create_encoder;
 use crate::generator::create_log_generator;
 use crate::model::metric::{Labels, MetricEvent};
-use crate::schedule::core_loop::{self, GateContext, TickContext, TickResult};
+use crate::schedule::core_loop::{
+    self, GateContext, TickContext, TickOutput, TickResult, WriteCommand,
+};
 use crate::schedule::is_in_spike;
 use crate::schedule::stats::ScenarioStats;
 use crate::schedule::ParsedSchedule;
@@ -105,7 +107,7 @@ pub fn run_logs_with_sink_gated(
     let mut buf: Vec<u8> = Vec::with_capacity(512);
 
     let mut tick_fn = |ctx: &TickContext<'_>,
-                       sink: &mut dyn Sink,
+                       output: &mut TickOutput,
                        _events_buf: &mut Vec<MetricEvent>|
      -> Result<TickResult, SondaError> {
         let mut event = generator.generate(ctx.tick);
@@ -130,17 +132,18 @@ pub fn run_logs_with_sink_gated(
         buf.clear();
         encoder.encode_log(&event, &mut buf)?;
         let bytes_written = buf.len() as u64;
-        sink.write_log_event(&event, &buf)?;
-        let delivered = sink.last_write_delivered();
+        output.writes.push(WriteCommand::LogEvent {
+            event,
+            bytes: std::mem::take(&mut buf),
+        });
 
         Ok(TickResult {
             bytes_written,
-            delivered,
+            delivered: true,
         })
     };
 
-    let stats_for_flush = stats.clone();
-    let loop_result = match gate_ctx {
+    match gate_ctx {
         None => core_loop::run_schedule_loop(
             &schedule,
             config.rate,
@@ -158,12 +161,6 @@ pub fn run_logs_with_sink_gated(
             sink,
             &mut tick_fn,
         ),
-    };
-
-    let flush_result = sink.flush();
-    match loop_result {
-        Ok(()) => core_loop::apply_flush_policy(&schedule, stats_for_flush.as_ref(), flush_result),
-        Err(e) => Err(e),
     }
 }
 

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -33,9 +33,9 @@ use crate::SondaError;
 /// # Errors
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-pub fn run_logs(config: &LogScenarioConfig) -> Result<(), SondaError> {
+pub async fn run_logs(config: &LogScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, config.labels.as_ref())?;
-    run_logs_with_sink(config, sink.as_mut(), None, None)
+    run_logs_with_sink(config, &mut sink, None, None).await
 }
 
 /// Run a log scenario to completion, writing encoded events into the provided sink.
@@ -64,22 +64,22 @@ pub fn run_logs(config: &LogScenarioConfig) -> Result<(), SondaError> {
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 /// If an error occurs during the loop and flushing also fails, the loop error
 /// is returned (the flush error is discarded to preserve the original cause).
-pub fn run_logs_with_sink(
+pub async fn run_logs_with_sink(
     config: &LogScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_logs_with_sink_gated(config, sink, shutdown, stats, None)
+    run_logs_with_sink_gated(config, sink, shutdown, stats, None).await
 }
 
 /// Run a log scenario with optional `while:` / `after:` gating.
 ///
 /// Logs cannot be `while:` upstreams (compile-time `NonMetricsTarget`),
 /// but they can be `while:`-gated downstreams.
-pub fn run_logs_with_sink_gated(
+pub async fn run_logs_with_sink_gated(
     config: &LogScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
@@ -144,36 +144,65 @@ pub fn run_logs_with_sink_gated(
     };
 
     match gate_ctx {
-        None => core_loop::run_schedule_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            sink,
-            &mut tick_fn,
-        ),
-        Some(ctx) => core_loop::gated_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            ctx,
-            sink,
-            &mut tick_fn,
-        ),
+        None => {
+            core_loop::run_schedule_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
+        Some(ctx) => {
+            core_loop::gated_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                ctx,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, HashMap};
+    use std::sync::Mutex;
 
     use super::*;
     use crate::config::{BaseScheduleConfig, GapConfig, LogScenarioConfig};
     use crate::encoder::EncoderConfig;
     use crate::generator::{LogGeneratorConfig, TemplateConfig};
-    use crate::sink::memory::MemorySink;
     use crate::sink::SinkConfig;
+
+    type SharedBuf = Arc<Mutex<Vec<u8>>>;
+
+    struct ProbeSink(SharedBuf);
+
+    impl Sink for ProbeSink {
+        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+            self.0
+                .lock()
+                .expect("probe sink mutex poisoned")
+                .extend_from_slice(data);
+            Ok(())
+        }
+        fn flush(&mut self) -> Result<(), SondaError> {
+            Ok(())
+        }
+    }
+
+    fn probe_sink() -> (Box<dyn Sink>, SharedBuf) {
+        let buf: SharedBuf = Arc::new(Mutex::new(Vec::new()));
+        let sink: Box<dyn Sink> = Box::new(ProbeSink(SharedBuf::clone(&buf)));
+        (sink, buf)
+    }
 
     /// Build a minimal valid `LogScenarioConfig` for use in tests.
     ///
@@ -220,15 +249,18 @@ mod tests {
     ///
     /// At rate=10 and duration=1s we expect 10 events (within ±3 tolerance to
     /// accommodate OS scheduling jitter without making the test fragile).
-    #[test]
-    fn run_logs_with_sink_rate_10_duration_1s_produces_approx_10_lines() {
+    #[tokio::test]
+    async fn run_logs_with_sink_rate_10_duration_1s_produces_approx_10_lines() {
         let config = make_config(10.0, Some("1s"));
-        let mut sink = MemorySink::new();
+        let (mut sink, buf) = probe_sink();
 
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
         // Count newline-terminated JSON lines.
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let line_count = output.lines().count();
         assert!(
             (7..=13).contains(&line_count),
@@ -237,14 +269,17 @@ mod tests {
     }
 
     /// Every emitted line must be non-empty valid JSON with a `message` key.
-    #[test]
-    fn run_logs_with_sink_each_line_is_valid_json() {
+    #[tokio::test]
+    async fn run_logs_with_sink_each_line_is_valid_json() {
         let config = make_config(10.0, Some("1s"));
-        let mut sink = MemorySink::new();
+        let (mut sink, buf) = probe_sink();
 
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             let parsed: serde_json::Value = serde_json::from_str(line)
                 .unwrap_or_else(|e| panic!("line is not valid JSON: {e}\nline: {line}"));
@@ -261,15 +296,15 @@ mod tests {
 
     /// If the shutdown flag is cleared (false) before the scenario would
     /// naturally finish, the runner must exit cleanly without error.
-    #[test]
-    fn run_logs_with_sink_shutdown_flag_stops_runner() {
+    #[tokio::test]
+    async fn run_logs_with_sink_shutdown_flag_stops_runner() {
         use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::Arc;
         use std::thread;
         use std::time::Duration;
 
         let config = make_config(5.0, None); // runs indefinitely without shutdown
-        let mut sink = MemorySink::new();
+        let (mut sink, _buf) = probe_sink();
         let shutdown = Arc::new(AtomicBool::new(true));
 
         let flag_clone = Arc::clone(&shutdown);
@@ -279,7 +314,7 @@ mod tests {
             flag_clone.store(false, Ordering::SeqCst);
         });
 
-        let result = run_logs_with_sink(&config, &mut sink, Some(shutdown.as_ref()), None);
+        let result = run_logs_with_sink(&config, &mut sink, Some(shutdown.as_ref()), None).await;
         assert!(
             result.is_ok(),
             "runner must return Ok when stopped via shutdown flag"
@@ -296,8 +331,8 @@ mod tests {
     /// and run for 500ms — the scenario starts in a non-gap period initially
     /// but then immediately transitions into the gap for the rest of the run,
     /// so zero or very few events are emitted.
-    #[test]
-    fn run_logs_with_sink_gap_suppresses_output() {
+    #[tokio::test]
+    async fn run_logs_with_sink_gap_suppresses_output() {
         // gap: every=10s, for=9s → gap starts at 1s.
         // duration=2s → after 1s of normal events, 1s is spent in a gap.
         let mut config = make_config(100.0, Some("2s"));
@@ -306,10 +341,13 @@ mod tests {
             r#for: "9s".to_string(), // gap from second 1 to second 10
         });
 
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         let line_count = output.lines().count();
         // Only ~100 events from the first second (before the gap). The gap covers
         // seconds 1–10, so the remaining 1s of the 2s run is silent.
@@ -325,15 +363,17 @@ mod tests {
 
     /// When a finite duration is set, the runner must exit at the right time.
     /// Verify this is respected by running at low rate for 500ms.
-    #[test]
-    fn run_logs_with_sink_duration_500ms_exits_promptly() {
+    #[tokio::test]
+    async fn run_logs_with_sink_duration_500ms_exits_promptly() {
         use std::time::Instant;
 
         let config = make_config(5.0, Some("500ms"));
-        let mut sink = MemorySink::new();
+        let (mut sink, _buf) = probe_sink();
 
         let t0 = Instant::now();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("must not error");
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("must not error");
         let elapsed = t0.elapsed();
 
         // Should exit within 2 seconds of the 500ms duration.
@@ -503,18 +543,21 @@ sink:
 
     /// When labels are configured, every emitted JSON line must include the
     /// labels object with the correct key-value pairs.
-    #[test]
-    fn run_logs_with_sink_labels_appear_in_json_output() {
+    #[tokio::test]
+    async fn run_logs_with_sink_labels_appear_in_json_output() {
         let mut config = make_config(10.0, Some("1s"));
         let mut label_map = HashMap::new();
         label_map.insert("device".to_string(), "wlan0".to_string());
         label_map.insert("hostname".to_string(), "router_01".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(
             !lines.is_empty(),
@@ -537,13 +580,16 @@ sink:
 
     /// When no labels are configured, the labels object in JSON output must be
     /// empty (not absent).
-    #[test]
-    fn run_logs_with_sink_no_labels_produces_empty_labels_object() {
+    #[tokio::test]
+    async fn run_logs_with_sink_no_labels_produces_empty_labels_object() {
         let config = make_config(10.0, Some("500ms"));
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             let parsed: serde_json::Value = serde_json::from_str(line)
                 .unwrap_or_else(|e| panic!("line is not valid JSON: {e}\nline: {line}"));
@@ -556,8 +602,8 @@ sink:
     }
 
     /// Labels in syslog encoder should appear as structured data.
-    #[test]
-    fn run_logs_with_sink_labels_appear_in_syslog_output() {
+    #[tokio::test]
+    async fn run_logs_with_sink_labels_appear_in_syslog_output() {
         let mut config = make_config(10.0, Some("500ms"));
         config.encoder = EncoderConfig::Syslog {
             hostname: None,
@@ -567,10 +613,13 @@ sink:
         label_map.insert("env".to_string(), "prod".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(
             !lines.is_empty(),
@@ -616,8 +665,8 @@ sink:
 
     /// When the entire run is inside a spike window, every JSON line must
     /// contain the spike label key in the labels object.
-    #[test]
-    fn run_logs_with_sink_spike_labels_appear_during_spike_window() {
+    #[tokio::test]
+    async fn run_logs_with_sink_spike_labels_appear_during_spike_window() {
         let spike = crate::config::CardinalitySpikeConfig {
             label: "pod_name".to_string(),
             every: "10s".to_string(),
@@ -628,11 +677,14 @@ sink:
             seed: None,
         };
         let config = make_config_with_spike(10.0, Some("1s"), spike);
-        let mut sink = MemorySink::new();
+        let (mut sink, buf) = probe_sink();
 
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(
             !lines.is_empty(),
@@ -655,13 +707,16 @@ sink:
     }
 
     /// When no spike windows are configured, labels object must not contain spike keys.
-    #[test]
-    fn run_logs_with_sink_no_spike_config_produces_no_spike_labels() {
+    #[tokio::test]
+    async fn run_logs_with_sink_no_spike_config_produces_no_spike_labels() {
         let config = make_config(10.0, Some("500ms"));
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             let parsed: serde_json::Value = serde_json::from_str(line)
                 .unwrap_or_else(|e| panic!("line is not valid JSON: {e}\nline: {line}"));
@@ -688,8 +743,8 @@ sink:
     }
 
     /// Dynamic labels with counter strategy appear in every JSON log line.
-    #[test]
-    fn run_logs_dynamic_labels_counter_appear_in_output() {
+    #[tokio::test]
+    async fn run_logs_dynamic_labels_counter_appear_in_output() {
         let config = make_config_with_dynamic_labels(
             10.0,
             Some("1s"),
@@ -701,10 +756,13 @@ sink:
                 },
             }],
         );
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(!lines.is_empty(), "runner must produce output");
 
@@ -724,8 +782,8 @@ sink:
     }
 
     /// Dynamic labels with values list cycle through values in log output.
-    #[test]
-    fn run_logs_dynamic_labels_values_list_cycle_in_output() {
+    #[tokio::test]
+    async fn run_logs_dynamic_labels_values_list_cycle_in_output() {
         let config = make_config_with_dynamic_labels(
             10.0,
             Some("1s"),
@@ -736,10 +794,13 @@ sink:
                 },
             }],
         );
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(!lines.is_empty());
 
@@ -768,8 +829,8 @@ sink:
     }
 
     /// Cardinality ceiling is respected in log output.
-    #[test]
-    fn run_logs_dynamic_labels_respects_cardinality_ceiling() {
+    #[tokio::test]
+    async fn run_logs_dynamic_labels_respects_cardinality_ceiling() {
         let config = make_config_with_dynamic_labels(
             50.0,
             Some("1s"),
@@ -781,10 +842,13 @@ sink:
                 },
             }],
         );
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let mut distinct_values = std::collections::HashSet::new();
         for line in output.lines() {
             let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
@@ -801,8 +865,8 @@ sink:
     }
 
     /// Dynamic labels and static labels coexist in log output.
-    #[test]
-    fn run_logs_dynamic_labels_and_static_labels_coexist() {
+    #[tokio::test]
+    async fn run_logs_dynamic_labels_and_static_labels_coexist() {
         let mut config = make_config_with_dynamic_labels(
             10.0,
             Some("1s"),
@@ -818,10 +882,13 @@ sink:
         label_map.insert("env".to_string(), "staging".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             let parsed: serde_json::Value = serde_json::from_str(line)
                 .unwrap_or_else(|e| panic!("line is not valid JSON: {e}\nline: {line}"));
@@ -837,8 +904,8 @@ sink:
     }
 
     /// Dynamic label wins on key collision with static label in log output.
-    #[test]
-    fn run_logs_dynamic_label_wins_on_key_collision() {
+    #[tokio::test]
+    async fn run_logs_dynamic_label_wins_on_key_collision() {
         let mut config = make_config_with_dynamic_labels(
             10.0,
             Some("500ms"),
@@ -854,10 +921,13 @@ sink:
         label_map.insert("hostname".to_string(), "static-value".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        run_logs_with_sink(&config, &mut sink, None, None).expect("log runner must not error");
+        let (mut sink, buf) = probe_sink();
+        run_logs_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("log runner must not error");
 
-        let output = String::from_utf8(sink.buffer.clone()).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             let parsed: serde_json::Value = serde_json::from_str(line)
                 .unwrap_or_else(|e| panic!("line is not valid JSON: {e}\nline: {line}"));

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -1,13 +1,8 @@
 //! The log scenario event loop.
-//!
-//! The log runner ties together the log generator, encoder, and sink with the
-//! shared schedule loop from [`core_loop::run_schedule_loop`](super::core_loop::run_schedule_loop).
-//! Only the log-specific per-tick work (log event generation, label injection,
-//! encoding) lives here; all schedule infrastructure (rate control, gap/burst/spike
-//! windows, stats tracking, shutdown handling) is in the shared loop.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
+
+use tokio_util::sync::CancellationToken;
 
 use crate::config::LogScenarioConfig;
 use crate::encoder::create_encoder;
@@ -23,80 +18,26 @@ use crate::sink::{create_sink, Sink};
 use crate::SondaError;
 
 /// Run a log scenario to completion, emitting encoded log events at the configured rate.
-///
-/// This is the primary entry point. It constructs a sink from the config and
-/// delegates to [`run_logs_with_sink`] with no shutdown flag and no stats collection.
-///
-/// This function blocks the calling thread until the scenario duration has
-/// elapsed. If no duration is specified in the config it runs indefinitely.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run_logs(config: &LogScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, config.labels.as_ref()).await?;
-    run_logs_with_sink(config, &mut sink, None, None).await
+    let cancel = CancellationToken::new();
+    run_logs_with_sink(config, &mut sink, &cancel, None).await
 }
 
 /// Run a log scenario to completion, writing encoded events into the provided sink.
-///
-/// This function builds the log generator, encoder, and label set from the
-/// config, then delegates to the shared schedule loop via
-/// [`core_loop::run_schedule_loop`](super::core_loop::run_schedule_loop).
-/// The log-specific per-tick work (event generation, label injection, encoding,
-/// and sink writing) is captured in a closure passed to the shared loop.
-///
-/// # Parameters
-///
-/// * `config` — the log scenario configuration.
-/// * `sink` — the destination for encoded log events.
-/// * `shutdown` — an optional atomic flag; when set to `false` the loop exits
-///   cleanly after the current tick, flushes the sink, and returns `Ok(())`.
-///   Pass `None` if no external shutdown signal is needed (e.g., in tests).
-/// * `stats` — an optional shared stats object. When `Some`, the runner updates
-///   `total_events`, `bytes_emitted`, `current_rate`, `in_gap`, `in_burst`, and
-///   `errors` on each tick. The write lock is held only for the brief counter
-///   update, not during encode/write. Pass `None` to skip stats collection with
-///   no overhead (e.g., in direct CLI usage or tests).
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-/// If an error occurs during the loop and flushing also fails, the loop error
-/// is returned (the flush error is discarded to preserve the original cause).
 pub async fn run_logs_with_sink(
     config: &LogScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_logs_with_sink_gated(config, sink, shutdown, stats, None).await
-}
-
-/// Run a log scenario with optional `while:` / `after:` gating.
-///
-/// Logs cannot be `while:` upstreams (compile-time `NonMetricsTarget`),
-/// but they can be `while:`-gated downstreams.
-pub fn run_logs_with_sink_gated_blocking(
-    config: &LogScenarioConfig,
-    shutdown: Option<&AtomicBool>,
-    stats: Option<Arc<RwLock<ScenarioStats>>>,
-    gate_ctx: Option<GateContext>,
-) -> Result<(), SondaError> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
-    rt.block_on(async {
-        let mut sink = create_sink(&config.sink, config.labels.as_ref()).await?;
-        run_logs_with_sink_gated(config, &mut sink, shutdown, stats, gate_ctx).await
-    })
+    run_logs_with_sink_gated(config, sink, cancel, stats, None).await
 }
 
 pub async fn run_logs_with_sink_gated(
     config: &LogScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
 ) -> Result<(), SondaError> {
@@ -161,21 +102,14 @@ pub async fn run_logs_with_sink_gated(
 
     match gate_ctx {
         None => {
-            core_loop::run_schedule_loop(
-                &schedule,
-                config.rate,
-                shutdown,
-                stats,
-                sink,
-                &mut tick_fn,
-            )
-            .await
+            core_loop::run_schedule_loop(&schedule, config.rate, cancel, stats, sink, &mut tick_fn)
+                .await
         }
         Some(ctx) => {
             core_loop::gated_loop(
                 &schedule,
                 config.rate,
-                shutdown,
+                cancel,
                 stats,
                 ctx,
                 sink,
@@ -273,7 +207,7 @@ mod tests {
         let config = make_config(10.0, Some("1s"));
         let (mut sink, buf) = probe_sink();
 
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -293,7 +227,7 @@ mod tests {
         let config = make_config(10.0, Some("1s"));
         let (mut sink, buf) = probe_sink();
 
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -313,31 +247,25 @@ mod tests {
     // Shutdown flag: setting the flag stops the runner before duration expires
     // -------------------------------------------------------------------------
 
-    /// If the shutdown flag is cleared (false) before the scenario would
-    /// naturally finish, the runner must exit cleanly without error.
+    /// Cancelling the token before the scenario would naturally finish causes
+    /// the runner to exit cleanly.
     #[tokio::test]
-    async fn run_logs_with_sink_shutdown_flag_stops_runner() {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::Arc;
+    async fn run_logs_with_sink_cancel_stops_runner() {
         use std::thread;
         use std::time::Duration;
 
-        let config = make_config(5.0, None); // runs indefinitely without shutdown
+        let config = make_config(5.0, None);
         let (mut sink, _buf) = probe_sink();
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
 
-        let flag_clone = Arc::clone(&shutdown);
-        // Clear the shutdown flag after 300ms so the runner exits soon.
+        let cancel_for_thread = cancel.clone();
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(300));
-            flag_clone.store(false, Ordering::SeqCst);
+            cancel_for_thread.cancel();
         });
 
-        let result = run_logs_with_sink(&config, &mut sink, Some(shutdown.as_ref()), None).await;
-        assert!(
-            result.is_ok(),
-            "runner must return Ok when stopped via shutdown flag"
-        );
+        let result = run_logs_with_sink(&config, &mut sink, &cancel, None).await;
+        assert!(result.is_ok());
     }
 
     // -------------------------------------------------------------------------
@@ -361,7 +289,7 @@ mod tests {
         });
 
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -390,7 +318,7 @@ mod tests {
         let (mut sink, _buf) = probe_sink();
 
         let t0 = Instant::now();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("must not error");
         let elapsed = t0.elapsed();
@@ -571,7 +499,7 @@ sink:
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -603,7 +531,7 @@ sink:
     async fn run_logs_with_sink_no_labels_produces_empty_labels_object() {
         let config = make_config(10.0, Some("500ms"));
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -633,7 +561,7 @@ sink:
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -698,7 +626,7 @@ sink:
         let config = make_config_with_spike(10.0, Some("1s"), spike);
         let (mut sink, buf) = probe_sink();
 
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -730,7 +658,7 @@ sink:
     async fn run_logs_with_sink_no_spike_config_produces_no_spike_labels() {
         let config = make_config(10.0, Some("500ms"));
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -776,7 +704,7 @@ sink:
             }],
         );
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -814,7 +742,7 @@ sink:
             }],
         );
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -862,7 +790,7 @@ sink:
             }],
         );
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -902,7 +830,7 @@ sink:
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 
@@ -941,7 +869,7 @@ sink:
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        run_logs_with_sink(&config, &mut sink, None, None)
+        run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("log runner must not error");
 

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -35,33 +35,41 @@ use tokio::sync::watch;
 
 /// Run all scenarios in `entries` concurrently, one OS thread per scenario.
 /// Set `shutdown` to `false` to stop all running scenarios.
-pub fn run_multi(entries: Vec<ScenarioEntry>, shutdown: Arc<AtomicBool>) -> Result<(), SondaError> {
+pub async fn run_multi(
+    entries: Vec<ScenarioEntry>,
+    shutdown: Arc<AtomicBool>,
+) -> Result<(), SondaError> {
     // Expand, validate, and resolve phase offsets for all entries atomically.
     let prepared = prepare_entries(entries)?;
 
     let mut handles = Vec::with_capacity(prepared.len());
     let mut per_handle_shutdowns: Vec<Arc<AtomicBool>> = Vec::with_capacity(prepared.len());
+    let mut errors: Vec<String> = Vec::new();
     for (i, prepared_entry) in prepared.into_iter().enumerate() {
         let id = format!("multi-{i}");
         let scenario_shutdown = Arc::new(AtomicBool::new(true));
-        let handle = launch_scenario(
+        match launch_scenario(
             id,
             prepared_entry.entry,
             Arc::clone(&scenario_shutdown),
             prepared_entry.start_delay,
-        )?;
-        per_handle_shutdowns.push(scenario_shutdown);
-        handles.push(handle);
+        )
+        .await
+        {
+            Ok(handle) => {
+                per_handle_shutdowns.push(scenario_shutdown);
+                handles.push(handle);
+            }
+            Err(e) => errors.push(e.to_string()),
+        }
     }
 
     let done = Arc::new(AtomicBool::new(false));
     let watchdog = spawn_shutdown_watchdog(shutdown, per_handle_shutdowns, Arc::clone(&done));
 
-    let mut errors: Vec<String> = Vec::new();
     for mut handle in handles {
-        match handle.join(None) {
-            Ok(()) => {}
-            Err(e) => errors.push(e.to_string()),
+        if let Err(e) = handle.join(None) {
+            errors.push(e.to_string());
         }
     }
 
@@ -117,7 +125,7 @@ pub fn signal_shutdown(shutdown: &AtomicBool) {
 /// reference must resolve inside `file`. Each handle owns an independent
 /// shutdown flag — see [`run_multi_compiled`] for the master-stop-all path.
 #[cfg(feature = "config")]
-pub fn launch_multi_compiled(
+pub async fn launch_multi_compiled(
     file: CompiledFile,
     resolver: Option<Arc<dyn GateBusResolver>>,
 ) -> Result<Vec<crate::schedule::handle::ScenarioHandle>, SondaError> {
@@ -300,7 +308,9 @@ pub fn launch_multi_compiled(
             plan.upstream_bus,
             plan.gate_ctx,
             resolver.clone(),
-        ) {
+        )
+        .await
+        {
             Ok(handle) => {
                 if let (Some(d), Some(r)) = (deferred, resolver.as_ref()) {
                     r.insert_pending(PendingResolution {
@@ -386,8 +396,11 @@ struct ActiveSubscription {
 /// Non-gated entries launch on the existing non-gated path with no per-tick
 /// overhead.
 #[cfg(feature = "config")]
-pub fn run_multi_compiled(file: CompiledFile, shutdown: Arc<AtomicBool>) -> Result<(), SondaError> {
-    let handles = launch_multi_compiled(file, None)?;
+pub async fn run_multi_compiled(
+    file: CompiledFile,
+    shutdown: Arc<AtomicBool>,
+) -> Result<(), SondaError> {
+    let handles = launch_multi_compiled(file, None).await?;
     let per_handle_shutdowns: Vec<Arc<AtomicBool>> =
         handles.iter().map(|h| Arc::clone(&h.shutdown)).collect();
 
@@ -530,37 +543,37 @@ mod tests {
     // Happy path: multiple scenarios complete successfully
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn run_multi_with_empty_scenarios_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_empty_scenarios_returns_ok() {
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(vec![], shutdown);
+        let result = run_multi(vec![], shutdown).await;
         assert!(result.is_ok(), "empty scenario list should return Ok");
     }
 
-    #[test]
-    fn run_multi_with_single_metrics_scenario_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_single_metrics_scenario_returns_ok() {
         let entries = vec![metrics_entry_stdout("single_metric")];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_ok(),
             "single metrics scenario should complete without error"
         );
     }
 
-    #[test]
-    fn run_multi_with_single_logs_scenario_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_single_logs_scenario_returns_ok() {
         let entries = vec![logs_entry_stdout("single_logs")];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_ok(),
             "single logs scenario should complete without error"
         );
     }
 
-    #[test]
-    fn run_multi_with_metrics_and_logs_both_complete() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_metrics_and_logs_both_complete() {
         // Two scenarios concurrently — both should run to completion within
         // their 100ms durations and return Ok.
         let entries = vec![
@@ -568,22 +581,22 @@ mod tests {
             logs_entry_stdout("concurrent_logs"),
         ];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_ok(),
             "both concurrent scenarios should complete without error"
         );
     }
 
-    #[test]
-    fn run_multi_three_concurrent_scenarios_all_complete() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_three_concurrent_scenarios_all_complete() {
         let entries = vec![
             metrics_entry_stdout("m1"),
             metrics_entry_stdout("m2"),
             logs_entry_stdout("l1"),
         ];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_ok(),
             "three concurrent scenarios should all complete without error"
@@ -594,8 +607,8 @@ mod tests {
     // Shutdown flag: setting it stops all threads
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn run_multi_shutdown_flag_stops_all_threads_within_two_seconds() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_shutdown_flag_stops_all_threads_within_two_seconds() {
         // Both scenarios have no duration (would run indefinitely). We
         // signal shutdown after a short delay and verify all threads stop
         // well within 2 seconds.
@@ -665,7 +678,7 @@ mod tests {
         });
 
         let start = Instant::now();
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "shutdown should not produce an error");
@@ -690,8 +703,8 @@ mod tests {
     // Error handling: errors from individual threads are collected
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn run_multi_with_invalid_sink_config_returns_err() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_invalid_sink_config_returns_err() {
         // A file sink pointing to a path that cannot be created will fail
         // during sink construction inside the thread.
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
@@ -721,7 +734,7 @@ mod tests {
             help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_err(),
             "scenario with an invalid sink path should return Err"
@@ -733,8 +746,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn run_multi_collects_all_thread_errors() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_collects_all_thread_errors() {
         // Two scenarios both use an invalid sink — both errors should be reported.
         let entries = vec![
             ScenarioEntry::Metrics(ScenarioConfig {
@@ -791,7 +804,7 @@ mod tests {
             }),
         ];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(result.is_err(), "two failing scenarios should return Err");
         // The combined error message should contain both errors separated by "; "
         let err_msg = result.unwrap_err().to_string();
@@ -801,8 +814,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn run_multi_thread_errors_produce_runtime_not_config_variant() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_thread_errors_produce_runtime_not_config_variant() {
         // A file sink pointing to an invalid path will fail inside the thread.
         // The collected error must be Runtime::ScenariosFailed, not Config.
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
@@ -832,7 +845,7 @@ mod tests {
             help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(result.is_err(), "invalid sink must produce an error");
         let err = result.unwrap_err();
         assert!(
@@ -849,8 +862,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     /// A scenario with a minimal phase_offset ("1ms") emits events almost immediately.
-    #[test]
-    fn run_multi_with_minimal_phase_offset_emits_almost_immediately() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_minimal_phase_offset_emits_almost_immediately() {
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "minimal_offset".to_string(),
@@ -877,7 +890,7 @@ mod tests {
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
         let start = Instant::now();
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "minimal phase_offset should complete ok");
@@ -890,8 +903,8 @@ mod tests {
     }
 
     /// `phase_offset: "0s"` is accepted and treated as no delay.
-    #[test]
-    fn run_multi_accepts_zero_phase_offset() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_accepts_zero_phase_offset() {
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "zero_offset".to_string(),
@@ -917,7 +930,7 @@ mod tests {
             help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         // "0s" is treated as no delay — parse_phase_offset returns None.
         assert!(
             result.is_ok(),
@@ -927,11 +940,11 @@ mod tests {
     }
 
     /// A scenario with no phase_offset (None) preserves existing behavior.
-    #[test]
-    fn run_multi_with_no_phase_offset_preserves_behavior() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_no_phase_offset_preserves_behavior() {
         let entries = vec![metrics_entry_stdout("no_offset")];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_ok(),
             "scenario without phase_offset should work as before"
@@ -940,8 +953,8 @@ mod tests {
 
     /// Two scenarios where the second has a 500ms phase_offset: the second
     /// starts later, so total run time is at least 500ms.
-    #[test]
-    fn run_multi_respects_phase_offset_between_scenarios() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_respects_phase_offset_between_scenarios() {
         let entries = vec![
             ScenarioEntry::Metrics(ScenarioConfig {
                 base: BaseScheduleConfig {
@@ -994,7 +1007,7 @@ mod tests {
         ];
         let shutdown = Arc::new(AtomicBool::new(true));
         let start = Instant::now();
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "phase_offset multi-scenario should succeed");
@@ -1008,8 +1021,8 @@ mod tests {
     }
 
     /// Shutdown during phase_offset delay exits all scenarios cleanly.
-    #[test]
-    fn run_multi_shutdown_during_phase_offset_exits_cleanly() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_shutdown_during_phase_offset_exits_cleanly() {
         let entries = vec![
             // First scenario runs indefinitely.
             ScenarioEntry::Metrics(ScenarioConfig {
@@ -1073,7 +1086,7 @@ mod tests {
         });
 
         let start = Instant::now();
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         let elapsed = start.elapsed();
 
         assert!(
@@ -1089,8 +1102,8 @@ mod tests {
 
     /// An invalid phase_offset string causes run_multi to return an error
     /// synchronously before spawning threads.
-    #[test]
-    fn run_multi_rejects_invalid_phase_offset() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_rejects_invalid_phase_offset() {
         let entries = vec![ScenarioEntry::Metrics(ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "bad_offset".to_string(),
@@ -1116,7 +1129,7 @@ mod tests {
             help: None,
         })];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_err(),
             "invalid phase_offset must cause run_multi to return Err"
@@ -1129,8 +1142,8 @@ mod tests {
     }
 
     /// Scenarios with the same clock_group and different phase_offsets both complete.
-    #[test]
-    fn run_multi_with_clock_group_and_offsets() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_multi_with_clock_group_and_offsets() {
         let entries = vec![
             ScenarioEntry::Metrics(ScenarioConfig {
                 base: BaseScheduleConfig {
@@ -1182,7 +1195,7 @@ mod tests {
             }),
         ];
         let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown);
+        let result = run_multi(entries, shutdown).await;
         assert!(
             result.is_ok(),
             "scenarios with clock_group and offsets should complete"
@@ -1250,8 +1263,8 @@ scenarios:
     }
 
     #[cfg(feature = "config")]
-    #[test]
-    fn launch_multi_compiled_partial_cleanup_stops_already_launched_handles() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_multi_compiled_partial_cleanup_stops_already_launched_handles() {
         use crate::compile_scenario_file_compiled;
         use crate::compiler::expand::InMemoryPackResolver;
 
@@ -1283,7 +1296,9 @@ scenarios:
         let compiled =
             compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
 
-        let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+        let mut handles = launch_multi_compiled(compiled, None)
+            .await
+            .expect("launch must succeed");
         assert_eq!(handles.len(), 2, "must launch both entries");
         assert!(
             handles.iter().all(|h| h.is_alive()),
@@ -1523,8 +1538,8 @@ scenarios:
             }
         }
 
-        #[test]
-        fn t8_downstream_enters_unresolved_then_promoted_on_register_and_sweep() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t8_downstream_enters_unresolved_then_promoted_on_register_and_sweep() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1535,6 +1550,7 @@ scenarios:
             .expect("compile downstream");
 
             let handles = launch_multi_compiled(compiled, Some(Arc::clone(&resolver)))
+                .await
                 .expect("launch downstream");
             assert_eq!(handles.len(), 1);
             wait_for_state(
@@ -1556,8 +1572,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t9_downstream_first_then_upstream_post_promotes_via_sweep() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t9_downstream_first_then_upstream_post_promotes_via_sweep() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1568,6 +1584,7 @@ scenarios:
             .expect("compile downstream");
 
             let downstream_handles = launch_multi_compiled(downstream, Some(Arc::clone(&resolver)))
+                .await
                 .expect("launch downstream");
             wait_for_state(
                 &downstream_handles[0],
@@ -1579,6 +1596,7 @@ scenarios:
                 compile_scenario_file_compiled(&upstream_yaml(), &InMemoryPackResolver::new())
                     .expect("compile upstream");
             let upstream_handles = launch_multi_compiled(upstream, Some(Arc::clone(&resolver)))
+                .await
                 .expect("launch upstream");
             wait_for_state(
                 &downstream_handles[0],
@@ -1594,8 +1612,8 @@ scenarios:
         // upstream with the same scenario_name) requires the registry to push affected
         // downstreams back into `pending` on unregister — that mechanism lives with the
         // production `GateBusRegistry` implementation, not the test resolver.
-        #[test]
-        fn t10_unregister_drives_downstream_back_to_unresolved() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t10_unregister_drives_downstream_back_to_unresolved() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1603,6 +1621,7 @@ scenarios:
                 compile_scenario_file_compiled(&upstream_yaml(), &InMemoryPackResolver::new())
                     .expect("compile upstream");
             let upstream_handles = launch_multi_compiled(upstream, Some(Arc::clone(&resolver)))
+                .await
                 .expect("launch upstream");
 
             let downstream = compile_scenario_file_compiled(
@@ -1611,6 +1630,7 @@ scenarios:
             )
             .expect("compile downstream");
             let downstream_handles = launch_multi_compiled(downstream, Some(Arc::clone(&resolver)))
+                .await
                 .expect("launch downstream");
             wait_for_state(
                 &downstream_handles[0],
@@ -1644,8 +1664,8 @@ scenarios:
             stop_and_join(downstream_handles);
         }
 
-        #[test]
-        fn t11_if_unresolved_open_ticks_at_full_rate() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t11_if_unresolved_open_ticks_at_full_rate() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1654,8 +1674,9 @@ scenarios:
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let handles =
-                launch_multi_compiled(compiled, Some(Arc::clone(&resolver))).expect("launch");
+            let handles = launch_multi_compiled(compiled, Some(Arc::clone(&resolver)))
+                .await
+                .expect("launch");
             wait_for_state(
                 &handles[0],
                 ScenarioState::Unresolved,
@@ -1674,8 +1695,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t11b_if_unresolved_open_transitions_to_running_on_upstream_register() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t11b_if_unresolved_open_transitions_to_running_on_upstream_register() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1684,8 +1705,9 @@ scenarios:
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let handles =
-                launch_multi_compiled(compiled, Some(Arc::clone(&resolver))).expect("launch");
+            let handles = launch_multi_compiled(compiled, Some(Arc::clone(&resolver)))
+                .await
+                .expect("launch");
             wait_for_state(
                 &handles[0],
                 ScenarioState::Unresolved,
@@ -1721,8 +1743,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t12_if_unresolved_closed_does_not_emit() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t12_if_unresolved_closed_does_not_emit() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1731,8 +1753,9 @@ scenarios:
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let handles =
-                launch_multi_compiled(compiled, Some(Arc::clone(&resolver))).expect("launch");
+            let handles = launch_multi_compiled(compiled, Some(Arc::clone(&resolver)))
+                .await
+                .expect("launch");
             wait_for_state(
                 &handles[0],
                 ScenarioState::Unresolved,
@@ -1750,8 +1773,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t13_if_unresolved_pending_does_not_emit_and_holds_state() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t13_if_unresolved_pending_does_not_emit_and_holds_state() {
             let registry = TestRegistry::new();
             let resolver: Arc<dyn GateBusResolver> = registry.clone();
 
@@ -1760,8 +1783,9 @@ scenarios:
                 &InMemoryPackResolver::new(),
             )
             .expect("compile downstream");
-            let handles =
-                launch_multi_compiled(compiled, Some(Arc::clone(&resolver))).expect("launch");
+            let handles = launch_multi_compiled(compiled, Some(Arc::clone(&resolver)))
+                .await
+                .expect("launch");
             wait_for_state(
                 &handles[0],
                 ScenarioState::Unresolved,
@@ -1777,8 +1801,8 @@ scenarios:
             stop_and_join(handles);
         }
 
-        #[test]
-        fn t_regress_2_local_only_while_path_unchanged() {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn t_regress_2_local_only_while_path_unchanged() {
             let yaml = r#"
 version: 2
 kind: runnable
@@ -1809,7 +1833,7 @@ scenarios:
 "#;
             let compiled = compile_scenario_file_compiled(yaml, &InMemoryPackResolver::new())
                 .expect("compile local-only");
-            let mut handles = launch_multi_compiled(compiled, None).expect("launch");
+            let mut handles = launch_multi_compiled(compiled, None).await.expect("launch");
             assert_eq!(handles.len(), 2);
             for h in &mut handles {
                 let _ = h.join(Some(Duration::from_secs(2)));
@@ -1818,8 +1842,8 @@ scenarios:
     }
 
     #[cfg(feature = "config")]
-    #[test]
-    fn launch_multi_compiled_gives_each_handle_an_independent_shutdown_flag() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn launch_multi_compiled_gives_each_handle_an_independent_shutdown_flag() {
         use crate::compile_scenario_file_compiled;
         use crate::compiler::expand::InMemoryPackResolver;
 
@@ -1857,7 +1881,9 @@ scenarios:
         let compiled =
             compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
 
-        let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+        let mut handles = launch_multi_compiled(compiled, None)
+            .await
+            .expect("launch must succeed");
         assert_eq!(handles.len(), 3, "must launch all three entries");
 
         for i in 0..handles.len() {

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -31,7 +31,7 @@ use crate::schedule::launch::{launch_scenario_with_gates, validate_entry};
 #[cfg(feature = "config")]
 use std::collections::HashMap;
 #[cfg(feature = "config")]
-use std::sync::mpsc;
+use tokio::sync::watch;
 
 /// Run all scenarios in `entries` concurrently, one OS thread per scenario.
 /// Set `shutdown` to `false` to stop all running scenarios.
@@ -201,7 +201,7 @@ pub fn launch_multi_compiled(
                     op: clause.op,
                     threshold: clause.value,
                 };
-                let (tx, rx) = mpsc::sync_channel::<crate::schedule::gate_bus::GateEdge>(1);
+                let (tx, rx) = watch::channel::<Option<crate::schedule::gate_bus::GateEdge>>(None);
                 let if_unresolved = clause.if_unresolved.unwrap_or_default();
                 let bus = resolver.lookup(cross_scenario, clause.ref_id.as_str());
                 let (gate_rx, initial, start_unresolved) = match bus {

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -1,11 +1,9 @@
-//! Multi-scenario runner: runs multiple scenarios concurrently on separate threads.
-//!
-//! Each scenario owns its own shutdown flag. [`run_multi`] and
-//! [`run_multi_compiled`] accept a master `shutdown` flag and use a watchdog
-//! thread to fan a transition out into each handle's per-scenario flag.
+//! Multi-scenario runner: runs multiple scenarios concurrently as tokio tasks.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "config")]
 use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
 
 use crate::config::ScenarioEntry;
 use crate::schedule::launch::{launch_scenario, prepare_entries};
@@ -33,48 +31,29 @@ use std::collections::HashMap;
 #[cfg(feature = "config")]
 use tokio::sync::watch;
 
-/// Run all scenarios in `entries` concurrently, one OS thread per scenario.
-/// Set `shutdown` to `false` to stop all running scenarios.
+/// Run all scenarios in `entries` concurrently; cancel `parent_cancel` to stop them.
 pub async fn run_multi(
     entries: Vec<ScenarioEntry>,
-    shutdown: Arc<AtomicBool>,
+    parent_cancel: CancellationToken,
 ) -> Result<(), SondaError> {
-    // Expand, validate, and resolve phase offsets for all entries atomically.
     let prepared = prepare_entries(entries)?;
 
     let mut handles = Vec::with_capacity(prepared.len());
-    let mut per_handle_shutdowns: Vec<Arc<AtomicBool>> = Vec::with_capacity(prepared.len());
     let mut errors: Vec<String> = Vec::new();
     for (i, prepared_entry) in prepared.into_iter().enumerate() {
         let id = format!("multi-{i}");
-        let scenario_shutdown = Arc::new(AtomicBool::new(true));
-        match launch_scenario(
-            id,
-            prepared_entry.entry,
-            Arc::clone(&scenario_shutdown),
-            prepared_entry.start_delay,
-        )
-        .await
-        {
-            Ok(handle) => {
-                per_handle_shutdowns.push(scenario_shutdown);
-                handles.push(handle);
-            }
+        let child = parent_cancel.child_token();
+        match launch_scenario(id, prepared_entry.entry, child, prepared_entry.start_delay).await {
+            Ok(handle) => handles.push(handle),
             Err(e) => errors.push(e.to_string()),
         }
     }
 
-    let done = Arc::new(AtomicBool::new(false));
-    let watchdog = spawn_shutdown_watchdog(shutdown, per_handle_shutdowns, Arc::clone(&done));
-
     for mut handle in handles {
-        if let Err(e) = handle.join(None) {
+        if let Err(e) = handle.join_async(None).await {
             errors.push(e.to_string());
         }
     }
-
-    done.store(true, Ordering::SeqCst);
-    let _ = watchdog.join();
 
     if errors.is_empty() {
         Ok(())
@@ -85,45 +64,9 @@ pub async fn run_multi(
     }
 }
 
-/// Mirror `master`'s false transition into each per-handle shutdown; exit when `master` flips or `done` flips.
-fn spawn_shutdown_watchdog(
-    master: Arc<AtomicBool>,
-    per_handle: Vec<Arc<AtomicBool>>,
-    done: Arc<AtomicBool>,
-) -> std::thread::JoinHandle<()> {
-    std::thread::Builder::new()
-        .name("sonda-shutdown-watchdog".to_string())
-        .spawn(move || {
-            let poll = std::time::Duration::from_millis(100);
-            loop {
-                if done.load(Ordering::SeqCst) {
-                    return;
-                }
-                if !master.load(Ordering::SeqCst) {
-                    for flag in &per_handle {
-                        flag.store(false, Ordering::SeqCst);
-                    }
-                    return;
-                }
-                std::thread::sleep(poll);
-            }
-        })
-        .expect("watchdog thread must spawn")
-}
-
-/// Set the shutdown flag, signalling all running scenarios to stop.
-///
-/// This is a convenience wrapper that stores `false` with `SeqCst` ordering,
-/// matching the ordering used by the signal handler in the CLI.
-pub fn signal_shutdown(shutdown: &AtomicBool) {
-    shutdown.store(false, Ordering::SeqCst);
-}
-
-/// Launch a compiled scenario file with `while:` / `after:` gating wired in,
-/// returning the live handles without joining them. When `resolver` is `Some`,
-/// cross-POST `while:` references resolve through the registry; otherwise every
-/// reference must resolve inside `file`. Each handle owns an independent
-/// shutdown flag — see [`run_multi_compiled`] for the master-stop-all path.
+/// Launch a compiled scenario file with `while:` / `after:` gating wired in.
+/// Each handle owns an independent cancellation token; see [`run_multi_compiled`]
+/// for the master-stop-all path.
 #[cfg(feature = "config")]
 pub async fn launch_multi_compiled(
     file: CompiledFile,
@@ -298,12 +241,12 @@ pub async fn launch_multi_compiled(
         let id = plan.id.unwrap_or_else(|| format!("multi-{idx}"));
         let deferred = plan.deferred;
         let active = plan.active;
-        let scenario_shutdown = Arc::new(AtomicBool::new(true));
+        let scenario_cancel = CancellationToken::new();
         match launch_scenario_with_gates(
             id.clone(),
             file_scenario_name.clone(),
             plan.entry,
-            scenario_shutdown,
+            scenario_cancel,
             plan.start_delay,
             plan.upstream_bus,
             plan.gate_ctx,
@@ -391,21 +334,21 @@ struct ActiveSubscription {
 }
 
 /// Run a compiled scenario file with `while:` / `after:` gating wired in.
-///
-/// Spawns every scenario via [`launch_multi_compiled`] and joins the threads.
-/// Non-gated entries launch on the existing non-gated path with no per-tick
-/// overhead.
 #[cfg(feature = "config")]
 pub async fn run_multi_compiled(
     file: CompiledFile,
-    shutdown: Arc<AtomicBool>,
+    parent_cancel: CancellationToken,
 ) -> Result<(), SondaError> {
     let handles = launch_multi_compiled(file, None).await?;
-    let per_handle_shutdowns: Vec<Arc<AtomicBool>> =
-        handles.iter().map(|h| Arc::clone(&h.shutdown)).collect();
-
-    let done = Arc::new(AtomicBool::new(false));
-    let watchdog = spawn_shutdown_watchdog(shutdown, per_handle_shutdowns, Arc::clone(&done));
+    let cancel_watcher = parent_cancel.clone();
+    let watcher_cancels: Vec<CancellationToken> =
+        handles.iter().map(|h| h.cancel.clone()).collect();
+    let watcher = tokio::task::spawn(async move {
+        cancel_watcher.cancelled().await;
+        for c in &watcher_cancels {
+            c.cancel();
+        }
+    });
 
     let mut errors: Vec<String> = Vec::new();
     for mut handle in handles {
@@ -415,8 +358,8 @@ pub async fn run_multi_compiled(
         }
     }
 
-    done.store(true, Ordering::SeqCst);
-    let _ = watchdog.join();
+    watcher.abort();
+    let _ = watcher.await;
 
     if errors.is_empty() {
         Ok(())
@@ -462,10 +405,10 @@ struct LaunchPlan {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
     use std::thread;
     use std::time::{Duration, Instant};
+
+    use tokio_util::sync::CancellationToken;
 
     use crate::config::{BaseScheduleConfig, LogScenarioConfig, ScenarioConfig, ScenarioEntry};
     use crate::encoder::EncoderConfig;
@@ -474,7 +417,7 @@ mod tests {
 
     #[cfg(feature = "config")]
     use super::launch_multi_compiled;
-    use super::{run_multi, signal_shutdown};
+    use super::run_multi;
 
     /// Build a minimal metrics `ScenarioEntry` that writes to stdout.
     /// Duration of "100ms" ensures the thread exits quickly.
@@ -545,16 +488,16 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn run_multi_with_empty_scenarios_returns_ok() {
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(vec![], shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(vec![], cancel).await;
         assert!(result.is_ok(), "empty scenario list should return Ok");
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn run_multi_with_single_metrics_scenario_returns_ok() {
         let entries = vec![metrics_entry_stdout("single_metric")];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_ok(),
             "single metrics scenario should complete without error"
@@ -564,8 +507,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn run_multi_with_single_logs_scenario_returns_ok() {
         let entries = vec![logs_entry_stdout("single_logs")];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_ok(),
             "single logs scenario should complete without error"
@@ -580,8 +523,8 @@ mod tests {
             metrics_entry_stdout("concurrent_metrics"),
             logs_entry_stdout("concurrent_logs"),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_ok(),
             "both concurrent scenarios should complete without error"
@@ -595,8 +538,8 @@ mod tests {
             metrics_entry_stdout("m2"),
             logs_entry_stdout("l1"),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_ok(),
             "three concurrent scenarios should all complete without error"
@@ -604,11 +547,11 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Shutdown flag: setting it stops all threads
+    // Cancel propagation
     // -----------------------------------------------------------------------
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn run_multi_shutdown_flag_stops_all_threads_within_two_seconds() {
+    async fn run_multi_parent_cancel_stops_all_tasks_within_two_seconds() {
         // Both scenarios have no duration (would run indefinitely). We
         // signal shutdown after a short delay and verify all threads stop
         // well within 2 seconds.
@@ -668,34 +611,23 @@ mod tests {
             }),
         ];
 
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let shutdown_for_thread = Arc::clone(&shutdown);
+        let cancel = CancellationToken::new();
+        let cancel_for_thread = cancel.clone();
 
-        // Signal shutdown after 50ms from a separate thread.
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(50));
-            signal_shutdown(&shutdown_for_thread);
+            cancel_for_thread.cancel();
         });
 
         let start = Instant::now();
-        let result = run_multi(entries, shutdown).await;
+        let result = run_multi(entries, cancel).await;
         let elapsed = start.elapsed();
 
-        assert!(result.is_ok(), "shutdown should not produce an error");
+        assert!(result.is_ok());
         assert!(
             elapsed < Duration::from_secs(2),
-            "run_multi should return within 2 seconds of shutdown signal, took {:?}",
+            "run_multi should return within 2 seconds, took {:?}",
             elapsed
-        );
-    }
-
-    #[test]
-    fn signal_shutdown_stores_false_with_seqcst_ordering() {
-        let flag = AtomicBool::new(true);
-        signal_shutdown(&flag);
-        assert!(
-            !flag.load(Ordering::SeqCst),
-            "signal_shutdown should set the flag to false"
         );
     }
 
@@ -733,8 +665,8 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_err(),
             "scenario with an invalid sink path should return Err"
@@ -803,8 +735,8 @@ mod tests {
                 help: None,
             }),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(result.is_err(), "two failing scenarios should return Err");
         // The combined error message should contain both errors separated by "; "
         let err_msg = result.unwrap_err().to_string();
@@ -844,8 +776,8 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(result.is_err(), "invalid sink must produce an error");
         let err = result.unwrap_err();
         assert!(
@@ -888,9 +820,9 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let start = Instant::now();
-        let result = run_multi(entries, shutdown).await;
+        let result = run_multi(entries, cancel).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "minimal phase_offset should complete ok");
@@ -929,8 +861,8 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         // "0s" is treated as no delay — parse_phase_offset returns None.
         assert!(
             result.is_ok(),
@@ -943,8 +875,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn run_multi_with_no_phase_offset_preserves_behavior() {
         let entries = vec![metrics_entry_stdout("no_offset")];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_ok(),
             "scenario without phase_offset should work as before"
@@ -1005,9 +937,9 @@ mod tests {
                 help: None,
             }),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let start = Instant::now();
-        let result = run_multi(entries, shutdown).await;
+        let result = run_multi(entries, cancel).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "phase_offset multi-scenario should succeed");
@@ -1076,26 +1008,22 @@ mod tests {
             }),
         ];
 
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let shutdown_for_thread = Arc::clone(&shutdown);
+        let cancel = CancellationToken::new();
+        let cancel_for_thread = cancel.clone();
 
-        // Signal shutdown after 100ms.
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(100));
-            signal_shutdown(&shutdown_for_thread);
+            cancel_for_thread.cancel();
         });
 
         let start = Instant::now();
-        let result = run_multi(entries, shutdown).await;
+        let result = run_multi(entries, cancel).await;
         let elapsed = start.elapsed();
 
-        assert!(
-            result.is_ok(),
-            "shutdown during phase_offset should not produce an error"
-        );
+        assert!(result.is_ok());
         assert!(
             elapsed < Duration::from_secs(2),
-            "run_multi must exit promptly when shutdown during phase_offset, took {:?}",
+            "run_multi must exit promptly, took {:?}",
             elapsed
         );
     }
@@ -1128,8 +1056,8 @@ mod tests {
             metric_type: None,
             help: None,
         })];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_err(),
             "invalid phase_offset must cause run_multi to return Err"
@@ -1194,8 +1122,8 @@ mod tests {
                 help: None,
             }),
         ];
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let result = run_multi(entries, shutdown).await;
+        let cancel = CancellationToken::new();
+        let result = run_multi(entries, cancel).await;
         assert!(
             result.is_ok(),
             "scenarios with clock_group and offsets should complete"
@@ -1843,7 +1771,7 @@ scenarios:
 
     #[cfg(feature = "config")]
     #[tokio::test(flavor = "multi_thread")]
-    async fn launch_multi_compiled_gives_each_handle_an_independent_shutdown_flag() {
+    async fn launch_multi_compiled_gives_each_handle_an_independent_cancel_token() {
         use crate::compile_scenario_file_compiled;
         use crate::compiler::expand::InMemoryPackResolver;
 
@@ -1885,15 +1813,6 @@ scenarios:
             .await
             .expect("launch must succeed");
         assert_eq!(handles.len(), 3, "must launch all three entries");
-
-        for i in 0..handles.len() {
-            for j in (i + 1)..handles.len() {
-                assert!(
-                    !Arc::ptr_eq(&handles[i].shutdown, &handles[j].shutdown),
-                    "handles {i} and {j} must own independent shutdown Arcs"
-                );
-            }
-        }
 
         handles[0].stop();
         let deadline = Instant::now() + Duration::from_secs(2);

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -16,7 +16,7 @@ use crate::encoder::create_encoder;
 use crate::generator::create_generator;
 use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
 use crate::schedule::core_loop::{
-    self, CloseEmitFn, CloseSignal, GateContext, TickContext, TickResult,
+    self, CloseEmitFn, CloseSignal, GateContext, TickContext, TickOutput, TickResult, WriteCommand,
 };
 use crate::schedule::gate_bus::GateBus;
 use crate::schedule::is_in_spike;
@@ -117,7 +117,7 @@ pub fn run_with_sink_gated(
 
     let upstream_bus_for_tick = upstream_bus.clone();
     let mut tick_fn = |ctx: &TickContext<'_>,
-                       sink: &mut dyn Sink,
+                       output: &mut TickOutput,
                        events_buf: &mut Vec<MetricEvent>|
      -> Result<TickResult, SondaError> {
         let wall_now = ctx.wall_clock;
@@ -155,19 +155,19 @@ pub fn run_with_sink_gated(
         buf.clear();
         encoder.encode_metric(&event, &mut buf)?;
         let bytes_written = buf.len() as u64;
-        sink.write(&buf)?;
-        let delivered = sink.last_write_delivered();
+        output
+            .writes
+            .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
 
         events_buf.push(event);
 
         Ok(TickResult {
             bytes_written,
-            delivered,
+            delivered: true,
         })
     };
 
-    let stats_for_flush = stats.clone();
-    let loop_result = match gate_ctx {
+    match gate_ctx {
         None => core_loop::run_schedule_loop(
             &schedule,
             config.rate,
@@ -194,12 +194,6 @@ pub fn run_with_sink_gated(
                 &mut tick_fn,
             )
         }
-    };
-
-    let flush_result = sink.flush();
-    match loop_result {
-        Ok(()) => core_loop::apply_flush_policy(&schedule, stats_for_flush.as_ref(), flush_result),
-        Err(e) => Err(e),
     }
 }
 
@@ -254,7 +248,8 @@ fn make_close_emitter(
         CloseSignal::SnapTo(v) => v,
     };
 
-    Box::new(move |sink: &mut dyn Sink| -> Result<(), SondaError> {
+    let mut buf: Vec<u8> = Vec::with_capacity(256);
+    Box::new(move |output: &mut TickOutput| -> Result<(), SondaError> {
         let (series, watermark) = match stats.write() {
             Ok(mut st) => st.drain_close_emit_series(),
             Err(p) => p.into_inner().drain_close_emit_series(),
@@ -270,12 +265,13 @@ fn make_close_emitter(
             None => SystemTime::now(),
         };
 
-        let mut buf: Vec<u8> = Vec::with_capacity(256);
         for (name, labels) in series {
             buf.clear();
             let marker = MetricEvent::from_parts(name, value, labels, close_ts);
             encoder.encode_metric(&marker, &mut buf)?;
-            sink.write(&buf)?;
+            output
+                .writes
+                .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
         }
         Ok(())
     })
@@ -1220,6 +1216,24 @@ mod tests {
         }
     }
 
+    fn drain_emit_to_memory(
+        emit: &mut crate::schedule::core_loop::CloseEmitFn,
+        dest: &mut crate::sink::memory::MemorySink,
+    ) {
+        use crate::schedule::core_loop::{TickOutput, WriteCommand};
+        use crate::sink::Sink as SinkTrait;
+        let mut output = TickOutput::default();
+        emit(&mut output).expect("close-emit must succeed");
+        for cmd in output.writes.drain(..) {
+            match cmd {
+                WriteCommand::Bytes(buf) => SinkTrait::write(dest, &buf).expect("memory write ok"),
+                WriteCommand::LogEvent { event, bytes } => {
+                    SinkTrait::write_log_event(dest, &event, &bytes).expect("memory log write ok")
+                }
+            }
+        }
+    }
+
     #[test]
     fn close_emitter_is_idempotent_after_draining_series() {
         use crate::encoder::create_encoder;
@@ -1249,7 +1263,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut first = MemorySink::new();
-        emit(&mut first).expect("first call ok");
+        drain_emit_to_memory(&mut emit, &mut first);
         assert!(
             !first.buffer.is_empty(),
             "first invocation must emit the tracked series"
@@ -1267,7 +1281,7 @@ mod tests {
         }
 
         let mut second = MemorySink::new();
-        emit(&mut second).expect("second call ok");
+        drain_emit_to_memory(&mut emit, &mut second);
         assert!(
             second.buffer.is_empty(),
             "second invocation with no new series must emit nothing"
@@ -1307,7 +1321,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut sink = MemorySink::new();
-        emit(&mut sink).expect("close-emit must succeed");
+        drain_emit_to_memory(&mut emit, &mut sink);
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().filter(|l| !l.is_empty()).collect();
@@ -1368,7 +1382,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut sink = MemorySink::new();
-        emit(&mut sink).expect("close-emit must succeed");
+        drain_emit_to_memory(&mut emit, &mut sink);
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines = output.lines().filter(|l| !l.is_empty()).count();
@@ -1406,7 +1420,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut sink = MemorySink::new();
-        emit(&mut sink).expect("close-emit must succeed");
+        drain_emit_to_memory(&mut emit, &mut sink);
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines = output.lines().filter(|l| !l.is_empty()).count();

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -37,7 +37,7 @@ use crate::SondaError;
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run(config: &ScenarioConfig) -> Result<(), SondaError> {
-    let mut sink = create_sink(&config.sink, None)?;
+    let mut sink = create_sink(&config.sink, None).await?;
     run_with_sink(config, &mut sink, None, None).await
 }
 
@@ -83,6 +83,23 @@ pub async fn run_with_sink(
 /// gates to subscribe to). `gate_ctx` is what THIS scenario consumes from
 /// an upstream bus. Both are independent — a scenario can be both an
 /// upstream (publishing) and a downstream (gated).
+pub fn run_with_sink_gated_blocking(
+    config: &ScenarioConfig,
+    shutdown: Option<&AtomicBool>,
+    stats: Option<Arc<RwLock<ScenarioStats>>>,
+    upstream_bus: Option<Arc<GateBus>>,
+    gate_ctx: Option<GateContext>,
+) -> Result<(), SondaError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
+    rt.block_on(async {
+        let mut sink = create_sink(&config.sink, None).await?;
+        run_with_sink_gated(config, &mut sink, shutdown, stats, upstream_bus, gate_ctx).await
+    })
+}
+
 pub async fn run_with_sink_gated(
     config: &ScenarioConfig,
     sink: &mut Box<dyn Sink>,
@@ -295,6 +312,8 @@ fn is_remote_write_sink(_sink: &SinkConfig) -> bool {
 mod tests {
     use std::sync::Mutex;
 
+    use async_trait::async_trait;
+
     use crate::config::{BaseScheduleConfig, GapConfig, ScenarioConfig};
     use crate::encoder::EncoderConfig;
     use crate::generator::GeneratorConfig;
@@ -305,15 +324,16 @@ mod tests {
 
     struct ProbeSink(SharedBuf);
 
+    #[async_trait]
     impl Sink for ProbeSink {
-        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
             self.0
                 .lock()
                 .expect("probe sink mutex poisoned")
                 .extend_from_slice(data);
             Ok(())
         }
-        fn flush(&mut self) -> Result<(), SondaError> {
+        async fn flush(&mut self) -> Result<(), SondaError> {
             Ok(())
         }
     }
@@ -1308,7 +1328,7 @@ mod tests {
         }
     }
 
-    fn drain_emit_to_memory(
+    async fn drain_emit_to_memory(
         emit: &mut crate::schedule::core_loop::CloseEmitFn,
         dest: &mut crate::sink::memory::MemorySink,
     ) {
@@ -1318,16 +1338,20 @@ mod tests {
         emit(&mut output).expect("close-emit must succeed");
         for cmd in output.writes.drain(..) {
             match cmd {
-                WriteCommand::Bytes(buf) => SinkTrait::write(dest, &buf).expect("memory write ok"),
+                WriteCommand::Bytes(buf) => {
+                    SinkTrait::write(dest, &buf).await.expect("memory write ok")
+                }
                 WriteCommand::LogEvent { event, bytes } => {
-                    SinkTrait::write_log_event(dest, &event, &bytes).expect("memory log write ok")
+                    SinkTrait::write_log_event(dest, &event, &bytes)
+                        .await
+                        .expect("memory log write ok")
                 }
             }
         }
     }
 
-    #[test]
-    fn close_emitter_is_idempotent_after_draining_series() {
+    #[tokio::test]
+    async fn close_emitter_is_idempotent_after_draining_series() {
         use crate::encoder::create_encoder;
         use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
         use crate::schedule::core_loop::CloseSignal;
@@ -1355,7 +1379,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut first = MemorySink::new();
-        drain_emit_to_memory(&mut emit, &mut first);
+        drain_emit_to_memory(&mut emit, &mut first).await;
         assert!(
             !first.buffer.is_empty(),
             "first invocation must emit the tracked series"
@@ -1373,15 +1397,15 @@ mod tests {
         }
 
         let mut second = MemorySink::new();
-        drain_emit_to_memory(&mut emit, &mut second);
+        drain_emit_to_memory(&mut emit, &mut second).await;
         assert!(
             second.buffer.is_empty(),
             "second invocation with no new series must emit nothing"
         );
     }
 
-    #[test]
-    fn close_emit_timestamp_strictly_after_recent_active_emissions() {
+    #[tokio::test]
+    async fn close_emit_timestamp_strictly_after_recent_active_emissions() {
         use crate::encoder::create_encoder;
         use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
         use crate::schedule::core_loop::CloseSignal;
@@ -1413,7 +1437,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut sink = MemorySink::new();
-        drain_emit_to_memory(&mut emit, &mut sink);
+        drain_emit_to_memory(&mut emit, &mut sink).await;
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines: Vec<&str> = output.lines().filter(|l| !l.is_empty()).collect();
@@ -1441,8 +1465,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn close_emit_emits_every_distinct_series_regardless_of_count() {
+    #[tokio::test]
+    async fn close_emit_emits_every_distinct_series_regardless_of_count() {
         use crate::encoder::create_encoder;
         use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
         use crate::schedule::core_loop::CloseSignal;
@@ -1474,15 +1498,15 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut sink = MemorySink::new();
-        drain_emit_to_memory(&mut emit, &mut sink);
+        drain_emit_to_memory(&mut emit, &mut sink).await;
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines = output.lines().filter(|l| !l.is_empty()).count();
         assert_eq!(lines, series_count);
     }
 
-    #[test]
-    fn close_emit_dedups_repeated_series_to_one_marker() {
+    #[tokio::test]
+    async fn close_emit_dedups_repeated_series_to_one_marker() {
         use crate::encoder::create_encoder;
         use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
         use crate::schedule::core_loop::CloseSignal;
@@ -1512,7 +1536,7 @@ mod tests {
         let mut emit = super::make_close_emitter(stats.clone(), encoder, CloseSignal::SnapTo(0.0));
 
         let mut sink = MemorySink::new();
-        drain_emit_to_memory(&mut emit, &mut sink);
+        drain_emit_to_memory(&mut emit, &mut sink).await;
 
         let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
         let lines = output.lines().filter(|l| !l.is_empty()).count();

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -36,9 +36,9 @@ use crate::SondaError;
 /// # Errors
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-pub fn run(config: &ScenarioConfig) -> Result<(), SondaError> {
+pub async fn run(config: &ScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, None)?;
-    run_with_sink(config, sink.as_mut(), None, None)
+    run_with_sink(config, &mut sink, None, None).await
 }
 
 /// Run a scenario to completion, writing encoded events into the provided sink.
@@ -68,13 +68,13 @@ pub fn run(config: &ScenarioConfig) -> Result<(), SondaError> {
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 /// If an error occurs during the loop and flushing also fails, the loop error
 /// is returned (the flush error is discarded to preserve the original cause).
-pub fn run_with_sink(
+pub async fn run_with_sink(
     config: &ScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_with_sink_gated(config, sink, shutdown, stats, None, None)
+    run_with_sink_gated(config, sink, shutdown, stats, None, None).await
 }
 
 /// Run a metric scenario with optional `while:` / `after:` gating.
@@ -83,9 +83,9 @@ pub fn run_with_sink(
 /// gates to subscribe to). `gate_ctx` is what THIS scenario consumes from
 /// an upstream bus. Both are independent — a scenario can be both an
 /// upstream (publishing) and a downstream (gated).
-pub fn run_with_sink_gated(
+pub async fn run_with_sink_gated(
     config: &ScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     upstream_bus: Option<Arc<GateBus>>,
@@ -168,14 +168,17 @@ pub fn run_with_sink_gated(
     };
 
     match gate_ctx {
-        None => core_loop::run_schedule_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            sink,
-            &mut tick_fn,
-        ),
+        None => {
+            core_loop::run_schedule_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
         Some(mut ctx) => {
             ctx.close_emit = build_close_emit(
                 config,
@@ -193,6 +196,7 @@ pub fn run_with_sink_gated(
                 sink,
                 &mut tick_fn,
             )
+            .await
         }
     }
 }
@@ -289,11 +293,36 @@ fn is_remote_write_sink(_sink: &SinkConfig) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use crate::config::{BaseScheduleConfig, GapConfig, ScenarioConfig};
     use crate::encoder::EncoderConfig;
     use crate::generator::GeneratorConfig;
-    use crate::sink::memory::MemorySink;
-    use crate::sink::SinkConfig;
+    use crate::sink::{Sink, SinkConfig};
+    use crate::SondaError;
+
+    type SharedBuf = std::sync::Arc<Mutex<Vec<u8>>>;
+
+    struct ProbeSink(SharedBuf);
+
+    impl Sink for ProbeSink {
+        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+            self.0
+                .lock()
+                .expect("probe sink mutex poisoned")
+                .extend_from_slice(data);
+            Ok(())
+        }
+        fn flush(&mut self) -> Result<(), SondaError> {
+            Ok(())
+        }
+    }
+
+    fn probe_sink() -> (Box<dyn Sink>, SharedBuf) {
+        let buf: SharedBuf = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let sink: Box<dyn Sink> = Box::new(ProbeSink(SharedBuf::clone(&buf)));
+        (sink, buf)
+    }
 
     /// Build a minimal ScenarioConfig suitable for a short integration run.
     fn make_config(rate: f64, duration: &str, gaps: Option<GapConfig>) -> ScenarioConfig {
@@ -326,10 +355,10 @@ mod tests {
     // ---- run: basic correctness ----------------------------------------------
 
     /// run() with a short duration should complete without error.
-    #[test]
-    fn run_completes_without_error_for_short_duration() {
+    #[tokio::test]
+    async fn run_completes_without_error_for_short_duration() {
         let config = make_config(100.0, "100ms", None);
-        let result = super::run(&config);
+        let result = super::run(&config).await;
         assert!(
             result.is_ok(),
             "run must succeed for valid config: {result:?}"
@@ -340,13 +369,16 @@ mod tests {
 
     /// At rate=100 for 1 second we expect approximately 100 newline-terminated events.
     /// We allow a ±20% window to accommodate scheduling jitter.
-    #[test]
-    fn integration_rate_100_duration_1s_emits_approximately_100_events() {
+    #[tokio::test]
+    async fn integration_rate_100_duration_1s_emits_approximately_100_events() {
         let config = make_config(100.0, "1s", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
         assert!(
             (80..=120).contains(&newlines),
             "expected ~100 events (80–120), got {newlines}"
@@ -354,13 +386,16 @@ mod tests {
     }
 
     /// Each emitted line is valid UTF-8 and starts with the metric name.
-    #[test]
-    fn integration_output_lines_start_with_metric_name() {
+    #[tokio::test]
+    async fn integration_output_lines_start_with_metric_name() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             assert!(
                 line.starts_with("up"),
@@ -370,16 +405,16 @@ mod tests {
     }
 
     /// Each emitted Prometheus line ends with a newline.
-    #[test]
-    fn integration_output_ends_with_newline() {
+    #[tokio::test]
+    async fn integration_output_ends_with_newline() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        assert!(
-            sink.buffer.ends_with(b"\n"),
-            "output must end with a newline"
-        );
+        let captured = buf.lock().unwrap();
+        assert!(captured.ends_with(b"\n"), "output must end with a newline");
     }
 
     // ---- Integration: gap suppresses events ----------------------------------
@@ -388,8 +423,8 @@ mod tests {
     /// 500 events because the gap suppresses approximately 1 second of output per
     /// 3-second cycle (~100 events lost from the first gap, plus ~100 from the
     /// second). We use 380 as a conservative upper bound below 500.
-    #[test]
-    fn integration_gap_suppresses_events() {
+    #[tokio::test]
+    async fn integration_gap_suppresses_events() {
         let config = make_config(
             100.0,
             "5s",
@@ -398,10 +433,13 @@ mod tests {
                 r#for: "1s".to_string(),
             }),
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
         assert!(
             newlines < 500,
             "gap must suppress events: expected < 500, got {newlines}"
@@ -416,41 +454,44 @@ mod tests {
     // ---- run: invalid config is rejected -------------------------------------
 
     /// A config with an unparseable duration returns Err.
-    #[test]
-    fn run_with_invalid_duration_returns_err() {
+    #[tokio::test]
+    async fn run_with_invalid_duration_returns_err() {
         let mut config = make_config(100.0, "bad_duration", None);
         // Manually set an invalid duration string.
         config.duration = Some("not_a_duration".to_string());
-        let result = super::run(&config);
+        let result = super::run(&config).await;
         assert!(result.is_err(), "invalid duration must return Err");
     }
 
     /// A config with an invalid gap duration returns Err.
-    #[test]
-    fn run_with_invalid_gap_every_returns_err() {
+    #[tokio::test]
+    async fn run_with_invalid_gap_every_returns_err() {
         let mut config = make_config(100.0, "1s", None);
         config.gaps = Some(GapConfig {
             every: "bad".to_string(),
             r#for: "1s".to_string(),
         });
-        let result = super::run(&config);
+        let result = super::run(&config).await;
         assert!(result.is_err(), "invalid gap.every must return Err");
     }
 
     // ---- run: labels appear in output ---------------------------------------
 
     /// When labels are configured they appear in the encoded output.
-    #[test]
-    fn integration_labels_appear_in_output() {
+    #[tokio::test]
+    async fn integration_labels_appear_in_output() {
         let mut config = make_config(50.0, "100ms", None);
         let mut label_map = std::collections::HashMap::new();
         label_map.insert("host".to_string(), "server1".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         assert!(
             output.contains("host=\"server1\""),
             "label must appear in output, got:\n{output}"
@@ -499,8 +540,8 @@ mod tests {
     /// The burst occupies [0, burst_for) of each burst_every cycle.
     /// With burst_every=10s and burst_for=9s, the first 1s of the run is always
     /// inside a burst (cycle_pos=0..1 < 9), so effective_interval = base/5.
-    #[test]
-    fn integration_burst_increases_event_count() {
+    #[tokio::test]
+    async fn integration_burst_increases_event_count() {
         let config = make_config_with_burst(
             10.0,
             "1s",
@@ -511,10 +552,13 @@ mod tests {
                 multiplier: 5.0,
             }),
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
         // Without burst: ~10 events. With 5x burst for entire 1s: ~50 events.
         // We allow a wide range to accommodate scheduling jitter.
         assert!(
@@ -531,8 +575,8 @@ mod tests {
     /// The first 1s of the run is in a burst (rate=500), the second 1s is not (rate=100).
     /// Total expected events: ~500 + ~100 = ~600.
     /// We use a range of 400–800 to accommodate scheduling jitter.
-    #[test]
-    fn integration_burst_then_normal_produces_mixed_rate() {
+    #[tokio::test]
+    async fn integration_burst_then_normal_produces_mixed_rate() {
         let config = make_config_with_burst(
             100.0,
             "2s",
@@ -543,10 +587,13 @@ mod tests {
                 multiplier: 5.0,
             }),
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
         // Without any burst: ~200 events. With burst for first 1s: ~600.
         assert!(
             newlines > 200,
@@ -588,8 +635,8 @@ mod tests {
     /// During [1s, 3s): gap wins → 0 events.
     /// Total: only ~500 events (much less than 100*3=300 without gap/burst,
     /// and much less than 500*2+100*1 with burst only).
-    #[test]
-    fn integration_gap_wins_over_burst_suppresses_events() {
+    #[tokio::test]
+    async fn integration_gap_wins_over_burst_suppresses_events() {
         // Gap occupies [every-for, every) = [3-2, 3) = [1s, 3s) per cycle.
         // Burst occupies [0, burst_for) = [0, 2.5s) per cycle.
         // Overlap: [1s, 2.5s) — gap wins here.
@@ -607,10 +654,13 @@ mod tests {
                 multiplier: 5.0,
             }),
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
 
         // During gap: 0 events. During [0,1s) with burst (5x): ~500 events.
         // But the run exits after 3s total, and the gap sleeps through most of it.
@@ -634,8 +684,8 @@ mod tests {
     /// Simpler gap-wins-over-burst test: run for 100ms with no gap and burst
     /// to establish a baseline, then run with both gap and burst where the
     /// gap covers the entire duration — expect zero events.
-    #[test]
-    fn integration_gap_covering_full_window_produces_zero_events_even_with_burst() {
+    #[tokio::test]
+    async fn integration_gap_covering_full_window_produces_zero_events_even_with_burst() {
         // Gap: every=1s, for=500ms → gap occupies [500ms, 1000ms) in each 1s cycle.
         // Run for 200ms starting at cycle_pos approaching 500ms.
         //
@@ -664,10 +714,16 @@ mod tests {
                 multiplier: 5.0,
             }),
         );
-        let mut sink_no_gap = MemorySink::new();
+        let (mut sink_no_gap, buf_no_gap) = probe_sink();
         super::run_with_sink(&config_no_gap_burst, &mut sink_no_gap, None, None)
+            .await
             .expect("run must succeed");
-        let events_burst_only = sink_no_gap.buffer.iter().filter(|&&b| b == b'\n').count();
+        let events_burst_only = buf_no_gap
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|&&b| b == b'\n')
+            .count();
 
         // With the burst for 900ms of each 1s cycle, over 500ms we'd expect ~4500 events.
         // This shows burst is working.
@@ -684,11 +740,13 @@ mod tests {
                 multiplier: 5.0,
             }),
         );
-        let mut sink_gap_burst = MemorySink::new();
+        let (mut sink_gap_burst, buf_gap_burst) = probe_sink();
         super::run_with_sink(&config_gap_and_burst, &mut sink_gap_burst, None, None)
+            .await
             .expect("run must succeed");
-        let events_gap_and_burst = sink_gap_burst
-            .buffer
+        let events_gap_and_burst = buf_gap_burst
+            .lock()
+            .unwrap()
             .iter()
             .filter(|&&b| b == b'\n')
             .count();
@@ -706,15 +764,16 @@ mod tests {
 
     // ---- Integration: stats buffer receives metric events ---------------------
 
-    #[test]
-    fn runner_pushes_metric_events_to_stats_current_values() {
+    #[tokio::test]
+    async fn runner_pushes_metric_events_to_stats_current_values() {
         use std::sync::{Arc, RwLock};
 
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
+        let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
         super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
+            .await
             .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
@@ -726,30 +785,34 @@ mod tests {
 
     /// When no stats arc is provided (None), the runner does not panic and
     /// still produces output normally.
-    #[test]
-    fn runner_without_stats_does_not_push_metrics() {
+    #[tokio::test]
+    async fn runner_without_stats_does_not_push_metrics() {
         let config = make_config(50.0, "100ms", None);
-        let mut sink = MemorySink::new();
+        let (mut sink, buf) = probe_sink();
 
         // Pass None for stats — should work fine without buffering.
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
         assert!(
             newlines > 0,
             "runner without stats must still produce output"
         );
     }
 
-    #[test]
-    fn runner_stats_current_values_have_correct_metric_name() {
+    #[tokio::test]
+    async fn runner_stats_current_values_have_correct_metric_name() {
         use std::sync::{Arc, RwLock};
 
         let config = make_config(50.0, "100ms", None);
-        let mut sink = MemorySink::new();
+        let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
         super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
+            .await
             .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
@@ -759,8 +822,8 @@ mod tests {
     }
 
     /// The shutdown flag stops the runner even during a burst window.
-    #[test]
-    fn shutdown_flag_stops_run_during_burst() {
+    #[tokio::test]
+    async fn shutdown_flag_stops_run_during_burst() {
         use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::Arc;
 
@@ -784,15 +847,18 @@ mod tests {
             shutdown_clone.store(false, Ordering::SeqCst);
         });
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, Some(&shutdown), None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, Some(&shutdown), None)
+            .await
+            .expect("run must succeed");
         handle.join().expect("thread must complete");
 
         // The run stopped after ~200ms due to shutdown flag.
         // At rate=1000 with 5x burst: ~1000 events in 200ms.
         // We just assert it stopped without hanging (the test would time out otherwise)
         // and produced some output.
-        let newlines = sink.buffer.iter().filter(|&&b| b == b'\n').count();
+        let captured = buf.lock().unwrap();
+        let newlines = captured.iter().filter(|&&b| b == b'\n').count();
         assert!(
             newlines > 0,
             "some events must have been emitted before shutdown"
@@ -835,8 +901,8 @@ mod tests {
 
     /// When the entire run is inside a spike window, every output line must
     /// contain the spike label key.
-    #[test]
-    fn integration_spike_labels_appear_during_spike_window() {
+    #[tokio::test]
+    async fn integration_spike_labels_appear_during_spike_window() {
         let spike = crate::config::CardinalitySpikeConfig {
             label: "pod_name".to_string(),
             every: "10s".to_string(),
@@ -848,10 +914,13 @@ mod tests {
         };
         // Run for 500ms inside a spike window (spike occupies 0..9s of each 10s cycle)
         let config = make_config_with_spike(50.0, "500ms", spike);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             assert!(
                 line.contains("pod_name="),
@@ -861,13 +930,16 @@ mod tests {
     }
 
     /// When no spike windows are configured, output does not contain spike labels.
-    #[test]
-    fn integration_no_spike_config_produces_no_spike_labels() {
+    #[tokio::test]
+    async fn integration_no_spike_config_produces_no_spike_labels() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         for line in output.lines() {
             assert!(
                 !line.contains("pod_name="),
@@ -877,8 +949,8 @@ mod tests {
     }
 
     /// Counter strategy produces unique values bounded by cardinality.
-    #[test]
-    fn integration_spike_counter_strategy_produces_bounded_values() {
+    #[tokio::test]
+    async fn integration_spike_counter_strategy_produces_bounded_values() {
         let spike = crate::config::CardinalitySpikeConfig {
             label: "pod_name".to_string(),
             every: "10s".to_string(),
@@ -889,10 +961,13 @@ mod tests {
             seed: None,
         };
         let config = make_config_with_spike(50.0, "500ms", spike);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("output must be valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("output must be valid UTF-8");
         let mut seen_values = std::collections::HashSet::new();
         for line in output.lines() {
             // Extract value of pod_name from Prometheus output like: pod_name="pod-0"
@@ -917,8 +992,8 @@ mod tests {
     }
 
     /// Stats correctly reports `in_cardinality_spike` during a spike window.
-    #[test]
-    fn integration_spike_stats_reports_in_cardinality_spike() {
+    #[tokio::test]
+    async fn integration_spike_stats_reports_in_cardinality_spike() {
         use std::sync::{Arc, RwLock};
 
         let spike = crate::config::CardinalitySpikeConfig {
@@ -931,10 +1006,11 @@ mod tests {
             seed: None,
         };
         let config = make_config_with_spike(50.0, "200ms", spike);
-        let mut sink = MemorySink::new();
+        let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
         super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
+            .await
             .expect("run must succeed");
 
         // The entire 200ms run is inside the spike window (0..9s of 10s cycle).
@@ -949,15 +1025,16 @@ mod tests {
     // ---- Arc sharing: name and labels are reference-counted, not deep-cloned ---
 
     /// All metric events buffered in stats must share the same Arc<str> name
-    #[test]
-    fn current_values_holds_one_entry_for_single_series_scenario() {
+    #[tokio::test]
+    async fn current_values_holds_one_entry_for_single_series_scenario() {
         use std::sync::{Arc, RwLock};
 
         let config = make_config(200.0, "100ms", None);
-        let mut sink = MemorySink::new();
+        let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
         super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
+            .await
             .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
@@ -975,8 +1052,8 @@ mod tests {
     }
 
     /// Invalid metric name in config is caught before the hot loop, not during.
-    #[test]
-    fn invalid_metric_name_returns_config_error_before_loop() {
+    #[tokio::test]
+    async fn invalid_metric_name_returns_config_error_before_loop() {
         let config = ScenarioConfig {
             base: BaseScheduleConfig {
                 name: "123-invalid".to_string(),
@@ -1001,8 +1078,8 @@ mod tests {
             metric_type: None,
             help: None,
         };
-        let mut sink = MemorySink::new();
-        let result = super::run_with_sink(&config, &mut sink, None, None);
+        let (mut sink, _buf) = probe_sink();
+        let result = super::run_with_sink(&config, &mut sink, None, None).await;
         assert!(
             matches!(result, Err(crate::SondaError::Config(ref e)) if e.to_string().contains("123-invalid")),
             "expected Config error for invalid name, got: {result:?}"
@@ -1044,8 +1121,8 @@ mod tests {
     }
 
     /// Dynamic labels with counter strategy appear in every Prometheus line.
-    #[test]
-    fn dynamic_labels_counter_appear_in_metric_output() {
+    #[tokio::test]
+    async fn dynamic_labels_counter_appear_in_metric_output() {
         let config = make_config_with_dynamic_labels(
             10.0,
             "1s",
@@ -1057,10 +1134,13 @@ mod tests {
                 },
             }],
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(
             !lines.is_empty(),
@@ -1076,8 +1156,8 @@ mod tests {
     }
 
     /// Dynamic labels with values list cycle through the values.
-    #[test]
-    fn dynamic_labels_values_list_cycle_in_metric_output() {
+    #[tokio::test]
+    async fn dynamic_labels_values_list_cycle_in_metric_output() {
         let config = make_config_with_dynamic_labels(
             10.0,
             "1s",
@@ -1088,10 +1168,13 @@ mod tests {
                 },
             }],
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         let lines: Vec<&str> = output.lines().collect();
         assert!(!lines.is_empty());
 
@@ -1113,8 +1196,8 @@ mod tests {
     }
 
     /// Cardinality ceiling is respected: only cardinality distinct values appear.
-    #[test]
-    fn dynamic_labels_counter_respects_cardinality_ceiling_in_output() {
+    #[tokio::test]
+    async fn dynamic_labels_counter_respects_cardinality_ceiling_in_output() {
         let config = make_config_with_dynamic_labels(
             50.0,
             "1s",
@@ -1126,10 +1209,13 @@ mod tests {
                 },
             }],
         );
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         let mut distinct_values = std::collections::HashSet::new();
         for line in output.lines() {
             // Extract the hostname="..." value
@@ -1149,8 +1235,8 @@ mod tests {
     }
 
     /// Dynamic labels and static labels coexist: both appear in output.
-    #[test]
-    fn dynamic_labels_and_static_labels_coexist_in_output() {
+    #[tokio::test]
+    async fn dynamic_labels_and_static_labels_coexist_in_output() {
         let mut config = make_config_with_dynamic_labels(
             10.0,
             "1s",
@@ -1166,10 +1252,13 @@ mod tests {
         label_map.insert("env".to_string(), "prod".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         for line in output.lines() {
             assert!(
                 line.contains("env=\"prod\""),
@@ -1183,8 +1272,8 @@ mod tests {
     }
 
     /// Dynamic label wins on key collision with static label.
-    #[test]
-    fn dynamic_label_wins_on_key_collision_with_static() {
+    #[tokio::test]
+    async fn dynamic_label_wins_on_key_collision_with_static() {
         let mut config = make_config_with_dynamic_labels(
             10.0,
             "500ms",
@@ -1200,10 +1289,13 @@ mod tests {
         label_map.insert("hostname".to_string(), "static-value".to_string());
         config.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         for line in output.lines() {
             assert!(
                 line.contains("hostname=\"dynamic-"),

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -1,15 +1,9 @@
 //! The metric scenario event loop.
-//!
-//! The runner ties together all sonda-core components: it reads a
-//! [`ScenarioConfig`], builds the generator, encoder, and sink, then delegates
-//! to the shared [`core_loop::run_schedule_loop`](super::core_loop::run_schedule_loop)
-//! for rate control, gap/burst/spike window handling, stats tracking, and
-//! shutdown management. Only the metric-specific event generation and encoding
-//! logic lives here.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime};
+
+use tokio_util::sync::CancellationToken;
 
 use crate::config::ScenarioConfig;
 use crate::encoder::create_encoder;
@@ -26,84 +20,26 @@ use crate::sink::{create_sink, Sink, SinkConfig};
 use crate::SondaError;
 
 /// Run a scenario to completion, emitting encoded metric events at the configured rate.
-///
-/// This is the primary entry point. It constructs a sink from the config and then
-/// delegates to [`run_with_sink`] with no shutdown flag and no stats collection.
-///
-/// This function blocks the calling thread until the scenario duration has
-/// elapsed. If no duration is specified in the config it runs indefinitely.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run(config: &ScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, None).await?;
-    run_with_sink(config, &mut sink, None, None).await
+    let cancel = CancellationToken::new();
+    run_with_sink(config, &mut sink, &cancel, None).await
 }
 
 /// Run a scenario to completion, writing encoded events into the provided sink.
-///
-/// This function builds the metric generator, encoder, and label set from the
-/// config, then delegates to the shared schedule loop via
-/// [`core_loop::run_schedule_loop`](super::core_loop::run_schedule_loop).
-/// The metric-specific per-tick work (value generation, label spike injection,
-/// `MetricEvent` construction, encoding, and sink writing) is captured in a
-/// closure passed to the shared loop.
-///
-/// # Parameters
-///
-/// * `config` — the scenario configuration.
-/// * `sink` — the destination for encoded metric events.
-/// * `shutdown` — an optional atomic flag; when set to `false` the loop exits
-///   cleanly after the current tick, flushes the sink, and returns `Ok(())`.
-///   Pass `None` if no external shutdown signal is needed (e.g., in tests).
-/// * `stats` — an optional shared stats object. When `Some`, the runner updates
-///   `total_events`, `bytes_emitted`, `current_rate`, `in_gap`, `in_burst`, and
-///   `errors` on each tick. The write lock is held only for the brief counter
-///   update, not during encode/write. Pass `None` to skip stats collection with
-///   no overhead (e.g., in direct CLI usage or tests).
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-/// If an error occurs during the loop and flushing also fails, the loop error
-/// is returned (the flush error is discarded to preserve the original cause).
 pub async fn run_with_sink(
     config: &ScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_with_sink_gated(config, sink, shutdown, stats, None, None).await
-}
-
-/// Run a metric scenario with optional `while:` / `after:` gating.
-///
-/// `upstream_bus` is the bus this scenario PUBLISHES into (for downstream
-/// gates to subscribe to). `gate_ctx` is what THIS scenario consumes from
-/// an upstream bus. Both are independent — a scenario can be both an
-/// upstream (publishing) and a downstream (gated).
-pub fn run_with_sink_gated_blocking(
-    config: &ScenarioConfig,
-    shutdown: Option<&AtomicBool>,
-    stats: Option<Arc<RwLock<ScenarioStats>>>,
-    upstream_bus: Option<Arc<GateBus>>,
-    gate_ctx: Option<GateContext>,
-) -> Result<(), SondaError> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
-    rt.block_on(async {
-        let mut sink = create_sink(&config.sink, None).await?;
-        run_with_sink_gated(config, &mut sink, shutdown, stats, upstream_bus, gate_ctx).await
-    })
+    run_with_sink_gated(config, sink, cancel, stats, None, None).await
 }
 
 pub async fn run_with_sink_gated(
     config: &ScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     upstream_bus: Option<Arc<GateBus>>,
     gate_ctx: Option<GateContext>,
@@ -186,15 +122,8 @@ pub async fn run_with_sink_gated(
 
     match gate_ctx {
         None => {
-            core_loop::run_schedule_loop(
-                &schedule,
-                config.rate,
-                shutdown,
-                stats,
-                sink,
-                &mut tick_fn,
-            )
-            .await
+            core_loop::run_schedule_loop(&schedule, config.rate, cancel, stats, sink, &mut tick_fn)
+                .await
         }
         Some(mut ctx) => {
             ctx.close_emit = build_close_emit(
@@ -207,7 +136,7 @@ pub async fn run_with_sink_gated(
             core_loop::gated_loop(
                 &schedule,
                 config.rate,
-                shutdown,
+                cancel,
                 stats,
                 ctx,
                 sink,
@@ -313,6 +242,7 @@ mod tests {
     use std::sync::Mutex;
 
     use async_trait::async_trait;
+    use tokio_util::sync::CancellationToken;
 
     use crate::config::{BaseScheduleConfig, GapConfig, ScenarioConfig};
     use crate::encoder::EncoderConfig;
@@ -393,7 +323,7 @@ mod tests {
     async fn integration_rate_100_duration_1s_emits_approximately_100_events() {
         let config = make_config(100.0, "1s", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -410,7 +340,7 @@ mod tests {
     async fn integration_output_lines_start_with_metric_name() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -429,7 +359,7 @@ mod tests {
     async fn integration_output_ends_with_newline() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -454,7 +384,7 @@ mod tests {
             }),
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -506,7 +436,7 @@ mod tests {
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -573,7 +503,7 @@ mod tests {
             }),
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -608,7 +538,7 @@ mod tests {
             }),
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -675,7 +605,7 @@ mod tests {
             }),
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -735,9 +665,14 @@ mod tests {
             }),
         );
         let (mut sink_no_gap, buf_no_gap) = probe_sink();
-        super::run_with_sink(&config_no_gap_burst, &mut sink_no_gap, None, None)
-            .await
-            .expect("run must succeed");
+        super::run_with_sink(
+            &config_no_gap_burst,
+            &mut sink_no_gap,
+            &CancellationToken::new(),
+            None,
+        )
+        .await
+        .expect("run must succeed");
         let events_burst_only = buf_no_gap
             .lock()
             .unwrap()
@@ -761,9 +696,14 @@ mod tests {
             }),
         );
         let (mut sink_gap_burst, buf_gap_burst) = probe_sink();
-        super::run_with_sink(&config_gap_and_burst, &mut sink_gap_burst, None, None)
-            .await
-            .expect("run must succeed");
+        super::run_with_sink(
+            &config_gap_and_burst,
+            &mut sink_gap_burst,
+            &CancellationToken::new(),
+            None,
+        )
+        .await
+        .expect("run must succeed");
         let events_gap_and_burst = buf_gap_burst
             .lock()
             .unwrap()
@@ -792,9 +732,14 @@ mod tests {
         let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
-        super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
-            .await
-            .expect("run must succeed");
+        super::run_with_sink(
+            &config,
+            &mut sink,
+            &CancellationToken::new(),
+            Some(Arc::clone(&stats)),
+        )
+        .await
+        .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
         assert!(
@@ -811,7 +756,7 @@ mod tests {
         let (mut sink, buf) = probe_sink();
 
         // Pass None for stats — should work fine without buffering.
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -831,9 +776,14 @@ mod tests {
         let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
-        super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
-            .await
-            .expect("run must succeed");
+        super::run_with_sink(
+            &config,
+            &mut sink,
+            &CancellationToken::new(),
+            Some(Arc::clone(&stats)),
+        )
+        .await
+        .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
         for event in st.current_values.values() {
@@ -841,15 +791,12 @@ mod tests {
         }
     }
 
-    /// The shutdown flag stops the runner even during a burst window.
+    /// Cancelling the token stops the runner even during a burst window.
     #[tokio::test]
-    async fn shutdown_flag_stops_run_during_burst() {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::Arc;
-
+    async fn cancel_stops_run_during_burst() {
         let config = make_config_with_burst(
             1000.0,
-            "60s", // long duration — shutdown flag stops it
+            "60s",
             None,
             Some(crate::config::BurstConfig {
                 every: "10s".to_string(),
@@ -858,17 +805,16 @@ mod tests {
             }),
         );
 
-        let shutdown = Arc::new(AtomicBool::new(true));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel = CancellationToken::new();
+        let cancel_for_thread = cancel.clone();
 
-        // Set the flag to false after a short delay to trigger shutdown.
         let handle = std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(200));
-            shutdown_clone.store(false, Ordering::SeqCst);
+            cancel_for_thread.cancel();
         });
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, Some(&shutdown), None)
+        super::run_with_sink(&config, &mut sink, &cancel, None)
             .await
             .expect("run must succeed");
         handle.join().expect("thread must complete");
@@ -935,7 +881,7 @@ mod tests {
         // Run for 500ms inside a spike window (spike occupies 0..9s of each 10s cycle)
         let config = make_config_with_spike(50.0, "500ms", spike);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -954,7 +900,7 @@ mod tests {
     async fn integration_no_spike_config_produces_no_spike_labels() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -982,7 +928,7 @@ mod tests {
         };
         let config = make_config_with_spike(50.0, "500ms", spike);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -1029,9 +975,14 @@ mod tests {
         let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
-        super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
-            .await
-            .expect("run must succeed");
+        super::run_with_sink(
+            &config,
+            &mut sink,
+            &CancellationToken::new(),
+            Some(Arc::clone(&stats)),
+        )
+        .await
+        .expect("run must succeed");
 
         // The entire 200ms run is inside the spike window (0..9s of 10s cycle).
         // The final stats snapshot should show in_cardinality_spike = true.
@@ -1053,9 +1004,14 @@ mod tests {
         let (mut sink, _buf) = probe_sink();
         let stats = Arc::new(RwLock::new(crate::schedule::stats::ScenarioStats::default()));
 
-        super::run_with_sink(&config, &mut sink, None, Some(Arc::clone(&stats)))
-            .await
-            .expect("run must succeed");
+        super::run_with_sink(
+            &config,
+            &mut sink,
+            &CancellationToken::new(),
+            Some(Arc::clone(&stats)),
+        )
+        .await
+        .expect("run must succeed");
 
         let st = stats.read().expect("lock must not be poisoned");
         assert_eq!(
@@ -1099,7 +1055,8 @@ mod tests {
             help: None,
         };
         let (mut sink, _buf) = probe_sink();
-        let result = super::run_with_sink(&config, &mut sink, None, None).await;
+        let result =
+            super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None).await;
         assert!(
             matches!(result, Err(crate::SondaError::Config(ref e)) if e.to_string().contains("123-invalid")),
             "expected Config error for invalid name, got: {result:?}"
@@ -1155,7 +1112,7 @@ mod tests {
             }],
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -1189,7 +1146,7 @@ mod tests {
             }],
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -1230,7 +1187,7 @@ mod tests {
             }],
         );
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -1273,7 +1230,7 @@ mod tests {
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -1310,7 +1267,7 @@ mod tests {
         config.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 

--- a/sonda-core/src/schedule/stats.rs
+++ b/sonda-core/src/schedule/stats.rs
@@ -40,6 +40,35 @@ pub enum ScenarioState {
     Finished,
 }
 
+impl ScenarioState {
+    /// Operational states surfaced as separate gauge rows by the server metrics emitter.
+    pub fn operational_states() -> &'static [ScenarioState] {
+        &[
+            ScenarioState::Pending,
+            ScenarioState::Running,
+            ScenarioState::Paused,
+            ScenarioState::Held,
+            ScenarioState::Unresolved,
+        ]
+    }
+
+    /// Stable lowercase label text for Prometheus exposition.
+    pub fn as_label(&self) -> &'static str {
+        // Catch-all guards against future #[non_exhaustive] variants added by
+        // Phase 5; in-crate the match is exhaustive today.
+        #[allow(unreachable_patterns)]
+        match self {
+            ScenarioState::Pending => "pending",
+            ScenarioState::Running => "running",
+            ScenarioState::Paused => "paused",
+            ScenarioState::Held => "held",
+            ScenarioState::Unresolved => "unresolved",
+            ScenarioState::Finished => "finished",
+            _ => "unknown",
+        }
+    }
+}
+
 /// Live statistics for a running scenario, updated by the runner each tick.
 ///
 /// These counters are written by the scenario thread and read by callers
@@ -643,5 +672,52 @@ mod tests {
             ..Default::default()
         };
         assert!(!s.is_degraded(last - 1_000_000_000));
+    }
+
+    #[test]
+    fn operational_states_returns_five_states_in_documented_order() {
+        let states = ScenarioState::operational_states();
+        assert_eq!(states.len(), 5);
+        assert_eq!(states[0], ScenarioState::Pending);
+        assert_eq!(states[1], ScenarioState::Running);
+        assert_eq!(states[2], ScenarioState::Paused);
+        assert_eq!(states[3], ScenarioState::Held);
+        assert_eq!(states[4], ScenarioState::Unresolved);
+    }
+
+    #[test]
+    fn operational_states_excludes_finished() {
+        let states = ScenarioState::operational_states();
+        assert!(!states.contains(&ScenarioState::Finished));
+    }
+
+    #[test]
+    fn as_label_maps_every_variant_to_lowercase_text() {
+        assert_eq!(ScenarioState::Pending.as_label(), "pending");
+        assert_eq!(ScenarioState::Running.as_label(), "running");
+        assert_eq!(ScenarioState::Paused.as_label(), "paused");
+        assert_eq!(ScenarioState::Held.as_label(), "held");
+        assert_eq!(ScenarioState::Unresolved.as_label(), "unresolved");
+        assert_eq!(ScenarioState::Finished.as_label(), "finished");
+    }
+
+    #[test]
+    fn as_label_matches_serde_lowercase_rename() {
+        for state in [
+            ScenarioState::Pending,
+            ScenarioState::Running,
+            ScenarioState::Paused,
+            ScenarioState::Held,
+            ScenarioState::Unresolved,
+            ScenarioState::Finished,
+        ] {
+            let json = serde_json::to_string(&state).unwrap();
+            let serialized = json.trim_matches('"').to_string();
+            assert_eq!(
+                serialized,
+                state.as_label(),
+                "as_label must match serde rename for {state:?}"
+            );
+        }
     }
 }

--- a/sonda-core/src/schedule/summary_runner.rs
+++ b/sonda-core/src/schedule/summary_runner.rs
@@ -41,7 +41,7 @@ use crate::SondaError;
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run(config: &SummaryScenarioConfig) -> Result<(), SondaError> {
-    let mut sink = create_sink(&config.sink, None)?;
+    let mut sink = create_sink(&config.sink, None).await?;
     run_with_sink(config, &mut sink, None, None).await
 }
 
@@ -75,6 +75,22 @@ pub async fn run_with_sink(
 ///
 /// Summaries cannot be `while:` upstreams (compile-time
 /// `NonMetricsTarget`), but they can be `while:`-gated downstreams.
+pub fn run_with_sink_gated_blocking(
+    config: &SummaryScenarioConfig,
+    shutdown: Option<&AtomicBool>,
+    stats: Option<Arc<RwLock<ScenarioStats>>>,
+    gate_ctx: Option<GateContext>,
+) -> Result<(), SondaError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
+    rt.block_on(async {
+        let mut sink = create_sink(&config.sink, None).await?;
+        run_with_sink_gated(config, &mut sink, shutdown, stats, gate_ctx).await
+    })
+}
+
 pub async fn run_with_sink_gated(
     config: &SummaryScenarioConfig,
     sink: &mut Box<dyn Sink>,
@@ -268,6 +284,8 @@ pub async fn run_with_sink_gated(
 mod tests {
     use std::sync::Mutex;
 
+    use async_trait::async_trait;
+
     use crate::config::{BaseScheduleConfig, DistributionConfig, SummaryScenarioConfig};
     use crate::encoder::EncoderConfig;
     use crate::sink::{Sink, SinkConfig};
@@ -277,15 +295,16 @@ mod tests {
 
     struct ProbeSink(SharedBuf);
 
+    #[async_trait]
     impl Sink for ProbeSink {
-        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
             self.0
                 .lock()
                 .expect("probe sink mutex poisoned")
                 .extend_from_slice(data);
             Ok(())
         }
-        fn flush(&mut self) -> Result<(), SondaError> {
+        async fn flush(&mut self) -> Result<(), SondaError> {
             Ok(())
         }
     }

--- a/sonda-core/src/schedule/summary_runner.rs
+++ b/sonda-core/src/schedule/summary_runner.rs
@@ -40,9 +40,9 @@ use crate::SondaError;
 /// # Errors
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-pub fn run(config: &SummaryScenarioConfig) -> Result<(), SondaError> {
+pub async fn run(config: &SummaryScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, None)?;
-    run_with_sink(config, sink.as_mut(), None, None)
+    run_with_sink(config, &mut sink, None, None).await
 }
 
 /// Run a summary scenario to completion, writing encoded events into the
@@ -62,22 +62,22 @@ pub fn run(config: &SummaryScenarioConfig) -> Result<(), SondaError> {
 /// # Errors
 ///
 /// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
-pub fn run_with_sink(
+pub async fn run_with_sink(
     config: &SummaryScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_with_sink_gated(config, sink, shutdown, stats, None)
+    run_with_sink_gated(config, sink, shutdown, stats, None).await
 }
 
 /// Run a summary scenario with optional `while:` / `after:` gating.
 ///
 /// Summaries cannot be `while:` upstreams (compile-time
 /// `NonMetricsTarget`), but they can be `while:`-gated downstreams.
-pub fn run_with_sink_gated(
+pub async fn run_with_sink_gated(
     config: &SummaryScenarioConfig,
-    sink: &mut dyn Sink,
+    sink: &mut Box<dyn Sink>,
     shutdown: Option<&AtomicBool>,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
@@ -238,32 +238,63 @@ pub fn run_with_sink_gated(
     };
 
     match gate_ctx {
-        None => core_loop::run_schedule_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            sink,
-            &mut tick_fn,
-        ),
-        Some(ctx) => core_loop::gated_loop(
-            &schedule,
-            config.rate,
-            shutdown,
-            stats,
-            ctx,
-            sink,
-            &mut tick_fn,
-        ),
+        None => {
+            core_loop::run_schedule_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
+        Some(ctx) => {
+            core_loop::gated_loop(
+                &schedule,
+                config.rate,
+                shutdown,
+                stats,
+                ctx,
+                sink,
+                &mut tick_fn,
+            )
+            .await
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use crate::config::{BaseScheduleConfig, DistributionConfig, SummaryScenarioConfig};
     use crate::encoder::EncoderConfig;
-    use crate::sink::memory::MemorySink;
-    use crate::sink::SinkConfig;
+    use crate::sink::{Sink, SinkConfig};
+    use crate::SondaError;
+
+    type SharedBuf = std::sync::Arc<Mutex<Vec<u8>>>;
+
+    struct ProbeSink(SharedBuf);
+
+    impl Sink for ProbeSink {
+        fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+            self.0
+                .lock()
+                .expect("probe sink mutex poisoned")
+                .extend_from_slice(data);
+            Ok(())
+        }
+        fn flush(&mut self) -> Result<(), SondaError> {
+            Ok(())
+        }
+    }
+
+    fn probe_sink() -> (Box<dyn Sink>, SharedBuf) {
+        let buf: SharedBuf = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let sink: Box<dyn Sink> = Box::new(ProbeSink(SharedBuf::clone(&buf)));
+        (sink, buf)
+    }
 
     /// Build a minimal SummaryScenarioConfig for testing.
     fn make_config(
@@ -306,23 +337,31 @@ mod tests {
 
     // ---- Run completes without error ----------------------------------------
 
-    #[test]
-    fn run_completes_for_short_duration() {
+    #[tokio::test]
+    async fn run_completes_for_short_duration() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("summary run must succeed");
-        assert!(!sink.buffer.is_empty(), "summary run must produce output");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("summary run must succeed");
+        assert!(
+            !buf.lock().unwrap().is_empty(),
+            "summary run must produce output"
+        );
     }
 
     // ---- Output contains expected series names ------------------------------
 
-    #[test]
-    fn output_contains_quantile_count_sum_series() {
+    #[tokio::test]
+    async fn output_contains_quantile_count_sum_series() {
         let config = make_config(50.0, "200ms", None);
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
 
         assert!(
             output.contains("rpc_duration_seconds{"),
@@ -340,13 +379,16 @@ mod tests {
 
     // ---- quantile label present on quantile events ---------------------------
 
-    #[test]
-    fn quantile_events_have_quantile_label() {
+    #[tokio::test]
+    async fn quantile_events_have_quantile_label() {
         let config = make_config(50.0, "100ms", Some(vec![0.5, 0.99]));
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
 
         assert!(
             output.contains("quantile=\"0.5\""),
@@ -360,36 +402,41 @@ mod tests {
 
     // ---- Gap suppresses output -----------------------------------------------
 
-    #[test]
-    fn gap_suppresses_summary_output() {
+    #[tokio::test]
+    async fn gap_suppresses_summary_output() {
         let mut config = make_config(100.0, "2s", None);
         config.base.gaps = Some(crate::config::GapConfig {
             every: "1s".to_string(),
             r#for: "500ms".to_string(),
         });
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
         assert!(
-            !sink.buffer.is_empty(),
+            !buf.lock().unwrap().is_empty(),
             "summary with gaps must still produce some output"
         );
     }
 
     // ---- Labels from config are included ------------------------------------
 
-    #[test]
-    fn config_labels_appear_in_output() {
+    #[tokio::test]
+    async fn config_labels_appear_in_output() {
         let mut config = make_config(50.0, "100ms", Some(vec![0.5]));
         let mut label_map = std::collections::HashMap::new();
         label_map.insert("service".to_string(), "auth".to_string());
         config.base.labels = Some(label_map);
 
-        let mut sink = MemorySink::new();
-        super::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+        let (mut sink, buf) = probe_sink();
+        super::run_with_sink(&config, &mut sink, None, None)
+            .await
+            .expect("run must succeed");
 
-        let output = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+        let captured = buf.lock().unwrap();
+        let output = std::str::from_utf8(&captured).expect("valid UTF-8");
         assert!(
             output.contains("service=\"auth\""),
             "config labels must appear in output"

--- a/sonda-core/src/schedule/summary_runner.rs
+++ b/sonda-core/src/schedule/summary_runner.rs
@@ -22,7 +22,9 @@ use crate::encoder::create_encoder;
 use crate::generator::histogram::to_distribution;
 use crate::generator::summary::{SummaryGenerator, DEFAULT_SUMMARY_QUANTILES};
 use crate::model::metric::{Labels, MetricEvent, ValidatedMetricName};
-use crate::schedule::core_loop::{self, GateContext, TickContext, TickResult};
+use crate::schedule::core_loop::{
+    self, GateContext, TickContext, TickOutput, TickResult, WriteCommand,
+};
 use crate::schedule::is_in_spike;
 use crate::schedule::stats::ScenarioStats;
 use crate::schedule::ParsedSchedule;
@@ -144,7 +146,7 @@ pub fn run_with_sink_gated(
     let mut buf: Vec<u8> = Vec::with_capacity(1024);
 
     let mut tick_fn = |ctx: &TickContext<'_>,
-                       sink: &mut dyn Sink,
+                       output: &mut TickOutput,
                        events_buf: &mut Vec<MetricEvent>|
      -> Result<TickResult, SondaError> {
         let wall_now = ctx.wall_clock;
@@ -180,7 +182,9 @@ pub fn run_with_sink_gated(
             buf.clear();
             encoder.encode_metric(&event, &mut buf)?;
             total_bytes += buf.len() as u64;
-            sink.write(&buf)?;
+            output
+                .writes
+                .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
             events_buf.push(event);
         }
 
@@ -208,7 +212,9 @@ pub fn run_with_sink_gated(
         buf.clear();
         encoder.encode_metric(&sum_event, &mut buf)?;
         total_bytes += buf.len() as u64;
-        sink.write(&buf)?;
+        output
+            .writes
+            .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
         events_buf.push(sum_event);
 
         let count_event = MetricEvent::from_parts(
@@ -220,19 +226,18 @@ pub fn run_with_sink_gated(
         buf.clear();
         encoder.encode_metric(&count_event, &mut buf)?;
         total_bytes += buf.len() as u64;
-        sink.write(&buf)?;
+        output
+            .writes
+            .push(WriteCommand::Bytes(std::mem::take(&mut buf)));
         events_buf.push(count_event);
-
-        let delivered = sink.last_write_delivered();
 
         Ok(TickResult {
             bytes_written: total_bytes,
-            delivered,
+            delivered: true,
         })
     };
 
-    let stats_for_flush = stats.clone();
-    let loop_result = match gate_ctx {
+    match gate_ctx {
         None => core_loop::run_schedule_loop(
             &schedule,
             config.rate,
@@ -250,12 +255,6 @@ pub fn run_with_sink_gated(
             sink,
             &mut tick_fn,
         ),
-    };
-
-    let flush_result = sink.flush();
-    match loop_result {
-        Ok(()) => core_loop::apply_flush_policy(&schedule, stats_for_flush.as_ref(), flush_result),
-        Err(e) => Err(e),
     }
 }
 

--- a/sonda-core/src/schedule/summary_runner.rs
+++ b/sonda-core/src/schedule/summary_runner.rs
@@ -1,21 +1,8 @@
 //! The summary scenario event loop.
-//!
-//! The summary runner ties together the [`SummaryGenerator`], encoder, and
-//! sink with the shared schedule loop from
-//! [`core_loop::run_schedule_loop`](super::core_loop::run_schedule_loop).
-//!
-//! Each tick, the runner:
-//! 1. Advances the summary generator to get a [`SummarySample`].
-//! 2. For each quantile target, creates a `MetricEvent` with the base name
-//!    and a `quantile="{q}"` label.
-//! 3. Creates `{base}_count` and `{base}_sum` events.
-//! 4. Encodes all events and writes them to the sink.
-//!
-//! The core loop is unchanged — all summary-specific logic lives in the
-//! per-tick closure.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
+
+use tokio_util::sync::CancellationToken;
 
 use crate::config::SummaryScenarioConfig;
 use crate::encoder::create_encoder;
@@ -31,70 +18,26 @@ use crate::schedule::ParsedSchedule;
 use crate::sink::{create_sink, Sink};
 use crate::SondaError;
 
-/// Run a summary scenario to completion, emitting encoded summary events
-/// at the configured rate.
-///
-/// This is the primary entry point. It constructs a sink from the config and
-/// delegates to [`run_with_sink`] with no shutdown flag and no stats collection.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
+/// Run a summary scenario to completion at the configured rate.
 pub async fn run(config: &SummaryScenarioConfig) -> Result<(), SondaError> {
     let mut sink = create_sink(&config.sink, None).await?;
-    run_with_sink(config, &mut sink, None, None).await
+    let cancel = CancellationToken::new();
+    run_with_sink(config, &mut sink, &cancel, None).await
 }
 
-/// Run a summary scenario to completion, writing encoded events into the
-/// provided sink.
-///
-/// Builds the summary generator, encoder, and label sets from the config,
-/// then delegates to the shared schedule loop. The per-tick closure generates
-/// multiple `MetricEvent`s per tick (one per quantile + `_count` + `_sum`).
-///
-/// # Parameters
-///
-/// * `config` — the summary scenario configuration.
-/// * `sink` — the destination for encoded metric events.
-/// * `shutdown` — optional atomic flag for clean shutdown.
-/// * `stats` — optional shared stats for live telemetry.
-///
-/// # Errors
-///
-/// Returns [`SondaError`] if config validation, encoding, or sink I/O fails.
 pub async fn run_with_sink(
     config: &SummaryScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
 ) -> Result<(), SondaError> {
-    run_with_sink_gated(config, sink, shutdown, stats, None).await
-}
-
-/// Run a summary scenario with optional `while:` / `after:` gating.
-///
-/// Summaries cannot be `while:` upstreams (compile-time
-/// `NonMetricsTarget`), but they can be `while:`-gated downstreams.
-pub fn run_with_sink_gated_blocking(
-    config: &SummaryScenarioConfig,
-    shutdown: Option<&AtomicBool>,
-    stats: Option<Arc<RwLock<ScenarioStats>>>,
-    gate_ctx: Option<GateContext>,
-) -> Result<(), SondaError> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| crate::SondaError::Runtime(crate::RuntimeError::SpawnFailed(e)))?;
-    rt.block_on(async {
-        let mut sink = create_sink(&config.sink, None).await?;
-        run_with_sink_gated(config, &mut sink, shutdown, stats, gate_ctx).await
-    })
+    run_with_sink_gated(config, sink, cancel, stats, None).await
 }
 
 pub async fn run_with_sink_gated(
     config: &SummaryScenarioConfig,
     sink: &mut Box<dyn Sink>,
-    shutdown: Option<&AtomicBool>,
+    cancel: &CancellationToken,
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
 ) -> Result<(), SondaError> {
@@ -255,21 +198,14 @@ pub async fn run_with_sink_gated(
 
     match gate_ctx {
         None => {
-            core_loop::run_schedule_loop(
-                &schedule,
-                config.rate,
-                shutdown,
-                stats,
-                sink,
-                &mut tick_fn,
-            )
-            .await
+            core_loop::run_schedule_loop(&schedule, config.rate, cancel, stats, sink, &mut tick_fn)
+                .await
         }
         Some(ctx) => {
             core_loop::gated_loop(
                 &schedule,
                 config.rate,
-                shutdown,
+                cancel,
                 stats,
                 ctx,
                 sink,
@@ -285,6 +221,7 @@ mod tests {
     use std::sync::Mutex;
 
     use async_trait::async_trait;
+    use tokio_util::sync::CancellationToken;
 
     use crate::config::{BaseScheduleConfig, DistributionConfig, SummaryScenarioConfig};
     use crate::encoder::EncoderConfig;
@@ -360,7 +297,7 @@ mod tests {
     async fn run_completes_for_short_duration() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("summary run must succeed");
         assert!(
@@ -375,7 +312,7 @@ mod tests {
     async fn output_contains_quantile_count_sum_series() {
         let config = make_config(50.0, "200ms", None);
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -402,7 +339,7 @@ mod tests {
     async fn quantile_events_have_quantile_label() {
         let config = make_config(50.0, "100ms", Some(vec![0.5, 0.99]));
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -430,7 +367,7 @@ mod tests {
         });
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 
@@ -450,7 +387,7 @@ mod tests {
         config.base.labels = Some(label_map);
 
         let (mut sink, buf) = probe_sink();
-        super::run_with_sink(&config, &mut sink, None, None)
+        super::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
             .await
             .expect("run must succeed");
 

--- a/sonda-core/src/sink/channel.rs
+++ b/sonda-core/src/sink/channel.rs
@@ -8,6 +8,8 @@
 
 use std::sync::mpsc::SyncSender;
 
+use async_trait::async_trait;
+
 use crate::sink::Sink;
 use crate::SondaError;
 
@@ -26,50 +28,37 @@ use crate::SondaError;
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,no_run
 /// use std::sync::mpsc;
 /// use sonda_core::sink::{Sink, channel::ChannelSink};
 ///
+/// # async fn doc() {
 /// let (tx, rx) = mpsc::sync_channel(10);
 /// let mut sink = ChannelSink::new(tx);
-/// sink.write(b"hello\n").unwrap();
+/// sink.write(b"hello\n").await.unwrap();
 /// let data = rx.recv().unwrap();
 /// assert_eq!(data, b"hello\n");
+/// # }
 /// ```
 pub struct ChannelSink {
     tx: SyncSender<Vec<u8>>,
 }
 
 impl ChannelSink {
-    /// Create a new `ChannelSink` that sends encoded data over `tx`.
-    ///
-    /// The backing channel must be created with [`mpsc::sync_channel`](std::sync::mpsc::sync_channel)
-    /// to enforce bounded capacity.
     pub fn new(tx: SyncSender<Vec<u8>>) -> Self {
         Self { tx }
     }
 }
 
+#[async_trait]
 impl Sink for ChannelSink {
-    /// Send a copy of `data` over the channel.
-    ///
-    /// Blocks when the channel is at capacity until the receiver drains a slot.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if the receiver has been dropped and the
-    /// channel is disconnected.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.tx
             .send(data.to_vec())
             .map_err(|e| SondaError::Sink(std::io::Error::other(e.to_string())))
     }
 
-    /// No-op flush: channel delivery is synchronous per `send` call.
-    ///
-    /// Returns `Ok(())` unconditionally because the channel has no internal
-    /// buffer beyond what the receiver has not yet consumed.
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
 }
@@ -83,90 +72,73 @@ mod tests {
     use super::*;
     use crate::sink::Sink;
 
-    // -----------------------------------------------------------------------
-    // Happy path: write and receive
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn write_sends_exact_bytes_to_receiver() {
+    #[tokio::test]
+    async fn write_sends_exact_bytes_to_receiver() {
         let (tx, rx) = mpsc::sync_channel(10);
         let mut sink = ChannelSink::new(tx);
-        sink.write(b"hello\n").unwrap();
+        sink.write(b"hello\n").await.unwrap();
         let received = rx.recv().expect("receiver should get data");
         assert_eq!(received, b"hello\n");
     }
 
-    #[test]
-    fn write_empty_slice_sends_empty_vec() {
+    #[tokio::test]
+    async fn write_empty_slice_sends_empty_vec() {
         let (tx, rx) = mpsc::sync_channel(10);
         let mut sink = ChannelSink::new(tx);
-        sink.write(b"").unwrap();
+        sink.write(b"").await.unwrap();
         let received = rx.recv().expect("receiver should get empty vec");
         assert!(received.is_empty());
     }
 
-    #[test]
-    fn multiple_writes_send_in_order() {
+    #[tokio::test]
+    async fn multiple_writes_send_in_order() {
         let (tx, rx) = mpsc::sync_channel(10);
         let mut sink = ChannelSink::new(tx);
-        sink.write(b"first\n").unwrap();
-        sink.write(b"second\n").unwrap();
-        sink.write(b"third\n").unwrap();
+        sink.write(b"first\n").await.unwrap();
+        sink.write(b"second\n").await.unwrap();
+        sink.write(b"third\n").await.unwrap();
 
         assert_eq!(rx.recv().unwrap(), b"first\n");
         assert_eq!(rx.recv().unwrap(), b"second\n");
         assert_eq!(rx.recv().unwrap(), b"third\n");
     }
 
-    #[test]
-    fn flush_always_returns_ok() {
+    #[tokio::test]
+    async fn flush_always_returns_ok() {
         let (tx, _rx) = mpsc::sync_channel(10);
         let mut sink = ChannelSink::new(tx);
-        assert!(sink.flush().is_ok());
+        assert!(sink.flush().await.is_ok());
     }
 
-    #[test]
-    fn flush_does_not_affect_channel_contents() {
+    #[tokio::test]
+    async fn flush_does_not_affect_channel_contents() {
         let (tx, rx) = mpsc::sync_channel(10);
         let mut sink = ChannelSink::new(tx);
-        sink.write(b"data").unwrap();
-        sink.flush().unwrap();
+        sink.write(b"data").await.unwrap();
+        sink.flush().await.unwrap();
         let received = rx.recv().unwrap();
         assert_eq!(received, b"data");
     }
 
-    // -----------------------------------------------------------------------
-    // Error case: disconnected receiver returns Err
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn write_after_receiver_dropped_returns_err() {
+    #[tokio::test]
+    async fn write_after_receiver_dropped_returns_err() {
         let (tx, rx) = mpsc::sync_channel::<Vec<u8>>(10);
         let mut sink = ChannelSink::new(tx);
-        // Drop the receiver — channel is now disconnected.
         drop(rx);
-        let result = sink.write(b"orphaned");
+        let result = sink.write(b"orphaned").await;
         assert!(
             result.is_err(),
             "write to disconnected channel should return Err"
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Backpressure: bounded(10), fast writes block once channel is full
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn bounded_channel_provides_backpressure_without_oom() {
-        // Channel capacity = 10. We write 20 items. The receiver drains slowly.
-        // This verifies that the producer blocks (backpressure) rather than
-        // allocating unbounded memory.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn bounded_channel_provides_backpressure_without_oom() {
         let capacity = 10usize;
         let total_writes = 20usize;
         let (tx, rx) = mpsc::sync_channel(capacity);
         let mut sink = ChannelSink::new(tx);
 
-        // Spawn a slow receiver that drains one item every 5ms.
         let receiver_handle = thread::spawn(move || {
             let mut count = 0usize;
             while count < total_writes {
@@ -178,11 +150,11 @@ mod tests {
             count
         });
 
-        // Write all 20 items. The 11th write will block until the receiver
-        // drains a slot. This must not panic or OOM — it should just block.
         for i in 0..total_writes {
             let data = format!("item-{i}\n");
-            sink.write(data.as_bytes()).expect("write should succeed");
+            sink.write(data.as_bytes())
+                .await
+                .expect("write should succeed");
         }
 
         let received_count = receiver_handle
@@ -194,25 +166,20 @@ mod tests {
         );
     }
 
-    #[test]
-    fn channel_sink_write_count_matches_receive_count() {
+    #[tokio::test]
+    async fn channel_sink_write_count_matches_receive_count() {
         let (tx, rx) = mpsc::sync_channel(100);
         let mut sink = ChannelSink::new(tx);
 
         let n = 50usize;
         for i in 0..n {
-            sink.write(format!("line {i}").as_bytes()).unwrap();
+            sink.write(format!("line {i}").as_bytes()).await.unwrap();
         }
-        // Drop the sink to close the channel so the iterator terminates.
         drop(sink);
 
         let count = rx.into_iter().count();
         assert_eq!(count, n, "should receive exactly {n} items");
     }
-
-    // -----------------------------------------------------------------------
-    // Contract: Send + Sync
-    // -----------------------------------------------------------------------
 
     #[test]
     fn channel_sink_is_send() {
@@ -226,12 +193,12 @@ mod tests {
         assert_sync::<ChannelSink>();
     }
 
-    #[test]
-    fn channel_sink_usable_as_boxed_sink_trait_object() {
+    #[tokio::test]
+    async fn channel_sink_usable_as_boxed_sink_trait_object() {
         let (tx, rx) = mpsc::sync_channel(10);
         let mut sink: Box<dyn Sink> = Box::new(ChannelSink::new(tx));
-        sink.write(b"trait object test").unwrap();
-        sink.flush().unwrap();
+        sink.write(b"trait object test").await.unwrap();
+        sink.flush().await.unwrap();
         let data = rx.recv().unwrap();
         assert_eq!(data, b"trait object test");
     }

--- a/sonda-core/src/sink/file.rs
+++ b/sonda-core/src/sink/file.rs
@@ -1,34 +1,26 @@
 //! File sink — writes encoded telemetry to a file on disk.
 
-use std::fs::{self, File};
-use std::io::{BufWriter, Write};
 use std::path::Path;
+
+use async_trait::async_trait;
+use tokio::fs::{self, File};
+use tokio::io::{AsyncWriteExt, BufWriter};
 
 use super::Sink;
 use crate::SondaError;
 
 /// A sink that writes encoded event data to a file using a buffered writer.
-///
-/// Parent directories are created automatically if they do not exist.
-/// Wraps the underlying [`File`] in a [`BufWriter`] to batch syscalls and
-/// reduce per-event overhead.
 pub struct FileSink {
     writer: BufWriter<File>,
 }
 
 impl FileSink {
-    /// Create a new `FileSink` writing to the given path.
-    ///
-    /// Creates any missing parent directories before opening the file.
-    ///
-    /// # Errors
-    ///
-    /// Returns `SondaError::Sink` if the parent directories cannot be created
-    /// or the file cannot be opened for writing.
-    pub fn new(path: &Path) -> Result<Self, SondaError> {
+    /// Open `path` for writing, creating any missing parent directories.
+    pub async fn new(path: &Path) -> Result<Self, SondaError> {
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() {
                 fs::create_dir_all(parent)
+                    .await
                     .map_err(|e| {
                         std::io::Error::new(
                             e.kind(),
@@ -44,6 +36,7 @@ impl FileSink {
         }
 
         let file = File::create(path)
+            .await
             .map_err(|e| {
                 std::io::Error::new(
                     e.kind(),
@@ -58,16 +51,18 @@ impl FileSink {
     }
 }
 
+#[async_trait]
 impl Sink for FileSink {
-    /// Write `data` to the buffered file writer.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
-        self.writer.write_all(data).map_err(SondaError::Sink)?;
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        self.writer
+            .write_all(data)
+            .await
+            .map_err(SondaError::Sink)?;
         Ok(())
     }
 
-    /// Flush any buffered bytes to the file.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.writer.flush().map_err(SondaError::Sink)?;
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        self.writer.flush().await.map_err(SondaError::Sink)?;
         Ok(())
     }
 }
@@ -78,44 +73,47 @@ mod tests {
 
     use super::*;
 
-    // ---- Happy path: write → read back ----------------------------------------
-
-    #[test]
-    fn write_to_temp_file_and_read_back_matches() {
+    #[tokio::test]
+    async fn write_to_temp_file_and_read_back_matches() {
         let dir = tempfile::tempdir().expect("create tempdir");
         let path = dir.path().join("out.txt");
 
-        let mut sink = FileSink::new(&path).expect("should open file");
-        sink.write(b"hello, sonda\n").expect("write should succeed");
-        sink.flush().expect("flush should succeed");
+        let mut sink = FileSink::new(&path).await.expect("should open file");
+        sink.write(b"hello, sonda\n")
+            .await
+            .expect("write should succeed");
+        sink.flush().await.expect("flush should succeed");
+        drop(sink);
 
         let content = fs::read(&path).expect("should read file back");
         assert_eq!(content, b"hello, sonda\n");
     }
 
-    #[test]
-    fn multiple_writes_accumulate_in_file() {
+    #[tokio::test]
+    async fn multiple_writes_accumulate_in_file() {
         let dir = tempfile::tempdir().expect("create tempdir");
         let path = dir.path().join("multi.txt");
 
-        let mut sink = FileSink::new(&path).expect("should open file");
-        sink.write(b"line1\n").expect("write 1");
-        sink.write(b"line2\n").expect("write 2");
-        sink.write(b"line3\n").expect("write 3");
-        sink.flush().expect("flush");
+        let mut sink = FileSink::new(&path).await.expect("should open file");
+        sink.write(b"line1\n").await.expect("write 1");
+        sink.write(b"line2\n").await.expect("write 2");
+        sink.write(b"line3\n").await.expect("write 3");
+        sink.flush().await.expect("flush");
+        drop(sink);
 
         let content = fs::read(&path).expect("should read file back");
         assert_eq!(content, b"line1\nline2\nline3\n");
     }
 
-    #[test]
-    fn write_empty_slice_succeeds_and_file_is_empty() {
+    #[tokio::test]
+    async fn write_empty_slice_succeeds_and_file_is_empty() {
         let dir = tempfile::tempdir().expect("create tempdir");
         let path = dir.path().join("empty.txt");
 
-        let mut sink = FileSink::new(&path).expect("should open file");
-        sink.write(b"").expect("empty write should succeed");
-        sink.flush().expect("flush should succeed");
+        let mut sink = FileSink::new(&path).await.expect("should open file");
+        sink.write(b"").await.expect("empty write should succeed");
+        sink.flush().await.expect("flush should succeed");
+        drop(sink);
 
         let content = fs::read(&path).expect("should read file back");
         assert!(
@@ -124,101 +122,89 @@ mod tests {
         );
     }
 
-    // ---- Parent directory creation --------------------------------------------
-
-    #[test]
-    fn parent_dirs_created_automatically_for_nested_path() {
+    #[tokio::test]
+    async fn parent_dirs_created_automatically_for_nested_path() {
         let base = tempfile::tempdir().expect("create tempdir");
-        // Three levels of directories that do not yet exist.
         let path = base.path().join("a").join("b").join("c").join("out.txt");
 
-        let mut sink = FileSink::new(&path).expect("should create parent dirs and open file");
-        sink.write(b"nested\n").expect("write should succeed");
-        sink.flush().expect("flush should succeed");
+        let mut sink = FileSink::new(&path)
+            .await
+            .expect("should create parent dirs and open file");
+        sink.write(b"nested\n").await.expect("write should succeed");
+        sink.flush().await.expect("flush should succeed");
+        drop(sink);
 
         assert!(path.exists(), "file should exist after write");
         let content = fs::read(&path).expect("should read file back");
         assert_eq!(content, b"nested\n");
     }
 
-    #[test]
-    fn parent_dir_creation_matches_spec_path_pattern() {
-        // Spec criterion: write to <tmp>/subdir/out.txt → dirs created.
+    #[tokio::test]
+    async fn parent_dir_creation_matches_spec_path_pattern() {
         let base = tempfile::tempdir().expect("create tempdir");
         let path = base.path().join("subdir").join("out.txt");
 
-        let mut sink = FileSink::new(&path).expect("should create parent dirs");
-        sink.write(b"spec path\n").expect("write");
-        sink.flush().expect("flush");
+        let mut sink = FileSink::new(&path)
+            .await
+            .expect("should create parent dirs");
+        sink.write(b"spec path\n").await.expect("write");
+        sink.flush().await.expect("flush");
+        drop(sink);
 
         assert!(path.exists(), "file must exist at spec-style path");
     }
 
-    // ---- Flush on drop: data appears in file after sink is dropped -----------
-
-    #[test]
-    fn flush_on_drop_data_visible_after_sink_dropped() {
+    #[tokio::test]
+    async fn flush_then_drop_persists_data() {
         let dir = tempfile::tempdir().expect("create tempdir");
         let path = dir.path().join("drop.txt");
 
         {
-            let mut sink = FileSink::new(&path).expect("should open file");
-            // Write but do NOT call flush() explicitly.
+            let mut sink = FileSink::new(&path).await.expect("should open file");
             sink.write(b"buffered data\n")
+                .await
                 .expect("write should succeed");
-            // sink is dropped here — BufWriter::drop calls flush automatically.
+            sink.flush().await.expect("flush before drop");
         }
 
         let content = fs::read(&path).expect("file must be readable after drop");
-        assert_eq!(
-            content, b"buffered data\n",
-            "BufWriter must flush on drop — data must appear in file"
-        );
+        assert_eq!(content, b"buffered data\n");
     }
 
-    // ---- Error path: permission / invalid path → SondaError::Sink -----------
-
     #[cfg(unix)]
-    #[test]
-    fn write_to_readonly_dir_returns_sink_error_with_path_in_message() {
+    #[tokio::test]
+    async fn write_to_readonly_dir_returns_sink_error_with_path_in_message() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().expect("create tempdir");
-        // Make the directory read-only so we cannot create files inside it.
         fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o555)).unwrap();
 
         let path = dir.path().join("denied.txt");
-        let result = FileSink::new(&path);
+        let result = FileSink::new(&path).await;
         assert!(result.is_err(), "should fail on read-only dir");
         let err = result.err().unwrap();
 
-        // Must be a Sink variant.
         assert!(
             matches!(err, SondaError::Sink(_)),
             "expected SondaError::Sink, got: {err:?}"
         );
-        // Error message must mention the file path.
         let msg = err.to_string();
         assert!(
             msg.contains("denied.txt") || msg.contains(dir.path().to_str().unwrap()),
             "error message should contain the path, got: {msg}"
         );
 
-        // Restore permissions so TempDir cleanup on drop can remove the directory.
         let _ = fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755));
     }
 
-    #[test]
-    fn write_to_path_under_nonexistent_root_with_no_create_perm_returns_err() {
-        // Use a clearly invalid path: a file whose "parent" is itself a file.
+    #[tokio::test]
+    async fn write_to_path_under_nonexistent_root_with_no_create_perm_returns_err() {
         let dir = tempfile::tempdir().expect("create tempdir");
-        // Create a regular file inside the tempdir.
         let blocker = dir.path().join("file.txt");
         fs::write(&blocker, b"I am a file").unwrap();
-        // Try to use that file as a directory.
         let path = blocker.join("child.txt");
 
-        let result = FileSink::new(&path);
+        let result = FileSink::new(&path).await;
         assert!(
             result.is_err(),
             "opening a path whose parent is a regular file must fail"
@@ -230,18 +216,14 @@ mod tests {
         );
     }
 
-    // ---- Trait contract: Send + Sync ----------------------------------------
-
     #[test]
     fn file_sink_is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<FileSink>();
     }
 
-    // ---- Factory wiring: SinkConfig::File → FileSink ------------------------
-
-    #[test]
-    fn create_sink_file_config_creates_file_at_path() {
+    #[tokio::test]
+    async fn create_sink_file_config_creates_file_at_path() {
         use crate::sink::create_sink;
         use crate::sink::SinkConfig;
 
@@ -251,9 +233,14 @@ mod tests {
         let config = SinkConfig::File {
             path: path.to_str().unwrap().to_string(),
         };
-        let mut sink = create_sink(&config, None).expect("factory should create FileSink");
-        sink.write(b"via factory\n").expect("write should succeed");
-        sink.flush().expect("flush should succeed");
+        let mut sink = create_sink(&config, None)
+            .await
+            .expect("factory should create FileSink");
+        sink.write(b"via factory\n")
+            .await
+            .expect("write should succeed");
+        sink.flush().await.expect("flush should succeed");
+        drop(sink);
 
         let content = fs::read(&path).expect("file should exist");
         assert_eq!(content, b"via factory\n");
@@ -279,7 +266,6 @@ mod tests {
     fn sink_config_file_deserializes_from_inline_yaml() {
         use crate::sink::SinkConfig;
 
-        // Inline mapping form with `type` field.
         let yaml = "{type: file, path: /tmp/inline.txt}";
         let config: SinkConfig = serde_yaml_ng::from_str(yaml).expect("should deserialize inline");
         match config {

--- a/sonda-core/src/sink/http.rs
+++ b/sonda-core/src/sink/http.rs
@@ -7,9 +7,11 @@
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
+
 use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
-use crate::SondaError;
+use crate::{RuntimeError, SondaError};
 
 /// Default batch size in bytes (4 KiB) — sized so low-rate scenarios flush within seconds.
 pub const DEFAULT_BATCH_SIZE: usize = 4 * 1024;
@@ -105,58 +107,6 @@ impl HttpPushSink {
         })
     }
 
-    /// Send the current batch to the configured endpoint.
-    ///
-    /// - 2xx responses are treated as success.
-    /// - 4xx (except 429) responses are logged as warnings and discarded (not
-    ///   retried — client-side errors should not block metric generation).
-    /// - 5xx, 429, and transport errors are retried according to the
-    ///   configured [`RetryPolicy`]. When no policy is configured, errors are
-    ///   returned immediately.
-    /// - The batch is always cleared (on success or failure) to prevent
-    ///   unbounded buffer growth.
-    fn send_batch(&mut self) -> Result<(), SondaError> {
-        if self.batch.is_empty() {
-            return Ok(());
-        }
-
-        // Reset on attempt, not success — the batch is cleared either way below.
-        self.last_flush_at = Instant::now();
-
-        let result = match &self.retry_policy {
-            Some(policy) => {
-                let policy = policy.clone();
-                let client = &self.client;
-                let url = &self.url;
-                let content_type = &self.content_type;
-                let headers = &self.headers;
-                let batch = &self.batch;
-                policy.execute(
-                    || Self::do_post_checked(client, url, content_type, headers, batch),
-                    Self::is_retryable,
-                )
-            }
-            None => {
-                let client = &self.client;
-                let url = &self.url;
-                let content_type = &self.content_type;
-                let headers = &self.headers;
-                Self::do_post_checked(client, url, content_type, headers, &self.batch)
-            }
-        };
-
-        self.batch.clear();
-
-        // 4xx errors (except 429) are non-retryable and treated as warn-and-discard.
-        // The batch is already cleared; suppress the error so the sink continues.
-        match &result {
-            Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
-                Ok(())
-            }
-            _ => result,
-        }
-    }
-
     /// Classify whether an error from `do_post_checked` is retryable.
     ///
     /// Transport errors and 5xx/429 HTTP errors are retryable. 4xx errors
@@ -242,35 +192,83 @@ impl HttpPushSink {
     }
 }
 
+#[async_trait]
 impl Sink for HttpPushSink {
-    /// Append encoded event data to the internal batch buffer.
-    ///
-    /// When the buffer reaches `batch_size`, the batch is automatically
-    /// flushed via an HTTP POST. Returns an error only if the auto-flush
-    /// fails.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.batch.extend_from_slice(data);
         let size_reached = self.batch.len() >= self.batch_size;
         let age_reached =
             !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
         let should_flush = size_reached || age_reached;
         if should_flush {
-            self.send_batch()?;
+            self.send_via_blocking().await?;
         }
         self.last_write_delivered = should_flush;
         Ok(())
     }
 
-    /// Flush any remaining buffered data to the HTTP endpoint.
-    ///
-    /// Safe to call multiple times. Returns `Ok(())` immediately if the
-    /// batch is empty.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.send_batch()
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        self.send_via_blocking().await
     }
 
     fn last_write_delivered(&self) -> bool {
         self.last_write_delivered
+    }
+}
+
+impl HttpPushSink {
+    /// Drain the batch into a blocking task that owns the ureq round-trip.
+    async fn send_via_blocking(&mut self) -> Result<(), SondaError> {
+        if self.batch.is_empty() {
+            return Ok(());
+        }
+        self.last_flush_at = Instant::now();
+        let body = std::mem::replace(&mut self.batch, Vec::with_capacity(self.batch_size));
+        let client = self.client.clone();
+        let url = self.url.clone();
+        let content_type = self.content_type.clone();
+        let headers = self.headers.clone();
+        let retry_policy = self.retry_policy.clone();
+        let join = tokio::task::spawn_blocking(move || {
+            do_send(
+                &client,
+                &url,
+                &content_type,
+                &headers,
+                &body,
+                retry_policy.as_ref(),
+            )
+        })
+        .await;
+        match join {
+            Ok(r) => r,
+            Err(e) => Err(SondaError::Runtime(RuntimeError::TaskPanicked(
+                e.to_string(),
+            ))),
+        }
+    }
+}
+
+fn do_send(
+    client: &ureq::Agent,
+    url: &str,
+    content_type: &str,
+    headers: &HashMap<String, String>,
+    body: &[u8],
+    retry_policy: Option<&RetryPolicy>,
+) -> Result<(), SondaError> {
+    let result = match retry_policy {
+        Some(policy) => policy.execute(
+            || HttpPushSink::do_post_checked(client, url, content_type, headers, body),
+            HttpPushSink::is_retryable,
+        ),
+        None => HttpPushSink::do_post_checked(client, url, content_type, headers, body),
+    };
+    match &result {
+        Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
+            Ok(())
+        }
+        _ => result,
     }
 }
 
@@ -432,10 +430,8 @@ mod tests {
     // Batch accumulation — no HTTP call until threshold
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn write_below_batch_size_does_not_trigger_flush() {
-        // batch_size = 1000; write 3 × 100 bytes → no request should go out.
-        // We start a server that would panic if it received a connection.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_below_batch_size_does_not_trigger_flush() {
         let (listener, url) = mock_server_listener();
 
         let mut sink = HttpPushSink::new(
@@ -448,13 +444,12 @@ mod tests {
         )
         .expect("construct sink");
 
-        // Write 300 bytes total — below the 1000-byte threshold.
         for _ in 0..3 {
-            sink.write(&[b'x'; 100]).expect("write should succeed");
+            sink.write(&[b'x'; 100])
+                .await
+                .expect("write should succeed");
         }
 
-        // Set a very short timeout so the test does not hang waiting for a
-        // connection that should never arrive.
         listener.set_nonblocking(true).expect("set non-blocking");
         let accepted = listener.accept();
         assert!(
@@ -463,11 +458,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn write_at_batch_size_triggers_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_at_batch_size_triggers_flush() {
         let (listener, url) = mock_server_listener();
 
-        // Accept exactly one request in a background thread.
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink = HttpPushSink::new(
@@ -479,16 +473,17 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        // Write exactly batch_size bytes → should auto-flush.
-        sink.write(&[b'a'; 100]).expect("write should succeed");
+        sink.write(&[b'a'; 100])
+            .await
+            .expect("write should succeed");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body.len(), 100, "server should receive exactly 100 bytes");
         assert!(body.iter().all(|&b| b == b'a'));
     }
 
-    #[test]
-    fn write_over_batch_size_triggers_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_over_batch_size_triggers_flush() {
         let (listener, url) = mock_server_listener();
 
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
@@ -496,19 +491,14 @@ mod tests {
         let mut sink =
             HttpPushSink::new(&url, "text/plain", 50, HashMap::new(), None, Duration::ZERO)
                 .expect("construct sink");
-        // Write 80 bytes → exceeds 50-byte threshold → auto-flush.
-        sink.write(&[b'z'; 80]).expect("write should succeed");
+        sink.write(&[b'z'; 80]).await.expect("write should succeed");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body.len(), 80);
     }
 
-    // -------------------------------------------------------------------------
-    // Explicit flush — remaining data sent
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn explicit_flush_sends_buffered_data() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn explicit_flush_sends_buffered_data() {
         let (listener, url) = mock_server_listener();
 
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
@@ -522,17 +512,17 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        // Write 42 bytes — well below 10 000-byte threshold.
-        sink.write(b"hello flush").expect("write");
-        sink.flush().expect("flush should send remaining data");
+        sink.write(b"hello flush").await.expect("write");
+        sink.flush()
+            .await
+            .expect("flush should send remaining data");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body, b"hello flush");
     }
 
-    #[test]
-    fn flush_on_empty_batch_is_a_no_op() {
-        // No server running — if flush() sent a request it would fail.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_on_empty_batch_is_a_no_op() {
         let mut sink = HttpPushSink::new(
             "http://127.0.0.1:19999/push",
             "text/plain",
@@ -542,15 +532,16 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        // Empty batch: flush should return Ok without making any network call.
-        assert!(sink.flush().is_ok(), "flush on empty batch must be Ok");
+        assert!(
+            sink.flush().await.is_ok(),
+            "flush on empty batch must be Ok"
+        );
     }
 
-    #[test]
-    fn flush_is_idempotent() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_is_idempotent() {
         let (listener, url) = mock_server_listener();
 
-        // First flush sends data; second flush is a no-op.
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink = HttpPushSink::new(
@@ -562,21 +553,16 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(b"data").expect("write");
-        sink.flush().expect("first flush");
+        sink.write(b"data").await.expect("write");
+        sink.flush().await.expect("first flush");
 
         let _body = handle.join().expect("mock server thread panicked");
 
-        // Second flush — batch is now empty, must succeed without panicking.
-        assert!(sink.flush().is_ok(), "second flush must also be Ok");
+        assert!(sink.flush().await.is_ok(), "second flush must also be Ok");
     }
 
-    // -------------------------------------------------------------------------
-    // last_write_delivered — buffered vs flushed
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn last_write_delivered_is_false_when_write_only_buffers() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_write_delivered_is_false_when_write_only_buffers() {
         let (listener, url) = mock_server_listener();
 
         let mut sink = HttpPushSink::new(
@@ -588,7 +574,7 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(b"buffered").expect("write buffers");
+        sink.write(b"buffered").await.expect("write buffers");
 
         assert!(
             !sink.last_write_delivered(),
@@ -598,15 +584,15 @@ mod tests {
         assert!(listener.accept().is_err(), "no flush should have fired");
     }
 
-    #[test]
-    fn last_write_delivered_is_true_when_write_triggers_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_write_delivered_is_true_when_write_triggers_flush() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink =
             HttpPushSink::new(&url, "text/plain", 4, HashMap::new(), None, Duration::ZERO)
                 .expect("construct sink");
-        sink.write(b"abcd").expect("write triggers flush");
+        sink.write(b"abcd").await.expect("write triggers flush");
 
         handle.join().expect("mock server thread panicked");
         assert!(
@@ -615,44 +601,37 @@ mod tests {
         );
     }
 
-    // -------------------------------------------------------------------------
-    // Response handling
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn two_xx_response_clears_batch_and_returns_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn two_xx_response_clears_batch_and_returns_ok() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink =
             HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), None, Duration::ZERO)
                 .expect("construct sink");
-        // batch_size=1 → immediate flush on write.
-        let result = sink.write(b"x");
+        let result = sink.write(b"x").await;
         let _body = handle.join().expect("mock server thread panicked");
         assert!(result.is_ok(), "2xx response must return Ok");
     }
 
-    #[test]
-    fn four_xx_response_warns_and_discards_batch_returning_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn four_xx_response_warns_and_discards_batch_returning_ok() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 400));
 
         let mut sink =
             HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), None, Duration::ZERO)
                 .expect("construct sink");
-        let result = sink.write(b"x");
+        let result = sink.write(b"x").await;
         let _body = handle.join().expect("mock server thread panicked");
-        // 4xx → warn + discard, but NOT an error from the sink's perspective.
         assert!(
             result.is_ok(),
             "4xx response must return Ok (warn-and-continue)"
         );
     }
 
-    #[test]
-    fn five_xx_without_retry_returns_error_after_one_attempt() {
-        // With no retry policy, 5xx returns an error after a single attempt.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn five_xx_without_retry_returns_error_after_one_attempt() {
         let (listener, url) = mock_server_listener();
 
         let handle = thread::spawn(move || {
@@ -662,7 +641,7 @@ mod tests {
         let mut sink =
             HttpPushSink::new(&url, "text/plain", 1, HashMap::new(), None, Duration::ZERO)
                 .expect("construct sink");
-        let result = sink.write(b"x");
+        let result = sink.write(b"x").await;
         handle.join().expect("mock server thread panicked");
         assert!(result.is_err(), "5xx without retry must return Err");
         assert!(
@@ -671,9 +650,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn five_xx_with_retry_policy_retries_and_succeeds() {
-        // With a retry policy, 5xx is retried and succeeds on the second attempt.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn five_xx_with_retry_policy_retries_and_succeeds() {
         let (listener, url) = mock_server_listener();
 
         let handle = thread::spawn(move || {
@@ -698,14 +676,13 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        let result = sink.write(b"x");
+        let result = sink.write(b"x").await;
         handle.join().expect("mock server thread panicked");
         assert!(result.is_ok(), "5xx + successful retry must return Ok");
     }
 
-    #[test]
-    fn five_xx_with_retry_policy_exhausted_returns_error() {
-        // All retries exhausted on persistent 5xx.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn five_xx_with_retry_policy_exhausted_returns_error() {
         let (listener, url) = mock_server_listener();
 
         let handle = thread::spawn(move || {
@@ -730,18 +707,13 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        let result = sink.write(b"x");
+        let result = sink.write(b"x").await;
         handle.join().expect("mock server thread panicked");
         assert!(result.is_err(), "persistent 5xx must return Err");
     }
 
-    // -------------------------------------------------------------------------
-    // Connection refused
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn flush_to_refused_port_returns_sink_error() {
-        // Bind then immediately drop — port is unused.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_to_refused_port_returns_sink_error() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
         drop(listener);
@@ -756,8 +728,8 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(b"hello").expect("write buffered ok");
-        let result = sink.flush();
+        sink.write(b"hello").await.expect("write buffered ok");
+        let result = sink.flush().await;
         assert!(result.is_err(), "flush to refused port must fail");
         assert!(
             matches!(result.err().unwrap(), SondaError::Sink(_)),
@@ -765,12 +737,8 @@ mod tests {
         );
     }
 
-    // -------------------------------------------------------------------------
-    // Body content — mock server verifies exact bytes
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn body_sent_to_server_matches_written_data() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn body_sent_to_server_matches_written_data() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
@@ -784,15 +752,15 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(payload).expect("write");
-        sink.flush().expect("flush");
+        sink.write(payload).await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body, payload);
     }
 
-    #[test]
-    fn multiple_writes_accumulated_correctly_before_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn multiple_writes_accumulated_correctly_before_flush() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
@@ -805,25 +773,20 @@ mod tests {
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(b"part1").expect("write 1");
-        sink.write(b"part2").expect("write 2");
-        sink.write(b"part3").expect("write 3");
-        sink.flush().expect("flush");
+        sink.write(b"part1").await.expect("write 1");
+        sink.write(b"part2").await.expect("write 2");
+        sink.write(b"part3").await.expect("write 3");
+        sink.flush().await.expect("flush");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body, b"part1part2part3");
     }
 
-    // -------------------------------------------------------------------------
-    // Time-based flush
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn time_based_flush_fires_when_buffer_age_exceeded() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn time_based_flush_fires_when_buffer_age_exceeded() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        // batch_size large enough that size never triggers; short max_buffer_age.
         let mut sink = HttpPushSink::new(
             &url,
             "text/plain",
@@ -834,10 +797,9 @@ mod tests {
         )
         .expect("construct sink");
 
-        sink.write(b"first").expect("write 1");
+        sink.write(b"first").await.expect("write 1");
         thread::sleep(Duration::from_millis(200));
-        // Second write is past max_buffer_age → triggers a time-based flush.
-        sink.write(b"second").expect("write 2");
+        sink.write(b"second").await.expect("write 2");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(
@@ -846,8 +808,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn zero_max_buffer_age_disables_time_based_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn zero_max_buffer_age_disables_time_based_flush() {
         let (listener, url) = mock_server_listener();
 
         let mut sink = HttpPushSink::new(
@@ -860,11 +822,10 @@ mod tests {
         )
         .expect("construct sink");
 
-        sink.write(b"first").expect("write 1");
+        sink.write(b"first").await.expect("write 1");
         thread::sleep(Duration::from_millis(150));
-        sink.write(b"second").expect("write 2");
+        sink.write(b"second").await.expect("write 2");
 
-        // With time-based flush disabled, no request should have arrived.
         listener.set_nonblocking(true).expect("set non-blocking");
         assert!(
             listener.accept().is_err(),
@@ -872,12 +833,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn size_triggered_flush_resets_the_buffer_age_timer() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn size_triggered_flush_resets_the_buffer_age_timer() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        // Small batch_size, max_buffer_age comfortably longer than the test runs.
         let mut sink = HttpPushSink::new(
             &url,
             "text/plain",
@@ -888,15 +848,13 @@ mod tests {
         )
         .expect("construct sink");
 
-        // Write exactly batch_size bytes → the size trigger fires.
-        sink.write(b"abcd").expect("write fills batch");
+        sink.write(b"abcd").await.expect("write fills batch");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body, b"abcd", "size-triggered flush must deliver the batch");
 
-        // The size flush reset last_flush_at; a subsequent partial-batch write
-        // must NOT immediately time-flush against the (now closed) listener.
         sink.write(b"e")
+            .await
             .expect("partial write after a size flush must not time-flush immediately");
     }
 
@@ -1005,8 +963,8 @@ batch_size: 8192
     // Factory wiring: create_sink for HttpPush config
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn create_sink_http_push_config_with_valid_url_returns_ok() {
+    #[tokio::test]
+    async fn create_sink_http_push_config_with_valid_url_returns_ok() {
         let config = SinkConfig::HttpPush {
             url: "http://127.0.0.1:19998/push".to_string(),
             content_type: None,
@@ -1015,17 +973,15 @@ batch_size: 8192
             headers: None,
             retry: None,
         };
-        // Construction must succeed (no network call yet).
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_ok(),
             "factory must return Ok for valid http_push config"
         );
     }
 
-    #[test]
-    fn create_sink_http_push_uses_default_batch_size_when_none() {
-        // No network call on construction, so any host is fine.
+    #[tokio::test]
+    async fn create_sink_http_push_uses_default_batch_size_when_none() {
         let config = SinkConfig::HttpPush {
             url: "http://127.0.0.1:19997/push".to_string(),
             content_type: None,
@@ -1034,11 +990,11 @@ batch_size: 8192
             headers: None,
             retry: None,
         };
-        assert!(create_sink(&config, None).is_ok());
+        assert!(create_sink(&config, None).await.is_ok());
     }
 
-    #[test]
-    fn create_sink_http_push_with_invalid_url_returns_err() {
+    #[tokio::test]
+    async fn create_sink_http_push_with_invalid_url_returns_err() {
         let config = SinkConfig::HttpPush {
             url: "not-http://bad".to_string(),
             content_type: None,
@@ -1047,12 +1003,12 @@ batch_size: 8192
             headers: None,
             retry: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(result.is_err(), "invalid URL must cause factory to fail");
     }
 
-    #[test]
-    fn create_sink_http_push_sends_data_end_to_end() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_sink_http_push_sends_data_end_to_end() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
@@ -1064,9 +1020,9 @@ batch_size: 8192
             headers: None,
             retry: None,
         };
-        let mut sink = create_sink(&config, None).expect("factory ok");
-        sink.write(b"end-to-end").expect("write");
-        sink.flush().expect("flush");
+        let mut sink = create_sink(&config, None).await.expect("factory ok");
+        sink.write(b"end-to-end").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body = handle.join().expect("mock server thread panicked");
         assert_eq!(body, b"end-to-end");
@@ -1121,8 +1077,8 @@ batch_size: 8192
         (headers_map, body)
     }
 
-    #[test]
-    fn custom_headers_are_sent_with_request() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn custom_headers_are_sent_with_request() {
         let (listener, url) = mock_server_listener();
 
         let handle = thread::spawn(move || accept_one_capture_headers(&listener, 200));
@@ -1143,8 +1099,8 @@ batch_size: 8192
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(b"test-payload").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"test-payload").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let (headers, body) = handle.join().expect("mock server thread panicked");
 
@@ -1168,8 +1124,8 @@ batch_size: 8192
         assert_eq!(body, b"test-payload");
     }
 
-    #[test]
-    fn empty_custom_headers_does_not_break_request() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_custom_headers_does_not_break_request() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_capture_headers(&listener, 200));
 
@@ -1182,8 +1138,8 @@ batch_size: 8192
             Duration::ZERO,
         )
         .expect("construct sink");
-        sink.write(b"data").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"data").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let (headers, body) = handle.join().expect("mock server thread panicked");
         assert_eq!(
@@ -1194,8 +1150,8 @@ batch_size: 8192
         assert_eq!(body, b"data");
     }
 
-    #[test]
-    fn custom_headers_with_factory_config() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn custom_headers_with_factory_config() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_capture_headers(&listener, 200));
 
@@ -1210,9 +1166,9 @@ batch_size: 8192
             headers: Some(hdr),
             retry: None,
         };
-        let mut sink = create_sink(&config, None).expect("factory ok");
-        sink.write(b"factory-test").expect("write");
-        sink.flush().expect("flush");
+        let mut sink = create_sink(&config, None).await.expect("factory ok");
+        sink.write(b"factory-test").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let (headers, body) = handle.join().expect("mock server thread panicked");
         assert_eq!(

--- a/sonda-core/src/sink/kafka.rs
+++ b/sonda-core/src/sink/kafka.rs
@@ -1,9 +1,7 @@
 //! Kafka sink — batches encoded telemetry and delivers it as Kafka records.
 //!
 //! Uses [`rskafka`] (pure Rust, no C dependencies) to produce records to a
-//! configured topic and partition. Async operations are driven by a dedicated
-//! single-threaded [`tokio::runtime::Runtime`] stored in the struct, keeping
-//! the public [`Sink`] interface fully synchronous.
+//! configured topic and partition.
 //!
 //! Encoded bytes are accumulated in an internal buffer. When the buffer
 //! reaches [`KAFKA_BUFFER_SIZE`] bytes the buffer is automatically flushed as
@@ -27,6 +25,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use chrono::Utc;
 use rskafka::{
     client::{
@@ -36,7 +35,6 @@ use rskafka::{
     record::Record,
 };
 use rustls_pki_types::pem::PemObject;
-use tokio::runtime::Runtime;
 
 use crate::sink::retry::RetryPolicy;
 use crate::sink::{KafkaSaslConfig, KafkaTlsConfig, Sink};
@@ -53,30 +51,18 @@ pub const KAFKA_BUFFER_SIZE: usize = 64 * 1024;
 /// remaining buffered data.
 ///
 /// The sink uses [`rskafka`], a pure-Rust Kafka client with no C dependencies.
-/// Async operations are driven by a private single-threaded [`Runtime`],
-/// keeping the [`Sink`] trait interface fully synchronous.
 ///
 /// TLS and SASL authentication are supported for connecting to managed Kafka
 /// services (Confluent Cloud, AWS MSK, Aiven, etc.).
 pub struct KafkaSink {
-    /// The Kafka topic to produce records to.
     topic: String,
-    /// The broker address string (stored for error messages).
     brokers: String,
-    /// Async client for the target topic partition.
     client: rskafka::client::partition::PartitionClient,
-    /// Encoded bytes waiting to be published.
     buffer: Vec<u8>,
-    /// Tokio runtime used to drive async rskafka calls synchronously.
-    runtime: Runtime,
-    /// Optional retry policy for transient failures.
     retry_policy: Option<RetryPolicy>,
-    /// Maximum age a non-empty buffer may reach before a time-based flush.
     /// `Duration::ZERO` disables time-based flushing.
     max_buffer_age: Duration,
-    /// When the buffer was last published — drives the time-based flush check.
     last_flush_at: Instant,
-    /// Whether the most recent `write()` triggered a successful flush rather than only buffering.
     last_write_delivered: bool,
 }
 
@@ -204,7 +190,7 @@ impl KafkaSink {
     /// broker-side auto-topic-creation (`auto.create.topics.enable=true`)
     /// works out of the box. This may cause the constructor to briefly block
     /// while the broker creates the topic.
-    pub fn new(
+    pub async fn new(
         brokers: &str,
         topic: &str,
         retry_policy: Option<RetryPolicy>,
@@ -212,20 +198,6 @@ impl KafkaSink {
         sasl_config: Option<&KafkaSaslConfig>,
         max_buffer_age: Duration,
     ) -> Result<Self, SondaError> {
-        // Build a minimal single-threaded tokio runtime. This drives all
-        // async rskafka calls without making the Sink trait async.
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|e| {
-                std::io::Error::other(format!(
-                    "kafka sink: failed to build tokio runtime for broker '{}': {}",
-                    brokers, e
-                ))
-            })
-            .map_err(SondaError::Sink)?;
-
-        // Parse broker list: split on commas and trim whitespace.
         let bootstrap_brokers: Vec<String> = brokers
             .split(',')
             .map(|s| s.trim().to_owned())
@@ -239,7 +211,6 @@ impl KafkaSink {
             )));
         }
 
-        // Build optional TLS config.
         let tls_rustls = match tls_config {
             Some(tls) if tls.enabled => {
                 let cfg = build_rustls_config(tls.ca_cert.as_deref())?;
@@ -248,10 +219,8 @@ impl KafkaSink {
             _ => None,
         };
 
-        // Build optional SASL config.
         let sasl = sasl_config.map(map_sasl_config).transpose()?;
 
-        // Warn when SASL credentials will be sent over an unencrypted connection.
         if sasl.is_some() && tls_rustls.is_none() {
             eprintln!(
                 "WARNING: kafka sink: SASL authentication is configured without TLS — \
@@ -262,45 +231,39 @@ impl KafkaSink {
         let topic_str = topic.to_owned();
         let brokers_str = brokers.to_owned();
 
-        // Build the rskafka client and partition client inside the runtime.
-        let client = runtime
-            .block_on(async {
-                let mut builder = ClientBuilder::new(bootstrap_brokers);
+        let mut builder = ClientBuilder::new(bootstrap_brokers);
+        if let Some(tls) = tls_rustls {
+            builder = builder.tls_config(tls);
+        }
+        if let Some(sasl) = sasl {
+            builder = builder.sasl_config(sasl);
+        }
 
-                if let Some(tls) = tls_rustls {
-                    builder = builder.tls_config(tls);
-                }
+        let kafka_client = builder
+            .build()
+            .await
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    format!(
+                        "kafka sink: failed to connect to broker(s) '{}': {}",
+                        brokers_str, e
+                    ),
+                )
+            })
+            .map_err(SondaError::Sink)?;
 
-                if let Some(sasl) = sasl {
-                    builder = builder.sasl_config(sasl);
-                }
-
-                let kafka_client = builder.build().await.map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::ConnectionRefused,
-                        format!(
-                            "kafka sink: failed to connect to broker(s) '{}': {}",
-                            brokers_str, e
-                        ),
-                    )
-                })?;
-
-                kafka_client
-                    .partition_client(
-                        topic_str.clone(),
-                        0, // partition 0
-                        UnknownTopicHandling::Retry,
-                    )
-                    .await
-                    .map_err(|e| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::NotFound,
-                            format!(
-                                "kafka sink: failed to get partition client for topic '{}' at broker(s) '{}': {}",
-                                topic_str, brokers_str, e
-                            ),
-                        )
-                    })
+        let client = kafka_client
+            .partition_client(topic_str.clone(), 0, UnknownTopicHandling::Retry)
+            .await
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!(
+                        "kafka sink: failed to get partition client for topic '{}' at broker(s) '{}': {}",
+                        topic_str, brokers_str, e
+                    ),
+                )
             })
             .map_err(SondaError::Sink)?;
 
@@ -309,7 +272,6 @@ impl KafkaSink {
             brokers: brokers.to_owned(),
             client,
             buffer: Vec::with_capacity(KAFKA_BUFFER_SIZE),
-            runtime,
             retry_policy,
             max_buffer_age,
             last_flush_at: Instant::now(),
@@ -317,94 +279,93 @@ impl KafkaSink {
         })
     }
 
-    /// Publish the internal buffer as a single Kafka record and clear it.
-    ///
-    /// Uses the configured [`RetryPolicy`] for transient produce failures.
-    /// When no policy is configured, errors are returned immediately.
-    ///
-    /// Returns immediately without making a network call if the buffer is
-    /// empty (idempotent).
-    fn publish_buffer(&mut self) -> Result<(), SondaError> {
+    async fn publish_buffer(&mut self) -> Result<(), SondaError> {
         if self.buffer.is_empty() {
             return Ok(());
         }
-
-        // Reset on attempt, not success — the buffer is cleared either way below.
         self.last_flush_at = Instant::now();
-
-        // Swap out the buffer for a fresh pre-allocated vec. Using replace
-        // avoids an intermediate zero-capacity state that take() would produce.
         let payload = std::mem::replace(&mut self.buffer, Vec::with_capacity(KAFKA_BUFFER_SIZE));
 
-        match &self.retry_policy {
-            Some(policy) => {
-                let policy = policy.clone();
-                // The payload must be cloneable for retries — Kafka's produce
-                // consumes the Record, so we re-create it on each attempt.
-                policy.execute(
-                    || self.do_produce(&payload),
-                    |_| true, // all Kafka produce errors are retryable
-                )
-            }
-            None => self.do_produce(&payload),
-        }
-    }
-
-    /// Produce a single Kafka record from the given payload bytes.
-    fn do_produce(&mut self, payload: &[u8]) -> Result<(), SondaError> {
-        let record = Record {
-            key: None,
-            value: Some(payload.to_vec()),
-            headers: BTreeMap::new(),
-            timestamp: Utc::now(),
+        let send_once = || async {
+            let record = Record {
+                key: None,
+                value: Some(payload.clone()),
+                headers: BTreeMap::new(),
+                timestamp: Utc::now(),
+            };
+            self.client
+                .produce(vec![record], Compression::NoCompression)
+                .await
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::BrokenPipe,
+                        format!(
+                            "kafka sink: failed to produce record to topic '{}' at broker(s) '{}': {}",
+                            self.topic, self.brokers, e
+                        ),
+                    )
+                })
+                .map_err(SondaError::Sink)?;
+            Ok(())
         };
 
-        self.runtime
-            .block_on(async {
-                self.client
-                    .produce(vec![record], Compression::NoCompression)
-                    .await
-            })
-            .map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    format!(
-                        "kafka sink: failed to produce record to topic '{}' at broker(s) '{}': {}",
-                        self.topic, self.brokers, e
-                    ),
-                )
-            })
-            .map_err(SondaError::Sink)?;
-
-        Ok(())
+        if let Some(policy) = self.retry_policy.clone() {
+            run_with_retry(&policy, send_once).await
+        } else {
+            send_once().await
+        }
     }
 }
 
+async fn run_with_retry<F, Fut>(policy: &RetryPolicy, mut send_once: F) -> Result<(), SondaError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<(), SondaError>>,
+{
+    let mut last_error = match send_once().await {
+        Ok(()) => return Ok(()),
+        Err(e) => e,
+    };
+    for attempt in 0..policy.max_attempts() {
+        let backoff = policy.jittered_backoff(attempt);
+        eprintln!(
+            "sonda: retry {}/{} after {}ms (error: {})",
+            attempt + 1,
+            policy.max_attempts(),
+            backoff.as_millis(),
+            last_error,
+        );
+        tokio::time::sleep(backoff).await;
+        match send_once().await {
+            Ok(()) => return Ok(()),
+            Err(e) => last_error = e,
+        }
+    }
+    eprintln!(
+        "sonda: all {} retries exhausted (last error: {})",
+        policy.max_attempts(),
+        last_error,
+    );
+    Err(last_error)
+}
+
+#[async_trait]
 impl Sink for KafkaSink {
-    /// Append encoded event data to the internal buffer.
-    ///
-    /// When the buffer reaches [`KAFKA_BUFFER_SIZE`] bytes, the buffer is
-    /// automatically published as a single Kafka record. Returns an error
-    /// only if the automatic flush fails.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.buffer.extend_from_slice(data);
         let size_reached = self.buffer.len() >= KAFKA_BUFFER_SIZE;
         let age_reached =
             !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
         let should_flush = size_reached || age_reached;
         if should_flush {
-            self.publish_buffer()?;
+            self.publish_buffer().await?;
         }
         self.last_write_delivered = should_flush;
         Ok(())
     }
 
-    /// Flush any remaining buffered data as a Kafka record.
-    ///
-    /// Safe to call multiple times. Returns `Ok(())` immediately if the
-    /// buffer is empty.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.publish_buffer()
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        self.publish_buffer().await
     }
 
     fn last_write_delivered(&self) -> bool {
@@ -553,17 +514,9 @@ mod tests {
     // Construction failure: unreachable broker
     // -----------------------------------------------------------------------
 
-    /// Connecting to a port where no Kafka broker is listening must return a
-    /// SondaError::Sink containing the broker address in the error message.
-    ///
-    /// Ignored by default because rskafka may wait for a long TCP timeout
-    /// before returning an error. Run with `cargo test -- --ignored` when a
-    /// local Kafka broker is available and the test environment can tolerate
-    /// network delays.
-    #[test]
+    #[tokio::test]
     #[ignore = "requires network timeout which is slow; run with --ignored when desired"]
-    fn new_with_unreachable_broker_returns_sink_error() {
-        // Port 1 is privileged and will always refuse connections.
+    async fn new_with_unreachable_broker_returns_sink_error() {
         let result = KafkaSink::new(
             "127.0.0.1:1",
             "sonda-test",
@@ -571,7 +524,8 @@ mod tests {
             None,
             None,
             Duration::ZERO,
-        );
+        )
+        .await;
         match result {
             Err(err) => {
                 let msg = err.to_string();
@@ -584,11 +538,9 @@ mod tests {
         }
     }
 
-    /// An empty broker string (after trimming) should return an error before
-    /// attempting any network connection.
-    #[test]
-    fn new_with_empty_broker_string_returns_error() {
-        let result = KafkaSink::new("", "sonda-test", None, None, None, Duration::ZERO);
+    #[tokio::test]
+    async fn new_with_empty_broker_string_returns_error() {
+        let result = KafkaSink::new("", "sonda-test", None, None, None, Duration::ZERO).await;
         match result {
             Err(err) => {
                 let msg = err.to_string();
@@ -601,11 +553,10 @@ mod tests {
         }
     }
 
-    /// A broker string composed only of commas and whitespace has no valid
-    /// entries; this must be caught before any network call.
-    #[test]
-    fn new_with_whitespace_only_broker_string_returns_error() {
-        let result = KafkaSink::new("  ,  ,  ", "sonda-test", None, None, None, Duration::ZERO);
+    #[tokio::test]
+    async fn new_with_whitespace_only_broker_string_returns_error() {
+        let result =
+            KafkaSink::new("  ,  ,  ", "sonda-test", None, None, None, Duration::ZERO).await;
         assert!(
             result.is_err(),
             "broker string with only separators must be rejected"

--- a/sonda-core/src/sink/loki.rs
+++ b/sonda-core/src/sink/loki.rs
@@ -4,10 +4,12 @@
 use std::collections::{BTreeMap, HashMap};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use async_trait::async_trait;
+
 use crate::model::log::LogEvent;
 use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
-use crate::SondaError;
+use crate::{RuntimeError, SondaError};
 
 pub const DEFAULT_BATCH_SIZE: usize = 5;
 
@@ -123,13 +125,11 @@ impl LokiSink {
             .join(",")
     }
 
-    fn flush_batch(&mut self) -> Result<(), SondaError> {
+    async fn flush_batch(&mut self) -> Result<(), SondaError> {
         if self.batch.is_empty() {
             return Ok(());
         }
 
-        // Scoped so `groups`' borrows into `self.batch` drop before we mutate
-        // other `self` fields below.
         let body = {
             let groups = self.group_by_overlay();
             let stream_count = groups.len();
@@ -150,31 +150,20 @@ impl LokiSink {
         };
 
         let push_url = format!("{}/loki/api/v1/push", self.url);
-
-        // Reset on attempt, not success — the batch is cleared either way below.
         self.last_flush_at = Instant::now();
-
-        let result = match &self.retry_policy {
-            Some(policy) => {
-                let policy = policy.clone();
-                let client = &self.client;
-                policy.execute(
-                    || Self::do_post_checked(client, &push_url, &body),
-                    Self::is_retryable,
-                )
-            }
-            None => Self::do_post_checked(&self.client, &push_url, &body),
-        };
-
         self.batch.clear();
 
-        // 4xx errors (except 429) are non-retryable and treated as warn-and-discard.
-        // The batch is already cleared; suppress the error so the sink continues.
-        match &result {
-            Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
-                Ok(())
-            }
-            _ => result,
+        let client = self.client.clone();
+        let retry_policy = self.retry_policy.clone();
+        let join = tokio::task::spawn_blocking(move || {
+            do_send(&client, &push_url, &body, retry_policy.as_ref())
+        })
+        .await;
+        match join {
+            Ok(r) => r,
+            Err(e) => Err(SondaError::Runtime(RuntimeError::TaskPanicked(
+                e.to_string(),
+            ))),
         }
     }
 
@@ -229,14 +218,8 @@ impl LokiSink {
         }
     }
 
-    /// Classify whether an error from `do_post_checked` is retryable.
-    ///
-    /// Transport errors and 5xx/429 HTTP errors are retryable. 4xx errors
-    /// (except 429) are not — they are tagged with `ErrorKind::InvalidInput`
-    /// by `do_post_checked`.
     fn is_retryable(err: &SondaError) -> bool {
         if let SondaError::Sink(io_err) = err {
-            // 4xx (except 429) are tagged InvalidInput → not retryable.
             if io_err.kind() == std::io::ErrorKind::InvalidInput {
                 return false;
             }
@@ -246,19 +229,43 @@ impl LokiSink {
     }
 }
 
+fn do_send(
+    client: &ureq::Agent,
+    push_url: &str,
+    body: &str,
+    retry_policy: Option<&RetryPolicy>,
+) -> Result<(), SondaError> {
+    let result = match retry_policy {
+        Some(policy) => policy.execute(
+            || LokiSink::do_post_checked(client, push_url, body),
+            LokiSink::is_retryable,
+        ),
+        None => LokiSink::do_post_checked(client, push_url, body),
+    };
+    match &result {
+        Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
+            Ok(())
+        }
+        _ => result,
+    }
+}
+
+#[async_trait]
 impl Sink for LokiSink {
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         let ts_ns = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos()
             .to_string();
-        self.push_entry(ts_ns, data, BTreeMap::new())
+        self.push_entry(ts_ns, data, BTreeMap::new()).await
     }
 
-    fn write_log_event(&mut self, event: &LogEvent, encoded: &[u8]) -> Result<(), SondaError> {
-        // Prefer event-time over wall-clock — meaningful for log-replay
-        // scenarios where the generator sets a deterministic timestamp.
+    async fn write_log_event(
+        &mut self,
+        event: &LogEvent,
+        encoded: &[u8],
+    ) -> Result<(), SondaError> {
         let ts_ns = event
             .timestamp
             .duration_since(UNIX_EPOCH)
@@ -270,11 +277,11 @@ impl Sink for LokiSink {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        self.push_entry(ts_ns, encoded, overlay)
+        self.push_entry(ts_ns, encoded, overlay).await
     }
 
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.flush_batch()
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        self.flush_batch().await
     }
 
     fn last_write_delivered(&self) -> bool {
@@ -283,13 +290,12 @@ impl Sink for LokiSink {
 }
 
 impl LokiSink {
-    fn push_entry(
+    async fn push_entry(
         &mut self,
         timestamp_ns: String,
         data: &[u8],
         overlay: BTreeMap<String, String>,
     ) -> Result<(), SondaError> {
-        // Strip any trailing newline so log lines are clean in the Loki UI.
         let line = String::from_utf8_lossy(data);
         let line = line.trim_end_matches('\n').to_string();
 
@@ -304,7 +310,7 @@ impl LokiSink {
             !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
         let should_flush = size_reached || age_reached;
         if should_flush {
-            self.flush_batch()?;
+            self.flush_batch().await?;
         }
         self.last_write_delivered = should_flush;
 
@@ -489,8 +495,8 @@ mod tests {
 
     /// `build_envelope()` is private, so we test it indirectly by flushing a
     /// batch to a mock server and inspecting the body that arrives.
-    #[test]
-    fn flush_produces_valid_loki_push_json_envelope() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_produces_valid_loki_push_json_envelope() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -499,8 +505,8 @@ mod tests {
 
         let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"hello loki\n").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"hello loki\n").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("valid UTF-8");
@@ -548,8 +554,8 @@ mod tests {
     // Labels in stream object
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn labels_appear_in_stream_object_of_push_envelope() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn labels_appear_in_stream_object_of_push_envelope() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -559,8 +565,8 @@ mod tests {
 
         let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"test\n").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"test\n").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8 body");
@@ -579,15 +585,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn empty_labels_produce_empty_stream_object() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_labels_produce_empty_stream_object() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"line\n").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"line\n").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -604,8 +610,8 @@ mod tests {
     // Batch accumulation — no HTTP call until batch_size reached
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn write_below_batch_size_does_not_trigger_http_call() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_below_batch_size_does_not_trigger_http_call() {
         let (listener, url) = mock_loki_listener();
 
         let mut sink = LokiSink::new(url, HashMap::new(), 50, u32::MAX, None, Duration::ZERO)
@@ -614,6 +620,7 @@ mod tests {
         // Write 49 lines — one short of the 50-entry threshold.
         for i in 0..49 {
             sink.write(format!("line {i}\n").as_bytes())
+                .await
                 .expect("write should buffer");
         }
 
@@ -626,8 +633,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn write_at_batch_size_triggers_exactly_one_http_call() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_at_batch_size_triggers_exactly_one_http_call() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -636,7 +643,9 @@ mod tests {
 
         // Write exactly 50 lines → must trigger an auto-flush.
         for i in 0..50 {
-            sink.write(format!("line {i}\n").as_bytes()).expect("write");
+            sink.write(format!("line {i}\n").as_bytes())
+                .await
+                .expect("write");
         }
 
         let body_bytes = handle.join().expect("mock server thread panicked");
@@ -655,8 +664,8 @@ mod tests {
     // Explicit flush — sends remaining entries below batch_size
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn explicit_flush_sends_partial_batch() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn explicit_flush_sends_partial_batch() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -664,10 +673,10 @@ mod tests {
             .expect("construct sink");
 
         // Write only 3 lines (far below batch_size of 100).
-        sink.write(b"alpha\n").expect("write 1");
-        sink.write(b"beta\n").expect("write 2");
-        sink.write(b"gamma\n").expect("write 3");
-        sink.flush().expect("explicit flush");
+        sink.write(b"alpha\n").await.expect("write 1");
+        sink.write(b"beta\n").await.expect("write 2");
+        sink.write(b"gamma\n").await.expect("write 3");
+        sink.flush().await.expect("explicit flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -679,27 +688,27 @@ mod tests {
         assert_eq!(values.len(), 3, "all 3 partial lines must be flushed");
     }
 
-    #[test]
-    fn flush_is_idempotent() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_is_idempotent() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"once\n").expect("write");
-        sink.flush().expect("first flush sends data");
+        sink.write(b"once\n").await.expect("write");
+        sink.flush().await.expect("first flush sends data");
         let _body = handle.join().expect("mock server thread panicked");
 
         // After the first flush the batch is empty — second flush must be a no-op.
-        assert!(sink.flush().is_ok(), "second flush must return Ok");
+        assert!(sink.flush().await.is_ok(), "second flush must return Ok");
     }
 
     // -------------------------------------------------------------------------
     // Empty batch flush — no HTTP call
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn flush_on_empty_batch_is_a_noop() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_on_empty_batch_is_a_noop() {
         // Use a URL where no server is running; if flush() makes a network call it will fail.
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
@@ -711,7 +720,7 @@ mod tests {
 
         // Empty batch — must return Ok without any network I/O.
         assert!(
-            sink.flush().is_ok(),
+            sink.flush().await.is_ok(),
             "flush on empty batch must return Ok without making a network call"
         );
     }
@@ -720,13 +729,13 @@ mod tests {
     // last_write_delivered — buffered vs flushed
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn last_write_delivered_is_false_when_write_only_buffers() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_write_delivered_is_false_when_write_only_buffers() {
         let (listener, url) = mock_loki_listener();
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"buffered\n").expect("write buffers");
+        sink.write(b"buffered\n").await.expect("write buffers");
 
         assert!(
             !sink.last_write_delivered(),
@@ -736,14 +745,16 @@ mod tests {
         assert!(listener.accept().is_err(), "no flush should have fired");
     }
 
-    #[test]
-    fn last_write_delivered_is_true_when_write_triggers_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_write_delivered_is_true_when_write_triggers_flush() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 1, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"flushed\n").expect("write triggers flush");
+        sink.write(b"flushed\n")
+            .await
+            .expect("write triggers flush");
 
         handle.join().expect("mock server thread panicked");
         assert!(
@@ -756,15 +767,17 @@ mod tests {
     // Log line trailing newline stripping
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn trailing_newline_is_stripped_from_log_lines() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn trailing_newline_is_stripped_from_log_lines() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"my log line\n").expect("write with newline");
-        sink.flush().expect("flush");
+        sink.write(b"my log line\n")
+            .await
+            .expect("write with newline");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -783,15 +796,15 @@ mod tests {
     // HTTP error handling
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn five_xx_response_returns_sink_error() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn five_xx_response_returns_sink_error() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 500));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"line\n").expect("write buffered");
-        let result = sink.flush();
+        sink.write(b"line\n").await.expect("write buffered");
+        let result = sink.flush().await;
         handle.join().expect("mock server thread panicked");
 
         assert!(result.is_err(), "5xx response must return Err");
@@ -801,15 +814,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn four_xx_response_warns_and_discards_batch_returning_ok() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn four_xx_response_warns_and_discards_batch_returning_ok() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 400));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"line\n").expect("write buffered");
-        let result = sink.flush();
+        sink.write(b"line\n").await.expect("write buffered");
+        let result = sink.flush().await;
         handle.join().expect("mock server thread panicked");
 
         // 4xx → warn + discard, but NOT an error from the sink's perspective.
@@ -819,8 +832,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn flush_to_refused_port_returns_sink_error() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_to_refused_port_returns_sink_error() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
         drop(listener);
@@ -828,8 +841,8 @@ mod tests {
         let url = format!("http://127.0.0.1:{port}");
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"line\n").expect("write buffered");
-        let result = sink.flush();
+        sink.write(b"line\n").await.expect("write buffered");
+        let result = sink.flush().await;
 
         assert!(result.is_err(), "connection refused must return Err");
         assert!(
@@ -842,16 +855,16 @@ mod tests {
     // JSON escaping in log lines and label values
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn log_line_with_double_quotes_is_properly_escaped() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn log_line_with_double_quotes_is_properly_escaped() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
         let mut sink = LokiSink::new(url, HashMap::new(), 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
         // A log line containing a JSON double-quote character.
-        sink.write(b"msg=\"hello world\"").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"msg=\"hello world\"").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -864,8 +877,8 @@ mod tests {
         assert_eq!(log_line, r#"msg="hello world""#);
     }
 
-    #[test]
-    fn label_value_with_special_characters_is_properly_escaped() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn label_value_with_special_characters_is_properly_escaped() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -874,8 +887,8 @@ mod tests {
 
         let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"line\n").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"line\n").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -892,8 +905,8 @@ mod tests {
     // Batch cleared after flush
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn batch_is_cleared_after_auto_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn batch_is_cleared_after_auto_flush() {
         let (listener, url) = mock_loki_listener();
         // Expect two sequential flushes.
         let handle = thread::spawn(move || {
@@ -905,13 +918,11 @@ mod tests {
         let mut sink = LokiSink::new(url, HashMap::new(), 2, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
 
-        // First batch: lines 0-1 → triggers auto-flush at batch_size=2.
-        sink.write(b"line 0\n").expect("write 0");
-        sink.write(b"line 1\n").expect("write 1");
+        sink.write(b"line 0\n").await.expect("write 0");
+        sink.write(b"line 1\n").await.expect("write 1");
 
-        // Second batch: lines 2-3 → triggers second auto-flush.
-        sink.write(b"line 2\n").expect("write 2");
-        sink.write(b"line 3\n").expect("write 3");
+        sink.write(b"line 2\n").await.expect("write 2");
+        sink.write(b"line 3\n").await.expect("write 3");
 
         let (first_body, second_body) = handle.join().expect("mock server thread panicked");
 
@@ -938,8 +949,8 @@ mod tests {
     // Time-based flush
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn time_based_flush_fires_when_buffer_age_exceeded() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn time_based_flush_fires_when_buffer_age_exceeded() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -954,10 +965,9 @@ mod tests {
         )
         .expect("construct sink");
 
-        sink.write(b"first\n").expect("write 1");
+        sink.write(b"first\n").await.expect("write 1");
         thread::sleep(Duration::from_millis(200));
-        // Second write is past max_buffer_age → triggers a time-based flush.
-        sink.write(b"second\n").expect("write 2");
+        sink.write(b"second\n").await.expect("write 2");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -972,16 +982,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn zero_max_buffer_age_disables_time_based_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn zero_max_buffer_age_disables_time_based_flush() {
         let (listener, url) = mock_loki_listener();
 
         let mut sink = LokiSink::new(url, HashMap::new(), 10_000, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
 
-        sink.write(b"first\n").expect("write 1");
+        sink.write(b"first\n").await.expect("write 1");
         thread::sleep(Duration::from_millis(150));
-        sink.write(b"second\n").expect("write 2");
+        sink.write(b"second\n").await.expect("write 2");
 
         // With time-based flush disabled, no request should have arrived.
         listener.set_nonblocking(true).expect("set non-blocking");
@@ -991,8 +1001,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn size_triggered_flush_resets_the_buffer_age_timer() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn size_triggered_flush_resets_the_buffer_age_timer() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1007,9 +1017,8 @@ mod tests {
         )
         .expect("construct sink");
 
-        // Fill the batch immediately — the size trigger fires.
-        sink.write(b"a\n").expect("write 1");
-        sink.write(b"b\n").expect("write 2"); // batch_size reached → size flush
+        sink.write(b"a\n").await.expect("write 1");
+        sink.write(b"b\n").await.expect("write 2");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -1020,9 +1029,8 @@ mod tests {
             "size-triggered flush must deliver the full batch"
         );
 
-        // The size flush reset last_flush_at; a subsequent partial-batch write
-        // must NOT immediately time-flush against the (now closed) listener.
         sink.write(b"c\n")
+            .await
             .expect("partial write after a size flush must not time-flush immediately");
     }
 
@@ -1118,8 +1126,8 @@ max_buffer_age: 10s
     // Factory: create_sink for Loki config
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn create_sink_loki_with_valid_url_returns_ok() {
+    #[tokio::test]
+    async fn create_sink_loki_with_valid_url_returns_ok() {
         let config = SinkConfig::Loki {
             url: "http://localhost:3100".to_string(),
             batch_size: None,
@@ -1128,13 +1136,13 @@ max_buffer_age: 10s
             retry: None,
         };
         assert!(
-            create_sink(&config, None).is_ok(),
+            create_sink(&config, None).await.is_ok(),
             "factory must return Ok for valid loki config"
         );
     }
 
-    #[test]
-    fn create_sink_loki_with_invalid_max_buffer_age_returns_err() {
+    #[tokio::test]
+    async fn create_sink_loki_with_invalid_max_buffer_age_returns_err() {
         let config = SinkConfig::Loki {
             url: "http://localhost:3100".to_string(),
             batch_size: None,
@@ -1142,15 +1150,15 @@ max_buffer_age: 10s
             max_buffer_age: Some("garbage".to_string()),
             retry: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_err(),
             "invalid max_buffer_age must cause the factory to fail"
         );
     }
 
-    #[test]
-    fn create_sink_loki_with_labels_passes_them_to_sink() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_sink_loki_with_labels_passes_them_to_sink() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1163,10 +1171,12 @@ max_buffer_age: 10s
         };
         let mut labels = HashMap::new();
         labels.insert("job".to_string(), "sonda".to_string());
-        let mut sink = create_sink(&config, Some(&labels)).expect("factory ok");
+        let mut sink = create_sink(&config, Some(&labels))
+            .await
+            .expect("factory ok");
 
-        sink.write(b"test\n").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"test\n").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -1178,8 +1188,8 @@ max_buffer_age: 10s
         );
     }
 
-    #[test]
-    fn create_sink_loki_with_none_labels_uses_empty_labels() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_sink_loki_with_none_labels_uses_empty_labels() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1190,10 +1200,10 @@ max_buffer_age: 10s
             max_buffer_age: None,
             retry: None,
         };
-        let mut sink = create_sink(&config, None).expect("factory ok");
+        let mut sink = create_sink(&config, None).await.expect("factory ok");
 
-        sink.write(b"test\n").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"test\n").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body_bytes = handle.join().expect("mock server thread panicked");
         let body = String::from_utf8(body_bytes).expect("UTF-8");
@@ -1210,11 +1220,8 @@ max_buffer_age: 10s
         assert_eq!(DEFAULT_BATCH_SIZE, 5);
     }
 
-    #[test]
-    fn create_sink_loki_with_no_batch_size_uses_default() {
-        // Construction succeeds with `batch_size: None`; writing fewer entries
-        // than DEFAULT_BATCH_SIZE must not trigger a flush attempt against the
-        // non-existent server.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_sink_loki_with_no_batch_size_uses_default() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
         drop(listener);
@@ -1227,16 +1234,17 @@ max_buffer_age: 10s
             max_buffer_age: None,
             retry: None,
         };
-        let mut sink = create_sink(&config, None).expect("factory ok");
+        let mut sink = create_sink(&config, None).await.expect("factory ok");
 
         for i in 0..(DEFAULT_BATCH_SIZE - 1) as u32 {
             sink.write(format!("line {i}\n").as_bytes())
+                .await
                 .expect("write must succeed below batch_size");
         }
     }
 
-    #[test]
-    fn create_sink_loki_with_invalid_url_returns_err() {
+    #[tokio::test]
+    async fn create_sink_loki_with_invalid_url_returns_err() {
         let config = SinkConfig::Loki {
             url: "not-http://bad".to_string(),
             batch_size: None,
@@ -1244,7 +1252,7 @@ max_buffer_age: 10s
             max_buffer_age: None,
             retry: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(result.is_err(), "invalid URL must cause factory to fail");
     }
 
@@ -1339,8 +1347,8 @@ sink:
             .clone()
     }
 
-    #[test]
-    fn write_log_event_single_stream_when_no_per_event_labels() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_log_event_single_stream_when_no_per_event_labels() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1350,8 +1358,8 @@ sink:
         let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
         let event = make_log_event(&[], "hello");
-        sink.write_log_event(&event, b"hello").expect("write");
-        sink.flush().expect("flush");
+        sink.write_log_event(&event, b"hello").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let streams = parse_streams(handle.join().expect("mock server"));
         assert_eq!(streams.len(), 1, "no overlay → exactly one stream");
@@ -1360,8 +1368,8 @@ sink:
         assert_eq!(stream_obj["job"].as_str(), Some("sonda"));
     }
 
-    #[test]
-    fn write_log_event_multi_stream_grouping_by_event_labels() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_log_event_multi_stream_grouping_by_event_labels() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1374,10 +1382,16 @@ sink:
         let ev1 = make_log_event(&[("peer_address", "10.1.2.2")], "to peer 1");
         let ev2 = make_log_event(&[("peer_address", "10.1.7.2")], "to peer 2");
         let ev1b = make_log_event(&[("peer_address", "10.1.2.2")], "to peer 1 again");
-        sink.write_log_event(&ev1, b"line-a").expect("write 1");
-        sink.write_log_event(&ev2, b"line-b").expect("write 2");
-        sink.write_log_event(&ev1b, b"line-c").expect("write 3");
-        sink.flush().expect("flush");
+        sink.write_log_event(&ev1, b"line-a")
+            .await
+            .expect("write 1");
+        sink.write_log_event(&ev2, b"line-b")
+            .await
+            .expect("write 2");
+        sink.write_log_event(&ev1b, b"line-c")
+            .await
+            .expect("write 3");
+        sink.flush().await.expect("flush");
 
         let streams = parse_streams(handle.join().expect("mock server"));
         assert_eq!(
@@ -1404,8 +1418,8 @@ sink:
         assert_eq!(by_peer.get("10.1.7.2"), Some(&1), "ev2 alone");
     }
 
-    #[test]
-    fn write_log_event_overlay_overrides_constructor_label_on_conflict() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_log_event_overlay_overrides_constructor_label_on_conflict() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1416,8 +1430,8 @@ sink:
         let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
         let event = make_log_event(&[("region", "eu-west")], "overridden");
-        sink.write_log_event(&event, b"line").expect("write");
-        sink.flush().expect("flush");
+        sink.write_log_event(&event, b"line").await.expect("write");
+        sink.flush().await.expect("flush");
 
         let streams = parse_streams(handle.join().expect("mock server"));
         assert_eq!(streams.len(), 1);
@@ -1434,8 +1448,8 @@ sink:
         );
     }
 
-    #[test]
-    fn flush_with_stream_count_at_cap_succeeds() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_with_stream_count_at_cap_succeeds() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1444,9 +1458,10 @@ sink:
         for i in 0..3 {
             let ev = make_log_event(&[("peer", &format!("p{i}"))], "line");
             sink.write_log_event(&ev, format!("line-{i}").as_bytes())
+                .await
                 .expect("write");
         }
-        let flush_result = sink.flush();
+        let flush_result = sink.flush().await;
         assert!(
             flush_result.is_ok(),
             "exactly-at-cap must succeed: {flush_result:?}"
@@ -1456,8 +1471,8 @@ sink:
         assert_eq!(streams.len(), 3, "all three streams must be sent");
     }
 
-    #[test]
-    fn flush_exceeding_cap_returns_helpful_error_and_clears_batch() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_exceeding_cap_returns_helpful_error_and_clears_batch() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
         drop(listener);
@@ -1468,9 +1483,10 @@ sink:
         for i in 0..3 {
             let ev = make_log_event(&[("peer", &format!("p{i}"))], "line");
             sink.write_log_event(&ev, format!("line-{i}").as_bytes())
+                .await
                 .expect("write");
         }
-        let err = sink.flush().expect_err("over-cap flush must Err");
+        let err = sink.flush().await.expect_err("over-cap flush must Err");
         let msg = err.to_string();
         assert!(
             msg.contains("3 streams"),
@@ -1486,13 +1502,13 @@ sink:
         );
 
         assert!(
-            sink.flush().is_ok(),
+            sink.flush().await.is_ok(),
             "batch must be cleared after cap error"
         );
     }
 
-    #[test]
-    fn direct_write_falls_back_to_constructor_labels_only() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn direct_write_falls_back_to_constructor_labels_only() {
         let (listener, url) = mock_loki_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 204));
 
@@ -1501,9 +1517,11 @@ sink:
 
         let mut sink = LokiSink::new(url, labels, 100, u32::MAX, None, Duration::ZERO)
             .expect("construct sink");
-        sink.write(b"line via direct write").expect("write");
-        sink.write(b"another line via direct write").expect("write");
-        sink.flush().expect("flush");
+        sink.write(b"line via direct write").await.expect("write");
+        sink.write(b"another line via direct write")
+            .await
+            .expect("write");
+        sink.flush().await.expect("flush");
 
         let streams = parse_streams(handle.join().expect("mock server"));
         assert_eq!(streams.len(), 1, "direct write produces a single stream");

--- a/sonda-core/src/sink/memory.rs
+++ b/sonda-core/src/sink/memory.rs
@@ -4,6 +4,8 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use async_trait::async_trait;
+
 use super::Sink;
 use crate::SondaError;
 
@@ -15,7 +17,6 @@ pub struct CapturedRing {
 }
 
 impl CapturedRing {
-    /// Create an empty ring that retains at most `max` events.
     pub fn new(max: usize) -> Self {
         Self {
             events: VecDeque::with_capacity(max),
@@ -23,7 +24,6 @@ impl CapturedRing {
         }
     }
 
-    /// Append `event`, evicting the oldest entry once the cap is reached.
     pub fn push(&mut self, event: (Instant, Vec<u8>)) {
         if self.events.len() == self.max {
             self.events.pop_front();
@@ -31,22 +31,18 @@ impl CapturedRing {
         self.events.push_back(event);
     }
 
-    /// Borrow the retained events in insertion order.
     pub fn events(&self) -> &VecDeque<(Instant, Vec<u8>)> {
         &self.events
     }
 
-    /// Number of retained events.
     pub fn len(&self) -> usize {
         self.events.len()
     }
 
-    /// Whether the ring currently holds no events.
     pub fn is_empty(&self) -> bool {
         self.events.is_empty()
     }
 
-    /// Configured cap on retained events.
     pub fn capacity(&self) -> usize {
         self.max
     }
@@ -54,17 +50,14 @@ impl CapturedRing {
 
 /// An in-memory sink that accumulates all written bytes in a `Vec<u8>`.
 ///
-/// This sink is intended for use in tests across the project. It allows
-/// callers to inspect the exact bytes that would have been delivered to a
-/// real destination (file, socket, stdout) without any I/O.
+/// Intended for tests across the project: callers can inspect the exact bytes
+/// that would have been delivered to a real destination without any I/O.
 pub struct MemorySink {
-    /// All bytes written to this sink, in order.
     pub buffer: Vec<u8>,
     captured: Option<Arc<Mutex<CapturedRing>>>,
 }
 
 impl MemorySink {
-    /// Create a new, empty `MemorySink` with no per-write timestamp capture.
     pub fn new() -> Self {
         Self {
             buffer: Vec::new(),
@@ -72,8 +65,8 @@ impl MemorySink {
         }
     }
 
-    /// Create a `MemorySink` that records `(Instant, bytes)` on every write,
-    /// keeping at most `max_events` of the most recent entries.
+    /// Record `(Instant, bytes)` on every write, keeping the most recent
+    /// `max_events` entries.
     pub fn with_capture(max_events: usize) -> Self {
         Self {
             buffer: Vec::new(),
@@ -81,7 +74,7 @@ impl MemorySink {
         }
     }
 
-    /// Create a `MemorySink` whose timestamped writes land in `handle`.
+    /// Mirror writes into an externally-owned capture ring.
     pub fn with_shared_capture(handle: Arc<Mutex<CapturedRing>>) -> Self {
         Self {
             buffer: Vec::new(),
@@ -89,12 +82,10 @@ impl MemorySink {
         }
     }
 
-    /// Borrow a clone of the shared capture handle, if capture is enabled.
     pub fn capture_handle(&self) -> Option<Arc<Mutex<CapturedRing>>> {
         self.captured.as_ref().map(Arc::clone)
     }
 
-    /// Snapshot the currently retained capture ring, if capture is enabled.
     pub fn captured(&self) -> Option<Vec<(Instant, Vec<u8>)>> {
         let handle = self.captured.as_ref()?;
         let guard = handle.lock().ok()?;
@@ -108,8 +99,9 @@ impl Default for MemorySink {
     }
 }
 
+#[async_trait]
 impl Sink for MemorySink {
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.buffer.extend_from_slice(data);
         if let Some(handle) = self.captured.as_ref() {
             if let Ok(mut ring) = handle.lock() {
@@ -119,7 +111,7 @@ impl Sink for MemorySink {
         Ok(())
     }
 
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
 }
@@ -128,44 +120,43 @@ impl Sink for MemorySink {
 mod tests {
     use super::*;
 
-    #[test]
-    fn write_stores_exact_bytes_in_buffer() {
+    #[tokio::test]
+    async fn write_stores_exact_bytes_in_buffer() {
         let mut sink = MemorySink::new();
         let data = b"hello, world\n";
-        sink.write(data).unwrap();
+        sink.write(data).await.unwrap();
         assert_eq!(sink.buffer, data);
     }
 
-    #[test]
-    fn write_empty_slice_appends_nothing() {
+    #[tokio::test]
+    async fn write_empty_slice_appends_nothing() {
         let mut sink = MemorySink::new();
-        sink.write(b"").unwrap();
+        sink.write(b"").await.unwrap();
         assert!(sink.buffer.is_empty());
     }
 
-    #[test]
-    fn multiple_writes_accumulate_in_order() {
+    #[tokio::test]
+    async fn multiple_writes_accumulate_in_order() {
         let mut sink = MemorySink::new();
-        sink.write(b"foo").unwrap();
-        sink.write(b"bar").unwrap();
-        sink.write(b"baz").unwrap();
+        sink.write(b"foo").await.unwrap();
+        sink.write(b"bar").await.unwrap();
+        sink.write(b"baz").await.unwrap();
         assert_eq!(&sink.buffer, b"foobarbaz");
     }
 
-    #[test]
-    fn flush_is_noop_and_returns_ok() {
+    #[tokio::test]
+    async fn flush_is_noop_and_returns_ok() {
         let mut sink = MemorySink::new();
-        sink.write(b"data").unwrap();
-        let result = sink.flush();
+        sink.write(b"data").await.unwrap();
+        let result = sink.flush().await;
         assert!(result.is_ok());
-        // Buffer unchanged after flush
         assert_eq!(&sink.buffer, b"data");
     }
 
-    #[test]
-    fn flush_on_empty_sink_returns_ok() {
+    #[tokio::test]
+    async fn flush_on_empty_sink_returns_ok() {
         let mut sink = MemorySink::new();
-        assert!(sink.flush().is_ok());
+        assert!(sink.flush().await.is_ok());
     }
 
     #[test]
@@ -174,42 +165,39 @@ mod tests {
         assert!(sink.buffer.is_empty());
     }
 
-    #[test]
-    fn buffer_field_is_publicly_accessible() {
+    #[tokio::test]
+    async fn buffer_field_is_publicly_accessible() {
         let mut sink = MemorySink::new();
-        sink.write(b"inspect me").unwrap();
-        // Direct field access — confirms pub visibility
+        sink.write(b"inspect me").await.unwrap();
         assert_eq!(sink.buffer.len(), 10);
     }
 
-    /// Compile-time proof that MemorySink satisfies Send + Sync.
     #[test]
     fn memory_sink_is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<MemorySink>();
     }
 
-    /// Verify that a boxed Sink trait object compiles correctly with MemorySink.
-    #[test]
-    fn memory_sink_usable_as_boxed_sink_trait_object() {
+    #[tokio::test]
+    async fn memory_sink_usable_as_boxed_sink_trait_object() {
         let mut sink: Box<dyn Sink> = Box::new(MemorySink::new());
-        sink.write(b"trait object write").unwrap();
-        sink.flush().unwrap();
+        sink.write(b"trait object write").await.unwrap();
+        sink.flush().await.unwrap();
     }
 
-    #[test]
-    fn new_disables_capture() {
+    #[tokio::test]
+    async fn new_disables_capture() {
         let mut sink = MemorySink::new();
-        sink.write(b"x").unwrap();
+        sink.write(b"x").await.unwrap();
         assert!(sink.captured().is_none());
         assert!(sink.capture_handle().is_none());
     }
 
-    #[test]
-    fn with_capture_records_timestamped_writes() {
+    #[tokio::test]
+    async fn with_capture_records_timestamped_writes() {
         let mut sink = MemorySink::with_capture(8);
-        sink.write(b"first").unwrap();
-        sink.write(b"second").unwrap();
+        sink.write(b"first").await.unwrap();
+        sink.write(b"second").await.unwrap();
         let snap = sink.captured().expect("capture enabled");
         assert_eq!(snap.len(), 2);
         assert_eq!(snap[0].1, b"first");
@@ -217,11 +205,11 @@ mod tests {
         assert!(snap[1].0 >= snap[0].0);
     }
 
-    #[test]
-    fn capture_ring_evicts_oldest_when_full() {
+    #[tokio::test]
+    async fn capture_ring_evicts_oldest_when_full() {
         let mut sink = MemorySink::with_capture(3);
         for i in 0..5 {
-            sink.write(format!("e{i}").as_bytes()).unwrap();
+            sink.write(format!("e{i}").as_bytes()).await.unwrap();
         }
         let snap = sink.captured().expect("capture enabled");
         assert_eq!(snap.len(), 3);
@@ -230,33 +218,33 @@ mod tests {
         assert_eq!(snap[2].1, b"e4");
     }
 
-    #[test]
-    fn capture_handle_observes_writes_across_clones() {
+    #[tokio::test]
+    async fn capture_handle_observes_writes_across_clones() {
         let sink = MemorySink::with_capture(4);
         let handle = sink.capture_handle().expect("capture enabled");
         let mut sink = sink;
-        sink.write(b"a").unwrap();
-        sink.write(b"b").unwrap();
+        sink.write(b"a").await.unwrap();
+        sink.write(b"b").await.unwrap();
         let guard = handle.lock().unwrap();
         assert_eq!(guard.len(), 2);
         assert_eq!(guard.events()[0].1, b"a");
         assert_eq!(guard.events()[1].1, b"b");
     }
 
-    #[test]
-    fn with_shared_capture_writes_through_external_handle() {
+    #[tokio::test]
+    async fn with_shared_capture_writes_through_external_handle() {
         let handle = Arc::new(Mutex::new(CapturedRing::new(4)));
         let mut sink = MemorySink::with_shared_capture(Arc::clone(&handle));
-        sink.write(b"shared").unwrap();
+        sink.write(b"shared").await.unwrap();
         let guard = handle.lock().unwrap();
         assert_eq!(guard.len(), 1);
         assert_eq!(guard.events()[0].1, b"shared");
     }
 
-    #[test]
-    fn buffer_remains_populated_alongside_capture() {
+    #[tokio::test]
+    async fn buffer_remains_populated_alongside_capture() {
         let mut sink = MemorySink::with_capture(4);
-        sink.write(b"hello").unwrap();
+        sink.write(b"hello").await.unwrap();
         assert_eq!(&sink.buffer, b"hello");
         assert_eq!(sink.captured().unwrap().len(), 1);
     }

--- a/sonda-core/src/sink/memory.rs
+++ b/sonda-core/src/sink/memory.rs
@@ -1,7 +1,56 @@
 //! In-memory sink for testing.
 
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
 use super::Sink;
 use crate::SondaError;
+
+/// Ring of most-recent captured `(Instant, Vec<u8>)` events with a fixed cap.
+#[derive(Debug)]
+pub struct CapturedRing {
+    events: VecDeque<(Instant, Vec<u8>)>,
+    max: usize,
+}
+
+impl CapturedRing {
+    /// Create an empty ring that retains at most `max` events.
+    pub fn new(max: usize) -> Self {
+        Self {
+            events: VecDeque::with_capacity(max),
+            max: max.max(1),
+        }
+    }
+
+    /// Append `event`, evicting the oldest entry once the cap is reached.
+    pub fn push(&mut self, event: (Instant, Vec<u8>)) {
+        if self.events.len() == self.max {
+            self.events.pop_front();
+        }
+        self.events.push_back(event);
+    }
+
+    /// Borrow the retained events in insertion order.
+    pub fn events(&self) -> &VecDeque<(Instant, Vec<u8>)> {
+        &self.events
+    }
+
+    /// Number of retained events.
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    /// Whether the ring currently holds no events.
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Configured cap on retained events.
+    pub fn capacity(&self) -> usize {
+        self.max
+    }
+}
 
 /// An in-memory sink that accumulates all written bytes in a `Vec<u8>`.
 ///
@@ -11,12 +60,45 @@ use crate::SondaError;
 pub struct MemorySink {
     /// All bytes written to this sink, in order.
     pub buffer: Vec<u8>,
+    captured: Option<Arc<Mutex<CapturedRing>>>,
 }
 
 impl MemorySink {
-    /// Create a new, empty `MemorySink`.
+    /// Create a new, empty `MemorySink` with no per-write timestamp capture.
     pub fn new() -> Self {
-        Self { buffer: Vec::new() }
+        Self {
+            buffer: Vec::new(),
+            captured: None,
+        }
+    }
+
+    /// Create a `MemorySink` that records `(Instant, bytes)` on every write,
+    /// keeping at most `max_events` of the most recent entries.
+    pub fn with_capture(max_events: usize) -> Self {
+        Self {
+            buffer: Vec::new(),
+            captured: Some(Arc::new(Mutex::new(CapturedRing::new(max_events)))),
+        }
+    }
+
+    /// Create a `MemorySink` whose timestamped writes land in `handle`.
+    pub fn with_shared_capture(handle: Arc<Mutex<CapturedRing>>) -> Self {
+        Self {
+            buffer: Vec::new(),
+            captured: Some(handle),
+        }
+    }
+
+    /// Borrow a clone of the shared capture handle, if capture is enabled.
+    pub fn capture_handle(&self) -> Option<Arc<Mutex<CapturedRing>>> {
+        self.captured.as_ref().map(Arc::clone)
+    }
+
+    /// Snapshot the currently retained capture ring, if capture is enabled.
+    pub fn captured(&self) -> Option<Vec<(Instant, Vec<u8>)>> {
+        let handle = self.captured.as_ref()?;
+        let guard = handle.lock().ok()?;
+        Some(guard.events().iter().cloned().collect())
     }
 }
 
@@ -27,13 +109,16 @@ impl Default for MemorySink {
 }
 
 impl Sink for MemorySink {
-    /// Append `data` to the internal buffer.
     fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.buffer.extend_from_slice(data);
+        if let Some(handle) = self.captured.as_ref() {
+            if let Ok(mut ring) = handle.lock() {
+                ring.push((Instant::now(), data.to_vec()));
+            }
+        }
         Ok(())
     }
 
-    /// No-op flush — all data is already in memory.
     fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
@@ -110,5 +195,85 @@ mod tests {
         let mut sink: Box<dyn Sink> = Box::new(MemorySink::new());
         sink.write(b"trait object write").unwrap();
         sink.flush().unwrap();
+    }
+
+    #[test]
+    fn new_disables_capture() {
+        let mut sink = MemorySink::new();
+        sink.write(b"x").unwrap();
+        assert!(sink.captured().is_none());
+        assert!(sink.capture_handle().is_none());
+    }
+
+    #[test]
+    fn with_capture_records_timestamped_writes() {
+        let mut sink = MemorySink::with_capture(8);
+        sink.write(b"first").unwrap();
+        sink.write(b"second").unwrap();
+        let snap = sink.captured().expect("capture enabled");
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].1, b"first");
+        assert_eq!(snap[1].1, b"second");
+        assert!(snap[1].0 >= snap[0].0);
+    }
+
+    #[test]
+    fn capture_ring_evicts_oldest_when_full() {
+        let mut sink = MemorySink::with_capture(3);
+        for i in 0..5 {
+            sink.write(format!("e{i}").as_bytes()).unwrap();
+        }
+        let snap = sink.captured().expect("capture enabled");
+        assert_eq!(snap.len(), 3);
+        assert_eq!(snap[0].1, b"e2");
+        assert_eq!(snap[1].1, b"e3");
+        assert_eq!(snap[2].1, b"e4");
+    }
+
+    #[test]
+    fn capture_handle_observes_writes_across_clones() {
+        let sink = MemorySink::with_capture(4);
+        let handle = sink.capture_handle().expect("capture enabled");
+        let mut sink = sink;
+        sink.write(b"a").unwrap();
+        sink.write(b"b").unwrap();
+        let guard = handle.lock().unwrap();
+        assert_eq!(guard.len(), 2);
+        assert_eq!(guard.events()[0].1, b"a");
+        assert_eq!(guard.events()[1].1, b"b");
+    }
+
+    #[test]
+    fn with_shared_capture_writes_through_external_handle() {
+        let handle = Arc::new(Mutex::new(CapturedRing::new(4)));
+        let mut sink = MemorySink::with_shared_capture(Arc::clone(&handle));
+        sink.write(b"shared").unwrap();
+        let guard = handle.lock().unwrap();
+        assert_eq!(guard.len(), 1);
+        assert_eq!(guard.events()[0].1, b"shared");
+    }
+
+    #[test]
+    fn buffer_remains_populated_alongside_capture() {
+        let mut sink = MemorySink::with_capture(4);
+        sink.write(b"hello").unwrap();
+        assert_eq!(&sink.buffer, b"hello");
+        assert_eq!(sink.captured().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn captured_ring_capacity_minimum_is_one() {
+        let ring = CapturedRing::new(0);
+        assert_eq!(ring.capacity(), 1);
+        assert!(ring.is_empty());
+    }
+
+    #[test]
+    fn captured_ring_len_and_is_empty_track_state() {
+        let mut ring = CapturedRing::new(2);
+        assert!(ring.is_empty());
+        ring.push((Instant::now(), vec![1]));
+        assert_eq!(ring.len(), 1);
+        assert!(!ring.is_empty());
     }
 }

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -152,6 +152,23 @@ pub enum SinkConfig {
         address: String,
     },
 
+    /// In-process memory sink for tests and benchmarks.
+    ///
+    /// When `capture` is `true`, each write records its `Instant` alongside
+    /// the bytes, bounded to the most recent `max_events` entries. When
+    /// `capture` is `false`, the sink only accumulates bytes in its buffer.
+    #[cfg_attr(feature = "config", serde(rename = "memory"))]
+    Memory {
+        /// Whether to record `(Instant, bytes)` on every write.
+        #[cfg_attr(feature = "config", serde(default))]
+        capture: bool,
+
+        /// Cap on retained captured events. Defaults to `1_000_000` when
+        /// `capture` is `true` and the field is omitted.
+        #[cfg_attr(feature = "config", serde(default))]
+        max_events: Option<usize>,
+    },
+
     /// Batch encoded events and deliver them via HTTP POST.
     ///
     /// Bytes are accumulated in a buffer until `batch_size` bytes are reached,
@@ -396,6 +413,17 @@ pub fn create_sink(
             Ok(Box::new(tcp::TcpSink::new(address, rp)?))
         }
         SinkConfig::Udp { address } => Ok(Box::new(udp::UdpSink::new(address)?)),
+        SinkConfig::Memory {
+            capture,
+            max_events,
+        } => {
+            if *capture {
+                let max = max_events.unwrap_or(1_000_000);
+                Ok(Box::new(memory::MemorySink::with_capture(max)))
+            } else {
+                Ok(Box::new(memory::MemorySink::new()))
+            }
+        }
         #[cfg(feature = "http")]
         SinkConfig::HttpPush {
             url,
@@ -1392,6 +1420,79 @@ retry:
             sink.buffer, encoded,
             "default impl must forward the encoded bytes to write() unchanged"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // SinkConfig::Memory: factory wiring and capture path
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn create_sink_memory_without_capture_returns_ok() {
+        let cfg = SinkConfig::Memory {
+            capture: false,
+            max_events: None,
+        };
+        let mut sink = create_sink(&cfg, None).unwrap();
+        sink.write(b"hello").unwrap();
+        sink.flush().unwrap();
+    }
+
+    #[test]
+    fn create_sink_memory_with_capture_returns_usable_sink() {
+        let cfg = SinkConfig::Memory {
+            capture: true,
+            max_events: Some(8),
+        };
+        let mut sink = create_sink(&cfg, None).unwrap();
+        sink.write(b"one").unwrap();
+        sink.write(b"two").unwrap();
+        sink.flush().unwrap();
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_memory_deserializes_with_type_field() {
+        let yaml = "type: memory\ncapture: true\nmax_events: 64";
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(matches!(
+            config,
+            SinkConfig::Memory {
+                capture: true,
+                max_events: Some(64)
+            }
+        ));
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_memory_defaults_when_fields_omitted() {
+        let yaml = "type: memory";
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(matches!(
+            config,
+            SinkConfig::Memory {
+                capture: false,
+                max_events: None
+            }
+        ));
+    }
+
+    #[test]
+    fn sink_config_memory_is_cloneable_and_debuggable() {
+        let cfg = SinkConfig::Memory {
+            capture: true,
+            max_events: Some(16),
+        };
+        let cloned = cfg.clone();
+        assert!(matches!(
+            cloned,
+            SinkConfig::Memory {
+                capture: true,
+                max_events: Some(16)
+            }
+        ));
+        let s = format!("{cfg:?}");
+        assert!(s.contains("Memory"));
     }
 
     #[cfg(all(not(feature = "otlp"), feature = "config"))]

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -22,10 +22,12 @@ pub mod udp;
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
 use crate::model::log::LogEvent;
+use crate::sink::memory::CapturedRing;
 use crate::SondaError;
 
 /// A sink consumes encoded bytes and delivers them to a destination.
@@ -157,6 +159,9 @@ pub enum SinkConfig {
     /// When `capture` is `true`, each write records its `Instant` alongside
     /// the bytes, bounded to the most recent `max_events` entries. When
     /// `capture` is `false`, the sink only accumulates bytes in its buffer.
+    /// Programmatic embedders can pass `capture_handle: Some(arc)` to mirror
+    /// writes into an externally-owned ring; YAML scenarios always leave it
+    /// `None` because the field is `serde(skip)`.
     #[cfg_attr(feature = "config", serde(rename = "memory"))]
     Memory {
         /// Whether to record `(Instant, bytes)` on every write.
@@ -167,6 +172,10 @@ pub enum SinkConfig {
         /// `capture` is `true` and the field is omitted.
         #[cfg_attr(feature = "config", serde(default))]
         max_events: Option<usize>,
+
+        /// Programmatic capture handle for embedders. `None` for YAML.
+        #[cfg_attr(feature = "config", serde(skip))]
+        capture_handle: Option<Arc<Mutex<CapturedRing>>>,
     },
 
     /// Batch encoded events and deliver them via HTTP POST.
@@ -413,8 +422,13 @@ pub async fn create_sink(
         SinkConfig::Memory {
             capture,
             max_events,
+            capture_handle,
         } => {
-            if *capture {
+            if let Some(handle) = capture_handle {
+                Ok(Box::new(memory::MemorySink::with_shared_capture(
+                    Arc::clone(handle),
+                )))
+            } else if *capture {
                 let max = max_events.unwrap_or(1_000_000);
                 Ok(Box::new(memory::MemorySink::with_capture(max)))
             } else {
@@ -1415,6 +1429,7 @@ retry:
         let cfg = SinkConfig::Memory {
             capture: false,
             max_events: None,
+            capture_handle: None,
         };
         let mut sink = create_sink(&cfg, None).await.unwrap();
         sink.write(b"hello").await.unwrap();
@@ -1426,11 +1441,42 @@ retry:
         let cfg = SinkConfig::Memory {
             capture: true,
             max_events: Some(8),
+            capture_handle: None,
         };
         let mut sink = create_sink(&cfg, None).await.unwrap();
         sink.write(b"one").await.unwrap();
         sink.write(b"two").await.unwrap();
         sink.flush().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_sink_memory_with_shared_capture_handle_mirrors_writes() {
+        let ring = Arc::new(Mutex::new(memory::CapturedRing::new(8)));
+        let cfg = SinkConfig::Memory {
+            capture: false,
+            max_events: None,
+            capture_handle: Some(Arc::clone(&ring)),
+        };
+        let mut sink = create_sink(&cfg, None).await.unwrap();
+        sink.write(b"one").await.unwrap();
+        sink.write(b"two").await.unwrap();
+        let guard = ring.lock().unwrap();
+        assert_eq!(guard.len(), 2);
+        assert_eq!(guard.events()[0].1, b"one");
+        assert_eq!(guard.events()[1].1, b"two");
+    }
+
+    #[tokio::test]
+    async fn create_sink_memory_capture_handle_takes_precedence_over_capture_flag() {
+        let ring = Arc::new(Mutex::new(memory::CapturedRing::new(4)));
+        let cfg = SinkConfig::Memory {
+            capture: true,
+            max_events: Some(1_000_000),
+            capture_handle: Some(Arc::clone(&ring)),
+        };
+        let mut sink = create_sink(&cfg, None).await.unwrap();
+        sink.write(b"shared").await.unwrap();
+        assert_eq!(ring.lock().unwrap().len(), 1);
     }
 
     #[cfg(feature = "config")]
@@ -1442,7 +1488,8 @@ retry:
             config,
             SinkConfig::Memory {
                 capture: true,
-                max_events: Some(64)
+                max_events: Some(64),
+                capture_handle: None,
             }
         ));
     }
@@ -1456,7 +1503,23 @@ retry:
             config,
             SinkConfig::Memory {
                 capture: false,
-                max_events: None
+                max_events: None,
+                capture_handle: None,
+            }
+        ));
+    }
+
+    #[cfg(feature = "config")]
+    #[test]
+    fn sink_config_memory_capture_handle_is_skipped_in_yaml() {
+        let yaml = "type: memory\ncapture: true\nmax_events: 4\ncapture_handle: anything";
+        let config: SinkConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(matches!(
+            config,
+            SinkConfig::Memory {
+                capture: true,
+                max_events: Some(4),
+                capture_handle: None,
             }
         ));
     }
@@ -1466,17 +1529,37 @@ retry:
         let cfg = SinkConfig::Memory {
             capture: true,
             max_events: Some(16),
+            capture_handle: None,
         };
         let cloned = cfg.clone();
         assert!(matches!(
             cloned,
             SinkConfig::Memory {
                 capture: true,
-                max_events: Some(16)
+                max_events: Some(16),
+                capture_handle: None,
             }
         ));
         let s = format!("{cfg:?}");
         assert!(s.contains("Memory"));
+    }
+
+    #[test]
+    fn sink_config_memory_with_handle_is_cloneable_and_shares_ring() {
+        let ring = Arc::new(Mutex::new(memory::CapturedRing::new(2)));
+        let cfg = SinkConfig::Memory {
+            capture: false,
+            max_events: None,
+            capture_handle: Some(Arc::clone(&ring)),
+        };
+        let cloned = cfg.clone();
+        match cloned {
+            SinkConfig::Memory {
+                capture_handle: Some(h),
+                ..
+            } => assert!(Arc::ptr_eq(&h, &ring)),
+            _ => panic!("cloned variant must preserve the handle"),
+        }
     }
 
     #[cfg(all(not(feature = "otlp"), feature = "config"))]

--- a/sonda-core/src/sink/mod.rs
+++ b/sonda-core/src/sink/mod.rs
@@ -23,16 +23,17 @@ pub mod udp;
 use std::collections::HashMap;
 use std::path::Path;
 
+use async_trait::async_trait;
+
 use crate::model::log::LogEvent;
 use crate::SondaError;
 
 /// A sink consumes encoded bytes and delivers them to a destination.
+#[async_trait]
 pub trait Sink: Send + Sync {
-    /// Write encoded event data to the sink.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError>;
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError>;
 
-    /// Flush any buffered data to the destination.
-    fn flush(&mut self) -> Result<(), SondaError>;
+    async fn flush(&mut self) -> Result<(), SondaError>;
 
     /// Whether the most recent `write()` delivered data to the destination,
     /// or only buffered it. Non-batching sinks deliver on every write, so the
@@ -42,15 +43,14 @@ pub trait Sink: Send + Sync {
         true
     }
 
-    /// Write an encoded log event to the sink, with the originating
-    /// [`LogEvent`] alongside for sinks that build their own delivery
-    /// envelope from per-event context (e.g. labels).
-    ///
-    /// The default impl ignores the event reference and forwards to
-    /// [`Sink::write`], preserving the bytes-only contract every existing
-    /// sink relies on. Sinks that need per-event labels override this.
-    fn write_log_event(&mut self, _event: &LogEvent, encoded: &[u8]) -> Result<(), SondaError> {
-        self.write(encoded)
+    /// Write an encoded log event with originating context. Default impl
+    /// drops the event and forwards bytes to [`Sink::write`].
+    async fn write_log_event(
+        &mut self,
+        _event: &LogEvent,
+        encoded: &[u8],
+    ) -> Result<(), SondaError> {
+        self.write(encoded).await
     }
 }
 
@@ -388,11 +388,8 @@ pub enum SinkConfig {
 
 /// Create a boxed [`Sink`] from the given [`SinkConfig`].
 ///
-/// The optional `labels` parameter is used only by the Loki sink (feature
-/// `http`) to set stream labels. For all other sink types, pass `None`. Log
-/// scenarios pass the scenario-level labels here so that Loki stream labels
-/// are configured at the same level as every other signal type.
-pub fn create_sink(
+/// `labels` populates Loki stream labels; pass `None` for every other sink.
+pub async fn create_sink(
     config: &SinkConfig,
     labels: Option<&HashMap<String, String>>,
 ) -> Result<Box<dyn Sink>, SondaError> {
@@ -401,7 +398,7 @@ pub fn create_sink(
     let _ = &labels;
     match config {
         SinkConfig::Stdout => Ok(Box::new(stdout::StdoutSink::new())),
-        SinkConfig::File { path } => Ok(Box::new(file::FileSink::new(Path::new(path))?)),
+        SinkConfig::File { path } => Ok(Box::new(file::FileSink::new(Path::new(path)).await?)),
         SinkConfig::Tcp {
             address,
             retry: retry_cfg,
@@ -410,9 +407,9 @@ pub fn create_sink(
                 .as_ref()
                 .map(retry::RetryPolicy::from_config)
                 .transpose()?;
-            Ok(Box::new(tcp::TcpSink::new(address, rp)?))
+            Ok(Box::new(tcp::TcpSink::new(address, rp).await?))
         }
-        SinkConfig::Udp { address } => Ok(Box::new(udp::UdpSink::new(address)?)),
+        SinkConfig::Udp { address } => Ok(Box::new(udp::UdpSink::new(address).await?)),
         SinkConfig::Memory {
             capture,
             max_events,
@@ -490,14 +487,10 @@ pub fn create_sink(
                 None => Some(std::time::Duration::from_secs(5)),
             }
             .unwrap_or(std::time::Duration::ZERO);
-            Ok(Box::new(kafka::KafkaSink::new(
-                brokers,
-                topic,
-                rp,
-                tls.as_ref(),
-                sasl.as_ref(),
-                buffer_age,
-            )?))
+            Ok(Box::new(
+                kafka::KafkaSink::new(brokers, topic, rp, tls.as_ref(), sasl.as_ref(), buffer_age)
+                    .await?,
+            ))
         }
         #[cfg(feature = "http")]
         SinkConfig::Loki {
@@ -561,14 +554,17 @@ pub fn create_sink(
                 None => Some(std::time::Duration::from_secs(5)),
             }
             .unwrap_or(std::time::Duration::ZERO);
-            Ok(Box::new(otlp_grpc::OtlpGrpcSink::new(
-                endpoint,
-                *signal_type,
-                bs,
-                resource_attrs,
-                rp,
-                buffer_age,
-            )?))
+            Ok(Box::new(
+                otlp_grpc::OtlpGrpcSink::new(
+                    endpoint,
+                    *signal_type,
+                    bs,
+                    resource_attrs,
+                    rp,
+                    buffer_age,
+                )
+                .await?,
+            ))
         }
         #[cfg(not(feature = "http"))]
         SinkConfig::HttpPushDisabled { .. } => {
@@ -604,17 +600,17 @@ pub fn create_sink(
 mod tests {
     use super::*;
 
-    #[test]
-    fn create_sink_stdout_returns_ok() {
-        let result = create_sink(&SinkConfig::Stdout, None);
+    #[tokio::test]
+    async fn create_sink_stdout_returns_ok() {
+        let result = create_sink(&SinkConfig::Stdout, None).await;
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn create_sink_stdout_write_and_flush_succeed() {
-        let mut sink = create_sink(&SinkConfig::Stdout, None).unwrap();
-        assert!(sink.write(b"").is_ok());
-        assert!(sink.flush().is_ok());
+    #[tokio::test]
+    async fn create_sink_stdout_write_and_flush_succeed() {
+        let mut sink = create_sink(&SinkConfig::Stdout, None).await.unwrap();
+        assert!(sink.write(b"").await.is_ok());
+        assert!(sink.flush().await.is_ok());
     }
 
     #[cfg(feature = "config")]
@@ -625,13 +621,12 @@ mod tests {
         assert!(matches!(config, SinkConfig::Stdout));
     }
 
-    #[test]
-    fn sink_config_is_cloneable() {
+    #[tokio::test]
+    async fn sink_config_is_cloneable() {
         let config = SinkConfig::Stdout;
         let cloned = config.clone();
-        // Both variants should produce valid sinks
-        assert!(create_sink(&config, None).is_ok());
-        assert!(create_sink(&cloned, None).is_ok());
+        assert!(create_sink(&config, None).await.is_ok());
+        assert!(create_sink(&cloned, None).await.is_ok());
     }
 
     #[test]
@@ -969,10 +964,9 @@ sink:
     /// before returning an error. Run with `cargo test -- --ignored` when the
     /// test environment can tolerate network delays.
     #[cfg(feature = "kafka")]
-    #[test]
+    #[tokio::test]
     #[ignore = "requires network timeout which is slow; run with --ignored when desired"]
-    fn create_sink_kafka_with_unreachable_broker_returns_err() {
-        // Port 1 is privileged and will always refuse connections.
+    async fn create_sink_kafka_with_unreachable_broker_returns_err() {
         let config = SinkConfig::Kafka {
             brokers: "127.0.0.1:1".to_string(),
             topic: "sonda-test".to_string(),
@@ -981,17 +975,16 @@ sink:
             tls: None,
             sasl: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_err(),
             "create_sink should propagate the broker connection failure"
         );
     }
 
-    /// create_sink with an empty broker string returns Err immediately.
     #[cfg(feature = "kafka")]
-    #[test]
-    fn create_sink_kafka_with_empty_broker_returns_err() {
+    #[tokio::test]
+    async fn create_sink_kafka_with_empty_broker_returns_err() {
         let config = SinkConfig::Kafka {
             brokers: String::new(),
             topic: "sonda-test".to_string(),
@@ -1000,7 +993,7 @@ sink:
             tls: None,
             sasl: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_err(),
             "create_sink should reject an empty broker string"
@@ -1008,8 +1001,8 @@ sink:
     }
 
     #[cfg(feature = "kafka")]
-    #[test]
-    fn create_sink_kafka_with_invalid_max_buffer_age_returns_err() {
+    #[tokio::test]
+    async fn create_sink_kafka_with_invalid_max_buffer_age_returns_err() {
         let config = SinkConfig::Kafka {
             brokers: "127.0.0.1:9092".to_string(),
             topic: "sonda-test".to_string(),
@@ -1018,7 +1011,7 @@ sink:
             tls: None,
             sasl: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_err(),
             "create_sink should reject an unparseable max_buffer_age before connecting"
@@ -1134,11 +1127,9 @@ headers: {}
     // Feature gate: `http` feature controls HttpPush and Loki availability
     // ---------------------------------------------------------------------------
 
-    /// When the `http` feature is enabled, `SinkConfig::HttpPush` must be
-    /// constructible and the factory must produce a valid sink.
     #[cfg(feature = "http")]
-    #[test]
-    fn http_feature_enables_http_push_variant() {
+    #[tokio::test]
+    async fn http_feature_enables_http_push_variant() {
         let config = SinkConfig::HttpPush {
             url: "http://127.0.0.1:19999/push".to_string(),
             content_type: None,
@@ -1147,18 +1138,16 @@ headers: {}
             headers: None,
             retry: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_ok(),
             "HttpPush variant must be available when http feature is enabled"
         );
     }
 
-    /// When the `http` feature is enabled, `SinkConfig::Loki` must be
-    /// constructible and the factory must produce a valid sink.
     #[cfg(feature = "http")]
-    #[test]
-    fn http_feature_enables_loki_variant() {
+    #[tokio::test]
+    async fn http_feature_enables_loki_variant() {
         let config = SinkConfig::Loki {
             url: "http://127.0.0.1:19999".to_string(),
             batch_size: None,
@@ -1166,7 +1155,7 @@ headers: {}
             max_buffer_age: None,
             retry: None,
         };
-        let result = create_sink(&config, None);
+        let result = create_sink(&config, None).await;
         assert!(
             result.is_ok(),
             "Loki variant must be available when http feature is enabled"
@@ -1193,12 +1182,9 @@ headers: {}
         assert!(matches!(config, SinkConfig::Loki { .. }));
     }
 
-    /// Non-HTTP sinks (stdout, file, tcp, udp) must remain available
-    /// regardless of the `http` feature flag.
-    #[test]
-    fn non_http_sinks_available_without_http_feature() {
-        // This test compiles and runs with or without the `http` feature.
-        assert!(create_sink(&SinkConfig::Stdout, None).is_ok());
+    #[tokio::test]
+    async fn non_http_sinks_available_without_http_feature() {
+        assert!(create_sink(&SinkConfig::Stdout, None).await.is_ok());
     }
 
     // ---------------------------------------------------------------------------
@@ -1294,10 +1280,11 @@ retry:
     }
 
     #[cfg(not(feature = "kafka"))]
-    #[test]
-    fn create_sink_kafka_disabled_returns_feature_hint_error() {
+    #[tokio::test]
+    async fn create_sink_kafka_disabled_returns_feature_hint_error() {
         let config = SinkConfig::KafkaDisabled {};
         let err = create_sink(&config, None)
+            .await
             .err()
             .expect("must return Err for disabled variant");
         let msg = err.to_string();
@@ -1321,10 +1308,11 @@ retry:
     }
 
     #[cfg(not(feature = "http"))]
-    #[test]
-    fn create_sink_http_push_disabled_returns_feature_hint_error() {
+    #[tokio::test]
+    async fn create_sink_http_push_disabled_returns_feature_hint_error() {
         let config = SinkConfig::HttpPushDisabled {};
         let err = create_sink(&config, None)
+            .await
             .err()
             .expect("must return Err for disabled variant");
         let msg = err.to_string();
@@ -1348,10 +1336,11 @@ retry:
     }
 
     #[cfg(not(feature = "http"))]
-    #[test]
-    fn create_sink_loki_disabled_returns_feature_hint_error() {
+    #[tokio::test]
+    async fn create_sink_loki_disabled_returns_feature_hint_error() {
         let config = SinkConfig::LokiDisabled {};
         let err = create_sink(&config, None)
+            .await
             .err()
             .expect("must return Err for disabled variant");
         let msg = err.to_string();
@@ -1375,10 +1364,11 @@ retry:
     }
 
     #[cfg(not(feature = "remote-write"))]
-    #[test]
-    fn create_sink_remote_write_disabled_returns_feature_hint_error() {
+    #[tokio::test]
+    async fn create_sink_remote_write_disabled_returns_feature_hint_error() {
         let config = SinkConfig::RemoteWriteDisabled {};
         let err = create_sink(&config, None)
+            .await
             .err()
             .expect("must return Err for disabled variant");
         let msg = err.to_string();
@@ -1392,8 +1382,8 @@ retry:
         );
     }
 
-    #[test]
-    fn default_write_log_event_forwards_encoded_bytes_to_write() {
+    #[tokio::test]
+    async fn default_write_log_event_forwards_encoded_bytes_to_write() {
         use crate::model::log::{LogEvent, Severity};
         use crate::model::metric::Labels;
         use memory::MemorySink;
@@ -1410,10 +1400,8 @@ retry:
         );
         let encoded = b"<encoded payload>";
 
-        // MemorySink does not override `write_log_event`, so the call must
-        // route through the default impl and end up appended to `buffer`
-        // exactly as `write(encoded)` would.
         sink.write_log_event(&event, encoded)
+            .await
             .expect("default write_log_event must succeed");
 
         assert_eq!(
@@ -1422,31 +1410,27 @@ retry:
         );
     }
 
-    // ---------------------------------------------------------------------------
-    // SinkConfig::Memory: factory wiring and capture path
-    // ---------------------------------------------------------------------------
-
-    #[test]
-    fn create_sink_memory_without_capture_returns_ok() {
+    #[tokio::test]
+    async fn create_sink_memory_without_capture_returns_ok() {
         let cfg = SinkConfig::Memory {
             capture: false,
             max_events: None,
         };
-        let mut sink = create_sink(&cfg, None).unwrap();
-        sink.write(b"hello").unwrap();
-        sink.flush().unwrap();
+        let mut sink = create_sink(&cfg, None).await.unwrap();
+        sink.write(b"hello").await.unwrap();
+        sink.flush().await.unwrap();
     }
 
-    #[test]
-    fn create_sink_memory_with_capture_returns_usable_sink() {
+    #[tokio::test]
+    async fn create_sink_memory_with_capture_returns_usable_sink() {
         let cfg = SinkConfig::Memory {
             capture: true,
             max_events: Some(8),
         };
-        let mut sink = create_sink(&cfg, None).unwrap();
-        sink.write(b"one").unwrap();
-        sink.write(b"two").unwrap();
-        sink.flush().unwrap();
+        let mut sink = create_sink(&cfg, None).await.unwrap();
+        sink.write(b"one").await.unwrap();
+        sink.write(b"two").await.unwrap();
+        sink.flush().await.unwrap();
     }
 
     #[cfg(feature = "config")]
@@ -1505,10 +1489,11 @@ retry:
     }
 
     #[cfg(not(feature = "otlp"))]
-    #[test]
-    fn create_sink_otlp_grpc_disabled_returns_feature_hint_error() {
+    #[tokio::test]
+    async fn create_sink_otlp_grpc_disabled_returns_feature_hint_error() {
         let config = SinkConfig::OtlpGrpcDisabled {};
         let err = create_sink(&config, None)
+            .await
             .err()
             .expect("must return Err for disabled variant");
         let msg = err.to_string();

--- a/sonda-core/src/sink/otlp_grpc.rs
+++ b/sonda-core/src/sink/otlp_grpc.rs
@@ -10,19 +10,14 @@
 //!    accumulated items into an `ExportMetricsServiceRequest` or
 //!    `ExportLogsServiceRequest`, and sends it via gRPC unary call.
 //!
-//! Async gRPC operations are driven by a dedicated single-threaded
-//! [`tokio::runtime::Runtime`] stored in the struct, keeping the public
-//! [`Sink`] interface fully synchronous. This is the same pattern used by
-//! the Kafka sink.
-//!
 //! Requires the `otlp` feature flag.
 
 use std::marker::PhantomData;
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use bytes::Buf;
 use prost::Message;
-use tokio::runtime::Runtime;
 use tonic::client::Grpc;
 use tonic::codec::{Codec, Decoder, Encoder as TonicEncoder};
 use tonic::transport::Channel;
@@ -150,38 +145,21 @@ pub enum OtlpSignalType {
 
 /// Delivers OTLP protobuf telemetry to an OpenTelemetry Collector via gRPC.
 ///
-/// The sink accumulates encoded data points in an internal batch. When the
-/// batch reaches `batch_size` entries, or when `flush()` is called, the batch
-/// is wrapped in the appropriate OTLP export request and sent via gRPC unary
-/// call to the configured endpoint.
-///
-/// Uses a private single-threaded [`Runtime`] to drive async tonic calls,
-/// keeping the [`Sink`] trait interface fully synchronous.
+/// Encoded data points accumulate in an internal batch. When the batch reaches
+/// `batch_size`, or when `flush()` is called, the batch is wrapped in the
+/// appropriate OTLP export request and sent via a tonic gRPC unary call.
 pub struct OtlpGrpcSink {
-    /// Tokio runtime used to drive async tonic calls synchronously.
-    runtime: Runtime,
-    /// The gRPC channel (connection) to the OTLP endpoint.
     channel: Channel,
-    /// Accumulated metrics waiting to be sent.
     metric_batch: Vec<Metric>,
-    /// Accumulated log records waiting to be sent.
     log_batch: Vec<LogRecord>,
-    /// Flush threshold in number of data points / log records.
     batch_size: usize,
-    /// Whether this sink handles metrics or logs.
     signal_type: OtlpSignalType,
-    /// Resource attributes derived from scenario labels.
     resource_attrs: Vec<KeyValue>,
-    /// The endpoint URL string (stored for error messages).
     endpoint: String,
-    /// Optional retry policy for transient failures.
     retry_policy: Option<RetryPolicy>,
-    /// Maximum age a non-empty batch may reach before a time-based flush.
     /// `Duration::ZERO` disables time-based flushing.
     max_buffer_age: Duration,
-    /// When a batch was last sent — drives the time-based flush check.
     last_flush_at: Instant,
-    /// Whether the most recent `write()` triggered a successful flush rather than only buffering.
     last_write_delivered: bool,
 }
 
@@ -199,13 +177,7 @@ impl OtlpGrpcSink {
     /// - `max_buffer_age` — maximum age a non-empty batch may reach before a
     ///   time-based flush. `Duration::ZERO` disables time-based flushing.
     ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if:
-    /// - The tokio runtime cannot be created.
-    /// - The endpoint URL cannot be parsed.
-    /// - The gRPC connection cannot be established.
-    pub fn new(
+    pub async fn new(
         endpoint: &str,
         signal_type: OtlpSignalType,
         batch_size: usize,
@@ -213,46 +185,29 @@ impl OtlpGrpcSink {
         retry_policy: Option<RetryPolicy>,
         max_buffer_age: Duration,
     ) -> Result<Self, SondaError> {
-        // Build a minimal single-threaded tokio runtime.
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
+        let endpoint_str = endpoint.to_owned();
+        let channel = Channel::from_shared(endpoint_str.clone())
             .map_err(|e| {
                 std::io::Error::other(format!(
-                    "otlp grpc sink: failed to build tokio runtime for '{}': {}",
-                    endpoint, e
+                    "otlp grpc sink: invalid endpoint '{}': {}",
+                    endpoint_str, e
                 ))
             })
-            .map_err(SondaError::Sink)?;
-
-        let endpoint_str = endpoint.to_owned();
-
-        // Connect to the gRPC endpoint.
-        let channel = runtime
-            .block_on(async {
-                Channel::from_shared(endpoint_str.clone())
-                    .map_err(|e| {
-                        std::io::Error::other(format!(
-                            "otlp grpc sink: invalid endpoint '{}': {}",
-                            endpoint_str, e
-                        ))
-                    })?
-                    .connect()
-                    .await
-                    .map_err(|e| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::ConnectionRefused,
-                            format!(
-                                "otlp grpc sink: failed to connect to '{}': {}",
-                                endpoint_str, e
-                            ),
-                        )
-                    })
+            .map_err(SondaError::Sink)?
+            .connect()
+            .await
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    format!(
+                        "otlp grpc sink: failed to connect to '{}': {}",
+                        endpoint_str, e
+                    ),
+                )
             })
             .map_err(SondaError::Sink)?;
 
         Ok(Self {
-            runtime,
             channel,
             metric_batch: Vec::with_capacity(batch_size),
             log_batch: Vec::with_capacity(batch_size),
@@ -282,114 +237,70 @@ impl OtlpGrpcSink {
         }
     }
 
-    /// Flush the metric batch as an `ExportMetricsServiceRequest` via gRPC.
-    ///
-    /// Uses the configured [`RetryPolicy`] for transient gRPC failures.
-    fn flush_metrics(&mut self) -> Result<(), SondaError> {
+    async fn flush_metrics(&mut self) -> Result<(), SondaError> {
         if self.metric_batch.is_empty() {
             return Ok(());
         }
-
-        // Reset on attempt, not success — the batch is cleared either way below.
         self.last_flush_at = Instant::now();
-
         let metrics =
             std::mem::replace(&mut self.metric_batch, Vec::with_capacity(self.batch_size));
 
-        match &self.retry_policy {
-            Some(policy) => {
-                let policy = policy.clone();
-                // Clone metrics for potential retries since send_grpc_unary
-                // consumes the request.
-                policy.execute(
-                    || {
-                        let request = ExportMetricsServiceRequest {
-                            resource_metrics: vec![ResourceMetrics {
-                                resource: Some(self.build_resource()),
-                                scope_metrics: vec![ScopeMetrics {
-                                    scope: Some(Self::build_scope()),
-                                    metrics: metrics.clone(),
-                                }],
-                            }],
-                        };
-                        self.send_grpc_unary::<
-                            ExportMetricsServiceRequest,
-                            ExportMetricsServiceResponse,
-                        >(request, METRICS_EXPORT_PATH)
-                    },
-                    Self::is_retryable,
-                )
-            }
-            None => {
-                let request = ExportMetricsServiceRequest {
-                    resource_metrics: vec![ResourceMetrics {
-                        resource: Some(self.build_resource()),
-                        scope_metrics: vec![ScopeMetrics {
-                            scope: Some(Self::build_scope()),
-                            metrics,
-                        }],
+        let channel = self.channel.clone();
+        let endpoint = self.endpoint.clone();
+        let resource = self.build_resource();
+        let send_once = || async {
+            let request = ExportMetricsServiceRequest {
+                resource_metrics: vec![ResourceMetrics {
+                    resource: Some(resource.clone()),
+                    scope_metrics: vec![ScopeMetrics {
+                        scope: Some(Self::build_scope()),
+                        metrics: metrics.clone(),
                     }],
-                };
-                self.send_grpc_unary::<ExportMetricsServiceRequest, ExportMetricsServiceResponse>(
-                    request,
-                    METRICS_EXPORT_PATH,
-                )
-            }
-        }
+                }],
+            };
+            send_grpc_unary::<ExportMetricsServiceRequest, ExportMetricsServiceResponse>(
+                channel.clone(),
+                &endpoint,
+                request,
+                METRICS_EXPORT_PATH,
+            )
+            .await
+        };
+
+        run_with_retry(self.retry_policy.as_ref(), send_once).await
     }
 
-    /// Flush the log batch as an `ExportLogsServiceRequest` via gRPC.
-    ///
-    /// Uses the configured [`RetryPolicy`] for transient gRPC failures.
-    fn flush_logs(&mut self) -> Result<(), SondaError> {
+    async fn flush_logs(&mut self) -> Result<(), SondaError> {
         if self.log_batch.is_empty() {
             return Ok(());
         }
-
-        // Reset on attempt, not success — the batch is cleared either way below.
         self.last_flush_at = Instant::now();
-
         let log_records =
             std::mem::replace(&mut self.log_batch, Vec::with_capacity(self.batch_size));
 
-        match &self.retry_policy {
-            Some(policy) => {
-                let policy = policy.clone();
-                policy.execute(
-                    || {
-                        let request = ExportLogsServiceRequest {
-                            resource_logs: vec![ResourceLogs {
-                                resource: Some(self.build_resource()),
-                                scope_logs: vec![ScopeLogs {
-                                    scope: Some(Self::build_scope()),
-                                    log_records: log_records.clone(),
-                                }],
-                            }],
-                        };
-                        self.send_grpc_unary::<ExportLogsServiceRequest, ExportLogsServiceResponse>(
-                            request,
-                            LOGS_EXPORT_PATH,
-                        )
-                    },
-                    Self::is_retryable,
-                )
-            }
-            None => {
-                let request = ExportLogsServiceRequest {
-                    resource_logs: vec![ResourceLogs {
-                        resource: Some(self.build_resource()),
-                        scope_logs: vec![ScopeLogs {
-                            scope: Some(Self::build_scope()),
-                            log_records,
-                        }],
+        let channel = self.channel.clone();
+        let endpoint = self.endpoint.clone();
+        let resource = self.build_resource();
+        let send_once = || async {
+            let request = ExportLogsServiceRequest {
+                resource_logs: vec![ResourceLogs {
+                    resource: Some(resource.clone()),
+                    scope_logs: vec![ScopeLogs {
+                        scope: Some(Self::build_scope()),
+                        log_records: log_records.clone(),
                     }],
-                };
-                self.send_grpc_unary::<ExportLogsServiceRequest, ExportLogsServiceResponse>(
-                    request,
-                    LOGS_EXPORT_PATH,
-                )
-            }
-        }
+                }],
+            };
+            send_grpc_unary::<ExportLogsServiceRequest, ExportLogsServiceResponse>(
+                channel.clone(),
+                &endpoint,
+                request,
+                LOGS_EXPORT_PATH,
+            )
+            .await
+        };
+
+        run_with_retry(self.retry_policy.as_ref(), send_once).await
     }
 
     /// Classify whether a gRPC error is retryable.
@@ -417,52 +328,91 @@ impl OtlpGrpcSink {
         }
         false
     }
-
-    /// Send a gRPC unary call using the custom prost codec.
-    fn send_grpc_unary<T, U>(&mut self, request: T, path: &'static str) -> Result<(), SondaError>
-    where
-        T: Message + 'static,
-        U: Message + Default + 'static,
-    {
-        let channel = self.channel.clone();
-        let endpoint = self.endpoint.clone();
-
-        let result = self.runtime.block_on(async {
-            let mut client = Grpc::new(channel);
-            client.ready().await.map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::ConnectionRefused,
-                    format!("otlp grpc sink: service not ready at '{}': {}", endpoint, e),
-                )
-            })?;
-
-            let grpc_path = http::uri::PathAndQuery::from_static(path);
-            let codec: OtlpCodec<T, U> = OtlpCodec::default();
-            let tonic_request = tonic::Request::new(request);
-
-            client
-                .unary(tonic_request, grpc_path, codec)
-                .await
-                .map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        format!("otlp grpc sink: gRPC call to '{}' failed: {}", endpoint, e),
-                    )
-                })?;
-
-            Ok::<(), std::io::Error>(())
-        });
-
-        result.map_err(SondaError::Sink)
-    }
 }
 
+async fn send_grpc_unary<T, U>(
+    channel: Channel,
+    endpoint: &str,
+    request: T,
+    path: &'static str,
+) -> Result<(), SondaError>
+where
+    T: Message + 'static,
+    U: Message + Default + 'static,
+{
+    let mut client = Grpc::new(channel);
+    client
+        .ready()
+        .await
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                format!("otlp grpc sink: service not ready at '{}': {}", endpoint, e),
+            )
+        })
+        .map_err(SondaError::Sink)?;
+
+    let grpc_path = http::uri::PathAndQuery::from_static(path);
+    let codec: OtlpCodec<T, U> = OtlpCodec::default();
+    let tonic_request = tonic::Request::new(request);
+
+    client
+        .unary(tonic_request, grpc_path, codec)
+        .await
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                format!("otlp grpc sink: gRPC call to '{}' failed: {}", endpoint, e),
+            )
+        })
+        .map_err(SondaError::Sink)?;
+    Ok(())
+}
+
+async fn run_with_retry<F, Fut>(
+    policy: Option<&RetryPolicy>,
+    mut send_once: F,
+) -> Result<(), SondaError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<(), SondaError>>,
+{
+    let mut last_error = match send_once().await {
+        Ok(()) => return Ok(()),
+        Err(e) => e,
+    };
+    let Some(policy) = policy else {
+        return Err(last_error);
+    };
+    for attempt in 0..policy.max_attempts() {
+        if !OtlpGrpcSink::is_retryable(&last_error) {
+            return Err(last_error);
+        }
+        let backoff = policy.jittered_backoff(attempt);
+        eprintln!(
+            "sonda: retry {}/{} after {}ms (error: {})",
+            attempt + 1,
+            policy.max_attempts(),
+            backoff.as_millis(),
+            last_error,
+        );
+        tokio::time::sleep(backoff).await;
+        match send_once().await {
+            Ok(()) => return Ok(()),
+            Err(e) => last_error = e,
+        }
+    }
+    eprintln!(
+        "sonda: all {} retries exhausted (last error: {})",
+        policy.max_attempts(),
+        last_error,
+    );
+    Err(last_error)
+}
+
+#[async_trait]
 impl Sink for OtlpGrpcSink {
-    /// Accept length-prefixed OTLP protobuf bytes from the encoder.
-    ///
-    /// Parses each message from the data and adds it to the internal batch.
-    /// When the batch reaches `batch_size` entries, an automatic flush is triggered.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         match self.signal_type {
             OtlpSignalType::Metrics => {
                 let metrics = otlp::parse_length_prefixed_metrics(data)?;
@@ -472,7 +422,7 @@ impl Sink for OtlpGrpcSink {
                     && self.last_flush_at.elapsed() >= self.max_buffer_age;
                 let should_flush = size_reached || age_reached;
                 if should_flush {
-                    self.flush_metrics()?;
+                    self.flush_metrics().await?;
                 }
                 self.last_write_delivered = should_flush;
             }
@@ -484,7 +434,7 @@ impl Sink for OtlpGrpcSink {
                     && self.last_flush_at.elapsed() >= self.max_buffer_age;
                 let should_flush = size_reached || age_reached;
                 if should_flush {
-                    self.flush_logs()?;
+                    self.flush_logs().await?;
                 }
                 self.last_write_delivered = should_flush;
             }
@@ -492,14 +442,10 @@ impl Sink for OtlpGrpcSink {
         Ok(())
     }
 
-    /// Flush any remaining buffered data to the OTLP endpoint.
-    ///
-    /// Safe to call multiple times. Returns `Ok(())` immediately if the batch
-    /// is empty.
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         match self.signal_type {
-            OtlpSignalType::Metrics => self.flush_metrics(),
-            OtlpSignalType::Logs => self.flush_logs(),
+            OtlpSignalType::Metrics => self.flush_metrics().await,
+            OtlpSignalType::Logs => self.flush_logs().await,
         }
     }
 
@@ -520,24 +466,14 @@ mod tests {
     // Helpers
     // -----------------------------------------------------------------------
 
-    /// Build a sink with a lazy (non-connecting) channel pointed at a dead
-    /// address. `write()` buffers without network I/O; only a triggered flush
-    /// reaches the channel, where it fails — letting tests assert on buffer
-    /// state and on whether a flush was attempted, without a live collector.
+    /// Build a sink with a lazy (non-connecting) channel pointed at a dead address.
     fn lazy_sink(
         signal_type: OtlpSignalType,
         batch_size: usize,
         max_buffer_age: Duration,
     ) -> OtlpGrpcSink {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("build runtime");
-        let channel = runtime.block_on(async {
-            tonic::transport::Endpoint::from_static("http://127.0.0.1:1").connect_lazy()
-        });
+        let channel = tonic::transport::Endpoint::from_static("http://127.0.0.1:1").connect_lazy();
         OtlpGrpcSink {
-            runtime,
             channel,
             metric_batch: Vec::with_capacity(batch_size),
             log_batch: Vec::with_capacity(batch_size),
@@ -821,11 +757,9 @@ signal_type: logs
     // Construction failure: unreachable endpoint
     // -----------------------------------------------------------------------
 
-    /// Connecting to a port where no OTLP collector is listening must return a
-    /// SondaError::Sink.
-    #[test]
+    #[tokio::test]
     #[ignore = "requires network timeout; run with --ignored when desired"]
-    fn new_with_unreachable_endpoint_returns_sink_error() {
+    async fn new_with_unreachable_endpoint_returns_sink_error() {
         let result = OtlpGrpcSink::new(
             "http://127.0.0.1:1",
             OtlpSignalType::Metrics,
@@ -833,7 +767,8 @@ signal_type: logs
             vec![],
             None,
             Duration::ZERO,
-        );
+        )
+        .await;
         match result {
             Err(err) => {
                 let msg = err.to_string();
@@ -846,9 +781,8 @@ signal_type: logs
         }
     }
 
-    /// An invalid endpoint URL (not parseable) should return an error.
-    #[test]
-    fn new_with_invalid_endpoint_returns_error() {
+    #[tokio::test]
+    async fn new_with_invalid_endpoint_returns_error() {
         let result = OtlpGrpcSink::new(
             "not a url",
             OtlpSignalType::Metrics,
@@ -856,7 +790,8 @@ signal_type: logs
             vec![],
             None,
             Duration::ZERO,
-        );
+        )
+        .await;
         assert!(result.is_err(), "invalid endpoint URL must be rejected");
     }
 
@@ -939,22 +874,21 @@ sink:
     // Time-based flush
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn time_based_flush_fires_when_buffer_age_exceeded() {
-        // Large batch_size so size never triggers; short max_buffer_age.
+    #[tokio::test]
+    async fn time_based_flush_fires_when_buffer_age_exceeded() {
         let mut sink = lazy_sink(
             OtlpSignalType::Metrics,
             1_000_000,
             Duration::from_millis(50),
         );
 
-        sink.write(&one_metric_bytes("first")).expect("write 1");
+        sink.write(&one_metric_bytes("first"))
+            .await
+            .expect("write 1");
         assert_eq!(sink.metric_batch.len(), 1, "first write only buffers");
 
-        std::thread::sleep(Duration::from_millis(200));
-        // Second write is past max_buffer_age → triggers a time-based flush.
-        // The lazy channel has no peer, so the flush attempt fails.
-        let result = sink.write(&one_metric_bytes("second"));
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let result = sink.write(&one_metric_bytes("second")).await;
         assert!(
             result.is_err(),
             "second write past max_buffer_age must attempt a flush"
@@ -965,15 +899,15 @@ sink:
         );
     }
 
-    #[test]
-    fn time_based_flush_fires_for_log_signal() {
+    #[tokio::test]
+    async fn time_based_flush_fires_for_log_signal() {
         let mut sink = lazy_sink(OtlpSignalType::Logs, 1_000_000, Duration::from_millis(50));
 
-        sink.write(&one_log_bytes()).expect("write 1");
+        sink.write(&one_log_bytes()).await.expect("write 1");
         assert_eq!(sink.log_batch.len(), 1, "first write only buffers");
 
-        std::thread::sleep(Duration::from_millis(200));
-        let result = sink.write(&one_log_bytes());
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let result = sink.write(&one_log_bytes()).await;
         assert!(
             result.is_err(),
             "second log write past max_buffer_age must attempt a flush"
@@ -984,16 +918,21 @@ sink:
         );
     }
 
-    #[test]
-    fn zero_max_buffer_age_disables_time_based_flush() {
-        // Large batch_size, zero max_buffer_age — neither trigger should fire.
+    #[tokio::test]
+    async fn zero_max_buffer_age_disables_time_based_flush() {
         let mut sink = lazy_sink(OtlpSignalType::Metrics, 1_000_000, Duration::ZERO);
 
-        sink.write(&one_metric_bytes("first")).expect("write 1");
-        std::thread::sleep(Duration::from_millis(150));
-        sink.write(&one_metric_bytes("second")).expect("write 2");
-        std::thread::sleep(Duration::from_millis(150));
-        sink.write(&one_metric_bytes("third")).expect("write 3");
+        sink.write(&one_metric_bytes("first"))
+            .await
+            .expect("write 1");
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        sink.write(&one_metric_bytes("second"))
+            .await
+            .expect("write 2");
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        sink.write(&one_metric_bytes("third"))
+            .await
+            .expect("write 3");
 
         assert_eq!(
             sink.metric_batch.len(),
@@ -1002,41 +941,35 @@ sink:
         );
     }
 
-    #[test]
-    fn size_triggered_flush_still_works_and_resets_the_timer() {
-        // Small batch_size, max_buffer_age longer than the test runs.
+    #[tokio::test]
+    async fn size_triggered_flush_still_works_and_resets_the_timer() {
         let mut sink = lazy_sink(OtlpSignalType::Metrics, 2, Duration::from_secs(60));
 
-        sink.write(&one_metric_bytes("a")).expect("write 1 buffers");
+        sink.write(&one_metric_bytes("a"))
+            .await
+            .expect("write 1 buffers");
         assert_eq!(sink.metric_batch.len(), 1, "below batch_size: no flush");
 
-        // Second write fills the batch → size-triggered flush attempt.
-        let result = sink.write(&one_metric_bytes("b"));
+        let result = sink.write(&one_metric_bytes("b")).await;
         assert!(result.is_err(), "filling the batch must attempt a flush");
         assert!(
             sink.metric_batch.is_empty(),
             "size-triggered flush must drain the batch"
         );
 
-        // The size flush reset last_flush_at; a subsequent partial write must
-        // not immediately time-flush.
         sink.write(&one_metric_bytes("c"))
+            .await
             .expect("partial write after a size flush must not time-flush immediately");
         assert_eq!(sink.metric_batch.len(), 1, "partial write only buffers");
     }
 
-    // -----------------------------------------------------------------------
-    // last_write_delivered — buffered case
-    //
-    // Only the buffered case is unit-testable: the lazy channel has no peer,
-    // so a triggered flush always fails. Flushed-success is verified live.
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn last_write_delivered_is_false_when_metric_write_only_buffers() {
+    #[tokio::test]
+    async fn last_write_delivered_is_false_when_metric_write_only_buffers() {
         let mut sink = lazy_sink(OtlpSignalType::Metrics, 1_000_000, Duration::ZERO);
 
-        sink.write(&one_metric_bytes("buffered")).expect("write 1");
+        sink.write(&one_metric_bytes("buffered"))
+            .await
+            .expect("write 1");
 
         assert!(
             !sink.last_write_delivered(),
@@ -1044,11 +977,11 @@ sink:
         );
     }
 
-    #[test]
-    fn last_write_delivered_is_false_when_log_write_only_buffers() {
+    #[tokio::test]
+    async fn last_write_delivered_is_false_when_log_write_only_buffers() {
         let mut sink = lazy_sink(OtlpSignalType::Logs, 1_000_000, Duration::ZERO);
 
-        sink.write(&one_log_bytes()).expect("write 1");
+        sink.write(&one_log_bytes()).await.expect("write 1");
 
         assert!(
             !sink.last_write_delivered(),
@@ -1056,12 +989,8 @@ sink:
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Factory wiring: create_sink max_buffer_age parsing
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn create_sink_otlp_grpc_with_invalid_max_buffer_age_returns_err() {
+    #[tokio::test]
+    async fn create_sink_otlp_grpc_with_invalid_max_buffer_age_returns_err() {
         let config = SinkConfig::OtlpGrpc {
             endpoint: "http://127.0.0.1:1".to_string(),
             signal_type: OtlpSignalType::Metrics,
@@ -1070,7 +999,7 @@ sink:
             retry: None,
         };
         assert!(
-            create_sink(&config, None).is_err(),
+            create_sink(&config, None).await.is_err(),
             "invalid max_buffer_age must cause the factory to fail"
         );
     }

--- a/sonda-core/src/sink/remote_write.rs
+++ b/sonda-core/src/sink/remote_write.rs
@@ -18,12 +18,13 @@
 
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use prost::Message;
 
 use crate::encoder::remote_write::{parse_length_prefixed_timeseries, TimeSeries, WriteRequest};
 use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
-use crate::{EncoderError, SondaError};
+use crate::{EncoderError, RuntimeError, SondaError};
 
 /// Default batch size in TimeSeries entries — sized so low-rate scenarios flush within seconds.
 pub const DEFAULT_BATCH_SIZE: usize = 5;
@@ -108,87 +109,6 @@ impl RemoteWriteSink {
         })
     }
 
-    /// Build a WriteRequest from the current batch, prost-encode, snappy-compress,
-    /// and HTTP POST to the configured endpoint.
-    ///
-    /// Clears the batch on success or on unrecoverable error (to prevent unbounded
-    /// buffer growth).
-    fn send_batch(&mut self) -> Result<(), SondaError> {
-        if self.batch.is_empty() {
-            return Ok(());
-        }
-
-        // Reset on attempt, not success — the batch is cleared either way below.
-        self.last_flush_at = Instant::now();
-
-        // Build one WriteRequest containing all accumulated TimeSeries.
-        let write_request = WriteRequest {
-            timeseries: std::mem::take(&mut self.batch),
-        };
-
-        // Prost-encode the WriteRequest.
-        let encoded_len = write_request.encoded_len();
-        let mut proto_bytes = Vec::with_capacity(encoded_len);
-        write_request.encode(&mut proto_bytes).map_err(|e| {
-            SondaError::Encoder(EncoderError::Other(format!("protobuf encode error: {e}")))
-        })?;
-
-        // Snappy-compress using raw (block) format.
-        let mut snappy_encoder = snap::raw::Encoder::new();
-        let compressed = snappy_encoder.compress_vec(&proto_bytes).map_err(|e| {
-            SondaError::Encoder(EncoderError::Other(format!(
-                "snappy compression error: {e}"
-            )))
-        })?;
-
-        // POST with retry if configured.
-        let result = match &self.retry_policy {
-            Some(policy) => {
-                let policy = policy.clone();
-                policy.execute(|| self.do_post_checked(&compressed), Self::is_retryable)
-            }
-            None => self.do_post_checked(&compressed),
-        };
-
-        // 4xx errors (except 429) are non-retryable and treated as warn-and-discard.
-        match &result {
-            Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
-                Ok(())
-            }
-            _ => result,
-        }
-    }
-
-    /// Perform a single HTTP POST and classify the response.
-    ///
-    /// - 2xx: `Ok(())`.
-    /// - 4xx (except 429): warns and returns non-retryable `Err`.
-    /// - 429, 5xx, transport: retryable `Err`.
-    fn do_post_checked(&self, body: &[u8]) -> Result<(), SondaError> {
-        let status = self.do_post(body)?;
-
-        if (200..300).contains(&status) {
-            return Ok(());
-        }
-
-        if (400..500).contains(&status) && status != 429 {
-            eprintln!(
-                "sonda: remote_write sink: received HTTP {} from '{}'; discarding batch",
-                status, self.url
-            );
-            return Err(SondaError::Sink(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("HTTP {} from '{}'", status, self.url),
-            )));
-        }
-
-        Err(SondaError::Sink(std::io::Error::other(format!(
-            "HTTP {} from '{}'",
-            status, self.url
-        ))))
-    }
-
-    /// Classify whether an error is retryable.
     fn is_retryable(err: &SondaError) -> bool {
         if let SondaError::Sink(io_err) = err {
             let msg = io_err.to_string();
@@ -200,16 +120,30 @@ impl RemoteWriteSink {
         false
     }
 
-    /// Perform a single HTTP POST of snappy-compressed protobuf to the endpoint.
-    ///
-    /// Sets the required Prometheus remote write headers:
-    /// - `Content-Type: application/x-protobuf`
-    /// - `Content-Encoding: snappy`
-    /// - `X-Prometheus-Remote-Write-Version: 0.1.0`
-    fn do_post(&self, body: &[u8]) -> Result<u16, SondaError> {
-        let response = self
-            .client
-            .post(&self.url)
+    fn do_post_checked_at(client: &ureq::Agent, url: &str, body: &[u8]) -> Result<(), SondaError> {
+        let status = Self::do_post_at(client, url, body)?;
+        if (200..300).contains(&status) {
+            return Ok(());
+        }
+        if (400..500).contains(&status) && status != 429 {
+            eprintln!(
+                "sonda: remote_write sink: received HTTP {} from '{}'; discarding batch",
+                status, url
+            );
+            return Err(SondaError::Sink(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("HTTP {} from '{}'", status, url),
+            )));
+        }
+        Err(SondaError::Sink(std::io::Error::other(format!(
+            "HTTP {} from '{}'",
+            status, url
+        ))))
+    }
+
+    fn do_post_at(client: &ureq::Agent, url: &str, body: &[u8]) -> Result<u16, SondaError> {
+        let response = client
+            .post(url)
             .set("Content-Type", "application/x-protobuf")
             .set("Content-Encoding", "snappy")
             .set("X-Prometheus-Remote-Write-Version", "0.1.0")
@@ -220,18 +154,15 @@ impl RemoteWriteSink {
             Err(ureq::Error::Status(code, _)) => Ok(code),
             Err(e) => Err(SondaError::Sink(std::io::Error::new(
                 std::io::ErrorKind::ConnectionRefused,
-                format!("remote write to '{}' failed: {}", self.url, e),
+                format!("remote write to '{}' failed: {}", url, e),
             ))),
         }
     }
 }
 
+#[async_trait]
 impl Sink for RemoteWriteSink {
-    /// Accept length-prefixed TimeSeries bytes from the encoder.
-    ///
-    /// Parses each `TimeSeries` from the data and adds it to the internal batch.
-    /// When the batch reaches `batch_size` entries, an automatic flush is triggered.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         let timeseries_list = parse_length_prefixed_timeseries(data)?;
         self.batch.extend(timeseries_list);
 
@@ -240,24 +171,77 @@ impl Sink for RemoteWriteSink {
             !self.max_buffer_age.is_zero() && self.last_flush_at.elapsed() >= self.max_buffer_age;
         let should_flush = size_reached || age_reached;
         if should_flush {
-            self.send_batch()?;
+            self.send_via_blocking().await?;
         }
         self.last_write_delivered = should_flush;
 
         Ok(())
     }
 
-    /// Flush any remaining buffered TimeSeries to the remote write endpoint.
-    ///
-    /// Builds one `WriteRequest` containing all buffered `TimeSeries`, prost-encodes,
-    /// snappy-compresses, and HTTP POSTs the result. Safe to call multiple times;
-    /// returns `Ok(())` immediately if the batch is empty.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.send_batch()
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        self.send_via_blocking().await
     }
 
     fn last_write_delivered(&self) -> bool {
         self.last_write_delivered
+    }
+}
+
+impl RemoteWriteSink {
+    async fn send_via_blocking(&mut self) -> Result<(), SondaError> {
+        if self.batch.is_empty() {
+            return Ok(());
+        }
+        self.last_flush_at = Instant::now();
+        let write_request = WriteRequest {
+            timeseries: std::mem::take(&mut self.batch),
+        };
+        let encoded_len = write_request.encoded_len();
+        let mut proto_bytes = Vec::with_capacity(encoded_len);
+        write_request.encode(&mut proto_bytes).map_err(|e| {
+            SondaError::Encoder(EncoderError::Other(format!("protobuf encode error: {e}")))
+        })?;
+        let mut snappy_encoder = snap::raw::Encoder::new();
+        let compressed = snappy_encoder.compress_vec(&proto_bytes).map_err(|e| {
+            SondaError::Encoder(EncoderError::Other(format!(
+                "snappy compression error: {e}"
+            )))
+        })?;
+
+        let client = self.client.clone();
+        let url = self.url.clone();
+        let retry_policy = self.retry_policy.clone();
+        let join = tokio::task::spawn_blocking(move || {
+            do_send(&client, &url, &compressed, retry_policy.as_ref())
+        })
+        .await;
+        match join {
+            Ok(r) => r,
+            Err(e) => Err(SondaError::Runtime(RuntimeError::TaskPanicked(
+                e.to_string(),
+            ))),
+        }
+    }
+}
+
+fn do_send(
+    client: &ureq::Agent,
+    url: &str,
+    body: &[u8],
+    retry_policy: Option<&RetryPolicy>,
+) -> Result<(), SondaError> {
+    let result = match retry_policy {
+        Some(policy) => policy.execute(
+            || RemoteWriteSink::do_post_checked_at(client, url, body),
+            RemoteWriteSink::is_retryable,
+        ),
+        None => RemoteWriteSink::do_post_checked_at(client, url, body),
+    };
+    match &result {
+        Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
+            Ok(())
+        }
+        _ => result,
     }
 }
 
@@ -366,13 +350,13 @@ mod tests {
     // Batch accumulation and explicit flush
     // -------------------------------------------------------------------------
 
-    #[test]
-    fn write_below_batch_size_does_not_trigger_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_below_batch_size_does_not_trigger_flush() {
         let (listener, url) = mock_server_listener();
 
         let mut sink =
             RemoteWriteSink::new(&url, 100, None, Duration::ZERO).expect("construct sink");
-        sink.write(&encode_one("cpu", 1.0)).expect("write");
+        sink.write(&encode_one("cpu", 1.0)).await.expect("write");
 
         listener.set_nonblocking(true).expect("set non-blocking");
         assert!(
@@ -381,32 +365,30 @@ mod tests {
         );
     }
 
-    #[test]
-    fn explicit_flush_sends_buffered_data() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn explicit_flush_sends_buffered_data() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink =
             RemoteWriteSink::new(&url, 10_000, None, Duration::ZERO).expect("construct sink");
-        sink.write(&encode_one("cpu", 1.0)).expect("write");
-        sink.flush().expect("flush");
+        sink.write(&encode_one("cpu", 1.0)).await.expect("write");
+        sink.flush().await.expect("flush");
 
         let body = handle.join().expect("mock server thread panicked");
         let request = decode_write_request(&body);
         assert_eq!(request.timeseries.len(), 1, "flush must deliver the batch");
     }
 
-    // -------------------------------------------------------------------------
-    // last_write_delivered — buffered vs flushed
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn last_write_delivered_is_false_when_write_only_buffers() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_write_delivered_is_false_when_write_only_buffers() {
         let (listener, url) = mock_server_listener();
 
         let mut sink =
             RemoteWriteSink::new(&url, 100, None, Duration::ZERO).expect("construct sink");
-        sink.write(&encode_one("cpu", 1.0)).expect("write buffers");
+        sink.write(&encode_one("cpu", 1.0))
+            .await
+            .expect("write buffers");
 
         assert!(
             !sink.last_write_delivered(),
@@ -416,13 +398,14 @@ mod tests {
         assert!(listener.accept().is_err(), "no flush should have fired");
     }
 
-    #[test]
-    fn last_write_delivered_is_true_when_write_triggers_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn last_write_delivered_is_true_when_write_triggers_flush() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
         let mut sink = RemoteWriteSink::new(&url, 1, None, Duration::ZERO).expect("construct sink");
         sink.write(&encode_one("cpu", 1.0))
+            .await
             .expect("write triggers flush");
 
         handle.join().expect("mock server thread panicked");
@@ -432,23 +415,21 @@ mod tests {
         );
     }
 
-    // -------------------------------------------------------------------------
-    // Time-based flush
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn time_based_flush_fires_when_buffer_age_exceeded() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn time_based_flush_fires_when_buffer_age_exceeded() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        // batch_size large enough that size never triggers; short max_buffer_age.
         let mut sink = RemoteWriteSink::new(&url, 10_000, None, Duration::from_millis(50))
             .expect("construct sink");
 
-        sink.write(&encode_one("first", 1.0)).expect("write 1");
+        sink.write(&encode_one("first", 1.0))
+            .await
+            .expect("write 1");
         thread::sleep(Duration::from_millis(200));
-        // Second write is past max_buffer_age → triggers a time-based flush.
-        sink.write(&encode_one("second", 2.0)).expect("write 2");
+        sink.write(&encode_one("second", 2.0))
+            .await
+            .expect("write 2");
 
         let body = handle.join().expect("mock server thread panicked");
         let request = decode_write_request(&body);
@@ -459,18 +440,21 @@ mod tests {
         );
     }
 
-    #[test]
-    fn zero_max_buffer_age_disables_time_based_flush() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn zero_max_buffer_age_disables_time_based_flush() {
         let (listener, url) = mock_server_listener();
 
         let mut sink =
             RemoteWriteSink::new(&url, 10_000, None, Duration::ZERO).expect("construct sink");
 
-        sink.write(&encode_one("first", 1.0)).expect("write 1");
+        sink.write(&encode_one("first", 1.0))
+            .await
+            .expect("write 1");
         thread::sleep(Duration::from_millis(150));
-        sink.write(&encode_one("second", 2.0)).expect("write 2");
+        sink.write(&encode_one("second", 2.0))
+            .await
+            .expect("write 2");
 
-        // With time-based flush disabled, no request should have arrived.
         listener.set_nonblocking(true).expect("set non-blocking");
         assert!(
             listener.accept().is_err(),
@@ -478,18 +462,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn size_triggered_flush_resets_the_buffer_age_timer() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn size_triggered_flush_resets_the_buffer_age_timer() {
         let (listener, url) = mock_server_listener();
         let handle = thread::spawn(move || accept_one_and_respond(&listener, 200));
 
-        // Small batch_size, max_buffer_age comfortably longer than the test runs.
         let mut sink =
             RemoteWriteSink::new(&url, 2, None, Duration::from_secs(60)).expect("construct sink");
 
-        // Fill the batch — the size trigger fires.
-        sink.write(&encode_one("a", 1.0)).expect("write 1");
-        sink.write(&encode_one("b", 2.0)).expect("write 2");
+        sink.write(&encode_one("a", 1.0)).await.expect("write 1");
+        sink.write(&encode_one("b", 2.0)).await.expect("write 2");
 
         let body = handle.join().expect("mock server thread panicked");
         let request = decode_write_request(&body);
@@ -499,29 +481,24 @@ mod tests {
             "size-triggered flush must deliver the full batch"
         );
 
-        // The size flush reset last_flush_at; a subsequent partial-batch write
-        // must NOT immediately time-flush against the (now closed) listener.
         sink.write(&encode_one("c", 3.0))
+            .await
             .expect("partial write after a size flush must not time-flush immediately");
     }
 
-    // -------------------------------------------------------------------------
-    // Factory wiring: create_sink for RemoteWrite config
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn create_sink_remote_write_with_valid_url_returns_ok() {
+    #[tokio::test]
+    async fn create_sink_remote_write_with_valid_url_returns_ok() {
         let config = SinkConfig::RemoteWrite {
             url: "http://127.0.0.1:19999/api/v1/write".to_string(),
             batch_size: None,
             max_buffer_age: None,
             retry: None,
         };
-        assert!(create_sink(&config, None).is_ok());
+        assert!(create_sink(&config, None).await.is_ok());
     }
 
-    #[test]
-    fn create_sink_remote_write_with_invalid_max_buffer_age_returns_err() {
+    #[tokio::test]
+    async fn create_sink_remote_write_with_invalid_max_buffer_age_returns_err() {
         let config = SinkConfig::RemoteWrite {
             url: "http://127.0.0.1:19999/api/v1/write".to_string(),
             batch_size: None,
@@ -529,7 +506,7 @@ mod tests {
             retry: None,
         };
         assert!(
-            create_sink(&config, None).is_err(),
+            create_sink(&config, None).await.is_err(),
             "invalid max_buffer_age must cause the factory to fail"
         );
     }

--- a/sonda-core/src/sink/remote_write.rs
+++ b/sonda-core/src/sink/remote_write.rs
@@ -230,18 +230,12 @@ fn do_send(
     body: &[u8],
     retry_policy: Option<&RetryPolicy>,
 ) -> Result<(), SondaError> {
-    let result = match retry_policy {
+    match retry_policy {
         Some(policy) => policy.execute(
             || RemoteWriteSink::do_post_checked_at(client, url, body),
             RemoteWriteSink::is_retryable,
         ),
         None => RemoteWriteSink::do_post_checked_at(client, url, body),
-    };
-    match &result {
-        Err(SondaError::Sink(io_err)) if io_err.kind() == std::io::ErrorKind::InvalidInput => {
-            Ok(())
-        }
-        _ => result,
     }
 }
 
@@ -484,6 +478,41 @@ mod tests {
         sink.write(&encode_one("c", 3.0))
             .await
             .expect("partial write after a size flush must not time-flush immediately");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn http_4xx_propagates_as_sink_error() {
+        let (listener, url) = mock_server_listener();
+        let server = thread::spawn(move || accept_one_and_respond(&listener, 400));
+
+        let mut sink = RemoteWriteSink::new(&url, 1, None, Duration::ZERO).expect("construct sink");
+        let result = sink.write(&encode_one("cpu", 1.0)).await;
+        let _ = server.join();
+
+        match result {
+            Err(SondaError::Sink(io_err)) => {
+                assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidInput);
+                assert!(io_err.to_string().contains("HTTP 400"));
+            }
+            other => panic!("HTTP 4xx must surface as SondaError::Sink, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn http_5xx_propagates_as_sink_error() {
+        let (listener, url) = mock_server_listener();
+        let server = thread::spawn(move || accept_one_and_respond(&listener, 503));
+
+        let mut sink = RemoteWriteSink::new(&url, 1, None, Duration::ZERO).expect("construct sink");
+        let result = sink.write(&encode_one("cpu", 1.0)).await;
+        let _ = server.join();
+
+        match result {
+            Err(SondaError::Sink(io_err)) => {
+                assert!(io_err.to_string().contains("HTTP 503"));
+            }
+            other => panic!("HTTP 5xx must surface as SondaError::Sink, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/sonda-core/src/sink/retry.rs
+++ b/sonda-core/src/sink/retry.rs
@@ -173,6 +173,11 @@ impl RetryPolicy {
         Err(last_error)
     }
 
+    /// Configured retry-count cap (number of retries after the initial attempt).
+    pub fn max_attempts(&self) -> u32 {
+        self.max_attempts
+    }
+
     /// Compute a jittered backoff duration for the given attempt index (0-based).
     ///
     /// Uses exponential backoff with full jitter:
@@ -180,7 +185,7 @@ impl RetryPolicy {
     ///
     /// The jitter RNG is seeded from the backoff nanos and the current thread ID
     /// to avoid synchronized retries across sinks.
-    fn jittered_backoff(&self, attempt: u32) -> Duration {
+    pub fn jittered_backoff(&self, attempt: u32) -> Duration {
         // Compute the exponential base: initial_backoff * 2^attempt, capped at
         // max_backoff. Use checked_shl to avoid overflow for large attempt values.
         let multiplier: u32 = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);

--- a/sonda-core/src/sink/stdout.rs
+++ b/sonda-core/src/sink/stdout.rs
@@ -1,24 +1,20 @@
 //! Buffered stdout sink.
 
-use std::io::{BufWriter, Stdout, Write};
+use async_trait::async_trait;
+use tokio::io::{AsyncWriteExt, BufWriter, Stdout};
 
 use super::Sink;
 use crate::SondaError;
 
 /// A sink that writes encoded event data to stdout using a buffered writer.
-///
-/// Wraps `std::io::stdout()` in a [`BufWriter`] to avoid issuing a syscall for
-/// every event. Call [`flush`](StdoutSink::flush) to force any buffered data to
-/// be written before the program exits.
 pub struct StdoutSink {
     writer: BufWriter<Stdout>,
 }
 
 impl StdoutSink {
-    /// Create a new `StdoutSink` backed by buffered stdout.
     pub fn new() -> Self {
         Self {
-            writer: BufWriter::new(std::io::stdout()),
+            writer: BufWriter::new(tokio::io::stdout()),
         }
     }
 }
@@ -29,16 +25,18 @@ impl Default for StdoutSink {
     }
 }
 
+#[async_trait]
 impl Sink for StdoutSink {
-    /// Write `data` to the buffered stdout writer.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
-        self.writer.write_all(data).map_err(SondaError::Sink)?;
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        self.writer
+            .write_all(data)
+            .await
+            .map_err(SondaError::Sink)?;
         Ok(())
     }
 
-    /// Flush any buffered bytes to stdout.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        self.writer.flush().map_err(SondaError::Sink)?;
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        self.writer.flush().await.map_err(SondaError::Sink)?;
         Ok(())
     }
 }
@@ -57,26 +55,23 @@ mod tests {
         let _sink = StdoutSink::default();
     }
 
-    #[test]
-    fn write_and_flush_do_not_error() {
+    #[tokio::test]
+    async fn write_and_flush_do_not_error() {
         let mut sink = StdoutSink::new();
-        // Writing empty bytes is a valid no-op that still exercises the code path.
-        let write_result = sink.write(b"");
+        let write_result = sink.write(b"").await;
         assert!(write_result.is_ok());
-        let flush_result = sink.flush();
+        let flush_result = sink.flush().await;
         assert!(flush_result.is_ok());
     }
 
-    #[test]
-    fn write_non_empty_data_does_not_error() {
+    #[tokio::test]
+    async fn write_non_empty_data_does_not_error() {
         let mut sink = StdoutSink::new();
-        let result = sink.write(b"up{} 1 1700000000000\n");
+        let result = sink.write(b"up{} 1 1700000000000\n").await;
         assert!(result.is_ok());
-        // Flush to ensure buffered data is pushed through
-        assert!(sink.flush().is_ok());
+        assert!(sink.flush().await.is_ok());
     }
 
-    /// Compile-time proof that StdoutSink satisfies Send + Sync.
     #[test]
     fn stdout_sink_is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}

--- a/sonda-core/src/sink/tcp.rs
+++ b/sonda-core/src/sink/tcp.rs
@@ -1,43 +1,24 @@
 //! TCP sink — delivers encoded telemetry over a persistent TCP connection.
-//!
-//! When a retry policy is configured, the sink attempts to reconnect on
-//! write or flush failures before retrying the operation.
 
-use std::io::{BufWriter, Write};
-use std::net::TcpStream;
+use async_trait::async_trait;
+use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::net::TcpStream;
 
 use crate::sink::retry::RetryPolicy;
 use crate::sink::Sink;
 use crate::SondaError;
 
-/// Delivers encoded telemetry data over a TCP connection.
-///
-/// The underlying [`TcpStream`] is wrapped in a [`BufWriter`] to batch
-/// writes and reduce syscall overhead. When a [`RetryPolicy`] is configured,
-/// write and flush failures trigger a reconnection attempt before retrying.
+/// Delivers encoded telemetry over a buffered TCP connection.
 pub struct TcpSink {
     writer: BufWriter<TcpStream>,
-    /// Target address stored for reconnection and error messages.
     addr: String,
-    /// Optional retry policy for transient failures.
     retry_policy: Option<RetryPolicy>,
 }
 
 impl TcpSink {
-    /// Connect to `addr` and create a new [`TcpSink`].
-    ///
-    /// # Arguments
-    ///
-    /// - `addr` — remote address to connect to, e.g. `"127.0.0.1:9999"`.
-    /// - `retry_policy` — optional retry policy for transient failures.
-    ///   When `None`, errors are returned immediately (no retry).
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if the connection cannot be established
-    /// (e.g., connection refused, invalid address).
-    pub fn new(addr: &str, retry_policy: Option<RetryPolicy>) -> Result<Self, SondaError> {
+    pub async fn new(addr: &str, retry_policy: Option<RetryPolicy>) -> Result<Self, SondaError> {
         let stream = TcpStream::connect(addr)
+            .await
             .map_err(|e| std::io::Error::new(e.kind(), format!("TCP connect to {addr}: {e}")))
             .map_err(SondaError::Sink)?;
         Ok(Self {
@@ -47,9 +28,9 @@ impl TcpSink {
         })
     }
 
-    /// Attempt to reconnect to the stored address, replacing the writer.
-    fn reconnect(&mut self) -> Result<(), SondaError> {
+    async fn reconnect(&mut self) -> Result<(), SondaError> {
         let stream = TcpStream::connect(&self.addr)
+            .await
             .map_err(|e| {
                 std::io::Error::new(e.kind(), format!("TCP reconnect to {}: {e}", self.addr))
             })
@@ -57,82 +38,94 @@ impl TcpSink {
         self.writer = BufWriter::new(stream);
         Ok(())
     }
-}
 
-impl Sink for TcpSink {
-    /// Write `data` to the buffered TCP stream.
-    ///
-    /// When a retry policy is configured, failures trigger reconnection
-    /// attempts before retrying the write.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
-        let initial_result = self
-            .writer
+    async fn write_once(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        self.writer
             .write_all(data)
+            .await
             .map_err(|e| std::io::Error::new(e.kind(), format!("TCP write to {}: {e}", self.addr)))
-            .map_err(SondaError::Sink);
-
-        match initial_result {
-            Ok(()) => Ok(()),
-            Err(first_err) => {
-                if let Some(policy) = self.retry_policy.clone() {
-                    // On failure, reconnect and retry.
-                    policy.execute(
-                        || {
-                            self.reconnect()?;
-                            self.writer
-                                .write_all(data)
-                                .map_err(|e| {
-                                    std::io::Error::new(
-                                        e.kind(),
-                                        format!("TCP write to {}: {e}", self.addr),
-                                    )
-                                })
-                                .map_err(SondaError::Sink)
-                        },
-                        |_| true, // all TCP errors are retryable
-                    )
-                } else {
-                    Err(first_err)
-                }
-            }
-        }
+            .map_err(SondaError::Sink)
     }
 
-    /// Flush buffered data to the TCP stream.
-    ///
-    /// When a retry policy is configured, failures trigger reconnection
-    /// attempts before retrying the flush.
-    fn flush(&mut self) -> Result<(), SondaError> {
-        let initial_result = self
-            .writer
+    async fn flush_once(&mut self) -> Result<(), SondaError> {
+        self.writer
             .flush()
+            .await
             .map_err(|e| std::io::Error::new(e.kind(), format!("TCP flush to {}: {e}", self.addr)))
-            .map_err(SondaError::Sink);
+            .map_err(SondaError::Sink)
+    }
+}
 
-        match initial_result {
-            Ok(()) => Ok(()),
-            Err(first_err) => {
-                if let Some(policy) = self.retry_policy.clone() {
-                    policy.execute(
-                        || {
-                            self.reconnect()?;
-                            self.writer
-                                .flush()
-                                .map_err(|e| {
-                                    std::io::Error::new(
-                                        e.kind(),
-                                        format!("TCP flush to {}: {e}", self.addr),
-                                    )
-                                })
-                                .map_err(SondaError::Sink)
-                        },
-                        |_| true,
-                    )
-                } else {
-                    Err(first_err)
-                }
+#[async_trait]
+impl Sink for TcpSink {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        let mut last_error = match self.write_once(data).await {
+            Ok(()) => return Ok(()),
+            Err(e) => e,
+        };
+        let Some(policy) = self.retry_policy.clone() else {
+            return Err(last_error);
+        };
+        for attempt in 0..policy.max_attempts() {
+            let backoff = policy.jittered_backoff(attempt);
+            eprintln!(
+                "sonda: retry {}/{} after {}ms (error: {})",
+                attempt + 1,
+                policy.max_attempts(),
+                backoff.as_millis(),
+                last_error,
+            );
+            tokio::time::sleep(backoff).await;
+            if let Err(e) = self.reconnect().await {
+                last_error = e;
+                continue;
+            }
+            match self.write_once(data).await {
+                Ok(()) => return Ok(()),
+                Err(e) => last_error = e,
             }
         }
+        eprintln!(
+            "sonda: all {} retries exhausted (last error: {})",
+            policy.max_attempts(),
+            last_error,
+        );
+        Err(last_error)
+    }
+
+    async fn flush(&mut self) -> Result<(), SondaError> {
+        let mut last_error = match self.flush_once().await {
+            Ok(()) => return Ok(()),
+            Err(e) => e,
+        };
+        let Some(policy) = self.retry_policy.clone() else {
+            return Err(last_error);
+        };
+        for attempt in 0..policy.max_attempts() {
+            let backoff = policy.jittered_backoff(attempt);
+            eprintln!(
+                "sonda: retry {}/{} after {}ms (error: {})",
+                attempt + 1,
+                policy.max_attempts(),
+                backoff.as_millis(),
+                last_error,
+            );
+            tokio::time::sleep(backoff).await;
+            if let Err(e) = self.reconnect().await {
+                last_error = e;
+                continue;
+            }
+            match self.flush_once().await {
+                Ok(()) => return Ok(()),
+                Err(e) => last_error = e,
+            }
+        }
+        eprintln!(
+            "sonda: all {} retries exhausted (last error: {})",
+            policy.max_attempts(),
+            last_error,
+        );
+        Err(last_error)
     }
 }
 
@@ -145,20 +138,16 @@ mod tests {
     use super::*;
     use crate::sink::{create_sink, SinkConfig};
 
-    /// Bind a listener on an OS-assigned port and return (listener, addr_string).
     fn ephemeral_listener() -> (TcpListener, String) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
         let addr = listener.local_addr().expect("local addr").to_string();
         (listener, addr)
     }
 
-    // ---- Happy path: write + flush → data received on listener ---------------
-
-    #[test]
-    fn tcp_write_and_flush_data_arrives_at_listener() {
+    #[tokio::test]
+    async fn tcp_write_and_flush_data_arrives_at_listener() {
         let (listener, addr) = ephemeral_listener();
 
-        // Accept one connection in a background thread so we don't deadlock.
         let receiver = thread::spawn(move || {
             let (mut stream, _) = listener.accept().expect("accept");
             let mut buf = Vec::new();
@@ -166,18 +155,21 @@ mod tests {
             buf
         });
 
-        let mut sink = TcpSink::new(&addr, None).expect("connect should succeed");
-        sink.write(b"hello tcp\n").expect("write should succeed");
-        sink.flush().expect("flush should succeed");
-        // Drop the sink to close the connection so the receiver can finish.
+        let mut sink = TcpSink::new(&addr, None)
+            .await
+            .expect("connect should succeed");
+        sink.write(b"hello tcp\n")
+            .await
+            .expect("write should succeed");
+        sink.flush().await.expect("flush should succeed");
         drop(sink);
 
         let received = receiver.join().expect("receiver thread panicked");
         assert_eq!(received, b"hello tcp\n");
     }
 
-    #[test]
-    fn tcp_multiple_writes_arrive_in_order() {
+    #[tokio::test]
+    async fn tcp_multiple_writes_arrive_in_order() {
         let (listener, addr) = ephemeral_listener();
 
         let receiver = thread::spawn(move || {
@@ -187,19 +179,19 @@ mod tests {
             buf
         });
 
-        let mut sink = TcpSink::new(&addr, None).expect("connect");
-        sink.write(b"line1\n").expect("write 1");
-        sink.write(b"line2\n").expect("write 2");
-        sink.write(b"line3\n").expect("write 3");
-        sink.flush().expect("flush");
+        let mut sink = TcpSink::new(&addr, None).await.expect("connect");
+        sink.write(b"line1\n").await.expect("write 1");
+        sink.write(b"line2\n").await.expect("write 2");
+        sink.write(b"line3\n").await.expect("write 3");
+        sink.flush().await.expect("flush");
         drop(sink);
 
         let received = receiver.join().expect("receiver thread");
         assert_eq!(received, b"line1\nline2\nline3\n");
     }
 
-    #[test]
-    fn tcp_write_empty_slice_succeeds() {
+    #[tokio::test]
+    async fn tcp_write_empty_slice_succeeds() {
         let (listener, addr) = ephemeral_listener();
 
         let receiver = thread::spawn(move || {
@@ -209,25 +201,22 @@ mod tests {
             buf
         });
 
-        let mut sink = TcpSink::new(&addr, None).expect("connect");
-        sink.write(b"").expect("empty write should succeed");
-        sink.flush().expect("flush");
+        let mut sink = TcpSink::new(&addr, None).await.expect("connect");
+        sink.write(b"").await.expect("empty write should succeed");
+        sink.flush().await.expect("flush");
         drop(sink);
 
         let received = receiver.join().expect("receiver thread");
         assert!(received.is_empty());
     }
 
-    // ---- Error path: connection refused → SondaError::Sink ------------------
-
-    #[test]
-    fn tcp_connect_to_unused_port_returns_sink_error() {
-        // Find a port that is not listening by binding then dropping.
+    #[tokio::test]
+    async fn tcp_connect_to_unused_port_returns_sink_error() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let addr = listener.local_addr().expect("local addr").to_string();
-        drop(listener); // Port is now free and not listening.
+        drop(listener);
 
-        let result = TcpSink::new(&addr, None);
+        let result = TcpSink::new(&addr, None).await;
         assert!(result.is_err(), "connecting to closed port must fail");
         let err = result.err().unwrap();
         assert!(
@@ -236,13 +225,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn tcp_connect_refused_error_message_contains_address() {
+    #[tokio::test]
+    async fn tcp_connect_refused_error_message_contains_address() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
         let addr = listener.local_addr().expect("local addr").to_string();
         drop(listener);
 
-        let result = TcpSink::new(&addr, None);
+        let result = TcpSink::new(&addr, None).await;
         let err = result.err().unwrap();
         let msg = err.to_string();
         assert!(
@@ -251,11 +240,9 @@ mod tests {
         );
     }
 
-    // ---- Address parsing: invalid address → SondaError::Sink ----------------
-
-    #[test]
-    fn tcp_invalid_address_string_returns_sink_error() {
-        let result = TcpSink::new("not-a-host", None);
+    #[tokio::test]
+    async fn tcp_invalid_address_string_returns_sink_error() {
+        let result = TcpSink::new("not-a-host", None).await;
         assert!(result.is_err(), "invalid address must fail");
         assert!(
             matches!(result.err().unwrap(), SondaError::Sink(_)),
@@ -263,17 +250,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn tcp_valid_address_connects_successfully() {
+    #[tokio::test]
+    async fn tcp_valid_address_connects_successfully() {
         let (listener, addr) = ephemeral_listener();
         let _receiver = thread::spawn(move || {
             let _ = listener.accept();
         });
-        let result = TcpSink::new(&addr, None);
+        let result = TcpSink::new(&addr, None).await;
         assert!(result.is_ok(), "valid address must connect");
     }
-
-    // ---- Trait contract: Send + Sync -----------------------------------------
 
     #[test]
     fn tcp_sink_is_send_and_sync() {
@@ -281,10 +266,8 @@ mod tests {
         assert_send_sync::<TcpSink>();
     }
 
-    // ---- Factory wiring: SinkConfig::Tcp → TcpSink --------------------------
-
-    #[test]
-    fn create_sink_tcp_config_connects_and_delivers_data() {
+    #[tokio::test]
+    async fn create_sink_tcp_config_connects_and_delivers_data() {
         let (listener, addr) = ephemeral_listener();
 
         let receiver = thread::spawn(move || {
@@ -298,9 +281,11 @@ mod tests {
             address: addr.clone(),
             retry: None,
         };
-        let mut sink = create_sink(&config, None).expect("factory should create TcpSink");
-        sink.write(b"via factory\n").expect("write");
-        sink.flush().expect("flush");
+        let mut sink = create_sink(&config, None)
+            .await
+            .expect("factory should create TcpSink");
+        sink.write(b"via factory\n").await.expect("write");
+        sink.flush().await.expect("flush");
         drop(sink);
 
         let received = receiver.join().expect("receiver thread");

--- a/sonda-core/src/sink/udp.rs
+++ b/sonda-core/src/sink/udp.rs
@@ -1,21 +1,17 @@
 //! UDP sink — delivers encoded telemetry as individual datagrams.
 
-use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
+use std::net::{SocketAddr, ToSocketAddrs};
+
+use async_trait::async_trait;
+use tokio::net::UdpSocket;
 
 use crate::sink::Sink;
 use crate::SondaError;
 
-/// Maximum UDP payload size for a single datagram (IPv4).
-///
-/// The theoretical maximum is 65507 bytes (65535 − 20 IP header − 8 UDP header).
-/// Payloads larger than this cannot be sent as a single datagram.
+/// Maximum UDP payload size for a single datagram (IPv4: 65535 − 20 − 8).
 const MAX_UDP_PAYLOAD: usize = 65507;
 
 /// Delivers encoded telemetry data as UDP datagrams.
-///
-/// Each call to [`write`](UdpSink::write) sends one datagram. UDP is
-/// connectionless — no connection is established at construction time;
-/// a local ephemeral port is bound and the target address is stored.
 pub struct UdpSink {
     socket: UdpSocket,
     target: SocketAddr,
@@ -23,16 +19,7 @@ pub struct UdpSink {
 
 impl UdpSink {
     /// Bind an ephemeral local port and resolve `addr` for outgoing datagrams.
-    ///
-    /// `addr` may be a `"host:port"` string where the host is either a numeric
-    /// IP address or a DNS hostname. DNS resolution is performed at construction
-    /// time using [`ToSocketAddrs`]; the first resolved address is used.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if `addr` cannot be resolved, yields no
-    /// addresses, or if the local socket cannot be bound.
-    pub fn new(addr: &str) -> Result<Self, SondaError> {
+    pub async fn new(addr: &str) -> Result<Self, SondaError> {
         let target: SocketAddr = addr
             .to_socket_addrs()
             .map_err(|e| {
@@ -49,27 +36,22 @@ impl UdpSink {
                     format!("UDP address {addr} resolved to no addresses"),
                 ))
             })?;
-        // Bind on the wildcard address, matching the IP version of the target.
         let bind_addr = if target.is_ipv6() {
             ":::0"
         } else {
             "0.0.0.0:0"
         };
         let socket = UdpSocket::bind(bind_addr)
+            .await
             .map_err(|e| std::io::Error::new(e.kind(), format!("UDP bind for {addr}: {e}")))
             .map_err(SondaError::Sink)?;
         Ok(Self { socket, target })
     }
 }
 
+#[async_trait]
 impl Sink for UdpSink {
-    /// Send `data` as a single UDP datagram to the target address.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SondaError::Sink`] if `data` exceeds `MAX_UDP_PAYLOAD`
-    /// (65507 bytes) or if the underlying `send_to` fails.
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         if data.len() > MAX_UDP_PAYLOAD {
             return Err(SondaError::Sink(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -83,27 +65,26 @@ impl Sink for UdpSink {
         }
         self.socket
             .send_to(data, self.target)
+            .await
             .map_err(|e| std::io::Error::new(e.kind(), format!("UDP send_to {}: {e}", self.target)))
             .map_err(SondaError::Sink)?;
         Ok(())
     }
 
-    /// No-op for UDP — datagrams are not buffered.
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::net::UdpSocket;
+    use std::net::UdpSocket as StdUdpSocket;
 
     use super::*;
     use crate::sink::{create_sink, SinkConfig};
 
-    /// Bind a receiving UDP socket on an OS-assigned port. Returns (socket, addr_string).
-    fn ephemeral_receiver() -> (UdpSocket, String) {
-        let socket = UdpSocket::bind("127.0.0.1:0").expect("bind receiver");
+    fn ephemeral_receiver() -> (StdUdpSocket, String) {
+        let socket = StdUdpSocket::bind("127.0.0.1:0").expect("bind receiver");
         socket
             .set_read_timeout(Some(std::time::Duration::from_secs(2)))
             .expect("set timeout");
@@ -111,27 +92,27 @@ mod tests {
         (socket, addr)
     }
 
-    // ---- Happy path: write → recv matches ------------------------------------
-
-    #[test]
-    fn udp_write_datagram_arrives_at_receiver() {
+    #[tokio::test]
+    async fn udp_write_datagram_arrives_at_receiver() {
         let (receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
-        sink.write(b"hello udp\n").expect("write should succeed");
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
+        sink.write(b"hello udp\n")
+            .await
+            .expect("write should succeed");
 
         let mut buf = [0u8; 1024];
         let (len, _src) = receiver.recv_from(&mut buf).expect("recv_from");
         assert_eq!(&buf[..len], b"hello udp\n");
     }
 
-    #[test]
-    fn udp_multiple_writes_each_arrive_as_separate_datagram() {
+    #[tokio::test]
+    async fn udp_multiple_writes_each_arrive_as_separate_datagram() {
         let (receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
-        sink.write(b"datagram1").expect("write 1");
-        sink.write(b"datagram2").expect("write 2");
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
+        sink.write(b"datagram1").await.expect("write 1");
+        sink.write(b"datagram2").await.expect("write 2");
 
         let mut buf = [0u8; 1024];
         let (len1, _) = receiver.recv_from(&mut buf).expect("recv 1");
@@ -141,39 +122,35 @@ mod tests {
         assert_eq!(&buf[..len2], b"datagram2");
     }
 
-    #[test]
-    fn udp_write_empty_datagram_succeeds() {
+    #[tokio::test]
+    async fn udp_write_empty_datagram_succeeds() {
         let (receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
-        sink.write(b"").expect("empty write should succeed");
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
+        sink.write(b"").await.expect("empty write should succeed");
 
         let mut buf = [0u8; 1024];
         let (len, _) = receiver.recv_from(&mut buf).expect("recv");
         assert_eq!(len, 0);
     }
 
-    #[test]
-    fn udp_flush_is_noop_and_always_succeeds() {
+    #[tokio::test]
+    async fn udp_flush_is_noop_and_always_succeeds() {
         let (_receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
-        // Call flush multiple times — all must succeed (idempotent no-op).
-        sink.flush().expect("flush 1 should succeed");
-        sink.flush().expect("flush 2 should succeed");
-        sink.flush().expect("flush 3 should succeed");
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
+        sink.flush().await.expect("flush 1 should succeed");
+        sink.flush().await.expect("flush 2 should succeed");
+        sink.flush().await.expect("flush 3 should succeed");
     }
 
-    // ---- Oversized payload → SondaError::Sink --------------------------------
-
-    #[test]
-    fn udp_oversized_payload_returns_sink_error() {
+    #[tokio::test]
+    async fn udp_oversized_payload_returns_sink_error() {
         let (_receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
-        // 65508 bytes exceeds the 65507-byte limit.
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
         let oversized = vec![0u8; MAX_UDP_PAYLOAD + 1];
-        let result = sink.write(&oversized);
+        let result = sink.write(&oversized).await;
         assert!(result.is_err(), "oversized payload must return Err");
         let err = result.err().unwrap();
         assert!(
@@ -182,47 +159,38 @@ mod tests {
         );
     }
 
-    #[test]
-    fn udp_oversized_payload_error_message_mentions_sizes() {
+    #[tokio::test]
+    async fn udp_oversized_payload_error_message_mentions_sizes() {
         let (_receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
         let oversized = vec![0u8; MAX_UDP_PAYLOAD + 1];
-        let err = sink.write(&oversized).err().unwrap();
+        let err = sink.write(&oversized).await.err().unwrap();
         let msg = err.to_string();
-        // Message must include both the actual size and the limit.
         assert!(
             msg.contains("65508") || msg.contains("65507"),
             "error message should mention payload sizes; got: {msg}"
         );
     }
 
-    #[test]
-    fn udp_exactly_max_payload_succeeds() {
+    #[tokio::test]
+    async fn udp_exactly_max_payload_succeeds() {
         let (receiver, addr) = ephemeral_receiver();
 
-        let mut sink = UdpSink::new(&addr).expect("create UdpSink");
+        let mut sink = UdpSink::new(&addr).await.expect("create UdpSink");
         let max_payload = vec![0xABu8; MAX_UDP_PAYLOAD];
-        // This may fail at the OS level on loopback if the kernel refuses the
-        // datagram size, but must not fail in the size-check logic.
-        let result = sink.write(&max_payload);
-        // Whether the OS accepts it depends on system config; at minimum the
-        // size guard must not reject it.
+        let result = sink.write(&max_payload).await;
         if result.is_ok() {
             let mut buf = vec![0u8; MAX_UDP_PAYLOAD + 1];
             if let Ok((len, _)) = receiver.recv_from(&mut buf) {
                 assert_eq!(len, MAX_UDP_PAYLOAD);
             }
         }
-        // If the OS rejected it for other reasons that is acceptable — only
-        // the implementation's size guard is being tested here.
     }
 
-    // ---- Address parsing: invalid address → SondaError::Sink ----------------
-
-    #[test]
-    fn udp_invalid_address_string_returns_sink_error() {
-        let result = UdpSink::new("not-a-host");
+    #[tokio::test]
+    async fn udp_invalid_address_string_returns_sink_error() {
+        let result = UdpSink::new("not-a-host").await;
         assert!(result.is_err(), "invalid address must fail");
         assert!(
             matches!(result.err().unwrap(), SondaError::Sink(_)),
@@ -230,9 +198,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn udp_invalid_address_error_message_contains_address() {
-        let result = UdpSink::new("not-a-host");
+    #[tokio::test]
+    async fn udp_invalid_address_error_message_contains_address() {
+        let result = UdpSink::new("not-a-host").await;
         let err = result.err().unwrap();
         let msg = err.to_string();
         assert!(
@@ -241,14 +209,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn udp_valid_address_creates_sink_successfully() {
+    #[tokio::test]
+    async fn udp_valid_address_creates_sink_successfully() {
         let (_receiver, addr) = ephemeral_receiver();
-        let result = UdpSink::new(&addr);
+        let result = UdpSink::new(&addr).await;
         assert!(result.is_ok(), "valid address must succeed");
     }
-
-    // ---- Trait contract: Send + Sync -----------------------------------------
 
     #[test]
     fn udp_sink_is_send_and_sync() {
@@ -256,17 +222,17 @@ mod tests {
         assert_send_sync::<UdpSink>();
     }
 
-    // ---- Factory wiring: SinkConfig::Udp → UdpSink --------------------------
-
-    #[test]
-    fn create_sink_udp_config_delivers_datagram() {
+    #[tokio::test]
+    async fn create_sink_udp_config_delivers_datagram() {
         let (receiver, addr) = ephemeral_receiver();
 
         let config = SinkConfig::Udp {
             address: addr.clone(),
         };
-        let mut sink = create_sink(&config, None).expect("factory should create UdpSink");
-        sink.write(b"via factory\n").expect("write");
+        let mut sink = create_sink(&config, None)
+            .await
+            .expect("factory should create UdpSink");
+        sink.write(b"via factory\n").await.expect("write");
 
         let mut buf = [0u8; 1024];
         let (len, _) = receiver.recv_from(&mut buf).expect("recv");

--- a/sonda-core/tests/common/mod.rs
+++ b/sonda-core/tests/common/mod.rs
@@ -251,9 +251,9 @@ pub fn run_and_capture_stdout(entries: Vec<ScenarioEntry>) -> Vec<u8> {
                     }
                 }
 
-                let mut sink = CapturingSink {
+                let mut sink: Box<dyn Sink> = Box::new(CapturingSink {
                     buffer: buffer_for_thread,
-                };
+                });
                 run_entry_with_sink(&entry, &mut sink)
             })
             .expect("failed to spawn parity harness thread");
@@ -345,22 +345,36 @@ pub fn normalize_timestamps(bytes: &[u8]) -> Vec<u8> {
 ///
 /// The runner is driven with `shutdown: None` (the scenario's own
 /// `duration:` field bounds the run) and `stats: None` (parity tests do
-/// not inspect stats).
-fn run_entry_with_sink(entry: &ScenarioEntry, sink: &mut dyn Sink) -> Result<(), SondaError> {
-    // All four runners take the same shape: &Config, &mut dyn Sink,
-    // Option<&AtomicBool>, Option<Arc<RwLock<ScenarioStats>>>.
+/// not inspect stats). The async runner is driven from a per-call
+/// `current_thread` Tokio runtime so callers stay sync.
+fn run_entry_with_sink(entry: &ScenarioEntry, sink: &mut Box<dyn Sink>) -> Result<(), SondaError> {
     const NONE_ATOMIC: Option<&AtomicBool> = None;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime for test runner must build");
     match entry {
-        ScenarioEntry::Metrics(config) => runner::run_with_sink(config, sink, NONE_ATOMIC, None),
-        ScenarioEntry::Logs(config) => {
-            log_runner::run_logs_with_sink(config, sink, NONE_ATOMIC, None)
+        ScenarioEntry::Metrics(config) => {
+            rt.block_on(runner::run_with_sink(config, sink, NONE_ATOMIC, None))
         }
-        ScenarioEntry::Histogram(config) => {
-            histogram_runner::run_with_sink(config, sink, NONE_ATOMIC, None)
-        }
-        ScenarioEntry::Summary(config) => {
-            summary_runner::run_with_sink(config, sink, NONE_ATOMIC, None)
-        }
+        ScenarioEntry::Logs(config) => rt.block_on(log_runner::run_logs_with_sink(
+            config,
+            sink,
+            NONE_ATOMIC,
+            None,
+        )),
+        ScenarioEntry::Histogram(config) => rt.block_on(histogram_runner::run_with_sink(
+            config,
+            sink,
+            NONE_ATOMIC,
+            None,
+        )),
+        ScenarioEntry::Summary(config) => rt.block_on(summary_runner::run_with_sink(
+            config,
+            sink,
+            NONE_ATOMIC,
+            None,
+        )),
         // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary
         // (integration tests are a separate crate), so a wildcard arm is
         // required. A future signal variant has no runner wired in here yet.

--- a/sonda-core/tests/common/mod.rs
+++ b/sonda-core/tests/common/mod.rs
@@ -162,8 +162,9 @@ struct CapturingSink {
     buffer: Arc<Mutex<Vec<u8>>>,
 }
 
+#[async_trait::async_trait]
 impl Sink for CapturingSink {
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         let mut guard = self
             .buffer
             .lock()
@@ -172,7 +173,7 @@ impl Sink for CapturingSink {
         Ok(())
     }
 
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
 }

--- a/sonda-core/tests/common/mod.rs
+++ b/sonda-core/tests/common/mod.rs
@@ -19,9 +19,9 @@
 #![cfg(feature = "config")]
 #![allow(dead_code)]
 
+use sonda_core::CancellationToken;
 use std::collections::BTreeSet;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -178,54 +178,9 @@ impl Sink for CapturingSink {
     }
 }
 
-/// Run every entry in `entries` to completion against an in-memory sink,
-/// returning the raw concatenated stdout-equivalent bytes.
-///
-/// The harness mirrors a trimmed-down version of `launch_scenario`:
-///
-/// 1. `prepare_entries` expands csv_replay, desugars aliases, validates
-///    every entry, and resolves each entry's `phase_offset` into a
-///    `start_delay: Option<Duration>` — exactly the same preparation the
-///    production launcher does.
-/// 2. Each prepared entry runs on its own OS thread with a
-///    [`CapturingSink`] substituted for the user-configured sink. The
-///    shared `Arc<Mutex<Vec<u8>>>` is cloned into the thread so the parent
-///    can drain bytes after the thread joins.
-/// 3. Each thread honors its `start_delay` via `thread::sleep` (no shared
-///    shutdown signal — the scenario's own `duration:` field bounds the
-///    run, which must be set on every entry this harness sees).
-///
-/// The returned `Vec<u8>` is the raw byte stream a real stdout sink would
-/// have produced. Callers choose `assert_eq!` or a line-multiset comparison
-/// depending on whether order is deterministic for their scenario.
-///
-/// # Panics
-///
-/// Panics if `prepare_entries` fails, if a runner thread panics, or if a
-/// runner returns an error. For parity tests these are all bugs, not
-/// legitimate test outcomes.
-///
-/// # Determinism
-///
-/// All seeds, jitter seeds, and `seed:` fields must be pinned by the
-/// caller's configuration. The harness does not inject any randomness.
-/// Multi-entry output order is **not** deterministic — concurrent threads
-/// interleave writes at byte granularity. For multi-signal parity tests,
-/// compare via [`assert_line_multisets_equal`].
-///
-/// # Shutdown caveat
-///
-/// Unlike production
-/// [`launch_scenario`][sonda_core::schedule::launch::launch_scenario]
-/// — which polls a shared `Arc<AtomicBool>` every 50 ms during the
-/// `start_delay` window so an external stop signal can short-circuit the
-/// pre-roll — this harness only sleeps until the deadline elapses. It
-/// does **not** honor a shutdown signal during `start_delay`, and the
-/// runner threads are driven with `shutdown: None` thereafter. Every
-/// current call site is bounded by the scenario's own `duration:` field
-/// and never needs cancellation, so this is safe today; future callers
-/// that need cooperative cancellation must extend the harness rather
-/// than rely on it.
+/// Run every entry in `entries` to completion against an in-memory sink and
+/// return the concatenated stdout-equivalent bytes. Each entry must declare a
+/// `duration:` — the harness does not honor an external cancel signal.
 pub fn run_and_capture_stdout(entries: Vec<ScenarioEntry>) -> Vec<u8> {
     let prepared =
         prepare_entries(entries).expect("run_and_capture_stdout: prepare_entries must succeed");
@@ -342,40 +297,26 @@ pub fn normalize_timestamps(bytes: &[u8]) -> Vec<u8> {
     out
 }
 
-/// Dispatch a single `ScenarioEntry` to the runner matching its variant.
-///
-/// The runner is driven with `shutdown: None` (the scenario's own
-/// `duration:` field bounds the run) and `stats: None` (parity tests do
-/// not inspect stats). The async runner is driven from a per-call
-/// `current_thread` Tokio runtime so callers stay sync.
+/// Dispatch a single `ScenarioEntry` to the matching runner.
 fn run_entry_with_sink(entry: &ScenarioEntry, sink: &mut Box<dyn Sink>) -> Result<(), SondaError> {
-    const NONE_ATOMIC: Option<&AtomicBool> = None;
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .expect("tokio runtime for test runner must build");
+    let cancel = CancellationToken::new();
     match entry {
         ScenarioEntry::Metrics(config) => {
-            rt.block_on(runner::run_with_sink(config, sink, NONE_ATOMIC, None))
+            rt.block_on(runner::run_with_sink(config, sink, &cancel, None))
         }
-        ScenarioEntry::Logs(config) => rt.block_on(log_runner::run_logs_with_sink(
-            config,
-            sink,
-            NONE_ATOMIC,
-            None,
-        )),
-        ScenarioEntry::Histogram(config) => rt.block_on(histogram_runner::run_with_sink(
-            config,
-            sink,
-            NONE_ATOMIC,
-            None,
-        )),
-        ScenarioEntry::Summary(config) => rt.block_on(summary_runner::run_with_sink(
-            config,
-            sink,
-            NONE_ATOMIC,
-            None,
-        )),
+        ScenarioEntry::Logs(config) => {
+            rt.block_on(log_runner::run_logs_with_sink(config, sink, &cancel, None))
+        }
+        ScenarioEntry::Histogram(config) => {
+            rt.block_on(histogram_runner::run_with_sink(config, sink, &cancel, None))
+        }
+        ScenarioEntry::Summary(config) => {
+            rt.block_on(summary_runner::run_with_sink(config, sink, &cancel, None))
+        }
         // `ScenarioEntry` is `#[non_exhaustive]` across the crate boundary
         // (integration tests are a separate crate), so a wildcard arm is
         // required. A future signal variant has no runner wired in here yet.

--- a/sonda-core/tests/encoder_sink_matrix.rs
+++ b/sonda-core/tests/encoder_sink_matrix.rs
@@ -72,25 +72,27 @@ enum Op {
     StdoutSink,
 }
 
-fn check_memory_nonempty(bytes: &[u8], enc: &str) {
+async fn check_memory_nonempty(bytes: &[u8], enc: &str) {
     let mut sink = MemorySink::new();
-    sink.write(bytes).unwrap();
-    sink.flush().unwrap();
+    sink.write(bytes).await.unwrap();
+    sink.flush().await.unwrap();
     assert!(!sink.buffer.is_empty(), "{enc} encoder produced no output");
 }
 
-fn check_file_roundtrip(bytes: &[u8], tag: &str) {
+async fn check_file_roundtrip(bytes: &[u8], tag: &str) {
     let path = tmp_matrix_path(tag);
     let _ = std::fs::remove_file(&path);
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-    let mut sink = sonda_core::sink::file::FileSink::new(Path::new(&path)).unwrap();
-    sink.write(bytes).unwrap();
-    sink.flush().unwrap();
+    let mut sink = sonda_core::sink::file::FileSink::new(Path::new(&path))
+        .await
+        .unwrap();
+    sink.write(bytes).await.unwrap();
+    sink.flush().await.unwrap();
     drop(sink);
     assert_eq!(std::fs::read(&path).unwrap(), bytes);
 }
 
-fn check_tcp_delivery(bytes: &[u8]) {
+async fn check_tcp_delivery(bytes: &[u8]) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap().to_string();
     let expected = bytes.to_vec();
@@ -100,37 +102,49 @@ fn check_tcp_delivery(bytes: &[u8]) {
         s.read_to_end(&mut buf).unwrap();
         buf
     });
-    let mut sink = sonda_core::sink::tcp::TcpSink::new(&addr, None).unwrap();
-    sink.write(bytes).unwrap();
-    sink.flush().unwrap();
+    let mut sink = sonda_core::sink::tcp::TcpSink::new(&addr, None)
+        .await
+        .unwrap();
+    sink.write(bytes).await.unwrap();
+    sink.flush().await.unwrap();
     drop(sink);
     assert_eq!(rx.join().unwrap(), expected);
 }
 
-fn check_udp_delivery(bytes: &[u8]) {
+async fn check_udp_delivery(bytes: &[u8]) {
     let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
     socket
         .set_read_timeout(Some(Duration::from_secs(2)))
         .unwrap();
     let addr = socket.local_addr().unwrap().to_string();
-    let mut sink = sonda_core::sink::udp::UdpSink::new(&addr).unwrap();
-    sink.write(bytes).unwrap();
+    let mut sink = sonda_core::sink::udp::UdpSink::new(&addr).await.unwrap();
+    sink.write(bytes).await.unwrap();
     let mut buf = vec![0u8; 4096];
     let (len, _) = socket.recv_from(&mut buf).unwrap();
     assert_eq!(&buf[..len], bytes);
 }
 
-fn check_stdout(bytes: &[u8]) {
+async fn check_stdout(bytes: &[u8]) {
     let mut sink = sonda_core::sink::stdout::StdoutSink::new();
-    assert!(sink.write(bytes).is_ok());
-    assert!(sink.flush().is_ok());
+    assert!(sink.write(bytes).await.is_ok());
+    assert!(sink.flush().await.is_ok());
 }
 
 // ---------------------------------------------------------------------------
 // Encoder families
 // ---------------------------------------------------------------------------
 
-/// Prometheus text encoder: memory-shape checks + all delivery sinks.
+async fn run_op(bytes: &[u8], op: Op, tag: &str) {
+    match op {
+        Op::MemoryNonempty => check_memory_nonempty(bytes, tag).await,
+        Op::MemoryContainsIdentifier | Op::MemoryEndsNewline => unreachable!("handled inline"),
+        Op::FileSink => check_file_roundtrip(bytes, tag).await,
+        Op::TcpSink => check_tcp_delivery(bytes).await,
+        Op::UdpSink => check_udp_delivery(bytes).await,
+        Op::StdoutSink => check_stdout(bytes).await,
+    }
+}
+
 #[rstest]
 #[rustfmt::skip]
 #[case::memory_produces_nonempty_output(       Op::MemoryNonempty)]
@@ -140,21 +154,17 @@ fn check_stdout(bytes: &[u8]) {
 #[case::tcp_data_arrives_at_listener(          Op::TcpSink)]
 #[case::udp_datagram_arrives_at_receiver(      Op::UdpSink)]
 #[case::stdout_write_and_flush_succeed(        Op::StdoutSink)]
-fn prometheus_encoder_cases(#[case] op: Op) {
+#[tokio::test(flavor = "multi_thread")]
+async fn prometheus_encoder_cases(#[case] op: Op) {
     let config = EncoderConfig::PrometheusText { precision: None };
     let bytes = encode_event(&config, &test_event());
     match op {
-        Op::MemoryNonempty           => check_memory_nonempty(&bytes, "prometheus"),
         Op::MemoryContainsIdentifier => assert!(std::str::from_utf8(&bytes).unwrap().contains("matrix_test_metric")),
         Op::MemoryEndsNewline        => assert_eq!(*bytes.last().unwrap(), b'\n'),
-        Op::FileSink                 => check_file_roundtrip(&bytes, "prometheus"),
-        Op::TcpSink                  => check_tcp_delivery(&bytes),
-        Op::UdpSink                  => check_udp_delivery(&bytes),
-        Op::StdoutSink               => check_stdout(&bytes),
+        other                        => run_op(&bytes, other, "prometheus").await,
     }
 }
 
-/// InfluxDB Line Protocol encoder: memory-shape checks + all delivery sinks.
 #[rstest]
 #[rustfmt::skip]
 #[case::memory_produces_nonempty_output(       Op::MemoryNonempty)]
@@ -164,25 +174,21 @@ fn prometheus_encoder_cases(#[case] op: Op) {
 #[case::tcp_data_arrives_at_listener(          Op::TcpSink)]
 #[case::udp_datagram_arrives_at_receiver(      Op::UdpSink)]
 #[case::stdout_write_and_flush_succeed(        Op::StdoutSink)]
-fn influx_encoder_cases(#[case] op: Op) {
+#[tokio::test(flavor = "multi_thread")]
+async fn influx_encoder_cases(#[case] op: Op) {
     let config = EncoderConfig::InfluxLineProtocol { field_key: None, precision: None };
     let bytes = encode_event(&config, &test_event());
     match op {
-        Op::MemoryNonempty           => check_memory_nonempty(&bytes, "influx"),
         Op::MemoryContainsIdentifier => assert!(std::str::from_utf8(&bytes).unwrap().contains("matrix_test_metric")),
         Op::MemoryEndsNewline => {
             let text = std::str::from_utf8(&bytes).unwrap().trim_end_matches('\n').to_owned();
             let ts = text.split_whitespace().last().unwrap();
             assert!(ts.len() >= 19, "influx timestamp must be >=19 digits (nanosecond precision): {ts}");
         }
-        Op::FileSink   => check_file_roundtrip(&bytes, "influx"),
-        Op::TcpSink    => check_tcp_delivery(&bytes),
-        Op::UdpSink    => check_udp_delivery(&bytes),
-        Op::StdoutSink => check_stdout(&bytes),
+        other => run_op(&bytes, other, "influx").await,
     }
 }
 
-/// JSON Lines encoder: memory-shape checks + all delivery sinks.
 #[rstest]
 #[rustfmt::skip]
 #[case::memory_produces_nonempty_output(       Op::MemoryNonempty)]
@@ -192,20 +198,17 @@ fn influx_encoder_cases(#[case] op: Op) {
 #[case::tcp_data_arrives_at_listener(          Op::TcpSink)]
 #[case::udp_datagram_arrives_at_receiver(      Op::UdpSink)]
 #[case::stdout_write_and_flush_succeed(        Op::StdoutSink)]
-fn json_encoder_cases(#[case] op: Op) {
+#[tokio::test(flavor = "multi_thread")]
+async fn json_encoder_cases(#[case] op: Op) {
     let config = EncoderConfig::JsonLines { precision: None };
     let bytes = encode_event(&config, &test_event());
     match op {
-        Op::MemoryNonempty => check_memory_nonempty(&bytes, "json"),
         Op::MemoryContainsIdentifier => {
             let line = std::str::from_utf8(&bytes).unwrap().trim_end_matches('\n');
             assert!(serde_json::from_str::<serde_json::Value>(line).unwrap().is_object());
         }
         Op::MemoryEndsNewline => assert_eq!(*bytes.last().unwrap(), b'\n'),
-        Op::FileSink   => check_file_roundtrip(&bytes, "json"),
-        Op::TcpSink    => check_tcp_delivery(&bytes),
-        Op::UdpSink    => check_udp_delivery(&bytes),
-        Op::StdoutSink => check_stdout(&bytes),
+        other => run_op(&bytes, other, "json").await,
     }
 }
 
@@ -284,7 +287,8 @@ fn accept_http_ok(listener: &TcpListener) -> Vec<u8> {
 #[case::prometheus_http_push_body_matches(EncoderConfig::PrometheusText { precision: None },                            "text/plain; version=0.0.4")]
 #[case::influx_http_push_body_matches(    EncoderConfig::InfluxLineProtocol { field_key: None, precision: None },       "text/plain")]
 #[case::json_http_push_body_matches(      EncoderConfig::JsonLines { precision: None },                                 "application/x-ndjson")]
-fn encoder_http_push_body_matches(#[case] config: EncoderConfig, #[case] ct: &str) {
+#[tokio::test(flavor = "multi_thread")]
+async fn encoder_http_push_body_matches(#[case] config: EncoderConfig, #[case] ct: &str) {
     let (listener, url) = http_listener_url();
     let bytes = encode_event(&config, &test_event());
     let expected = bytes.clone();
@@ -292,8 +296,8 @@ fn encoder_http_push_body_matches(#[case] config: EncoderConfig, #[case] ct: &st
     let mut sink =
         sonda_core::sink::http::HttpPushSink::new(&url, ct, 10_000, HashMap::new(), None, Duration::ZERO)
             .unwrap();
-    sink.write(&bytes).unwrap();
-    sink.flush().unwrap();
+    sink.write(&bytes).await.unwrap();
+    sink.flush().await.unwrap();
     assert_eq!(server.join().unwrap(), expected);
 }
 
@@ -325,7 +329,11 @@ mod kafka_matrix {
             tls: None,
             sasl: None,
         };
-        let result = sonda_core::sink::create_sink(&cfg, None);
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(sonda_core::sink::create_sink(&cfg, None));
         let Err(e) = result else {
             panic!("expected Err from create_sink with empty broker, got Ok");
         };
@@ -362,15 +370,15 @@ mod otlp_matrix {
         )
     }
 
-    #[test]
-    fn otlp_x_memory_metric_produces_nonempty_output() {
+    #[tokio::test]
+    async fn otlp_x_memory_metric_produces_nonempty_output() {
         let mut buf = Vec::new();
         OtlpEncoder::new()
             .encode_metric(&test_event(), &mut buf)
             .unwrap();
         let mut sink = MemorySink::new();
-        sink.write(&buf).unwrap();
-        sink.flush().unwrap();
+        sink.write(&buf).await.unwrap();
+        sink.flush().await.unwrap();
         assert!(!sink.buffer.is_empty());
     }
 
@@ -383,15 +391,15 @@ mod otlp_matrix {
         assert_lp(&buf);
     }
 
-    #[test]
-    fn otlp_x_memory_log_produces_nonempty_output() {
+    #[tokio::test]
+    async fn otlp_x_memory_log_produces_nonempty_output() {
         let mut buf = Vec::new();
         OtlpEncoder::new()
             .encode_log(&log_event(Severity::Info, "msg"), &mut buf)
             .unwrap();
         let mut sink = MemorySink::new();
-        sink.write(&buf).unwrap();
-        sink.flush().unwrap();
+        sink.write(&buf).await.unwrap();
+        sink.flush().await.unwrap();
         assert!(!sink.buffer.is_empty());
     }
 
@@ -404,8 +412,8 @@ mod otlp_matrix {
         assert_lp(&buf);
     }
 
-    #[test]
-    fn otlp_x_memory_multi_metric_accumulates_in_sink() {
+    #[tokio::test]
+    async fn otlp_x_memory_multi_metric_accumulates_in_sink() {
         let enc = OtlpEncoder::new();
         let mut sink = MemorySink::new();
         for i in 0..3u64 {
@@ -415,9 +423,9 @@ mod otlp_matrix {
                 MetricEvent::with_timestamp("otlp_multi".to_owned(), i as f64, labels, ts).unwrap();
             let mut buf = Vec::new();
             enc.encode_metric(&event, &mut buf).unwrap();
-            sink.write(&buf).unwrap();
+            sink.write(&buf).await.unwrap();
         }
-        sink.flush().unwrap();
+        sink.flush().await.unwrap();
         assert!(sink.buffer.len() > 12);
     }
 }
@@ -432,7 +440,8 @@ mod otlp_matrix {
 #[case::prometheus_multi_event_accumulates_lines(EncoderConfig::PrometheusText { precision: None },                      "multi_event",  false)]
 #[case::influx_multi_event_accumulates_lines(    EncoderConfig::InfluxLineProtocol { field_key: None, precision: None }, "multi_influx", false)]
 #[case::json_multi_event_accumulates_lines(      EncoderConfig::JsonLines { precision: None },                           "multi_json",   true)]
-fn multi_event_pipeline_accumulates_correct_lines(
+#[tokio::test]
+async fn multi_event_pipeline_accumulates_correct_lines(
     #[case] config: EncoderConfig,
     #[case] metric_name: &str,
     #[case] validate_json: bool,
@@ -445,9 +454,9 @@ fn multi_event_pipeline_accumulates_correct_lines(
         let event = MetricEvent::with_timestamp(metric_name.to_owned(), i as f64, labels, ts).unwrap();
         let mut buf = Vec::new();
         encoder.encode_metric(&event, &mut buf).unwrap();
-        sink.write(&buf).unwrap();
+        sink.write(&buf).await.unwrap();
     }
-    sink.flush().unwrap();
+    sink.flush().await.unwrap();
     let text = std::str::from_utf8(&sink.buffer).unwrap();
     let lines: Vec<&str> = text.lines().collect();
     assert_eq!(lines.len(), 5);

--- a/sonda-core/tests/sink_error_policy.rs
+++ b/sonda-core/tests/sink_error_policy.rs
@@ -104,8 +104,8 @@ fn build_log_entry(name: &str, sink: SinkConfig, policy: OnSinkError) -> Scenari
     })
 }
 
-#[test]
-fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
+#[tokio::test(flavor = "multi_thread")]
+async fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
     let (listener, url) = mock_loki_listener();
     let stop = Arc::new(AtomicBool::new(false));
     let stop_listener = Arc::clone(&stop);
@@ -131,6 +131,7 @@ fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
         Arc::clone(&shutdown),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(800));
@@ -166,8 +167,8 @@ fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
     );
 }
 
-#[test]
-fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
+#[tokio::test(flavor = "multi_thread")]
+async fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
     // Bind then drop a listener so the port is guaranteed free — every flush
     // against it will fail to connect.
     let dead_url = {
@@ -195,6 +196,7 @@ fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
         Arc::clone(&shutdown),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     handle.join(Some(Duration::from_secs(3))).expect("join Ok");
@@ -217,8 +219,8 @@ fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
     );
 }
 
-#[test]
-fn fail_policy_exits_thread_with_sink_error() {
+#[tokio::test(flavor = "multi_thread")]
+async fn fail_policy_exits_thread_with_sink_error() {
     let (listener, url) = mock_loki_listener();
     let stop = Arc::new(AtomicBool::new(false));
     let stop_listener = Arc::clone(&stop);
@@ -244,6 +246,7 @@ fn fail_policy_exits_thread_with_sink_error() {
         Arc::clone(&shutdown),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     let join_result = handle.join(Some(Duration::from_secs(5)));

--- a/sonda-core/tests/sink_error_policy.rs
+++ b/sonda-core/tests/sink_error_policy.rs
@@ -13,6 +13,8 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+
+use sonda_core::CancellationToken;
 use std::thread;
 use std::time::Duration;
 
@@ -124,15 +126,10 @@ async fn warn_policy_keeps_thread_alive_under_persistent_sink_failure() {
         OnSinkError::Warn,
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handle = launch_scenario(
-        "warn-persistent".to_string(),
-        entry,
-        Arc::clone(&shutdown),
-        None,
-    )
-    .await
-    .expect("launch must succeed");
+    let cancel = CancellationToken::new();
+    let mut handle = launch_scenario("warn-persistent".to_string(), entry, cancel.clone(), None)
+        .await
+        .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(800));
     let snap_mid = handle.stats_snapshot();
@@ -189,15 +186,10 @@ async fn warn_policy_keeps_delivery_health_gated_on_real_flush() {
         OnSinkError::Warn,
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handle = launch_scenario(
-        "warn-dead-url".to_string(),
-        entry,
-        Arc::clone(&shutdown),
-        None,
-    )
-    .await
-    .expect("launch must succeed");
+    let cancel = CancellationToken::new();
+    let mut handle = launch_scenario("warn-dead-url".to_string(), entry, cancel.clone(), None)
+        .await
+        .expect("launch must succeed");
 
     handle.join(Some(Duration::from_secs(3))).expect("join Ok");
 
@@ -239,15 +231,10 @@ async fn fail_policy_exits_thread_with_sink_error() {
         OnSinkError::Fail,
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
-    let mut handle = launch_scenario(
-        "fail-propagates".to_string(),
-        entry,
-        Arc::clone(&shutdown),
-        None,
-    )
-    .await
-    .expect("launch must succeed");
+    let cancel = CancellationToken::new();
+    let mut handle = launch_scenario("fail-propagates".to_string(), entry, cancel.clone(), None)
+        .await
+        .expect("launch must succeed");
 
     let join_result = handle.join(Some(Duration::from_secs(5)));
 

--- a/sonda-core/tests/start_time_shift.rs
+++ b/sonda-core/tests/start_time_shift.rs
@@ -3,8 +3,9 @@
 
 #![cfg(feature = "config")]
 
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, RwLock};
+
+use sonda_core::CancellationToken;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -111,7 +112,7 @@ async fn metric_absolute_past_start_time_anchors_first_event_at_exact_instant() 
     let config = metric_config("up", 5.0, "1s", Some("2026-05-08T14:00:00Z"));
 
     let (mut sink, buf) = probe_sink();
-    runner::run_with_sink(&config, &mut sink, None, None)
+    runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
 
@@ -167,7 +168,7 @@ async fn metric_relative_future_offset_shifts_events_ahead() {
     let config = metric_config("up", 10.0, "400ms", Some("+24h"));
 
     let (mut sink, buf) = probe_sink();
-    runner::run_with_sink(&config, &mut sink, None, None)
+    runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
     let after = now_ms();
@@ -194,7 +195,7 @@ async fn metric_relative_past_offset_shifts_events_back() {
     let config = metric_config("up", 10.0, "400ms", Some("-7d"));
 
     let (mut sink, buf) = probe_sink();
-    runner::run_with_sink(&config, &mut sink, None, None)
+    runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
     let after = now_ms();
@@ -226,7 +227,7 @@ async fn metric_without_start_time_emits_at_real_now() {
     let config = metric_config("up", 10.0, "400ms", None);
 
     let (mut sink, buf) = probe_sink();
-    runner::run_with_sink(&config, &mut sink, None, None)
+    runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
     let after = now_ms();
@@ -264,7 +265,7 @@ fn assert_all_in_past_window(timestamps: &[i128]) {
 async fn metric_signal_honours_absolute_past_shift() {
     let config = metric_config("up", 5.0, "600ms", Some(ANCHOR_RFC3339));
     let (mut sink, buf) = probe_sink();
-    runner::run_with_sink(&config, &mut sink, None, None)
+    runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
     let captured = buf.lock().unwrap();
@@ -287,7 +288,7 @@ async fn log_signal_honours_absolute_past_shift() {
     };
 
     let (mut sink, buf) = probe_sink();
-    log_runner::run_logs_with_sink(&config, &mut sink, None, None)
+    log_runner::run_logs_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
 
@@ -323,7 +324,7 @@ async fn histogram_signal_honours_absolute_past_shift() {
     };
 
     let (mut sink, buf) = probe_sink();
-    histogram_runner::run_with_sink(&config, &mut sink, None, None)
+    histogram_runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
     let captured = buf.lock().unwrap();
@@ -348,7 +349,7 @@ async fn summary_signal_honours_absolute_past_shift() {
     };
 
     let (mut sink, buf) = probe_sink();
-    summary_runner::run_with_sink(&config, &mut sink, None, None)
+    summary_runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
         .await
         .expect("run must succeed");
     let captured = buf.lock().unwrap();
@@ -385,7 +386,7 @@ fn gated_close_emit_marker_lands_in_shifted_window() {
 
     let runner_handle = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink = sink_init;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -394,7 +395,7 @@ fn gated_close_emit_marker_lands_in_shifted_window() {
         rt.block_on(runner::run_with_sink_gated(
             &config,
             &mut sink,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(

--- a/sonda-core/tests/start_time_shift.rs
+++ b/sonda-core/tests/start_time_shift.rs
@@ -4,7 +4,7 @@
 #![cfg(feature = "config")]
 
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -18,9 +18,31 @@ use sonda_core::generator::{GeneratorConfig, LogGeneratorConfig, TemplateConfig}
 use sonda_core::schedule::gate_bus::{GateBus, SubscriptionSpec, WhileSpec};
 use sonda_core::schedule::stats::ScenarioStats;
 use sonda_core::schedule::{histogram_runner, log_runner, runner, summary_runner, GateContext};
-use sonda_core::sink::memory::MemorySink;
-use sonda_core::sink::SinkConfig;
-use sonda_core::OnSinkError;
+use sonda_core::sink::{Sink, SinkConfig};
+use sonda_core::{OnSinkError, SondaError};
+
+type SharedBuf = Arc<Mutex<Vec<u8>>>;
+
+struct ProbeSink(SharedBuf);
+
+impl Sink for ProbeSink {
+    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+        self.0
+            .lock()
+            .expect("probe sink mutex poisoned")
+            .extend_from_slice(data);
+        Ok(())
+    }
+    fn flush(&mut self) -> Result<(), SondaError> {
+        Ok(())
+    }
+}
+
+fn probe_sink() -> (Box<dyn Sink>, SharedBuf) {
+    let buf: SharedBuf = Arc::new(Mutex::new(Vec::new()));
+    let sink: Box<dyn Sink> = Box::new(ProbeSink(SharedBuf::clone(&buf)));
+    (sink, buf)
+}
 
 fn base(name: &str, rate: f64, duration: &str, start_time: Option<&str>) -> BaseScheduleConfig {
     BaseScheduleConfig {
@@ -81,16 +103,19 @@ fn now_ms() -> i128 {
         .as_millis() as i128
 }
 
-#[test]
-fn metric_absolute_past_start_time_anchors_first_event_at_exact_instant() {
+#[tokio::test]
+async fn metric_absolute_past_start_time_anchors_first_event_at_exact_instant() {
     // 2026-05-08T14:00:00Z = 1_778_248_800 s since epoch.
     let anchor_ms: i128 = 1_778_248_800_000;
     let config = metric_config("up", 5.0, "1s", Some("2026-05-08T14:00:00Z"));
 
-    let mut sink = MemorySink::new();
-    runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+    let (mut sink, buf) = probe_sink();
+    runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
 
-    let timestamps = prometheus_timestamps_ms(&sink.buffer);
+    let captured = buf.lock().unwrap();
+    let timestamps = prometheus_timestamps_ms(&captured);
     assert!(
         timestamps.len() >= 2,
         "need at least 2 events to check advancement, got {}",
@@ -135,16 +160,19 @@ fn metric_absolute_past_start_time_anchors_first_event_at_exact_instant() {
     );
 }
 
-#[test]
-fn metric_relative_future_offset_shifts_events_ahead() {
+#[tokio::test]
+async fn metric_relative_future_offset_shifts_events_ahead() {
     let before = now_ms();
     let config = metric_config("up", 10.0, "400ms", Some("+24h"));
 
-    let mut sink = MemorySink::new();
-    runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+    let (mut sink, buf) = probe_sink();
+    runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
     let after = now_ms();
 
-    let timestamps = prometheus_timestamps_ms(&sink.buffer);
+    let captured = buf.lock().unwrap();
+    let timestamps = prometheus_timestamps_ms(&captured);
     assert!(!timestamps.is_empty(), "expected emitted events");
 
     let shift = Duration::from_secs(24 * 3600).as_millis() as i128;
@@ -159,16 +187,19 @@ fn metric_relative_future_offset_shifts_events_ahead() {
     );
 }
 
-#[test]
-fn metric_relative_past_offset_shifts_events_back() {
+#[tokio::test]
+async fn metric_relative_past_offset_shifts_events_back() {
     let before = now_ms();
     let config = metric_config("up", 10.0, "400ms", Some("-7d"));
 
-    let mut sink = MemorySink::new();
-    runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+    let (mut sink, buf) = probe_sink();
+    runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
     let after = now_ms();
 
-    let timestamps = prometheus_timestamps_ms(&sink.buffer);
+    let captured = buf.lock().unwrap();
+    let timestamps = prometheus_timestamps_ms(&captured);
     assert!(!timestamps.is_empty(), "expected emitted events");
 
     let shift = Duration::from_secs(7 * 86_400).as_millis() as i128;
@@ -188,16 +219,19 @@ fn omitted_start_time_yields_now_variant() {
     assert_eq!(parse_start_time("now").unwrap(), StartTime::Now);
 }
 
-#[test]
-fn metric_without_start_time_emits_at_real_now() {
+#[tokio::test]
+async fn metric_without_start_time_emits_at_real_now() {
     let before = now_ms();
     let config = metric_config("up", 10.0, "400ms", None);
 
-    let mut sink = MemorySink::new();
-    runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+    let (mut sink, buf) = probe_sink();
+    runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
     let after = now_ms();
 
-    let timestamps = prometheus_timestamps_ms(&sink.buffer);
+    let captured = buf.lock().unwrap();
+    let timestamps = prometheus_timestamps_ms(&captured);
     assert!(!timestamps.is_empty(), "expected emitted events");
     for ts in &timestamps {
         assert!(
@@ -225,16 +259,19 @@ fn assert_all_in_past_window(timestamps: &[i128]) {
     }
 }
 
-#[test]
-fn metric_signal_honours_absolute_past_shift() {
+#[tokio::test]
+async fn metric_signal_honours_absolute_past_shift() {
     let config = metric_config("up", 5.0, "600ms", Some(ANCHOR_RFC3339));
-    let mut sink = MemorySink::new();
-    runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
-    assert_all_in_past_window(&prometheus_timestamps_ms(&sink.buffer));
+    let (mut sink, buf) = probe_sink();
+    runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
+    let captured = buf.lock().unwrap();
+    assert_all_in_past_window(&prometheus_timestamps_ms(&captured));
 }
 
-#[test]
-fn log_signal_honours_absolute_past_shift() {
+#[tokio::test]
+async fn log_signal_honours_absolute_past_shift() {
     let config = LogScenarioConfig {
         base: base("logshift", 5.0, "600ms", Some(ANCHOR_RFC3339)),
         generator: LogGeneratorConfig::Template {
@@ -248,12 +285,15 @@ fn log_signal_honours_absolute_past_shift() {
         encoder: EncoderConfig::JsonLines { precision: None },
     };
 
-    let mut sink = MemorySink::new();
-    log_runner::run_logs_with_sink(&config, &mut sink, None, None).expect("run must succeed");
+    let (mut sink, buf) = probe_sink();
+    log_runner::run_logs_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
 
     // JSON Lines stamps an RFC 3339 millis timestamp; the year is sufficient
     // to confirm the log event carries the shifted wall_clock, not real now.
-    let text = std::str::from_utf8(&sink.buffer).expect("valid UTF-8");
+    let captured = buf.lock().unwrap();
+    let text = std::str::from_utf8(&captured).expect("valid UTF-8");
     let lines: Vec<&str> = text.lines().filter(|l| !l.is_empty()).collect();
     assert!(!lines.is_empty(), "expected emitted log lines");
     for line in &lines {
@@ -264,8 +304,8 @@ fn log_signal_honours_absolute_past_shift() {
     }
 }
 
-#[test]
-fn histogram_signal_honours_absolute_past_shift() {
+#[tokio::test]
+async fn histogram_signal_honours_absolute_past_shift() {
     let config = HistogramScenarioConfig {
         base: base("latency", 5.0, "600ms", Some(ANCHOR_RFC3339)),
         buckets: Some(vec![0.1, 0.5, 1.0]),
@@ -281,13 +321,16 @@ fn histogram_signal_honours_absolute_past_shift() {
         help: None,
     };
 
-    let mut sink = MemorySink::new();
-    histogram_runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
-    assert_all_in_past_window(&prometheus_timestamps_ms(&sink.buffer));
+    let (mut sink, buf) = probe_sink();
+    histogram_runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
+    let captured = buf.lock().unwrap();
+    assert_all_in_past_window(&prometheus_timestamps_ms(&captured));
 }
 
-#[test]
-fn summary_signal_honours_absolute_past_shift() {
+#[tokio::test]
+async fn summary_signal_honours_absolute_past_shift() {
     let config = SummaryScenarioConfig {
         base: base("rpc_duration", 5.0, "600ms", Some(ANCHOR_RFC3339)),
         quantiles: Some(vec![0.5, 0.9]),
@@ -303,9 +346,12 @@ fn summary_signal_honours_absolute_past_shift() {
         help: None,
     };
 
-    let mut sink = MemorySink::new();
-    summary_runner::run_with_sink(&config, &mut sink, None, None).expect("run must succeed");
-    assert_all_in_past_window(&prometheus_timestamps_ms(&sink.buffer));
+    let (mut sink, buf) = probe_sink();
+    summary_runner::run_with_sink(&config, &mut sink, None, None)
+        .await
+        .expect("run must succeed");
+    let captured = buf.lock().unwrap();
+    assert_all_in_past_window(&prometheus_timestamps_ms(&captured));
 }
 
 #[test]
@@ -330,15 +376,21 @@ fn gated_close_emit_marker_lands_in_shifted_window() {
     };
 
     let config = metric_config("gated", 50.0, "2000ms", Some(ANCHOR_RFC3339));
-    let mut sink = MemorySink::new();
+    let (sink_init, buf) = probe_sink();
     let stats = Arc::new(RwLock::new(ScenarioStats::default()));
     let stats_for_thread = Arc::clone(&stats);
     let bus_for_thread = Arc::clone(&bus);
+    let buf_for_assert = SharedBuf::clone(&buf);
 
     let runner_handle = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        runner::run_with_sink_gated(
+        let mut sink = sink_init;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(runner::run_with_sink_gated(
             &config,
             &mut sink,
             Some(shutdown.as_ref()),
@@ -349,18 +401,18 @@ fn gated_close_emit_marker_lands_in_shifted_window() {
                     .with_delay(Some(delay))
                     .with_has_while(true),
             ),
-        )
+        ))
         .expect("gated runner must succeed");
-        sink
     });
 
     // Let the scenario accumulate shifted emissions, then close the gate so
     // the running → paused commit fires the close-emit marker.
     thread::sleep(Duration::from_millis(150));
     bus.tick(0.0);
-    let sink_after = runner_handle.join().expect("runner joined");
+    runner_handle.join().expect("runner joined");
 
-    let timestamps = prometheus_timestamps_ms(&sink_after.buffer);
+    let captured = buf_for_assert.lock().unwrap();
+    let timestamps = prometheus_timestamps_ms(&captured);
     assert!(
         timestamps.len() >= 2,
         "expected running samples plus a close marker, got {}",

--- a/sonda-core/tests/start_time_shift.rs
+++ b/sonda-core/tests/start_time_shift.rs
@@ -25,15 +25,16 @@ type SharedBuf = Arc<Mutex<Vec<u8>>>;
 
 struct ProbeSink(SharedBuf);
 
+#[async_trait::async_trait]
 impl Sink for ProbeSink {
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.0
             .lock()
             .expect("probe sink mutex poisoned")
             .extend_from_slice(data);
         Ok(())
     }
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
 }

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -105,7 +105,7 @@ fn run_with_capture(
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
 
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
@@ -123,14 +123,19 @@ fn run_with_capture(
         let gate_ctx = GateContext::new(rx, init)
             .with_delay(delay)
             .with_has_while(true);
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown.as_ref()),
             Some(stats_for_runner),
             None,
             Some(gate_ctx),
-        )
+        ))
         .expect("runner must succeed");
         let _ = bus_for_thread;
     });
@@ -292,8 +297,6 @@ fn stale_marker_disabled_emits_no_close_sample() {
 
 #[test]
 fn non_remote_write_sink_no_close_marker_by_default() {
-    use sonda_core::sink::memory::MemorySink;
-
     let bus = Arc::new(GateBus::new());
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -323,7 +326,9 @@ fn non_remote_write_sink_no_close_marker_by_default() {
         help: None,
     };
 
-    let mut sink = MemorySink::new();
+    let probe = CaptureSink::default();
+    let buf_handle = Arc::clone(&probe.buf);
+    let sink_for_thread: Box<dyn Sink> = Box::new(probe);
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -333,29 +338,34 @@ fn non_remote_write_sink_no_close_marker_by_default() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink,
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
-        )
+        ))
         .expect("runner must succeed");
-        sink
     });
 
     thread::sleep(Duration::from_millis(50));
     bus.tick(1.0);
     thread::sleep(Duration::from_millis(150));
     bus.tick(0.0);
-    let sink_after = runner.join().expect("runner joined");
+    runner.join().expect("runner joined");
 
     // Every emitted line must be a running-state sample with value 1.0
     // (the constant generator). A close-emit closure on a non-remote-write
     // sink with no `snap_to` should never be installed, so no additional
     // `NaN` (StaleMarker) or `0` (SnapTo(0)) sample line can appear.
-    let text = std::str::from_utf8(&sink_after.buffer).expect("utf-8");
+    let captured = buf_handle.lock().unwrap();
+    let text = std::str::from_utf8(&captured).expect("utf-8");
     let lines: Vec<&str> = text.lines().filter(|l| !l.is_empty()).collect();
     for line in &lines {
         let value_token = line
@@ -375,8 +385,6 @@ fn non_remote_write_sink_no_close_marker_by_default() {
 
 #[test]
 fn non_remote_write_sink_with_snap_to_emits_one_sample() {
-    use sonda_core::sink::memory::MemorySink;
-
     let bus = Arc::new(GateBus::new());
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -413,7 +421,9 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
         help: None,
     };
 
-    let mut sink = MemorySink::new();
+    let probe = CaptureSink::default();
+    let buf_handle = Arc::clone(&probe.buf);
+    let sink_for_thread: Box<dyn Sink> = Box::new(probe);
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -423,7 +433,12 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink,
             Some(shutdown.as_ref()),
@@ -434,21 +449,21 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
                     .with_delay(Some(delay))
                     .with_has_while(true),
             ),
-        )
+        ))
         .expect("runner must succeed");
-        sink
     });
 
     thread::sleep(Duration::from_millis(50));
     bus.tick(1.0);
     thread::sleep(Duration::from_millis(150));
     bus.tick(0.0);
-    let sink_after = runner.join().expect("runner joined");
+    runner.join().expect("runner joined");
 
     // Tokenize each line as `<name> <value> <timestamp>` rather than substring
     // match — the assertion stays robust if PrometheusText ever renders integer
     // values as `99.0` or trailing whitespace differently.
-    let text = std::str::from_utf8(&sink_after.buffer).expect("utf-8");
+    let captured = buf_handle.lock().unwrap();
+    let text = std::str::from_utf8(&captured).expect("utf-8");
     let snap_count = text
         .lines()
         .filter(|l| !l.is_empty())
@@ -480,7 +495,7 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -520,7 +535,12 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown.as_ref()),
@@ -531,7 +551,7 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
                     .with_delay(Some(delay))
                     .with_has_while(true),
             ),
-        )
+        ))
         .expect("runner must succeed");
     });
 
@@ -579,7 +599,7 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -619,14 +639,19 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
-        )
+        ))
         .expect("runner must succeed");
     });
 
@@ -653,8 +678,6 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
 
 #[test]
 fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
-    use sonda_core::sink::memory::MemorySink;
-
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -691,7 +714,9 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
         help: None,
     };
 
-    let mut sink = MemorySink::new();
+    let probe = CaptureSink::default();
+    let buf_handle = Arc::clone(&probe.buf);
+    let sink_for_thread: Box<dyn Sink> = Box::new(probe);
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -701,7 +726,12 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink,
             Some(shutdown.as_ref()),
@@ -712,16 +742,16 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
                     .with_delay(Some(delay))
                     .with_has_while(true),
             ),
-        )
+        ))
         .expect("runner must succeed");
-        sink
     });
 
     // Gate stays open for the whole 200ms duration — the loop exits via
     // LoopExit::DurationExpired, not a running→paused commit.
-    let sink_after = runner.join().expect("runner joined");
+    runner.join().expect("runner joined");
 
-    let text = std::str::from_utf8(&sink_after.buffer).expect("utf-8");
+    let captured = buf_handle.lock().unwrap();
+    let text = std::str::from_utf8(&captured).expect("utf-8");
     let snap_count = text
         .lines()
         .filter(|l| !l.is_empty())
@@ -754,7 +784,7 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -794,7 +824,12 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown.as_ref()),
@@ -810,7 +845,7 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
                     }))
                     .with_has_while(true),
             ),
-        )
+        ))
         .expect("runner must succeed");
     });
 
@@ -846,7 +881,7 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -886,14 +921,19 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown.as_ref()),
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
-        )
+        ))
         .expect("runner must succeed");
     });
 
@@ -928,7 +968,7 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -968,7 +1008,12 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let shutdown = Arc::new(AtomicBool::new(true));
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown.as_ref()),
@@ -984,7 +1029,7 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
                     }))
                     .with_has_while(true),
             ),
-        )
+        ))
         .expect("runner must succeed");
     });
 
@@ -1024,7 +1069,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
     let (rx, init) = bus.subscribe(while_gt_zero());
 
     let capture = CaptureSink::default();
-    let mut sink_handle = capture.clone();
+    let sink_for_thread: Box<dyn Sink> = Box::new(capture.clone());
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
@@ -1065,14 +1110,19 @@ fn shutdown_while_gate_open_emits_stale_marker() {
     let shutdown_for_thread = Arc::clone(&shutdown);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        sonda_core::schedule::runner::run_with_sink_gated(
+        let mut sink_handle = sink_for_thread;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime must build");
+        rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
             Some(shutdown_for_thread.as_ref()),
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
-        )
+        ))
         .expect("runner must succeed");
     });
 

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -15,8 +15,9 @@
 
 mod common;
 
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
+
+use sonda_core::CancellationToken;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -120,7 +121,7 @@ fn run_with_capture(
     // close the gate at the right moment.
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let gate_ctx = GateContext::new(rx, init)
             .with_delay(delay)
             .with_has_while(true);
@@ -132,7 +133,7 @@ fn run_with_capture(
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_runner),
             None,
             Some(gate_ctx),
@@ -338,7 +339,7 @@ fn non_remote_write_sink_no_close_marker_by_default() {
     let stats_for_thread = Arc::clone(&stats);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -347,7 +348,7 @@ fn non_remote_write_sink_no_close_marker_by_default() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -433,7 +434,7 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
     let stats_for_thread = Arc::clone(&stats);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -442,7 +443,7 @@ fn non_remote_write_sink_with_snap_to_emits_one_sample() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(
@@ -535,7 +536,7 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink_handle = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -544,7 +545,7 @@ fn debounce_cancelled_close_emits_no_stale_marker() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(
@@ -639,7 +640,7 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink_handle = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -648,7 +649,7 @@ fn duration_expiry_while_gate_open_emits_stale_marker() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -726,7 +727,7 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -735,7 +736,7 @@ fn duration_expiry_while_gate_open_drains_close_series_on_snap_to_sink() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(
@@ -824,7 +825,7 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink_handle = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -833,7 +834,7 @@ fn paused_to_finished_via_duration_after_running_emits_stale_marker() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(
@@ -921,7 +922,7 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink_handle = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -930,7 +931,7 @@ fn pending_to_finished_via_duration_emits_no_stale_marker() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -1008,7 +1009,7 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
     let bus_for_thread = Arc::clone(&bus);
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut sink_handle = sink_for_thread;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -1017,7 +1018,7 @@ fn multi_cycle_running_paused_to_finished_emits_one_stale_per_running_to_paused(
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown.as_ref()),
+            &cancel,
             Some(stats_for_thread),
             None,
             Some(
@@ -1074,7 +1075,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
     let stats = Arc::new(std::sync::RwLock::new(
         sonda_core::schedule::stats::ScenarioStats::default(),
     ));
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
 
     let config = ScenarioConfig {
         base: BaseScheduleConfig {
@@ -1108,7 +1109,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
 
     let stats_for_thread = Arc::clone(&stats);
     let bus_for_thread = Arc::clone(&bus);
-    let shutdown_for_thread = Arc::clone(&shutdown);
+    let cancel_for_thread = cancel.clone();
     let runner = thread::spawn(move || {
         let _ = bus_for_thread;
         let mut sink_handle = sink_for_thread;
@@ -1119,7 +1120,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
         rt.block_on(sonda_core::schedule::runner::run_with_sink_gated(
             &config,
             &mut sink_handle,
-            Some(shutdown_for_thread.as_ref()),
+            &cancel_for_thread,
             Some(stats_for_thread),
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -1128,7 +1129,7 @@ fn shutdown_while_gate_open_emits_stale_marker() {
     });
 
     thread::sleep(Duration::from_millis(150));
-    shutdown.store(false, std::sync::atomic::Ordering::SeqCst);
+    cancel.cancel();
     runner.join().expect("runner joined");
 
     let buf = capture.buf.lock().unwrap().clone();

--- a/sonda-core/tests/while_close_stale_marker.rs
+++ b/sonda-core/tests/while_close_stale_marker.rs
@@ -36,12 +36,13 @@ struct CaptureSink {
     buf: Arc<Mutex<Vec<u8>>>,
 }
 
+#[async_trait::async_trait]
 impl Sink for CaptureSink {
-    fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
+    async fn write(&mut self, data: &[u8]) -> Result<(), SondaError> {
         self.buf.lock().unwrap().extend_from_slice(data);
         Ok(())
     }
-    fn flush(&mut self) -> Result<(), SondaError> {
+    async fn flush(&mut self) -> Result<(), SondaError> {
         Ok(())
     }
 }

--- a/sonda-core/tests/while_close_workshop_repro.rs
+++ b/sonda-core/tests/while_close_workshop_repro.rs
@@ -128,8 +128,8 @@ fn label_value<'a>(ts: &'a TimeSeries, name: &str) -> Option<&'a str> {
         .map(|l| l.value.as_str())
 }
 
-#[test]
-fn workshop_paused_finished_cascade_emits_stale_marker_via_multi_runner() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_cascade_emits_stale_marker_via_multi_runner() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     // Workshop YAML compressed: 1500ms run, 200ms up / 400ms down (cycle 600ms).
@@ -191,7 +191,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     // Wait for both threads to finish (they exit when duration expires).
@@ -258,8 +260,8 @@ scenarios:
     );
 }
 
-#[test]
-fn workshop_paused_finished_cascade_default_batch_size_emits_stale_marker() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_cascade_default_batch_size_emits_stale_marker() {
     // Same scenario as above but WITHOUT explicit batch_size — falls to
     // DEFAULT_BATCH_SIZE = 5. close-emit writes one stale TimeSeries which
     // alone does NOT trigger auto-flush. Verifies invoke_close_emit's
@@ -309,7 +311,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
 
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut handles = handles;
@@ -363,8 +367,8 @@ scenarios:
 /// stats issue, this exposes it.
 ///
 /// Expectation: every gated metric has >=1 stale-NaN sample reach the wire.
-#[test]
-fn workshop_paused_finished_multi_entry_cascade_each_metric_emits_stale_marker() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_multi_entry_cascade_each_metric_emits_stale_marker() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     // Same compressed timing as Test workshop_paused_finished_cascade_emits_stale_marker_via_multi_runner
@@ -504,7 +508,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 8, "must launch primary + 7 downstream");
 
     let deadline = Instant::now() + Duration::from_secs(6);
@@ -587,8 +593,8 @@ scenarios:
 ///
 /// Compressed here: 5s duration, 600ms up / 1200ms down (cycle 1.8s), 200ms
 /// open / 0s close. ~2.7 cycles → at least 2 running→paused transitions.
-#[test]
-fn workshop_paused_finished_real_timescale_emits_stale_marker() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_paused_finished_real_timescale_emits_stale_marker() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     let yaml = format!(
@@ -635,7 +641,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(10);
@@ -1387,8 +1395,8 @@ scenarios:
     );
 }
 
-#[test]
-fn workshop_close_emit_timestamp_strictly_greater_than_active_emissions() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_close_emit_timestamp_strictly_greater_than_active_emissions() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     let yaml = format!(
@@ -1437,7 +1445,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1484,8 +1494,8 @@ scenarios:
     assert_close_ts_strictly_after_preceding_actives(&active_ts, &close_ts);
 }
 
-#[test]
-fn workshop_close_emit_stale_marker_timestamp_strictly_greater_than_active_emissions() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_close_emit_stale_marker_timestamp_strictly_greater_than_active_emissions() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     let yaml = format!(
@@ -1532,7 +1542,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + downstream");
 
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1693,8 +1705,8 @@ scenarios:
 /// TCP capture listener. Asserts at least one `bgp_oper_state` sample with
 /// value=0.0 reaches the wire AND that no stale-NaN sample is emitted (snap_to
 /// REPLACES the stale marker).
-#[test]
-fn workshop_snap_to_zero_reaches_wire_via_multi_runner() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workshop_snap_to_zero_reaches_wire_via_multi_runner() {
     let (url, captured, stop_listener) = spawn_capture_listener();
 
     let yaml = format!(
@@ -1734,7 +1746,9 @@ scenarios:
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(&yaml, &resolver).expect("compile must succeed");
 
-    let handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2, "must launch primary + gated_metric");
 
     let deadline = Instant::now() + Duration::from_secs(5);

--- a/sonda-core/tests/while_local_upstream_finishes.rs
+++ b/sonda-core/tests/while_local_upstream_finishes.rs
@@ -55,8 +55,8 @@ fn wait_for_not_alive(handle: &ScenarioHandle, timeout: Duration) {
     );
 }
 
-#[test]
-fn local_downstream_finishes_when_upstream_duration_expires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn local_downstream_finishes_when_upstream_duration_expires() {
     let yaml = r#"
 version: 2
 kind: runnable
@@ -89,7 +89,9 @@ scenarios:
 
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let mut handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2);
 
     {
@@ -108,8 +110,8 @@ scenarios:
     }
 }
 
-#[test]
-fn local_cascade_a_b_c_all_finish_when_a_finishes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn local_cascade_a_b_c_all_finish_when_a_finishes() {
     let yaml = r#"
 version: 2
 kind: runnable
@@ -153,7 +155,9 @@ scenarios:
 
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let mut handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 3);
 
     for id in ["a", "b", "c"] {
@@ -169,8 +173,8 @@ scenarios:
     }
 }
 
-#[test]
-fn local_downstream_paused_finishes_when_upstream_finishes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn local_downstream_paused_finishes_when_upstream_finishes() {
     // A non-repeating sequence drops below threshold on tick 1 and stays
     // there for the rest of the upstream's life. The downstream is
     // therefore reliably Paused (not Running) at the moment the upstream
@@ -209,7 +213,9 @@ scenarios:
 
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let mut handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2);
 
     {
@@ -229,8 +235,8 @@ scenarios:
     }
 }
 
-#[test]
-fn local_downstream_running_finishes_when_upstream_finishes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn local_downstream_running_finishes_when_upstream_finishes() {
     // Constant value > threshold keeps the downstream Running until the
     // upstream's duration expires.
     let yaml = r#"
@@ -265,7 +271,9 @@ scenarios:
 
     let resolver = InMemoryPackResolver::new();
     let compiled = compile_scenario_file_compiled(yaml, &resolver).expect("compile must succeed");
-    let mut handles = launch_multi_compiled(compiled, None).expect("launch must succeed");
+    let mut handles = launch_multi_compiled(compiled, None)
+        .await
+        .expect("launch must succeed");
     assert_eq!(handles.len(), 2);
 
     {

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -92,8 +92,8 @@ fn while_gt_zero() -> SubscriptionSpec {
     }
 }
 
-#[test]
-fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
     // Upstream metric oscillates 0 → 1 → 0 across 600ms; downstream gated
     // by `while: ref=upstream op=">" value=0`. Drive the bus directly so
     // the test is deterministic.
@@ -115,6 +115,7 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
         Some(gate_ctx),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Initially paused.
@@ -145,8 +146,8 @@ fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscription() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscription() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0); // gate open before subscription
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -164,6 +165,7 @@ fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscriptio
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(150));
@@ -181,8 +183,8 @@ fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subscriptio
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
     let bus = Arc::new(GateBus::new());
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -200,6 +202,7 @@ fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(150));
@@ -211,8 +214,8 @@ fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_no_catch_up_burst_on_resume() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_no_catch_up_burst_on_resume() {
     // Verify A1h: after a long pause, resume must emit at the configured
     // rate, not "catch up" with a burst of events.
     let bus = Arc::new(GateBus::new());
@@ -231,6 +234,7 @@ fn while_runtime_no_catch_up_burst_on_resume() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Phase 1: open then close after 200ms running.
@@ -299,8 +303,8 @@ fn metrics_entry_with_generator(
     })
 }
 
-#[test]
-fn while_runtime_sequence_generator_preserves_position_across_pause() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_sequence_generator_preserves_position_across_pause() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -326,6 +330,7 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Phase 1: emit ~3 events (150ms at 20/s). Single series → one entry.
@@ -368,8 +373,8 @@ fn while_runtime_sequence_generator_preserves_position_across_pause() {
     );
 }
 
-#[test]
-fn while_runtime_ramp_generator_slope_preserved_across_pause() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_ramp_generator_slope_preserved_across_pause() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -396,6 +401,7 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Phase 1: ~10 ticks emitted (200ms at 50/s). Single series → one entry.
@@ -436,8 +442,8 @@ fn while_runtime_ramp_generator_slope_preserved_across_pause() {
     );
 }
 
-#[test]
-fn while_runtime_finished_state_after_duration_expires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_finished_state_after_duration_expires() {
     let bus = Arc::new(GateBus::new());
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -454,6 +460,7 @@ fn while_runtime_finished_state_after_duration_expires() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     handle
@@ -463,8 +470,8 @@ fn while_runtime_finished_state_after_duration_expires() {
     assert!(matches!(snap.state, ScenarioState::Finished));
 }
 
-#[test]
-fn while_runtime_multiple_downstreams_share_one_upstream() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_multiple_downstreams_share_one_upstream() {
     // A2: two downstreams subscribe to the same upstream bus. Both must
     // transition together when the gate edge arrives.
     let bus = Arc::new(GateBus::new());
@@ -485,6 +492,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
         Some(GateContext::new(rx_a, init_a).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch a must succeed");
 
     let mut handle_b = launch_scenario_with_gates(
@@ -497,6 +505,7 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
         Some(GateContext::new(rx_b, init_b).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch b must succeed");
 
     // Both paused.
@@ -516,8 +525,8 @@ fn while_runtime_multiple_downstreams_share_one_upstream() {
     handle_b.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_logs_signal_can_be_gated_downstream() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_logs_signal_can_be_gated_downstream() {
     // BGP UPDOWN log scenario: a logs entry gated by `while:` must
     // transition through pending/running/paused.
     let bus = Arc::new(GateBus::new());
@@ -536,6 +545,7 @@ fn while_runtime_logs_signal_can_be_gated_downstream() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(50));
@@ -564,8 +574,8 @@ fn while_runtime_logs_signal_can_be_gated_downstream() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_delay_open_debounces_pause_to_running_transition() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_delay_open_debounces_pause_to_running_transition() {
     // A2a: delay.open debounces close→open. Sub during gate-closed
     // (pending → paused), then open: must wait at least delay.open
     // before emitting events.
@@ -596,6 +606,7 @@ fn while_runtime_delay_open_debounces_pause_to_running_transition() {
         ),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     bus.tick(1.0);
@@ -622,8 +633,8 @@ fn while_runtime_delay_open_debounces_pause_to_running_transition() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_strict_lt_threshold_gating() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_strict_lt_threshold_gating() {
     // Inverse direction: `while: ref=src op="<" value=10` opens when
     // upstream drops below threshold.
     let bus = Arc::new(GateBus::new());
@@ -650,6 +661,7 @@ fn while_runtime_strict_lt_threshold_gating() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(50));
@@ -663,8 +675,8 @@ fn while_runtime_strict_lt_threshold_gating() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn scenario_restart_does_not_leak_gate_bus() {
+#[tokio::test(flavor = "multi_thread")]
+async fn scenario_restart_does_not_leak_gate_bus() {
     // Risk #4 from phases.md: spawn 50 short-lived gated scenarios in
     // a loop, assert the bus's Arc count returns to baseline after each
     // scenario finishes.
@@ -685,6 +697,7 @@ fn scenario_restart_does_not_leak_gate_bus() {
             Some(GateContext::new(rx, init).with_has_while(true)),
             None,
         )
+        .await
         .expect("launch must succeed");
         handle
             .join(Some(Duration::from_secs(2)))
@@ -700,8 +713,8 @@ fn scenario_restart_does_not_leak_gate_bus() {
     );
 }
 
-#[test]
-fn while_runtime_delay_close_debounces_running_to_paused_transition() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_delay_close_debounces_running_to_paused_transition() {
     // delay.close: a brief gate-close-then-reopen within the debounce
     // window must NOT pause the scenario; a sustained close (≥ delay.close)
     // does. Mirrors the delay.open debounce test but for the opposite
@@ -733,6 +746,7 @@ fn while_runtime_delay_close_debounces_running_to_paused_transition() {
         ),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(150));
@@ -767,8 +781,8 @@ fn while_runtime_delay_close_debounces_running_to_paused_transition() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
     // Subscribe with both after: and while: on the same upstream. Initial
     // value 1 → after-not-fired (op="<", threshold=1, strict), gate closed
     // (op="<", threshold=1, strict) — state = Pending. Drive value to 0
@@ -809,6 +823,7 @@ fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
         ),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(80));
@@ -834,8 +849,8 @@ fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
     // Use a single upstream where after.op=">" threshold=100 and
     // while.op="<" threshold=10. Sequence:
     //
@@ -879,6 +894,7 @@ fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
         ),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Pending: gate is initially open but after has not fired.
@@ -918,8 +934,8 @@ fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
     // While Pending (after not yet satisfied), repeated WhileOpen /
     // WhileClose edges on the same upstream must not transition the
     // scenario out of Pending. Single-bus approach: after.op=">"
@@ -960,6 +976,7 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
         ),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Toggle the gate several times while still Pending. None of these
@@ -998,8 +1015,8 @@ fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
     // Subscribe with after.op=">" threshold=100 at value=5: after has not
     // fired, gate is irrelevant (after gates Pending entry). Broadcast
     // UpstreamGone while still Pending. With if_unresolved=None, the
@@ -1037,6 +1054,7 @@ fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
         ),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     thread::sleep(Duration::from_millis(80));
@@ -1073,12 +1091,12 @@ fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() {
     handle.join(Some(Duration::from_secs(2))).ok();
 }
 
-#[test]
-fn while_runtime_steady_within_5pct_of_baseline() {
+#[tokio::test(flavor = "multi_thread")]
+async fn while_runtime_steady_within_5pct_of_baseline() {
     // Perf-regression gate (A10): a scenario with `while:` open the entire
     // run must produce within 5% of the event count of the same scenario
     // without `while:`. Both runs are short (300ms) to keep the test fast.
-    fn run_baseline() -> u64 {
+    async fn run_baseline() -> u64 {
         let entry = metrics_entry("baseline", 1000.0, 300);
         let shutdown = Arc::new(AtomicBool::new(true));
         let mut handle = launch_scenario_with_gates(
@@ -1091,12 +1109,13 @@ fn while_runtime_steady_within_5pct_of_baseline() {
             None,
             None,
         )
+        .await
         .unwrap();
         handle.join(Some(Duration::from_secs(2))).unwrap();
         handle.stats_snapshot().total_events
     }
 
-    fn run_gated_open() -> u64 {
+    async fn run_gated_open() -> u64 {
         let bus = Arc::new(GateBus::new());
         bus.tick(1.0);
         let (rx, init) = bus.subscribe(while_gt_zero());
@@ -1112,17 +1131,18 @@ fn while_runtime_steady_within_5pct_of_baseline() {
             Some(GateContext::new(rx, init).with_has_while(true)),
             None,
         )
+        .await
         .unwrap();
         handle.join(Some(Duration::from_secs(2))).unwrap();
         handle.stats_snapshot().total_events
     }
 
     // Warm-up to stabilize TLB / page-fault behavior.
-    let _ = run_baseline();
-    let _ = run_gated_open();
+    let _ = run_baseline().await;
+    let _ = run_gated_open().await;
 
-    let baseline = run_baseline();
-    let gated = run_gated_open();
+    let baseline = run_baseline().await;
+    let gated = run_gated_open().await;
 
     let baseline_f = baseline as f64;
     let gated_f = gated as f64;
@@ -1231,8 +1251,8 @@ scenarios:
         .expect("legacy delay.close shorthand must still parse");
 }
 
-#[test]
-fn nan_upstream_value_keeps_downstream_paused() {
+#[tokio::test(flavor = "multi_thread")]
+async fn nan_upstream_value_keeps_downstream_paused() {
     let bus = Arc::new(GateBus::new());
     bus.tick(f64::NAN);
     let (rx, init) = bus.subscribe(while_gt_zero());
@@ -1254,6 +1274,7 @@ fn nan_upstream_value_keeps_downstream_paused() {
         Some(GateContext::new(rx, init).with_has_while(true)),
         None,
     )
+    .await
     .expect("launch must succeed");
 
     // Re-publish NaN periodically to confirm the runtime defense holds

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -8,7 +8,6 @@
 
 mod common;
 
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -22,6 +21,7 @@ use sonda_core::schedule::launch::launch_scenario_with_gates;
 use sonda_core::schedule::stats::ScenarioState;
 use sonda_core::schedule::GateContext;
 use sonda_core::sink::SinkConfig;
+use sonda_core::CancellationToken;
 
 fn metrics_entry(name: &str, rate: f64, duration_ms: u64) -> ScenarioEntry {
     ScenarioEntry::Metrics(ScenarioConfig {
@@ -101,7 +101,7 @@ async fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let gate_ctx = GateContext::new(rx, init).with_has_while(true);
 
     let entry = metrics_entry("downstream", 200.0, 600);
@@ -109,7 +109,7 @@ async fn issue_295_repro_gated_scenario_emits_only_when_gate_open() {
         "downstream".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(gate_ctx),
@@ -153,13 +153,13 @@ async fn while_runtime_state_starts_pending_then_running_when_gate_open_at_subsc
     let (rx, init) = bus.subscribe(while_gt_zero());
     assert_eq!(init.while_gate_open, Some(true));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("d1", 100.0, 300);
     let mut handle = launch_scenario_with_gates(
         "d1".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -190,13 +190,13 @@ async fn while_runtime_state_starts_paused_when_gate_closed_at_subscription() {
     let (rx, init) = bus.subscribe(while_gt_zero());
     assert_eq!(init.while_gate_open, Some(false));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("d2", 100.0, 300);
     let mut handle = launch_scenario_with_gates(
         "d2".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -222,13 +222,13 @@ async fn while_runtime_no_catch_up_burst_on_resume() {
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("d3", 100.0, 1500);
     let mut handle = launch_scenario_with_gates(
         "d3".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -309,7 +309,7 @@ async fn while_runtime_sequence_generator_preserves_position_across_pause() {
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let values = vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0];
     let entry = metrics_entry_with_generator(
         "seq_gated",
@@ -324,7 +324,7 @@ async fn while_runtime_sequence_generator_preserves_position_across_pause() {
         "seq_gated".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -379,7 +379,7 @@ async fn while_runtime_ramp_generator_slope_preserved_across_pause() {
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     // Sawtooth (saturation desugars to this): 0 → 100 over 4s at 50/s.
     let entry = metrics_entry_with_generator(
         "sat_gated",
@@ -395,7 +395,7 @@ async fn while_runtime_ramp_generator_slope_preserved_across_pause() {
         "sat_gated".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -448,13 +448,13 @@ async fn while_runtime_finished_state_after_duration_expires() {
     bus.tick(1.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("d4", 50.0, 200);
     let mut handle = launch_scenario_with_gates(
         "d4".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -480,13 +480,13 @@ async fn while_runtime_multiple_downstreams_share_one_upstream() {
     let (rx_a, init_a) = bus.subscribe(while_gt_zero());
     let (rx_b, init_b) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
 
     let mut handle_a = launch_scenario_with_gates(
         "a".to_string(),
         None,
         metrics_entry("a", 100.0, 500),
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx_a, init_a).with_has_while(true)),
@@ -499,7 +499,7 @@ async fn while_runtime_multiple_downstreams_share_one_upstream() {
         "b".to_string(),
         None,
         metrics_entry("b", 100.0, 500),
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx_b, init_b).with_has_while(true)),
@@ -533,13 +533,13 @@ async fn while_runtime_logs_signal_can_be_gated_downstream() {
     bus.tick(0.0);
     let (rx, init) = bus.subscribe(while_gt_zero());
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = logs_entry("bgp_log", 200.0, 600);
     let mut handle = launch_scenario_with_gates(
         "bgp_log".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -590,13 +590,13 @@ async fn while_runtime_delay_open_debounces_pause_to_running_transition() {
         close_snap_to: None,
     };
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("debounced", 200.0, 1500);
     let mut handle = launch_scenario_with_gates(
         "debounced".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -649,13 +649,13 @@ async fn while_runtime_strict_lt_threshold_gating() {
     let (rx, init) = bus.subscribe(spec);
     assert_eq!(init.while_gate_open, Some(false));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("inv", 100.0, 500);
     let mut handle = launch_scenario_with_gates(
         "inv".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),
@@ -685,13 +685,13 @@ async fn scenario_restart_does_not_leak_gate_bus() {
 
     for i in 0..20 {
         let (rx, init) = bus.subscribe(while_gt_zero());
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let entry = metrics_entry(&format!("ephemeral_{i}"), 50.0, 80);
         let mut handle = launch_scenario_with_gates(
             format!("ephemeral_{i}"),
             None,
             entry,
-            shutdown,
+            cancel,
             None,
             None,
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -730,13 +730,13 @@ async fn while_runtime_delay_close_debounces_running_to_paused_transition() {
         close_snap_to: None,
     };
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("debounced_close", 200.0, 2000);
     let mut handle = launch_scenario_with_gates(
         "debounced_close".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -807,13 +807,13 @@ async fn while_runtime_pending_to_running_when_after_fires_with_gate_open() {
         "gate must be closed at value=1"
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("after_open", 100.0, 1000);
     let mut handle = launch_scenario_with_gates(
         "after_open".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -878,13 +878,13 @@ async fn while_runtime_pending_to_paused_when_after_fires_with_gate_closed() {
     assert!(!init.after_already_fired);
     assert_eq!(init.while_gate_open, Some(true));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("after_paused", 100.0, 1500);
     let mut handle = launch_scenario_with_gates(
         "after_paused".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -960,13 +960,13 @@ async fn while_runtime_pending_absorbs_while_edges_before_after_fires() {
     assert!(!init.after_already_fired);
     assert_eq!(init.while_gate_open, Some(false));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("absorb", 100.0, 2000);
     let mut handle = launch_scenario_with_gates(
         "absorb".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -1038,13 +1038,13 @@ async fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() 
     assert!(!init.after_already_fired);
     assert_eq!(init.while_gate_open, Some(true));
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("pending_upstream_gone", 100.0, 5000);
     let mut handle = launch_scenario_with_gates(
         "pending_upstream_gone".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(
@@ -1098,12 +1098,12 @@ async fn while_runtime_steady_within_5pct_of_baseline() {
     // without `while:`. Both runs are short (300ms) to keep the test fast.
     async fn run_baseline() -> u64 {
         let entry = metrics_entry("baseline", 1000.0, 300);
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut handle = launch_scenario_with_gates(
             "baseline".to_string(),
             None,
             entry,
-            shutdown,
+            cancel,
             None,
             None,
             None,
@@ -1120,12 +1120,12 @@ async fn while_runtime_steady_within_5pct_of_baseline() {
         bus.tick(1.0);
         let (rx, init) = bus.subscribe(while_gt_zero());
         let entry = metrics_entry("gated", 1000.0, 300);
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut handle = launch_scenario_with_gates(
             "gated".to_string(),
             None,
             entry,
-            shutdown,
+            cancel,
             None,
             Some(Arc::clone(&bus)),
             Some(GateContext::new(rx, init).with_has_while(true)),
@@ -1262,13 +1262,13 @@ async fn nan_upstream_value_keeps_downstream_paused() {
         "NaN upstream must close the gate at subscription"
     );
 
-    let shutdown = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     let entry = metrics_entry("nan_paused", 200.0, 600);
     let mut handle = launch_scenario_with_gates(
         "nan_paused".to_string(),
         None,
         entry,
-        Arc::clone(&shutdown),
+        cancel.clone(),
         None,
         None,
         Some(GateContext::new(rx, init).with_has_while(true)),

--- a/sonda-server/CLAUDE.md
+++ b/sonda-server/CLAUDE.md
@@ -21,8 +21,12 @@ src/
 ├── auth.rs             ← require_api_key middleware (Bearer token), unauthorized() helper,
 │                         extract_bearer_token(), constant-time key comparison via subtle
 ├── routes/
-│   ├── mod.rs          ← router() function: splits public (/health) and protected (/scenarios/*,
-│                         /events) sub-routers; applies auth middleware via route_layer on protected routes
+│   ├── mod.rs          ← router_with_config() function: splits three sub-routers — public (/health),
+│                         protected observability (/scenarios/{id}/stats, /scenarios/{id}/metrics,
+│                         /metrics, /server/metrics), and protected control (/scenarios POST/GET,
+│                         /scenarios/{id} GET/DELETE, /events). Auth + request-metrics middleware
+│                         applied per protected sub-router; the control sub-router additionally
+│                         carries the timeout + body-limit + global-concurrency tower stack.
 │   ├── health.rs       ← GET /health → {"status": "ok"}
 │   ├── events.rs       ← POST /events: synchronous single-event emission. Tagged-enum
 │                         request body, dispatches on signal_type, builds LogEvent/MetricEvent,
@@ -88,9 +92,15 @@ Server Error` with a JSON error body instead of panicking. The per-scenario stat
 
 ## Concurrency Model
 
-Each scenario runs on a dedicated thread (spawned by `sonda_core::schedule::launch::launch_scenario`).
-The axum handler stores and queries `ScenarioHandle` instances from sonda-core. This keeps sonda-core
-synchronous while the server handles HTTP I/O asynchronously via tokio.
+Scenarios run as tokio tasks on the shared multi-thread runtime that hosts the axum HTTP layer
+(spawned by `sonda_core::schedule::launch::launch_scenario`). sonda-core is async-native: the
+runner loop, the encoder layer, and every sink share the same runtime as the HTTP handlers. The
+axum handler stores `ScenarioHandle` instances in `AppState` and queries them via the lock-free
+`stats_snapshot()` path. Per-request bounding is provided by `--max-inflight-requests` (a
+`tower::limit::GlobalConcurrencyLimitLayer` over an `Arc<Semaphore>`); per-scenario bounding is
+provided by `--max-scenarios`. Worker count defaults to `min(available_parallelism(), 16)` —
+host-CPU- and cgroup-aware, with a hard ceiling so a 64-core production host doesn't spawn 64
+worker threads.
 
 ## Authentication
 
@@ -135,7 +145,7 @@ Keep `SONDA_SUBCOMMANDS` in sync with `sonda`'s clap definitions.
 | `serde` + `serde_json` + `serde_yaml_ng` | Request/response serialization       |
 | `anyhow`           | Error handling in binary code                             |
 | `clap`             | CLI argument parsing                                      |
-| `tower-http`       | CORS and trace middleware                                 |
+| `tower-http`       | Timeout + request-body limit middleware for control routes |
 | `tracing` + `tracing-subscriber` | Structured logging                      |
 | `subtle`           | Constant-time byte comparison for API key auth            |
 | `uuid`             | Generating scenario IDs                                   |

--- a/sonda-server/CLAUDE.md
+++ b/sonda-server/CLAUDE.md
@@ -26,7 +26,7 @@ src/
 │   ├── health.rs       ← GET /health → {"status": "ok"}
 │   ├── events.rs       ← POST /events: synchronous single-event emission. Tagged-enum
 │                         request body, dispatches on signal_type, builds LogEvent/MetricEvent,
-│                         delegates to sonda_core::emit::{emit_log, emit_metric} via spawn_blocking.
+│                         awaits sonda_core::emit::{emit_log, emit_metric} directly.
 │                         Maps SondaError variants to HTTP status (Config→422, Sink→502, others→500).
 │   ├── sink_warnings.rs ← shared loopback pre-flight helpers (extract_host,
 │                          is_loopback_host, sink_loopback_warnings, collect_warnings_for_sink,

--- a/sonda-server/Cargo.toml
+++ b/sonda-server/Cargo.toml
@@ -33,14 +33,14 @@ serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["env"] }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["timeout", "limit"] }
+tower = { version = "0.5", features = ["limit"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 subtle = "2"
 
 [dev-dependencies]
-tower = "0.5"
 http-body-util = "0.1"
 hyper = "1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls"] }

--- a/sonda-server/Cargo.toml
+++ b/sonda-server/Cargo.toml
@@ -47,3 +47,6 @@ libc = "0.2"
 tempfile = "3"
 insta = { workspace = true, features = ["filters", "redactions"] }
 rstest = { workspace = true }
+
+[lints]
+workspace = true

--- a/sonda-server/Cargo.toml
+++ b/sonda-server/Cargo.toml
@@ -27,6 +27,7 @@ path = "src/main.rs"
 sonda-core = { workspace = true }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }

--- a/sonda-server/build.rs
+++ b/sonda-server/build.rs
@@ -1,0 +1,41 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    let sha = git_head_sha().unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=SONDA_GIT_SHA={sha}");
+
+    if let Some(head) = git_head_path() {
+        println!("cargo:rerun-if-changed={}", head.display());
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn git_head_sha() -> Option<String> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&manifest_dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(output.stdout).ok()?;
+    let trimmed = sha.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn git_head_path() -> Option<PathBuf> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let candidate = PathBuf::from(manifest_dir).join("../.git/HEAD");
+    if candidate.exists() {
+        Some(candidate)
+    } else {
+        None
+    }
+}

--- a/sonda-server/src/gate_registry.rs
+++ b/sonda-server/src/gate_registry.rs
@@ -9,6 +9,7 @@ use sonda_core::schedule::gate_bus::{
     RegistryError, WhileSpec,
 };
 use sonda_core::schedule::stats::ScenarioStats;
+use sonda_core::ScenarioState;
 use sonda_core::UnresolvedBehavior;
 
 type BusKey = (String, String);
@@ -150,6 +151,23 @@ impl GateBusResolver for GateBusRegistry {
         let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
         let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
 
+        let stale_pending: Vec<String> = pending
+            .iter()
+            .filter(|(_, entry)| entry.scenario_name == scenario_name)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for handle_id in stale_pending {
+            let entry = pending.remove(&handle_id).expect("just snapshotted");
+            entry.edge_sender.send_replace(Some(GateEdge::UpstreamGone));
+            if let Some(stats_arc) = entry.stats.upgrade() {
+                if let Ok(mut s) = stats_arc.write() {
+                    if s.state != ScenarioState::Finished {
+                        s.transition_state(ScenarioState::Unresolved);
+                    }
+                }
+            }
+        }
+
         for key in removed_keys {
             let Some(refs) = subs.remove(&key) else {
                 continue;
@@ -224,6 +242,36 @@ impl GateBusResolver for GateBusRegistry {
         let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
         let (key, sub) = SubscriberRef::from_pending(pending);
         subs.entry(key).or_default().push(sub);
+    }
+
+    fn cancel_pending_for_upstream(
+        &self,
+        scenario_name: &str,
+        entry_id: &str,
+    ) -> Vec<RegistryError> {
+        let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
+        let matching: Vec<String> = pending
+            .iter()
+            .filter(|(_, p)| p.scenario_name == scenario_name && p.entry_id == entry_id)
+            .map(|(k, _)| k.clone())
+            .collect();
+        let mut errors = Vec::with_capacity(matching.len());
+        for handle_id in matching {
+            let entry = pending.remove(&handle_id).expect("just snapshotted");
+            entry.edge_sender.send_replace(Some(GateEdge::UpstreamGone));
+            if let Some(stats_arc) = entry.stats.upgrade() {
+                if let Ok(mut s) = stats_arc.write() {
+                    if s.state != ScenarioState::Finished {
+                        s.transition_state(ScenarioState::Unresolved);
+                    }
+                }
+            }
+            errors.push(RegistryError::UpstreamCancelled {
+                scenario_name: entry.scenario_name,
+                entry_id: entry.entry_id,
+            });
+        }
+        errors
     }
 }
 
@@ -431,6 +479,111 @@ mod tests {
             "no edge should be delivered for a dead-weak subscriber"
         );
         assert!(reg.pending_for_handle("h-dead").is_none());
+    }
+
+    #[test]
+    fn downstream_resolves_with_upstream_cancelled_error_when_upstream_cancels() {
+        let reg = GateBusRegistry::new();
+        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
+        let (alive, weak) = live_stats();
+        reg.insert_pending(make_pending(
+            "h-pending",
+            "post-upstream",
+            "metric_a",
+            weak,
+            tx,
+        ));
+        assert!(
+            reg.pending_for_handle("h-pending").is_some(),
+            "pending entry must be present before cancellation"
+        );
+
+        let errors = reg.cancel_pending_for_upstream("post-upstream", "metric_a");
+
+        assert_eq!(
+            errors.len(),
+            1,
+            "exactly one error must be returned for the cancelled pending entry"
+        );
+        assert!(
+            matches!(
+                &errors[0],
+                RegistryError::UpstreamCancelled { scenario_name, entry_id }
+                if scenario_name == "post-upstream" && entry_id == "metric_a"
+            ),
+            "error must be UpstreamCancelled for the matching upstream, got: {:?}",
+            errors[0]
+        );
+        assert!(
+            reg.pending_for_handle("h-pending").is_none(),
+            "pending entry must be removed after cancellation"
+        );
+        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
+            .expect("waiter must receive UpstreamGone within 200ms");
+        assert_eq!(edge, GateEdge::UpstreamGone);
+        drop(alive);
+    }
+
+    #[test]
+    fn cancel_pending_for_upstream_only_affects_matching_upstream() {
+        let reg = GateBusRegistry::new();
+        let (tx_a, mut rx_a) = watch::channel::<Option<GateEdge>>(None);
+        let (tx_b, mut rx_b) = watch::channel::<Option<GateEdge>>(None);
+        let (alive_a, weak_a) = live_stats();
+        let (alive_b, weak_b) = live_stats();
+        reg.insert_pending(make_pending(
+            "h-a",
+            "post-upstream",
+            "metric_a",
+            weak_a,
+            tx_a,
+        ));
+        reg.insert_pending(make_pending("h-b", "post-other", "metric_b", weak_b, tx_b));
+
+        let errors = reg.cancel_pending_for_upstream("post-upstream", "metric_a");
+        assert_eq!(errors.len(), 1);
+        assert!(
+            reg.pending_for_handle("h-a").is_none(),
+            "matching pending must be removed"
+        );
+        assert!(
+            reg.pending_for_handle("h-b").is_some(),
+            "non-matching pending must remain"
+        );
+        assert_eq!(
+            watch_recv_timeout(&mut rx_a, Duration::from_millis(200)),
+            Ok(GateEdge::UpstreamGone),
+            "matching waiter must receive UpstreamGone"
+        );
+        assert!(
+            watch_recv_timeout(&mut rx_b, Duration::from_millis(50)).is_err(),
+            "non-matching waiter must not receive any edge"
+        );
+        drop(alive_a);
+        drop(alive_b);
+    }
+
+    #[test]
+    fn unregister_signals_pending_downstreams_waiting_on_that_upstream() {
+        let reg = GateBusRegistry::new();
+        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
+        let (alive, weak) = live_stats();
+        reg.insert_pending(make_pending("h-pending", "nope", "entry-x", weak, tx));
+        assert!(
+            reg.pending_for_handle("h-pending").is_some(),
+            "pending entry must be present before unregister"
+        );
+
+        reg.unregister("nope");
+
+        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
+            .expect("waiter must receive UpstreamGone within 200ms");
+        assert_eq!(edge, GateEdge::UpstreamGone);
+        assert!(
+            reg.pending_for_handle("h-pending").is_none(),
+            "pending entry must be removed after unregister"
+        );
+        drop(alive);
     }
 
     #[test]

--- a/sonda-server/src/gate_registry.rs
+++ b/sonda-server/src/gate_registry.rs
@@ -158,7 +158,7 @@ impl GateBusResolver for GateBusRegistry {
                 if sub.stats.strong_count() == 0 {
                     continue;
                 }
-                let _ = sub.sender.try_send(GateEdge::UpstreamGone);
+                sub.sender.send_replace(Some(GateEdge::UpstreamGone));
                 let handle_id = sub.handle_id.clone();
                 let pending_entry = sub.into_pending(key.0.clone(), key.1.clone());
                 pending.insert(handle_id, pending_entry);
@@ -231,9 +231,9 @@ impl GateBusResolver for GateBusRegistry {
 mod tests {
     use super::*;
     use sonda_core::compiler::WhileOp;
-    use std::sync::mpsc;
     use std::thread;
     use std::time::Duration;
+    use tokio::sync::watch;
 
     fn while_spec() -> WhileSpec {
         WhileSpec {
@@ -268,6 +268,24 @@ mod tests {
         )
     }
 
+    fn watch_recv_timeout(
+        rx: &mut watch::Receiver<Option<GateEdge>>,
+        timeout: Duration,
+    ) -> Result<GateEdge, ()> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+        rt.block_on(async {
+            if !rx.has_changed().unwrap_or(false)
+                && tokio::time::timeout(timeout, rx.changed()).await.is_err()
+            {
+                return Err(());
+            }
+            (*rx.borrow_and_update()).ok_or(())
+        })
+    }
+
     #[test]
     fn t_reg_1_register_then_lookup_roundtrip() {
         let reg = GateBusRegistry::new();
@@ -285,7 +303,7 @@ mod tests {
         let reg = GateBusRegistry::new();
         let bus = Arc::new(GateBus::new());
         reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
-        let (tx, _rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (tx, _rx) = watch::channel::<Option<GateEdge>>(None);
         let (_alive, weak) = live_stats();
         let got = reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone());
         assert!(got.is_some());
@@ -301,7 +319,7 @@ mod tests {
     #[test]
     fn t_reg_3_subscribe_with_no_upstream_returns_none_then_insert_pending() {
         let reg = GateBusRegistry::new();
-        let (tx, _rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (tx, _rx) = watch::channel::<Option<GateEdge>>(None);
         let (_alive, weak) = live_stats();
         let got = reg.subscribe(("missing", "m"), "h2", weak.clone(), tx.clone());
         assert!(got.is_none());
@@ -315,7 +333,7 @@ mod tests {
     fn t_reg_4_sweep_pending_resolves_after_register() {
         let reg = GateBusRegistry::new();
         let (alive, weak) = live_stats();
-        let (tx, _rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (tx, _rx) = watch::channel::<Option<GateEdge>>(None);
         reg.insert_pending(make_pending("h1", "upstream", "m", weak, tx));
 
         let bus = Arc::new(GateBus::new());
@@ -336,15 +354,14 @@ mod tests {
         let reg = GateBusRegistry::new();
         let bus = Arc::new(GateBus::new());
         reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
-        let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
         let (alive, weak) = live_stats();
         reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone())
             .expect("sub");
         reg.track_subscriber(make_pending("h1", "post-a", "m", weak, tx));
 
         reg.unregister("post-a");
-        let edge = rx
-            .recv_timeout(Duration::from_millis(200))
+        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
             .expect("UpstreamGone within 200ms");
         assert_eq!(edge, GateEdge::UpstreamGone);
         assert!(reg.lookup("post-a", "m").is_none());
@@ -362,14 +379,14 @@ mod tests {
         bus_a.tick(1.0);
         reg.register("post-a", "m", Arc::clone(&bus_a))
             .expect("reg-a");
-        let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
         let (alive, weak) = live_stats();
         reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone())
             .expect("sub");
         reg.track_subscriber(make_pending("h1", "post-a", "m", weak, tx));
 
         reg.unregister("post-a");
-        let _ = rx.recv_timeout(Duration::from_millis(200));
+        let _ = watch_recv_timeout(&mut rx, Duration::from_millis(200));
 
         let bus_b = Arc::new(GateBus::new());
         bus_b.tick(1.0);
@@ -378,8 +395,7 @@ mod tests {
         let promoted = reg.sweep_pending();
         assert_eq!(promoted, 1, "sweep must re-resolve the pending subscriber");
 
-        let edge = rx
-            .recv_timeout(Duration::from_millis(200))
+        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
             .expect("WhileOpen within 200ms");
         assert_eq!(edge, GateEdge::WhileOpen);
         drop(alive);
@@ -400,7 +416,7 @@ mod tests {
         let reg = GateBusRegistry::new();
         let bus = Arc::new(GateBus::new());
         reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
-        let (tx, rx) = mpsc::sync_channel::<GateEdge>(1);
+        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
         {
             let (alive_local, weak) = live_stats();
             reg.subscribe(("post-a", "m"), "h-dead", weak.clone(), tx.clone())
@@ -409,7 +425,7 @@ mod tests {
             drop(alive_local);
         }
         reg.unregister("post-a");
-        let edge = rx.recv_timeout(Duration::from_millis(100));
+        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(100));
         assert!(
             edge.is_err(),
             "no edge should be delivered for a dead-weak subscriber"
@@ -447,7 +463,7 @@ mod tests {
             kept.push(stats);
             let handle_id = format!("h{i}");
             let h = thread::spawn(move || {
-                let (tx, _rx) = mpsc::sync_channel::<GateEdge>(1);
+                let (tx, _rx) = watch::channel::<Option<GateEdge>>(None);
                 let _ = r.subscribe(("post-a", "m"), &handle_id, weak.clone(), tx.clone());
                 r.track_subscriber(make_pending(&handle_id, "post-a", "m", weak, tx));
             });

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -64,7 +64,7 @@ struct Args {
     #[arg(long, env = "SONDA_CATALOG")]
     catalog: Option<PathBuf>,
 
-    /// Tokio worker thread count. Defaults to `std::thread::available_parallelism()`.
+    /// Tokio worker thread count. Defaults to min(available_parallelism(), 16).
     #[arg(long, value_parser = clap::builder::RangedU64ValueParser::<u64>::new().range(1..))]
     workers: Option<u64>,
 
@@ -77,7 +77,8 @@ struct Args {
     max_inflight_requests: Option<usize>,
 
     /// Per-request timeout in seconds applied to control-plane routes. Returns 408 on expiry.
-    #[arg(long, default_value_t = 30)]
+    #[arg(long, default_value_t = 30,
+          value_parser = clap::builder::RangedU64ValueParser::<u64>::new().range(1..))]
     request_timeout: u64,
 
     /// Maximum request body size in bytes accepted by control-plane routes. Returns 413 when exceeded.
@@ -109,6 +110,7 @@ fn main() -> anyhow::Result<()> {
         std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(1)
+            .min(16)
     });
     let max_inflight_requests = args.max_inflight_requests.unwrap_or(workers * 4);
 

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -5,22 +5,27 @@
 
 mod auth;
 mod gate_registry;
+mod middleware;
 mod routes;
 mod state;
 
+use std::collections::HashMap;
 use std::env;
 use std::io::Write;
 use std::net::SocketAddr;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{exit, Command};
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use clap::Parser;
+use tokio::sync::Semaphore;
 use tracing::{info, warn};
 
+use crate::routes::RouterConfig;
 use crate::state::AppState;
 
 /// Subcommands the dispatch shim forwards to the sibling `sonda` binary.
@@ -58,6 +63,26 @@ struct Args {
     /// Can also be set via the `SONDA_CATALOG` environment variable.
     #[arg(long, env = "SONDA_CATALOG")]
     catalog: Option<PathBuf>,
+
+    /// Tokio worker thread count. Defaults to `std::thread::available_parallelism()`.
+    #[arg(long, value_parser = clap::builder::RangedU64ValueParser::<u64>::new().range(1..))]
+    workers: Option<u64>,
+
+    /// Maximum concurrent scenario rows in `AppState`. `0` means unlimited.
+    #[arg(long, default_value_t = 0)]
+    max_scenarios: usize,
+
+    /// Maximum concurrent in-flight control-plane HTTP requests. Defaults to `4 * workers`.
+    #[arg(long)]
+    max_inflight_requests: Option<usize>,
+
+    /// Per-request timeout in seconds applied to control-plane routes. Returns 408 on expiry.
+    #[arg(long, default_value_t = 30)]
+    request_timeout: u64,
+
+    /// Maximum request body size in bytes accepted by control-plane routes. Returns 413 when exceeded.
+    #[arg(long, default_value_t = 1_048_576)]
+    max_body_bytes: usize,
 }
 
 impl std::fmt::Debug for Args {
@@ -67,15 +92,36 @@ impl std::fmt::Debug for Args {
             .field("bind", &self.bind)
             .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
             .field("catalog", &self.catalog)
+            .field("workers", &self.workers)
+            .field("max_scenarios", &self.max_scenarios)
+            .field("max_inflight_requests", &self.max_inflight_requests)
+            .field("request_timeout", &self.request_timeout)
+            .field("max_body_bytes", &self.max_body_bytes)
             .finish()
     }
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     maybe_dispatch_to_sonda_cli();
 
-    // Tracing on stderr — stdout is reserved for the bound-port announce.
+    let args = Args::parse();
+    let workers = args.workers.map(|n| n as usize).unwrap_or_else(|| {
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1)
+    });
+    let max_inflight_requests = args.max_inflight_requests.unwrap_or(workers * 4);
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(workers)
+        .enable_all()
+        .build()
+        .context("failed to build tokio runtime")?;
+
+    runtime.block_on(async move { run(args, workers, max_inflight_requests).await })
+}
+
+async fn run(args: Args, workers: usize, max_inflight_requests: usize) -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -83,8 +129,6 @@ async fn main() -> anyhow::Result<()> {
         )
         .with_writer(std::io::stderr)
         .init();
-
-    let args = Args::parse();
 
     let bind_addr: SocketAddr = format!("{}:{}", args.bind, args.port)
         .parse()
@@ -116,9 +160,35 @@ async fn main() -> anyhow::Result<()> {
         info!(catalog = %dir.display(), "pack catalog enabled for POST /scenarios");
     }
 
-    let mut state = AppState::with_api_key(api_key);
-    state.catalog_dir = args.catalog.map(Arc::new);
-    let app = routes::router(state.clone());
+    let permits = if args.max_scenarios == 0 {
+        warn!("--max-scenarios 0 — scenario row cap disabled (unlimited)");
+        Semaphore::new(Semaphore::MAX_PERMITS)
+    } else {
+        Semaphore::new(args.max_scenarios)
+    };
+
+    let state = AppState {
+        scenarios: Arc::new(RwLock::new(HashMap::new())),
+        api_key: api_key.map(Arc::new),
+        catalog_dir: args.catalog.clone().map(Arc::new),
+        gate_bus_registry: Arc::new(crate::gate_registry::GateBusRegistry::new()),
+        scenario_permits: Arc::new(permits),
+        started_at: Instant::now(),
+        worker_threads: workers,
+        max_scenarios: args.max_scenarios,
+        request_counters: Arc::new(RwLock::new(
+            HashMap::<crate::state::RouteKey, AtomicU64>::new(),
+        )),
+        request_histograms: Arc::new(RwLock::new(HashMap::new())),
+    };
+
+    let inflight_semaphore = Arc::new(Semaphore::new(max_inflight_requests));
+    let router_cfg = RouterConfig {
+        request_timeout: Duration::from_secs(args.request_timeout),
+        max_body_bytes: args.max_body_bytes,
+        inflight_semaphore,
+    };
+    let app = routes::router_with_config(state.clone(), router_cfg);
 
     let listener = tokio::net::TcpListener::bind(bind_addr)
         .await
@@ -134,7 +204,7 @@ async fn main() -> anyhow::Result<()> {
 
     announce_bound_port(bound_addr.port())?;
 
-    info!(addr = %bound_addr, "sonda-server listening");
+    info!(addr = %bound_addr, workers, "sonda-server listening");
 
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(
@@ -290,6 +360,15 @@ mod tests {
             len_before,
             sorted.len(),
             "SONDA_SUBCOMMANDS contains duplicates"
+        );
+    }
+
+    #[test]
+    fn sonda_git_sha_env_is_injected_by_build_rs() {
+        let sha = env!("SONDA_GIT_SHA");
+        assert!(
+            !sha.is_empty(),
+            "SONDA_GIT_SHA must be injected (either a git rev or the 'unknown' fallback)"
         );
     }
 }

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -231,13 +231,17 @@ async fn shutdown_signal(state: AppState, #[cfg(unix)] mut sigterm: tokio::signa
         }
     }
 
-    // Write lock: join() consumes the inner JoinHandle.
+    // Write lock: join consumes the inner JoinHandle.
+    let mut ids_handles: Vec<(String, sonda_core::ScenarioHandle)> = Vec::new();
     if let Ok(mut scenarios) = state.scenarios.write() {
-        for (id, handle) in scenarios.iter_mut() {
-            match handle.join(Some(Duration::from_secs(5))) {
-                Ok(_) => info!(scenario = %id, "scenario thread joined"),
-                Err(e) => warn!(scenario = %id, error = %e, "scenario thread join failed"),
-            }
+        for (id, handle) in scenarios.drain() {
+            ids_handles.push((id, handle));
+        }
+    }
+    for (id, mut handle) in ids_handles {
+        match handle.join_async(Some(Duration::from_secs(5))).await {
+            Ok(_) => info!(scenario = %id, "scenario task joined"),
+            Err(e) => warn!(scenario = %id, error = %e, "scenario task join failed"),
         }
     }
 }

--- a/sonda-server/src/middleware/metrics.rs
+++ b/sonda-server/src/middleware/metrics.rs
@@ -1,0 +1,77 @@
+//! RED-metric instrumentation middleware.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use axum::extract::{MatchedPath, Request, State};
+use axum::middleware::Next;
+use axum::response::Response;
+
+use crate::state::AppState;
+
+pub async fn record_request_metrics(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|p| p.as_str().to_string())
+        .unwrap_or_else(|| "<unmatched>".to_string());
+    let method = request.method().as_str().to_string();
+    let started = Instant::now();
+
+    let response = next.run(request).await;
+
+    let status = response.status().as_u16();
+    let elapsed = started.elapsed().as_secs_f64();
+
+    increment_counter(&state, route.clone(), method.clone(), status);
+    observe_histogram(&state, route, method, elapsed);
+
+    response
+}
+
+fn increment_counter(state: &AppState, route: String, method: String, status: u16) {
+    let key = (route, method, status);
+    {
+        let guard = state
+            .request_counters
+            .read()
+            .expect("request_counters lock poisoned");
+        if let Some(counter) = guard.get(&key) {
+            counter.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+    }
+    // Slow path: another writer may have created the entry between the read
+    // drop and the write acquire — entry().or_insert_with handles both cases.
+    let mut guard = state
+        .request_counters
+        .write()
+        .expect("request_counters lock poisoned");
+    guard
+        .entry(key)
+        .or_insert_with(|| AtomicU64::new(0))
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+fn observe_histogram(state: &AppState, route: String, method: String, seconds: f64) {
+    let key = (route, method);
+    {
+        let guard = state
+            .request_histograms
+            .read()
+            .expect("request_histograms lock poisoned");
+        if let Some(shard) = guard.get(&key) {
+            shard.observe(seconds);
+            return;
+        }
+    }
+    let mut guard = state
+        .request_histograms
+        .write()
+        .expect("request_histograms lock poisoned");
+    guard.entry(key).or_default().observe(seconds);
+}

--- a/sonda-server/src/middleware/mod.rs
+++ b/sonda-server/src/middleware/mod.rs
@@ -1,0 +1,3 @@
+//! HTTP middleware for sonda-server.
+
+pub mod metrics;

--- a/sonda-server/src/routes/events.rs
+++ b/sonda-server/src/routes/events.rs
@@ -95,9 +95,7 @@ pub async fn post_events(State(_state): State<AppState>, body: axum::body::Bytes
             };
             let sink_type = sink_kind(&sink);
             let labels_for_sink = (!labels.is_empty()).then_some(labels);
-            let result =
-                run_blocking(move || emit_log(&event, &encoder, &sink, labels_for_sink.as_ref()))
-                    .await;
+            let result = emit_log(&event, &encoder, &sink, labels_for_sink.as_ref()).await;
             ("logs", sink_type, result)
         }
         EventRequest::Metrics {
@@ -112,10 +110,7 @@ pub async fn post_events(State(_state): State<AppState>, body: axum::body::Bytes
             };
             let sink_type = sink_kind(&sink);
             let labels_for_sink = (!labels.is_empty()).then_some(labels);
-            let result = run_blocking(move || {
-                emit_metric(&event, &encoder, &sink, labels_for_sink.as_ref())
-            })
-            .await;
+            let result = emit_metric(&event, &encoder, &sink, labels_for_sink.as_ref()).await;
             ("metrics", sink_type, result)
         }
     };
@@ -178,18 +173,6 @@ fn labels_from_map(map: &HashMap<String, String>) -> Result<Labels, SondaError> 
     }
     let pairs: Vec<(&str, &str)> = map.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
     Labels::from_pairs(&pairs)
-}
-
-async fn run_blocking<F>(f: F) -> Result<(), SondaError>
-where
-    F: FnOnce() -> Result<(), SondaError> + Send + 'static,
-{
-    match tokio::task::spawn_blocking(f).await {
-        Ok(r) => r,
-        Err(_join_err) => Err(SondaError::Runtime(
-            sonda_core::RuntimeError::ThreadPanicked,
-        )),
-    }
 }
 
 fn error_response(err: SondaError) -> Response {

--- a/sonda-server/src/routes/events.rs
+++ b/sonda-server/src/routes/events.rs
@@ -209,6 +209,7 @@ fn sink_kind(sink: &SinkConfig) -> &'static str {
         SinkConfig::File { .. } => "file",
         SinkConfig::Tcp { .. } => "tcp",
         SinkConfig::Udp { .. } => "udp",
+        SinkConfig::Memory { .. } => "memory",
         #[cfg(feature = "http")]
         SinkConfig::HttpPush { .. } => "http_push",
         #[cfg(feature = "http")]

--- a/sonda-server/src/routes/mod.rs
+++ b/sonda-server/src/routes/mod.rs
@@ -1,40 +1,86 @@
 //! HTTP route definitions for sonda-server.
-//!
-//! Routes are split into two sub-routers:
-//! - **Public**: `/health` — always accessible, no authentication required.
-//! - **Protected**: `/scenarios/*` — guarded by the [`require_api_key`] middleware
-//!   when an API key is configured. When no key is configured, these routes are
-//!   also publicly accessible (backwards compatible).
-//!
-//! The `route_layer` approach ensures that only matched routes run through the
-//! auth middleware. Unmatched paths get a plain 404 from the router, not a 401.
 
 pub mod events;
 pub mod health;
 pub mod scenarios;
+pub mod server_metrics;
 pub mod sink_warnings;
 
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::http::StatusCode;
 use axum::middleware;
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
+use tokio::sync::Semaphore;
+use tower::limit::GlobalConcurrencyLimitLayer;
+use tower::ServiceBuilder;
+use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::timeout::TimeoutLayer;
 
 use crate::auth::require_api_key;
+use crate::middleware::metrics::record_request_metrics;
 use crate::state::AppState;
 
-/// Build the application router with all routes wired up.
-///
-/// The returned [`Router`] is ready to be handed to the axum server. State is
-/// injected via [`axum::extract::State`] in each handler.
-///
-/// The router is composed of two sub-trees:
-/// - A **public** router for endpoints that must always be accessible (health
-///   checks, readiness probes).
-/// - A **protected** router for scenario management endpoints, guarded by
-///   bearer-token authentication when an API key is configured.
+#[derive(Clone)]
+pub struct RouterConfig {
+    pub request_timeout: Duration,
+    pub max_body_bytes: usize,
+    pub inflight_semaphore: Arc<Semaphore>,
+}
+
+impl RouterConfig {
+    #[allow(dead_code)]
+    pub fn test_defaults() -> Self {
+        Self {
+            request_timeout: Duration::from_secs(30),
+            max_body_bytes: 1_048_576,
+            inflight_semaphore: Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
+        }
+    }
+}
+
+#[allow(dead_code)]
 pub fn router(state: AppState) -> Router {
+    router_with_config(state, RouterConfig::test_defaults())
+}
+
+pub fn router_with_config(state: AppState, cfg: RouterConfig) -> Router {
     let public = Router::new().route("/health", get(health::health));
 
-    let protected = Router::new()
+    let protected_observability = Router::new()
+        .route("/scenarios/{id}/stats", get(scenarios::get_scenario_stats))
+        .route(
+            "/scenarios/{id}/metrics",
+            get(scenarios::get_scenario_metrics),
+        )
+        .route("/metrics", get(scenarios::get_aggregate_metrics))
+        .route("/server/metrics", get(server_metrics::get_server_metrics))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            record_request_metrics,
+        ))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_api_key,
+        ));
+
+    // RequestBodyLimit must wrap a service whose response body is
+    // axum::body::Body; Timeout wraps the response into a type that
+    // RequestBodyLimitLayer's downstream bound rejects, so timeout goes
+    // inside the body limit at the layer-application level.
+    let control_stack = ServiceBuilder::new()
+        .layer(RequestBodyLimitLayer::new(cfg.max_body_bytes))
+        .layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            cfg.request_timeout,
+        ))
+        .layer(GlobalConcurrencyLimitLayer::with_semaphore(
+            cfg.inflight_semaphore.clone(),
+        ));
+
+    let protected_control = Router::new()
         .route(
             "/scenarios",
             get(scenarios::list_scenarios).post(scenarios::post_scenario),
@@ -43,19 +89,21 @@ pub fn router(state: AppState) -> Router {
             "/scenarios/{id}",
             get(scenarios::get_scenario).delete(scenarios::delete_scenario),
         )
-        .route("/scenarios/{id}/stats", get(scenarios::get_scenario_stats))
-        .route(
-            "/scenarios/{id}/metrics",
-            get(scenarios::get_scenario_metrics),
-        )
-        .route("/metrics", get(scenarios::get_aggregate_metrics))
-        .route("/events", axum::routing::post(events::post_events))
+        .route("/events", post(events::post_events))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            record_request_metrics,
+        ))
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             require_api_key,
-        ));
+        ))
+        .layer(control_stack);
 
-    public.merge(protected).with_state(state)
+    public
+        .merge(protected_observability)
+        .merge(protected_control)
+        .with_state(state)
 }
 
 #[cfg(test)]

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -597,13 +597,15 @@ async fn launch_compiled(
     warnings: Vec<String>,
 ) -> Result<Response, Response> {
     let resolver: Arc<dyn sonda_core::GateBusResolver> = state.gate_bus_registry.clone();
-    let mut handles = launch_multi_compiled(compiled, Some(resolver)).map_err(|e| {
-        warn!(error = %e, "POST /scenarios: failed to launch scenarios");
-        match e {
-            sonda_core::SondaError::Config(_) => unprocessable(e),
-            _ => internal_error(e),
-        }
-    })?;
+    let mut handles = launch_multi_compiled(compiled, Some(resolver))
+        .await
+        .map_err(|e| {
+            warn!(error = %e, "POST /scenarios: failed to launch scenarios");
+            match e {
+                sonda_core::SondaError::Config(_) => unprocessable(e),
+                _ => internal_error(e),
+            }
+        })?;
 
     if handles.is_empty() {
         warn!("POST /scenarios: gated launch produced zero handles");

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -30,6 +30,7 @@ use sonda_core::compiler::parse::detect_version;
 use sonda_core::encoder::prometheus::PrometheusText;
 use sonda_core::encoder::Encoder;
 use sonda_core::{GateBusResolver, ScenarioState, ScenarioStats};
+use tokio::sync::{OwnedSemaphorePermit, TryAcquireError};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -585,16 +586,78 @@ pub async fn post_scenario(
     log_warnings("POST /scenarios", &warnings);
     drop(warning_entries);
 
-    launch_compiled(state, *compiled, warnings).await
+    let needed = compiled.entries.len();
+    let permits = match acquire_permits(&state, needed) {
+        Ok(p) => p,
+        Err(PermitError::CapacityExceeded) => {
+            warn!(
+                needed,
+                "POST /scenarios: scenario cap reached, returning 429"
+            );
+            return Err(capacity_exceeded_response(&state, needed));
+        }
+        Err(PermitError::SemaphoreClosed) => {
+            warn!("POST /scenarios: scenario_permits semaphore is closed");
+            return Err(internal_error("scenario permit semaphore is closed"));
+        }
+    };
+
+    launch_compiled(state, *compiled, warnings, permits).await
 }
 
-/// Launch every entry in `compiled` through the gated multi-runner and store
-/// the resulting handles in [`AppState`]. Single-vs-multi response shape is
-/// decided post-launch from the count of returned handles.
+enum PermitError {
+    CapacityExceeded,
+    SemaphoreClosed,
+}
+
+fn acquire_permits(
+    state: &AppState,
+    needed: usize,
+) -> Result<Vec<OwnedSemaphorePermit>, PermitError> {
+    let mut permits = Vec::with_capacity(needed);
+    for _ in 0..needed {
+        match state.scenario_permits.clone().try_acquire_owned() {
+            Ok(p) => permits.push(p),
+            Err(TryAcquireError::NoPermits) => return Err(PermitError::CapacityExceeded),
+            Err(TryAcquireError::Closed) => return Err(PermitError::SemaphoreClosed),
+        }
+    }
+    Ok(permits)
+}
+
+fn capacity_exceeded_response(state: &AppState, _needed: usize) -> Response {
+    let mut by_state = serde_json::Map::new();
+    for op in ScenarioState::operational_states() {
+        by_state.insert(op.as_label().to_string(), json!(0));
+    }
+    by_state.insert(ScenarioState::Finished.as_label().to_string(), json!(0));
+    let mut total = 0u64;
+    if let Ok(scenarios) = state.scenarios.read() {
+        for handle in scenarios.values() {
+            total += 1;
+            let label = handle.stats_snapshot().state.as_label();
+            if let Some(v) = by_state.get_mut(label) {
+                *v = json!(v.as_u64().unwrap_or(0) + 1);
+            }
+        }
+    }
+    let max = state.max_scenarios;
+    let detail = format!(
+        "{total} scenarios active (max {max}); DELETE finished or stuck scenarios to free slots"
+    );
+    let body = json!({
+        "error": "capacity_exceeded",
+        "detail": detail,
+        "by_state": by_state,
+    });
+    (StatusCode::TOO_MANY_REQUESTS, Json(body)).into_response()
+}
+
 async fn launch_compiled(
     state: AppState,
     compiled: CompiledFile,
     warnings: Vec<String>,
+    mut permits: Vec<OwnedSemaphorePermit>,
 ) -> Result<Response, Response> {
     let resolver: Arc<dyn sonda_core::GateBusResolver> = state.gate_bus_registry.clone();
     let mut handles = launch_multi_compiled(compiled, Some(resolver))
@@ -622,6 +685,9 @@ async fn launch_compiled(
         let name = handle.name.clone();
         let state_str = state_string(&handle.stats_snapshot()).to_string();
         info!(id = %new_id, name = %name, state = %state_str, "scenario launched");
+        if let Some(permit) = permits.pop() {
+            handle.attach_permit(permit);
+        }
         created.push(CreatedScenario {
             id: new_id,
             name,
@@ -766,6 +832,9 @@ pub async fn delete_scenario(
         handle.stop();
         (handle, scenario_name_to_unregister)
     };
+
+    // Release the slot before the join window — row cap, not task-CPU cap.
+    drop(handle.take_permit());
 
     if let Err(e) = handle.join_async(Some(Duration::from_secs(5))).await {
         warn!(id = %id, error = %e, "DELETE /scenarios/{id}: scenario task returned an error");

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -751,49 +751,34 @@ pub async fn delete_scenario(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, Response> {
-    // Acquire a write lock so we can mutate the handle (join requires &mut self).
-    let mut scenarios = state
-        .scenarios
-        .write()
-        .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
+    let (mut handle, scenario_name_to_unregister) = {
+        let mut scenarios = state
+            .scenarios
+            .write()
+            .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
+        let handle = scenarios
+            .remove(&id)
+            .ok_or_else(|| not_found(format!("scenario not found: {id}")))?;
+        handle
+            .cleaned_up
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let scenario_name_to_unregister = handle.scenario_name.clone();
+        handle.stop();
+        (handle, scenario_name_to_unregister)
+    };
 
-    let handle = scenarios
-        .get_mut(&id)
-        .ok_or_else(|| not_found(format!("scenario not found: {id}")))?;
-
-    // Pre-mark so the StateGuard skips its own unregister; Phase 1 owns it.
-    handle
-        .cleaned_up
-        .store(true, std::sync::atomic::Ordering::SeqCst);
-    let scenario_name_to_unregister = handle.scenario_name.clone();
-
-    // Signal the scenario to stop (idempotent — safe to call on already-stopped).
-    handle.stop();
-
-    // Wait for the thread to exit, with a 5-second timeout.
-    let was_running_before_join = handle.is_running();
-    if let Err(e) = handle.join(Some(Duration::from_secs(5))) {
-        warn!(id = %id, error = %e, "DELETE /scenarios/{id}: scenario thread returned an error");
+    if let Err(e) = handle.join_async(Some(Duration::from_secs(5))).await {
+        warn!(id = %id, error = %e, "DELETE /scenarios/{id}: scenario task returned an error");
     }
 
-    // Determine the final status based on whether the thread exited in time.
     let status = if handle.is_running() {
         warn!(id = %id, "DELETE /scenarios/{id}: join timed out after 5s, scenario force-stopped");
         "force_stopped".to_string()
-    } else if was_running_before_join {
-        "stopped".to_string()
     } else {
-        // Thread had already exited before DELETE was called.
         "stopped".to_string()
     };
 
-    // Read final stats before responding.
     let final_stats = handle.stats_snapshot();
-
-    // Remove the handle from the map to free resources (fixes memory leak).
-    scenarios.remove(&id);
-    // Lock order: scenarios then registry.
-    drop(scenarios);
 
     if let Some(name) = scenario_name_to_unregister {
         state.gate_bus_registry.unregister(&name);
@@ -1140,8 +1125,7 @@ mod tests {
     use axum::body::Body;
     use http_body_util::BodyExt;
     use hyper::{Request, StatusCode};
-    use sonda_core::ScenarioHandle;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use sonda_core::{CancellationToken, ScenarioHandle};
     use std::sync::{Arc, RwLock};
     use std::thread;
     use std::time::{Duration, Instant};
@@ -1149,39 +1133,33 @@ mod tests {
 
     // ---- Helpers ---------------------------------------------------------------
 
-    /// Build a ScenarioHandle with a background thread that increments stats.
-    ///
-    /// The thread emits `event_count` events at `interval` apart, incrementing
-    /// total_events and bytes_emitted on each tick.
+    /// Build a ScenarioHandle with a background task that increments stats.
     fn make_handle(id: &str, name: &str, event_count: u64, interval: Duration) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel_clone = cancel.clone();
         let stats_clone = Arc::clone(&stats);
 
-        let thread = thread::Builder::new()
-            .name(format!("test-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                for _ in 0..event_count {
-                    if !shutdown_clone.load(Ordering::SeqCst) {
-                        break;
-                    }
-                    thread::sleep(interval);
-                    if let Ok(mut st) = stats_clone.write() {
-                        st.total_events += 1;
-                        st.bytes_emitted += 64;
-                    }
+        let task = tokio::task::spawn(async move {
+            for _ in 0..event_count {
+                if cancel_clone.is_cancelled() {
+                    break;
                 }
-                Ok(())
-            })
-            .expect("thread must spawn");
+                tokio::time::sleep(interval).await;
+                if let Ok(mut st) = stats_clone.write() {
+                    st.total_events += 1;
+                    st.bytes_emitted += 64;
+                }
+            }
+            Ok::<_, sonda_core::SondaError>(())
+        });
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             100.0,
@@ -1195,30 +1173,22 @@ mod tests {
         )
     }
 
-    /// Build a ScenarioHandle that has already finished (thread exits immediately).
+    /// Build a ScenarioHandle whose task exits immediately.
     fn make_stopped_handle(id: &str, name: &str) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
+        cancel.cancel();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
-        let shutdown_clone = Arc::clone(&shutdown);
 
-        let thread = thread::Builder::new()
-            .name(format!("test-stopped-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                // Check shutdown immediately and exit.
-                let _ = shutdown_clone.load(Ordering::SeqCst);
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async { Ok::<_, sonda_core::SondaError>(()) });
 
-        // Give thread time to finish.
         thread::sleep(Duration::from_millis(50));
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             100.0,
@@ -1643,7 +1613,7 @@ scenarios:
     // ---- GET /scenarios/{id}: stats.total_events > 0 after running ------------
 
     /// After running for a short time, stats.total_events > 0.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn get_scenario_stats_total_events_positive_after_running() {
         // Thread emits events every 10ms. After 200ms we should have ~20 events.
         let h = make_handle("id-events", "events_check", 500, Duration::from_millis(10));
@@ -2660,7 +2630,7 @@ scenarios:
     // ---- DELETE returns final stats (total_events) -------------------------
 
     /// DELETE returns total_events reflecting events emitted before stop.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn delete_returns_final_stats_with_total_events() {
         // Thread emits events every 10ms. Wait 200ms so some events accumulate.
         let h = make_handle("id-del-stats", "del_stats", 1000, Duration::from_millis(10));
@@ -3019,34 +2989,19 @@ scenarios:
         initial_stats: ScenarioStats,
         running: bool,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(running));
+        let cancel = CancellationToken::new();
+        if !running {
+            cancel.cancel();
+        }
         let stats = Arc::new(RwLock::new(initial_stats));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel_clone = cancel.clone();
 
-        let thread = if running {
-            // Long-running thread that waits for shutdown.
-            thread::Builder::new()
-                .name(format!("test-stats-{name}"))
-                .spawn(move || -> Result<(), sonda_core::SondaError> {
-                    while shutdown_clone.load(Ordering::SeqCst) {
-                        thread::sleep(Duration::from_millis(10));
-                    }
-                    Ok(())
-                })
-                .expect("thread must spawn")
-        } else {
-            // Thread exits immediately.
-            thread::Builder::new()
-                .name(format!("test-stats-stopped-{name}"))
-                .spawn(move || -> Result<(), sonda_core::SondaError> {
-                    let _ = shutdown_clone.load(Ordering::SeqCst);
-                    Ok(())
-                })
-                .expect("thread must spawn")
-        };
+        let task = tokio::task::spawn(async move {
+            cancel_clone.cancelled().await;
+            Ok::<_, sonda_core::SondaError>(())
+        });
 
         if !running {
-            // Give the thread time to exit.
             thread::sleep(Duration::from_millis(50));
         }
 
@@ -3054,8 +3009,8 @@ scenarios:
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             target_rate,
@@ -3179,7 +3134,7 @@ scenarios:
     // ---- Fields update as scenario progresses --------------------------------
 
     /// Stats fields update as the scenario background thread emits events.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stats_endpoint_fields_update_as_scenario_progresses() {
         // Thread emits events every 10ms.
         let h = make_handle(
@@ -3485,36 +3440,31 @@ scenarios:
         .expect("test metric name must be valid")
     }
 
-    /// Helper: build a ScenarioHandle with pre-populated metric events in the buffer.
+    /// Build a ScenarioHandle with pre-populated metric events in the buffer.
     fn make_handle_with_metrics(
         id: &str,
         name: &str,
         events: Vec<sonda_core::model::metric::MetricEvent>,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut stats = ScenarioStats::default();
         for event in events {
             stats.push_metric(event);
         }
         let stats = Arc::new(RwLock::new(stats));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel_clone = cancel.clone();
 
-        let thread = thread::Builder::new()
-            .name(format!("test-metrics-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                while shutdown_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async move {
+            cancel_clone.cancelled().await;
+            Ok::<_, sonda_core::SondaError>(())
+        });
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -3766,23 +3716,18 @@ scenarios:
         labels: Vec<(&str, &str)>,
         events: Vec<sonda_core::model::metric::MetricEvent>,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut stats = ScenarioStats::default();
         for event in events {
             stats.push_metric(event);
         }
         let stats = Arc::new(RwLock::new(stats));
-        let shutdown_clone = Arc::clone(&shutdown);
+        let cancel_clone = cancel.clone();
 
-        let thread = thread::Builder::new()
-            .name(format!("test-agg-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                while shutdown_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async move {
+            cancel_clone.cancelled().await;
+            Ok::<_, sonda_core::SondaError>(())
+        });
 
         let mut label_map = std::collections::HashMap::new();
         for (k, v) in labels {
@@ -3793,8 +3738,8 @@ scenarios:
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -4324,28 +4269,22 @@ scenarios:
 
     // ---- Helper: build a handle whose thread ignores the shutdown flag ------
 
-    /// Build a ScenarioHandle whose thread sleeps for a long time, ignoring
-    /// the shutdown flag. This simulates a scenario that cannot be stopped
-    /// gracefully within the join timeout.
+    /// Build a ScenarioHandle whose task sleeps for a long time, ignoring cancel.
     fn make_unjoinable_handle(id: &str, name: &str) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        let thread = thread::Builder::new()
-            .name(format!("test-unjoinable-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                // Ignore shutdown — sleep for a very long time.
-                thread::sleep(Duration::from_secs(300));
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async {
+            tokio::time::sleep(Duration::from_secs(300)).await;
+            Ok::<_, sonda_core::SondaError>(())
+        });
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             50.0,
@@ -4359,27 +4298,25 @@ scenarios:
         )
     }
 
-    /// Build a ScenarioHandle whose thread panics immediately.
+    /// Build a ScenarioHandle whose task panics immediately.
     fn make_panicking_handle(id: &str, name: &str) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let stats = Arc::new(RwLock::new(ScenarioStats::default()));
 
-        let thread = thread::Builder::new()
-            .name(format!("test-panic-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                panic!("intentional panic for testing");
-            })
-            .expect("thread must spawn");
+        let task = tokio::task::spawn(async {
+            panic!("intentional panic for testing");
+            #[allow(unreachable_code)]
+            Ok::<_, sonda_core::SondaError>(())
+        });
 
-        // Give the thread time to panic.
         thread::sleep(Duration::from_millis(50));
 
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -5278,28 +5215,23 @@ scenarios:
         meta: Option<sonda_core::PromMeta>,
         events: Vec<sonda_core::model::metric::MetricEvent>,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut stats = ScenarioStats::default();
         for event in events {
             stats.push_metric(event);
         }
         let stats = Arc::new(RwLock::new(stats));
-        let shutdown_clone = Arc::clone(&shutdown);
-        let thread = thread::Builder::new()
-            .name(format!("test-meta-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                while shutdown_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let cancel_clone = cancel.clone();
+        let task = tokio::task::spawn(async move {
+            cancel_clone.cancelled().await;
+            Ok::<_, sonda_core::SondaError>(())
+        });
         ScenarioHandle::new(
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -5401,22 +5333,17 @@ scenarios:
         labels: Vec<(&str, &str)>,
         events: Vec<sonda_core::model::metric::MetricEvent>,
     ) -> ScenarioHandle {
-        let shutdown = Arc::new(AtomicBool::new(true));
+        let cancel = CancellationToken::new();
         let mut stats = ScenarioStats::default();
         for event in events {
             stats.push_metric(event);
         }
         let stats = Arc::new(RwLock::new(stats));
-        let shutdown_clone = Arc::clone(&shutdown);
-        let thread = thread::Builder::new()
-            .name(format!("test-agg-meta-{name}"))
-            .spawn(move || -> Result<(), sonda_core::SondaError> {
-                while shutdown_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(())
-            })
-            .expect("thread must spawn");
+        let cancel_clone = cancel.clone();
+        let task = tokio::task::spawn(async move {
+            cancel_clone.cancelled().await;
+            Ok::<_, sonda_core::SondaError>(())
+        });
         let mut label_map = std::collections::HashMap::new();
         for (k, v) in labels {
             label_map.insert(k.to_string(), v.to_string());
@@ -5425,8 +5352,8 @@ scenarios:
             id.to_string(),
             name.to_string(),
             None,
-            shutdown,
-            Some(thread),
+            cancel,
+            Some(task),
             Instant::now(),
             stats,
             10.0,
@@ -5859,7 +5786,7 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn t18_get_scenario_for_unresolved_returns_pending_ref() {
         let (_, state) = test_router();
         let resp = post_with_query(
@@ -5909,7 +5836,7 @@ scenarios:
         cleanup_scenarios(&state);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn t19_stats_endpoint_has_current_state_secs_and_cumulative_attempts() {
         let (_, state) = test_router();
         let resp = post_with_query(

--- a/sonda-server/src/routes/server_metrics.rs
+++ b/sonda-server/src/routes/server_metrics.rs
@@ -1,0 +1,276 @@
+//! `GET /server/metrics` — process-level RED and saturation telemetry.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::sync::atomic::Ordering;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use sonda_core::ScenarioState;
+
+use crate::state::{AppState, HistogramShard};
+
+const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+pub async fn get_server_metrics(State(state): State<AppState>) -> Result<Response, Response> {
+    let mut buf = String::with_capacity(4096);
+
+    write_active_scenarios(&state, &mut buf).map_err(internal)?;
+    write_scenarios_finished_total(&state, &mut buf).map_err(internal)?;
+    write_worker_threads(&state, &mut buf).map_err(internal)?;
+    write_max_scenarios(&state, &mut buf).map_err(internal)?;
+    write_requests_total(&state, &mut buf).map_err(internal)?;
+    write_request_duration_seconds(&state, &mut buf).map_err(internal)?;
+    write_sink_errors_total(&state, &mut buf).map_err(internal)?;
+    write_uptime_seconds(&state, &mut buf).map_err(internal)?;
+    write_build_info(&mut buf).map_err(internal)?;
+
+    Ok((
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, PROMETHEUS_CONTENT_TYPE)],
+        buf,
+    )
+        .into_response())
+}
+
+fn internal(_: std::fmt::Error) -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "failed to emit server metrics",
+    )
+        .into_response()
+}
+
+fn write_active_scenarios(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    let mut by_state: BTreeMap<&'static str, u64> = BTreeMap::new();
+    for op in ScenarioState::operational_states() {
+        by_state.insert(op.as_label(), 0);
+    }
+    {
+        let scenarios = match state.scenarios.read() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        for handle in scenarios.values() {
+            let snap = handle.stats_snapshot();
+            if snap.state == ScenarioState::Finished {
+                continue;
+            }
+            let label = snap.state.as_label();
+            *by_state.entry(label).or_insert(0) += 1;
+        }
+    }
+
+    writeln!(
+        buf,
+        "# HELP sonda_server_active_scenarios Scenarios currently held in each operational state."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_active_scenarios gauge")?;
+    for op in ScenarioState::operational_states() {
+        let label = op.as_label();
+        let value = by_state.get(label).copied().unwrap_or(0);
+        writeln!(
+            buf,
+            "sonda_server_active_scenarios{{state=\"{label}\"}} {value}"
+        )?;
+    }
+    Ok(())
+}
+
+fn write_scenarios_finished_total(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    let mut finished: u64 = 0;
+    {
+        let scenarios = match state.scenarios.read() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        for handle in scenarios.values() {
+            if handle.stats_snapshot().state == ScenarioState::Finished {
+                finished += 1;
+            }
+        }
+    }
+    writeln!(
+        buf,
+        "# HELP sonda_server_scenarios_finished_total Scenarios that have reached the Finished state and not yet been deleted."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_scenarios_finished_total counter")?;
+    writeln!(buf, "sonda_server_scenarios_finished_total {finished}")
+}
+
+fn write_worker_threads(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    writeln!(
+        buf,
+        "# HELP sonda_server_worker_threads Configured tokio multi-thread worker count."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_worker_threads gauge")?;
+    writeln!(buf, "sonda_server_worker_threads {}", state.worker_threads)
+}
+
+fn write_max_scenarios(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    writeln!(
+        buf,
+        "# HELP sonda_server_max_scenarios Configured scenario row cap (0 means unlimited)."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_max_scenarios gauge")?;
+    writeln!(buf, "sonda_server_max_scenarios {}", state.max_scenarios)
+}
+
+fn write_requests_total(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    writeln!(
+        buf,
+        "# HELP sonda_server_requests_total HTTP requests served, per matched route, method, and status."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_requests_total counter")?;
+    let snapshot: Vec<((String, String, u16), u64)> = {
+        let guard = match state.request_counters.read() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let mut rows: Vec<_> = guard
+            .iter()
+            .map(|((r, m, s), c)| ((r.clone(), m.clone(), *s), c.load(Ordering::Relaxed)))
+            .collect();
+        rows.sort_by(|a, b| a.0.cmp(&b.0));
+        rows
+    };
+    for ((route, method, status), value) in &snapshot {
+        writeln!(
+            buf,
+            "sonda_server_requests_total{{route=\"{}\",method=\"{}\",status=\"{}\"}} {}",
+            escape_label(route),
+            escape_label(method),
+            status,
+            value
+        )?;
+    }
+    Ok(())
+}
+
+fn write_request_duration_seconds(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    writeln!(
+        buf,
+        "# HELP sonda_server_request_duration_seconds HTTP request duration in seconds, per matched route and method."
+    )?;
+    writeln!(
+        buf,
+        "# TYPE sonda_server_request_duration_seconds histogram"
+    )?;
+    let snapshots: Vec<((String, String), _)> = {
+        let guard = match state.request_histograms.read() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let mut rows: Vec<_> = guard
+            .iter()
+            .map(|(k, shard)| (k.clone(), shard.snapshot()))
+            .collect();
+        rows.sort_by(|a, b| a.0.cmp(&b.0));
+        rows
+    };
+    for ((route, method), snap) in &snapshots {
+        let route_esc = escape_label(route);
+        let method_esc = escape_label(method);
+        for (i, bound) in HistogramShard::BUCKET_BOUNDS.iter().enumerate() {
+            writeln!(
+                buf,
+                "sonda_server_request_duration_seconds_bucket{{route=\"{route_esc}\",method=\"{method_esc}\",le=\"{bound}\"}} {}",
+                snap.buckets[i]
+            )?;
+        }
+        writeln!(
+            buf,
+            "sonda_server_request_duration_seconds_bucket{{route=\"{route_esc}\",method=\"{method_esc}\",le=\"+Inf\"}} {}",
+            snap.plus_inf
+        )?;
+        writeln!(
+            buf,
+            "sonda_server_request_duration_seconds_sum{{route=\"{route_esc}\",method=\"{method_esc}\"}} {}",
+            snap.sum
+        )?;
+        writeln!(
+            buf,
+            "sonda_server_request_duration_seconds_count{{route=\"{route_esc}\",method=\"{method_esc}\"}} {}",
+            snap.count
+        )?;
+    }
+    Ok(())
+}
+
+fn write_sink_errors_total(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    writeln!(
+        buf,
+        "# HELP sonda_server_sink_errors_total Lifetime sink-write failures, summed across scenarios per sink_type."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_sink_errors_total counter")?;
+    let mut totals: BTreeMap<&'static str, u64> = BTreeMap::new();
+    {
+        let scenarios = match state.scenarios.read() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        for handle in scenarios.values() {
+            let snap = handle.stats_snapshot();
+            *totals.entry(handle.sink_type()).or_insert(0) += snap.total_sink_failures;
+        }
+    }
+    for (sink_type, value) in totals {
+        writeln!(
+            buf,
+            "sonda_server_sink_errors_total{{sink_type=\"{sink_type}\"}} {value}"
+        )?;
+    }
+    Ok(())
+}
+
+fn write_uptime_seconds(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    let uptime = state.started_at.elapsed().as_secs_f64();
+    writeln!(
+        buf,
+        "# HELP sonda_server_uptime_seconds Seconds since the server process started."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_uptime_seconds gauge")?;
+    writeln!(buf, "sonda_server_uptime_seconds {uptime}")
+}
+
+fn write_build_info(buf: &mut String) -> std::fmt::Result {
+    let version = env!("CARGO_PKG_VERSION");
+    let git_sha = env!("SONDA_GIT_SHA");
+    writeln!(
+        buf,
+        "# HELP sonda_server_build_info Build-time version and git SHA. Constant gauge always set to 1."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_build_info gauge")?;
+    writeln!(
+        buf,
+        "sonda_server_build_info{{version=\"{}\",git_sha=\"{}\"}} 1",
+        escape_label(version),
+        escape_label(git_sha)
+    )
+}
+
+fn escape_label(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_label_handles_backslash_quote_and_newline() {
+        assert_eq!(escape_label(r#"a\b"c"#), r#"a\\b\"c"#);
+        assert_eq!(escape_label("line\nbreak"), "line\\nbreak");
+        assert_eq!(escape_label("plain"), "plain");
+    }
+}

--- a/sonda-server/src/state.rs
+++ b/sonda-server/src/state.rs
@@ -2,11 +2,99 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
 use sonda_core::ScenarioHandle;
+use tokio::sync::Semaphore;
 
 use crate::gate_registry::GateBusRegistry;
+
+pub type RouteKey = (String, String, u16);
+pub type HistogramKey = (String, String);
+
+pub struct HistogramShard {
+    pub buckets: [AtomicU64; 11],
+    pub plus_inf: AtomicU64,
+    pub sum_bits: AtomicU64,
+    pub count: AtomicU64,
+}
+
+impl HistogramShard {
+    pub const BUCKET_BOUNDS: [f64; 11] = [
+        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+    ];
+
+    pub fn new() -> Self {
+        Self {
+            buckets: [
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+            ],
+            plus_inf: AtomicU64::new(0),
+            sum_bits: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        }
+    }
+
+    pub fn observe(&self, seconds: f64) {
+        use std::sync::atomic::Ordering;
+        for (i, bound) in Self::BUCKET_BOUNDS.iter().enumerate() {
+            if seconds <= *bound {
+                self.buckets[i].fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        self.plus_inf.fetch_add(1, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+        // Atomic sum tracked as f64 bit-pattern via CAS loop.
+        let mut current = self.sum_bits.load(Ordering::Relaxed);
+        loop {
+            let updated = f64::from_bits(current) + seconds;
+            match self.sum_bits.compare_exchange_weak(
+                current,
+                updated.to_bits(),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    pub fn snapshot(&self) -> HistogramSnapshot {
+        use std::sync::atomic::Ordering;
+        HistogramSnapshot {
+            buckets: self.buckets.each_ref().map(|a| a.load(Ordering::Relaxed)),
+            plus_inf: self.plus_inf.load(Ordering::Relaxed),
+            sum: f64::from_bits(self.sum_bits.load(Ordering::Relaxed)),
+            count: self.count.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl Default for HistogramShard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct HistogramSnapshot {
+    pub buckets: [u64; 11],
+    pub plus_inf: u64,
+    pub sum: f64,
+    pub count: u64,
+}
 
 /// Shared application state for the HTTP server.
 ///
@@ -28,6 +116,18 @@ pub struct AppState {
     pub catalog_dir: Option<Arc<PathBuf>>,
     /// Registry of cross-POST `while:` upstream buses.
     pub gate_bus_registry: Arc<GateBusRegistry>,
+    /// Permits gating the `--max-scenarios` row cap.
+    pub scenario_permits: Arc<Semaphore>,
+    /// Process start time for `sonda_server_uptime_seconds`.
+    pub started_at: Instant,
+    /// Configured tokio worker thread count exposed via `sonda_server_worker_threads`.
+    pub worker_threads: usize,
+    /// Configured `--max-scenarios` value exposed via `sonda_server_max_scenarios`.
+    pub max_scenarios: usize,
+    /// Per-`(route, method, status)` request counters.
+    pub request_counters: Arc<RwLock<HashMap<RouteKey, AtomicU64>>>,
+    /// Per-`(route, method)` duration histograms.
+    pub request_histograms: Arc<RwLock<HashMap<HistogramKey, HistogramShard>>>,
 }
 
 impl AppState {
@@ -38,16 +138,29 @@ impl AppState {
             api_key: None,
             catalog_dir: None,
             gate_bus_registry: Arc::new(GateBusRegistry::new()),
+            scenario_permits: Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
+            started_at: Instant::now(),
+            worker_threads: 1,
+            max_scenarios: 0,
+            request_counters: Arc::new(RwLock::new(HashMap::new())),
+            request_histograms: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
     /// Create a new, empty application state with an optional API key.
+    #[allow(dead_code)]
     pub fn with_api_key(api_key: Option<String>) -> Self {
         Self {
             scenarios: Arc::new(RwLock::new(HashMap::new())),
             api_key: api_key.map(Arc::new),
             catalog_dir: None,
             gate_bus_registry: Arc::new(GateBusRegistry::new()),
+            scenario_permits: Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
+            started_at: Instant::now(),
+            worker_threads: 1,
+            max_scenarios: 0,
+            request_counters: Arc::new(RwLock::new(HashMap::new())),
+            request_histograms: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }
@@ -191,5 +304,40 @@ mod tests {
     fn app_state_is_clone() {
         fn assert_clone<T: Clone>() {}
         assert_clone::<AppState>();
+    }
+
+    #[test]
+    fn new_defaults_semaphore_to_max_permits() {
+        let state = AppState::new();
+        assert_eq!(
+            state.scenario_permits.available_permits(),
+            Semaphore::MAX_PERMITS
+        );
+        assert_eq!(state.max_scenarios, 0);
+        assert_eq!(state.worker_threads, 1);
+    }
+
+    #[test]
+    fn started_at_is_recorded_on_construction() {
+        let before = Instant::now();
+        let state = AppState::new();
+        let after = Instant::now();
+        assert!(state.started_at >= before);
+        assert!(state.started_at <= after);
+    }
+
+    #[test]
+    fn histogram_shard_observe_records_bucket_count_and_sum() {
+        let shard = HistogramShard::new();
+        shard.observe(0.004);
+        shard.observe(0.5);
+        let snap = shard.snapshot();
+        assert_eq!(snap.count, 2);
+        assert_eq!(snap.plus_inf, 2);
+        assert!((snap.sum - 0.504).abs() < 1e-9);
+        // 0.004 falls in the 0.005 bucket and every higher bucket.
+        assert_eq!(snap.buckets[0], 1);
+        // 0.5 also falls in 0.5 bucket and above.
+        assert_eq!(snap.buckets[6], 2);
     }
 }

--- a/sonda-server/tests/bounded_scheduler.rs
+++ b/sonda-server/tests/bounded_scheduler.rs
@@ -385,6 +385,37 @@ fn body_limit_returns_413_with_structured_error() {
 }
 
 #[test]
+fn request_timeout_zero_is_rejected_at_parse_time() {
+    use std::process::{Command, Stdio};
+
+    let binary = env!("CARGO_BIN_EXE_sonda-server");
+    let out = Command::new(binary)
+        .args([
+            "--port",
+            "0",
+            "--bind",
+            "127.0.0.1",
+            "--request-timeout",
+            "0",
+        ])
+        .env_remove("SONDA_API_KEY")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("must spawn sonda-server");
+    assert!(
+        !out.status.success(),
+        "--request-timeout 0 must exit non-zero, got status {:?}",
+        out.status
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("request-timeout") || stderr.contains("request_timeout"),
+        "clap rejection must mention the flag, got stderr: {stderr}"
+    );
+}
+
+#[test]
 fn request_timeout_returns_408_with_structured_error() {
     let (port, _guard) = common::start_server_with(&["--request-timeout", "1"], &[]);
     let client = reqwest::blocking::Client::builder()

--- a/sonda-server/tests/bounded_scheduler.rs
+++ b/sonda-server/tests/bounded_scheduler.rs
@@ -1,0 +1,695 @@
+//! End-to-end integration tests for the bounded scheduler and /server/metrics endpoint.
+
+mod common;
+
+use std::io::{BufRead, BufReader};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+const LONG_RUNNING_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: cap_test
+    signal_type: metrics
+    name: cap_test
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+const SHORT_YAML: &str = r#"
+version: 2
+kind: runnable
+defaults:
+  rate: 50
+  duration: 200ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: short_scn
+    signal_type: metrics
+    name: short_scn
+    generator:
+      type: constant
+      value: 1.0
+"#;
+
+fn unique_yaml(template: &str, name: &str) -> String {
+    template
+        .replace("id: cap_test", &format!("id: {name}"))
+        .replace("name: cap_test", &format!("name: {name}"))
+        .replace("id: short_scn", &format!("id: {name}"))
+        .replace("name: short_scn", &format!("name: {name}"))
+}
+
+#[test]
+fn delete_frees_slot_before_join_window_elapses() {
+    let (port, _guard) = common::start_server_with(&["--max-scenarios", "1"], &[]);
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let body = unique_yaml(LONG_RUNNING_YAML, "slot_first");
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(body)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(resp.status().as_u16(), 201);
+    let json: serde_json::Value = resp.json().expect("JSON");
+    let id = json["id"].as_str().expect("id").to_string();
+
+    let delete_url = format!("{base}/scenarios/{id}");
+    let delete_client = client.clone();
+    let delete_started = Instant::now();
+    let delete_join = thread::spawn(move || {
+        delete_client
+            .delete(delete_url)
+            .send()
+            .expect("DELETE must succeed")
+            .status()
+            .as_u16()
+    });
+
+    // Give DELETE 50ms to remove the row + drop the permit.
+    thread::sleep(Duration::from_millis(50));
+
+    let second_body = unique_yaml(LONG_RUNNING_YAML, "slot_second");
+    let second_post_started = Instant::now();
+    let second_resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(second_body)
+        .send()
+        .expect("second POST must succeed");
+    let second_elapsed = second_post_started.elapsed();
+
+    assert_eq!(
+        second_resp.status().as_u16(),
+        201,
+        "second POST must succeed after DELETE removes the row, not 5s later (DELETE wall {:?})",
+        delete_started.elapsed(),
+    );
+    assert!(
+        second_elapsed < Duration::from_millis(500),
+        "second POST returned in {second_elapsed:?}; expected < 500ms after slot release",
+    );
+
+    let delete_status = delete_join.join().expect("DELETE thread joined");
+    assert_eq!(delete_status, 200, "DELETE must return 200");
+}
+
+#[test]
+fn sixth_scenario_returns_429_when_max_scenarios_is_five() {
+    let (port, _guard) = common::start_server_with(&["--max-scenarios", "5"], &[]);
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    for i in 0..5 {
+        let body = unique_yaml(LONG_RUNNING_YAML, &format!("cap_scn_{i}"));
+        let resp = client
+            .post(format!("{base}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(body)
+            .send()
+            .expect("POST must succeed");
+        assert_eq!(resp.status().as_u16(), 201, "POST #{i} must return 201");
+    }
+
+    let body = unique_yaml(LONG_RUNNING_YAML, "cap_scn_overflow");
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(body)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(
+        resp.status().as_u16(),
+        429,
+        "6th POST must return 429 Too Many Requests"
+    );
+
+    let body: serde_json::Value = resp.json().expect("JSON body");
+    assert_eq!(body["error"], "capacity_exceeded");
+    assert!(body["detail"].as_str().unwrap().contains("max 5"));
+    let by_state = &body["by_state"];
+    assert!(by_state.is_object(), "by_state must be an object");
+    for label in [
+        "pending",
+        "running",
+        "paused",
+        "held",
+        "unresolved",
+        "finished",
+    ] {
+        assert!(
+            by_state.get(label).is_some(),
+            "by_state must contain '{label}'"
+        );
+    }
+}
+
+#[test]
+fn finished_scenarios_count_against_cap() {
+    let (port, _guard) = common::start_server_with(&["--max-scenarios", "5"], &[]);
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    for i in 0..5 {
+        let body = unique_yaml(SHORT_YAML, &format!("done_{i}"));
+        let resp = client
+            .post(format!("{base}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(body)
+            .send()
+            .expect("POST must succeed");
+        assert_eq!(resp.status().as_u16(), 201);
+    }
+
+    // Allow the short scenarios to finish.
+    thread::sleep(Duration::from_millis(800));
+
+    let body = unique_yaml(SHORT_YAML, "done_overflow");
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(body)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(
+        resp.status().as_u16(),
+        429,
+        "Finished rows still consume slots"
+    );
+    let json: serde_json::Value = resp.json().expect("JSON");
+    let finished = json["by_state"]["finished"].as_u64().unwrap_or(0);
+    assert_eq!(finished, 5, "all 5 should be in Finished state");
+
+    let metrics = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET /server/metrics must succeed");
+    assert_eq!(metrics.status().as_u16(), 200);
+    let text = metrics.text().expect("body");
+    assert!(
+        !text.contains("sonda_server_active_scenarios{state=\"finished\"}"),
+        "Finished scenarios must NOT appear in active_scenarios gauge. Got:\n{text}"
+    );
+    assert!(
+        text.contains("sonda_server_scenarios_finished_total 5"),
+        "scenarios_finished_total must report 5 after all rows reach Finished. Got:\n{text}"
+    );
+}
+
+#[test]
+fn max_scenarios_zero_allows_unlimited_posts() {
+    let (port, mut child) = common::spawn_server_with(&["--max-scenarios", "0"], &[]);
+    let stderr = child.stderr.take().expect("child stderr must be piped");
+    let (tx, rx) = mpsc::channel::<String>();
+    let stderr_thread = thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            let _ = tx.send(line);
+        }
+    });
+
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    for i in 0..10 {
+        let body = unique_yaml(LONG_RUNNING_YAML, &format!("unl_{i}"));
+        let resp = client
+            .post(format!("{base}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(body)
+            .send()
+            .expect("POST must succeed");
+        assert_eq!(resp.status().as_u16(), 201, "POST #{i} must return 201");
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let mut saw_warn = false;
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(200)) {
+            Ok(line) => {
+                if line.contains("scenario row cap disabled") || line.contains("max-scenarios 0") {
+                    saw_warn = true;
+                    break;
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+
+    child.kill().ok();
+    child.wait().ok();
+    let _ = stderr_thread.join();
+
+    assert!(
+        saw_warn,
+        "expected --max-scenarios 0 WARN line on stderr; none captured before timeout"
+    );
+}
+
+#[test]
+fn server_metrics_emits_all_nine_series_with_zero_state_rows() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let resp = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET must succeed");
+    assert_eq!(resp.status().as_u16(), 200);
+    let text = resp.text().expect("body");
+
+    for series in [
+        "sonda_server_active_scenarios",
+        "sonda_server_scenarios_finished_total",
+        "sonda_server_worker_threads",
+        "sonda_server_max_scenarios",
+        "sonda_server_requests_total",
+        "sonda_server_request_duration_seconds",
+        "sonda_server_sink_errors_total",
+        "sonda_server_uptime_seconds",
+        "sonda_server_build_info",
+    ] {
+        assert!(
+            text.contains(series),
+            "/server/metrics must contain `{series}`. Got:\n{text}"
+        );
+    }
+
+    for label in ["pending", "running", "paused", "held", "unresolved"] {
+        let needle = format!("sonda_server_active_scenarios{{state=\"{label}\"}} 0");
+        assert!(
+            text.contains(&needle),
+            "expected zero-row `{needle}`. Got:\n{text}"
+        );
+    }
+}
+
+#[test]
+fn server_metrics_requires_bearer_token_when_api_key_set() {
+    let (port, _guard) = common::start_server_with(&[], &[("SONDA_API_KEY", "topsecret")]);
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let resp = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET must succeed");
+    assert_eq!(
+        resp.status().as_u16(),
+        401,
+        "GET /server/metrics without auth must return 401"
+    );
+
+    let resp = client
+        .get(format!("{base}/server/metrics"))
+        .header("authorization", "Bearer topsecret")
+        .send()
+        .expect("GET must succeed");
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+#[test]
+fn requests_total_uses_matched_path_for_route_label() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let body = unique_yaml(LONG_RUNNING_YAML, "route_lbl");
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(body)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(resp.status().as_u16(), 201);
+    let json: serde_json::Value = resp.json().expect("JSON");
+    let id = json["id"].as_str().expect("id").to_string();
+
+    let _ = client
+        .get(format!("{base}/scenarios/{id}/stats"))
+        .send()
+        .expect("GET stats must succeed");
+
+    let resp = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET /server/metrics must succeed");
+    let text = resp.text().expect("body");
+
+    let needle = "route=\"/scenarios/{id}/stats\"";
+    assert!(
+        text.contains(needle),
+        "route label must be the matched-path template `{needle}`, NOT the concrete UUID. Got:\n{text}"
+    );
+    assert!(
+        !text.contains(&format!("route=\"/scenarios/{id}/stats\"")),
+        "route label MUST NOT include the concrete UUID"
+    );
+}
+
+#[test]
+fn body_limit_returns_413_with_structured_error() {
+    let (port, _guard) = common::start_server_with(&["--max-body-bytes", "1024"], &[]);
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let huge_body = "x".repeat(8 * 1024);
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(huge_body)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(
+        resp.status().as_u16(),
+        413,
+        "oversized body must return 413 Payload Too Large"
+    );
+}
+
+#[test]
+fn request_timeout_returns_408_with_structured_error() {
+    let (port, _guard) = common::start_server_with(&["--request-timeout", "1"], &[]);
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .build()
+        .expect("HTTP client");
+    let base = format!("http://127.0.0.1:{port}");
+
+    // /events builds the sink in the handler; TEST-NET-1 drops SYNs so the
+    // TCP connect hangs past `--request-timeout 1`.
+    let body = serde_json::json!({
+        "signal_type": "logs",
+        "log": {"severity": "info", "message": "x"},
+        "encoder": {"type": "json_lines"},
+        "sink": {
+            "type": "tcp",
+            "address": "192.0.2.1:1"
+        },
+    });
+
+    let resp = client
+        .post(format!("{base}/events"))
+        .header("content-type", "application/json")
+        .body(body.to_string())
+        .send()
+        .expect("POST must succeed");
+
+    assert_eq!(
+        resp.status().as_u16(),
+        408,
+        "request awaiting beyond --request-timeout must return 408 Request Timeout"
+    );
+}
+
+#[test]
+fn single_worker_runtime_drains_three_scenarios_on_sigterm() {
+    let (port, mut child) =
+        common::spawn_server_with(&["--workers", "1", "--max-scenarios", "10"], &[]);
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    for i in 0..3 {
+        let body = unique_yaml(LONG_RUNNING_YAML, &format!("workers1_{i}"));
+        let resp = client
+            .post(format!("{base}/scenarios"))
+            .header("content-type", "application/x-yaml")
+            .body(body)
+            .send()
+            .expect("POST must succeed");
+        assert_eq!(resp.status().as_u16(), 201, "POST #{i} must return 201");
+    }
+
+    // Sanity-check the process is still alive before signalling.
+    let health = client
+        .get(format!("{base}/health"))
+        .send()
+        .expect("GET /health must succeed");
+    assert_eq!(health.status().as_u16(), 200);
+
+    let started = Instant::now();
+    unsafe {
+        libc::kill(child.id() as i32, libc::SIGTERM);
+    }
+    let status = child.wait().expect("must wait for child");
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed <= Duration::from_secs(6),
+        "single-worker runtime must drain 3 scenarios within 6s of SIGTERM; took {elapsed:?}"
+    );
+    assert!(
+        status.success(),
+        "SIGTERM must produce a clean exit, got {status:?}"
+    );
+}
+
+#[test]
+fn health_remains_responsive_when_control_plane_is_saturated() {
+    let (port, _guard) = common::start_server_with(&["--max-inflight-requests", "1"], &[]);
+    let base = format!("http://127.0.0.1:{port}");
+
+    // Hold the /events permit open via a TCP connect to TEST-NET-1 (drops SYNs).
+    let saturator_base = base.clone();
+    let (started_tx, started_rx) = mpsc::channel::<()>();
+    let saturator = thread::spawn(move || {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("HTTP client");
+        let body = serde_json::json!({
+            "signal_type": "logs",
+            "log": {"severity": "info", "message": "saturator"},
+            "encoder": {"type": "json_lines"},
+            "sink": {
+                "type": "tcp",
+                "address": "192.0.2.1:1"
+            },
+        });
+        let req = client
+            .post(format!("{saturator_base}/events"))
+            .header("content-type", "application/json")
+            .body(body.to_string());
+        started_tx.send(()).ok();
+        req.send().ok();
+    });
+
+    started_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("saturator thread did not start");
+    // Allow the saturator's send() to reach the server and await the TCP connect.
+    thread::sleep(Duration::from_millis(500));
+
+    let client = common::http_client();
+    let health = client
+        .get(format!("{base}/health"))
+        .send()
+        .expect("GET /health must succeed");
+    assert_eq!(
+        health.status().as_u16(),
+        200,
+        "/health must stay reachable while POST holds the concurrency permit"
+    );
+
+    let server_metrics = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET /server/metrics must succeed");
+    assert_eq!(
+        server_metrics.status().as_u16(),
+        200,
+        "/server/metrics must stay reachable while POST holds the concurrency permit"
+    );
+
+    // A second POST on the same route must be queued behind the saturator's permit.
+    let gated_client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_millis(800))
+        .build()
+        .expect("HTTP client");
+    let gated_body = serde_json::json!({
+        "signal_type": "logs",
+        "log": {"severity": "info", "message": "gated"},
+        "encoder": {"type": "json_lines"},
+        "sink": {
+            "type": "tcp",
+            "address": "192.0.2.1:1"
+        },
+    });
+    let gated_started = Instant::now();
+    let gated_result = gated_client
+        .post(format!("{base}/events"))
+        .header("content-type", "application/json")
+        .body(gated_body.to_string())
+        .send();
+    let gated_elapsed = gated_started.elapsed();
+
+    assert!(
+        gated_elapsed >= Duration::from_millis(500),
+        "second POST on the saturated route should have been queued; elapsed {gated_elapsed:?} (result: {gated_result:?})"
+    );
+
+    drop(saturator);
+}
+
+#[test]
+fn global_inflight_limit_gates_across_routes() {
+    let (port, _guard) = common::start_server_with(&["--max-inflight-requests", "1"], &[]);
+    let base = format!("http://127.0.0.1:{port}");
+
+    // Hold the only permit on /events via a TCP connect to TEST-NET-1 (drops SYNs).
+    let saturator_base = base.clone();
+    let (started_tx, started_rx) = mpsc::channel::<()>();
+    let saturator = thread::spawn(move || {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("HTTP client");
+        let body = serde_json::json!({
+            "signal_type": "logs",
+            "log": {"severity": "info", "message": "saturator"},
+            "encoder": {"type": "json_lines"},
+            "sink": {
+                "type": "tcp",
+                "address": "192.0.2.1:1"
+            },
+        });
+        let req = client
+            .post(format!("{saturator_base}/events"))
+            .header("content-type", "application/json")
+            .body(body.to_string());
+        started_tx.send(()).ok();
+        req.send().ok();
+    });
+
+    started_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("saturator thread did not start");
+    // Allow the saturator's send() to reach the server and await the TCP connect.
+    thread::sleep(Duration::from_millis(500));
+
+    // POST /scenarios must be gated by the same global permit even though it is
+    // a different route than /events.
+    let gated_client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_millis(1500))
+        .build()
+        .expect("HTTP client");
+    let gated_body = unique_yaml(LONG_RUNNING_YAML, "cross_route");
+    let gated_started = Instant::now();
+    let gated_result = gated_client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(gated_body)
+        .send();
+    let gated_elapsed = gated_started.elapsed();
+
+    assert!(
+        gated_elapsed >= Duration::from_millis(500),
+        "POST /scenarios should have been queued behind the /events permit; elapsed {gated_elapsed:?} (result: {gated_result:?})"
+    );
+
+    drop(saturator);
+}
+
+#[test]
+fn observability_endpoints_reachable_under_concurrent_post_saturation() {
+    let (port, _guard) = common::start_server_with(&["--max-inflight-requests", "1"], &[]);
+    let base = format!("http://127.0.0.1:{port}");
+
+    // First, register a scenario so /scenarios/{id}/metrics has a real id to hit.
+    let client = common::http_client();
+    let body = unique_yaml(LONG_RUNNING_YAML, "sat_obs");
+    let resp = client
+        .post(format!("{base}/scenarios"))
+        .header("content-type", "application/x-yaml")
+        .body(body)
+        .send()
+        .expect("POST must succeed");
+    assert_eq!(resp.status().as_u16(), 201);
+    let json: serde_json::Value = resp.json().expect("JSON");
+    let id = json["id"].as_str().expect("id").to_string();
+
+    let saturator_base = base.clone();
+    let (started_tx, started_rx) = mpsc::channel::<()>();
+    let saturator = thread::spawn(move || {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("HTTP client");
+        let body = serde_json::json!({
+            "signal_type": "logs",
+            "log": {"severity": "info", "message": "saturator"},
+            "encoder": {"type": "json_lines"},
+            "sink": {
+                "type": "tcp",
+                "address": "192.0.2.1:1"
+            },
+        });
+        let req = client
+            .post(format!("{saturator_base}/events"))
+            .header("content-type", "application/json")
+            .body(body.to_string());
+        started_tx.send(()).ok();
+        req.send().ok();
+    });
+
+    started_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("saturator thread did not start");
+    thread::sleep(Duration::from_millis(500));
+
+    let health = client
+        .get(format!("{base}/health"))
+        .send()
+        .expect("GET /health");
+    assert_eq!(health.status().as_u16(), 200);
+
+    let server_metrics = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET /server/metrics");
+    assert_eq!(server_metrics.status().as_u16(), 200);
+
+    let scenario_metrics = client
+        .get(format!("{base}/scenarios/{id}/metrics"))
+        .send()
+        .expect("GET /scenarios/{id}/metrics");
+    assert_eq!(
+        scenario_metrics.status().as_u16(),
+        200,
+        "scenario scrape must stay reachable while control-plane POST holds the permit"
+    );
+
+    drop(saturator);
+}
+
+#[test]
+fn build_info_exposes_version_and_git_sha() {
+    let (port, _guard) = common::start_server();
+    let client = common::http_client();
+    let base = format!("http://127.0.0.1:{port}");
+
+    let resp = client
+        .get(format!("{base}/server/metrics"))
+        .send()
+        .expect("GET must succeed");
+    let text = resp.text().expect("body");
+    assert!(text.contains("sonda_server_build_info{version="));
+    assert!(text.contains("git_sha="));
+}

--- a/sonda-server/tests/build_info.rs
+++ b/sonda-server/tests/build_info.rs
@@ -1,0 +1,34 @@
+//! Verifies `build.rs` SHA injection and its no-git fallback contract.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn sonda_git_sha_is_injected_at_compile_time() {
+    let sha = env!("SONDA_GIT_SHA");
+    assert!(!sha.is_empty());
+    assert!(
+        sha == "unknown" || (sha.len() >= 7 && sha.chars().all(|c| c.is_ascii_hexdigit())),
+        "SONDA_GIT_SHA must be 'unknown' or a hex SHA, got: {sha:?}"
+    );
+}
+
+#[test]
+fn build_rs_fallback_returns_unknown_when_git_directory_is_absent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let no_git_dir: PathBuf = dir.path().into();
+    let result = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&no_git_dir)
+        .output();
+    match result {
+        Ok(out) => assert!(
+            !out.status.success(),
+            "git rev-parse HEAD in a non-git directory must fail; build.rs falls back to 'unknown' on this path"
+        ),
+        Err(_) => {
+            // git binary not present at all — the build.rs path still
+            // catches the spawn error and falls back to 'unknown'.
+        }
+    }
+}

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -156,4 +156,4 @@ This crate depends on:
 - `owo-colors` for colored terminal output (with `supports-colors` feature for auto-detection)
 - `dialoguer` for interactive terminal prompts in `sonda new` (pure Rust, musl-compatible)
 
-It should NOT depend on: `axum`, `tokio`, `hyper`, or any server-related crate.
+It depends on `tokio` (runtime construction in `main` to drive the async `launch_scenario` API). It should NOT depend on: `axum`, `hyper`, or any server-specific HTTP crate.

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = { workspace = true }
 dialoguer = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio-util = { version = "0.7", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -39,3 +39,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tempfile = "3"
 insta = { workspace = true, features = ["filters"] }
 rstest = { workspace = true }
+
+[lints]
+workspace = true

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -34,6 +34,7 @@ owo-colors = { version = "4", features = ["supports-colors"] }
 serde_json = { workspace = true }
 dialoguer = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -10,13 +10,13 @@ mod sink_format;
 mod status;
 
 use std::process;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
 use clap::Parser;
 use owo_colors::OwoColorize;
 use owo_colors::Stream::Stderr;
+use sonda_core::CancellationToken;
 
 use cli::{Cli, Commands, Verbosity};
 use sonda_core::PreparedEntry;
@@ -43,11 +43,11 @@ fn run() -> anyhow::Result<()> {
         )
         .init();
 
-    let running = Arc::new(AtomicBool::new(true));
+    let cancel = CancellationToken::new();
     {
-        let r = Arc::clone(&running);
+        let c = cancel.clone();
         ctrlc::set_handler(move || {
-            r.store(false, Ordering::SeqCst);
+            c.cancel();
         })
         .expect("failed to register Ctrl+C handler");
     }
@@ -61,7 +61,7 @@ fn run() -> anyhow::Result<()> {
         .build()?;
 
     match cli.command {
-        Commands::Run(ref args) => run_scenario(&rt, args, &cli, catalog, verbosity, &running)?,
+        Commands::Run(ref args) => run_scenario(&rt, args, &cli, catalog, verbosity, &cancel)?,
         Commands::List(ref args) => list_catalog(args, catalog)?,
         Commands::Show(ref args) => show_entry(args, catalog)?,
         Commands::New(ref args) => new::run(args)?,
@@ -76,7 +76,7 @@ fn run_scenario(
     cli_opts: &Cli,
     catalog: Option<&std::path::Path>,
     verbosity: Verbosity,
-    running: &Arc<AtomicBool>,
+    cancel: &CancellationToken,
 ) -> anyhow::Result<()> {
     let mut compiled = scenario_loader::load_scenario_compiled(&args.scenario, catalog)?;
     config::apply_run_overrides_compiled(&mut compiled, args)?;
@@ -92,7 +92,7 @@ fn run_scenario(
         if verbosity == Verbosity::Verbose {
             status::print_version();
         }
-        run_compiled_with_progress(rt, compiled, running, verbosity)?;
+        run_compiled_with_progress(rt, compiled, cancel, verbosity)?;
         return Ok(());
     }
 
@@ -106,9 +106,9 @@ fn run_scenario(
 
     if prepared.len() == 1 {
         let p = prepared.into_iter().next().expect("len checked above");
-        run_single_scenario(rt, "cli-run".to_string(), p, running, verbosity)?;
+        run_single_scenario(rt, "cli-run".to_string(), p, cancel, verbosity)?;
     } else {
-        launch_and_join_prepared(rt, "cli-run", prepared, running, verbosity)?;
+        launch_and_join_prepared(rt, "cli-run", prepared, cancel, verbosity)?;
     }
     Ok(())
 }
@@ -204,7 +204,7 @@ fn run_single_scenario(
     rt: &tokio::runtime::Runtime,
     name: String,
     prepared: PreparedEntry,
-    running: &Arc<AtomicBool>,
+    cancel: &CancellationToken,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
     status::print_start(&prepared.entry, verbosity, None);
@@ -212,7 +212,7 @@ fn run_single_scenario(
         .block_on(sonda_core::launch_scenario(
             name,
             prepared.entry,
-            Arc::clone(running),
+            cancel.child_token(),
             prepared.start_delay,
         ))
         .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -278,7 +278,7 @@ fn launch_and_join_prepared(
     rt: &tokio::runtime::Runtime,
     id_prefix: &str,
     prepared: Vec<PreparedEntry>,
-    running: &Arc<AtomicBool>,
+    cancel: &CancellationToken,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
     let run_start = Instant::now();
@@ -298,7 +298,7 @@ fn launch_and_join_prepared(
             .block_on(sonda_core::launch_scenario(
                 id,
                 p.entry,
-                Arc::clone(running),
+                cancel.child_token(),
                 p.start_delay,
             ))
             .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -362,7 +362,7 @@ fn launch_and_join_prepared(
 fn run_compiled_with_progress(
     rt: &tokio::runtime::Runtime,
     compiled: sonda_core::compiler::compile_after::CompiledFile,
-    running: &Arc<AtomicBool>,
+    cancel: &CancellationToken,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
     let handles = rt
@@ -371,11 +371,14 @@ fn run_compiled_with_progress(
         ))
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    let per_handle_shutdowns: Vec<Arc<AtomicBool>> =
-        handles.iter().map(|h| Arc::clone(&h.shutdown)).collect();
-    let done = Arc::new(AtomicBool::new(false));
-    let watchdog =
-        spawn_ctrlc_watchdog(Arc::clone(running), per_handle_shutdowns, Arc::clone(&done));
+    let handle_cancels: Vec<CancellationToken> = handles.iter().map(|h| h.cancel.clone()).collect();
+    let cancel_watcher = cancel.clone();
+    let watcher = rt.spawn(async move {
+        cancel_watcher.cancelled().await;
+        for c in &handle_cancels {
+            c.cancel();
+        }
+    });
 
     let progress = maybe_start_progress_multi(&handles, verbosity);
 
@@ -386,8 +389,10 @@ fn run_compiled_with_progress(
         }
     }
 
-    done.store(true, Ordering::SeqCst);
-    let _ = watchdog.join();
+    watcher.abort();
+    rt.block_on(async {
+        let _ = watcher.await;
+    });
 
     if let Some(p) = progress {
         p.stop();
@@ -397,31 +402,6 @@ fn run_compiled_with_progress(
         return Err(anyhow::anyhow!("{}", errors.join("; ")));
     }
     Ok(())
-}
-
-fn spawn_ctrlc_watchdog(
-    master: Arc<AtomicBool>,
-    per_handle: Vec<Arc<AtomicBool>>,
-    done: Arc<AtomicBool>,
-) -> std::thread::JoinHandle<()> {
-    std::thread::Builder::new()
-        .name("sonda-cli-shutdown-watchdog".to_string())
-        .spawn(move || {
-            let poll = std::time::Duration::from_millis(100);
-            loop {
-                if done.load(Ordering::SeqCst) {
-                    return;
-                }
-                if !master.load(Ordering::SeqCst) {
-                    for flag in &per_handle {
-                        flag.store(false, Ordering::SeqCst);
-                    }
-                    return;
-                }
-                std::thread::sleep(poll);
-            }
-        })
-        .expect("watchdog thread must spawn")
 }
 
 fn stop_infos_for_groups(

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -56,8 +56,12 @@ fn run() -> anyhow::Result<()> {
     let verbosity = Verbosity::from_flags(cli.quiet, cli.verbose);
     let catalog = cli.catalog.as_deref();
 
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
     match cli.command {
-        Commands::Run(ref args) => run_scenario(args, &cli, catalog, verbosity, &running)?,
+        Commands::Run(ref args) => run_scenario(&rt, args, &cli, catalog, verbosity, &running)?,
         Commands::List(ref args) => list_catalog(args, catalog)?,
         Commands::Show(ref args) => show_entry(args, catalog)?,
         Commands::New(ref args) => new::run(args)?,
@@ -67,6 +71,7 @@ fn run() -> anyhow::Result<()> {
 }
 
 fn run_scenario(
+    rt: &tokio::runtime::Runtime,
     args: &cli::RunArgs,
     cli_opts: &Cli,
     catalog: Option<&std::path::Path>,
@@ -87,7 +92,7 @@ fn run_scenario(
         if verbosity == Verbosity::Verbose {
             status::print_version();
         }
-        run_compiled_with_progress(compiled, running, verbosity)?;
+        run_compiled_with_progress(rt, compiled, running, verbosity)?;
         return Ok(());
     }
 
@@ -101,9 +106,9 @@ fn run_scenario(
 
     if prepared.len() == 1 {
         let p = prepared.into_iter().next().expect("len checked above");
-        run_single_scenario("cli-run".to_string(), p, running, verbosity)?;
+        run_single_scenario(rt, "cli-run".to_string(), p, running, verbosity)?;
     } else {
-        launch_and_join_prepared("cli-run", prepared, running, verbosity)?;
+        launch_and_join_prepared(rt, "cli-run", prepared, running, verbosity)?;
     }
     Ok(())
 }
@@ -196,19 +201,21 @@ fn handle_pre_launch(prepared: &[PreparedEntry], verbosity: Verbosity, dry_run: 
 }
 
 fn run_single_scenario(
+    rt: &tokio::runtime::Runtime,
     name: String,
     prepared: PreparedEntry,
     running: &Arc<AtomicBool>,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
     status::print_start(&prepared.entry, verbosity, None);
-    let mut handle = sonda_core::launch_scenario(
-        name,
-        prepared.entry,
-        Arc::clone(running),
-        prepared.start_delay,
-    )
-    .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let mut handle = rt
+        .block_on(sonda_core::launch_scenario(
+            name,
+            prepared.entry,
+            Arc::clone(running),
+            prepared.start_delay,
+        ))
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
     let progress = maybe_start_progress(&handle, verbosity);
     let join_result = handle.join(None);
     if let Some(p) = progress {
@@ -268,6 +275,7 @@ struct StopInfo {
 }
 
 fn launch_and_join_prepared(
+    rt: &tokio::runtime::Runtime,
     id_prefix: &str,
     prepared: Vec<PreparedEntry>,
     running: &Arc<AtomicBool>,
@@ -286,7 +294,13 @@ fn launch_and_join_prepared(
             p.entry.clock_group_is_auto(),
         ));
         let id = format!("{id_prefix}-{i}");
-        let handle = sonda_core::launch_scenario(id, p.entry, Arc::clone(running), p.start_delay)
+        let handle = rt
+            .block_on(sonda_core::launch_scenario(
+                id,
+                p.entry,
+                Arc::clone(running),
+                p.start_delay,
+            ))
             .map_err(|e| anyhow::anyhow!("{}", e))?;
         handles.push(handle);
     }
@@ -346,11 +360,15 @@ fn launch_and_join_prepared(
 }
 
 fn run_compiled_with_progress(
+    rt: &tokio::runtime::Runtime,
     compiled: sonda_core::compiler::compile_after::CompiledFile,
     running: &Arc<AtomicBool>,
     verbosity: Verbosity,
 ) -> anyhow::Result<()> {
-    let handles = sonda_core::schedule::multi_runner::launch_multi_compiled(compiled, None)
+    let handles = rt
+        .block_on(sonda_core::schedule::multi_runner::launch_multi_compiled(
+            compiled, None,
+        ))
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
     let per_handle_shutdowns: Vec<Arc<AtomicBool>> =

--- a/sonda/src/sink_format.rs
+++ b/sonda/src/sink_format.rs
@@ -46,6 +46,7 @@ pub fn sink_display(sink: &SinkConfig) -> String {
         SinkConfig::Memory {
             capture,
             max_events,
+            ..
         } => {
             if *capture {
                 let cap = max_events.unwrap_or(1_000_000);
@@ -119,6 +120,7 @@ mod tests {
         let s = SinkConfig::Memory {
             capture: false,
             max_events: None,
+            capture_handle: None,
         };
         assert_eq!(sink_display(&s), "memory");
     }
@@ -128,6 +130,7 @@ mod tests {
         let s = SinkConfig::Memory {
             capture: true,
             max_events: Some(2048),
+            capture_handle: None,
         };
         assert_eq!(sink_display(&s), "memory (capture, max_events=2048)");
     }

--- a/sonda/src/sink_format.rs
+++ b/sonda/src/sink_format.rs
@@ -43,6 +43,17 @@ pub fn sink_display(sink: &SinkConfig) -> String {
         SinkConfig::File { path } => format!("file ({path})"),
         SinkConfig::Tcp { address, .. } => format!("tcp ({address})"),
         SinkConfig::Udp { address } => format!("udp ({address})"),
+        SinkConfig::Memory {
+            capture,
+            max_events,
+        } => {
+            if *capture {
+                let cap = max_events.unwrap_or(1_000_000);
+                format!("memory (capture, max_events={cap})")
+            } else {
+                "memory".to_string()
+            }
+        }
         #[cfg(feature = "http")]
         SinkConfig::HttpPush { url, .. } => format!("http_push ({url})"),
         #[cfg(not(feature = "http"))]
@@ -101,6 +112,24 @@ mod tests {
             address: "127.0.0.1:8888".to_string(),
         };
         assert_eq!(sink_display(&s), "udp (127.0.0.1:8888)");
+    }
+
+    #[test]
+    fn memory_without_capture_renders_bare() {
+        let s = SinkConfig::Memory {
+            capture: false,
+            max_events: None,
+        };
+        assert_eq!(sink_display(&s), "memory");
+    }
+
+    #[test]
+    fn memory_with_capture_renders_max_events() {
+        let s = SinkConfig::Memory {
+            capture: true,
+            max_events: Some(2048),
+        };
+        assert_eq!(sink_display(&s), "memory (capture, max_events=2048)");
     }
 
     #[cfg(feature = "http")]


### PR DESCRIPTION
## Summary

Replaces the std::thread-per-scenario scheduler with bounded tokio task spawning
on a shared multi-thread runtime. Closes the adoption-review gaps on resource
limits and server-process self-instrumentation. Adds the operator surface
(`--workers`, `--max-scenarios`, `--max-inflight-requests`, `--request-timeout`,
`--max-body-bytes`, and `GET /server/metrics` with RED + saturation series)
that production deployments need.

10 commits collapse into a single atomic commit on main. Single git revert if
anything regresses post-release.

## Architectural validation

End-to-end measurement against the prior thread-per-scenario baseline on
identical hardware:

| | macOS M3 Pro (11-core) | Linux container (--cpus=4 --memory=4g) |
|---|---|---|
| Threads at N=1000 | 12 (`min(11,16)+main`) | 5 (`min(4,16)+main`) |
| RSS at N=1000 | 410.5 MB | 331.5 MB |
| Drift mean (ms-proxy) | 16.5 ms | 3.06 ms |
| Dropped-tick % | 0.00% | 0.00% |
| Old design capable? | yes (1001 threads) | **no** (1000 × 8 MB stack > 4 GB) |

N=1000 scenarios at 100 Hz on a 4-core / 4 GB Linux container is structurally
impossible on the old thread-per-scenario design. The new scheduler makes it
routine.

## North-star integration

Validated against the `autocon5/sonda` workshops stack
(`github.com/network-observability/workshops` @
`5fbdafa2e64c48aaa620a6d379ed57021136f406`):

| Assertion | Result |
|---|---|
| Prometheus: `bgp_oper_state` flows with Telegraf-normalized labels | PASS — 6 series across srl1+srl2 |
| Alertmanager: `BgpSessionNotUp` fires for synthetic-down peer | PASS — active on srl2/10.1.11.1 |
| Loki: sonda log streams ingested via `{pipeline=\"direct\"}` | PASS — 3 streams with real BGP / config content |

Telegraf scrapes sonda-server and rewrites raw exposition to canonical schema
before Prometheus scrape. Schema parity holds out-of-the-box — existing alert
rules and dashboards work unchanged with sonda driving the data.

## What ships

- **Scheduler.** `tokio::task::spawn` per scenario on a shared multi-thread
  runtime. `tokio_util::sync::CancellationToken` for parent → child shutdown
  fan-out. Dedicated watchdog thread deleted. Per-scenario async-native sink
  trait via `async_trait`; private `tokio::runtime::Runtime` fields dropped
  from `OtlpGrpcSink` and `KafkaSink`.

- **Operator surface on `sonda-server`.**
  - `--workers N` — tokio worker thread count. Defaults to
    `min(available_parallelism(), 16)` — cgroup-aware on Linux containers,
    capped at 16 on larger hosts.
  - `--max-scenarios N` — row cap on `AppState.scenarios` via
    `Arc<Semaphore>`. `0` means unlimited (with WARN log at startup).
  - `--max-inflight-requests N` — global concurrency cap on the protected
    control sub-router via `tower::limit::GlobalConcurrencyLimitLayer`.
  - `--request-timeout SECS` (default 30) — handler-execution bound returning
    HTTP 408. Clap-validated `>= 1`.
  - `--max-body-bytes N` (default 1 MiB) — body cap returning HTTP 413.

- **`GET /server/metrics`.** Prometheus text exposition. Nine series:
  `sonda_server_active_scenarios{state=...}` (gauge),
  `sonda_server_scenarios_finished_total` (counter),
  `sonda_server_worker_threads`, `sonda_server_max_scenarios`,
  `sonda_server_requests_total{route,method,status}`,
  `sonda_server_request_duration_seconds{route,method,le}` (histogram),
  `sonda_server_sink_errors_total{sink_type}`,
  `sonda_server_uptime_seconds`, `sonda_server_build_info{version,git_sha}`.
  Hand-rolled emitter. Route labels use `axum::extract::MatchedPath` (route
  template, not resolved URI) so cardinality stays bounded.

- **Three-sub-router HTTP surface.** `public` (no auth, no Tower stack — hosts
  `/health`), `protected_observability` (auth-gated, no Tower load-control —
  hosts the metrics endpoints so Prometheus scrapes stay green during
  saturation), `protected_control` (auth-gated + full Tower stack — hosts
  POST/DELETE and list/inspect routes).

- **Helm chart.** `ServiceMonitor` defaults to scraping `/server/metrics`.
  Optional `bearerTokenSecret` plumbing for API-key-gated deployments.

- **`build.rs`.** Injects `SONDA_GIT_SHA` from `git rev-parse HEAD`, falls back
  to `\"unknown\"` for Docker-tarball builds.

## Public API additions on sonda-core

All on `#[non_exhaustive]` types:

- `ScenarioHandle::cancel: CancellationToken` (field), `task: Option<tokio::task::JoinHandle<()>>` (field),
  `attach_permit`, `take_permit`, `sink_type`, `with_sink_type`, `join_async`.
- `ScenarioState::operational_states()`, `as_label()`.
- `SinkConfig::Memory.capture_handle: Option<Arc<Mutex<CapturedRing>>>` (`#[serde(skip)]`).
- `RegistryError::UpstreamCancelled` variant.
- `GateBusResolver::cancel_pending_for_upstream` trait method.

## Dependency changes

- `tower-http` features changed to `{timeout, limit}`.
- `tower` promoted to direct dep with `{limit}` feature.
- `tokio-util` added (`CancellationToken`).
- `async_trait` added.
- No other new top-level crates.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace --all-features` — 2923 / 2923
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::await_holding_lock`
- [x] `cargo clippy -p sonda-core --no-default-features -- -D warnings`
- [x] `cargo nextest run -p sonda-core --no-default-features` — 1299 / 1299
- [x] `cargo fmt --all -- --check`
- [x] `cargo audit`
- [x] `cargo nextest run -p sonda-core --all-features --test while_close_workshop_repro` — 11 / 11
- [x] `mkdocs build --strict`
- [x] 10-row scheduler benchmark sweep on landing tip + freshness comparison
      against the original baseline commit
- [x] Linux container production-target row (`--cpus=4 --memory=4g`)
- [x] autocon5/sonda real-stack end-to-end against a locally-built
      `sonda:phase5-validation` image

## Tracked follow-ups (separate post-squash PRs)

- `cleanup_scenarios` test-helper migration to `join_async`. Touches ~103
  `#[tokio::test]` (current_thread) tests; race-sensitive — kept out of this
  release to avoid risking a clean ship.
- `/metrics` → `/scenarios/metrics` rename + 308 redirect for symmetry with
  `/scenarios/{id}/metrics`. User-visible behavior change with its own
  deprecation cycle.
- `gate_bus` polling fallback redesign — Notify+AtomicU8 alternative to the
  current `tokio::sync::watch` clone-vs-version-consumption pattern. Design
  + rationale at #465. The 2 ms `try_recv` loop in `recv_edge_timeout` stays
  in place until a stress-tested replacement lands.

## Merge instructions

**Squash-merge** is mandatory. Atomic-revert is the headline release-safety
property. Do NOT rebase-merge (would push 10 individual commits onto main and
defeat the atomic story).

Refs adoption-review performance + north-star promise. Refs #465.