### PR TITLE
feat: `sonda test` — alert expectations verified against Prometheus (W2 phase 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_yaml_ng = "0.10"
 serde_json = "1"
 anyhow = "1"
 thiserror = "2"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 ureq = { version = "2", default-features = false, features = ["tls"] }
 insta = { version = "1.40", features = ["json", "yaml"] }
 rstest = "0.26"

--- a/docs/site/docs/reference/cli-flags.md
+++ b/docs/site/docs/reference/cli-flags.md
@@ -278,8 +278,9 @@ sonda test examples/alert-expectation-test.yaml \
 
 | Flag | Description |
 |------|-------------|
-| `--prometheus-url <URL>` | Base URL of the Prometheus-compatible API evaluating the alert rules (e.g. `http://localhost:9090`). Required; also read from `SONDA_PROMETHEUS_URL`. |
+| `--prometheus-url <URL>` | Base URL of the Prometheus-compatible API evaluating the alert rules (e.g. `http://localhost:9090`). Required except with `--dry-run`; also read from `SONDA_PROMETHEUS_URL`. |
 | `--interval <DUR>` | Poll interval for alert-state checks. Default `5s`. |
+| `--query-timeout <DUR>` | Overall timeout for each alert-state query (connect + read), so a stalled endpoint fails fast instead of hanging. Default `10s`. |
 
 The scenario runs exactly as `sonda run` would (no overrides). Firing
 deadlines are measured from scenario start; resolution deadlines from

--- a/docs/site/docs/reference/cli-flags.md
+++ b/docs/site/docs/reference/cli-flags.md
@@ -264,12 +264,35 @@ sonda new -o my-scenario.yaml
 
 The prompts cover signal type, generator, rate, duration, sink, and output destination. Cancel with Ctrl+C at any point. Nothing is written until you confirm the output path.
 
+## `sonda test`
+
+Run a scenario and verify its top-level `expect:` alert expectations against
+a Prometheus-compatible query API. See
+[Alert testing](../test/alert-testing.md#automate-it-with-sonda-test) for the
+`expect:` block format.
+
+```bash
+sonda test examples/alert-expectation-test.yaml \
+  --prometheus-url http://localhost:8428
+```
+
+| Flag | Description |
+|------|-------------|
+| `--prometheus-url <URL>` | Base URL of the Prometheus-compatible API evaluating the alert rules (e.g. `http://localhost:9090`). Required; also read from `SONDA_PROMETHEUS_URL`. |
+| `--interval <DUR>` | Poll interval for alert-state checks. Default `5s`. |
+
+The scenario runs exactly as `sonda run` would (no overrides). Firing
+deadlines are measured from scenario start; resolution deadlines from
+scenario end. A scenario without an `expect:` block is rejected. With
+`--dry-run`, the scenario and its expectations are validated and printed
+without emitting events or contacting Prometheus.
+
 ## Exit codes
 
 | Code | Meaning |
 |------|---------|
-| `0` | Success. |
-| `1` | Runtime error (scenario failed, sink unreachable, validation rejected the YAML). |
+| `0` | Success. For `sonda test`: every alert expectation held. |
+| `1` | Runtime error (scenario failed, sink unreachable, validation rejected the YAML), or a `sonda test` expectation failed. |
 | `2` | Clap parse error (unknown flag, unrecognized subcommand, missing required argument). |
 
 ## Status output

--- a/docs/site/docs/reference/cli-flags.md
+++ b/docs/site/docs/reference/cli-flags.md
@@ -288,6 +288,12 @@ scenario end. A scenario without an `expect:` block is rejected. With
 `--dry-run`, the scenario and its expectations are validated and printed
 without emitting events or contacting Prometheus.
 
+Before the scenario starts, a preflight confirms the endpoint answers a
+query for every expectation. Only the first expectation is retried (3
+attempts, for a Prometheus still starting up in CI); the rest are probed
+once each, so preflight against a dead endpoint fails within about three
+query timeouts regardless of how many expectations the scenario declares.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/docs/site/docs/test/alert-testing.md
+++ b/docs/site/docs/test/alert-testing.md
@@ -795,6 +795,52 @@ The table below maps every pattern on this page to its generator and example fil
 | Push to VictoriaMetrics | any | `vm-push-scenario.yaml` |
 | Remote write | any | `remote-write-vm.yaml` |
 
+## Automate it with `sonda test`
+
+Everything above ends with you checking the Prometheus alerts page by hand.
+`sonda test` closes that loop: declare the expected outcome in the scenario
+file itself, and Sonda runs the scenario, polls the evaluator's `ALERTS`
+metric, and exits non-zero when reality disagrees.
+
+```yaml title="expect block (appended to any runnable scenario)"
+expect:
+  alerts:
+    - alert: HighCpuUsage
+      labels:
+        severity: critical
+      firing_within: 90s
+      resolves_within: 6m
+```
+
+- `firing_within` counts from scenario start: the alert must reach the
+  `firing` state (not just `pending`) before the deadline.
+- `resolves_within` counts from scenario end and is optional: once emission
+  stops, the alert must stop firing. Leave slack for staleness — a pushed
+  series takes a few minutes to go stale after the last sample.
+- `labels` narrows the match when one rule name fires for many label sets.
+
+Run it against any Prometheus-compatible query API (Prometheus,
+VictoriaMetrics with vmalert):
+
+```bash
+sonda test examples/alert-expectation-test.yaml \
+  --prometheus-url http://localhost:8428
+```
+
+```text
+  PASS HighCpuUsage firing after 22s (within 90s)
+  PASS HighCpuUsage resolved after 4m41s (within 6m of scenario end)
+
+  PASS 1 alert expectation(s) verified (scenario ran 60s)
+```
+
+The exit code is the contract: `0` when every expectation holds, non-zero
+otherwise — which makes alert rules testable in CI. The
+[CI validation walkthrough](end-to-end-pipelines.md) shows the full pipeline;
+`--dry-run` validates the scenario and its `expect:` block without emitting
+or contacting Prometheus. The `expect:` block is pure metadata to `sonda run`
+— the same file works for both commands.
+
 ## Where to next
 
 - [End-to-end pipelines](end-to-end-pipelines.md) — confirm alerts fire through vmalert, Alertmanager, and a webhook receiver.

--- a/examples/alert-expectation-test.yaml
+++ b/examples/alert-expectation-test.yaml
@@ -1,0 +1,47 @@
+# Alert expectation test — `sonda test` end to end.
+#
+# Holds `docker_alert_cpu` above the critical threshold so the HighCpuUsage
+# rule (examples/alertmanager/alert-rules.yml: docker_alert_cpu > 90 for 5s)
+# must fire, then lets it resolve after the scenario ends. The `expect:`
+# block turns that into a pass/fail check with CI-friendly exit codes.
+#
+# Run against the alerting Compose profile
+# (examples/docker-compose-victoriametrics.yml --profile alerting):
+#
+#   sonda test examples/alert-expectation-test.yaml \
+#     --prometheus-url http://localhost:8428
+#
+# vmalert evaluates every 5s with `for: 5s`, so firing_within: 90s has slack
+# to spare. Resolution relies on the series going stale after emission stops,
+# which takes a few minutes — hence the generous resolves_within.
+
+version: 2
+kind: runnable
+
+defaults:
+  rate: 5
+  duration: 60s
+  encoder:
+    type: remote_write
+  sink:
+    type: remote_write
+    url: http://localhost:8428/api/v1/write
+
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: docker_alert_cpu
+    generator:
+      type: constant
+      value: 95.0
+    labels:
+      host: sonda-test
+      service: payment-service
+
+expect:
+  alerts:
+    - alert: HighCpuUsage
+      labels:
+        severity: critical
+      firing_within: 90s
+      resolves_within: 6m

--- a/scripts/validate_docs_commands.py
+++ b/scripts/validate_docs_commands.py
@@ -35,12 +35,13 @@ DOCS_GLOB_ROOT = Path("docs/site/docs")
 # `mkdocs build` emits site output under `docs/site/site/`; skip it.
 DOCS_GLOB_EXCLUDE = (Path("docs/site/site"),)
 
-KNOWN_SUBCOMMANDS: frozenset[str] = frozenset({"run", "list", "show", "new"})
+KNOWN_SUBCOMMANDS: frozenset[str] = frozenset({"run", "list", "show", "new", "test"})
 
 # ``--dry-run`` is declared as a global flag (``#[arg(long, global = true)]``)
-# but only has an observable effect on ``run``. The validator only injects it
-# for ``run`` commands.
-DRY_RUNNABLE_SINGLE: frozenset[str] = frozenset({"run"})
+# and short-circuits before any network I/O on both ``run`` and ``test``
+# (``test --dry-run`` validates the scenario and its expect: block without
+# contacting Prometheus). The validator injects it for both.
+DRY_RUNNABLE_SINGLE: frozenset[str] = frozenset({"run", "test"})
 
 DEFAULT_SONDA_BINARY = Path("target/release/sonda")
 
@@ -581,19 +582,19 @@ def validate_command(
 def _build_dry_run_argv(
     cmd: ExtractedCommand, sonda_bin: Path
 ) -> list[str]:
-    """Replace ``sonda`` with ``sonda_bin`` and inject ``--dry-run`` for the
-    ``run`` subcommand if not already present.
+    """Replace ``sonda`` with ``sonda_bin`` and inject ``--dry-run`` for
+    dry-runnable subcommands if not already present.
 
     ``--dry-run`` is declared as a clap global flag, so clap accepts it in
-    either position. We inject after the ``run`` verb purely as a stylistic
-    choice so the rendered command reads as ``sonda run --dry-run <args>``.
+    either position. We inject after the verb purely as a stylistic choice
+    so the rendered command reads as ``sonda run --dry-run <args>``.
     """
     argv = list(cmd.argv)
     argv[0] = str(sonda_bin)
     if "--dry-run" in argv:
         return argv
     for i, tok in enumerate(argv):
-        if tok == "run":
+        if tok in DRY_RUNNABLE_SINGLE:
             argv.insert(i + 1, "--dry-run")
             return argv
     return argv

--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -133,6 +133,17 @@ src/
 │                          + Σ delay; clock_group is auto-named
 │                          `chain_{lowest_lex_id}` per connected component
 │                          when none is explicit. Feature-gated (config).
+├── verify/
+│   ├── mod.rs          ← alert-expectation types for `sonda test`: ExpectConfig,
+│   │                      AlertExpectation, AlertState, parse_expectations() (config feature).
+│   │                      The `expect:` block is pure metadata to the compiler and runtime.
+│   ├── evaluator.rs    ← pure, feature-free verdicts: Observation timelines + a deadline
+│   │                      → Outcome (Pass | Late | Missed | Undecided). Owns EVERY deadline
+│   │                      comparison — acquisition layers must never decide pass/fail.
+│   └── prometheus.rs   ← acquisition (feature = "http"): blocking PrometheusClient with a
+│                          mandatory per-request timeout, queries the ALERTS metric via the
+│                          instant-query API. Errors are SondaError::Verify, retryable by
+│                          polling loops. Alertmanager acquisition is planned as a sibling.
 └── config/
     ├── mod.rs          ← BaseScheduleConfig (shared schedule/delivery fields: name, rate, duration,
     │                      gaps, bursts, cardinality_spikes, dynamic_labels, labels, sink,

--- a/sonda-core/src/compiler/mod.rs
+++ b/sonda-core/src/compiler/mod.rs
@@ -107,6 +107,13 @@ pub struct ScenarioFile {
     /// Empty when `kind: composable` — composable files carry no entries.
     #[cfg_attr(feature = "config", serde(default))]
     pub scenarios: Vec<Entry>,
+    /// Optional alert expectations consumed by `sonda test`. Pure metadata —
+    /// ignored by every compiler phase and by the runtime.
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub expect: Option<crate::verify::ExpectConfig>,
 }
 
 /// Discriminator declaring the role of a v2 YAML file.

--- a/sonda-core/src/compiler/normalize.rs
+++ b/sonda-core/src/compiler/normalize.rs
@@ -1432,6 +1432,7 @@ scenarios:
             description: None,
             defaults: None,
             scenarios: Vec::new(),
+            expect: None,
         };
         let normalized = normalize(file).expect("must normalize empty list");
         assert_eq!(normalized.version, 2);

--- a/sonda-core/src/compiler/parse.rs
+++ b/sonda-core/src/compiler/parse.rs
@@ -255,6 +255,10 @@ struct FlatFile {
     #[serde(default)]
     overrides: Option<std::collections::BTreeMap<String, crate::packs::MetricOverride>>,
 
+    // Alert expectations (sonda test) — metadata, passed through untouched.
+    #[serde(default)]
+    expect: Option<crate::verify::ExpectConfig>,
+
     // Histogram / summary fields
     #[serde(default)]
     distribution: Option<crate::config::DistributionConfig>,
@@ -343,6 +347,7 @@ impl FlatFile {
             description: None,
             defaults: None,
             scenarios: vec![entry],
+            expect: self.expect,
         }
     }
 }
@@ -449,6 +454,7 @@ fn parse_composable(yaml: &str) -> Result<ScenarioFile, ParseError> {
         description: header.description,
         defaults: None,
         scenarios: Vec::new(),
+        expect: None,
     })
 }
 

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod packs;
 pub mod schedule;
 pub mod sink;
 pub(crate) mod util;
+pub mod verify;
 
 pub use compiler::UnresolvedBehavior;
 pub use config::aliases::{desugar_entry, desugar_scenario_config};

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -125,6 +125,42 @@ pub enum SondaError {
     /// surface YAML validation feedback are not confused by thread panics.
     #[error("runtime error: {0}")]
     Runtime(#[from] RuntimeError),
+
+    /// An error from alert-expectation verification (`sonda test`).
+    ///
+    /// Network and response failures while querying a verification endpoint.
+    /// Separated from [`ConfigError`] so callers can distinguish "your YAML
+    /// is wrong" from "the TSDB is unreachable" — both reach the user, but
+    /// only one is theirs to fix by editing the scenario.
+    #[error("verification error: {0}")]
+    Verify(#[from] VerifyError),
+}
+
+/// Errors from querying an alert-verification endpoint.
+///
+/// Produced by [`verify::prometheus::PrometheusClient`]: transient network
+/// failures, HTTP errors, timeouts, and malformed API payloads. Callers
+/// polling in a loop typically treat these as retryable until a deadline.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum VerifyError {
+    /// The endpoint could not be queried (connection, HTTP status, timeout).
+    #[error("query against {url} failed: {reason}")]
+    Query {
+        /// The query URL that failed.
+        url: String,
+        /// Human-readable failure description from the HTTP layer.
+        reason: String,
+    },
+
+    /// The endpoint responded, but not with a usable API payload.
+    #[error("unusable response from {url}: {reason}")]
+    BadResponse {
+        /// The query URL that produced the response.
+        url: String,
+        /// What made the payload unusable.
+        reason: String,
+    },
 }
 
 /// Errors related to scenario configuration validation.

--- a/sonda-core/src/verify/evaluator.rs
+++ b/sonda-core/src/verify/evaluator.rs
@@ -1,0 +1,285 @@
+//! Pure verdict evaluation for alert expectations.
+//!
+//! The evaluator owns the one comparison this feature exists to make:
+//! *did the observed transition happen at or before its deadline?* It is
+//! deliberately feature-free and I/O-free — acquisition (polling a
+//! Prometheus API now, Alertmanager later) produces an [`Observation`]
+//! timeline, and the evaluator turns that timeline plus a deadline into an
+//! [`Outcome`]. Every deadline decision is made here and nowhere else.
+//!
+//! Time base: observation timestamps are durations since a caller-chosen
+//! anchor — scenario start for firing checks, scenario end for resolution
+//! checks. The evaluator never reads a clock.
+
+use std::time::Duration;
+
+use crate::verify::AlertState;
+
+/// One timestamped poll of an alert's state.
+#[derive(Debug, Clone)]
+pub struct Observation {
+    /// Time of the observation, measured **when the query returned**,
+    /// relative to the caller's anchor (scenario start or end).
+    pub at: Duration,
+    /// The observed state, or the stringified query error.
+    pub state: Result<AlertState, String>,
+}
+
+impl Observation {
+    /// Convenience constructor.
+    pub fn new(at: Duration, state: Result<AlertState, String>) -> Self {
+        Self { at, state }
+    }
+}
+
+/// The verdict for one check (firing or resolution) of one expectation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Outcome {
+    /// The transition was observed at `at`, and `at <= deadline`.
+    Pass {
+        /// When the transition was first observed.
+        at: Duration,
+    },
+    /// The transition was observed, but only after the deadline.
+    Late {
+        /// When the transition was first observed.
+        at: Duration,
+        /// The deadline it missed.
+        deadline: Duration,
+    },
+    /// Polling covered the deadline and the transition never happened.
+    Missed {
+        /// The deadline that passed.
+        deadline: Duration,
+        /// The most recent query error before the deadline, if any —
+        /// distinguishes "the alert never fired" from "we could not ask".
+        last_error: Option<String>,
+    },
+    /// Polling stopped before the deadline without observing the
+    /// transition — no verdict is provable from the data. Callers must
+    /// treat this as a failure and say *why* it is not a [`Outcome::Missed`]
+    /// (e.g. the poller died).
+    Undecided,
+}
+
+impl Outcome {
+    /// Whether this outcome counts as a pass.
+    pub fn passed(&self) -> bool {
+        matches!(self, Outcome::Pass { .. })
+    }
+}
+
+/// Evaluate a firing check: the alert must reach `Firing` by `deadline`.
+///
+/// Observation timestamps are relative to scenario start.
+pub fn evaluate_firing(observations: &[Observation], deadline: Duration) -> Outcome {
+    evaluate(observations, deadline, |state| {
+        matches!(state, AlertState::Firing)
+    })
+}
+
+/// Evaluate a resolution check: the alert must stop firing by `deadline`.
+///
+/// Observation timestamps are relative to scenario end. Query errors never
+/// count as resolution — only a successful query showing a non-firing state
+/// does.
+pub fn evaluate_resolution(observations: &[Observation], deadline: Duration) -> Outcome {
+    evaluate(observations, deadline, |state| {
+        !matches!(state, AlertState::Firing)
+    })
+}
+
+/// Shared walk: find the first observation whose state satisfies `is_success`
+/// and compare its timestamp against the deadline. When none does, the
+/// verdict depends on whether polling provably covered the deadline.
+fn evaluate(
+    observations: &[Observation],
+    deadline: Duration,
+    is_success: impl Fn(&AlertState) -> bool,
+) -> Outcome {
+    let mut last_error = None;
+    let mut covered = false;
+    for observation in observations {
+        match &observation.state {
+            Ok(state) if is_success(state) => {
+                return if observation.at <= deadline {
+                    Outcome::Pass { at: observation.at }
+                } else {
+                    Outcome::Late {
+                        at: observation.at,
+                        deadline,
+                    }
+                };
+            }
+            Ok(_) => {}
+            Err(e) => {
+                // Only errors before the deadline explain a miss; a late
+                // error cannot be why the transition wasn't seen in time.
+                if observation.at <= deadline {
+                    last_error = Some(e.clone());
+                }
+            }
+        }
+        if observation.at >= deadline {
+            covered = true;
+        }
+    }
+    if covered {
+        Outcome::Missed {
+            deadline,
+            last_error,
+        }
+    } else {
+        Outcome::Undecided
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ms(v: u64) -> Duration {
+        Duration::from_millis(v)
+    }
+
+    fn firing(at: u64) -> Observation {
+        Observation::new(ms(at), Ok(AlertState::Firing))
+    }
+
+    fn inactive(at: u64) -> Observation {
+        Observation::new(ms(at), Ok(AlertState::Inactive))
+    }
+
+    fn pending(at: u64) -> Observation {
+        Observation::new(ms(at), Ok(AlertState::Pending))
+    }
+
+    fn error(at: u64, msg: &str) -> Observation {
+        Observation::new(ms(at), Err(msg.to_string()))
+    }
+
+    #[test]
+    fn firing_on_time_passes() {
+        let outcome = evaluate_firing(&[inactive(100), pending(200), firing(300)], ms(500));
+        assert_eq!(outcome, Outcome::Pass { at: ms(300) });
+    }
+
+    #[test]
+    fn firing_exactly_at_deadline_passes() {
+        let outcome = evaluate_firing(&[firing(500)], ms(500));
+        assert_eq!(outcome, Outcome::Pass { at: ms(500) });
+    }
+
+    #[test]
+    fn firing_after_deadline_is_late_not_pass() {
+        // Blocker 1, reproduction B: observed 3s after a 200ms deadline.
+        let outcome = evaluate_firing(&[firing(3000)], ms(200));
+        assert_eq!(
+            outcome,
+            Outcome::Late {
+                at: ms(3000),
+                deadline: ms(200)
+            }
+        );
+        assert!(!outcome.passed());
+    }
+
+    #[test]
+    fn no_firing_with_coverage_is_missed() {
+        let outcome = evaluate_firing(&[inactive(100), inactive(600)], ms(500));
+        assert_eq!(
+            outcome,
+            Outcome::Missed {
+                deadline: ms(500),
+                last_error: None
+            }
+        );
+    }
+
+    #[test]
+    fn missed_carries_last_error_before_deadline() {
+        let outcome = evaluate_firing(
+            &[
+                error(100, "refused"),
+                error(400, "timed out"),
+                inactive(600),
+            ],
+            ms(500),
+        );
+        assert_eq!(
+            outcome,
+            Outcome::Missed {
+                deadline: ms(500),
+                last_error: Some("timed out".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn errors_after_deadline_do_not_explain_a_miss() {
+        let outcome = evaluate_firing(&[inactive(100), error(600, "late error")], ms(500));
+        assert_eq!(
+            outcome,
+            Outcome::Missed {
+                deadline: ms(500),
+                last_error: None
+            }
+        );
+    }
+
+    #[test]
+    fn polling_that_stops_early_is_undecided() {
+        // Coverage not proven: last observation is before the deadline.
+        let outcome = evaluate_firing(&[inactive(100), inactive(200)], ms(500));
+        assert_eq!(outcome, Outcome::Undecided);
+    }
+
+    #[test]
+    fn empty_timeline_is_undecided() {
+        assert_eq!(evaluate_firing(&[], ms(500)), Outcome::Undecided);
+    }
+
+    #[test]
+    fn resolution_on_time_passes() {
+        let outcome = evaluate_resolution(&[firing(100), inactive(180)], ms(200));
+        assert_eq!(outcome, Outcome::Pass { at: ms(180) });
+    }
+
+    #[test]
+    fn resolution_after_deadline_is_late() {
+        // Blocker 1, reproduction A: resolved 322ms after a 200ms deadline.
+        let outcome = evaluate_resolution(&[inactive(322)], ms(200));
+        assert_eq!(
+            outcome,
+            Outcome::Late {
+                at: ms(322),
+                deadline: ms(200)
+            }
+        );
+    }
+
+    #[test]
+    fn query_errors_never_count_as_resolution() {
+        // W1: a dead endpoint must not read as "resolved" — and with only
+        // errors through the deadline, the miss carries the last error.
+        let outcome = evaluate_resolution(
+            &[firing(50), error(150, "connection refused"), firing(250)],
+            ms(200),
+        );
+        assert_eq!(
+            outcome,
+            Outcome::Missed {
+                deadline: ms(200),
+                last_error: Some("connection refused".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn pending_counts_as_resolved() {
+        // Resolution means "not firing" — pending after recovery qualifies.
+        let outcome = evaluate_resolution(&[firing(50), pending(120)], ms(200));
+        assert_eq!(outcome, Outcome::Pass { at: ms(120) });
+    }
+}

--- a/sonda-core/src/verify/evaluator.rs
+++ b/sonda-core/src/verify/evaluator.rs
@@ -41,7 +41,11 @@ pub enum Outcome {
         /// When the transition was first observed.
         at: Duration,
     },
-    /// The transition was observed, but only after the deadline.
+    /// The transition was observed after the deadline, **and** a successful
+    /// observation at or before the deadline showed it had not happened yet.
+    /// Without that evidence the window is unobserved and the verdict is
+    /// [`Outcome::Undecided`], not `Late` — a single post-deadline sample
+    /// cannot prove lateness.
     Late {
         /// When the transition was first observed.
         at: Duration,
@@ -56,11 +60,21 @@ pub enum Outcome {
         /// distinguishes "the alert never fired" from "we could not ask".
         last_error: Option<String>,
     },
-    /// Polling stopped before the deadline without observing the
-    /// transition — no verdict is provable from the data. Callers must
-    /// treat this as a failure and say *why* it is not a [`Outcome::Missed`]
-    /// (e.g. the poller died).
-    Undecided,
+    /// The deadline window was not actually observed, so no verdict is
+    /// provable from the data. Two ways to get here: polling stopped before
+    /// the deadline without seeing the transition, or the transition *was*
+    /// seen after the deadline but no successful observation inside the
+    /// window proved it hadn't already happened. Callers must treat this as
+    /// a failure and say *why* it is not a [`Outcome::Missed`] (e.g. the
+    /// poller died, or the first successful query landed too late).
+    Undecided {
+        /// When the transition was eventually observed, if it was — after
+        /// the deadline, with no pre-deadline evidence to make it `Late`.
+        observed_at: Option<Duration>,
+        /// The most recent query error at or before the deadline, if any —
+        /// often the reason the window went unobserved.
+        last_error: Option<String>,
+    },
 }
 
 impl Outcome {
@@ -91,8 +105,11 @@ pub fn evaluate_resolution(observations: &[Observation], deadline: Duration) -> 
 }
 
 /// Shared walk: find the first observation whose state satisfies `is_success`
-/// and compare its timestamp against the deadline. When none does, the
-/// verdict depends on whether polling provably covered the deadline.
+/// and compare its timestamp against the deadline. A verdict is only as good
+/// as its evidence: `Late` additionally requires a successful pre-deadline
+/// observation showing a non-success state (proof the transition had not
+/// happened by the deadline), and `Missed` requires that polling provably
+/// covered the deadline. Everything short of that evidence is `Undecided`.
 fn evaluate(
     observations: &[Observation],
     deadline: Duration,
@@ -100,19 +117,32 @@ fn evaluate(
 ) -> Outcome {
     let mut last_error = None;
     let mut covered = false;
+    let mut evidence = false;
     for observation in observations {
         match &observation.state {
             Ok(state) if is_success(state) => {
                 return if observation.at <= deadline {
                     Outcome::Pass { at: observation.at }
-                } else {
+                } else if evidence {
                     Outcome::Late {
                         at: observation.at,
                         deadline,
                     }
+                } else {
+                    // Success seen only after the deadline, with nothing
+                    // successful inside the window: the window went
+                    // unobserved, so "late" cannot be asserted.
+                    Outcome::Undecided {
+                        observed_at: Some(observation.at),
+                        last_error,
+                    }
                 };
             }
-            Ok(_) => {}
+            Ok(_) => {
+                if observation.at <= deadline {
+                    evidence = true;
+                }
+            }
             Err(e) => {
                 // Only errors before the deadline explain a miss; a late
                 // error cannot be why the transition wasn't seen in time.
@@ -131,7 +161,10 @@ fn evaluate(
             last_error,
         }
     } else {
-        Outcome::Undecided
+        Outcome::Undecided {
+            observed_at: None,
+            last_error,
+        }
     }
 }
 
@@ -173,8 +206,9 @@ mod tests {
 
     #[test]
     fn firing_after_deadline_is_late_not_pass() {
-        // Blocker 1, reproduction B: observed 3s after a 200ms deadline.
-        let outcome = evaluate_firing(&[firing(3000)], ms(200));
+        // Round-1 blocker 1, reproduction B: observed 3s after a 200ms
+        // deadline — with a pre-deadline sample proving it wasn't firing yet.
+        let outcome = evaluate_firing(&[inactive(100), firing(3000)], ms(200));
         assert_eq!(
             outcome,
             Outcome::Late {
@@ -183,6 +217,49 @@ mod tests {
             }
         );
         assert!(!outcome.passed());
+    }
+
+    #[test]
+    fn late_success_without_window_coverage_is_undecided_not_late() {
+        // Round-2 W5: a single post-deadline sample proves nothing about the
+        // window — asserting Late from it would be a confident wrong verdict.
+        let outcome = evaluate_firing(&[firing(3000)], ms(200));
+        assert_eq!(
+            outcome,
+            Outcome::Undecided {
+                observed_at: Some(ms(3000)),
+                last_error: None
+            }
+        );
+        assert!(!outcome.passed());
+    }
+
+    #[test]
+    fn errors_inside_window_do_not_count_as_late_evidence() {
+        // Round-2 W5: a failed query proves nothing about the alert's state,
+        // so errors-then-late-success is Undecided, carrying the error.
+        let outcome = evaluate_firing(&[error(100, "refused"), firing(3000)], ms(200));
+        assert_eq!(
+            outcome,
+            Outcome::Undecided {
+                observed_at: Some(ms(3000)),
+                last_error: Some("refused".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn evidence_exactly_at_deadline_supports_late() {
+        // Boundary: a successful non-success sample at at == deadline is
+        // window coverage.
+        let outcome = evaluate_firing(&[inactive(200), firing(900)], ms(200));
+        assert_eq!(
+            outcome,
+            Outcome::Late {
+                at: ms(900),
+                deadline: ms(200)
+            }
+        );
     }
 
     #[test]
@@ -232,12 +309,24 @@ mod tests {
     fn polling_that_stops_early_is_undecided() {
         // Coverage not proven: last observation is before the deadline.
         let outcome = evaluate_firing(&[inactive(100), inactive(200)], ms(500));
-        assert_eq!(outcome, Outcome::Undecided);
+        assert_eq!(
+            outcome,
+            Outcome::Undecided {
+                observed_at: None,
+                last_error: None
+            }
+        );
     }
 
     #[test]
     fn empty_timeline_is_undecided() {
-        assert_eq!(evaluate_firing(&[], ms(500)), Outcome::Undecided);
+        assert_eq!(
+            evaluate_firing(&[], ms(500)),
+            Outcome::Undecided {
+                observed_at: None,
+                last_error: None
+            }
+        );
     }
 
     #[test]
@@ -248,13 +337,28 @@ mod tests {
 
     #[test]
     fn resolution_after_deadline_is_late() {
-        // Blocker 1, reproduction A: resolved 322ms after a 200ms deadline.
-        let outcome = evaluate_resolution(&[inactive(322)], ms(200));
+        // Round-1 blocker 1, reproduction A: resolved 322ms after a 200ms
+        // deadline, with a pre-deadline sample showing it still firing.
+        let outcome = evaluate_resolution(&[firing(150), inactive(322)], ms(200));
         assert_eq!(
             outcome,
             Outcome::Late {
                 at: ms(322),
                 deadline: ms(200)
+            }
+        );
+    }
+
+    #[test]
+    fn lone_late_resolution_without_coverage_is_undecided() {
+        // Round-2 W5 mirrored on the resolution side: the first successful
+        // query landing after the deadline is not proof of lateness.
+        let outcome = evaluate_resolution(&[inactive(322)], ms(200));
+        assert_eq!(
+            outcome,
+            Outcome::Undecided {
+                observed_at: Some(ms(322)),
+                last_error: None
             }
         );
     }

--- a/sonda-core/src/verify/mod.rs
+++ b/sonda-core/src/verify/mod.rs
@@ -17,13 +17,28 @@
 //! the [`prometheus`] client (feature `http`) polls a Prometheus-compatible
 //! API's `ALERTS` metric to check each expectation.
 
+pub mod evaluator;
 #[cfg(feature = "http")]
 pub mod prometheus;
 
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use crate::{ConfigError, SondaError};
+use crate::SondaError;
+
+/// Observed state of one alert at a single poll.
+///
+/// Produced by acquisition (the [`prometheus`] client today, Alertmanager
+/// sampling in a later phase) and consumed by the [`evaluator`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertState {
+    /// No alert series matched the expectation's selector.
+    Inactive,
+    /// Matched series exist, but none is firing.
+    Pending,
+    /// At least one matched series is firing.
+    Firing,
+}
 
 /// Top-level `expect:` block of a scenario file.
 #[derive(Debug, Clone)]
@@ -87,6 +102,8 @@ impl AlertExpectation {
 /// unknown fields, an empty alert list, or invalid duration strings.
 #[cfg(feature = "config")]
 pub fn parse_expectations(yaml: &str) -> Result<Option<ExpectConfig>, SondaError> {
+    use crate::ConfigError;
+
     #[derive(serde::Deserialize)]
     struct ExpectProbe {
         #[serde(default)]

--- a/sonda-core/src/verify/mod.rs
+++ b/sonda-core/src/verify/mod.rs
@@ -1,0 +1,196 @@
+//! Alert expectation verification — the engine behind `sonda test`.
+//!
+//! A scenario file may carry a top-level `expect:` block declaring which
+//! alerts the generated signals should trigger, and how quickly:
+//!
+//! ```yaml
+//! expect:
+//!   alerts:
+//!     - alert: HighCpuUsage
+//!       firing_within: 2m
+//!       resolves_within: 1m
+//!       labels: { severity: critical }
+//! ```
+//!
+//! The block is pure metadata to the compiler and runtime — scenarios run
+//! identically with or without it. [`parse_expectations`] extracts it, and
+//! the [`prometheus`] client (feature `http`) polls a Prometheus-compatible
+//! API's `ALERTS` metric to check each expectation.
+
+#[cfg(feature = "http")]
+pub mod prometheus;
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use crate::{ConfigError, SondaError};
+
+/// Top-level `expect:` block of a scenario file.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "config", serde(deny_unknown_fields))]
+pub struct ExpectConfig {
+    /// Alert expectations, checked in order. Must not be empty.
+    pub alerts: Vec<AlertExpectation>,
+}
+
+/// One alert the scenario is expected to trigger.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "config", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "config", serde(deny_unknown_fields))]
+pub struct AlertExpectation {
+    /// Alert rule name — matched against the `alertname` label of the
+    /// `ALERTS` metric.
+    pub alert: String,
+    /// Additional label matchers the firing alert must carry.
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub labels: Option<BTreeMap<String, String>>,
+    /// How long after scenario start the alert must reach `firing`
+    /// (e.g. `"2m"`).
+    pub firing_within: String,
+    /// How long after scenario end the alert must stop firing. `None`
+    /// skips the resolution check.
+    #[cfg_attr(
+        feature = "config",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub resolves_within: Option<String>,
+}
+
+impl AlertExpectation {
+    /// Parsed `firing_within` deadline.
+    pub fn firing_within(&self) -> Result<Duration, SondaError> {
+        crate::config::validate::parse_duration(&self.firing_within)
+    }
+
+    /// Parsed `resolves_within` deadline, when present.
+    pub fn resolves_within(&self) -> Result<Option<Duration>, SondaError> {
+        self.resolves_within
+            .as_deref()
+            .map(crate::config::validate::parse_duration)
+            .transpose()
+    }
+}
+
+/// Extract and validate the `expect:` block from scenario YAML.
+///
+/// Returns `Ok(None)` when the file has no `expect:` block. The probe is
+/// deliberately lenient about every other key — full scenario validation is
+/// the compiler's job, and callers run both.
+///
+/// # Errors
+///
+/// Returns [`SondaError::Config`] when the block is present but malformed:
+/// unknown fields, an empty alert list, or invalid duration strings.
+#[cfg(feature = "config")]
+pub fn parse_expectations(yaml: &str) -> Result<Option<ExpectConfig>, SondaError> {
+    #[derive(serde::Deserialize)]
+    struct ExpectProbe {
+        #[serde(default)]
+        expect: Option<serde_yaml_ng::Value>,
+    }
+
+    let probe: ExpectProbe = serde_yaml_ng::from_str(yaml)
+        .map_err(|e| SondaError::Config(ConfigError::invalid(format!("invalid YAML: {e}"))))?;
+    let Some(raw) = probe.expect else {
+        return Ok(None);
+    };
+    let config: ExpectConfig = serde_yaml_ng::from_value(raw).map_err(|e| {
+        SondaError::Config(ConfigError::invalid(format!("invalid expect block: {e}")))
+    })?;
+
+    if config.alerts.is_empty() {
+        return Err(SondaError::Config(ConfigError::invalid(
+            "expect.alerts must list at least one alert",
+        )));
+    }
+    for expectation in &config.alerts {
+        if expectation.alert.is_empty() {
+            return Err(SondaError::Config(ConfigError::invalid(
+                "expect.alerts[].alert must not be empty",
+            )));
+        }
+        expectation.firing_within()?;
+        expectation.resolves_within()?;
+    }
+    Ok(Some(config))
+}
+
+#[cfg(all(test, feature = "config"))]
+mod tests {
+    use super::*;
+
+    const FULL: &str = "
+version: 2
+kind: runnable
+scenarios: []
+expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 2m
+      resolves_within: 1m
+      labels: { severity: critical }
+    - alert: ElevatedCpuUsage
+      firing_within: 90s
+";
+
+    #[test]
+    fn parses_full_expect_block() {
+        let config = parse_expectations(FULL)
+            .expect("parse ok")
+            .expect("present");
+        assert_eq!(config.alerts.len(), 2);
+        assert_eq!(config.alerts[0].alert, "HighCpuUsage");
+        assert_eq!(
+            config.alerts[0].firing_within().expect("duration"),
+            Duration::from_secs(120)
+        );
+        assert_eq!(
+            config.alerts[0].resolves_within().expect("duration"),
+            Some(Duration::from_secs(60))
+        );
+        assert_eq!(config.alerts[1].resolves_within().expect("none"), None);
+        let labels = config.alerts[0].labels.as_ref().expect("labels");
+        assert_eq!(labels.get("severity").map(String::as_str), Some("critical"));
+    }
+
+    #[test]
+    fn absent_block_is_none() {
+        let yaml = "version: 2\nkind: runnable\nscenarios: []\n";
+        assert!(parse_expectations(yaml).expect("parse ok").is_none());
+    }
+
+    #[test]
+    fn empty_alert_list_is_rejected() {
+        let yaml = "version: 2\nexpect:\n  alerts: []\n";
+        let err = parse_expectations(yaml).expect_err("must fail");
+        assert!(err.to_string().contains("at least one alert"));
+    }
+
+    #[test]
+    fn invalid_duration_is_rejected() {
+        let yaml = "
+expect:
+  alerts:
+    - alert: X
+      firing_within: banana
+";
+        assert!(parse_expectations(yaml).is_err());
+    }
+
+    #[test]
+    fn unknown_expectation_field_is_rejected() {
+        let yaml = "
+expect:
+  alerts:
+    - alert: X
+      firing_within: 1m
+      fires_within: 1m
+";
+        let err = parse_expectations(yaml).expect_err("must fail");
+        assert!(err.to_string().contains("invalid expect block"));
+    }
+}

--- a/sonda-core/src/verify/prometheus.rs
+++ b/sonda-core/src/verify/prometheus.rs
@@ -1,0 +1,196 @@
+//! Prometheus-compatible client for alert-state polling.
+//!
+//! Queries the instant-query API (`/api/v1/query`) for the built-in
+//! `ALERTS` metric, which every Prometheus-compatible evaluator (Prometheus,
+//! VictoriaMetrics/vmalert) exposes with an `alertstate` label of `pending`
+//! or `firing` while a rule is active.
+
+use std::fmt::Write as _;
+
+use crate::verify::AlertExpectation;
+use crate::{ConfigError, SondaError};
+
+/// Observed state of one alert at a single poll.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertState {
+    /// No `ALERTS` series matched the expectation's selector.
+    Inactive,
+    /// Matched series exist, but none with `alertstate="firing"`.
+    Pending,
+    /// At least one matched series has `alertstate="firing"`.
+    Firing,
+}
+
+/// Minimal blocking client for the Prometheus instant-query API.
+pub struct PrometheusClient {
+    query_url: String,
+    agent: ureq::Agent,
+}
+
+impl PrometheusClient {
+    /// Create a client for a Prometheus-compatible base URL
+    /// (e.g. `http://localhost:9090`).
+    pub fn new(base_url: &str) -> Self {
+        let base = base_url.trim_end_matches('/');
+        Self {
+            query_url: format!("{base}/api/v1/query"),
+            agent: ureq::AgentBuilder::new().build(),
+        }
+    }
+
+    /// Query the current state of an expected alert.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SondaError::Config`] when the endpoint is unreachable or
+    /// responds with a non-success API status — callers decide whether to
+    /// retry (transient network errors during startup are normal).
+    pub fn alert_state(&self, expectation: &AlertExpectation) -> Result<AlertState, SondaError> {
+        let query = alerts_query(expectation);
+        let body = self
+            .agent
+            .get(&self.query_url)
+            .query("query", &query)
+            .call()
+            .map_err(|e| {
+                SondaError::Config(ConfigError::invalid(format!(
+                    "prometheus query failed against {}: {e}",
+                    self.query_url
+                )))
+            })?
+            .into_string()
+            .map_err(|e| {
+                SondaError::Config(ConfigError::invalid(format!(
+                    "prometheus response could not be read: {e}"
+                )))
+            })?;
+        parse_alert_state(&body)
+    }
+}
+
+/// Build the `ALERTS{...}` selector for an expectation.
+///
+/// Matches on `alertname` plus any extra label matchers. `alertstate` is
+/// intentionally not constrained — the response distinguishes pending from
+/// firing so one query answers both.
+pub fn alerts_query(expectation: &AlertExpectation) -> String {
+    let mut selector = String::from("ALERTS{");
+    let _ = write!(
+        selector,
+        "alertname=\"{}\"",
+        escape_label_value(&expectation.alert)
+    );
+    if let Some(labels) = &expectation.labels {
+        for (key, value) in labels {
+            let _ = write!(selector, ",{key}=\"{}\"", escape_label_value(value));
+        }
+    }
+    selector.push('}');
+    selector
+}
+
+/// Escape a PromQL label-matcher value (backslash, quote, newline).
+fn escape_label_value(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
+}
+
+/// Parse an instant-query response into an [`AlertState`].
+pub fn parse_alert_state(body: &str) -> Result<AlertState, SondaError> {
+    let parsed: serde_json::Value = serde_json::from_str(body).map_err(|e| {
+        SondaError::Config(ConfigError::invalid(format!(
+            "prometheus response is not valid JSON: {e}"
+        )))
+    })?;
+    if parsed["status"] != "success" {
+        return Err(SondaError::Config(ConfigError::invalid(format!(
+            "prometheus query returned status {:?}",
+            parsed["status"]
+        ))));
+    }
+    let empty = Vec::new();
+    let results = parsed["data"]["result"].as_array().unwrap_or(&empty);
+    if results.is_empty() {
+        return Ok(AlertState::Inactive);
+    }
+    let firing = results
+        .iter()
+        .any(|series| series["metric"]["alertstate"] == "firing");
+    Ok(if firing {
+        AlertState::Firing
+    } else {
+        AlertState::Pending
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn expectation(labels: Option<BTreeMap<String, String>>) -> AlertExpectation {
+        AlertExpectation {
+            alert: "HighCpuUsage".into(),
+            labels,
+            firing_within: "1m".into(),
+            resolves_within: None,
+        }
+    }
+
+    #[test]
+    fn query_matches_alertname_only() {
+        assert_eq!(
+            alerts_query(&expectation(None)),
+            "ALERTS{alertname=\"HighCpuUsage\"}"
+        );
+    }
+
+    #[test]
+    fn query_includes_extra_label_matchers() {
+        let labels = BTreeMap::from([
+            ("severity".to_string(), "critical".to_string()),
+            ("team".to_string(), "net\"ops".to_string()),
+        ]);
+        assert_eq!(
+            alerts_query(&expectation(Some(labels))),
+            "ALERTS{alertname=\"HighCpuUsage\",severity=\"critical\",team=\"net\\\"ops\"}"
+        );
+    }
+
+    #[test]
+    fn empty_result_is_inactive() {
+        let body = r#"{"status":"success","data":{"resultType":"vector","result":[]}}"#;
+        assert_eq!(parse_alert_state(body).expect("ok"), AlertState::Inactive);
+    }
+
+    #[test]
+    fn pending_only_is_pending() {
+        let body = r#"{"status":"success","data":{"result":[
+            {"metric":{"alertname":"HighCpuUsage","alertstate":"pending"},"value":[1,"1"]}
+        ]}}"#;
+        assert_eq!(parse_alert_state(body).expect("ok"), AlertState::Pending);
+    }
+
+    #[test]
+    fn any_firing_series_is_firing() {
+        let body = r#"{"status":"success","data":{"result":[
+            {"metric":{"alertname":"HighCpuUsage","alertstate":"pending"},"value":[1,"1"]},
+            {"metric":{"alertname":"HighCpuUsage","alertstate":"firing"},"value":[1,"1"]}
+        ]}}"#;
+        assert_eq!(parse_alert_state(body).expect("ok"), AlertState::Firing);
+    }
+
+    #[test]
+    fn error_status_is_rejected() {
+        let body = r#"{"status":"error","errorType":"bad_data","error":"boom"}"#;
+        assert!(parse_alert_state(body).is_err());
+    }
+}

--- a/sonda-core/src/verify/prometheus.rs
+++ b/sonda-core/src/verify/prometheus.rs
@@ -1,27 +1,22 @@
-//! Prometheus-compatible client for alert-state polling.
+//! Prometheus-compatible acquisition for alert-state polling.
 //!
 //! Queries the instant-query API (`/api/v1/query`) for the built-in
 //! `ALERTS` metric, which every Prometheus-compatible evaluator (Prometheus,
 //! VictoriaMetrics/vmalert) exposes with an `alertstate` label of `pending`
-//! or `firing` while a rule is active.
+//! or `firing` while a rule is active. This module only *acquires* state —
+//! deadline decisions belong to [`crate::verify::evaluator`].
 
 use std::fmt::Write as _;
+use std::time::Duration;
 
-use crate::verify::AlertExpectation;
-use crate::{ConfigError, SondaError};
-
-/// Observed state of one alert at a single poll.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AlertState {
-    /// No `ALERTS` series matched the expectation's selector.
-    Inactive,
-    /// Matched series exist, but none with `alertstate="firing"`.
-    Pending,
-    /// At least one matched series has `alertstate="firing"`.
-    Firing,
-}
+use crate::verify::{AlertExpectation, AlertState};
+use crate::{SondaError, VerifyError};
 
 /// Minimal blocking client for the Prometheus instant-query API.
+///
+/// Every request carries an overall timeout — a stalled endpoint returns a
+/// [`VerifyError::Query`] instead of parking the calling thread forever,
+/// which keeps polling loops bounded and interruptible.
 pub struct PrometheusClient {
     query_url: String,
     agent: ureq::Agent,
@@ -29,12 +24,13 @@ pub struct PrometheusClient {
 
 impl PrometheusClient {
     /// Create a client for a Prometheus-compatible base URL
-    /// (e.g. `http://localhost:9090`).
-    pub fn new(base_url: &str) -> Self {
+    /// (e.g. `http://localhost:9090`), with an overall per-request timeout
+    /// covering connect, write, and read.
+    pub fn new(base_url: &str, timeout: Duration) -> Self {
         let base = base_url.trim_end_matches('/');
         Self {
             query_url: format!("{base}/api/v1/query"),
-            agent: ureq::AgentBuilder::new().build(),
+            agent: ureq::AgentBuilder::new().timeout(timeout).build(),
         }
     }
 
@@ -42,9 +38,9 @@ impl PrometheusClient {
     ///
     /// # Errors
     ///
-    /// Returns [`SondaError::Config`] when the endpoint is unreachable or
-    /// responds with a non-success API status — callers decide whether to
-    /// retry (transient network errors during startup are normal).
+    /// Returns [`SondaError::Verify`] when the endpoint is unreachable,
+    /// times out, or responds with an unusable payload — callers polling in
+    /// a loop treat these as retryable until their deadline.
     pub fn alert_state(&self, expectation: &AlertExpectation) -> Result<AlertState, SondaError> {
         let query = alerts_query(expectation);
         let body = self
@@ -53,18 +49,24 @@ impl PrometheusClient {
             .query("query", &query)
             .call()
             .map_err(|e| {
-                SondaError::Config(ConfigError::invalid(format!(
-                    "prometheus query failed against {}: {e}",
-                    self.query_url
-                )))
+                SondaError::Verify(VerifyError::Query {
+                    url: self.query_url.clone(),
+                    reason: e.to_string(),
+                })
             })?
             .into_string()
             .map_err(|e| {
-                SondaError::Config(ConfigError::invalid(format!(
-                    "prometheus response could not be read: {e}"
-                )))
+                SondaError::Verify(VerifyError::BadResponse {
+                    url: self.query_url.clone(),
+                    reason: format!("response could not be read: {e}"),
+                })
             })?;
-        parse_alert_state(&body)
+        parse_alert_state(&body).map_err(|reason| {
+            SondaError::Verify(VerifyError::BadResponse {
+                url: self.query_url.clone(),
+                reason,
+            })
+        })
     }
 }
 
@@ -103,18 +105,15 @@ fn escape_label_value(value: &str) -> String {
     escaped
 }
 
-/// Parse an instant-query response into an [`AlertState`].
-pub fn parse_alert_state(body: &str) -> Result<AlertState, SondaError> {
-    let parsed: serde_json::Value = serde_json::from_str(body).map_err(|e| {
-        SondaError::Config(ConfigError::invalid(format!(
-            "prometheus response is not valid JSON: {e}"
-        )))
-    })?;
+/// Parse an instant-query response body into an [`AlertState`].
+///
+/// Returns a human-readable reason on failure; the caller wraps it with the
+/// query URL into a [`VerifyError::BadResponse`].
+pub fn parse_alert_state(body: &str) -> Result<AlertState, String> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(body).map_err(|e| format!("not valid JSON: {e}"))?;
     if parsed["status"] != "success" {
-        return Err(SondaError::Config(ConfigError::invalid(format!(
-            "prometheus query returned status {:?}",
-            parsed["status"]
-        ))));
+        return Err(format!("query returned status {:?}", parsed["status"]));
     }
     let empty = Vec::new();
     let results = parsed["data"]["result"].as_array().unwrap_or(&empty);
@@ -192,5 +191,28 @@ mod tests {
     fn error_status_is_rejected() {
         let body = r#"{"status":"error","errorType":"bad_data","error":"boom"}"#;
         assert!(parse_alert_state(body).is_err());
+    }
+
+    #[test]
+    fn stalled_endpoint_times_out_with_verify_error() {
+        // A listener that accepts but never answers must produce a bounded
+        // Verify::Query error, not a parked thread (blocker 2).
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let _keep_alive = std::thread::spawn(move || {
+            let _streams: Vec<_> = listener.incoming().take(1).collect();
+            std::thread::sleep(std::time::Duration::from_secs(30));
+        });
+        let client = PrometheusClient::new(
+            &format!("http://{addr}"),
+            std::time::Duration::from_millis(300),
+        );
+        let started = std::time::Instant::now();
+        let result = client.alert_state(&expectation(None));
+        assert!(started.elapsed() < std::time::Duration::from_secs(5));
+        match result {
+            Err(SondaError::Verify(VerifyError::Query { .. })) => {}
+            other => panic!("expected Verify::Query error, got {other:?}"),
+        }
     }
 }

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -30,7 +30,7 @@ use crate::state::AppState;
 
 /// Subcommands the dispatch shim forwards to the sibling `sonda` binary.
 /// Mirror of `sonda`'s clap definition.
-const SONDA_SUBCOMMANDS: &[&str] = &["run", "list", "show", "new"];
+const SONDA_SUBCOMMANDS: &[&str] = &["run", "list", "show", "new", "test"];
 
 /// Command-line arguments for sonda-server.
 ///
@@ -326,7 +326,7 @@ mod tests {
 
     #[test]
     fn dispatch_list_covers_all_known_subcommands() {
-        let expected = ["run", "list", "show", "new"];
+        let expected = ["run", "list", "show", "new", "test"];
         assert_eq!(SONDA_SUBCOMMANDS.len(), expected.len());
         for name in expected {
             assert!(

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -109,12 +109,22 @@ the single discovery surface. The verbosity model is captured in the `Verbosity`
   and maps detected patterns to operational vocabulary aliases. `-o <path>` writes to a file;
   otherwise the YAML is printed to stdout.
 
+- **`sonda test`** — run a scenario and verify its top-level `expect:` alert expectations
+  against a Prometheus-compatible API (`--prometheus-url`, env `SONDA_PROMETHEUS_URL`).
+  A poller thread watches the `ALERTS` metric while the scenario runs through the same
+  machinery as `sonda run`; firing deadlines count from scenario start, resolution deadlines
+  from scenario end. Exits non-zero when any expectation fails — this is the CI entry point
+  for alert-rule testing. Orchestration in `test_cmd.rs`; expectation parsing and the
+  Prometheus client live in `sonda_core::verify`.
+
 All subcommands route through the unified `sonda_core::prepare_entries` + `sonda_core::launch_scenario`
 API. No per-signal-type dispatch in main.rs.
 
 ## Adding a New Subcommand
 
-The CLI is intentionally restricted to four verbs. Adding a fifth verb is an architectural decision
+The CLI is intentionally restricted to five verbs (`test` was added as the alert-testing
+entry point — rationale: it composes `run` with verification and cannot be expressed as a
+`run` flag without overloading its exit-code contract). Adding another verb is an architectural decision
 that should be paired with a written rationale — most workflows are better expressed by adding flags
 to `sonda run` or by extending the catalog metadata that `sonda list` / `sonda show` surface. If
 a new verb is genuinely warranted:

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -114,8 +114,10 @@ the single discovery surface. The verbosity model is captured in the `Verbosity`
   A poller thread watches the `ALERTS` metric while the scenario runs through the same
   machinery as `sonda run`; firing deadlines count from scenario start, resolution deadlines
   from scenario end. Exits non-zero when any expectation fails — this is the CI entry point
-  for alert-rule testing. Orchestration in `test_cmd.rs`; expectation parsing and the
-  Prometheus client live in `sonda_core::verify`.
+  for alert-rule testing. `test_cmd.rs` only orchestrates and renders: it records timestamped
+  observation timelines and every pass/fail decision is made by
+  `sonda_core::verify::evaluator` (parsing and the Prometheus client also live in
+  `sonda_core::verify`).
 
 All subcommands route through the unified `sonda_core::prepare_entries` + `sonda_core::launch_scenario`
 API. No per-signal-type dispatch in main.rs.

--- a/sonda/src/cli.rs
+++ b/sonda/src/cli.rs
@@ -130,13 +130,17 @@ pub struct TestArgs {
     pub scenario: String,
 
     /// Base URL of the Prometheus-compatible API evaluating the alert rules
-    /// (e.g. `http://localhost:9090`).
+    /// (e.g. `http://localhost:9090`). Required except with `--dry-run`.
     #[arg(long, env = "SONDA_PROMETHEUS_URL")]
-    pub prometheus_url: String,
+    pub prometheus_url: Option<String>,
 
     /// Poll interval for alert-state checks (e.g. `5s`).
     #[arg(long, default_value = "5s")]
     pub interval: String,
+
+    /// Overall timeout for each alert-state query (connect + read).
+    #[arg(long, default_value = "10s")]
+    pub query_timeout: String,
 }
 
 #[derive(Debug, Args)]

--- a/sonda/src/cli.rs
+++ b/sonda/src/cli.rs
@@ -60,6 +60,8 @@ pub enum Commands {
     Show(ShowArgs),
     /// Scaffold a new scenario YAML.
     New(NewArgs),
+    /// Run a scenario and verify its `expect:` alert expectations.
+    Test(TestArgs),
 }
 
 #[derive(Debug, Args)]
@@ -119,6 +121,22 @@ pub struct ListArgs {
 pub struct ShowArgs {
     /// `@name` of a catalog entry.
     pub name: String,
+}
+
+#[derive(Debug, Args)]
+pub struct TestArgs {
+    /// Path to a v2 YAML file with an `expect:` block, or `@name` for a
+    /// catalog reference.
+    pub scenario: String,
+
+    /// Base URL of the Prometheus-compatible API evaluating the alert rules
+    /// (e.g. `http://localhost:9090`).
+    #[arg(long, env = "SONDA_PROMETHEUS_URL")]
+    pub prometheus_url: String,
+
+    /// Poll interval for alert-state checks (e.g. `5s`).
+    #[arg(long, default_value = "5s")]
+    pub interval: String,
 }
 
 #[derive(Debug, Args)]

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -8,6 +8,7 @@ mod progress;
 mod scenario_loader;
 mod sink_format;
 mod status;
+mod test_cmd;
 
 use std::process;
 use std::sync::Arc;
@@ -65,6 +66,7 @@ fn run() -> anyhow::Result<()> {
         Commands::List(ref args) => list_catalog(args, catalog)?,
         Commands::Show(ref args) => show_entry(args, catalog)?,
         Commands::New(ref args) => new::run(args)?,
+        Commands::Test(ref args) => test_cmd::run(&rt, args, &cli, catalog, verbosity, &cancel)?,
     }
 
     Ok(())

--- a/sonda/src/test_cmd.rs
+++ b/sonda/src/test_cmd.rs
@@ -134,35 +134,48 @@ pub fn run(
 
 /// Confirm the endpoint answers a query for **every** expectation before
 /// starting the scenario — a malformed selector on any of them should fail
-/// here, not mid-run (review M3). A few retries tolerate a Prometheus that
-/// is still starting up in CI; each attempt is bounded by the query timeout.
+/// here, not mid-run (review M3). Retries apply only to the first
+/// expectation, as a connectivity gate tolerating a Prometheus still
+/// starting up in CI; once it answers, the remaining selectors are probed
+/// exactly once each. Against a dead endpoint the total cost is therefore
+/// bounded by 3 query timeouts, independent of expectation count (review M4).
 fn preflight(
     client: &PrometheusClient,
     expect: &ExpectConfig,
     cancel: &CancellationToken,
 ) -> anyhow::Result<()> {
     const ATTEMPTS: u32 = 3;
-    let mut last_err = None;
+    let Some(first) = expect.alerts.first() else {
+        return Ok(());
+    };
+    let mut gate = None;
     for attempt in 0..ATTEMPTS {
         if cancel.is_cancelled() {
             bail!("interrupted");
         }
-        match expect
-            .alerts
-            .iter()
-            .try_for_each(|expectation| client.alert_state(expectation).map(|_| ()))
-        {
-            Ok(()) => return Ok(()),
-            Err(e) => last_err = Some(e),
+        match client.alert_state(first) {
+            Ok(_) => {
+                gate = None;
+                break;
+            }
+            Err(e) => gate = Some(e),
         }
         if attempt + 1 < ATTEMPTS {
             std::thread::sleep(Duration::from_secs(2));
         }
     }
-    bail!(
-        "{}",
-        last_err.map_or_else(|| "unreachable".to_string(), |e| e.to_string())
-    )
+    if let Some(e) = gate {
+        bail!("{e}");
+    }
+    for expectation in &expect.alerts[1..] {
+        if cancel.is_cancelled() {
+            bail!("interrupted");
+        }
+        client
+            .alert_state(expectation)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    Ok(())
 }
 
 /// Poll every expectation until it is settled — firing observed, or a fresh
@@ -215,6 +228,12 @@ fn spawn_firing_poller(
 /// Poll resolution for every expectation that fired, recording query errors
 /// as observations (review W1) with timestamps captured after each query.
 /// Timestamps are relative to scenario end.
+///
+/// All pending expectations are polled in **one** loop, each settling
+/// independently against the shared `ended_at` anchor — exactly like the
+/// firing poller. Serializing them would let one expectation's wait push
+/// another's first query past its own deadline, leaving that window
+/// unobserved (round-2 review blocker).
 fn check_resolutions(
     client: &PrometheusClient,
     expect: &ExpectConfig,
@@ -223,40 +242,55 @@ fn check_resolutions(
     interval: Duration,
     cancel: &CancellationToken,
 ) -> anyhow::Result<Vec<Option<Outcome>>> {
-    let mut outcomes = Vec::with_capacity(expect.alerts.len());
-    for (index, expectation) in expect.alerts.iter().enumerate() {
-        let deadline = expectation
-            .resolves_within()
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        // Resolution applies only when a deadline is declared and the alert
-        // actually fired (on time or late) — a never-fired alert's story is
-        // already told by its firing failure.
-        let fired = matches!(
-            firing_outcomes[index],
-            Outcome::Pass { .. } | Outcome::Late { .. }
-        );
-        let Some(deadline) = deadline.filter(|_| fired) else {
-            outcomes.push(None);
-            continue;
-        };
+    let mut timelines: Vec<Option<(Duration, Vec<Observation>)>> = expect
+        .alerts
+        .iter()
+        .enumerate()
+        .map(|(index, expectation)| {
+            let deadline = expectation
+                .resolves_within()
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            // Resolution applies only when a deadline is declared and the
+            // alert actually fired (on time or late) — a never-fired alert's
+            // story is already told by its firing failure.
+            let fired = matches!(
+                firing_outcomes[index],
+                Outcome::Pass { .. } | Outcome::Late { .. }
+            );
+            Ok(deadline.filter(|_| fired).map(|d| (d, Vec::new())))
+        })
+        .collect::<anyhow::Result<_>>()?;
 
-        let mut timeline: Vec<Observation> = Vec::new();
-        loop {
-            if cancel.is_cancelled() {
-                bail!("interrupted during resolution checks");
-            }
-            let state = client.alert_state(expectation).map_err(|e| e.to_string());
+    let mut pending: Vec<usize> = timelines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| entry.as_ref().map(|_| index))
+        .collect();
+    while !pending.is_empty() {
+        if cancel.is_cancelled() {
+            bail!("interrupted during resolution checks");
+        }
+        pending.retain(|&index| {
+            let Some((deadline, timeline)) = &mut timelines[index] else {
+                return false;
+            };
+            let state = client
+                .alert_state(&expect.alerts[index])
+                .map_err(|e| e.to_string());
             let at = ended_at.elapsed();
             let resolved = matches!(state, Ok(ref s) if !matches!(s, AlertState::Firing));
             timeline.push(Observation::new(at, state));
-            if resolved || at >= deadline {
-                break;
-            }
+            !(resolved || at >= *deadline)
+        });
+        if !pending.is_empty() {
             std::thread::sleep(interval);
         }
-        outcomes.push(Some(evaluate_resolution(&timeline, deadline)));
     }
-    Ok(outcomes)
+
+    Ok(timelines
+        .into_iter()
+        .map(|entry| entry.map(|(deadline, timeline)| evaluate_resolution(&timeline, deadline)))
+        .collect())
 }
 
 fn report(
@@ -299,17 +333,29 @@ fn report(
                     expectation.firing_within
                 );
             }
-            _ => {
+            Outcome::Undecided {
+                observed_at,
+                last_error,
+            } => {
                 failures += 1;
                 let why = if poller_died {
-                    "the poller thread stopped unexpectedly"
+                    "the poller thread stopped unexpectedly".to_string()
                 } else {
-                    "polling ended before the deadline"
+                    undecided_reason(observed_at, "firing")
                 };
                 eprintln!(
-                    "  {} {alert}: no verdict — {why}, so firing within {} is unproven",
+                    "  {} {alert}: no verdict — {why}, so firing within {} is unproven{}",
                     fail_marker(),
-                    expectation.firing_within
+                    expectation.firing_within,
+                    error_detail(last_error)
+                );
+            }
+            // Outcome is #[non_exhaustive]; treat future variants as failures.
+            other => {
+                failures += 1;
+                eprintln!(
+                    "  {} {alert}: unrecognized firing outcome {other:?}",
+                    fail_marker()
                 );
             }
         }
@@ -340,10 +386,22 @@ fn report(
                     fail_marker()
                 );
             }
-            Some(_) => {
+            Some(Outcome::Undecided {
+                observed_at,
+                last_error,
+            }) => {
                 failures += 1;
                 eprintln!(
-                    "  {} {alert}: no resolution verdict — polling ended before the deadline",
+                    "  {} {alert}: no resolution verdict — {}, so resolving within {resolves_within} is unproven{}",
+                    fail_marker(),
+                    undecided_reason(observed_at, "resolution"),
+                    error_detail(last_error)
+                );
+            }
+            Some(other) => {
+                failures += 1;
+                eprintln!(
+                    "  {} {alert}: unrecognized resolution outcome {other:?}",
                     fail_marker()
                 );
             }
@@ -362,6 +420,25 @@ fn report(
     } else {
         bail!("{failures} alert expectation(s) failed");
     }
+}
+
+/// Explain an [`Outcome::Undecided`]: either the transition was eventually
+/// seen but nothing successful covered the deadline window, or polling
+/// stopped before the deadline.
+fn undecided_reason(observed_at: &Option<Duration>, transition: &str) -> String {
+    match observed_at {
+        Some(at) => format!(
+            "{transition} was first observed at {at:.0?} with no successful query inside the window"
+        ),
+        None => "polling ended before the deadline".to_string(),
+    }
+}
+
+fn error_detail(last_error: &Option<String>) -> String {
+    last_error
+        .as_deref()
+        .map(|e| format!(" (last query error: {e})"))
+        .unwrap_or_default()
 }
 
 fn pass_marker() -> String {

--- a/sonda/src/test_cmd.rs
+++ b/sonda/src/test_cmd.rs
@@ -1,38 +1,27 @@
 //! `sonda test` — run a scenario and verify its `expect:` alert expectations.
 //!
-//! Orchestration: a poller thread watches the Prometheus `ALERTS` metric
-//! while the scenario runs through the exact same machinery as `sonda run`.
-//! Firing deadlines are measured from scenario start; resolution deadlines
-//! from scenario end. The process exits non-zero when any expectation fails,
-//! which is the whole point — `sonda test` in CI turns alert rules into a
-//! test suite.
+//! Orchestration and rendering only: a poller thread records timestamped
+//! [`Observation`]s of the Prometheus `ALERTS` metric while the scenario
+//! runs through the exact same machinery as `sonda run`; every deadline
+//! decision is made by `sonda_core::verify::evaluator` over those
+//! timelines. Firing deadlines are measured from scenario start, resolution
+//! deadlines from scenario end. The process exits non-zero when any
+//! expectation fails — `sonda test` in CI turns alert rules into a test
+//! suite.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context};
 use owo_colors::{OwoColorize, Stream::Stderr};
-use sonda_core::verify::prometheus::{AlertState, PrometheusClient};
-use sonda_core::verify::{parse_expectations, AlertExpectation, ExpectConfig};
+use sonda_core::verify::evaluator::{evaluate_firing, evaluate_resolution, Observation, Outcome};
+use sonda_core::verify::prometheus::PrometheusClient;
+use sonda_core::verify::{parse_expectations, AlertState, ExpectConfig};
 use sonda_core::CancellationToken;
 
 use crate::cli::{self, Cli, Verbosity};
-
-/// Outcome of one expectation's firing check.
-struct FiringOutcome {
-    /// Index into `ExpectConfig::alerts`.
-    index: usize,
-    /// Seconds after scenario start when `firing` was first observed.
-    fired_after: Option<Duration>,
-    /// Last poll error, surfaced when the deadline passes without an answer.
-    last_error: Option<String>,
-}
-
-/// Outcome of one expectation's resolution check.
-struct ResolutionOutcome {
-    index: usize,
-    resolved_after: Option<Duration>,
-}
 
 pub fn run(
     rt: &tokio::runtime::Runtime,
@@ -52,9 +41,11 @@ pub fn run(
     };
     let interval = sonda_core::config::validate::parse_duration(&args.interval)
         .map_err(|e| anyhow::anyhow!("invalid --interval: {e}"))?;
+    let query_timeout = sonda_core::config::validate::parse_duration(&args.query_timeout)
+        .map_err(|e| anyhow::anyhow!("invalid --query-timeout: {e}"))?;
 
     // --dry-run validates and prints the scenario without emitting or
-    // polling; the expectations were already validated above.
+    // polling — and therefore without needing an endpoint at all.
     if cli_opts.dry_run {
         let run_args = run_args_for(&args.scenario);
         crate::run_scenario(rt, &run_args, cli_opts, catalog, verbosity, cancel)?;
@@ -65,59 +56,103 @@ pub fn run(
         return Ok(());
     }
 
-    let client = PrometheusClient::new(&args.prometheus_url);
-    preflight(&client, &expect.alerts[0], cancel).with_context(|| {
-        format!(
-            "prometheus preflight against {} failed",
-            args.prometheus_url
-        )
-    })?;
+    let Some(prometheus_url) = args.prometheus_url.as_deref() else {
+        bail!("--prometheus-url is required (or set SONDA_PROMETHEUS_URL); only --dry-run works without it");
+    };
 
-    // Firing poller runs alongside the scenario: deadlines are measured from
-    // scenario start, and an alert may legitimately keep an expectation
-    // waiting past scenario end (evaluation intervals lag emission).
+    let client = PrometheusClient::new(prometheus_url, query_timeout);
+    preflight(&client, &expect, cancel)
+        .with_context(|| format!("prometheus preflight against {prometheus_url} failed"))?;
+
+    // The firing poller runs alongside the scenario. `stop` cuts it short
+    // when the scenario itself fails — no point waiting out deadlines to
+    // report a sink error (review W3).
     let started_at = Instant::now();
-    let (outcome_tx, outcome_rx) = mpsc::channel::<FiringOutcome>();
+    let stop = Arc::new(AtomicBool::new(false));
+    let (timeline_tx, timeline_rx) = mpsc::channel::<Vec<Vec<Observation>>>();
     let poller = spawn_firing_poller(
-        PrometheusClient::new(&args.prometheus_url),
+        PrometheusClient::new(prometheus_url, query_timeout),
         expect.clone(),
         started_at,
         interval,
         cancel.clone(),
-        outcome_tx,
+        Arc::clone(&stop),
+        timeline_tx,
     )?;
 
     let run_args = run_args_for(&args.scenario);
     let run_result = crate::run_scenario(rt, &run_args, cli_opts, catalog, verbosity, cancel);
     let ended_at = Instant::now();
 
-    let firing: Vec<FiringOutcome> = outcome_rx.iter().take(expect.alerts.len()).collect();
-    let _ = poller.join();
-    run_result?;
+    if run_result.is_err() {
+        stop.store(true, Ordering::SeqCst);
+        let _ = poller.join();
+        return run_result;
+    }
 
+    let poller_died = poller.join().is_err();
+    let firing_timelines = timeline_rx.try_recv().ok();
     if cancel.is_cancelled() {
         bail!("interrupted before alert expectations could be verified");
     }
 
-    let resolutions = check_resolutions(&client, &expect, &firing, ended_at, interval, cancel)?;
-    report(&expect, &firing, &resolutions, started_at, ended_at)
+    // A panicked or silent poller yields no timelines; the evaluator maps
+    // empty timelines to Undecided, and the report says why (review W4).
+    let firing_timelines =
+        firing_timelines.unwrap_or_else(|| vec![Vec::new(); expect.alerts.len()]);
+
+    let firing_outcomes: Vec<Outcome> = expect
+        .alerts
+        .iter()
+        .zip(&firing_timelines)
+        .map(|(expectation, timeline)| {
+            let deadline = expectation
+                .firing_within()
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            Ok(evaluate_firing(timeline, deadline))
+        })
+        .collect::<anyhow::Result<_>>()?;
+
+    let resolution_outcomes = check_resolutions(
+        &client,
+        &expect,
+        &firing_outcomes,
+        ended_at,
+        interval,
+        cancel,
+    )?;
+
+    report(
+        &expect,
+        &firing_outcomes,
+        &resolution_outcomes,
+        poller_died,
+        started_at,
+        ended_at,
+    )
 }
 
-/// Confirm the endpoint answers the query API before starting the scenario.
-/// A few retries tolerate a Prometheus that is still starting up in CI.
+/// Confirm the endpoint answers a query for **every** expectation before
+/// starting the scenario — a malformed selector on any of them should fail
+/// here, not mid-run (review M3). A few retries tolerate a Prometheus that
+/// is still starting up in CI; each attempt is bounded by the query timeout.
 fn preflight(
     client: &PrometheusClient,
-    probe: &AlertExpectation,
+    expect: &ExpectConfig,
     cancel: &CancellationToken,
 ) -> anyhow::Result<()> {
-    const ATTEMPTS: u32 = 5;
+    const ATTEMPTS: u32 = 3;
     let mut last_err = None;
     for attempt in 0..ATTEMPTS {
         if cancel.is_cancelled() {
             bail!("interrupted");
         }
-        match client.alert_state(probe) {
-            Ok(_) => return Ok(()),
+        match expect
+            .alerts
+            .iter()
+            .try_for_each(|expectation| client.alert_state(expectation).map(|_| ()))
+        {
+            Ok(()) => return Ok(()),
             Err(e) => last_err = Some(e),
         }
         if attempt + 1 < ATTEMPTS {
@@ -130,15 +165,20 @@ fn preflight(
     )
 }
 
+/// Poll every expectation until it is settled — firing observed, or a fresh
+/// post-query elapsed time at/past its deadline — then send the complete
+/// per-expectation timelines. Timestamps are captured when each query
+/// returns, never reused across queries (review blocker 1).
+#[allow(clippy::too_many_arguments)]
 fn spawn_firing_poller(
     client: PrometheusClient,
     expect: ExpectConfig,
     started_at: Instant,
     interval: Duration,
     cancel: CancellationToken,
-    outcomes: mpsc::Sender<FiringOutcome>,
+    stop: Arc<AtomicBool>,
+    timelines_out: mpsc::Sender<Vec<Vec<Observation>>>,
 ) -> anyhow::Result<std::thread::JoinHandle<()>> {
-    // Deadlines validated at parse time; recompute here for the thread.
     let deadlines: Vec<Duration> = expect
         .alerts
         .iter()
@@ -149,155 +189,163 @@ fn spawn_firing_poller(
     let handle = std::thread::Builder::new()
         .name("sonda-test-poller".into())
         .spawn(move || {
+            let mut timelines: Vec<Vec<Observation>> = vec![Vec::new(); expect.alerts.len()];
             let mut pending: Vec<usize> = (0..expect.alerts.len()).collect();
-            let mut last_errors: Vec<Option<String>> = vec![None; expect.alerts.len()];
-            while !pending.is_empty() && !cancel.is_cancelled() {
-                let elapsed = started_at.elapsed();
+            while !pending.is_empty() && !cancel.is_cancelled() && !stop.load(Ordering::SeqCst) {
                 pending.retain(|&index| {
-                    match client.alert_state(&expect.alerts[index]) {
-                        Ok(AlertState::Firing) => {
-                            let _ = outcomes.send(FiringOutcome {
-                                index,
-                                fired_after: Some(started_at.elapsed()),
-                                last_error: None,
-                            });
-                            return false;
-                        }
-                        Ok(_) => last_errors[index] = None,
-                        // Transient query errors don't fail the expectation;
-                        // they surface only if the deadline passes.
-                        Err(e) => last_errors[index] = Some(e.to_string()),
-                    }
-                    if elapsed >= deadlines[index] {
-                        let _ = outcomes.send(FiringOutcome {
-                            index,
-                            fired_after: None,
-                            last_error: last_errors[index].clone(),
-                        });
-                        return false;
-                    }
-                    true
+                    let state = client
+                        .alert_state(&expect.alerts[index])
+                        .map_err(|e| e.to_string());
+                    let at = started_at.elapsed();
+                    let fired = matches!(state, Ok(AlertState::Firing));
+                    timelines[index].push(Observation::new(at, state));
+                    // Settled once firing is seen or coverage of the
+                    // deadline is recorded; the evaluator makes the verdict.
+                    !(fired || at >= deadlines[index])
                 });
                 if !pending.is_empty() {
                     std::thread::sleep(interval);
                 }
             }
-            // Cancellation: flush unfinished expectations as undecided so the
-            // main thread's collect never blocks forever.
-            for index in pending {
-                let _ = outcomes.send(FiringOutcome {
-                    index,
-                    fired_after: None,
-                    last_error: Some("interrupted".into()),
-                });
-            }
+            let _ = timelines_out.send(timelines);
         })?;
     Ok(handle)
 }
 
+/// Poll resolution for every expectation that fired, recording query errors
+/// as observations (review W1) with timestamps captured after each query.
+/// Timestamps are relative to scenario end.
 fn check_resolutions(
     client: &PrometheusClient,
     expect: &ExpectConfig,
-    firing: &[FiringOutcome],
+    firing_outcomes: &[Outcome],
     ended_at: Instant,
     interval: Duration,
     cancel: &CancellationToken,
-) -> anyhow::Result<Vec<ResolutionOutcome>> {
-    let mut outcomes = Vec::new();
+) -> anyhow::Result<Vec<Option<Outcome>>> {
+    let mut outcomes = Vec::with_capacity(expect.alerts.len());
     for (index, expectation) in expect.alerts.iter().enumerate() {
-        let Some(deadline) = expectation
+        let deadline = expectation
             .resolves_within()
-            .map_err(|e| anyhow::anyhow!("{e}"))?
-        else {
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        // Resolution applies only when a deadline is declared and the alert
+        // actually fired (on time or late) — a never-fired alert's story is
+        // already told by its firing failure.
+        let fired = matches!(
+            firing_outcomes[index],
+            Outcome::Pass { .. } | Outcome::Late { .. }
+        );
+        let Some(deadline) = deadline.filter(|_| fired) else {
+            outcomes.push(None);
             continue;
         };
-        // An alert that never fired has nothing to resolve; the firing
-        // failure already tells the story.
-        let fired = firing
-            .iter()
-            .find(|o| o.index == index)
-            .is_some_and(|o| o.fired_after.is_some());
-        if !fired {
-            continue;
-        }
-        let mut resolved_after = None;
+
+        let mut timeline: Vec<Observation> = Vec::new();
         loop {
             if cancel.is_cancelled() {
                 bail!("interrupted during resolution checks");
             }
-            let elapsed = ended_at.elapsed();
-            if let Ok(state) = client.alert_state(expectation) {
-                if state != AlertState::Firing {
-                    resolved_after = Some(elapsed);
-                    break;
-                }
-            }
-            if elapsed >= deadline {
+            let state = client.alert_state(expectation).map_err(|e| e.to_string());
+            let at = ended_at.elapsed();
+            let resolved = matches!(state, Ok(ref s) if !matches!(s, AlertState::Firing));
+            timeline.push(Observation::new(at, state));
+            if resolved || at >= deadline {
                 break;
             }
             std::thread::sleep(interval);
         }
-        outcomes.push(ResolutionOutcome {
-            index,
-            resolved_after,
-        });
+        outcomes.push(Some(evaluate_resolution(&timeline, deadline)));
     }
     Ok(outcomes)
 }
 
 fn report(
     expect: &ExpectConfig,
-    firing: &[FiringOutcome],
-    resolutions: &[ResolutionOutcome],
+    firing: &[Outcome],
+    resolutions: &[Option<Outcome>],
+    poller_died: bool,
     started_at: Instant,
     ended_at: Instant,
 ) -> anyhow::Result<()> {
     let mut failures = 0usize;
     eprintln!();
     for (index, expectation) in expect.alerts.iter().enumerate() {
-        let outcome = firing.iter().find(|o| o.index == index);
-        match outcome.and_then(|o| o.fired_after) {
-            Some(after) => {
+        let alert = &expectation.alert;
+        match &firing[index] {
+            Outcome::Pass { at } => eprintln!(
+                "  {} {alert} firing after {:.0?} (within {})",
+                pass_marker(),
+                at,
+                expectation.firing_within
+            ),
+            Outcome::Late { at, .. } => {
+                failures += 1;
                 eprintln!(
-                    "  {} {} firing after {:.0?} (within {})",
-                    pass_marker(),
-                    expectation.alert,
-                    after,
+                    "  {} {alert} fired after {:.0?} — later than firing_within {}",
+                    fail_marker(),
+                    at,
                     expectation.firing_within
                 );
             }
-            None => {
+            Outcome::Missed { last_error, .. } => {
                 failures += 1;
-                let detail = outcome
-                    .and_then(|o| o.last_error.as_deref())
+                let detail = last_error
+                    .as_deref()
                     .map(|e| format!(" (last query error: {e})"))
                     .unwrap_or_default();
                 eprintln!(
-                    "  {} {} did not fire within {}{detail}",
+                    "  {} {alert} did not fire within {}{detail}",
                     fail_marker(),
-                    expectation.alert,
+                    expectation.firing_within
+                );
+            }
+            _ => {
+                failures += 1;
+                let why = if poller_died {
+                    "the poller thread stopped unexpectedly"
+                } else {
+                    "polling ended before the deadline"
+                };
+                eprintln!(
+                    "  {} {alert}: no verdict — {why}, so firing within {} is unproven",
+                    fail_marker(),
                     expectation.firing_within
                 );
             }
         }
-        if let Some(resolution) = resolutions.iter().find(|r| r.index == index) {
-            match resolution.resolved_after {
-                Some(after) => eprintln!(
-                    "  {} {} resolved after {:.0?} (within {} of scenario end)",
-                    pass_marker(),
-                    expectation.alert,
-                    after,
-                    expectation.resolves_within.as_deref().unwrap_or("-")
-                ),
-                None => {
-                    failures += 1;
-                    eprintln!(
-                        "  {} {} still firing {} after scenario end",
-                        fail_marker(),
-                        expectation.alert,
-                        expectation.resolves_within.as_deref().unwrap_or("-")
-                    );
-                }
+        let resolves_within = expectation.resolves_within.as_deref().unwrap_or("-");
+        match &resolutions[index] {
+            None => {}
+            Some(Outcome::Pass { at }) => eprintln!(
+                "  {} {alert} resolved after {:.0?} (within {resolves_within} of scenario end)",
+                pass_marker(),
+                at
+            ),
+            Some(Outcome::Late { at, .. }) => {
+                failures += 1;
+                eprintln!(
+                    "  {} {alert} resolved after {:.0?} — later than resolves_within {resolves_within}",
+                    fail_marker(),
+                    at
+                );
+            }
+            Some(Outcome::Missed { last_error, .. }) => {
+                failures += 1;
+                let detail = last_error
+                    .as_deref()
+                    .map(|e| format!(" (last query error: {e})"))
+                    .unwrap_or_default();
+                eprintln!(
+                    "  {} {alert} still firing {resolves_within} after scenario end{detail}",
+                    fail_marker()
+                );
+            }
+            Some(_) => {
+                failures += 1;
+                eprintln!(
+                    "  {} {alert}: no resolution verdict — polling ended before the deadline",
+                    fail_marker()
+                );
             }
         }
     }

--- a/sonda/src/test_cmd.rs
+++ b/sonda/src/test_cmd.rs
@@ -1,0 +1,340 @@
+//! `sonda test` — run a scenario and verify its `expect:` alert expectations.
+//!
+//! Orchestration: a poller thread watches the Prometheus `ALERTS` metric
+//! while the scenario runs through the exact same machinery as `sonda run`.
+//! Firing deadlines are measured from scenario start; resolution deadlines
+//! from scenario end. The process exits non-zero when any expectation fails,
+//! which is the whole point — `sonda test` in CI turns alert rules into a
+//! test suite.
+
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context};
+use owo_colors::{OwoColorize, Stream::Stderr};
+use sonda_core::verify::prometheus::{AlertState, PrometheusClient};
+use sonda_core::verify::{parse_expectations, AlertExpectation, ExpectConfig};
+use sonda_core::CancellationToken;
+
+use crate::cli::{self, Cli, Verbosity};
+
+/// Outcome of one expectation's firing check.
+struct FiringOutcome {
+    /// Index into `ExpectConfig::alerts`.
+    index: usize,
+    /// Seconds after scenario start when `firing` was first observed.
+    fired_after: Option<Duration>,
+    /// Last poll error, surfaced when the deadline passes without an answer.
+    last_error: Option<String>,
+}
+
+/// Outcome of one expectation's resolution check.
+struct ResolutionOutcome {
+    index: usize,
+    resolved_after: Option<Duration>,
+}
+
+pub fn run(
+    rt: &tokio::runtime::Runtime,
+    args: &cli::TestArgs,
+    cli_opts: &Cli,
+    catalog: Option<&std::path::Path>,
+    verbosity: Verbosity,
+    cancel: &CancellationToken,
+) -> anyhow::Result<()> {
+    let yaml = crate::config::resolve_scenario_source(&args.scenario, catalog)?;
+    let Some(expect) = parse_expectations(&yaml).map_err(|e| anyhow::anyhow!("{e}"))? else {
+        bail!(
+            "scenario {} has no `expect:` block — nothing to verify. \
+             Add one (see the alert-testing guide) or use `sonda run`.",
+            args.scenario
+        );
+    };
+    let interval = sonda_core::config::validate::parse_duration(&args.interval)
+        .map_err(|e| anyhow::anyhow!("invalid --interval: {e}"))?;
+
+    // --dry-run validates and prints the scenario without emitting or
+    // polling; the expectations were already validated above.
+    if cli_opts.dry_run {
+        let run_args = run_args_for(&args.scenario);
+        crate::run_scenario(rt, &run_args, cli_opts, catalog, verbosity, cancel)?;
+        eprintln!(
+            "  expect: {} alert expectation(s) parsed OK",
+            expect.alerts.len()
+        );
+        return Ok(());
+    }
+
+    let client = PrometheusClient::new(&args.prometheus_url);
+    preflight(&client, &expect.alerts[0], cancel).with_context(|| {
+        format!(
+            "prometheus preflight against {} failed",
+            args.prometheus_url
+        )
+    })?;
+
+    // Firing poller runs alongside the scenario: deadlines are measured from
+    // scenario start, and an alert may legitimately keep an expectation
+    // waiting past scenario end (evaluation intervals lag emission).
+    let started_at = Instant::now();
+    let (outcome_tx, outcome_rx) = mpsc::channel::<FiringOutcome>();
+    let poller = spawn_firing_poller(
+        PrometheusClient::new(&args.prometheus_url),
+        expect.clone(),
+        started_at,
+        interval,
+        cancel.clone(),
+        outcome_tx,
+    )?;
+
+    let run_args = run_args_for(&args.scenario);
+    let run_result = crate::run_scenario(rt, &run_args, cli_opts, catalog, verbosity, cancel);
+    let ended_at = Instant::now();
+
+    let firing: Vec<FiringOutcome> = outcome_rx.iter().take(expect.alerts.len()).collect();
+    let _ = poller.join();
+    run_result?;
+
+    if cancel.is_cancelled() {
+        bail!("interrupted before alert expectations could be verified");
+    }
+
+    let resolutions = check_resolutions(&client, &expect, &firing, ended_at, interval, cancel)?;
+    report(&expect, &firing, &resolutions, started_at, ended_at)
+}
+
+/// Confirm the endpoint answers the query API before starting the scenario.
+/// A few retries tolerate a Prometheus that is still starting up in CI.
+fn preflight(
+    client: &PrometheusClient,
+    probe: &AlertExpectation,
+    cancel: &CancellationToken,
+) -> anyhow::Result<()> {
+    const ATTEMPTS: u32 = 5;
+    let mut last_err = None;
+    for attempt in 0..ATTEMPTS {
+        if cancel.is_cancelled() {
+            bail!("interrupted");
+        }
+        match client.alert_state(probe) {
+            Ok(_) => return Ok(()),
+            Err(e) => last_err = Some(e),
+        }
+        if attempt + 1 < ATTEMPTS {
+            std::thread::sleep(Duration::from_secs(2));
+        }
+    }
+    bail!(
+        "{}",
+        last_err.map_or_else(|| "unreachable".to_string(), |e| e.to_string())
+    )
+}
+
+fn spawn_firing_poller(
+    client: PrometheusClient,
+    expect: ExpectConfig,
+    started_at: Instant,
+    interval: Duration,
+    cancel: CancellationToken,
+    outcomes: mpsc::Sender<FiringOutcome>,
+) -> anyhow::Result<std::thread::JoinHandle<()>> {
+    // Deadlines validated at parse time; recompute here for the thread.
+    let deadlines: Vec<Duration> = expect
+        .alerts
+        .iter()
+        .map(|e| e.firing_within())
+        .collect::<Result<_, _>>()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let handle = std::thread::Builder::new()
+        .name("sonda-test-poller".into())
+        .spawn(move || {
+            let mut pending: Vec<usize> = (0..expect.alerts.len()).collect();
+            let mut last_errors: Vec<Option<String>> = vec![None; expect.alerts.len()];
+            while !pending.is_empty() && !cancel.is_cancelled() {
+                let elapsed = started_at.elapsed();
+                pending.retain(|&index| {
+                    match client.alert_state(&expect.alerts[index]) {
+                        Ok(AlertState::Firing) => {
+                            let _ = outcomes.send(FiringOutcome {
+                                index,
+                                fired_after: Some(started_at.elapsed()),
+                                last_error: None,
+                            });
+                            return false;
+                        }
+                        Ok(_) => last_errors[index] = None,
+                        // Transient query errors don't fail the expectation;
+                        // they surface only if the deadline passes.
+                        Err(e) => last_errors[index] = Some(e.to_string()),
+                    }
+                    if elapsed >= deadlines[index] {
+                        let _ = outcomes.send(FiringOutcome {
+                            index,
+                            fired_after: None,
+                            last_error: last_errors[index].clone(),
+                        });
+                        return false;
+                    }
+                    true
+                });
+                if !pending.is_empty() {
+                    std::thread::sleep(interval);
+                }
+            }
+            // Cancellation: flush unfinished expectations as undecided so the
+            // main thread's collect never blocks forever.
+            for index in pending {
+                let _ = outcomes.send(FiringOutcome {
+                    index,
+                    fired_after: None,
+                    last_error: Some("interrupted".into()),
+                });
+            }
+        })?;
+    Ok(handle)
+}
+
+fn check_resolutions(
+    client: &PrometheusClient,
+    expect: &ExpectConfig,
+    firing: &[FiringOutcome],
+    ended_at: Instant,
+    interval: Duration,
+    cancel: &CancellationToken,
+) -> anyhow::Result<Vec<ResolutionOutcome>> {
+    let mut outcomes = Vec::new();
+    for (index, expectation) in expect.alerts.iter().enumerate() {
+        let Some(deadline) = expectation
+            .resolves_within()
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+        else {
+            continue;
+        };
+        // An alert that never fired has nothing to resolve; the firing
+        // failure already tells the story.
+        let fired = firing
+            .iter()
+            .find(|o| o.index == index)
+            .is_some_and(|o| o.fired_after.is_some());
+        if !fired {
+            continue;
+        }
+        let mut resolved_after = None;
+        loop {
+            if cancel.is_cancelled() {
+                bail!("interrupted during resolution checks");
+            }
+            let elapsed = ended_at.elapsed();
+            if let Ok(state) = client.alert_state(expectation) {
+                if state != AlertState::Firing {
+                    resolved_after = Some(elapsed);
+                    break;
+                }
+            }
+            if elapsed >= deadline {
+                break;
+            }
+            std::thread::sleep(interval);
+        }
+        outcomes.push(ResolutionOutcome {
+            index,
+            resolved_after,
+        });
+    }
+    Ok(outcomes)
+}
+
+fn report(
+    expect: &ExpectConfig,
+    firing: &[FiringOutcome],
+    resolutions: &[ResolutionOutcome],
+    started_at: Instant,
+    ended_at: Instant,
+) -> anyhow::Result<()> {
+    let mut failures = 0usize;
+    eprintln!();
+    for (index, expectation) in expect.alerts.iter().enumerate() {
+        let outcome = firing.iter().find(|o| o.index == index);
+        match outcome.and_then(|o| o.fired_after) {
+            Some(after) => {
+                eprintln!(
+                    "  {} {} firing after {:.0?} (within {})",
+                    pass_marker(),
+                    expectation.alert,
+                    after,
+                    expectation.firing_within
+                );
+            }
+            None => {
+                failures += 1;
+                let detail = outcome
+                    .and_then(|o| o.last_error.as_deref())
+                    .map(|e| format!(" (last query error: {e})"))
+                    .unwrap_or_default();
+                eprintln!(
+                    "  {} {} did not fire within {}{detail}",
+                    fail_marker(),
+                    expectation.alert,
+                    expectation.firing_within
+                );
+            }
+        }
+        if let Some(resolution) = resolutions.iter().find(|r| r.index == index) {
+            match resolution.resolved_after {
+                Some(after) => eprintln!(
+                    "  {} {} resolved after {:.0?} (within {} of scenario end)",
+                    pass_marker(),
+                    expectation.alert,
+                    after,
+                    expectation.resolves_within.as_deref().unwrap_or("-")
+                ),
+                None => {
+                    failures += 1;
+                    eprintln!(
+                        "  {} {} still firing {} after scenario end",
+                        fail_marker(),
+                        expectation.alert,
+                        expectation.resolves_within.as_deref().unwrap_or("-")
+                    );
+                }
+            }
+        }
+    }
+    let total = expect.alerts.len();
+    let elapsed = ended_at.duration_since(started_at);
+    eprintln!();
+    if failures == 0 {
+        eprintln!(
+            "  {} {total} alert expectation(s) verified (scenario ran {:.0?})",
+            pass_marker(),
+            elapsed
+        );
+        Ok(())
+    } else {
+        bail!("{failures} alert expectation(s) failed");
+    }
+}
+
+fn pass_marker() -> String {
+    format!("{}", "PASS".if_supports_color(Stderr, |t| t.green()))
+}
+
+fn fail_marker() -> String {
+    format!("{}", "FAIL".if_supports_color(Stderr, |t| t.red()))
+}
+
+/// `sonda test` runs the scenario exactly as written — no overrides.
+fn run_args_for(scenario: &str) -> cli::RunArgs {
+    cli::RunArgs {
+        scenario: scenario.to_string(),
+        duration: None,
+        rate: None,
+        sink: None,
+        endpoint: None,
+        encoder: None,
+        output: None,
+        labels: Vec::new(),
+        on_sink_error: None,
+    }
+}

--- a/sonda/tests/cli_test_cmd.rs
+++ b/sonda/tests/cli_test_cmd.rs
@@ -1,0 +1,223 @@
+//! Integration tests for `sonda test`.
+//!
+//! A minimal in-process HTTP responder plays the role of the Prometheus
+//! query API, scripted per test: how many polls return "inactive" before the
+//! alert reports firing, and whether it eventually resolves.
+
+mod common;
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use common::sonda_bin;
+use tempfile::TempDir;
+
+const EMPTY_RESULT: &str = r#"{"status":"success","data":{"resultType":"vector","result":[]}}"#;
+const FIRING_RESULT: &str = r#"{"status":"success","data":{"resultType":"vector","result":[{"metric":{"alertname":"HighCpuUsage","alertstate":"firing"},"value":[1,"1"]}]}}"#;
+
+/// Serve canned instant-query responses. `body_for(n)` picks the body for
+/// the n-th request (0-based); the server runs until the listener drops at
+/// the end of the test.
+fn mock_prometheus(
+    body_for: impl Fn(usize) -> &'static str + Send + 'static,
+) -> (String, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock prometheus");
+    let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_clone = Arc::clone(&hits);
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { break };
+            let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+            // Drain request headers; the query itself doesn't matter here.
+            let mut line = String::new();
+            while reader.read_line(&mut line).is_ok() {
+                if line == "\r\n" || line.is_empty() {
+                    break;
+                }
+                line.clear();
+            }
+            let n = hits_clone.fetch_add(1, Ordering::SeqCst);
+            let body = body_for(n);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+    (base_url, hits)
+}
+
+fn scenario_with_expect(expect_block: &str) -> String {
+    format!(
+        "version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 300ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: memory
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 95.0
+{expect_block}"
+    )
+}
+
+fn write_scenario(dir: &TempDir, yaml: &str) -> std::path::PathBuf {
+    let path = dir.path().join("scenario.yaml");
+    std::fs::write(&path, yaml).expect("write scenario");
+    path
+}
+
+#[test]
+fn passes_when_alert_fires_and_resolves() {
+    // Firing from the first poll; inactive again once resolution polling
+    // starts (from request 3 on).
+    let (url, _hits) = mock_prometheus(|n| if n < 3 { FIRING_RESULT } else { EMPTY_RESULT });
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 5s
+      resolves_within: 5s
+",
+        ),
+    );
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}\nstderr: {stderr}",
+        output.status
+    );
+    assert!(stderr.contains("firing after"), "stderr: {stderr}");
+    assert!(stderr.contains("resolved after"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("1 alert expectation(s) verified"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn fails_when_alert_never_fires() {
+    let (url, _hits) = mock_prometheus(|_| EMPTY_RESULT);
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 1s
+",
+        ),
+    );
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "must exit non-zero\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("did not fire within 1s"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("1 alert expectation(s) failed"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn rejects_scenario_without_expect_block() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(&dir, &scenario_with_expect(""));
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", "http://127.0.0.1:1"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success());
+    assert!(stderr.contains("no `expect:` block"), "stderr: {stderr}");
+}
+
+#[test]
+fn dry_run_validates_without_polling() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 2m
+",
+        ),
+    );
+
+    // Unreachable URL proves --dry-run never talks to Prometheus.
+    let output = Command::new(sonda_bin())
+        .args(["--dry-run", "test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", "http://127.0.0.1:1"])
+        .output()
+        .expect("run sonda test --dry-run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("1 alert expectation(s) parsed OK"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn run_still_accepts_files_with_expect_blocks() {
+    // The expect block is pure metadata — `sonda run` must not reject it.
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 2m
+",
+        ),
+    );
+
+    let output = Command::new(sonda_bin())
+        .args(["run", path.to_str().expect("utf8 path")])
+        .output()
+        .expect("run sonda run");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/sonda/tests/cli_test_cmd.rs
+++ b/sonda/tests/cli_test_cmd.rs
@@ -18,40 +18,48 @@ use tempfile::TempDir;
 const EMPTY_RESULT: &str = r#"{"status":"success","data":{"resultType":"vector","result":[]}}"#;
 const FIRING_RESULT: &str = r#"{"status":"success","data":{"resultType":"vector","result":[{"metric":{"alertname":"HighCpuUsage","alertstate":"firing"},"value":[1,"1"]}]}}"#;
 
-/// Serve canned instant-query responses. `body_for(n)` picks the body for
-/// the n-th request (0-based); the server runs until the listener drops at
-/// the end of the test.
+/// Serve scripted instant-query responses. `respond(n)` picks the body and
+/// an artificial delay for the n-th request (0-based); each connection is
+/// handled on its own thread so a stalled response never blocks the next
+/// request. The server runs until the listener drops at test end.
 fn mock_prometheus(
-    body_for: impl Fn(usize) -> &'static str + Send + 'static,
+    respond: impl Fn(usize) -> (&'static str, std::time::Duration) + Send + Sync + 'static,
 ) -> (String, Arc<AtomicUsize>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock prometheus");
     let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
     let hits = Arc::new(AtomicUsize::new(0));
     let hits_clone = Arc::clone(&hits);
+    let respond = Arc::new(respond);
     std::thread::spawn(move || {
         for stream in listener.incoming() {
             let Ok(mut stream) = stream else { break };
-            let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
-            // Drain request headers; the query itself doesn't matter here.
-            let mut line = String::new();
-            while reader.read_line(&mut line).is_ok() {
-                if line == "\r\n" || line.is_empty() {
-                    break;
-                }
-                line.clear();
-            }
             let n = hits_clone.fetch_add(1, Ordering::SeqCst);
-            let body = body_for(n);
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            let _ = stream.write_all(response.as_bytes());
+            let respond = Arc::clone(&respond);
+            std::thread::spawn(move || {
+                let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+                // Drain request headers; the query itself doesn't matter here.
+                let mut line = String::new();
+                while reader.read_line(&mut line).is_ok() {
+                    if line == "\r\n" || line.is_empty() {
+                        break;
+                    }
+                    line.clear();
+                }
+                let (body, stall) = respond(n);
+                std::thread::sleep(stall);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes());
+            });
         }
     });
     (base_url, hits)
 }
+
+const NO_STALL: std::time::Duration = std::time::Duration::ZERO;
 
 fn scenario_with_expect(expect_block: &str) -> String {
     format!(
@@ -85,7 +93,8 @@ fn write_scenario(dir: &TempDir, yaml: &str) -> std::path::PathBuf {
 fn passes_when_alert_fires_and_resolves() {
     // Firing from the first poll; inactive again once resolution polling
     // starts (from request 3 on).
-    let (url, _hits) = mock_prometheus(|n| if n < 3 { FIRING_RESULT } else { EMPTY_RESULT });
+    let (url, _hits) =
+        mock_prometheus(|n| (if n < 3 { FIRING_RESULT } else { EMPTY_RESULT }, NO_STALL));
     let dir = TempDir::new().expect("tempdir");
     let path = write_scenario(
         &dir,
@@ -120,7 +129,7 @@ fn passes_when_alert_fires_and_resolves() {
 
 #[test]
 fn fails_when_alert_never_fires() {
-    let (url, _hits) = mock_prometheus(|_| EMPTY_RESULT);
+    let (url, _hits) = mock_prometheus(|_| (EMPTY_RESULT, NO_STALL));
     let dir = TempDir::new().expect("tempdir");
     let path = write_scenario(
         &dir,
@@ -193,6 +202,284 @@ fn dry_run_validates_without_polling() {
     assert!(
         stderr.contains("1 alert expectation(s) parsed OK"),
         "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn fails_when_alert_fires_after_deadline() {
+    // Review blocker 1, reproduction B: the alert eventually reports firing,
+    // but only after firing_within has passed — must be a failure, not a
+    // pass. Request 0 is the preflight (fast); the poller's queries stall
+    // 400ms against a 200ms deadline.
+    let (url, _hits) = mock_prometheus(|n| {
+        if n == 0 {
+            (EMPTY_RESULT, NO_STALL)
+        } else {
+            (FIRING_RESULT, std::time::Duration::from_millis(400))
+        }
+    });
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 200ms
+",
+        ),
+    );
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "late firing must fail\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("later than firing_within 200ms"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn fails_when_second_resolution_is_delayed_past_deadline() {
+    // Review blocker 1, reproduction A: resolution checks run sequentially,
+    // so the first expectation's wait pushes the second's first query past
+    // its own (short) deadline. The late observation must be a failure.
+    let switch_at = std::time::Instant::now() + std::time::Duration::from_millis(1200);
+    let (url, _hits) = mock_prometheus(move |_| {
+        (
+            if std::time::Instant::now() < switch_at {
+                FIRING_RESULT
+            } else {
+                EMPTY_RESULT
+            },
+            NO_STALL,
+        )
+    });
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: SlowToResolve
+      firing_within: 5s
+      resolves_within: 4s
+    - alert: MustResolveFast
+      firing_within: 5s
+      resolves_within: 200ms
+",
+        ),
+    );
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "late second resolution must fail\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("later than resolves_within 200ms"),
+        "stderr: {stderr}"
+    );
+    // The first expectation's generous deadline still passes.
+    assert!(
+        stderr.contains("SlowToResolve resolved after"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn bounded_failure_when_endpoint_stalls_before_answering() {
+    // Review blocker 2, reproduction C: an endpoint that accepts the
+    // connection and never answers in time must produce a bounded non-zero
+    // exit (preflight timeout), not a SIGINT-proof hang.
+    let (url, _hits) = mock_prometheus(|_| (EMPTY_RESULT, std::time::Duration::from_secs(60)));
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 200ms
+",
+        ),
+    );
+
+    let started = std::time::Instant::now();
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url])
+        .args(["--interval", "100ms", "--query-timeout", "300ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "stall must fail\nstderr: {stderr}"
+    );
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(20),
+        "must fail in bounded time, took {:?}",
+        started.elapsed()
+    );
+    assert!(stderr.contains("preflight"), "stderr: {stderr}");
+}
+
+#[test]
+fn mid_run_stall_surfaces_query_errors_on_missed_deadline() {
+    // Stall only after preflight: every poll times out, the deadline passes,
+    // and the failure must carry the query error instead of hanging or
+    // silently passing.
+    let (url, _hits) = mock_prometheus(|n| {
+        if n == 0 {
+            (EMPTY_RESULT, NO_STALL)
+        } else {
+            (EMPTY_RESULT, std::time::Duration::from_secs(30))
+        }
+    });
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 600ms
+",
+        ),
+    );
+
+    let started = std::time::Instant::now();
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url])
+        .args(["--interval", "100ms", "--query-timeout", "300ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(20),
+        "must fail in bounded time, took {:?}",
+        started.elapsed()
+    );
+    assert!(
+        stderr.contains("did not fire within 600ms") && stderr.contains("last query error"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn dry_run_works_without_prometheus_url() {
+    // Review M2: --dry-run never contacts the endpoint, so it must not
+    // demand one.
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 2m
+",
+        ),
+    );
+
+    let output = Command::new(sonda_bin())
+        .args(["--dry-run", "test", path.to_str().expect("utf8 path")])
+        .env_remove("SONDA_PROMETHEUS_URL")
+        .output()
+        .expect("run sonda test --dry-run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("1 alert expectation(s) parsed OK"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn missing_prometheus_url_is_rejected_outside_dry_run() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 2m
+",
+        ),
+    );
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .env_remove("SONDA_PROMETHEUS_URL")
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success());
+    assert!(
+        stderr.contains("--prometheus-url is required"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn failed_scenario_reports_immediately_without_waiting_out_deadlines() {
+    // Review W3: a scenario that dies at launch (unreachable TCP sink) must
+    // surface its own error promptly instead of blocking behind a long
+    // firing_within.
+    let (url, _hits) = mock_prometheus(|_| (EMPTY_RESULT, NO_STALL));
+    let dir = TempDir::new().expect("tempdir");
+    let yaml = "version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 300ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: tcp
+    address: 127.0.0.1:1
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 95.0
+expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 60s
+";
+    let path = write_scenario(&dir, yaml);
+
+    let started = std::time::Instant::now();
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(15),
+        "run failure must not wait out firing_within, took {:?}",
+        started.elapsed()
     );
 }
 

--- a/sonda/tests/cli_test_cmd.rs
+++ b/sonda/tests/cli_test_cmd.rs
@@ -18,12 +18,14 @@ use tempfile::TempDir;
 const EMPTY_RESULT: &str = r#"{"status":"success","data":{"resultType":"vector","result":[]}}"#;
 const FIRING_RESULT: &str = r#"{"status":"success","data":{"resultType":"vector","result":[{"metric":{"alertname":"HighCpuUsage","alertstate":"firing"},"value":[1,"1"]}]}}"#;
 
-/// Serve scripted instant-query responses. `respond(n)` picks the body and
-/// an artificial delay for the n-th request (0-based); each connection is
-/// handled on its own thread so a stalled response never blocks the next
+/// Serve scripted instant-query responses. `respond(n, request_line)` picks
+/// the body and an artificial delay for the n-th request (0-based); the raw
+/// request line carries the query, so tests with several expectations can
+/// script per-alert behavior by matching on the alert name. Each connection
+/// is handled on its own thread so a stalled response never blocks the next
 /// request. The server runs until the listener drops at test end.
 fn mock_prometheus(
-    respond: impl Fn(usize) -> (&'static str, std::time::Duration) + Send + Sync + 'static,
+    respond: impl Fn(usize, &str) -> (&'static str, std::time::Duration) + Send + Sync + 'static,
 ) -> (String, Arc<AtomicUsize>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock prometheus");
     let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
@@ -37,7 +39,9 @@ fn mock_prometheus(
             let respond = Arc::clone(&respond);
             std::thread::spawn(move || {
                 let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
-                // Drain request headers; the query itself doesn't matter here.
+                let mut request_line = String::new();
+                let _ = reader.read_line(&mut request_line);
+                // Drain the remaining headers.
                 let mut line = String::new();
                 while reader.read_line(&mut line).is_ok() {
                     if line == "\r\n" || line.is_empty() {
@@ -45,7 +49,7 @@ fn mock_prometheus(
                     }
                     line.clear();
                 }
-                let (body, stall) = respond(n);
+                let (body, stall) = respond(n, &request_line);
                 std::thread::sleep(stall);
                 let response = format!(
                     "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
@@ -94,7 +98,7 @@ fn passes_when_alert_fires_and_resolves() {
     // Firing from the first poll; inactive again once resolution polling
     // starts (from request 3 on).
     let (url, _hits) =
-        mock_prometheus(|n| (if n < 3 { FIRING_RESULT } else { EMPTY_RESULT }, NO_STALL));
+        mock_prometheus(|n, _| (if n < 3 { FIRING_RESULT } else { EMPTY_RESULT }, NO_STALL));
     let dir = TempDir::new().expect("tempdir");
     let path = write_scenario(
         &dir,
@@ -129,7 +133,7 @@ fn passes_when_alert_fires_and_resolves() {
 
 #[test]
 fn fails_when_alert_never_fires() {
-    let (url, _hits) = mock_prometheus(|_| (EMPTY_RESULT, NO_STALL));
+    let (url, _hits) = mock_prometheus(|_, _| (EMPTY_RESULT, NO_STALL));
     let dir = TempDir::new().expect("tempdir");
     let path = write_scenario(
         &dir,
@@ -207,16 +211,15 @@ fn dry_run_validates_without_polling() {
 
 #[test]
 fn fails_when_alert_fires_after_deadline() {
-    // Review blocker 1, reproduction B: the alert eventually reports firing,
-    // but only after firing_within has passed — must be a failure, not a
-    // pass. Request 0 is the preflight (fast); the poller's queries stall
-    // 400ms against a 200ms deadline.
-    let (url, _hits) = mock_prometheus(|n| {
-        if n == 0 {
-            (EMPTY_RESULT, NO_STALL)
-        } else {
-            (FIRING_RESULT, std::time::Duration::from_millis(400))
-        }
+    // Round-1 blocker 1, reproduction B: the alert eventually reports
+    // firing, but only after firing_within has passed — must be a failure,
+    // not a pass. Request 0 is the preflight (fast); the poller's first
+    // query returns inactive immediately (window coverage — without it the
+    // verdict is Undecided, not Late), then queries stall 400ms against the
+    // 200ms deadline.
+    let (url, _hits) = mock_prometheus(|n, _| match n {
+        0 | 1 => (EMPTY_RESULT, NO_STALL),
+        _ => (FIRING_RESULT, std::time::Duration::from_millis(400)),
     });
     let dir = TempDir::new().expect("tempdir");
     let path = write_scenario(
@@ -248,13 +251,18 @@ fn fails_when_alert_fires_after_deadline() {
 
 #[test]
 fn fails_when_second_resolution_is_delayed_past_deadline() {
-    // Review blocker 1, reproduction A: resolution checks run sequentially,
-    // so the first expectation's wait pushes the second's first query past
-    // its own (short) deadline. The late observation must be a failure.
-    let switch_at = std::time::Instant::now() + std::time::Duration::from_millis(1200);
-    let (url, _hits) = mock_prometheus(move |_| {
+    // A genuinely blown resolution deadline must be a failure: both alerts
+    // stay firing until 1200ms after the first request, so MustResolveFast
+    // is observed still firing through its whole 200ms window (concurrent
+    // resolution polling covers it from scenario end — round-2 review
+    // blocker) while SlowToResolve's 4s deadline still passes. The switch
+    // is anchored on the mock's first request, not process spawn, so binary
+    // startup time doesn't skew the fixture (round-2 review M5).
+    let first_hit = Arc::new(std::sync::OnceLock::new());
+    let (url, _hits) = mock_prometheus(move |_, _| {
+        let started = *first_hit.get_or_init(std::time::Instant::now);
         (
-            if std::time::Instant::now() < switch_at {
+            if started.elapsed() < std::time::Duration::from_millis(1200) {
                 FIRING_RESULT
             } else {
                 EMPTY_RESULT
@@ -286,10 +294,10 @@ fn fails_when_second_resolution_is_delayed_past_deadline() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         !output.status.success(),
-        "late second resolution must fail\nstderr: {stderr}"
+        "blown second resolution deadline must fail\nstderr: {stderr}"
     );
     assert!(
-        stderr.contains("later than resolves_within 200ms"),
+        stderr.contains("MustResolveFast still firing 200ms after scenario end"),
         "stderr: {stderr}"
     );
     // The first expectation's generous deadline still passes.
@@ -300,11 +308,64 @@ fn fails_when_second_resolution_is_delayed_past_deadline() {
 }
 
 #[test]
+fn parallel_resolutions_do_not_blind_each_others_windows() {
+    // Round-2 review blocker, discriminating case: SlowLane needs ~10 polls
+    // (~1s) to resolve against a 3s deadline while FastLane resolves on its
+    // very first resolution query against a 300ms one. With concurrent
+    // resolution polling both PASS. If polling regresses to sequential,
+    // SlowLane's wait pushes FastLane's first query past 300ms and the run
+    // fails — this test must go red.
+    let slow_hits = Arc::new(AtomicUsize::new(0));
+    let fast_hits = Arc::new(AtomicUsize::new(0));
+    let (url, _hits) = mock_prometheus(move |_, request_line| {
+        if request_line.contains("SlowLane") {
+            // Hits 0 (preflight) and 1 (firing poll) must show firing; then
+            // ~10 firing resolution polls before resolving.
+            let n = slow_hits.fetch_add(1, Ordering::SeqCst);
+            (if n < 12 { FIRING_RESULT } else { EMPTY_RESULT }, NO_STALL)
+        } else {
+            let n = fast_hits.fetch_add(1, Ordering::SeqCst);
+            (if n < 2 { FIRING_RESULT } else { EMPTY_RESULT }, NO_STALL)
+        }
+    });
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: SlowLane
+      firing_within: 5s
+      resolves_within: 3s
+    - alert: FastLane
+      firing_within: 5s
+      resolves_within: 300ms
+",
+        ),
+    );
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "both resolutions meet their own deadlines and must pass\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("2 alert expectation(s) verified"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
 fn bounded_failure_when_endpoint_stalls_before_answering() {
     // Review blocker 2, reproduction C: an endpoint that accepts the
     // connection and never answers in time must produce a bounded non-zero
     // exit (preflight timeout), not a SIGINT-proof hang.
-    let (url, _hits) = mock_prometheus(|_| (EMPTY_RESULT, std::time::Duration::from_secs(60)));
+    let (url, _hits) = mock_prometheus(|_, _| (EMPTY_RESULT, std::time::Duration::from_secs(60)));
     let dir = TempDir::new().expect("tempdir");
     let path = write_scenario(
         &dir,
@@ -342,7 +403,7 @@ fn mid_run_stall_surfaces_query_errors_on_missed_deadline() {
     // Stall only after preflight: every poll times out, the deadline passes,
     // and the failure must carry the query error instead of hanging or
     // silently passing.
-    let (url, _hits) = mock_prometheus(|n| {
+    let (url, _hits) = mock_prometheus(|n, _| {
         if n == 0 {
             (EMPTY_RESULT, NO_STALL)
         } else {
@@ -442,7 +503,7 @@ fn failed_scenario_reports_immediately_without_waiting_out_deadlines() {
     // Review W3: a scenario that dies at launch (unreachable TCP sink) must
     // surface its own error promptly instead of blocking behind a long
     // firing_within.
-    let (url, _hits) = mock_prometheus(|_| (EMPTY_RESULT, NO_STALL));
+    let (url, _hits) = mock_prometheus(|_, _| (EMPTY_RESULT, NO_STALL));
     let dir = TempDir::new().expect("tempdir");
     let yaml = "version: 2
 kind: runnable


### PR DESCRIPTION

## Summary

Roadmap W2, phase 1: scenarios gain a declarative `expect:` block, and the new fifth verb `sonda test` runs the scenario while polling a Prometheus-compatible API's `ALERTS` metric — firing deadlines from scenario start, resolution deadlines from scenario end, exit code as the contract. Alert rules become a test suite you can put in CI.

```yaml
expect:
  alerts:
    - alert: HighCpuUsage
      labels: { severity: critical }
      firing_within: 90s
      resolves_within: 6m
```

```bash
sonda test examples/alert-expectation-test.yaml --prometheus-url http://localhost:8428
```

## Changes

- **`feat(core)`** — `sonda_core::verify`: expectation types + `parse_expectations` (config feature) and a blocking `PrometheusClient` (http feature) that classifies `ALERTS` query responses as inactive/pending/firing, with PromQL label-value escaping. The `expect:` block is added to the scenario-file AST as pure metadata — every compiler phase and `sonda run` ignore it.
- **`feat(cli)`** — `sonda test`: preflight with retries, a poller thread alongside the same run machinery `sonda run` uses, per-expectation firing/resolution outcomes, colored PASS/FAIL report, exit 0/1 contract. `--dry-run` validates without emitting or contacting Prometheus; `--prometheus-url` also reads `SONDA_PROMETHEUS_URL`. Server dispatch shim forwards the new verb. Rationale for the fifth verb is documented in `sonda/CLAUDE.md` per its own policy.
- **`docs`** — alert-testing guide section, CLI reference entry with the exit-code contract, runnable `examples/alert-expectation-test.yaml` paired with the alerting Compose profile, and the docs-command validator taught the new verb (its `--dry-run` injector now keys off the dry-runnable set instead of hardcoding `run` — that hardcoding was masking real execution of docs commands).

## Test plan

- Core unit tests: expect parsing/validation (5), PromQL selector + response classification (6).
- CLI integration tests against a scripted in-process mock Prometheus: fire-and-resolve pass, never-fires failure with exit 1, missing-`expect:` rejection, `--dry-run` isolation (unreachable URL never contacted), and `sonda run` compatibility with `expect:` files.
- `cargo build/test/clippy --all-targets/fmt` across the workspace pass (1,935 tests; the only 2 failures are the known root-only `sink::file` permission tests). `--no-default-features` and the wasm32 pure-engine check both pass. `mkdocs build --strict` passes. `python3 scripts/validate_docs_commands.py`: 153 commands, 0 failed.
- Not covered here (follow-up): a live end-to-end run against the vmalert Compose stack — candidate for the Live Infra UAT matrix.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)
