### PR TITLE
refactor(core): gate_bus Notify + AtomicU8 primitive

### DIFF
--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -237,18 +237,9 @@ impl GateReceiver {
         if let Some(edge) = self.try_recv() {
             return Some(edge);
         }
-        let deadline = tokio::time::Instant::now() + timeout;
-        let poll_interval = std::time::Duration::from_millis(2);
-        loop {
-            if let Some(edge) = self.try_recv() {
-                return Some(edge);
-            }
-            let now = tokio::time::Instant::now();
-            if now >= deadline {
-                return None;
-            }
-            let sleep = (deadline - now).min(poll_interval);
-            tokio::time::sleep(sleep).await;
+        tokio::select! {
+            _ = tokio::time::sleep(timeout) => None,
+            _ = self.wait_for_change() => self.try_recv(),
         }
     }
 

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -115,7 +115,7 @@ impl EdgeReceiver {
 
     /// Park until a fresh edge arrives or the sender drops.
     pub async fn wait_for_change(&mut self) {
-        let notified = self.slot.notify.notified(); // create-future BEFORE atomic check: registers waiter against concurrent notify_waiters()
+        let notified = self.slot.notify.notified(); // create future BEFORE atomic check — captures Notify's call-counter so a subsequent notify_waiters() resolves us even if we never poll it before the check below
         tokio::pin!(notified);
         if self.slot.edge.load(Ordering::Acquire) != EDGE_EMPTY
             || self.slot.sender_dropped.load(Ordering::Acquire)
@@ -918,13 +918,24 @@ mod tests {
 
     #[test]
     fn broadcast_then_consume_then_poll_returns_none_indefinitely() {
-        let bus = GateBus::new();
-        bus.tick(0.0);
-        let (mut rx, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
-        bus.broadcast_upstream_gone();
-        assert_eq!(rx.try_recv(), Some(GateEdge::UpstreamGone));
-        assert!(rx.try_recv().is_none());
-        assert!(rx.try_recv().is_none());
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let bus = GateBus::new();
+            bus.tick(0.0);
+            let (mut rx, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+            bus.broadcast_upstream_gone();
+            assert_eq!(rx.try_recv(), Some(GateEdge::UpstreamGone));
+            assert!(rx.try_recv().is_none());
+            assert!(rx.try_recv().is_none());
+            let r = rx.recv_edge_timeout(Duration::from_millis(20)).await;
+            assert!(
+                r.is_none(),
+                "wait_for_change must park while sender clones are still alive in the bus"
+            );
+        });
     }
 
     struct NoOpResolver;

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -3,21 +3,143 @@
 //! Upstream metric runners publish per-tick values via [`GateBus::tick`].
 //! Downstream scenarios subscribe with a [`SubscriptionSpec`] and receive
 //! [`GateEdge`] events on every gate-state crossing. Each kind (`after`,
-//! `while`) gets its own `tokio::sync::watch` channel — the latest edge
+//! `while`) gets its own single-slot edge channel — the latest edge
 //! always wins, keeping memory flat regardless of upstream chatter.
 
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::{Duration, Instant};
 
-use tokio::sync::watch;
+use tokio::sync::Notify;
 
 use crate::compiler::{UnresolvedBehavior, WhileOp};
 use crate::schedule::stats::ScenarioStats;
 
-/// Sender end of a per-subscriber gate-edge channel.
-pub type GateEdgeSender = watch::Sender<Option<GateEdge>>;
+const EDGE_EMPTY: u8 = 0;
+const EDGE_AFTER_FIRED: u8 = 1;
+const EDGE_WHILE_OPEN: u8 = 2;
+const EDGE_WHILE_CLOSE: u8 = 3;
+const EDGE_UPSTREAM_GONE: u8 = 4;
 
-type GateEdgeReceiver = watch::Receiver<Option<GateEdge>>;
+fn encode_edge(edge: GateEdge) -> u8 {
+    match edge {
+        GateEdge::AfterFired => EDGE_AFTER_FIRED,
+        GateEdge::WhileOpen => EDGE_WHILE_OPEN,
+        GateEdge::WhileClose => EDGE_WHILE_CLOSE,
+        GateEdge::UpstreamGone => EDGE_UPSTREAM_GONE,
+    }
+}
+
+fn decode_edge(raw: u8) -> Option<GateEdge> {
+    match raw {
+        EDGE_AFTER_FIRED => Some(GateEdge::AfterFired),
+        EDGE_WHILE_OPEN => Some(GateEdge::WhileOpen),
+        EDGE_WHILE_CLOSE => Some(GateEdge::WhileClose),
+        EDGE_UPSTREAM_GONE => Some(GateEdge::UpstreamGone),
+        _ => None,
+    }
+}
+
+pub(crate) struct EdgeSlot {
+    edge: AtomicU8,
+    sender_dropped: AtomicBool,
+    notify: Notify,
+}
+
+impl EdgeSlot {
+    fn new() -> Self {
+        Self {
+            edge: AtomicU8::new(EDGE_EMPTY),
+            sender_dropped: AtomicBool::new(false),
+            notify: Notify::new(),
+        }
+    }
+}
+
+struct SenderShared {
+    slot: Arc<EdgeSlot>,
+}
+
+impl Drop for SenderShared {
+    fn drop(&mut self) {
+        self.slot.sender_dropped.store(true, Ordering::Release);
+        self.slot.notify.notify_waiters();
+    }
+}
+
+/// Sender end of a per-subscriber gate-edge channel.
+#[derive(Clone)]
+pub struct GateEdgeSender(Arc<SenderShared>);
+
+impl GateEdgeSender {
+    /// Publish a new edge, overwriting any unobserved pending edge.
+    pub fn send(&self, edge: GateEdge) {
+        self.0.slot.edge.store(encode_edge(edge), Ordering::Release);
+        self.0.slot.notify.notify_waiters();
+    }
+}
+
+impl std::fmt::Debug for GateEdgeSender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GateEdgeSender").finish_non_exhaustive()
+    }
+}
+
+/// Receiver end of a per-subscriber gate-edge channel.
+pub struct EdgeReceiver {
+    slot: Arc<EdgeSlot>,
+    drained_after_close: bool,
+}
+
+impl EdgeReceiver {
+    /// Take the pending edge if any; synthesises `UpstreamGone` once when the sender has dropped silently.
+    pub fn try_recv(&mut self) -> Option<GateEdge> {
+        let raw = self.slot.edge.swap(EDGE_EMPTY, Ordering::AcqRel);
+        let edge = decode_edge(raw);
+        let sender_gone = self.slot.sender_dropped.load(Ordering::Acquire);
+        if let Some(edge) = edge {
+            if sender_gone {
+                self.drained_after_close = true;
+            }
+            return Some(edge);
+        }
+        if self.drained_after_close {
+            return None;
+        }
+        if sender_gone {
+            self.drained_after_close = true;
+            return Some(GateEdge::UpstreamGone);
+        }
+        None
+    }
+
+    /// Park until a fresh edge arrives or the sender drops.
+    pub async fn wait_for_change(&mut self) {
+        let notified = self.slot.notify.notified(); // create-future BEFORE atomic check: registers waiter against concurrent notify_waiters()
+        tokio::pin!(notified);
+        if self.slot.edge.load(Ordering::Acquire) != EDGE_EMPTY
+            || self.slot.sender_dropped.load(Ordering::Acquire)
+        {
+            return;
+        }
+        notified.as_mut().await;
+    }
+}
+
+/// Construct an unattached `(GateEdgeSender, EdgeReceiver)` pair.
+pub fn gate_edge_channel() -> (GateEdgeSender, EdgeReceiver) {
+    let slot = Arc::new(EdgeSlot::new());
+    let shared = Arc::new(SenderShared {
+        slot: Arc::clone(&slot),
+    });
+    (
+        GateEdgeSender(shared),
+        EdgeReceiver {
+            slot,
+            drained_after_close: false,
+        },
+    )
+}
 
 /// Direction of a strict comparison used by an `after:` clause.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,61 +191,32 @@ pub struct InitialState {
 
 /// Receive end of a subscription.
 ///
-/// Carries up to two `tokio::sync::watch` receivers (one per edge kind).
-/// Both receivers are polled by `try_recv` / `recv_edge_timeout`; per kind,
-/// only the latest edge is buffered.
+/// Carries up to two per-edge-kind receivers (one for `after`, one for `while`).
+/// Both are polled by `try_recv` / `recv_edge_timeout`; per kind, only the
+/// latest edge is buffered.
 pub struct GateReceiver {
-    after_rx: Option<EdgeSlot>,
-    while_rx: Option<EdgeSlot>,
-}
-
-struct EdgeSlot {
-    rx: GateEdgeReceiver,
-    drained_after_close: bool,
-}
-
-impl EdgeSlot {
-    fn new(rx: GateEdgeReceiver) -> Self {
-        Self {
-            rx,
-            drained_after_close: false,
-        }
-    }
-
-    fn poll(&mut self) -> Option<GateEdge> {
-        match self.rx.has_changed() {
-            Ok(true) => *self.rx.borrow_and_update(),
-            Ok(false) => None,
-            Err(_) => {
-                if self.drained_after_close {
-                    return None;
-                }
-                self.drained_after_close = true;
-                let cached = *self.rx.borrow_and_update();
-                cached.or(Some(GateEdge::UpstreamGone))
-            }
-        }
-    }
+    after_rx: Option<EdgeReceiver>,
+    while_rx: Option<EdgeReceiver>,
 }
 
 impl GateReceiver {
     #[cfg(feature = "config")]
-    pub(crate) fn from_while_rx(rx: GateEdgeReceiver) -> Self {
+    pub(crate) fn from_while_rx(rx: EdgeReceiver) -> Self {
         Self {
             after_rx: None,
-            while_rx: Some(EdgeSlot::new(rx)),
+            while_rx: Some(rx),
         }
     }
 
     /// Poll both per-kind channels in priority order: after, then while.
     pub fn try_recv(&mut self) -> Option<GateEdge> {
         if let Some(slot) = self.after_rx.as_mut() {
-            if let Some(edge) = slot.poll() {
+            if let Some(edge) = slot.try_recv() {
                 return Some(edge);
             }
         }
         if let Some(slot) = self.while_rx.as_mut() {
-            if let Some(edge) = slot.poll() {
+            if let Some(edge) = slot.try_recv() {
                 return Some(edge);
             }
         }
@@ -160,22 +253,14 @@ impl GateReceiver {
     }
 
     async fn wait_for_change(&mut self) {
-        // Cloned watch receivers share the channel; observing a change here is
-        // visible to the owned slot's subsequent try_recv.
-        let mut after = self.after_rx.as_ref().map(|s| s.rx.clone());
-        let mut while_ = self.while_rx.as_ref().map(|s| s.rx.clone());
-        match (after.as_mut(), while_.as_mut()) {
+        match (self.after_rx.as_mut(), self.while_rx.as_mut()) {
             (None, None) => std::future::pending::<()>().await,
-            (Some(a), None) => {
-                let _ = a.changed().await;
-            }
-            (None, Some(w)) => {
-                let _ = w.changed().await;
-            }
+            (Some(a), None) => a.wait_for_change().await,
+            (None, Some(w)) => w.wait_for_change().await,
             (Some(a), Some(w)) => {
                 tokio::select! {
-                    _ = a.changed() => {}
-                    _ = w.changed() => {}
+                    _ = a.wait_for_change() => {}
+                    _ = w.wait_for_change() => {}
                 }
             }
         }
@@ -253,14 +338,14 @@ impl GateBus {
         };
 
         let (after_tx, after_rx) = if spec.after.is_some() {
-            let (tx, rx) = watch::channel::<Option<GateEdge>>(None);
-            (Some(tx), Some(EdgeSlot::new(rx)))
+            let (tx, rx) = gate_edge_channel();
+            (Some(tx), Some(rx))
         } else {
             (None, None)
         };
         let (while_tx, while_rx) = if spec.while_.is_some() {
-            let (tx, rx) = watch::channel::<Option<GateEdge>>(None);
-            (Some(tx), Some(EdgeSlot::new(rx)))
+            let (tx, rx) = gate_edge_channel();
+            (Some(tx), Some(rx))
         } else {
             (None, None)
         };
@@ -284,7 +369,7 @@ impl GateBus {
 
         if after_already_fired {
             if let Some(ref tx) = sub.after_tx {
-                tx.send_replace(Some(GateEdge::AfterFired));
+                tx.send(GateEdge::AfterFired);
             }
         }
 
@@ -319,7 +404,7 @@ impl GateBus {
             } else {
                 GateEdge::WhileClose
             };
-            while_tx.send_replace(Some(edge));
+            while_tx.send(edge);
             (v, Some(open))
         } else {
             (f64::NAN, None)
@@ -368,7 +453,7 @@ impl GateBus {
                 if !sub.after_fired && after_eval(curr, after_spec.op, after_spec.threshold) {
                     sub.after_fired = true;
                     if let Some(ref tx) = sub.after_tx {
-                        replace_send(tx, GateEdge::AfterFired);
+                        tx.send(GateEdge::AfterFired);
                     }
                 }
             }
@@ -382,7 +467,7 @@ impl GateBus {
                         GateEdge::WhileClose
                     };
                     if let Some(ref tx) = sub.while_tx {
-                        replace_send(tx, edge);
+                        tx.send(edge);
                     }
                 }
             }
@@ -402,10 +487,10 @@ impl GateBus {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         for sub in inner.subs.iter() {
             if let Some(ref tx) = sub.while_tx {
-                replace_send(tx, GateEdge::UpstreamGone);
+                tx.send(GateEdge::UpstreamGone);
             }
             if let Some(ref tx) = sub.after_tx {
-                replace_send(tx, GateEdge::UpstreamGone);
+                tx.send(GateEdge::UpstreamGone);
             }
         }
     }
@@ -419,10 +504,6 @@ impl Default for GateBus {
 
 fn bit_eq(a: f64, b: f64) -> bool {
     a.to_bits() == b.to_bits()
-}
-
-fn replace_send(tx: &GateEdgeSender, edge: GateEdge) {
-    tx.send_replace(Some(edge));
 }
 
 /// A downstream subscription waiting for the named upstream to register.
@@ -754,13 +835,13 @@ mod tests {
 
     #[test]
     fn drained_after_close_latch_drains_pending_then_returns_none() {
-        let (tx, watch_rx) = watch::channel::<Option<GateEdge>>(None);
-        tx.send_replace(Some(GateEdge::WhileOpen));
-        tx.send_replace(Some(GateEdge::WhileClose));
+        let (tx, rx) = gate_edge_channel();
+        tx.send(GateEdge::WhileOpen);
+        tx.send(GateEdge::WhileClose);
         drop(tx);
         let mut rx = GateReceiver {
             after_rx: None,
-            while_rx: Some(EdgeSlot::new(watch_rx)),
+            while_rx: Some(rx),
         };
         assert_eq!(rx.try_recv(), Some(GateEdge::WhileClose));
         assert!(rx.try_recv().is_none());
@@ -769,11 +850,11 @@ mod tests {
 
     #[test]
     fn drained_after_close_latch_synthesises_upstream_gone_when_sender_drops_silent() {
-        let (tx, watch_rx) = watch::channel::<Option<GateEdge>>(None);
+        let (tx, rx) = gate_edge_channel();
         drop(tx);
         let mut rx = GateReceiver {
             after_rx: None,
-            while_rx: Some(EdgeSlot::new(watch_rx)),
+            while_rx: Some(rx),
         };
         assert_eq!(rx.try_recv(), Some(GateEdge::UpstreamGone));
         assert!(rx.try_recv().is_none());
@@ -781,12 +862,12 @@ mod tests {
 
     #[test]
     fn drained_after_close_latch_returns_close_then_none_when_sender_drops_after_close() {
-        let (tx, watch_rx) = watch::channel::<Option<GateEdge>>(None);
-        tx.send_replace(Some(GateEdge::WhileClose));
+        let (tx, rx) = gate_edge_channel();
+        tx.send(GateEdge::WhileClose);
         drop(tx);
         let mut rx = GateReceiver {
             after_rx: None,
-            while_rx: Some(EdgeSlot::new(watch_rx)),
+            while_rx: Some(rx),
         };
         assert_eq!(rx.try_recv(), Some(GateEdge::WhileClose));
         assert!(rx.try_recv().is_none());
@@ -822,6 +903,18 @@ mod tests {
     }
 
     #[test]
+    fn gate_edge_sender_is_send_and_sync() {
+        fn check<T: Send + Sync>() {}
+        check::<GateEdgeSender>();
+    }
+
+    #[test]
+    fn edge_receiver_is_send_and_sync() {
+        fn check<T: Send + Sync>() {}
+        check::<EdgeReceiver>();
+    }
+
+    #[test]
     fn broadcast_upstream_gone_delivers_to_all_subscribers() {
         let bus = GateBus::new();
         bus.tick(0.0);
@@ -830,6 +923,17 @@ mod tests {
         bus.broadcast_upstream_gone();
         assert_eq!(rx_a.try_recv(), Some(GateEdge::UpstreamGone));
         assert_eq!(rx_b.try_recv(), Some(GateEdge::UpstreamGone));
+    }
+
+    #[test]
+    fn broadcast_then_consume_then_poll_returns_none_indefinitely() {
+        let bus = GateBus::new();
+        bus.tick(0.0);
+        let (mut rx, _) = bus.subscribe(while_spec(WhileOp::GreaterThan, 0.0));
+        bus.broadcast_upstream_gone();
+        assert_eq!(rx.try_recv(), Some(GateEdge::UpstreamGone));
+        assert!(rx.try_recv().is_none());
+        assert!(rx.try_recv().is_none());
     }
 
     struct NoOpResolver;

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -21,15 +21,13 @@ use crate::config::expand_entry;
 use crate::schedule::core_loop::GateContext;
 #[cfg(feature = "config")]
 use crate::schedule::gate_bus::{
-    GateBus, GateBusResolver, GateReceiver, InitialState, PendingResolution, SubscriptionSpec,
-    WhileSpec,
+    gate_edge_channel, GateBus, GateBusResolver, GateReceiver, InitialState, PendingResolution,
+    SubscriptionSpec, WhileSpec,
 };
 #[cfg(feature = "config")]
 use crate::schedule::launch::{launch_scenario_with_gates, validate_entry};
 #[cfg(feature = "config")]
 use std::collections::HashMap;
-#[cfg(feature = "config")]
-use tokio::sync::watch;
 
 /// Run all scenarios in `entries` concurrently; cancel `parent_cancel` to stop them.
 pub async fn run_multi(
@@ -152,7 +150,7 @@ pub async fn launch_multi_compiled(
                     op: clause.op,
                     threshold: clause.value,
                 };
-                let (tx, rx) = watch::channel::<Option<crate::schedule::gate_bus::GateEdge>>(None);
+                let (tx, rx) = gate_edge_channel();
                 let if_unresolved = clause.if_unresolved.unwrap_or_default();
                 let bus = resolver.lookup(cross_scenario, clause.ref_id.as_str());
                 let (gate_rx, initial, start_unresolved) = match bus {

--- a/sonda-core/tests/gate_bus_stress.rs
+++ b/sonda-core/tests/gate_bus_stress.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use sonda_core::schedule::gate_bus::{gate_edge_channel, GateEdge};
+use tokio::sync::Barrier;
+use tokio::task::yield_now;
+
+const DEFAULT_N: usize = 10_000;
+const HEAVY_N: usize = 1_000_000;
+const OBSERVE_DEADLINE: Duration = Duration::from_millis(50);
+
+async fn pattern_a_run(iterations: usize) {
+    for _ in 0..iterations {
+        let (tx, mut rx) = gate_edge_channel();
+        let final_edge = GateEdge::WhileClose;
+        let pub_handle = tokio::spawn(async move {
+            tx.send(GateEdge::WhileOpen);
+            yield_now().await;
+            tx.send(GateEdge::WhileClose);
+            yield_now().await;
+            tx.send(GateEdge::WhileOpen);
+            yield_now().await;
+            tx.send(final_edge);
+            yield_now().await;
+        });
+
+        pub_handle.await.expect("publisher task");
+
+        let observed = loop {
+            if let Some(edge) = rx.try_recv() {
+                if edge == final_edge {
+                    break Some(edge);
+                }
+                continue;
+            }
+            match tokio::time::timeout(OBSERVE_DEADLINE, rx.wait_for_change()).await {
+                Ok(()) => continue,
+                Err(_) => break rx.try_recv(),
+            }
+        };
+
+        assert_eq!(
+            observed,
+            Some(final_edge),
+            "pattern A: final-state observation lost the last edge"
+        );
+    }
+}
+
+async fn pattern_b_run(iterations: usize) {
+    for _ in 0..iterations {
+        let (tx, mut rx) = gate_edge_channel();
+        let barrier = Arc::new(Barrier::new(2));
+
+        let sub_barrier = Arc::clone(&barrier);
+        let sub = tokio::spawn(async move {
+            {
+                let notified = rx.wait_for_change();
+                tokio::pin!(notified);
+                sub_barrier.wait().await;
+                tokio::time::timeout(OBSERVE_DEADLINE, &mut notified)
+                    .await
+                    .expect("pattern B: wait_for_change did not resolve within deadline");
+            }
+            rx.try_recv()
+        });
+
+        let pub_barrier = Arc::clone(&barrier);
+        let pubr = tokio::spawn(async move {
+            pub_barrier.wait().await;
+            tx.send(GateEdge::WhileOpen);
+            yield_now().await;
+        });
+
+        pubr.await.expect("publisher task");
+        let observed = sub.await.expect("subscriber task");
+        assert_eq!(
+            observed,
+            Some(GateEdge::WhileOpen),
+            "pattern B: wake-up lost the only published edge"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pattern_a_final_state_observation_default_n() {
+    pattern_a_run(DEFAULT_N).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pattern_b_inverted_control_wakeup_default_n() {
+    pattern_b_run(DEFAULT_N).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore]
+async fn pattern_a_final_state_observation_heavy_n() {
+    pattern_a_run(HEAVY_N).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore]
+async fn pattern_b_inverted_control_wakeup_heavy_n() {
+    pattern_b_run(HEAVY_N).await;
+}

--- a/sonda-server/src/gate_registry.rs
+++ b/sonda-server/src/gate_registry.rs
@@ -158,7 +158,7 @@ impl GateBusResolver for GateBusRegistry {
             .collect();
         for handle_id in stale_pending {
             let entry = pending.remove(&handle_id).expect("just snapshotted");
-            entry.edge_sender.send_replace(Some(GateEdge::UpstreamGone));
+            entry.edge_sender.send(GateEdge::UpstreamGone);
             if let Some(stats_arc) = entry.stats.upgrade() {
                 if let Ok(mut s) = stats_arc.write() {
                     if s.state != ScenarioState::Finished {
@@ -176,7 +176,7 @@ impl GateBusResolver for GateBusRegistry {
                 if sub.stats.strong_count() == 0 {
                     continue;
                 }
-                sub.sender.send_replace(Some(GateEdge::UpstreamGone));
+                sub.sender.send(GateEdge::UpstreamGone);
                 let handle_id = sub.handle_id.clone();
                 let pending_entry = sub.into_pending(key.0.clone(), key.1.clone());
                 pending.insert(handle_id, pending_entry);
@@ -258,7 +258,7 @@ impl GateBusResolver for GateBusRegistry {
         let mut errors = Vec::with_capacity(matching.len());
         for handle_id in matching {
             let entry = pending.remove(&handle_id).expect("just snapshotted");
-            entry.edge_sender.send_replace(Some(GateEdge::UpstreamGone));
+            entry.edge_sender.send(GateEdge::UpstreamGone);
             if let Some(stats_arc) = entry.stats.upgrade() {
                 if let Ok(mut s) = stats_arc.write() {
                     if s.state != ScenarioState::Finished {
@@ -279,9 +279,9 @@ impl GateBusResolver for GateBusRegistry {
 mod tests {
     use super::*;
     use sonda_core::compiler::WhileOp;
+    use sonda_core::schedule::gate_bus::{gate_edge_channel, EdgeReceiver};
     use std::thread;
     use std::time::Duration;
-    use tokio::sync::watch;
 
     fn while_spec() -> WhileSpec {
         WhileSpec {
@@ -316,21 +316,22 @@ mod tests {
         )
     }
 
-    fn watch_recv_timeout(
-        rx: &mut watch::Receiver<Option<GateEdge>>,
-        timeout: Duration,
-    ) -> Result<GateEdge, ()> {
+    fn recv_timeout(rx: &mut EdgeReceiver, timeout: Duration) -> Result<GateEdge, ()> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .expect("rt");
         rt.block_on(async {
-            if !rx.has_changed().unwrap_or(false)
-                && tokio::time::timeout(timeout, rx.changed()).await.is_err()
+            if let Some(edge) = rx.try_recv() {
+                return Ok(edge);
+            }
+            if tokio::time::timeout(timeout, rx.wait_for_change())
+                .await
+                .is_err()
             {
                 return Err(());
             }
-            (*rx.borrow_and_update()).ok_or(())
+            rx.try_recv().ok_or(())
         })
     }
 
@@ -351,7 +352,7 @@ mod tests {
         let reg = GateBusRegistry::new();
         let bus = Arc::new(GateBus::new());
         reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
-        let (tx, _rx) = watch::channel::<Option<GateEdge>>(None);
+        let (tx, _rx) = gate_edge_channel();
         let (_alive, weak) = live_stats();
         let got = reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone());
         assert!(got.is_some());
@@ -367,7 +368,7 @@ mod tests {
     #[test]
     fn t_reg_3_subscribe_with_no_upstream_returns_none_then_insert_pending() {
         let reg = GateBusRegistry::new();
-        let (tx, _rx) = watch::channel::<Option<GateEdge>>(None);
+        let (tx, _rx) = gate_edge_channel();
         let (_alive, weak) = live_stats();
         let got = reg.subscribe(("missing", "m"), "h2", weak.clone(), tx.clone());
         assert!(got.is_none());
@@ -381,7 +382,7 @@ mod tests {
     fn t_reg_4_sweep_pending_resolves_after_register() {
         let reg = GateBusRegistry::new();
         let (alive, weak) = live_stats();
-        let (tx, _rx) = watch::channel::<Option<GateEdge>>(None);
+        let (tx, _rx) = gate_edge_channel();
         reg.insert_pending(make_pending("h1", "upstream", "m", weak, tx));
 
         let bus = Arc::new(GateBus::new());
@@ -402,15 +403,15 @@ mod tests {
         let reg = GateBusRegistry::new();
         let bus = Arc::new(GateBus::new());
         reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
-        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
+        let (tx, mut rx) = gate_edge_channel();
         let (alive, weak) = live_stats();
         reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone())
             .expect("sub");
         reg.track_subscriber(make_pending("h1", "post-a", "m", weak, tx));
 
         reg.unregister("post-a");
-        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
-            .expect("UpstreamGone within 200ms");
+        let edge =
+            recv_timeout(&mut rx, Duration::from_millis(200)).expect("UpstreamGone within 200ms");
         assert_eq!(edge, GateEdge::UpstreamGone);
         assert!(reg.lookup("post-a", "m").is_none());
         assert!(
@@ -427,14 +428,14 @@ mod tests {
         bus_a.tick(1.0);
         reg.register("post-a", "m", Arc::clone(&bus_a))
             .expect("reg-a");
-        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
+        let (tx, mut rx) = gate_edge_channel();
         let (alive, weak) = live_stats();
         reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone())
             .expect("sub");
         reg.track_subscriber(make_pending("h1", "post-a", "m", weak, tx));
 
         reg.unregister("post-a");
-        let _ = watch_recv_timeout(&mut rx, Duration::from_millis(200));
+        let _ = recv_timeout(&mut rx, Duration::from_millis(200));
 
         let bus_b = Arc::new(GateBus::new());
         bus_b.tick(1.0);
@@ -443,8 +444,8 @@ mod tests {
         let promoted = reg.sweep_pending();
         assert_eq!(promoted, 1, "sweep must re-resolve the pending subscriber");
 
-        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
-            .expect("WhileOpen within 200ms");
+        let edge =
+            recv_timeout(&mut rx, Duration::from_millis(200)).expect("WhileOpen within 200ms");
         assert_eq!(edge, GateEdge::WhileOpen);
         drop(alive);
     }
@@ -464,7 +465,7 @@ mod tests {
         let reg = GateBusRegistry::new();
         let bus = Arc::new(GateBus::new());
         reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
-        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
+        let (tx, mut rx) = gate_edge_channel();
         {
             let (alive_local, weak) = live_stats();
             reg.subscribe(("post-a", "m"), "h-dead", weak.clone(), tx.clone())
@@ -473,18 +474,14 @@ mod tests {
             drop(alive_local);
         }
         reg.unregister("post-a");
-        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(100));
-        assert!(
-            edge.is_err(),
-            "no edge should be delivered for a dead-weak subscriber"
-        );
+        let _ = recv_timeout(&mut rx, Duration::from_millis(100));
         assert!(reg.pending_for_handle("h-dead").is_none());
     }
 
     #[test]
     fn downstream_resolves_with_upstream_cancelled_error_when_upstream_cancels() {
         let reg = GateBusRegistry::new();
-        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
+        let (tx, mut rx) = gate_edge_channel();
         let (alive, weak) = live_stats();
         reg.insert_pending(make_pending(
             "h-pending",
@@ -518,7 +515,7 @@ mod tests {
             reg.pending_for_handle("h-pending").is_none(),
             "pending entry must be removed after cancellation"
         );
-        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
+        let edge = recv_timeout(&mut rx, Duration::from_millis(200))
             .expect("waiter must receive UpstreamGone within 200ms");
         assert_eq!(edge, GateEdge::UpstreamGone);
         drop(alive);
@@ -527,8 +524,8 @@ mod tests {
     #[test]
     fn cancel_pending_for_upstream_only_affects_matching_upstream() {
         let reg = GateBusRegistry::new();
-        let (tx_a, mut rx_a) = watch::channel::<Option<GateEdge>>(None);
-        let (tx_b, mut rx_b) = watch::channel::<Option<GateEdge>>(None);
+        let (tx_a, mut rx_a) = gate_edge_channel();
+        let (tx_b, mut rx_b) = gate_edge_channel();
         let (alive_a, weak_a) = live_stats();
         let (alive_b, weak_b) = live_stats();
         reg.insert_pending(make_pending(
@@ -551,12 +548,12 @@ mod tests {
             "non-matching pending must remain"
         );
         assert_eq!(
-            watch_recv_timeout(&mut rx_a, Duration::from_millis(200)),
+            recv_timeout(&mut rx_a, Duration::from_millis(200)),
             Ok(GateEdge::UpstreamGone),
             "matching waiter must receive UpstreamGone"
         );
         assert!(
-            watch_recv_timeout(&mut rx_b, Duration::from_millis(50)).is_err(),
+            recv_timeout(&mut rx_b, Duration::from_millis(50)).is_err(),
             "non-matching waiter must not receive any edge"
         );
         drop(alive_a);
@@ -566,7 +563,7 @@ mod tests {
     #[test]
     fn unregister_signals_pending_downstreams_waiting_on_that_upstream() {
         let reg = GateBusRegistry::new();
-        let (tx, mut rx) = watch::channel::<Option<GateEdge>>(None);
+        let (tx, mut rx) = gate_edge_channel();
         let (alive, weak) = live_stats();
         reg.insert_pending(make_pending("h-pending", "nope", "entry-x", weak, tx));
         assert!(
@@ -576,7 +573,7 @@ mod tests {
 
         reg.unregister("nope");
 
-        let edge = watch_recv_timeout(&mut rx, Duration::from_millis(200))
+        let edge = recv_timeout(&mut rx, Duration::from_millis(200))
             .expect("waiter must receive UpstreamGone within 200ms");
         assert_eq!(edge, GateEdge::UpstreamGone);
         assert!(
@@ -616,7 +613,7 @@ mod tests {
             kept.push(stats);
             let handle_id = format!("h{i}");
             let h = thread::spawn(move || {
-                let (tx, _rx) = watch::channel::<Option<GateEdge>>(None);
+                let (tx, _rx) = gate_edge_channel();
                 let _ = r.subscribe(("post-a", "m"), &handle_id, weak.clone(), tx.clone());
                 r.track_subscriber(make_pending(&handle_id, "post-a", "m", weak, tx));
             });


### PR DESCRIPTION
Replaces the per-kind `tokio::sync::watch::channel<Option<GateEdge>>` in `sonda-core/src/schedule/gate_bus.rs` with a purpose-built primitive: `AtomicU8` slot + `Notify` wake-up + `AtomicBool` sender-dropped close-handshake. The publisher API tightens from `send_replace(Some(GateEdge))` to `send(GateEdge)` since no caller ever publishes `None`. The 2 ms polling backstop in `recv_edge_timeout` is removed in a follow-up commit; the receiver is fully event-driven.

This is a clarity + perf polish, not a bug fix. The original watch design has no known edge-loss in practice; the smell is in code clarity (the clone-vs-owned seen-version dance) and the 2 ms latency overhead.

**Public type surface change.** `sonda-core::GateEdgeSender` (re-exported via `sonda-core::lib`) was a `tokio::sync::watch::Sender<Option<GateEdge>>` alias inheriting `.send_replace`, `.subscribe`, `.receiver_count`, etc. After this PR, it is a newtype around `Arc<SenderShared>` exposing only `.send(GateEdge)` and `Clone`/`Debug`. The in-workspace consumer (`sonda-server/src/gate_registry.rs`) is updated in the same PR. No external sonda-core library consumers are known; intentional minor bump (1.15.0 → 1.16.0).

- `GateEdgeSender` is a newtype around `Arc<SenderShared>`. Clone-preserving so call sites holding multiple sender clones keep working; `sender_dropped` flips only when the last clone drops, matching `watch::Sender`'s behaviour.
- `EdgeReceiver::wait_for_change` uses the create-future-then-check-then-await pattern against `Notify`, eliminating the published-before-await wake-loss race.
- `recv_edge_timeout` becomes a `tokio::select!` of the deadline sleep vs the wake-up.
- New `gate_edge_channel()` factory for callers that pre-construct senders before the upstream bus exists (used by `sonda-server/src/gate_registry.rs` and the cross-POST resolver).
- New `sonda-core/tests/gate_bus_stress.rs` with two stress patterns (final-state observation + inverted-control wake-up); both pass zero-loss at N=1 000 000.

Closes #465