### PR TITLE
test(e2e): prove sonda test against a live vmalert stack

### DIFF
--- a/.github/workflows/live-infra-uat.yml
+++ b/.github/workflows/live-infra-uat.yml
@@ -68,10 +68,12 @@ jobs:
           mkdir -p compose-logs
           docker compose -f examples/docker-compose-victoriametrics.yml \
             --profile loki --profile otel-collector --profile prometheus \
+            --profile alerting \
             ps > compose-logs/ps.txt 2>&1 || true
-          for svc in victoriametrics vmagent prometheus loki otel-collector; do
+          for svc in victoriametrics vmagent prometheus loki otel-collector vmalert alertmanager; do
             docker compose -f examples/docker-compose-victoriametrics.yml \
               --profile loki --profile otel-collector --profile prometheus \
+              --profile alerting \
               logs --no-color --tail 500 "$svc" \
               > "compose-logs/${svc}.log" 2>&1 || true
           done

--- a/docs/site/docs/test/alert-testing.md
+++ b/docs/site/docs/test/alert-testing.md
@@ -808,6 +808,7 @@ expect:
     - alert: HighCpuUsage
       labels:
         severity: critical
+        host: sonda-test
       firing_within: 90s
       resolves_within: 6m
 ```
@@ -818,6 +819,11 @@ expect:
   stops, the alert must stop firing. Leave slack for staleness — a pushed
   series takes a few minutes to go stale after the last sample.
 - `labels` narrows the match when one rule name fires for many label sets.
+  **Always include a label unique to your scenario** (here `host`, matching
+  the scenario's own `labels:`): the `ALERTS` metric is global, so an
+  unscoped expectation is satisfied by *any* firing alert with that name —
+  including ones your scenario never caused. On a shared or long-lived
+  Prometheus that turns a real failure into a false pass.
 
 Run it against any Prometheus-compatible query API (Prometheus,
 VictoriaMetrics with vmalert):

--- a/docs/site/docs/test/alert-testing.md
+++ b/docs/site/docs/test/alert-testing.md
@@ -841,6 +841,15 @@ otherwise — which makes alert rules testable in CI. The
 or contacting Prometheus. The `expect:` block is pure metadata to `sonda run`
 — the same file works for both commands.
 
+Resolution above leans on series staleness (emission stops, the rule's
+query eventually empties out), which takes minutes. For a fast, explicit
+recovery, `examples/alert-lifecycle-test.yaml` adds a second phase that
+drops the same series below the threshold — the alert resolves within a
+couple of evaluation rounds of scenario end. Both examples run
+continuously against a live VictoriaMetrics + vmalert stack in CI (the
+Live Infra UAT workflow), alongside a negative control that proves a
+non-firing alert exits `1`.
+
 ## Where to next
 
 - [End-to-end pipelines](end-to-end-pipelines.md) — confirm alerts fire through vmalert, Alertmanager, and a webhook receiver.

--- a/docs/site/docs/test/end-to-end-pipelines.md
+++ b/docs/site/docs/test/end-to-end-pipelines.md
@@ -330,9 +330,11 @@ Pick the tab that matches your scenario.
     | Logs | `json_lines` | `loki` | `examples/loki-json-lines.yaml` | `curl -sG 'http://localhost:3100/loki/api/v1/query_range' --data-urlencode 'query={job="sonda"}' \| jq '.data.result \| length'` |
     | Logs | `json_lines` | `kafka` | `examples/kafka-json-logs.yaml` | `docker exec <kafka> /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic sonda-logs --from-beginning --timeout-ms 5000` |
     | Metrics | `influx_lp` | `file` | `examples/influx-file.yaml` | `wc -l < /tmp/sonda-influx-output.txt` |
+    | Metrics | `remote_write` | `remote_write` (VM + vmalert) | `examples/alert-lifecycle-test.yaml` | `sonda test examples/alert-lifecycle-test.yaml --prometheus-url http://localhost:8428 --interval 5s` — self-verifying: exit 0 means the alert fired *and* resolved on deadline |
+    | Metrics | `remote_write` | `remote_write` (VM + vmalert, negative control) | `tests/e2e/alert-negative-control.yaml` | Same `sonda test` shape — must exit 1 with `did not fire within`, proving the failure path fails |
 
     !!! info "Compose profiles"
