### PR TITLE
docs: surface --help text, self-contain pack example, document workers cap

### DIFF
--- a/docs/site/docs/deploy/server-metrics.md
+++ b/docs/site/docs/deploy/server-metrics.md
@@ -95,7 +95,7 @@ If this counter climbs without a corresponding burst of new scenarios, your auto
 
 #### `sonda_server_worker_threads`
 
-Gauge. The tokio multi-thread worker count configured at startup — that is, the value of [`--workers`](server.md#tuning-resource-limits) or the cgroup-aware default `std::thread::available_parallelism()`.
+Gauge. The tokio multi-thread worker count configured at startup — that is, the value of [`--workers`](server.md#tuning-resource-limits) or the default `min(std::thread::available_parallelism(), 16)`. On Linux the default queries `sched_getaffinity`, so the count reflects the cpuset the process is allowed to run on, not CFS CPU quotas — see [Tuning resource limits](server.md#tuning-resource-limits) for the full caveat.
 
 #### `sonda_server_max_scenarios`
 

--- a/docs/site/docs/deploy/server.md
+++ b/docs/site/docs/deploy/server.md
@@ -232,7 +232,7 @@ RUST_LOG=debug sonda-server --port 8080
 | `--bind <ADDR>` | -- | `0.0.0.0` | Bind address |
 | `--api-key <KEY>` | `SONDA_API_KEY` | (unset) | Bearer token for `/scenarios/*`, `/events`, and metrics endpoints. See [Authentication](#authentication). |
 | `--catalog <DIR>` | `SONDA_CATALOG` | (unset) | Directory of scenario and pack YAML files. Lets `POST /scenarios` resolve `pack: <name>` references. See [Pack references over HTTP](http-api.md#pack-references-over-http). |
-| `--workers <N>` | -- | `available_parallelism()` | Tokio worker thread count. See [Tuning resource limits](#tuning-resource-limits). |
+| `--workers <N>` | -- | `min(available_parallelism(), 16)` | Tokio worker thread count. See [Tuning resource limits](#tuning-resource-limits). |
 | `--max-scenarios <N>` | -- | `0` (unlimited) | Maximum concurrent scenario rows. POSTs beyond the cap return [`429 capacity_exceeded`](http-api.md#capacity-and-resource-errors). |
 | `--max-inflight-requests <N>` | -- | `4 * workers` | Maximum concurrent in-flight control-plane HTTP requests. |
 | `--request-timeout <SECS>` | -- | `30` | Per-request timeout on control-plane routes. Returns [`408 request_timeout`](http-api.md#capacity-and-resource-errors) on expiry. |
@@ -248,7 +248,7 @@ The five resource-limit flags shape what the server accepts, how many scenarios 
 
 #### `--workers <N>`
 
-The size of the tokio multi-thread runtime. Bound: `N >= 1`. The default is `std::thread::available_parallelism()`, which respects cgroup CPU quotas — so the same binary picks 16 workers on a 16-core host and 2 workers on a Kubernetes pod with `cpu: 2000m` set. Override only when you want to deviate from the cgroup setting (for example, pin a workload to one worker to reduce context-switching noise during benchmarking).
+The size of the tokio multi-thread runtime. Bound: `N >= 1`. The default is `min(std::thread::available_parallelism(), 16)`. On Linux, `available_parallelism()` queries `sched_getaffinity`, so the count reflects the cpuset the process is allowed to run on — which is the full set of node CPUs by default in Kubernetes. CFS CPU quotas (`resources.limits.cpu`) do **not** reduce this count; if you want the worker pool to match a quota-restricted budget, set `--workers` explicitly. The `16` ceiling ensures that on a 64-core host sonda-server does not spawn 64 worker threads — the scheduler benefit drops off well before that and the extra threads add context-switch overhead. Override only when you want to deviate from the default (for example, `--workers 32` on a thoroughly benchmarked host that genuinely uses the parallelism, or `--workers 1` to pin a workload during benchmarking).
 
 The configured value is exported on [`sonda_server_worker_threads`](server-metrics.md#sonda_server_worker_threads) — use it to confirm the runtime sees the value you expect.
 

--- a/examples/pack-scenario.yaml
+++ b/examples/pack-scenario.yaml
@@ -8,7 +8,11 @@
 # a specific device and interface.
 #
 # Run with:
-#   sonda --catalog sonda-core/tests/fixtures/packs run examples/pack-scenario.yaml
+#   sonda --catalog examples/packs run examples/pack-scenario.yaml
+#
+# The pack referenced below (`telegraf_snmp_interface`) is shipped alongside
+# this file under `examples/packs/`, so the command above runs against a
+# self-contained catalog without depending on the repo's test fixtures.
 
 version: 2
 kind: runnable

--- a/examples/packs/telegraf-snmp-interface.yaml
+++ b/examples/packs/telegraf-snmp-interface.yaml
@@ -1,0 +1,47 @@
+# Telegraf SNMP interface metrics pack.
+#
+# Models the standard interface metrics collected by the Telegraf SNMP
+# input plugin. Metric names and label keys match the Telegraf-normalized
+# schema exactly, so sonda output can replace real device telemetry in
+# dashboards and alert rules.
+
+version: 2
+kind: composable
+name: telegraf_snmp_interface
+description: "Standard SNMP interface metrics (Telegraf-normalized)"
+category: network
+
+shared_labels:
+  device: ""
+  ifName: ""
+  ifAlias: ""
+  ifIndex: ""
+  job: snmp
+
+metrics:
+  - name: ifOperStatus
+    generator:
+      type: constant
+      value: 1.0
+
+  - name: ifHCInOctets
+    generator:
+      type: step
+      start: 0.0
+      step_size: 125000.0
+
+  - name: ifHCOutOctets
+    generator:
+      type: step
+      start: 0.0
+      step_size: 62500.0
+
+  - name: ifInErrors
+    generator:
+      type: constant
+      value: 0.0
+
+  - name: ifOutErrors
+    generator:
+      type: constant
+      value: 0.0

--- a/sonda/src/cli.rs
+++ b/sonda/src/cli.rs
@@ -7,9 +7,11 @@ use clap::{Args, Parser, Subcommand};
 #[derive(Debug, Parser)]
 #[command(name = "sonda", version, about = "Synthetic telemetry generator", styles = clap_styles())]
 pub struct Cli {
+    /// Suppress status banners on stderr. Errors still print.
     #[arg(short, long, global = true, conflicts_with = "verbose")]
     pub quiet: bool,
 
+    /// Print the resolved scenario config on startup.
     #[arg(short, long, global = true, conflicts_with = "quiet")]
     pub verbose: bool,
 
@@ -65,27 +67,35 @@ pub struct RunArgs {
     /// Path to a v2 YAML file, or `@name` for a catalog reference.
     pub scenario: String,
 
+    /// Override the scenario duration (e.g. `30s`, `1m`, `1h`).
     #[arg(long)]
     pub duration: Option<String>,
 
+    /// Override the scenario rate in events per second.
     #[arg(long)]
     pub rate: Option<f64>,
 
+    /// Override the sink type (e.g. `stdout`, `tcp`, `udp`, `file`, `http_push`, `loki`, `otlp_grpc`, `remote_write`).
     #[arg(long, help_heading = "Sink")]
     pub sink: Option<String>,
 
+    /// Endpoint URL for network sinks (TCP/UDP address, HTTP URL, etc.).
     #[arg(long, help_heading = "Sink")]
     pub endpoint: Option<String>,
 
+    /// Override the encoder type (e.g. `prometheus_text`, `influx_lp`, `json_lines`, `otlp`, `remote_write`, `syslog`).
     #[arg(long, help_heading = "Encoder")]
     pub encoder: Option<String>,
 
+    /// Write output to a file instead of using `--sink`. Mutually exclusive with `--sink`.
     #[arg(short = 'o', long, conflicts_with = "sink", help_heading = "Sink")]
     pub output: Option<PathBuf>,
 
+    /// Add a scenario label as `key=value`. Repeat the flag to add multiple labels.
     #[arg(long = "label", value_parser = parse_label, help_heading = "Scenario")]
     pub labels: Vec<(String, String)>,
 
+    /// Behaviour on sink write failure: `warn` (mark scenario degraded and keep emitting) or `fail` (terminate the scenario).
     #[arg(long, value_parser = parse_on_sink_error, help_heading = "Scenario")]
     pub on_sink_error: Option<sonda_core::OnSinkError>,
 }


### PR DESCRIPTION
Three docs/UX polish items from the 2026-06-16 SRE adoption re-assessment, batched into one `docs:` commit.

- **`sonda/src/cli.rs`**: add doc comments to every override flag on `RunArgs` (`--duration`, `--rate`, `--sink`, `--endpoint`, `--encoder`, `--output`, `--label`, `--on-sink-error`). clap derives `--help` text from doc comments, so the previously blank descriptions now populate. The value enumerations match the canonical serde-renamed names verbatim (`prometheus_text`, `influx_lp`, `json_lines`, `http_push`, `otlp_grpc`, `warn`/`fail`, etc.) — a user who copy-pastes from `--help` gets a value that the parser actually accepts.
- **`examples/pack-scenario.yaml`** + **new `examples/packs/telegraf-snmp-interface.yaml`**: the example previously referenced `--catalog sonda-core/tests/fixtures/packs`, a test fixture path. Now ships a copy of the pack alongside the example under `examples/packs/`. The run command is `sonda --catalog examples/packs run examples/pack-scenario.yaml`, runnable straight from a fresh clone.
- **`docs/site/docs/deploy/server.md`**: the `--workers` prose said the default was `available_parallelism()`. The actual implementation caps it at 16 workers, so a 64-core production host does not spawn 64 worker threads. Updated the values table + the prose with the rationale.

## Test plan

- [x] `cargo build --workspace`: clean
- [x] `cargo nextest --workspace --all-features`: 2931/2931 passed
- [x] `cargo clippy --workspace --all-targets --all-features -D warnings`: clean
- [x] `cargo fmt --all -- --check`: clean
- [x] `mkdocs build --strict`: clean
- [x] Live `sonda run --help`: all 8 flags now show descriptions
- [x] Live `sonda --catalog examples/packs --dry-run run examples/pack-scenario.yaml`: `Validation: OK (5 scenarios)`
- [x] Confirmed against the parser: `--on-sink-error warn` accepted; `--on-sink-error continue` (old wrong value in initial draft) rejected with `expected 'warn' or 'fail'` — the new doc text matches the parser exactly.