### PR TITLE
feat(server): run sonda-server as non-root UID 65532 by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,11 +82,17 @@ RUN RUST_TARGET=$(cat /tmp/rust-target) && \
     cp "target/${RUST_TARGET}/release/sonda" /out/sonda && \
     cp "target/${RUST_TARGET}/release/sonda-server" /out/sonda-server
 
+# UID 65532 = upstream "nonroot" convention (distroless/nonroot, chainguard)
+RUN echo 'sonda:x:65532:65532::/:' > /tmp/passwd.sonda
+
 # Stage 2: Minimal runtime image
 FROM scratch
 
 COPY --from=builder /out/sonda /sonda
 COPY --from=builder /out/sonda-server /sonda-server
+COPY --from=builder /tmp/passwd.sonda /etc/passwd
+
+USER 65532:65532
 
 EXPOSE 8080
 

--- a/docs/site/docs/deploy/kubernetes.md
+++ b/docs/site/docs/deploy/kubernetes.md
@@ -95,10 +95,46 @@ helm install sonda ./helm/sonda \
 
 ### Security
 
+The container image runs as UID 65532 (the upstream "nonroot" convention used by distroless and Chainguard images). The chart ships matching `podSecurityContext` and `securityContext` defaults that satisfy the [restricted Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) and pass Kyverno or OPA Gatekeeper policies that enforce `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and `capabilities.drop: [ALL]` out of the box.
+
 | Value | Default | Description |
 |-------|---------|-------------|
-| `podSecurityContext` | `{}` | Pod-level security context (e.g., `fsGroup`) |
-| `securityContext` | `{}` | Container-level security context (e.g., `runAsNonRoot`, `readOnlyRootFilesystem`, `capabilities`) |
+| `podSecurityContext.runAsNonRoot` | `true` | Reject the pod if any container would run as UID 0 |
+| `podSecurityContext.runAsUser` | `65532` | UID the pod runs as |
+| `podSecurityContext.runAsGroup` | `65532` | GID the pod runs as |
+| `podSecurityContext.fsGroup` | `65532` | GID applied to mounted volumes |
+| `podSecurityContext.seccompProfile.type` | `RuntimeDefault` | Apply the container runtime's default seccomp profile |
+| `securityContext.runAsNonRoot` | `true` | Reject the container if it would run as UID 0 |
+| `securityContext.runAsUser` | `65532` | UID the container process runs as |
+| `securityContext.runAsGroup` | `65532` | GID the container process runs as |
+| `securityContext.allowPrivilegeEscalation` | `false` | Disallow `setuid` / file-capability escalation |
+| `securityContext.readOnlyRootFilesystem` | `true` | Mount `/` read-only; the server writes nothing outside `/tmp` and volume mounts |
+| `securityContext.capabilities.drop` | `[ALL]` | Drop every Linux capability |
+
+Override individual fields if your cluster uses a different UID convention, or replace the whole block to relax a constraint. The example below pins the container to UID 1000 (a common convention for managed clusters that mount Persistent Volumes with a fixed owner):
+
+```yaml title="my-values.yaml"
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+```
+
+!!! warning "Lists are replaced, not merged"
+    Helm deep-merges maps but replaces lists wholesale. Scalar overrides like `--set securityContext.runAsUser=1000` work key-by-key against the defaults above. Overriding `capabilities.drop`, however, replaces the entire `[ALL]` default — supply the full list you want (typically `[ALL]` plus any explicit exceptions) rather than the delta.
 
 ### Authentication
 

--- a/helm/sonda/values.yaml
+++ b/helm/sonda/values.yaml
@@ -49,17 +49,26 @@ resources:
     cpu: 500m
     memory: 256Mi
 
-# Pod-level security context.
-podSecurityContext: {}
-  # fsGroup: 1000
+# Pod-level security context. Defaults match the non-root image (UID 65532).
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
 
-# Container-level security context.
-securityContext: {}
-  # runAsNonRoot: true
-  # readOnlyRootFilesystem: true
-  # capabilities:
-  #   drop:
-  #     - ALL
+# Container-level security context. Defaults match the non-root image (UID 65532).
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  allowPrivilegeEscalation: false
+  # File-sink users: mount a writable volume or set readOnlyRootFilesystem: false.
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 # Scenario YAML files to mount as a ConfigMap.
 # Each key becomes a file under /scenarios in the container.


### PR DESCRIPTION
Closes the longstanding gap that blocked sonda from clusters enforcing `runAsNonRoot` via PSP, OPA, Kyverno, or the Kubernetes `restricted` Pod Security Standard.

- **Dockerfile**: generate a `/etc/passwd` entry for UID 65532 in the builder stage, copy it into the `FROM scratch` runtime stage, add `USER 65532:65532`. UID 65532 matches the upstream "nonroot" convention used by distroless, Chainguard, and OpenShift's restricted PSA.
- **Helm chart**: flip `podSecurityContext` and `securityContext` defaults from empty maps to populated values matching the new image. Pod context: `runAsNonRoot`, `runAsUser`/`runAsGroup`/`fsGroup: 65532`, `seccompProfile.type: RuntimeDefault`. Container context: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`. Operators with different cluster conventions can still override via `--set`.
- **`helm/sonda/Chart.yaml`** `version: 1.16.0 -> 1.17.0`; `appVersion` left at `1.16.0` (release-please bumps `appVersion` on the next workspace release).
- **`docs/site/docs/deploy/kubernetes.md`**: rewrite the Security section to describe the secure-by-default posture, expand the values table to cover every populated key with its concrete default, and add a worked override example.
- One inline comment in `values.yaml` next to `readOnlyRootFilesystem: true` flagging the file-sink override requirement for operators not using stdout/network sinks.

## Test plan

- [x] `docker inspect` shows `User: "65532:65532"`
- [x] `docker run --rm sonda --version` runs as non-root
- [x] `docker run --rm --read-only sonda --version` runs (binary writes nothing to disk by default)
- [x] `helm lint helm/sonda` passes (0 failures)
- [x] `helm template` renders both pod- and container-level `securityContext` populated
- [x] `helm template --set podSecurityContext.runAsUser=1000 --set securityContext.runAsUser=1000` override propagates
- [x] `helm install` in k3d cluster: pod reaches Ready 1/1, kubelet-confirmed UID/GID = 65532
- [x] HTTP API (`/health`, `/metrics`, `POST /scenarios`, `GET /scenarios`) unchanged behaviour under non-root
- [x] Auth flow (`--api-key` + Bearer token) unchanged behaviour under non-root
- [x] Image size unchanged (26.2 MB multi-arch scratch)