### PR TITLE
fix(ci): pin dtolnay/rust-toolchain to 1.95.0 + add drift guard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,12 @@ updates:
     commit-message:
       prefix: "ci"
     target-branch: "main"
+    ignore:
+      # dtolnay/rust-toolchain's tags ARE the Rust toolchain versions it installs —
+      # so auto-bumping `@1.95.0 → @1.100.0` would request a nonexistent Rust
+      # release and break the Release workflow. Bump this manually in sync with
+      # rust-toolchain.toml.
+      - dependency-name: "dtolnay/rust-toolchain"
 
   # Track image tags in examples/docker-compose-victoriametrics.yml so the
   # Live Infra UAT gate gets continuous backend-bump signal.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,3 +225,27 @@ jobs:
       # Uses the actions runner's default Python 3.
       - name: Validate documented sonda commands
         run: python3 scripts/validate_docs_commands.py
+
+  release-pin-check:
+    name: release.yml rust-toolchain pin matches rust-toolchain.toml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Belt-and-braces guard against the `dtolnay/rust-toolchain@<X>` pin in
+      # release.yml drifting away from rust-toolchain.toml's `channel`.
+      # Dependabot has bumped this action twice (PRs #302, #443), both times
+      # requesting a nonexistent Rust release because the action's tag IS the
+      # toolchain version it installs. Dependabot is now configured to ignore
+      # the action; this check catches the next failure mode (a human edits
+      # one file but forgets the other).
+      - name: Verify release.yml pin matches rust-toolchain.toml
+        run: |
+          pinned=$(grep -oE 'dtolnay/rust-toolchain@[0-9.]+' .github/workflows/release.yml | head -1 | cut -d@ -f2)
+          expected=$(grep '^channel' rust-toolchain.toml | sed 's/.*"\(.*\)".*/\1/')
+          if [ "$pinned" != "$expected" ]; then
+            echo "::error::release.yml pins dtolnay/rust-toolchain@${pinned} but rust-toolchain.toml channel is ${expected}. Bump both together."
+            exit 1
+          fi
+          echo "OK: both pinned to ${pinned}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,12 @@ jobs:
         # rustup name) which does not have the target std — surfacing as
         # `error[E0463]: can't find crate for core`. Bumping rust-toolchain.toml
         # requires bumping this version too.
-        uses: dtolnay/rust-toolchain@1.100.0
+        #
+        # DO NOT let Dependabot bump this. The `dtolnay/rust-toolchain` action's
+        # tag IS the Rust toolchain version it installs — `@1.100.0` would request
+        # a nonexistent Rust release. Dependabot is configured to ignore this
+        # action (see .github/dependabot.yml) for exactly this reason.
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.16.1"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.16.1"
+version = "1.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.16.1"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
## Root cause

The `dtolnay/rust-toolchain` action's tag IS the Rust toolchain version it installs — not an action version. Dependabot bumped `@1.95.0 → @1.100.0` in #443; the bumped tag requested a nonexistent Rust release. Failed run: https://github.com/davidban77/sonda/actions/runs/27652523173

```
error: could not download nonexistent rust version `1.100.0-aarch64-apple-darwin`:
http request returned an unsuccessful status code: 404
```

This is the second occurrence of the same Dependabot bug. PR #416 fixed it manually on 2026-05-25; Dependabot re-opened the identical bump as #443 and was merged again on 2026-06-16 because no ignore directive was added the first time.

## Changes — two layers of defence

**Layer 1 — Dependabot ignore.** Add a `dtolnay/rust-toolchain` ignore directive to `.github/dependabot.yml` so the action is no longer eligible for automated bumps. Stops the bump PR from ever opening.

**Layer 2 — CI assertion.** New `release-pin-check` job in `ci.yml` that fails if `release.yml`'s `dtolnay/rust-toolchain@<X>` pin doesn't equal `rust-toolchain.toml`'s `channel`. Catches a human edit that touches one file but forgets the other, or any future config refactor that drops Layer 1. ~5 seconds, no toolchain install.

Plus:

- Pin `.github/workflows/release.yml` back to `dtolnay/rust-toolchain@1.95.0` to match `rust-toolchain.toml`.
- Extend the comment block above the `uses:` line to spell out why this action must not be auto-bumped.
- `Cargo.lock` catches up to the 1.16.1 → 1.17.0 workspace sync.