-        Loki, Kafka, Prometheus, and the OTel Collector are behind profiles to keep the base stack lean. Bring up only what each row needs. The vmagent row uses the default stack — no extra profile.
+        Loki, Kafka, Prometheus, the OTel Collector, and the alerting stack (vmalert + Alertmanager, needed by the two `sonda test` rows) are behind profiles to keep the base stack lean. Bring up only what each row needs. The vmagent row uses the default stack — no extra profile.
         ```bash
         docker compose -f examples/docker-compose-victoriametrics.yml \
           --profile loki --profile kafka --profile prometheus --profile otel-collector up -d

--- a/examples/alert-expectation-test.yaml
+++ b/examples/alert-expectation-test.yaml
@@ -38,10 +38,14 @@ scenarios:
       host: sonda-test
       service: payment-service
 
+# The expectation matches on this scenario's own `host` label — ALERTS is
+# global, so scoping keeps a foreign HighCpuUsage from another series in
+# the same datastore from satisfying the firing check.
 expect:
   alerts:
     - alert: HighCpuUsage
       labels:
         severity: critical
+        host: sonda-test
       firing_within: 90s
       resolves_within: 6m

--- a/examples/alert-lifecycle-test.yaml
+++ b/examples/alert-lifecycle-test.yaml
@@ -1,0 +1,71 @@
+# Full alert lifecycle test — firing AND fast resolution, end to end.
+#
+# Two phases write the same series: a high phase holds `docker_alert_cpu`
+# above the critical threshold so HighCpuUsage
+# (examples/alertmanager/alert-rules.yml: docker_alert_cpu > 90 for 5s)
+# must fire, then a recovery phase drops the value to 30 so the rule's
+# query empties out and the alert genuinely resolves — no waiting for
+# series staleness. Both entries carry identical labels on purpose: the
+# recovery samples must land in the *same* series, so the newest sample
+# wins the instant-query lookback. Distinct labels would leave the stale
+# 95s visible for minutes.
+#
+# Run against the alerting Compose profile
+# (examples/docker-compose-victoriametrics.yml --profile alerting):
+#
+#   sonda test examples/alert-lifecycle-test.yaml \
+#     --prometheus-url http://localhost:8428 --interval 5s
+#
+# Timeline: firing at ~15s (5s `for:` + 5s evaluation interval + write
+# latency), recovery starts at 60s, alert resolves within a couple of
+# evaluation rounds — observed almost immediately once the scenario ends
+# at 90s. This is the fast counterpart to
+# examples/alert-expectation-test.yaml, which proves the staleness-based
+# resolution path instead.
+#
+# Compare examples/alert-expectation-test.yaml (single phase, resolution
+# via staleness). This file is exercised live by the e2e harness
+# (scripts/live_infra_uat.py, alert-test-pass row).
+
+version: 2
+kind: runnable
+
+defaults:
+  rate: 5
+  encoder:
+    type: remote_write
+  sink:
+    type: remote_write
+    url: http://localhost:8428/api/v1/write
+
+scenarios:
+  - id: cpu_high
+    signal_type: metrics
+    name: docker_alert_cpu
+    duration: 60s
+    generator:
+      type: constant
+      value: 95.0
+    labels:
+      host: sonda-test
+      service: payment-service
+
+  - id: cpu_recovery
+    signal_type: metrics
+    name: docker_alert_cpu
+    duration: 30s
+    phase_offset: "60s"
+    generator:
+      type: constant
+      value: 30.0
+    labels:
+      host: sonda-test
+      service: payment-service
+
+expect:
+  alerts:
+    - alert: HighCpuUsage
+      labels:
+        severity: critical
+      firing_within: 90s
+      resolves_within: 2m

--- a/examples/alert-lifecycle-test.yaml
+++ b/examples/alert-lifecycle-test.yaml
@@ -62,10 +62,14 @@ scenarios:
       host: sonda-test
       service: payment-service
 
+# The expectation matches on this scenario's own `host` label — ALERTS is
+# global, so scoping keeps a foreign HighCpuUsage from another series in
+# the same datastore from satisfying the firing check.
 expect:
   alerts:
     - alert: HighCpuUsage
       labels:
         severity: critical
+        host: sonda-test
       firing_within: 90s
       resolves_within: 2m

--- a/scripts/live_infra_uat.py
+++ b/scripts/live_infra_uat.py
@@ -74,6 +74,19 @@ class MatrixRow:
     # primary suspect (the backend the row queries); additional entries cover
     # forwarders in the path (e.g., otel-collector).
     failure_log_containers: tuple[str, ...]
+    # CLI verb to invoke. "run" pushes data and then polls verify_url;
+    # "test" is self-verifying (its exit code IS the verdict), so rows
+    # using it leave verify_url empty and set the expectations below.
+    verb: str = "run"
+    # Extra argv appended after the scenario path (e.g. --prometheus-url).
+    extra_args: tuple[str, ...] = ()
+    # Expected exit code. Non-zero rows are negative controls proving the
+    # failure path fails; expect_stderr then pins WHICH failure it was.
+    expect_exit: int = 0
+    # Substring that must appear in stderr. Empty = no stderr assertion.
+    expect_stderr: str = ""
+    # Per-row wall-clock budget. Alert-lifecycle rows outlive the default.
+    timeout_s: float = SCENARIO_TIMEOUT_S
 
 
 @dataclasses.dataclass
@@ -140,6 +153,44 @@ MATRIX: tuple[MatrixRow, ...] = (
         ),
         failure_log_containers=("otel-collector", "loki"),
     ),
+    # -- `sonda test` alert rows (self-verifying: exit code is the verdict) --
+    # Negative control runs first so the ALERTS metric has no residue from
+    # an earlier firing when it asserts "did not fire".
+    MatrixRow(
+        name="alert-test-fail-control",
+        profiles=("alerting",),
+        subcommand="metrics",
+        scenario=Path("tests/e2e/alert-negative-control.yaml"),
+        verify_url="",
+        failure_log_containers=("vmalert", "victoriametrics"),
+        verb="test",
+        extra_args=(
+            "--prometheus-url",
+            "http://localhost:8428",
+            "--interval",
+            "5s",
+        ),
+        expect_exit=1,
+        expect_stderr="did not fire within",
+        timeout_s=120.0,
+    ),
+    MatrixRow(
+        name="alert-test-pass",
+        profiles=("alerting",),
+        subcommand="metrics",
+        scenario=Path("examples/alert-lifecycle-test.yaml"),
+        verify_url="",
+        failure_log_containers=("vmalert", "victoriametrics"),
+        verb="test",
+        extra_args=(
+            "--prometheus-url",
+            "http://localhost:8428",
+            "--interval",
+            "5s",
+        ),
+        # 90s scenario + firing/resolution polling; observed ~105s live.
+        timeout_s=300.0,
+    ),
 )
 
 # Backends keyed by compose profile. The empty-tuple key is for the default
@@ -157,6 +208,10 @@ BACKENDS_BY_PROFILE: dict[str, tuple[Backend, ...]] = {
     ),
     "otel-collector": (
         Backend(name="otel-collector", health_url="http://localhost:13133/"),
+    ),
+    "alerting": (
+        Backend(name="vmalert", health_url="http://localhost:8880/health"),
+        Backend(name="alertmanager", health_url="http://localhost:9093/-/healthy"),
     ),
 }
 
@@ -403,15 +458,18 @@ def run_scenario(
     scenario: Path,
     repo_root: Path,
     *,
+    verb: str = "run",
+    extra_args: Sequence[str] = (),
     timeout_s: float = SCENARIO_TIMEOUT_S,
 ) -> subprocess.CompletedProcess[str]:
-    """Invoke ``sonda run <scenario>`` and return the completed process.
-    Run from ``repo_root`` so relative paths resolve. The ``subcommand``
-    parameter is kept on ``MatrixRow`` as a hint about the signal type
-    documented in the matrix; the 1.9 CLI dispatches purely by YAML."""
+    """Invoke ``sonda <verb> <scenario> [extra_args...]`` and return the
+    completed process. Run from ``repo_root`` so relative paths resolve.
+    The ``subcommand`` parameter is kept on ``MatrixRow`` as a hint about
+    the signal type documented in the matrix; the 1.9 CLI dispatches purely
+    by YAML."""
     _ = subcommand
     return subprocess.run(
-        [str(sonda_bin), "run", str(scenario)],
+        [str(sonda_bin), verb, str(scenario), *extra_args],
         capture_output=True,
         text=True,
         timeout=timeout_s,
@@ -439,13 +497,19 @@ def run_row(
 
     try:
         proc = run_scenario(
-            sonda_bin, row.subcommand, row.scenario, repo_root,
+            sonda_bin,
+            row.subcommand,
+            row.scenario,
+            repo_root,
+            verb=row.verb,
+            extra_args=row.extra_args,
+            timeout_s=row.timeout_s,
         )
     except subprocess.TimeoutExpired:
         return RowResult(
             row=row,
             ok=False,
-            message=f"scenario timed out after {SCENARIO_TIMEOUT_S:.0f}s",
+            message=f"scenario timed out after {row.timeout_s:.0f}s",
             duration_s=_now_s() - start,
         )
     except FileNotFoundError:
@@ -456,29 +520,42 @@ def run_row(
             duration_s=_now_s() - start,
         )
 
-    if proc.returncode != 0:
+    if proc.returncode != row.expect_exit:
         stderr_tail = (proc.stderr or "").strip().splitlines()[-20:]
         return RowResult(
             row=row,
             ok=False,
             message=(
-                f"sonda exited {proc.returncode}\n"
+                f"sonda exited {proc.returncode} (expected {row.expect_exit})\n"
                 + "\n".join(f"    {line}" for line in stderr_tail)
             ),
             duration_s=_now_s() - start,
         )
 
-    verify_url = materialize_verify_url(row.verify_url)
-    if not wait_for_verify(verify_url):
+    if row.expect_stderr and row.expect_stderr not in (proc.stderr or ""):
+        stderr_tail = (proc.stderr or "").strip().splitlines()[-20:]
         return RowResult(
             row=row,
             ok=False,
             message=(
-                f"verify URL did not return non-empty data.result within "
-                f"{VERIFY_TIMEOUT_S:.0f}s: {verify_url}"
+                f"stderr missing expected substring {row.expect_stderr!r}\n"
+                + "\n".join(f"    {line}" for line in stderr_tail)
             ),
             duration_s=_now_s() - start,
         )
+
+    if row.verify_url:
+        verify_url = materialize_verify_url(row.verify_url)
+        if not wait_for_verify(verify_url):
+            return RowResult(
+                row=row,
+                ok=False,
+                message=(
+                    f"verify URL did not return non-empty data.result within "
+                    f"{VERIFY_TIMEOUT_S:.0f}s: {verify_url}"
+                ),
+                duration_s=_now_s() - start,
+            )
 
     return RowResult(row=row, ok=True, duration_s=_now_s() - start)
 
@@ -931,9 +1008,31 @@ class _MatrixIntegrityTests(unittest.TestCase):
         for row in MATRIX:
             self.assertIn(row.subcommand, {"metrics", "logs"}, row.name)
 
-    def test_scenario_paths_are_under_examples(self) -> None:
+    def test_scenario_paths_are_under_known_roots(self) -> None:
+        # examples/ for user-facing scenarios; tests/ for harness-only
+        # fixtures (e.g. the deliberately-failing negative control).
         for row in MATRIX:
-            self.assertEqual(row.scenario.parts[0], "examples", row.name)
+            self.assertIn(row.scenario.parts[0], {"examples", "tests"}, row.name)
+
+    def test_verbs_are_known(self) -> None:
+        for row in MATRIX:
+            self.assertIn(row.verb, {"run", "test"}, row.name)
+
+    def test_self_verifying_rows_have_no_verify_url(self) -> None:
+        # `sonda test` rows carry their verdict in the exit code — a verify
+        # URL on one would mean the row's success criteria are ambiguous.
+        for row in MATRIX:
+            if row.verb == "test":
+                self.assertEqual(row.verify_url, "", row.name)
+            else:
+                self.assertTrue(row.verify_url, row.name)
+
+    def test_negative_controls_pin_their_failure(self) -> None:
+        # A row expected to fail must also pin WHICH failure via stderr,
+        # otherwise any crash would satisfy it.
+        for row in MATRIX:
+            if row.expect_exit != 0:
+                self.assertTrue(row.expect_stderr, row.name)
 
     def test_profiles_are_recognised(self) -> None:
         # Every profile a row asks for must appear in BACKENDS_BY_PROFILE,

--- a/scripts/live_infra_uat.py
+++ b/scripts/live_infra_uat.py
@@ -154,8 +154,9 @@ MATRIX: tuple[MatrixRow, ...] = (
         failure_log_containers=("otel-collector", "loki"),
     ),
     # -- `sonda test` alert rows (self-verifying: exit code is the verdict) --
-    # Negative control runs first so the ALERTS metric has no residue from
-    # an earlier firing when it asserts "did not fire".
+    # Both fixtures scope their expectations to their own `host` label, so
+    # neither row's verdict can come from the other's ALERTS residue —
+    # ordering between them is a readability choice, not a correctness one.
     MatrixRow(
         name="alert-test-fail-control",
         profiles=("alerting",),
@@ -188,6 +189,10 @@ MATRIX: tuple[MatrixRow, ...] = (
             "--interval",
             "5s",
         ),
+        # Exit 0 already implies both checks held; pinning the resolution
+        # line proves the half this scenario exists to exercise actually
+        # ran, rather than inferring it.
+        expect_stderr="resolved after",
         # 90s scenario + firing/resolution polling; observed ~105s live.
         timeout_s=300.0,
     ),

--- a/tests/e2e/alert-negative-control.yaml
+++ b/tests/e2e/alert-negative-control.yaml
@@ -1,0 +1,38 @@
+# Negative control for the e2e harness — this test MUST fail.
+#
+# Emits `docker_alert_cpu` well below the HighCpuUsage threshold
+# (rule: docker_alert_cpu > 90 for 5s), then expects the alert to fire
+# anyway. `sonda test` must exit 1 with "did not fire within" — proving
+# against a live vmalert that the exit-code contract cannot false-pass.
+# Exercised by scripts/live_infra_uat.py (alert-test-fail-control row);
+# not a usage example, which is why it lives here and not in examples/.
+
+version: 2
+kind: runnable
+
+defaults:
+  rate: 5
+  duration: 10s
+  encoder:
+    type: remote_write
+  sink:
+    type: remote_write
+    url: http://localhost:8428/api/v1/write
+
+scenarios:
+  - id: cpu_low
+    signal_type: metrics
+    name: docker_alert_cpu
+    generator:
+      type: constant
+      value: 10.0
+    labels:
+      host: sonda-negative-control
+      service: payment-service
+
+expect:
+  alerts:
+    - alert: HighCpuUsage
+      labels:
+        severity: critical
+      firing_within: 20s

--- a/tests/e2e/alert-negative-control.yaml
+++ b/tests/e2e/alert-negative-control.yaml
@@ -6,6 +6,11 @@
 # against a live vmalert that the exit-code contract cannot false-pass.
 # Exercised by scripts/live_infra_uat.py (alert-test-fail-control row);
 # not a usage example, which is why it lives here and not in examples/.
+#
+# The expectation matches on this scenario's own `host` label: the ALERTS
+# metric is global, so without it a HighCpuUsage alert fired by any other
+# series in the same datastore would satisfy the expectation and turn the
+# control's guaranteed failure into a pass.
 
 version: 2
 kind: runnable
@@ -35,4 +40,5 @@ expect:
     - alert: HighCpuUsage
       labels:
         severity: critical
+        host: sonda-negative-control
       firing_within: 20s


### PR DESCRIPTION

## Summary

Stacked on #516 (base is its branch — merge #516 first and this retargets to `main`). #516 proved `sonda test` against a mock; this PR proves it against the real thing: two new Live Infra UAT rows run the full alert round trip through VictoriaMetrics + vmalert (the compose stack's pinned v1.149.0) on every CI run — a positive lifecycle case and a negative control — so the mock-only coverage gap called out in both review rounds is closed with a repeatable, live gate.

Already verified live before opening this PR (real VM + vmalert binaries, same pinned versions, the repo's own `examples/alertmanager/alert-rules.yml`) — all three paths green:

```
sonda test examples/alert-lifecycle-test.yaml --prometheus-url http://localhost:8428 --interval 5s
  PASS HighCpuUsage firing after 45s (within 90s)
  PASS HighCpuUsage resolved after 15s (within 2m of scenario end)
  PASS 1 alert expectation(s) verified (scenario ran 90s)          → exit 0

