### PR TITLE
fix(docs): repair the alert lab memory-leak preset and surface engine errors

### DIFF
--- a/docs/site/docs/javascripts/alert-lab.js
+++ b/docs/site/docs/javascripts/alert-lab.js
@@ -68,19 +68,20 @@ const PRESETS = [
   {
     name: "Memory leak",
     op: ">",
-    threshold: 85,
-    forSecs: 20,
+    threshold: 70,
+    forSecs: 12,
     story:
-      "The leak crosses the threshold with plenty of runway left — pending for 20 seconds, then firing until the end of the window. Leaks are the easy case for for:.",
+      "The leak crosses the threshold about two-thirds in — pending for 12 seconds, then firing until the end of the window. Leaks are the easy case for for:.",
     yaml: scenario(
       "process_memory_percent",
       `    generator:
       type: leak
       baseline: 12.0
       ceiling: 96.0
-      time_to_ceiling: 100s
+      time_to_ceiling: 120s
 `,
-      { rate: 4, duration: "120s" }
+      // Rate 2 so the 240-tick sample window covers the full 120s ramp.
+      { rate: 2, duration: "120s" }
     ),
   },
   {
@@ -170,6 +171,7 @@ function boot() {
     play: document.getElementById("al-play"),
     state: document.getElementById("al-state"),
     chart: document.getElementById("al-chart"),
+    error: document.getElementById("al-error"),
     story: document.getElementById("al-story"),
     open: document.getElementById("al-open"),
   };
@@ -212,6 +214,18 @@ function boot() {
     await ensureWasm();
     const result = JSON.parse(sample_scenario(preset.yaml, MAX_TICKS));
     entry = result.ok && result.entries.length ? result.entries[0] : null;
+    if (!entry) {
+      // Surface the engine's own message instead of a silent blank chart —
+      // either a compile error or the reason the entry was skipped.
+      const reason = !result.ok
+        ? result.error
+        : result.skipped.length
+          ? result.skipped[0].reason
+          : "the scenario produced no metrics entries";
+      showError(el, reason || "the scenario could not be sampled");
+      return;
+    }
+    hideError(el);
     reevaluate();
     if (!reducedMotion) startSweep();
   };
@@ -266,6 +280,18 @@ function boot() {
   }).observe(document.body, { attributes: true, attributeFilter: ["data-md-color-scheme"] });
 
   loadPreset();
+}
+
+function showError(el, message) {
+  el.error.hidden = false;
+  el.error.textContent = message;
+  setStateChip(el.state, "inactive");
+  const ctx = el.chart.getContext("2d");
+  ctx.clearRect(0, 0, el.chart.width, el.chart.height);
+}
+
+function hideError(el) {
+  el.error.hidden = true;
 }
 
 function finalStateSummary(evaled) {
@@ -365,8 +391,7 @@ function draw(el, entry, evaled, rule, upTo) {
   const xSteps = Math.min(6, Math.max(2, Math.floor(plotW / 110)));
   for (let step = 0; step <= xSteps; step++) {
     const secs = (spanSecs * step) / xSteps;
-    const label = secs >= 60 ? `${Math.floor(secs / 60)}m${Math.round(secs % 60) || ""}${secs % 60 ? "s" : ""}` : `${Math.round(secs)}s`;
-    ctx.fillText(label, pad.left + (secs / spanSecs) * plotW, pad.top + plotH + 16);
+    ctx.fillText(formatSeconds(secs), pad.left + (secs / spanSecs) * plotW, pad.top + plotH + 16);
   }
 
   // Threshold line.
@@ -435,6 +460,14 @@ function formatNumber(value) {
   if (Math.abs(value) >= 1000) return value.toFixed(0);
   if (Math.abs(value) >= 10) return value.toFixed(1);
   return value.toFixed(2);
+}
+
+function formatSeconds(secs) {
+  const rounded = Math.round(secs);
+  if (rounded < 60) return `${rounded}s`;
+  const mins = Math.floor(rounded / 60);
+  const rest = rounded % 60;
+  return rest ? `${mins}m${rest}s` : `${mins}m`;
 }
 
 if (window.document$ && typeof window.document$.subscribe === "function") {

--- a/docs/site/docs/javascripts/playground.js
+++ b/docs/site/docs/javascripts/playground.js
@@ -419,12 +419,11 @@ function formatNumber(value) {
 }
 
 function formatSeconds(secs) {
-  if (secs >= 60) {
-    const mins = Math.floor(secs / 60);
-    const rest = Math.round(secs % 60);
-    return rest ? `${mins}m${rest}s` : `${mins}m`;
-  }
-  return `${Math.round(secs)}s`;
+  const rounded = Math.round(secs);
+  if (rounded < 60) return `${rounded}s`;
+  const mins = Math.floor(rounded / 60);
+  const rest = rounded % 60;
+  return rest ? `${mins}m${rest}s` : `${mins}m`;
 }
 
 if (window.document$ && typeof window.document$.subscribe === "function") {

--- a/docs/site/docs/playground/alert-lab.md
+++ b/docs/site/docs/playground/alert-lab.md
@@ -42,6 +42,7 @@ shows the alert state the way Prometheus would walk it:
     <button id="al-play" type="button" class="md-button md-button--primary sonda-playground__run">Play</button>
     <span id="al-state" class="sonda-lab-chip sonda-lab-chip--inactive" role="status" aria-live="polite">inactive</span>
   </div>
+  <div id="al-error" class="sonda-playground__error" hidden></div>
   <canvas id="al-chart" class="sonda-playground__chart" height="380"
     aria-label="Signal chart with alert-state lane"></canvas>
   <p id="al-story" class="sonda-lab-story"></p>


### PR DESCRIPTION


## Summary

Follow-up to #511 — the fix commit was pushed moments after that PR was merged, so it needs its own ride to `main`. The alert lab's memory-leak preset rendered a blank chart; this repairs the preset and makes the lab surface engine errors instead of failing silently.

## Changes

- The leak preset was invalid two ways: `time_to_ceiling` (100s) was shorter than the scenario `duration` (120s), which the engine rejects, and at rate 4 the 240-tick sample window only covered the first half of the ramp, so the threshold was never reached. The preset now uses `time_to_ceiling` equal to the duration at rate 2 — the full ramp fits, crossing the threshold about two-thirds in: pending, then firing to the end of the window.
- When the engine returns no entries (compile error or skipped entry), the lab now shows the engine's own message in an error panel instead of a blank chart.
- Fixes an axis-label rounding bug shared with the playground (119.5s rendered as "1m60s" instead of "2m").

## Test plan

- `mkdocs build --strict` passes.
- All four presets verified end-to-end in a real Chromium session: every one paints, the error panel stays hidden, and each lands in its intended final state — blips → firing, memory leak → firing, latency spikes → pending, noisy CPU → pending. No page errors.
- Docs-only change; no Rust code touched.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)
