### PR TITLE
fix(docs): point the alert lab's playground link at the playground

### DIFF
--- a/docs/site/docs/javascripts/alert-lab.js
+++ b/docs/site/docs/javascripts/alert-lab.js
@@ -210,7 +210,9 @@ function boot() {
     el.threshold.value = String(preset.threshold);
     el.forSel.value = String(preset.forSecs);
     el.story.textContent = preset.story;
-    el.open.href = "./#yaml=" + toBase64Url(preset.yaml);
+    // Relative to /playground/alert-lab/, the playground index is one level
+    // up — "./" would point the link back at this very page.
+    el.open.href = "../#yaml=" + toBase64Url(preset.yaml);
     await ensureWasm();
     const result = JSON.parse(sample_scenario(preset.yaml, MAX_TICKS));
     entry = result.ok && result.entries.length ? result.entries[0] : null;


### PR DESCRIPTION

## Summary

One-commit follow-up: this fix was pushed to the #512 branch moments after that PR was merged, so it never reached `main`. The alert lab's "Edit this scenario in the playground" link did nothing when tapped.

## Changes

- The link was built with `./#yaml=…`, which resolves to the alert-lab page itself — clicking it only changed the URL hash. It now uses `../#yaml=…`, which lands on the playground index, where the hash is read and the scenario loads into the editor.

## Test plan

- `mkdocs build --strict` passes.
- Verified as a full click-through in Chromium: alert lab → link → `/playground/` → editor pre-filled with the blip scenario → chart rendered.
- Docs-only change; no Rust code touched.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)