sonda test tests/e2e/alert-negative-control.yaml --prometheus-url http://localhost:8428 --interval 5s
  FAIL HighCpuUsage did not fire within 20s
  error: 1 alert expectation(s) failed                             → exit 1, in exactly 20s

sonda test examples/alert-expectation-test.yaml --prometheus-url http://localhost:8428 --interval 10s
  PASS HighCpuUsage firing after 50s (within 90s)                  (documented example, verbatim —
  PASS HighCpuUsage resolved after 340s (within 6m of scenario end) staleness-based resolution path)
  PASS 1 alert expectation(s) verified (scenario ran 60s)          → exit 0
```

## Changes

- `examples/alert-lifecycle-test.yaml` — new two-phase scenario: 60s at 95 (fires `HighCpuUsage`), then 30s at 30 **on the same series** so the rule's query empties out and the alert genuinely resolves within a couple of evaluation rounds — no waiting minutes for staleness. Complements `examples/alert-expectation-test.yaml`, which keeps proving the staleness-based resolution path.
- `tests/e2e/alert-negative-control.yaml` — deliberately-failing fixture (below-threshold emission, expects the alert anyway). Lives under `tests/e2e/`, not `examples/`, because it is not a usage example.
- `scripts/live_infra_uat.py` — matrix rows can now be **self-verifying**: new `verb` (`run`|`test`), `extra_args`, `expect_exit`, `expect_stderr`, and per-row `timeout_s` fields. `sonda test` rows carry their verdict in the exit code, so they set no verify URL; negative controls must pin *which* failure via a stderr substring, otherwise any crash would satisfy them. Two rows added (`alert-test-fail-control` first, so the `ALERTS` metric has no residue when it asserts "did not fire"; then `alert-test-pass`), plus `alerting`-profile backends (vmalert, Alertmanager) and four new matrix-integrity self-tests.
- `.github/workflows/live-infra-uat.yml` — failure log collection now includes the `alerting` profile (vmalert + alertmanager logs).
- Docs: coverage matrix gains both rows (`test/end-to-end-pipelines.md`); the alert-testing guide explains the fast recovery-phase resolution vs. the staleness path and notes both run continuously in CI.

## Test plan

- Live in-container round trips against `victoria-metrics-prod` + `vmalert-prod` v1.149.0 with the repo's own alert rules: all three results quoted above (positive lifecycle exit 0; negative control exit 1 with the pinned message; documented staleness example verbatim exit 0).
- `python3 scripts/live_infra_uat.py --self-test` — 36 tests pass (was 32; four new matrix-integrity checks).
- `python3 scripts/validate_docs_commands.py` — 153 commands, 0 failed; `mkdocs build --strict` clean.
- No Rust changes: cargo gates unaffected (green on the base branch at 38e8911).
- The Live Infra UAT workflow run on this PR is itself the repeatable proof — check the `alert-test-pass` / `alert-test-fail-control` rows in its log.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)