### PR TITLE
docs(site): alert lab and homepage revamp — phases 3 and 4

### DIFF
--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -16,7 +16,7 @@ hide:
 
 <div class="sonda-hero__ctas" markdown>
 [Get started in 5 minutes](get-started/quickstart.md){ .md-button .md-button--primary }
-[See what you can test](test/index.md){ .md-button }
+[Try it in your browser](playground/index.md){ .md-button }
 [See it on GitHub](https://github.com/davidban77/sonda){ .md-button }
 </div>
 
@@ -95,6 +95,106 @@ cpu_usage{host="web-01"} 85.35533905932738 1777243960481
 ```
 
 Sonda includes a CLI (`sonda`) and an optional HTTP server (`sonda-server`). The CLI is enough for laptop and CI use. The server accepts scenarios over a REST API. The same scenario file runs from your laptop, from CI, or from [`sonda-server`](deploy/server.md). For a guided walkthrough that pushes to Prometheus or Loki, see [Getting Started](get-started/quickstart.md).
+
+## No install required
+
+The real Sonda engine runs in your browser, compiled to WebAssembly. Edit a scenario and watch the signal it produces — then run the same YAML unchanged with `sonda run`.
+
+<div class="grid cards" markdown>
+
+-   :material-chart-bell-curve: __[Scenario playground](playground/index.md)__
+
+    Edit scenario YAML and see the exact values Sonda will emit — every
+    generator, operational alias, and encoder, with real compile errors.
+
+-   :material-bell-ring: __[Alert lab](playground/alert-lab.md)__
+
+    Set a threshold and a `for:` duration against a failure pattern and watch
+    the alert go pending → firing → resolved, in sync with the signal.
+
+</div>
+
+## What do you want to test?
+
+Every one of these is a small YAML file. Pick the failure, not the framework.
+
+=== "Alert rules"
+
+    Trigger, resolve, and debounce alerts with signals shaped like real failures.
+
+    ```yaml
+    generator:
+      type: spike_event
+      baseline: 120.0
+      spike_height: 400.0
+      spike_duration: 5s
+      spike_interval: 30s
+    ```
+
+    [Alert testing →](test/alert-testing.md)
+
+=== "Cardinality"
+
+    Inject label churn on a schedule and watch what your TSDB does under it.
+
+    ```yaml
+    cardinality_spikes:
+      - label: pod
+        every: 60s
+        for: 10s
+        cardinality: 500
+        strategy: random
+    ```
+
+    [Capacity planning →](test/capacity-planning.md)
+
+=== "Incident replay"
+
+    Export a Grafana panel from a real outage and replay it at the original cadence.
+
+    ```yaml
+    generator:
+      type: csv_replay
+      file: incident-2026-05-18.csv
+      timescale: 4.0   # replay 4x faster
+    ```
+
+    [Grafana exports →](import/grafana-exports.md)
+
+=== "Fleet dashboards"
+
+    Fill a demo dashboard with a believable fleet instead of one flat line.
+
+    ```yaml
+    generator: { type: steady, center: 45.0, noise: 3.0 }
+    dynamic_labels:
+      - key: host
+        strategy: counter
+        prefix: web-
+        cardinality: 12
+    ```
+
+    [Send to a real backend →](get-started/send-to-a-backend.md)
+
+## Why not a bash loop?
+
+Honest answer: a bash loop piping to `curl` is fine for checking that the port
+is open. It stops being fine the moment the *shape* of the data matters —
+alert thresholds, rate() windows, cardinality limits, retention behavior.
+
+| | bash + curl | Avalanche | flog | Sonda |
+|---|---|---|---|---|
+| Realistic value shapes (`sine`, `flap`, `leak`) | hand-rolled | — | — | ✓ |
+| Correlated failures (`after:`, `while:`) | — | — | — | ✓ |
+| Replay real incidents from CSV | — | — | — | ✓ |
+| Metrics *and* logs, histograms, summaries | scripted | metrics only | logs only | ✓ |
+| Remote-write, OTLP, Kafka, Loki, InfluxDB LP | curl-able only | remote-write | files/stdout | ✓ |
+| Scheduled gaps, bursts, cardinality spikes | — | churn only | — | ✓ |
+| Single static binary | n/a | ✓ | ✓ | ✓ |
+
+Avalanche is excellent at raw cardinality volume and flog at log throughput —
+if that's the whole job, use them. Sonda is for when the pipeline has to be
+tested against telemetry that *behaves* like production.
 
 ## Why Sonda
 

--- a/docs/site/docs/javascripts/alert-lab.js
+++ b/docs/site/docs/javascripts/alert-lab.js
@@ -1,0 +1,446 @@
+/* Sonda docs — alert lab.
+ *
+ * Drives the #sonda-alert-lab page: a preset scenario is sampled by the real
+ * sonda-core engine (same wasm bundle as the playground), a Prometheus-style
+ * evaluator walks the series against a threshold + `for:` duration, and a
+ * playback sweep draws the signal with an alert-state lane underneath
+ * (inactive / pending / firing, with resolve markers).
+ */
+import init, { sample_scenario } from "./sonda_wasm.js";
+
+const MAX_TICKS = 240;
+const SWEEP_SECONDS = 11; // wall-clock length of one full playback sweep
+
+const STATE_COLORS = {
+  inactive: { light: "rgba(100, 116, 139, 0.25)", dark: "rgba(148, 163, 184, 0.25)" },
+  pending: { light: "#eab308", dark: "#facc15" },
+  firing: { light: "#dc2626", dark: "#f87171" },
+};
+
+/* The blip preset needs an irregular shape: two short dips a `for:` guard
+ * should swallow, then one outage long enough to page. A sequence generator
+ * expresses that exactly; the values array is built here to keep the YAML
+ * readable. Rate 2/s, so counts below are in half-seconds. */
+const BLIP_VALUES = [].concat(
+  Array(56).fill(1), // 28s healthy
+  Array(4).fill(0), //  2s blip
+  Array(50).fill(1), // 25s healthy
+  Array(6).fill(0), //  3s blip
+  Array(44).fill(1), // 22s healthy
+  Array(36).fill(0), // 18s real outage
+  Array(44).fill(1) // recovery
+);
+
+function scenario(name, generatorYaml, { rate = 4, duration = "60s", labels = "" } = {}) {
+  return `version: 2
+kind: runnable
+defaults:
+  rate: ${rate}
+  duration: ${duration}
+  encoder: { type: prometheus_text }
+  sink: { type: stdout }
+scenarios:
+  - id: lab
+    signal_type: metrics
+    name: ${name}
+${generatorYaml}${labels}
+`;
+}
+
+const PRESETS = [
+  {
+    name: "Link blips, then a real outage",
+    op: "<",
+    threshold: 1,
+    forSecs: 6,
+    story:
+      "Two short blips stay pending and never page — the real 18-second outage fires and resolves on recovery. Set for: to 0s to feel the difference.",
+    yaml: scenario(
+      "link_up",
+      `    generator:
+      type: sequence
+      values: [${BLIP_VALUES.join(", ")}]
+      repeat: false
+`,
+      { rate: 2, duration: "120s" }
+    ),
+  },
+  {
+    name: "Memory leak",
+    op: ">",
+    threshold: 85,
+    forSecs: 20,
+    story:
+      "The leak crosses the threshold with plenty of runway left — pending for 20 seconds, then firing until the end of the window. Leaks are the easy case for for:.",
+    yaml: scenario(
+      "process_memory_percent",
+      `    generator:
+      type: leak
+      baseline: 12.0
+      ceiling: 96.0
+      time_to_ceiling: 100s
+`,
+      { rate: 4, duration: "120s" }
+    ),
+  },
+  {
+    name: "Latency spikes",
+    op: ">",
+    threshold: 300,
+    forSecs: 12,
+    story:
+      "Each spike lasts 5 seconds — shorter than for: 12s, so the alert only ever reaches pending. Drop for: to 0s and every spike pages. Which on-call rotation do you want?",
+    yaml: scenario(
+      "request_latency_ms",
+      `    generator:
+      type: spike_event
+      baseline: 120.0
+      spike_height: 400.0
+      spike_duration: 5s
+      spike_interval: 30s
+`,
+      { rate: 4, duration: "120s" }
+    ),
+  },
+  {
+    name: "Noisy CPU near the line",
+    op: ">",
+    threshold: 64,
+    forSecs: 12,
+    story:
+      "Noise brushes the threshold on every peak — without for: this alert flaps constantly. With it, only a sustained excursion could page.",
+    yaml: scenario(
+      "cpu_usage",
+      `    generator:
+      type: steady
+      center: 55.0
+      amplitude: 9.0
+      period: 30s
+      noise: 4.0
+      noise_seed: 3
+`,
+      { rate: 4, duration: "120s" }
+    ),
+  },
+];
+
+let wasmReady = null;
+function ensureWasm() {
+  if (!wasmReady) {
+    wasmReady = init({ module_or_path: new URL("./sonda_wasm_bg.wasm", import.meta.url) });
+  }
+  return wasmReady;
+}
+
+/* Walk the series the way a Prometheus rule walks scrape samples: pending
+ * while the condition holds but hasn't lasted `for:` yet, firing once it
+ * has, back to inactive (recording a resolve) when it goes false. */
+function evaluate(values, tickSecs, op, threshold, forSecs) {
+  const states = new Array(values.length);
+  const resolves = [];
+  let run = 0;
+  let wasFiring = false;
+  for (let i = 0; i < values.length; i++) {
+    const cond = op === ">" ? values[i] > threshold : values[i] < threshold;
+    if (!cond) {
+      if (wasFiring) resolves.push(i);
+      run = 0;
+      wasFiring = false;
+      states[i] = "inactive";
+    } else {
+      run += 1;
+      const heldSecs = (run - 1) * tickSecs;
+      states[i] = heldSecs >= forSecs ? "firing" : "pending";
+      wasFiring = states[i] === "firing";
+    }
+  }
+  return { states, resolves };
+}
+
+function boot() {
+  const root = document.getElementById("sonda-alert-lab");
+  if (!root || root.dataset.ready) return;
+  root.dataset.ready = "1";
+
+  const el = {
+    preset: document.getElementById("al-preset"),
+    op: document.getElementById("al-op"),
+    threshold: document.getElementById("al-threshold"),
+    forSel: document.getElementById("al-for"),
+    play: document.getElementById("al-play"),
+    state: document.getElementById("al-state"),
+    chart: document.getElementById("al-chart"),
+    story: document.getElementById("al-story"),
+    open: document.getElementById("al-open"),
+  };
+
+  PRESETS.forEach((preset, index) => {
+    const option = document.createElement("option");
+    option.value = String(index);
+    option.textContent = preset.name;
+    el.preset.appendChild(option);
+  });
+
+  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  let entry = null; // sampled series from the engine
+  let evaled = null;
+  let animation = 0;
+
+  const currentRule = () => ({
+    op: el.op.value,
+    threshold: Number(el.threshold.value),
+    forSecs: Number(el.forSel.value),
+  });
+
+  const reevaluate = () => {
+    if (!entry) return;
+    const rule = currentRule();
+    evaled = evaluate(entry.values, entry.tick_secs, rule.op, rule.threshold, rule.forSecs);
+    stopSweep();
+    draw(el, entry, evaled, rule, entry.values.length);
+    setStateChip(el.state, finalStateSummary(evaled));
+    el.play.textContent = "Play";
+  };
+
+  const loadPreset = async () => {
+    const preset = PRESETS[Number(el.preset.value)];
+    el.op.value = preset.op;
+    el.threshold.value = String(preset.threshold);
+    el.forSel.value = String(preset.forSecs);
+    el.story.textContent = preset.story;
+    el.open.href = "./#yaml=" + toBase64Url(preset.yaml);
+    await ensureWasm();
+    const result = JSON.parse(sample_scenario(preset.yaml, MAX_TICKS));
+    entry = result.ok && result.entries.length ? result.entries[0] : null;
+    reevaluate();
+    if (!reducedMotion) startSweep();
+  };
+
+  function stopSweep() {
+    if (animation) {
+      window.cancelAnimationFrame(animation);
+      animation = 0;
+    }
+  }
+
+  function startSweep() {
+    if (!entry || !evaled) return;
+    stopSweep();
+    const rule = currentRule();
+    const total = entry.values.length;
+    const start = performance.now();
+    el.play.textContent = "Replay";
+    const frame = (now) => {
+      const progress = Math.min(1, (now - start) / (SWEEP_SECONDS * 1000));
+      const upTo = Math.max(2, Math.round(progress * total));
+      draw(el, entry, evaled, rule, upTo);
+      setStateChip(el.state, evaled.states[upTo - 1]);
+      if (progress < 1) {
+        animation = window.requestAnimationFrame(frame);
+      } else {
+        animation = 0;
+        setStateChip(el.state, finalStateSummary(evaled));
+      }
+    };
+    animation = window.requestAnimationFrame(frame);
+  }
+
+  el.preset.addEventListener("change", loadPreset);
+  el.op.addEventListener("change", reevaluate);
+  el.threshold.addEventListener("input", reevaluate);
+  el.forSel.addEventListener("change", reevaluate);
+  el.play.addEventListener("click", () => {
+    if (reducedMotion) reevaluate();
+    else startSweep();
+  });
+
+  new ResizeObserver(() => {
+    if (entry && evaled && !animation) {
+      draw(el, entry, evaled, currentRule(), entry.values.length);
+    }
+  }).observe(el.chart.parentElement);
+  new MutationObserver(() => {
+    if (entry && evaled && !animation) {
+      draw(el, entry, evaled, currentRule(), entry.values.length);
+    }
+  }).observe(document.body, { attributes: true, attributeFilter: ["data-md-color-scheme"] });
+
+  loadPreset();
+}
+
+function finalStateSummary(evaled) {
+  if (evaled.states.includes("firing")) return "firing";
+  if (evaled.states.includes("pending")) return "pending";
+  return "inactive";
+}
+
+function setStateChip(chip, state) {
+  chip.textContent = state;
+  chip.className = `sonda-lab-chip sonda-lab-chip--${state}`;
+}
+
+function toBase64Url(text) {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  bytes.forEach((b) => (binary += String.fromCharCode(b)));
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function palette() {
+  const dark = document.body.getAttribute("data-md-color-scheme") === "slate";
+  return {
+    dark,
+    grid: dark ? "rgba(148, 163, 184, 0.25)" : "rgba(100, 116, 139, 0.25)",
+    text: dark ? "#94a3b8" : "#64748b",
+    trace: "#f97316",
+    thresholdLine: dark ? "#f87171" : "#dc2626",
+    firingBand: dark ? "rgba(248, 113, 113, 0.10)" : "rgba(220, 38, 38, 0.07)",
+    resolve: dark ? "#4ade80" : "#16a34a",
+  };
+}
+
+function draw(el, entry, evaled, rule, upTo) {
+  const colors = palette();
+  const canvas = el.chart;
+  const dpr = window.devicePixelRatio || 1;
+  const cssWidth = canvas.parentElement.clientWidth;
+  const cssHeight = 380;
+  canvas.width = cssWidth * dpr;
+  canvas.height = cssHeight * dpr;
+  canvas.style.width = cssWidth + "px";
+  canvas.style.height = cssHeight + "px";
+  const ctx = canvas.getContext("2d");
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, cssWidth, cssHeight);
+
+  const laneH = 26;
+  const laneGap = 34;
+  const pad = { left: 48, right: 12, top: 12, bottom: 26 + laneH + laneGap };
+  const plotW = cssWidth - pad.left - pad.right;
+  const plotH = cssHeight - pad.top - pad.bottom;
+  const laneY = pad.top + plotH + laneGap;
+
+  const values = entry.values;
+  const spanSecs = (values.length - 1) * entry.tick_secs;
+  let min = Math.min(...values, rule.threshold);
+  let max = Math.max(...values, rule.threshold);
+  if (max - min < 1e-9) {
+    min -= 1;
+    max += 1;
+  }
+  const range = max - min;
+  min -= range * 0.1;
+  max += range * 0.1;
+
+  const x = (i) => pad.left + ((i * entry.tick_secs) / spanSecs) * plotW;
+  const y = (v) => pad.top + (1 - (v - min) / (max - min)) * plotH;
+
+  // Firing bands behind the trace, only up to the sweep cursor. Consecutive
+  // ticks are merged into one rect so bands render seamlessly at any DPR.
+  ctx.fillStyle = colors.firingBand;
+  for (const run of stateRuns(evaled.states, upTo)) {
+    if (run.state === "firing") {
+      ctx.fillRect(x(run.start), pad.top, x(run.end) - x(run.start), plotH);
+    }
+  }
+
+  // Grid + axis labels.
+  ctx.strokeStyle = colors.grid;
+  ctx.fillStyle = colors.text;
+  ctx.lineWidth = 1;
+  ctx.font = "11px ui-monospace, monospace";
+  ctx.setLineDash([2, 5]);
+  for (let row = 0; row <= 4; row++) {
+    const value = min + ((max - min) * row) / 4;
+    const gy = y(value);
+    ctx.beginPath();
+    ctx.moveTo(pad.left, gy);
+    ctx.lineTo(cssWidth - pad.right, gy);
+    ctx.stroke();
+    ctx.textAlign = "right";
+    ctx.fillText(formatNumber(value), pad.left - 6, gy + 4);
+  }
+  ctx.setLineDash([]);
+  ctx.textAlign = "center";
+  const xSteps = Math.min(6, Math.max(2, Math.floor(plotW / 110)));
+  for (let step = 0; step <= xSteps; step++) {
+    const secs = (spanSecs * step) / xSteps;
+    const label = secs >= 60 ? `${Math.floor(secs / 60)}m${Math.round(secs % 60) || ""}${secs % 60 ? "s" : ""}` : `${Math.round(secs)}s`;
+    ctx.fillText(label, pad.left + (secs / spanSecs) * plotW, pad.top + plotH + 16);
+  }
+
+  // Threshold line.
+  ctx.strokeStyle = colors.thresholdLine;
+  ctx.setLineDash([6, 4]);
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  ctx.moveTo(pad.left, y(rule.threshold));
+  ctx.lineTo(cssWidth - pad.right, y(rule.threshold));
+  ctx.stroke();
+  ctx.setLineDash([]);
+  ctx.textAlign = "left";
+  ctx.fillStyle = colors.thresholdLine;
+  ctx.fillText(`${rule.op} ${rule.threshold}`, pad.left + 4, y(rule.threshold) - 5);
+
+  // Signal trace up to the sweep cursor.
+  ctx.strokeStyle = colors.trace;
+  ctx.lineWidth = 2;
+  ctx.lineJoin = "round";
+  ctx.beginPath();
+  for (let i = 0; i < upTo; i++) {
+    const px = x(i);
+    const py = y(values[i]);
+    if (i === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
+  }
+  ctx.stroke();
+
+  // Alert-state lane, drawn as merged runs for seamless segments.
+  ctx.fillStyle = colors.text;
+  ctx.textAlign = "left";
+  ctx.font = "10px ui-monospace, monospace";
+  ctx.fillText("ALERT STATE", pad.left, laneY - 7);
+  const stateColor = (s) => STATE_COLORS[s][colors.dark ? "dark" : "light"];
+  for (const run of stateRuns(evaled.states, upTo)) {
+    ctx.fillStyle = stateColor(run.state);
+    ctx.fillRect(x(run.start), laneY, Math.max(1, x(run.end) - x(run.start)), laneH);
+  }
+  // Resolve markers.
+  ctx.strokeStyle = colors.resolve;
+  ctx.lineWidth = 2;
+  for (const idx of evaled.resolves) {
+    if (idx >= upTo) continue;
+    ctx.beginPath();
+    ctx.moveTo(x(idx), laneY - 4);
+    ctx.lineTo(x(idx), laneY + laneH + 4);
+    ctx.stroke();
+  }
+}
+
+/* Group consecutive same-state ticks into runs [start, end) for seamless
+ * rectangle rendering. */
+function stateRuns(states, upTo) {
+  const runs = [];
+  let start = 0;
+  for (let i = 1; i <= upTo; i++) {
+    if (i === upTo || states[i] !== states[start]) {
+      runs.push({ state: states[start], start, end: i });
+      start = i;
+    }
+  }
+  return runs;
+}
+
+function formatNumber(value) {
+  if (Math.abs(value) >= 1000) return value.toFixed(0);
+  if (Math.abs(value) >= 10) return value.toFixed(1);
+  return value.toFixed(2);
+}
+
+if (window.document$ && typeof window.document$.subscribe === "function") {
+  window.document$.subscribe(boot);
+} else if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", boot);
+} else {
+  boot();
+}

--- a/docs/site/docs/javascripts/sonda-hero.js
+++ b/docs/site/docs/javascripts/sonda-hero.js
@@ -1,0 +1,91 @@
+/* Sonda docs — ambient hero signal.
+ *
+ * Draws a slow, continuously scrolling synthetic signal (steady wave with
+ * periodic spikes — Sonda's own vocabulary) behind the homepage hero content.
+ * Deliberately quiet: low alpha, no interaction. Skipped entirely under
+ * prefers-reduced-motion, and paused while the tab is hidden via the
+ * browser's own requestAnimationFrame throttling.
+ */
+(function () {
+  "use strict";
+
+  var reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+  function init() {
+    if (reducedMotion.matches) return; // static gradient hero is the fallback
+    var hero = document.querySelector(".sonda-hero");
+    if (!hero || hero.dataset.sondaHeroLive) return;
+    hero.dataset.sondaHeroLive = "1";
+
+    var canvas = document.createElement("canvas");
+    canvas.className = "sonda-hero__canvas";
+    canvas.setAttribute("aria-hidden", "true");
+    hero.insertBefore(canvas, hero.firstChild);
+    var ctx = canvas.getContext("2d");
+
+    /* The signal: a steady oscillation with a spike every few seconds —
+     * the same shapes the generators page documents. */
+    function sample(t) {
+      var base = Math.sin(t * 0.55) * 0.28 + Math.sin(t * 0.13) * 0.1;
+      var spikePhase = t % 9;
+      if (spikePhase > 7.6 && spikePhase < 8.2) {
+        var p = (spikePhase - 7.6) / 0.6;
+        base += Math.sin(p * Math.PI) * 0.55;
+      }
+      return base;
+    }
+
+    function draw(nowMs) {
+      var dpr = window.devicePixelRatio || 1;
+      var w = hero.clientWidth;
+      var h = hero.clientHeight;
+      if (canvas.width !== w * dpr || canvas.height !== h * dpr) {
+        canvas.width = w * dpr;
+        canvas.height = h * dpr;
+        canvas.style.width = w + "px";
+        canvas.style.height = h + "px";
+      }
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, w, h);
+
+      var t0 = nowMs / 1000;
+      var midY = h * 0.88;
+      var amp = h * 0.1;
+      var windowSecs = 14; // seconds of signal visible across the hero width
+
+      ctx.beginPath();
+      for (var px = 0; px <= w; px += 3) {
+        var t = t0 - windowSecs + (px / w) * windowSecs;
+        var y = midY - sample(t) * amp;
+        if (px === 0) ctx.moveTo(px, y);
+        else ctx.lineTo(px, y);
+      }
+      ctx.strokeStyle = "rgba(253, 186, 116, 0.33)";
+      ctx.lineWidth = 2;
+      ctx.lineJoin = "round";
+      ctx.shadowColor = "rgba(253, 186, 116, 0.45)";
+      ctx.shadowBlur = 10;
+      ctx.stroke();
+      ctx.shadowBlur = 0;
+
+      // Emphasized "now" point at the leading edge.
+      var yNow = midY - sample(t0) * amp;
+      ctx.beginPath();
+      ctx.arc(w - 2, yNow, 3, 0, Math.PI * 2);
+      ctx.fillStyle = "rgba(253, 186, 116, 0.75)";
+      ctx.fill();
+
+      window.requestAnimationFrame(draw);
+    }
+
+    window.requestAnimationFrame(draw);
+  }
+
+  if (window.document$ && typeof window.document$.subscribe === "function") {
+    window.document$.subscribe(init);
+  } else if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/docs/site/docs/playground/alert-lab.md
+++ b/docs/site/docs/playground/alert-lab.md
@@ -1,0 +1,79 @@
+---
+title: Alert lab
+description: Watch an alert go inactive, pending, firing, and resolved against a live Sonda signal — threshold, comparison, and for-duration semantics in your browser.
+hide:
+  - navigation
+  - toc
+---
+
+<div class="sonda-section-hero" markdown>
+<span class="sonda-section-hero__eyebrow">Alert lab</span>
+
+# Watch an alert fire — before you page anyone
+
+Pick a failure pattern, set a threshold and a `for:` duration, and press play.
+The signal comes from the real Sonda engine (the same
+[WebAssembly build](index.md) as the playground); the lane below the chart
+shows the alert state the way Prometheus would walk it:
+<span class="sonda-lab-chip sonda-lab-chip--inactive">inactive</span> →
+<span class="sonda-lab-chip sonda-lab-chip--pending">pending</span> →
+<span class="sonda-lab-chip sonda-lab-chip--firing">firing</span> → resolved.
+</div>
+
+<div id="sonda-alert-lab" class="sonda-playground">
+  <div class="sonda-playground__controls">
+    <label class="sonda-playground__label" for="al-preset">Scenario</label>
+    <select id="al-preset" class="sonda-playground__select" aria-label="Failure pattern preset"></select>
+    <label class="sonda-playground__label" for="al-op">Alert when</label>
+    <select id="al-op" class="sonda-playground__select" aria-label="Comparison operator">
+      <option value=">">value &gt;</option>
+      <option value="<">value &lt;</option>
+    </select>
+    <input id="al-threshold" class="sonda-playground__select sonda-lab-number" type="number"
+      step="1" aria-label="Threshold value">
+    <label class="sonda-playground__label" for="al-for">for:</label>
+    <select id="al-for" class="sonda-playground__select" aria-label="For duration">
+      <option value="0">0s</option>
+      <option value="6">6s</option>
+      <option value="12">12s</option>
+      <option value="20">20s</option>
+      <option value="30">30s</option>
+    </select>
+    <button id="al-play" type="button" class="md-button md-button--primary sonda-playground__run">Play</button>
+    <span id="al-state" class="sonda-lab-chip sonda-lab-chip--inactive" role="status" aria-live="polite">inactive</span>
+  </div>
+  <canvas id="al-chart" class="sonda-playground__chart" height="380"
+    aria-label="Signal chart with alert-state lane"></canvas>
+  <p id="al-story" class="sonda-lab-story"></p>
+  <p class="sonda-lab-open-link"><a id="al-open" href="index.md">Edit this scenario in the playground →</a></p>
+  <noscript><p><strong>The alert lab needs JavaScript</strong> — it runs the Sonda engine
+  in your browser via WebAssembly.</p></noscript>
+</div>
+
+## What the lane is showing
+
+The evaluator walks the sampled series exactly the way a Prometheus alert rule
+would walk scrape samples:
+
+- **inactive** — the condition is false.
+- **pending** — the condition is true, but hasn't held for the full `for:`
+  duration yet. If the signal recovers first, no alert ever fires. This is
+  what makes `for:` the standard defense against flapping.
+- **firing** — the condition has held continuously for `for:`. This is when
+  Alertmanager would notify you.
+- **resolved** — the condition went false while firing (marked with a tick on
+  the lane).
+
+Try the *Link blips, then a real outage* preset both ways: with `for: 6s` the
+two short blips never page, and the real outage still fires. Set `for: 0s`
+and every blip becomes a page — that's the on-call experience `for:` exists
+to prevent.
+
+## Run it for real
+
+The lab simulates rule evaluation; the real thing is one config file away.
+[Alert testing](../test/alert-testing.md) walks the same patterns against a
+live Prometheus + Alertmanager stack (the repository ships a
+[Compose stack](../deploy/docker.md) with vmalert wired up), and
+[CI validation](../test/end-to-end-pipelines.md) turns them into exit codes
+for your pipeline.

--- a/docs/site/docs/stylesheets/sonda.css
+++ b/docs/site/docs/stylesheets/sonda.css
@@ -905,3 +905,63 @@
   font-size: 0.72rem;
   margin-top: 0;
 }
+
+/* ---------- Alert lab --------------------------------------------------- */
+
+.sonda-lab-number {
+  width: 5.5rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+
+.sonda-lab-chip {
+  display: inline-block;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.65rem;
+  border-radius: 999px;
+}
+
+.sonda-lab-chip--inactive {
+  background: rgba(100, 116, 139, 0.15);
+  color: var(--md-default-fg-color--light);
+}
+
+.sonda-lab-chip--pending {
+  background: rgba(234, 179, 8, 0.18);
+  color: #a16207;
+}
+
+[data-md-color-scheme="slate"] .sonda-lab-chip--pending { color: #facc15; }
+
+.sonda-lab-chip--firing {
+  background: rgba(220, 38, 38, 0.15);
+  color: #dc2626;
+}
+
+[data-md-color-scheme="slate"] .sonda-lab-chip--firing { color: #f87171; }
+
+.md-typeset .sonda-lab-story {
+  margin: 0.9rem 0 0.25rem;
+  font-size: 0.85rem;
+  color: var(--md-default-fg-color--light);
+  max-width: 46rem;
+}
+
+.md-typeset .sonda-lab-open-link {
+  margin: 0.25rem 0 0;
+  font-size: 0.8rem;
+}
+
+/* ---------- Homepage live hero canvas ----------------------------------- */
+
+.sonda-hero__canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+  pointer-events: none;
+}

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -59,7 +59,10 @@ extra_css:
 
 extra_javascript:
   - javascripts/sonda-term.js
+  - javascripts/sonda-hero.js
   - path: javascripts/playground.js
+    type: module
+  - path: javascripts/alert-lab.js
     type: module
 
 markdown_extensions:
@@ -192,7 +195,9 @@ nav:
       - Quickstart: get-started/quickstart.md
       - Your first scenario: get-started/your-first-scenario.md
       - Send to a real backend: get-started/send-to-a-backend.md
-  - Playground: playground/index.md
+  - Playground:
+      - playground/index.md
+      - Alert lab: playground/alert-lab.md
   - Build scenarios:
       - build/index.md
       - Concepts: build/concepts.md


### PR DESCRIPTION
<p align="right">
  ``&lt;img src="../.github/assets/sonda-logo.svg" alt="" width="40" height="40"&gt;``
</p>

## Summary

The last two phases of the UX revamp, building on the wasm engine that landed in #510. Phase 3 is the **alert lab**: pick a failure pattern, set a threshold and a `for:` duration, and watch the alert walk inactive → pending → firing → resolved in sync with the signal — Sonda's core use case, demonstrated in the browser in ten seconds. Phase 4 redesigns the homepage into a product landing: a live ambient hero signal, use-case tabs, in-browser try-it cards, and an honest comparison table.

## Changes

**Alert lab** (`playground/alert-lab.md` + `alert-lab.js`, new nav entry under Playground)
- Four presets: link blips then a real outage (the `for:` debounce story), memory leak, latency spikes, noisy CPU near the line. Signals come from the same committed wasm bundle as the playground.
- A Prometheus-style evaluator walks the sampled series; an animated sweep draws the trace with a state lane underneath — pending amber, firing red with a shaded band on the chart, resolves marked in green. Controls re-evaluate live; a link opens the current scenario in the playground via the shared URL-hash format; `prefers-reduced-motion` renders the full timeline statically.

**Homepage**
- Ambient canvas hero: a slowly scrolling steady-wave-plus-spikes signal along the hero's lower edge (low alpha, skipped under reduced motion); the middle CTA now points at the playground.
- "No install required" cards for the playground and alert lab.
- "What do you want to test?" tabs — six-line YAML per use case (alert rules, cardinality, incident replay, fleet dashboards), each linking into the matching guide.
- "Why not a bash loop?" comparison vs bash+curl, Avalanche, and flog, honest about what each is good at.

## Test plan

- `mkdocs build --strict` passes.
- Alert lab verified in a real Chromium session: sweep playback, state-lane correctness on the blip preset (short blips pending-only, the long outage fires and resolves), live re-evaluation when changing `for:`, no page errors.
- Homepage verified in Chromium: hero animation position, use-case tabs, comparison table, try-it cards.
- Docs-only change — no Rust code touched (`cargo` gates unaffected).

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpUH7idmVwuey9P4YyZuKu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpUH7idmVwuey9P4YyZuKu)_