### PR TITLE
ci: move cargo audit to a dedicated scheduled workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,37 @@
+name: Audit
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: audit-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Audit dependencies
+        run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,6 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
 
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
-
-      - name: Audit dependencies
-        run: cargo audit
-
   sonda-server:
     name: sonda-server Build & Integration Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Move `cargo audit` out of the main "Build, Test, Clippy, Fmt" job into a dedicated `audit.yml` workflow so it also runs on a weekly schedule — catching freshly-published RustSec advisories even when no PR is open (the way the quinn-proto advisory was only caught incidentally by an unrelated PR). This mirrors rastreo, so both projects now share an identical audit workflow.

- New `.github/workflows/audit.yml`: runs `cargo audit` on push, PR, a Monday 06:00 UTC cron, and manual dispatch
- Remove the audit steps from the main CI job; the `.cargo/audit.toml` allow-list still applies automatically

Action needed: audit was previously a step inside "Build, Test, Clippy, Fmt", so it gated merges implicitly. It's now a standalone "Audit" check — add "Audit" to this branch's required status checks so an audit failure keeps blocking merges.
