### PR TITLE
docs(readme): fix invalid crate-version + license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 </p>
 
 <p align="center">
-  <a href="https://crates.io/crates/sonda"><img alt="crates.io" src="https://img.shields.io/crates/v/sonda.svg?logo=rust&color=1e3a8a"></a>
-  <a href="https://crates.io/crates/sonda-core"><img alt="sonda-core on crates.io" src="https://img.shields.io/crates/v/sonda-core.svg?label=sonda-core&color=1e40af"></a>
+  <a href="https://crates.io/crates/sonda"><img alt="crates.io" src="https://badgen.net/crates/v/sonda?icon=rust"></a>
+  <a href="https://crates.io/crates/sonda-core"><img alt="sonda-core on crates.io" src="https://badgen.net/crates/v/sonda-core?label=sonda-core"></a>
   <a href="https://github.com/davidban77/sonda/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/davidban77/sonda/ci.yml?branch=main&color=1e40af"></a>
   <a href="https://github.com/davidban77/sonda/blob/main/Cargo.toml"><img alt="MSRV" src="https://img.shields.io/badge/MSRV-1.75-3b82f6"></a>
-  <a href="https://github.com/davidban77/sonda/blob/main/LICENSE-MIT"><img alt="License" src="https://img.shields.io/crates/l/sonda.svg?color=f97316"></a>
+  <a href="https://github.com/davidban77/sonda/blob/main/LICENSE-MIT"><img alt="License" src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-f97316"></a>
 </p>
 
 # Sonda


### PR DESCRIPTION
shields.io's `crates/v/<crate>` and `crates/l/<crate>` endpoints are currently returning "invalid" for many crates (sonda, sonda-core, serde, tokio, anyhow, etc.) because their backend fetcher fails against the crates.io API. The CI and MSRV badges from shields.io still work because they use different endpoints.

- **crates.io version badges** (`sonda`, `sonda-core`) — switch to badgen.net (alternative shield provider that queries crates.io live). Verified: both render `v1.16.1` correctly.
- **License badge** — replace the broken `crates/l/sonda` lookup with a static shields.io badge encoding the SPDX expression (`MIT OR Apache--2.0`) directly. The license rarely changes; hardcoding removes the upstream dependency.

The MSRV and CI badges are untouched — both still work as-is on shields.io's other endpoints.

## Test plan

- [x] `badgen.net/crates/v/sonda?icon=rust` renders `v1.16.1` with the Rust logo
- [x] `badgen.net/crates/v/sonda-core?label=sonda-core` renders `v1.16.1`
- [x] `shields.io/badge/license-MIT%20OR%20Apache--2.0-f97316` renders the static license string