### PR TITLE
feat: sonda test verdicts from stored samples + foreign-label warning (W2 phase 2)

### DIFF
--- a/docs/site/docs/reference/cli-flags.md
+++ b/docs/site/docs/reference/cli-flags.md
@@ -281,12 +281,21 @@ sonda test examples/alert-expectation-test.yaml \
 | `--prometheus-url <URL>` | Base URL of the Prometheus-compatible API evaluating the alert rules (e.g. `http://localhost:9090`). Required except with `--dry-run`; also read from `SONDA_PROMETHEUS_URL`. |
 | `--interval <DUR>` | Poll interval for alert-state checks. Default `5s`. |
 | `--query-timeout <DUR>` | Overall timeout for each alert-state query (connect + read), so a stalled endpoint fails fast instead of hanging. Default `10s`. |
+| `--query-step <DUR>` | Grid resolution for the post-hoc range queries that produce the verdict timelines. Match your rule evaluation interval. Default `5s`. |
 
 The scenario runs exactly as `sonda run` would (no overrides). Firing
 deadlines are measured from scenario start; resolution deadlines from
 scenario end. A scenario without an `expect:` block is rejected. With
 `--dry-run`, the scenario and its expectations are validated and printed
 without emitting events or contacting Prometheus.
+
+Verdicts are read from the datastore, not from the polling loop: live
+polling (at `--interval`) only decides when each check has settled, then a
+range query reconstructs what actually happened from the stored `ALERTS`
+samples at `--query-step` resolution. Reported transition times are sample
+times — independent of how often `sonda test` polled. If the range API is
+unavailable, the verdict falls back to the live poll timeline with a
+warning.
 
 Before the scenario starts, a preflight confirms the endpoint answers a
 query for every expectation. Only the first expectation is retried (3

--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -141,9 +141,13 @@ src/
 │   │                      → Outcome (Pass | Late | Missed | Undecided). Owns EVERY deadline
 │   │                      comparison — acquisition layers must never decide pass/fail.
 │   └── prometheus.rs   ← acquisition (feature = "http"): blocking PrometheusClient with a
-│                          mandatory per-request timeout, queries the ALERTS metric via the
-│                          instant-query API. Errors are SondaError::Verify, retryable by
-│                          polling loops. Alertmanager acquisition is planned as a sibling.
+│                          mandatory per-request timeout. Instant queries (alert_state) drive
+│                          live settling; range queries (range_timeline) reconstruct verdict
+│                          timelines from the stored ALERTS samples — grid parse in
+│                          parse_range_timeline, firing-series labels collected for the
+│                          foreign_label_values provenance check (verify/mod.rs). Errors are
+│                          SondaError::Verify, retryable by polling loops. Alertmanager
+│                          acquisition is planned as a sibling.
 └── config/
     ├── mod.rs          ← BaseScheduleConfig (shared schedule/delivery fields: name, rate, duration,
     │                      gaps, bursts, cardinality_spikes, dynamic_labels, labels, sink,

--- a/sonda-core/src/verify/mod.rs
+++ b/sonda-core/src/verify/mod.rs
@@ -90,6 +90,31 @@ impl AlertExpectation {
     }
 }
 
+/// Label values on a matched alert series that the scenario never emitted.
+///
+/// The `ALERTS` metric is global: an expectation can match an alert another
+/// series caused. This compares a matched series' labels against the label
+/// values the scenario actually emits — for every label key the scenario
+/// uses, a differing value on the series means the alert (at least partly)
+/// came from outside the scenario. Callers surface these as warnings so an
+/// under-scoped expectation is loud instead of silently green. Label keys
+/// the scenario never sets (e.g. `alertname`, `alertstate`, rule labels
+/// like `severity`) are not compared — the scenario has no opinion on them.
+pub fn foreign_label_values(
+    series: &BTreeMap<String, String>,
+    emitted: &BTreeMap<String, std::collections::BTreeSet<String>>,
+) -> Vec<(String, String)> {
+    series
+        .iter()
+        .filter(|(key, value)| {
+            emitted
+                .get(*key)
+                .is_some_and(|values| !values.contains(*value))
+        })
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
 /// Extract and validate the `expect:` block from scenario YAML.
 ///
 /// Returns `Ok(None)` when the file has no `expect:` block. The probe is
@@ -134,6 +159,74 @@ pub fn parse_expectations(yaml: &str) -> Result<Option<ExpectConfig>, SondaError
         expectation.resolves_within()?;
     }
     Ok(Some(config))
+}
+
+#[cfg(test)]
+mod provenance_tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    fn emitted(pairs: &[(&str, &[&str])]) -> BTreeMap<String, BTreeSet<String>> {
+        pairs
+            .iter()
+            .map(|(k, vs)| {
+                (
+                    k.to_string(),
+                    vs.iter().map(|v| v.to_string()).collect::<BTreeSet<_>>(),
+                )
+            })
+            .collect()
+    }
+
+    fn series(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn matching_values_produce_no_warnings() {
+        let foreign = foreign_label_values(
+            &series(&[("host", "sonda-test"), ("alertname", "HighCpuUsage")]),
+            &emitted(&[("host", &["sonda-test"])]),
+        );
+        assert!(foreign.is_empty());
+    }
+
+    #[test]
+    fn differing_value_on_an_emitted_key_is_foreign() {
+        // The #527 review's exact case: expectation matched an alert from
+        // host=ci-test-node while the scenario only emitted host=sonda-test.
+        let foreign = foreign_label_values(
+            &series(&[("host", "ci-test-node"), ("severity", "critical")]),
+            &emitted(&[("host", &["sonda-test"]), ("service", &["payments"])]),
+        );
+        assert_eq!(
+            foreign,
+            vec![("host".to_string(), "ci-test-node".to_string())]
+        );
+    }
+
+    #[test]
+    fn keys_the_scenario_never_sets_are_ignored() {
+        // alertname / alertstate / rule labels are not scenario labels.
+        let foreign = foreign_label_values(
+            &series(&[("alertname", "HighCpuUsage"), ("severity", "critical")]),
+            &emitted(&[("host", &["sonda-test"])]),
+        );
+        assert!(foreign.is_empty());
+    }
+
+    #[test]
+    fn any_emitted_value_for_the_key_matches() {
+        // Multi-entry scenarios can emit several values for one key.
+        let foreign = foreign_label_values(
+            &series(&[("host", "b")]),
+            &emitted(&[("host", &["a", "b"])]),
+        );
+        assert!(foreign.is_empty());
+    }
 }
 
 #[cfg(all(test, feature = "config"))]

--- a/sonda-core/src/verify/prometheus.rs
+++ b/sonda-core/src/verify/prometheus.rs
@@ -1,14 +1,25 @@
 //! Prometheus-compatible acquisition for alert-state polling.
 //!
-//! Queries the instant-query API (`/api/v1/query`) for the built-in
-//! `ALERTS` metric, which every Prometheus-compatible evaluator (Prometheus,
-//! VictoriaMetrics/vmalert) exposes with an `alertstate` label of `pending`
-//! or `firing` while a rule is active. This module only *acquires* state —
-//! deadline decisions belong to [`crate::verify::evaluator`].
+//! Two acquisition paths against the built-in `ALERTS` metric, which every
+//! Prometheus-compatible evaluator (Prometheus, VictoriaMetrics/vmalert)
+//! exposes with an `alertstate` label of `pending` or `firing` while a rule
+//! is active:
+//!
+//! - **Instant queries** (`/api/v1/query`) drive *live* polling — deciding
+//!   when a check has settled and can stop waiting.
+//! - **Range queries** (`/api/v1/query_range`) produce the *verdict*
+//!   timeline after the fact: the actual samples the evaluator wrote, at
+//!   the rule-evaluation cadence, free of the caller's poll-interval
+//!   quantization and of latency introduced by polling other expectations.
+//!
+//! This module only *acquires* state — deadline decisions belong to
+//! [`crate::verify::evaluator`].
 
+use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::time::Duration;
 
+use crate::verify::evaluator::Observation;
 use crate::verify::{AlertExpectation, AlertState};
 use crate::{SondaError, VerifyError};
 
@@ -19,7 +30,19 @@ use crate::{SondaError, VerifyError};
 /// which keeps polling loops bounded and interruptible.
 pub struct PrometheusClient {
     query_url: String,
+    range_url: String,
     agent: ureq::Agent,
+}
+
+/// The reconstructed history of one expectation over a queried window.
+#[derive(Debug, Clone)]
+pub struct RangeTimeline {
+    /// One observation per grid step, anchored on the caller's anchor
+    /// timestamp. A step with no matching sample is `Inactive`.
+    pub observations: Vec<Observation>,
+    /// Label sets of every distinct firing series seen in the window —
+    /// input for [`crate::verify::foreign_label_values`] provenance checks.
+    pub firing_series: Vec<BTreeMap<String, String>>,
 }
 
 impl PrometheusClient {
@@ -30,6 +53,7 @@ impl PrometheusClient {
         let base = base_url.trim_end_matches('/');
         Self {
             query_url: format!("{base}/api/v1/query"),
+            range_url: format!("{base}/api/v1/query_range"),
             agent: ureq::AgentBuilder::new().timeout(timeout).build(),
         }
     }
@@ -68,6 +92,137 @@ impl PrometheusClient {
             })
         })
     }
+
+    /// Reconstruct an expectation's state history over `[start, end]` (unix
+    /// seconds) at `step` resolution, with observation timestamps measured
+    /// from `anchor` (unix seconds — scenario start for firing checks,
+    /// scenario end for resolution checks).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SondaError::Verify`] when the endpoint is unreachable,
+    /// times out, or responds with an unusable payload.
+    pub fn range_timeline(
+        &self,
+        expectation: &AlertExpectation,
+        start: f64,
+        end: f64,
+        step: Duration,
+        anchor: f64,
+    ) -> Result<RangeTimeline, SondaError> {
+        let query = alerts_query(expectation);
+        let body = self
+            .agent
+            .get(&self.range_url)
+            .query("query", &query)
+            .query("start", &format!("{start:.3}"))
+            .query("end", &format!("{end:.3}"))
+            .query("step", &format!("{:.3}", step.as_secs_f64()))
+            .call()
+            .map_err(|e| {
+                SondaError::Verify(VerifyError::Query {
+                    url: self.range_url.clone(),
+                    reason: e.to_string(),
+                })
+            })?
+            .into_string()
+            .map_err(|e| {
+                SondaError::Verify(VerifyError::BadResponse {
+                    url: self.range_url.clone(),
+                    reason: format!("response could not be read: {e}"),
+                })
+            })?;
+        parse_range_timeline(&body, start, end, step.as_secs_f64(), anchor).map_err(|reason| {
+            SondaError::Verify(VerifyError::BadResponse {
+                url: self.range_url.clone(),
+                reason,
+            })
+        })
+    }
+}
+
+/// Parse a range-query response into a [`RangeTimeline`].
+///
+/// The grid runs `start..=end` at `step` (all unix seconds). Prometheus
+/// aligns matrix samples to the requested grid, so states are keyed by
+/// millisecond-rounded timestamps; a grid point with no matching sample is
+/// `Inactive` — the rule produced no series there (with staleness markers,
+/// exactly what an instant query at that moment would have said). Steps at
+/// or before `anchor` clamp to zero.
+pub fn parse_range_timeline(
+    body: &str,
+    start: f64,
+    end: f64,
+    step_secs: f64,
+    anchor: f64,
+) -> Result<RangeTimeline, String> {
+    if !step_secs.is_finite() || step_secs <= 0.0 {
+        return Err(format!("step must be positive, got {step_secs}"));
+    }
+    let parsed: serde_json::Value =
+        serde_json::from_str(body).map_err(|e| format!("not valid JSON: {e}"))?;
+    if parsed["status"] != "success" {
+        return Err(format!("query returned status {:?}", parsed["status"]));
+    }
+    let result_type = &parsed["data"]["resultType"];
+    if result_type != "matrix" {
+        return Err(format!(
+            "expected resultType \"matrix\", got {result_type:?}"
+        ));
+    }
+    let empty = Vec::new();
+    let series_list = parsed["data"]["result"].as_array().unwrap_or(&empty);
+
+    let mut firing_at: std::collections::BTreeSet<i64> = std::collections::BTreeSet::new();
+    let mut pending_at: std::collections::BTreeSet<i64> = std::collections::BTreeSet::new();
+    let mut firing_series: Vec<BTreeMap<String, String>> = Vec::new();
+    for series in series_list {
+        let firing = series["metric"]["alertstate"] == "firing";
+        if firing {
+            let labels: BTreeMap<String, String> = series["metric"]
+                .as_object()
+                .map(|m| {
+                    m.iter()
+                        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                        .collect()
+                })
+                .unwrap_or_default();
+            if !firing_series.contains(&labels) {
+                firing_series.push(labels);
+            }
+        }
+        for value in series["values"].as_array().unwrap_or(&empty) {
+            let Some(ts) = value[0].as_f64() else {
+                continue;
+            };
+            let key = (ts * 1000.0).round() as i64;
+            if firing {
+                firing_at.insert(key);
+            } else {
+                pending_at.insert(key);
+            }
+        }
+    }
+
+    let mut observations = Vec::new();
+    let steps = ((end - start) / step_secs).floor() as u64;
+    for index in 0..=steps {
+        let ts = start + index as f64 * step_secs;
+        let key = (ts * 1000.0).round() as i64;
+        let state = if firing_at.contains(&key) {
+            AlertState::Firing
+        } else if pending_at.contains(&key) {
+            AlertState::Pending
+        } else {
+            AlertState::Inactive
+        };
+        let at = Duration::from_secs_f64((ts - anchor).max(0.0));
+        observations.push(Observation::new(at, Ok(state)));
+    }
+    Ok(RangeTimeline {
+        observations,
+        firing_series,
+    })
 }
 
 /// Build the `ALERTS{...}` selector for an expectation.
@@ -191,6 +346,102 @@ mod tests {
     fn error_status_is_rejected() {
         let body = r#"{"status":"error","errorType":"bad_data","error":"boom"}"#;
         assert!(parse_alert_state(body).is_err());
+    }
+
+    fn states(timeline: &RangeTimeline) -> Vec<AlertState> {
+        timeline
+            .observations
+            .iter()
+            .map(|o| *o.state.as_ref().expect("range states are never errors"))
+            .collect()
+    }
+
+    #[test]
+    fn range_grid_reconstructs_the_full_lifecycle() {
+        // Grid 100..=120 step 5: inactive, pending, firing, firing, gone.
+        let body = r#"{"status":"success","data":{"resultType":"matrix","result":[
+            {"metric":{"alertname":"HighCpuUsage","alertstate":"pending","host":"sonda-test"},
+             "values":[[105,"1"]]},
+            {"metric":{"alertname":"HighCpuUsage","alertstate":"firing","host":"sonda-test"},
+             "values":[[110,"1"],[115,"1"]]}
+        ]}}"#;
+        let timeline = parse_range_timeline(body, 100.0, 120.0, 5.0, 100.0).expect("parse");
+        assert_eq!(
+            states(&timeline),
+            vec![
+                AlertState::Inactive,
+                AlertState::Pending,
+                AlertState::Firing,
+                AlertState::Firing,
+                AlertState::Inactive,
+            ]
+        );
+        // Observations are anchored: first at 0s, last at 20s.
+        assert_eq!(timeline.observations[0].at, Duration::from_secs(0));
+        assert_eq!(timeline.observations[4].at, Duration::from_secs(20));
+        assert_eq!(timeline.firing_series.len(), 1);
+        assert_eq!(
+            timeline.firing_series[0].get("host").map(String::as_str),
+            Some("sonda-test")
+        );
+    }
+
+    #[test]
+    fn range_transition_time_is_the_sample_time_not_a_poll_time() {
+        // The whole point of range acquisition: the firing observation's
+        // timestamp comes from the stored sample (anchor+5s), regardless of
+        // when or how often anyone polled.
+        let body = r#"{"status":"success","data":{"resultType":"matrix","result":[
+            {"metric":{"alertname":"X","alertstate":"firing"},"values":[[1005,"1"],[1010,"1"]]}
+        ]}}"#;
+        let timeline = parse_range_timeline(body, 1000.0, 1010.0, 5.0, 1000.0).expect("parse");
+        let first_firing = timeline
+            .observations
+            .iter()
+            .find(|o| matches!(o.state, Ok(AlertState::Firing)))
+            .expect("firing observed");
+        assert_eq!(first_firing.at, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn range_empty_result_is_all_inactive_with_full_coverage() {
+        let body = r#"{"status":"success","data":{"resultType":"matrix","result":[]}}"#;
+        let timeline = parse_range_timeline(body, 0.0, 10.0, 5.0, 0.0).expect("parse");
+        assert_eq!(
+            states(&timeline),
+            vec![
+                AlertState::Inactive,
+                AlertState::Inactive,
+                AlertState::Inactive
+            ]
+        );
+        assert!(timeline.firing_series.is_empty());
+    }
+
+    #[test]
+    fn range_collects_distinct_firing_series_labels() {
+        let body = r#"{"status":"success","data":{"resultType":"matrix","result":[
+            {"metric":{"alertname":"X","alertstate":"firing","host":"a"},"values":[[5,"1"]]},
+            {"metric":{"alertname":"X","alertstate":"firing","host":"b"},"values":[[5,"1"]]},
+            {"metric":{"alertname":"X","alertstate":"firing","host":"a"},"values":[[10,"1"]]}
+        ]}}"#;
+        let timeline = parse_range_timeline(body, 0.0, 10.0, 5.0, 0.0).expect("parse");
+        assert_eq!(timeline.firing_series.len(), 2);
+    }
+
+    #[test]
+    fn range_vector_result_is_rejected() {
+        // An instant-query response fed to the range parser is a bad
+        // payload, not an empty timeline.
+        let body = r#"{"status":"success","data":{"resultType":"vector","result":[]}}"#;
+        let err = parse_range_timeline(body, 0.0, 10.0, 5.0, 0.0).expect_err("must reject");
+        assert!(err.contains("matrix"), "{err}");
+    }
+
+    #[test]
+    fn range_zero_step_is_rejected() {
+        let body = r#"{"status":"success","data":{"resultType":"matrix","result":[]}}"#;
+        assert!(parse_range_timeline(body, 0.0, 10.0, 0.0, 0.0).is_err());
     }
 
     #[test]

--- a/sonda-core/src/verify/prometheus.rs
+++ b/sonda-core/src/verify/prometheus.rs
@@ -34,6 +34,45 @@ pub struct PrometheusClient {
     agent: ureq::Agent,
 }
 
+/// Snapshot of the datastore's clock, expressed as an offset from the
+/// local one.
+///
+/// Range samples carry *server* timestamps; verdict anchors captured from
+/// the *local* clock must be translated into server coordinates before any
+/// subtraction, or the clock offset between the two hosts is silently
+/// baked into every verdict — one second of skew flips a tight deadline,
+/// and negative skew can turn a missed deadline into a false pass.
+#[derive(Debug, Clone, Copy)]
+pub struct ServerClock {
+    offset_secs: f64,
+}
+
+impl ServerClock {
+    /// A clock with no offset — for when the server's clock could not be
+    /// measured and local time is the only (warned-about) option.
+    pub fn identity() -> Self {
+        Self { offset_secs: 0.0 }
+    }
+
+    /// Measured server-minus-local offset in seconds.
+    pub fn offset_secs(&self) -> f64 {
+        self.offset_secs
+    }
+
+    /// A local wall-clock instant, expressed in server coordinates.
+    pub fn at(&self, t: std::time::SystemTime) -> f64 {
+        t.duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs_f64())
+            .unwrap_or(0.0)
+            + self.offset_secs
+    }
+
+    /// The current moment, expressed in server coordinates.
+    pub fn now(&self) -> f64 {
+        self.at(std::time::SystemTime::now())
+    }
+}
+
 /// The reconstructed history of one expectation over a queried window.
 #[derive(Debug, Clone)]
 pub struct RangeTimeline {
@@ -93,9 +132,52 @@ impl PrometheusClient {
         })
     }
 
-    /// Reconstruct an expectation's state history over `[start, end]` (unix
-    /// seconds) at `step` resolution, with observation timestamps measured
-    /// from `anchor` (unix seconds — scenario start for firing checks,
+    /// Measure the server's clock with an instant `time()` query,
+    /// bracketing the request with local readings so the offset is taken
+    /// against the request's midpoint.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SondaError::Verify`] when the endpoint is unreachable,
+    /// times out, or responds with an unusable payload — callers should
+    /// fall back to [`ServerClock::identity`] with a warning rather than
+    /// abort.
+    pub fn server_clock(&self) -> Result<ServerClock, SondaError> {
+        let local_before = ServerClock::identity().now();
+        let body = self
+            .agent
+            .get(&self.query_url)
+            .query("query", "time()")
+            .call()
+            .map_err(|e| {
+                SondaError::Verify(VerifyError::Query {
+                    url: self.query_url.clone(),
+                    reason: e.to_string(),
+                })
+            })?
+            .into_string()
+            .map_err(|e| {
+                SondaError::Verify(VerifyError::BadResponse {
+                    url: self.query_url.clone(),
+                    reason: format!("response could not be read: {e}"),
+                })
+            })?;
+        let local_after = ServerClock::identity().now();
+        let server = parse_server_time(&body).map_err(|reason| {
+            SondaError::Verify(VerifyError::BadResponse {
+                url: self.query_url.clone(),
+                reason,
+            })
+        })?;
+        Ok(ServerClock {
+            offset_secs: server - (local_before + local_after) / 2.0,
+        })
+    }
+
+    /// Reconstruct an expectation's state history over `[start, end]`
+    /// (**server** unix seconds — see [`ServerClock`]) at `step`
+    /// resolution, with observation timestamps measured from `anchor`
+    /// (also server unix seconds — scenario start for firing checks,
     /// scenario end for resolution checks).
     ///
     /// # Errors
@@ -138,6 +220,38 @@ impl PrometheusClient {
                 reason,
             })
         })
+    }
+}
+
+/// Parse an instant `time()` response into the server's evaluation
+/// timestamp in unix seconds.
+///
+/// Prometheus answers with a scalar (`result: [ts, "ts"]`); VictoriaMetrics
+/// answers with a one-series vector whose `value: [ts, "..."]`. In both
+/// shapes the *evaluation timestamp* field is the server's clock — the
+/// stringified value is not used, because VM computes `time()` at
+/// `now - search.latencyOffset` (30s behind by default) while stamping the
+/// evaluation timestamp with the actual now.
+///
+/// Returns a human-readable reason on failure; the caller wraps it with
+/// the query URL into a [`VerifyError::BadResponse`].
+pub fn parse_server_time(body: &str) -> Result<f64, String> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(body).map_err(|e| format!("not valid JSON: {e}"))?;
+    if parsed["status"] != "success" {
+        return Err(format!("query returned status {:?}", parsed["status"]));
+    }
+    let data = &parsed["data"];
+    match &data["resultType"] {
+        t if t == "scalar" => data["result"][0]
+            .as_f64()
+            .ok_or_else(|| "scalar result carries no timestamp".to_string()),
+        t if t == "vector" => data["result"][0]["value"][0]
+            .as_f64()
+            .ok_or_else(|| "vector result carries no timestamp".to_string()),
+        other => Err(format!(
+            "expected resultType \"scalar\" or \"vector\", got {other:?}"
+        )),
     }
 }
 
@@ -427,6 +541,40 @@ mod tests {
         ]}}"#;
         let timeline = parse_range_timeline(body, 0.0, 10.0, 5.0, 0.0).expect("parse");
         assert_eq!(timeline.firing_series.len(), 2);
+    }
+
+    #[test]
+    fn server_time_parses_prometheus_scalar() {
+        let body = r#"{"status":"success","data":{"resultType":"scalar","result":[1754700000.123,"1754700000.123"]}}"#;
+        let ts = parse_server_time(body).expect("parse");
+        assert!((ts - 1_754_700_000.123).abs() < 1e-6);
+    }
+
+    #[test]
+    fn server_time_parses_victoriametrics_vector_from_eval_timestamp() {
+        // VM answers time() as a one-series vector, and computes the string
+        // value at now - search.latencyOffset (30s behind by default). The
+        // evaluation timestamp is the server's actual clock — observed live
+        // against v1.149.0.
+        let body = r#"{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1786311458,"1786311428.689"]}]}}"#;
+        let ts = parse_server_time(body).expect("parse");
+        assert!((ts - 1_786_311_458.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn server_time_rejects_empty_vector_and_matrix() {
+        let empty = r#"{"status":"success","data":{"resultType":"vector","result":[]}}"#;
+        assert!(parse_server_time(empty).is_err());
+        let matrix = r#"{"status":"success","data":{"resultType":"matrix","result":[]}}"#;
+        assert!(parse_server_time(matrix).is_err());
+    }
+
+    #[test]
+    fn server_clock_translates_local_instants() {
+        let clock = ServerClock { offset_secs: -6.0 };
+        let t = std::time::UNIX_EPOCH + Duration::from_secs(1_000);
+        assert!((clock.at(t) - 994.0).abs() < 1e-9);
+        assert_eq!(ServerClock::identity().offset_secs(), 0.0);
     }
 
     #[test]

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -111,13 +111,17 @@ the single discovery surface. The verbosity model is captured in the `Verbosity`
 
 - **`sonda test`** — run a scenario and verify its top-level `expect:` alert expectations
   against a Prometheus-compatible API (`--prometheus-url`, env `SONDA_PROMETHEUS_URL`).
-  A poller thread watches the `ALERTS` metric while the scenario runs through the same
-  machinery as `sonda run`; firing deadlines count from scenario start, resolution deadlines
-  from scenario end. Exits non-zero when any expectation fails — this is the CI entry point
-  for alert-rule testing. `test_cmd.rs` only orchestrates and renders: it records timestamped
-  observation timelines and every pass/fail decision is made by
-  `sonda_core::verify::evaluator` (parsing and the Prometheus client also live in
-  `sonda_core::verify`).
+  Live polling of the `ALERTS` metric (a poller thread beside the same run machinery as
+  `sonda run`) only decides when each check has *settled*; the verdict timeline is then
+  reconstructed by a range query over the stored samples at `--query-step` resolution, so
+  transition times are sample times, not poll times (fallback to the live timeline, with a
+  warning, when the range API fails). Firing deadlines count from scenario start, resolution
+  deadlines from scenario end. Exits non-zero when any expectation fails — this is the CI
+  entry point for alert-rule testing. Matched firing series are provenance-checked against
+  the scenario's own emitted labels (`ALERTS` is global; a foreign label value warns).
+  `test_cmd.rs` only orchestrates and renders: every pass/fail decision is made by
+  `sonda_core::verify::evaluator` (parsing, the Prometheus client, and the provenance
+  check also live in `sonda_core::verify`).
 
 All subcommands route through the unified `sonda_core::prepare_entries` + `sonda_core::launch_scenario`
 API. No per-signal-type dispatch in main.rs.

--- a/sonda/src/cli.rs
+++ b/sonda/src/cli.rs
@@ -141,6 +141,11 @@ pub struct TestArgs {
     /// Overall timeout for each alert-state query (connect + read).
     #[arg(long, default_value = "10s")]
     pub query_timeout: String,
+
+    /// Grid resolution for the post-hoc range queries that produce the
+    /// verdict timelines. Match your rule evaluation interval.
+    #[arg(long, default_value = "5s")]
+    pub query_step: String,
 }
 
 #[derive(Debug, Args)]

--- a/sonda/src/test_cmd.rs
+++ b/sonda/src/test_cmd.rs
@@ -1,27 +1,49 @@
 //! `sonda test` — run a scenario and verify its `expect:` alert expectations.
 //!
-//! Orchestration and rendering only: a poller thread records timestamped
-//! [`Observation`]s of the Prometheus `ALERTS` metric while the scenario
-//! runs through the exact same machinery as `sonda run`; every deadline
-//! decision is made by `sonda_core::verify::evaluator` over those
-//! timelines. Firing deadlines are measured from scenario start, resolution
-//! deadlines from scenario end. The process exits non-zero when any
-//! expectation fails — `sonda test` in CI turns alert rules into a test
-//! suite.
+//! Orchestration and rendering only: every deadline decision is made by
+//! `sonda_core::verify::evaluator` over [`Observation`] timelines. Two
+//! acquisition layers feed it:
+//!
+//! - **Live polling** (instant queries) runs while the scenario does and
+//!   only decides *when each check has settled* — firing observed, resolved,
+//!   or deadline covered.
+//! - **Range queries** then reconstruct the verdict timeline from the
+//!   samples the rule evaluator actually stored, at rule-evaluation
+//!   resolution — so verdicts are not quantized by the poll interval or
+//!   skewed by time spent polling other expectations. When range
+//!   acquisition fails or disagrees with what live polling saw (remote-
+//!   write lag), the live timeline is the warned-about fallback.
+//!
+//! Firing deadlines are measured from scenario start, resolution deadlines
+//! from scenario end. The process exits non-zero when any expectation
+//! fails — `sonda test` in CI turns alert rules into a test suite.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, Context};
 use owo_colors::{OwoColorize, Stream::Stderr};
 use sonda_core::verify::evaluator::{evaluate_firing, evaluate_resolution, Observation, Outcome};
 use sonda_core::verify::prometheus::PrometheusClient;
-use sonda_core::verify::{parse_expectations, AlertState, ExpectConfig};
+use sonda_core::verify::{foreign_label_values, parse_expectations, AlertState, ExpectConfig};
 use sonda_core::CancellationToken;
 
 use crate::cli::{self, Cli, Verbosity};
+
+/// Which check a verdict timeline is being acquired for — determines what
+/// "the range data is missing something live polling saw" means.
+#[derive(Clone, Copy)]
+enum Check {
+    Firing,
+    Resolution,
+}
+
+/// Per-expectation live resolution polling result: `None` when the check
+/// doesn't apply, otherwise the deadline and the recorded timeline.
+type ResolutionPoll = Option<(Duration, Vec<Observation>)>;
 
 pub fn run(
     rt: &tokio::runtime::Runtime,
@@ -43,6 +65,11 @@ pub fn run(
         .map_err(|e| anyhow::anyhow!("invalid --interval: {e}"))?;
     let query_timeout = sonda_core::config::validate::parse_duration(&args.query_timeout)
         .map_err(|e| anyhow::anyhow!("invalid --query-timeout: {e}"))?;
+    let query_step = sonda_core::config::validate::parse_duration(&args.query_step)
+        .map_err(|e| anyhow::anyhow!("invalid --query-step: {e}"))?;
+    if query_step.is_zero() {
+        bail!("--query-step must be positive");
+    }
 
     // --dry-run validates and prints the scenario without emitting or
     // polling — and therefore without needing an endpoint at all.
@@ -66,7 +93,10 @@ pub fn run(
 
     // The firing poller runs alongside the scenario. `stop` cuts it short
     // when the scenario itself fails — no point waiting out deadlines to
-    // report a sink error (review W3).
+    // report a sink error (review W3). The wall clock is captured at the
+    // same moment as the monotonic anchor: range queries speak unix time,
+    // observation timestamps speak durations-since-anchor.
+    let started_wall = SystemTime::now();
     let started_at = Instant::now();
     let stop = Arc::new(AtomicBool::new(false));
     let (timeline_tx, timeline_rx) = mpsc::channel::<Vec<Vec<Observation>>>();
@@ -90,30 +120,54 @@ pub fn run(
         return run_result;
     }
 
+    let ended_wall = started_wall + ended_at.duration_since(started_at);
     let poller_died = poller.join().is_err();
     let firing_timelines = timeline_rx.try_recv().ok();
     if cancel.is_cancelled() {
         bail!("interrupted before alert expectations could be verified");
     }
 
-    // A panicked or silent poller yields no timelines; the evaluator maps
-    // empty timelines to Undecided, and the report says why (review W4).
-    let firing_timelines =
-        firing_timelines.unwrap_or_else(|| vec![Vec::new(); expect.alerts.len()]);
+    // A panicked or silent poller yields no live timelines; range
+    // acquisition below can still recover a verdict from the datastore,
+    // and when it can't, the evaluator maps the empty timeline to
+    // Undecided and the report says why (review W4).
+    let live_firing = firing_timelines.unwrap_or_else(|| vec![Vec::new(); expect.alerts.len()]);
 
-    let firing_outcomes: Vec<Outcome> = expect
-        .alerts
-        .iter()
-        .zip(&firing_timelines)
-        .map(|(expectation, timeline)| {
-            let deadline = expectation
-                .firing_within()
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
-            Ok(evaluate_firing(timeline, deadline))
-        })
-        .collect::<anyhow::Result<_>>()?;
+    // One settling pause before the verdict queries: the rule evaluator
+    // remote-writes ALERTS on its own cadence, and the freshest samples
+    // need a beat to land.
+    std::thread::sleep(query_step.min(Duration::from_secs(5)));
+    if cancel.is_cancelled() {
+        bail!("interrupted before alert expectations could be verified");
+    }
 
-    let resolution_outcomes = check_resolutions(
+    let mut warnings: Vec<String> = Vec::new();
+    let mut matched_firing_series: Vec<BTreeMap<String, String>> = Vec::new();
+
+    let anchor_start = unix_secs(started_wall);
+    let mut firing_outcomes: Vec<Outcome> = Vec::with_capacity(expect.alerts.len());
+    for (index, expectation) in expect.alerts.iter().enumerate() {
+        if cancel.is_cancelled() {
+            bail!("interrupted before alert expectations could be verified");
+        }
+        let deadline = expectation
+            .firing_within()
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let (timeline, series) = verdict_timeline(
+            &client,
+            expectation,
+            &live_firing[index],
+            deadline,
+            anchor_start,
+            query_step,
+            Check::Firing,
+            &mut warnings,
+        );
+        matched_firing_series.extend(series);
+        firing_outcomes.push(evaluate_firing(&timeline, deadline));
+    }
+
+    let resolution_live = poll_resolutions(
         &client,
         &expect,
         &firing_outcomes,
@@ -121,6 +175,51 @@ pub fn run(
         interval,
         cancel,
     )?;
+
+    let anchor_end = unix_secs(ended_wall);
+    let mut resolution_outcomes: Vec<Option<Outcome>> = Vec::with_capacity(expect.alerts.len());
+    for (expectation, live) in expect.alerts.iter().zip(&resolution_live) {
+        if cancel.is_cancelled() {
+            bail!("interrupted during resolution checks");
+        }
+        let Some((deadline, live)) = live else {
+            resolution_outcomes.push(None);
+            continue;
+        };
+        let (timeline, series) = verdict_timeline(
+            &client,
+            expectation,
+            live,
+            *deadline,
+            anchor_end,
+            query_step,
+            Check::Resolution,
+            &mut warnings,
+        );
+        matched_firing_series.extend(series);
+        resolution_outcomes.push(Some(evaluate_resolution(&timeline, *deadline)));
+    }
+
+    // Provenance: an expectation that matched an alert carrying label
+    // values this scenario never emitted is probably under-scoped —
+    // ALERTS is global (#527 review).
+    let emitted = emitted_label_values(&args.scenario, catalog);
+    let mut foreign_seen: BTreeSet<(String, String)> = BTreeSet::new();
+    for series in &matched_firing_series {
+        for (key, value) in foreign_label_values(series, &emitted) {
+            if foreign_seen.insert((key.clone(), value.clone())) {
+                warnings.push(format!(
+                    "matched an ALERTS series with {key}=\"{value}\", which this scenario \
+                     never emits — another series may have triggered the alert; scope \
+                     `expect.labels` to something unique to this scenario"
+                ));
+            }
+        }
+    }
+
+    for warning in &warnings {
+        eprintln!("  {} {warning}", warn_marker());
+    }
 
     report(
         &expect,
@@ -130,6 +229,123 @@ pub fn run(
         started_at,
         ended_at,
     )
+}
+
+fn unix_secs(t: SystemTime) -> f64 {
+    t.duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+/// Acquire the verdict timeline for one check: a range query over the
+/// window live polling settled, falling back to the live timeline (with a
+/// warning) when the range API fails or its data lags what polling saw.
+/// Verdicts are still made only by the evaluator — this chooses *which
+/// observations* it gets, never what they mean.
+#[allow(clippy::too_many_arguments)]
+fn verdict_timeline(
+    client: &PrometheusClient,
+    expectation: &sonda_core::verify::AlertExpectation,
+    live: &[Observation],
+    deadline: Duration,
+    window_anchor: f64,
+    query_step: Duration,
+    check: Check,
+    warnings: &mut Vec<String>,
+) -> (Vec<Observation>, Vec<BTreeMap<String, String>>) {
+    const ATTEMPTS: u32 = 3;
+    let step_secs = query_step.as_secs_f64();
+    // The window ends one step past where live polling settled; a dead
+    // poller leaves no timeline, so aim one step past the deadline and let
+    // the now-clamp below decide how much of that is real.
+    let settled = live
+        .last()
+        .map(|o| o.at)
+        .unwrap_or(deadline + query_step)
+        .as_secs_f64();
+    let desired_end = window_anchor + settled + step_secs;
+
+    let mut last_error = None;
+    for attempt in 0..ATTEMPTS {
+        // Never query past now: future grid points would read as Inactive
+        // and could fabricate coverage the datastore doesn't have.
+        let end = desired_end.min(unix_secs(SystemTime::now()));
+        if end <= window_anchor {
+            break;
+        }
+        match client.range_timeline(expectation, window_anchor, end, query_step, window_anchor) {
+            Ok(timeline) => {
+                if range_covers_live(live, &timeline.observations, check) {
+                    return (timeline.observations, timeline.firing_series);
+                }
+                last_error = None;
+            }
+            Err(e) => last_error = Some(e.to_string()),
+        }
+        if attempt + 1 < ATTEMPTS {
+            std::thread::sleep(Duration::from_secs(1));
+        }
+    }
+    let reason = last_error.map_or_else(
+        || "range data lags what live polling observed".to_string(),
+        |e| format!("range query failed: {e}"),
+    );
+    warnings.push(format!(
+        "{} verdict for {} uses the live poll timeline ({reason})",
+        match check {
+            Check::Firing => "firing",
+            Check::Resolution => "resolution",
+        },
+        expectation.alert
+    ));
+    (live.to_vec(), Vec::new())
+}
+
+/// Whether the range grid reflects the decisive state live polling saw —
+/// remote-write lag can leave the freshest samples unwritten at query time.
+fn range_covers_live(live: &[Observation], range: &[Observation], check: Check) -> bool {
+    match check {
+        Check::Firing => {
+            let live_fired = live
+                .iter()
+                .any(|o| matches!(o.state, Ok(AlertState::Firing)));
+            let range_fired = range
+                .iter()
+                .any(|o| matches!(o.state, Ok(AlertState::Firing)));
+            !live_fired || range_fired
+        }
+        Check::Resolution => {
+            let live_resolved = live
+                .iter()
+                .any(|o| matches!(o.state, Ok(ref s) if !matches!(s, AlertState::Firing)));
+            let range_still_firing_at_end =
+                matches!(range.last().map(|o| &o.state), Some(Ok(AlertState::Firing)));
+            !live_resolved || !range_still_firing_at_end
+        }
+    }
+}
+
+/// Every label value the compiled scenario emits, keyed by label name.
+/// Best-effort: the scenario already compiled and ran, so a load failure
+/// here only disables provenance warnings, never the verdict.
+fn emitted_label_values(
+    scenario: &str,
+    catalog: Option<&std::path::Path>,
+) -> BTreeMap<String, BTreeSet<String>> {
+    let mut emitted: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    if let Ok(compiled) = crate::scenario_loader::load_scenario_compiled(scenario, catalog) {
+        for entry in &compiled.entries {
+            if let Some(labels) = &entry.labels {
+                for (key, value) in labels {
+                    emitted
+                        .entry(key.clone())
+                        .or_default()
+                        .insert(value.clone());
+                }
+            }
+        }
+    }
+    emitted
 }
 
 /// Confirm the endpoint answers a query for **every** expectation before
@@ -225,24 +441,26 @@ fn spawn_firing_poller(
     Ok(handle)
 }
 
-/// Poll resolution for every expectation that fired, recording query errors
-/// as observations (review W1) with timestamps captured after each query.
-/// Timestamps are relative to scenario end.
+/// Live-poll resolution for every expectation that fired, recording query
+/// errors as observations (review W1) with timestamps captured after each
+/// query, relative to scenario end. This only decides *when each check has
+/// settled* — resolved, or deadline covered; the verdict timeline comes
+/// from a range query afterwards.
 ///
 /// All pending expectations are polled in **one** loop, each settling
 /// independently against the shared `ended_at` anchor — exactly like the
 /// firing poller. Serializing them would let one expectation's wait push
 /// another's first query past its own deadline, leaving that window
 /// unobserved (round-2 review blocker).
-fn check_resolutions(
+fn poll_resolutions(
     client: &PrometheusClient,
     expect: &ExpectConfig,
     firing_outcomes: &[Outcome],
     ended_at: Instant,
     interval: Duration,
     cancel: &CancellationToken,
-) -> anyhow::Result<Vec<Option<Outcome>>> {
-    let mut timelines: Vec<Option<(Duration, Vec<Observation>)>> = expect
+) -> anyhow::Result<Vec<ResolutionPoll>> {
+    let mut timelines: Vec<ResolutionPoll> = expect
         .alerts
         .iter()
         .enumerate()
@@ -287,10 +505,7 @@ fn check_resolutions(
         }
     }
 
-    Ok(timelines
-        .into_iter()
-        .map(|entry| entry.map(|(deadline, timeline)| evaluate_resolution(&timeline, deadline)))
-        .collect())
+    Ok(timelines)
 }
 
 fn report(
@@ -307,17 +522,17 @@ fn report(
         let alert = &expectation.alert;
         match &firing[index] {
             Outcome::Pass { at } => eprintln!(
-                "  {} {alert} firing after {:.0?} (within {})",
+                "  {} {alert} firing after {} (within {})",
                 pass_marker(),
-                at,
+                fmt_after(*at),
                 expectation.firing_within
             ),
             Outcome::Late { at, .. } => {
                 failures += 1;
                 eprintln!(
-                    "  {} {alert} fired after {:.0?} — later than firing_within {}",
+                    "  {} {alert} fired after {} — later than firing_within {}",
                     fail_marker(),
-                    at,
+                    fmt_after(*at),
                     expectation.firing_within
                 );
             }
@@ -363,16 +578,16 @@ fn report(
         match &resolutions[index] {
             None => {}
             Some(Outcome::Pass { at }) => eprintln!(
-                "  {} {alert} resolved after {:.0?} (within {resolves_within} of scenario end)",
+                "  {} {alert} resolved after {} (within {resolves_within} of scenario end)",
                 pass_marker(),
-                at
+                fmt_after(*at)
             ),
             Some(Outcome::Late { at, .. }) => {
                 failures += 1;
                 eprintln!(
-                    "  {} {alert} resolved after {:.0?} — later than resolves_within {resolves_within}",
+                    "  {} {alert} resolved after {} — later than resolves_within {resolves_within}",
                     fail_marker(),
-                    at
+                    fmt_after(*at)
                 );
             }
             Some(Outcome::Missed { last_error, .. }) => {
@@ -441,12 +656,25 @@ fn error_detail(last_error: &Option<String>) -> String {
         .unwrap_or_default()
 }
 
+/// Render a transition offset; zero reads "0s", not "0ns".
+fn fmt_after(at: Duration) -> String {
+    if at.is_zero() {
+        "0s".to_string()
+    } else {
+        format!("{at:.0?}")
+    }
+}
+
 fn pass_marker() -> String {
     format!("{}", "PASS".if_supports_color(Stderr, |t| t.green()))
 }
 
 fn fail_marker() -> String {
     format!("{}", "FAIL".if_supports_color(Stderr, |t| t.red()))
+}
+
+fn warn_marker() -> String {
+    format!("{}", "WARN".if_supports_color(Stderr, |t| t.yellow()))
 }
 
 /// `sonda test` runs the scenario exactly as written — no overrides.

--- a/sonda/src/test_cmd.rs
+++ b/sonda/src/test_cmd.rs
@@ -22,12 +22,12 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{bail, Context};
 use owo_colors::{OwoColorize, Stream::Stderr};
 use sonda_core::verify::evaluator::{evaluate_firing, evaluate_resolution, Observation, Outcome};
-use sonda_core::verify::prometheus::PrometheusClient;
+use sonda_core::verify::prometheus::{PrometheusClient, ServerClock};
 use sonda_core::verify::{foreign_label_values, parse_expectations, AlertState, ExpectConfig};
 use sonda_core::CancellationToken;
 
@@ -91,6 +91,18 @@ pub fn run(
     preflight(&client, &expect, cancel)
         .with_context(|| format!("prometheus preflight against {prometheus_url} failed"))?;
 
+    // Verdict anchors must live on the *server's* clock — range samples
+    // carry server timestamps, and subtracting a local anchor from them
+    // bakes any clock skew straight into the verdicts.
+    let clock = client.server_clock().unwrap_or_else(|e| {
+        eprintln!(
+            "  {} could not measure the server clock ({e}); assuming zero offset — \
+             verdict times may be skewed by any clock difference",
+            warn_marker()
+        );
+        ServerClock::identity()
+    });
+
     // The firing poller runs alongside the scenario. `stop` cuts it short
     // when the scenario itself fails — no point waiting out deadlines to
     // report a sink error (review W3). The wall clock is captured at the
@@ -144,7 +156,7 @@ pub fn run(
     let mut warnings: Vec<String> = Vec::new();
     let mut matched_firing_series: Vec<BTreeMap<String, String>> = Vec::new();
 
-    let anchor_start = unix_secs(started_wall);
+    let anchor_start = clock.at(started_wall);
     let mut firing_outcomes: Vec<Outcome> = Vec::with_capacity(expect.alerts.len());
     for (index, expectation) in expect.alerts.iter().enumerate() {
         if cancel.is_cancelled() {
@@ -155,6 +167,7 @@ pub fn run(
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         let (timeline, series) = verdict_timeline(
             &client,
+            &clock,
             expectation,
             &live_firing[index],
             deadline,
@@ -176,7 +189,7 @@ pub fn run(
         cancel,
     )?;
 
-    let anchor_end = unix_secs(ended_wall);
+    let anchor_end = clock.at(ended_wall);
     let mut resolution_outcomes: Vec<Option<Outcome>> = Vec::with_capacity(expect.alerts.len());
     for (expectation, live) in expect.alerts.iter().zip(&resolution_live) {
         if cancel.is_cancelled() {
@@ -188,6 +201,7 @@ pub fn run(
         };
         let (timeline, series) = verdict_timeline(
             &client,
+            &clock,
             expectation,
             live,
             *deadline,
@@ -231,20 +245,16 @@ pub fn run(
     )
 }
 
-fn unix_secs(t: SystemTime) -> f64 {
-    t.duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs_f64())
-        .unwrap_or(0.0)
-}
-
 /// Acquire the verdict timeline for one check: a range query over the
 /// window live polling settled, falling back to the live timeline (with a
 /// warning) when the range API fails or its data lags what polling saw.
 /// Verdicts are still made only by the evaluator — this chooses *which
-/// observations* it gets, never what they mean.
+/// observations* it gets, never what they mean. All window arithmetic is
+/// in **server** coordinates (`window_anchor` comes from [`ServerClock`]).
 #[allow(clippy::too_many_arguments)]
 fn verdict_timeline(
     client: &PrometheusClient,
+    clock: &ServerClock,
     expectation: &sonda_core::verify::AlertExpectation,
     live: &[Observation],
     deadline: Duration,
@@ -267,9 +277,10 @@ fn verdict_timeline(
 
     let mut last_error = None;
     for attempt in 0..ATTEMPTS {
-        // Never query past now: future grid points would read as Inactive
-        // and could fabricate coverage the datastore doesn't have.
-        let end = desired_end.min(unix_secs(SystemTime::now()));
+        // Never query past the server's now: future grid points would read
+        // as Inactive and could fabricate coverage the datastore doesn't
+        // have. Local now would defeat the clamp under skew.
+        let end = desired_end.min(clock.now());
         if end <= window_anchor {
             break;
         }

--- a/sonda/tests/cli_test_cmd.rs
+++ b/sonda/tests/cli_test_cmd.rs
@@ -18,14 +18,15 @@ use tempfile::TempDir;
 const EMPTY_RESULT: &str = r#"{"status":"success","data":{"resultType":"vector","result":[]}}"#;
 const FIRING_RESULT: &str = r#"{"status":"success","data":{"resultType":"vector","result":[{"metric":{"alertname":"HighCpuUsage","alertstate":"firing"},"value":[1,"1"]}]}}"#;
 
-/// Serve scripted instant-query responses. `respond(n, request_line)` picks
-/// the body and an artificial delay for the n-th request (0-based); the raw
-/// request line carries the query, so tests with several expectations can
-/// script per-alert behavior by matching on the alert name. Each connection
-/// is handled on its own thread so a stalled response never blocks the next
-/// request. The server runs until the listener drops at test end.
+/// Serve scripted query responses. `respond(n, request_line)` picks the
+/// body and an artificial delay for the n-th request (0-based); the raw
+/// request line carries the path and query, so responders distinguish
+/// instant queries from `/api/v1/query_range` and script per-alert behavior
+/// by matching on the alert name. Each connection is handled on its own
+/// thread so a stalled response never blocks the next request. The server
+/// runs until the listener drops at test end.
 fn mock_prometheus(
-    respond: impl Fn(usize, &str) -> (&'static str, std::time::Duration) + Send + Sync + 'static,
+    respond: impl Fn(usize, &str) -> (String, std::time::Duration) + Send + Sync + 'static,
 ) -> (String, Arc<AtomicUsize>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock prometheus");
     let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
@@ -65,6 +66,96 @@ fn mock_prometheus(
 
 const NO_STALL: std::time::Duration = std::time::Duration::ZERO;
 
+/// Extract `(start, end, step)` from a `/api/v1/query_range` request line;
+/// `None` for instant queries.
+fn parse_range_params(request_line: &str) -> Option<(f64, f64, f64)> {
+    if !request_line.contains("/api/v1/query_range") {
+        return None;
+    }
+    let target = request_line.split_whitespace().nth(1)?;
+    let (_, params) = target.split_once('?')?;
+    let (mut start, mut end, mut step) = (None, None, None);
+    for pair in params.split('&') {
+        let (key, value) = pair.split_once('=')?;
+        match key {
+            "start" => start = value.parse().ok(),
+            "end" => end = value.parse().ok(),
+            "step" => step = value.parse().ok(),
+            _ => {}
+        }
+    }
+    Some((start?, end?, step?))
+}
+
+/// Build a range-query matrix body: one firing series (with `host`) whose
+/// samples cover the grid points where `unix_ts - anchor_unix` falls inside
+/// `[fire_at, resolve_at)` seconds.
+fn matrix_body(
+    start: f64,
+    end: f64,
+    step: f64,
+    anchor_unix: f64,
+    fire_at: Option<f64>,
+    resolve_at: Option<f64>,
+    host: &str,
+) -> String {
+    let mut values = Vec::new();
+    let steps = ((end - start) / step).floor() as u64;
+    for index in 0..=steps {
+        let ts = start + index as f64 * step;
+        let offset = ts - anchor_unix;
+        let firing = fire_at.is_some_and(|f| offset >= f) && resolve_at.is_none_or(|r| offset < r);
+        if firing {
+            values.push(format!("[{ts:.3},\"1\"]"));
+        }
+    }
+    if values.is_empty() {
+        return r#"{"status":"success","data":{"resultType":"matrix","result":[]}}"#.to_string();
+    }
+    format!(
+        r#"{{"status":"success","data":{{"resultType":"matrix","result":[{{"metric":{{"alertname":"HighCpuUsage","alertstate":"firing","host":"{host}"}},"values":[{}]}}]}}}}"#,
+        values.join(",")
+    )
+}
+
+/// A time-consistent fake alert: firing during `[fire_at, resolve_at)`
+/// seconds measured from the mock's first request. Instant and range
+/// queries answer from the same clock, so live polling and post-hoc range
+/// acquisition see one coherent world.
+fn alert_world(
+    fire_at: Option<f64>,
+    resolve_at: Option<f64>,
+    host: &'static str,
+) -> impl Fn(usize, &str) -> (String, std::time::Duration) + Send + Sync + 'static {
+    let anchor: Arc<std::sync::OnceLock<(std::time::Instant, f64)>> =
+        Arc::new(std::sync::OnceLock::new());
+    move |_, request_line| {
+        let (mono0, unix0) = *anchor.get_or_init(|| {
+            (
+                std::time::Instant::now(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .expect("epoch")
+                    .as_secs_f64(),
+            )
+        });
+        if let Some((start, end, step)) = parse_range_params(request_line) {
+            (
+                matrix_body(start, end, step, unix0, fire_at, resolve_at, host),
+                NO_STALL,
+            )
+        } else {
+            let offset = mono0.elapsed().as_secs_f64();
+            let firing =
+                fire_at.is_some_and(|f| offset >= f) && resolve_at.is_none_or(|r| offset < r);
+            (
+                (if firing { FIRING_RESULT } else { EMPTY_RESULT }).to_string(),
+                NO_STALL,
+            )
+        }
+    }
+}
+
 fn scenario_with_expect(expect_block: &str) -> String {
     format!(
         "version: 2
@@ -95,10 +186,9 @@ fn write_scenario(dir: &TempDir, yaml: &str) -> std::path::PathBuf {
 
 #[test]
 fn passes_when_alert_fires_and_resolves() {
-    // Firing from the first poll; inactive again once resolution polling
-    // starts (from request 3 on).
-    let (url, _hits) =
-        mock_prometheus(|n, _| (if n < 3 { FIRING_RESULT } else { EMPTY_RESULT }, NO_STALL));
+    // Firing from the first instant, resolving one second in — shortly
+    // after the 300ms scenario ends.
+    let (url, _hits) = mock_prometheus(alert_world(Some(0.0), Some(1.0), "sonda-test"));
     let dir = TempDir::new().expect("tempdir");
     let path = write_scenario(
         &dir,
@@ -115,6 +205,7 @@ fn passes_when_alert_fires_and_resolves() {
     let output = Command::new(sonda_bin())
         .args(["test", path.to_str().expect("utf8 path")])
         .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .args(["--query-step", "200ms"])
         .output()
         .expect("run sonda test");
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -133,7 +224,7 @@ fn passes_when_alert_fires_and_resolves() {
 
 #[test]
 fn fails_when_alert_never_fires() {
-    let (url, _hits) = mock_prometheus(|_, _| (EMPTY_RESULT, NO_STALL));
+    let (url, _hits) = mock_prometheus(alert_world(None, None, "sonda-test"));
     let dir = TempDir::new().expect("tempdir");
     let path = write_scenario(
         &dir,
@@ -149,6 +240,7 @@ fn fails_when_alert_never_fires() {
     let output = Command::new(sonda_bin())
         .args(["test", path.to_str().expect("utf8 path")])
         .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .args(["--query-step", "200ms"])
         .output()
         .expect("run sonda test");
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -211,16 +303,12 @@ fn dry_run_validates_without_polling() {
 
 #[test]
 fn fails_when_alert_fires_after_deadline() {
-    // Round-1 blocker 1, reproduction B: the alert eventually reports
-    // firing, but only after firing_within has passed — must be a failure,
-    // not a pass. Request 0 is the preflight (fast); the poller's first
-    // query returns inactive immediately (window coverage — without it the
-    // verdict is Undecided, not Late), then queries stall 400ms against the
-    // 200ms deadline.
-    let (url, _hits) = mock_prometheus(|n, _| match n {
-        0 | 1 => (EMPTY_RESULT, NO_STALL),
-        _ => (FIRING_RESULT, std::time::Duration::from_millis(400)),
-    });
+    // #516 round-1 blocker 1, reproduction B: the alert fires, but only
+    // after firing_within has passed — must be a failure, not a pass. The
+    // world fires at 300ms against a 200ms deadline; the range grid has
+    // pre-deadline coverage (inactive samples) and then the late firing
+    // sample, so the verdict is Late.
+    let (url, _hits) = mock_prometheus(alert_world(Some(0.3), None, "sonda-test"));
     let dir = TempDir::new().expect("tempdir");
     let path = write_scenario(
         &dir,
@@ -236,6 +324,7 @@ fn fails_when_alert_fires_after_deadline() {
     let output = Command::new(sonda_bin())
         .args(["test", path.to_str().expect("utf8 path")])
         .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .args(["--query-step", "200ms"])
         .output()
         .expect("run sonda test");
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -253,23 +342,10 @@ fn fails_when_alert_fires_after_deadline() {
 fn fails_when_second_resolution_is_delayed_past_deadline() {
     // A genuinely blown resolution deadline must be a failure: both alerts
     // stay firing until 1200ms after the first request, so MustResolveFast
-    // is observed still firing through its whole 200ms window (concurrent
-    // resolution polling covers it from scenario end — round-2 review
-    // blocker) while SlowToResolve's 4s deadline still passes. The switch
-    // is anchored on the mock's first request, not process spawn, so binary
-    // startup time doesn't skew the fixture (round-2 review M5).
-    let first_hit = Arc::new(std::sync::OnceLock::new());
-    let (url, _hits) = mock_prometheus(move |_, _| {
-        let started = *first_hit.get_or_init(std::time::Instant::now);
-        (
-            if started.elapsed() < std::time::Duration::from_millis(1200) {
-                FIRING_RESULT
-            } else {
-                EMPTY_RESULT
-            },
-            NO_STALL,
-        )
-    });
+    // is still firing through its whole 200ms window while SlowToResolve's
+    // 4s deadline passes. The world is anchored on the mock's first
+    // request, not process spawn (#527 review M5).
+    let (url, _hits) = mock_prometheus(alert_world(Some(0.0), Some(1.2), "sonda-test"));
     let dir = TempDir::new().expect("tempdir");
     let path = write_scenario(
         &dir,
@@ -289,6 +365,7 @@ fn fails_when_second_resolution_is_delayed_past_deadline() {
     let output = Command::new(sonda_bin())
         .args(["test", path.to_str().expect("utf8 path")])
         .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .args(["--query-step", "200ms"])
         .output()
         .expect("run sonda test");
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -309,23 +386,18 @@ fn fails_when_second_resolution_is_delayed_past_deadline() {
 
 #[test]
 fn parallel_resolutions_do_not_blind_each_others_windows() {
-    // Round-2 review blocker, discriminating case: SlowLane needs ~10 polls
-    // (~1s) to resolve against a 3s deadline while FastLane resolves on its
-    // very first resolution query against a 300ms one. With concurrent
-    // resolution polling both PASS. If polling regresses to sequential,
-    // SlowLane's wait pushes FastLane's first query past 300ms and the run
-    // fails — this test must go red.
-    let slow_hits = Arc::new(AtomicUsize::new(0));
-    let fast_hits = Arc::new(AtomicUsize::new(0));
-    let (url, _hits) = mock_prometheus(move |_, request_line| {
+    // #516 round-2 blocker heritage: SlowLane keeps firing for 1.5s against
+    // a 3s resolution deadline while FastLane resolves right at scenario
+    // end against a 300ms one. Both must PASS — no expectation's window may
+    // be blinded by another's wait, whether by concurrent polling or by the
+    // range-acquired verdict timelines.
+    let slow = alert_world(Some(0.0), Some(1.5), "sonda-test");
+    let fast = alert_world(Some(0.0), Some(0.4), "sonda-test");
+    let (url, _hits) = mock_prometheus(move |n, request_line| {
         if request_line.contains("SlowLane") {
-            // Hits 0 (preflight) and 1 (firing poll) must show firing; then
-            // ~10 firing resolution polls before resolving.
-            let n = slow_hits.fetch_add(1, Ordering::SeqCst);
-            (if n < 12 { FIRING_RESULT } else { EMPTY_RESULT }, NO_STALL)
+            slow(n, request_line)
         } else {
-            let n = fast_hits.fetch_add(1, Ordering::SeqCst);
-            (if n < 2 { FIRING_RESULT } else { EMPTY_RESULT }, NO_STALL)
+            fast(n, request_line)
         }
     });
     let dir = TempDir::new().expect("tempdir");
@@ -347,6 +419,7 @@ fn parallel_resolutions_do_not_blind_each_others_windows() {
     let output = Command::new(sonda_bin())
         .args(["test", path.to_str().expect("utf8 path")])
         .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .args(["--query-step", "200ms"])
         .output()
         .expect("run sonda test");
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -365,7 +438,8 @@ fn bounded_failure_when_endpoint_stalls_before_answering() {
     // Review blocker 2, reproduction C: an endpoint that accepts the
     // connection and never answers in time must produce a bounded non-zero
     // exit (preflight timeout), not a SIGINT-proof hang.
-    let (url, _hits) = mock_prometheus(|_, _| (EMPTY_RESULT, std::time::Duration::from_secs(60)));
+    let (url, _hits) =
+        mock_prometheus(|_, _| (EMPTY_RESULT.to_string(), std::time::Duration::from_secs(60)));
     let dir = TempDir::new().expect("tempdir");
     let path = write_scenario(
         &dir,
@@ -405,9 +479,9 @@ fn mid_run_stall_surfaces_query_errors_on_missed_deadline() {
     // silently passing.
     let (url, _hits) = mock_prometheus(|n, _| {
         if n == 0 {
-            (EMPTY_RESULT, NO_STALL)
+            (EMPTY_RESULT.to_string(), NO_STALL)
         } else {
-            (EMPTY_RESULT, std::time::Duration::from_secs(30))
+            (EMPTY_RESULT.to_string(), std::time::Duration::from_secs(30))
         }
     });
     let dir = TempDir::new().expect("tempdir");
@@ -427,6 +501,7 @@ fn mid_run_stall_surfaces_query_errors_on_missed_deadline() {
         .args(["test", path.to_str().expect("utf8 path")])
         .args(["--prometheus-url", &url])
         .args(["--interval", "100ms", "--query-timeout", "300ms"])
+        .args(["--query-step", "300ms"])
         .output()
         .expect("run sonda test");
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -438,6 +513,99 @@ fn mid_run_stall_surfaces_query_errors_on_missed_deadline() {
     );
     assert!(
         stderr.contains("did not fire within 600ms") && stderr.contains("last query error"),
+        "stderr: {stderr}"
+    );
+    // With the range API also stalled, the verdict falls back to the live
+    // poll timeline — and says so.
+    assert!(
+        stderr.contains("uses the live poll timeline"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn firing_verdict_uses_sample_time_not_poll_time() {
+    // The range-acquisition contract: transition times come from the stored
+    // samples, not from when polling happened to look. The alert fires at
+    // 300ms against a 1s deadline, but the live poll interval is a huge 2s
+    // — poll-based verdicts would see the firing at ~2s and call it Late.
+    // The range grid shows the 400ms sample, so this must PASS. Goes red if
+    // verdicts revert to the poll timeline.
+    let (url, _hits) = mock_prometheus(alert_world(Some(0.3), None, "sonda-test"));
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 1s
+",
+        ),
+    );
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url, "--interval", "2s"])
+        .args(["--query-step", "200ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "sample-time verdict must pass despite the coarse poll interval\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("firing after 400ms (within 1s)"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn warns_when_matched_series_carries_foreign_label_values() {
+    // #527 review, W2 follow-up: ALERTS is global, so an expectation can
+    // match an alert another series caused. When the matched firing series
+    // carries a label value the scenario never emits, say so.
+    let (url, _hits) = mock_prometheus(alert_world(Some(0.0), None, "intruder-host"));
+    let dir = TempDir::new().expect("tempdir");
+    let yaml = "version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 300ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: memory
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 95.0
+    labels:
+      host: sonda-test
+expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 5s
+";
+    let path = write_scenario(&dir, yaml);
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .args(["--query-step", "200ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // The firing check itself passes — the warning is advisory.
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("WARN")
+            && stderr.contains("host=\"intruder-host\"")
+            && stderr.contains("scope `expect.labels`"),
         "stderr: {stderr}"
     );
 }
@@ -503,7 +671,7 @@ fn failed_scenario_reports_immediately_without_waiting_out_deadlines() {
     // Review W3: a scenario that dies at launch (unreachable TCP sink) must
     // surface its own error promptly instead of blocking behind a long
     // firing_within.
-    let (url, _hits) = mock_prometheus(|_, _| (EMPTY_RESULT, NO_STALL));
+    let (url, _hits) = mock_prometheus(|_, _| (EMPTY_RESULT.to_string(), NO_STALL));
     let dir = TempDir::new().expect("tempdir");
     let yaml = "version: 2
 kind: runnable

--- a/sonda/tests/cli_test_cmd.rs
+++ b/sonda/tests/cli_test_cmd.rs
@@ -127,10 +127,25 @@ fn alert_world(
     resolve_at: Option<f64>,
     host: &'static str,
 ) -> impl Fn(usize, &str) -> (String, std::time::Duration) + Send + Sync + 'static {
+    skewed_alert_world(fire_at, resolve_at, host, 0.0)
+}
+
+/// [`alert_world`] whose *server clock* runs `skew` seconds ahead of the
+/// local one (negative = behind). `time()` queries, matrix sample
+/// timestamps, and range-window interpretation all live on that server
+/// clock; alert behaviour stays fixed relative to first contact. A world
+/// with skew is the discriminating fixture for verdict-anchor bugs: the
+/// reported transition times must not move with the skew.
+fn skewed_alert_world(
+    fire_at: Option<f64>,
+    resolve_at: Option<f64>,
+    host: &'static str,
+    skew: f64,
+) -> impl Fn(usize, &str) -> (String, std::time::Duration) + Send + Sync + 'static {
     let anchor: Arc<std::sync::OnceLock<(std::time::Instant, f64)>> =
         Arc::new(std::sync::OnceLock::new());
     move |_, request_line| {
-        let (mono0, unix0) = *anchor.get_or_init(|| {
+        let (mono0, unix0_local) = *anchor.get_or_init(|| {
             (
                 std::time::Instant::now(),
                 std::time::SystemTime::now()
@@ -139,9 +154,22 @@ fn alert_world(
                     .as_secs_f64(),
             )
         });
-        if let Some((start, end, step)) = parse_range_params(request_line) {
+        let unix0_server = unix0_local + skew;
+        if request_line.contains("query=time") {
+            let server_now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("epoch")
+                .as_secs_f64()
+                + skew;
             (
-                matrix_body(start, end, step, unix0, fire_at, resolve_at, host),
+                format!(
+                    r#"{{"status":"success","data":{{"resultType":"scalar","result":[{server_now:.3},"{server_now:.3}"]}}}}"#
+                ),
+                NO_STALL,
+            )
+        } else if let Some((start, end, step)) = parse_range_params(request_line) {
+            (
+                matrix_body(start, end, step, unix0_server, fire_at, resolve_at, host),
                 NO_STALL,
             )
         } else {
@@ -557,6 +585,79 @@ fn firing_verdict_uses_sample_time_not_poll_time() {
     );
     assert!(
         stderr.contains("firing after 400ms (within 1s)"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn verdicts_survive_a_server_clock_running_ahead() {
+    // #528 review blocker, direction 1: the server's clock is 1s ahead of
+    // the local one. The alert fires 400ms in (real time) against a 1s
+    // deadline — a clear pass. A local-anchored conversion would read the
+    // firing sample as landing at 1.4s and flip the verdict to Late.
+    let (url, _hits) = mock_prometheus(skewed_alert_world(Some(0.3), None, "sonda-test", 1.0));
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 1s
+",
+        ),
+    );
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .args(["--query-step", "200ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "server-clock skew must not move the verdict\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("firing after 400ms (within 1s)"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn verdicts_survive_a_server_clock_running_behind() {
+    // #528 review blocker, direction 2 — the dangerous one: the server's
+    // clock is 1.5s behind. The alert fires at 2s (real time) against a 1s
+    // deadline, so FAIL is the only correct verdict. A local-anchored
+    // conversion would see the firing sample at 2 - 1.5 = 0.5s and report
+    // a false PASS with the deadline apparently met.
+    let (url, _hits) = mock_prometheus(skewed_alert_world(Some(2.0), None, "sonda-test", -1.5));
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(
+        &dir,
+        &scenario_with_expect(
+            "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 1s
+",
+        ),
+    );
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .args(["--query-step", "200ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "a missed deadline must not become a pass under negative skew\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("did not fire within 1s"),
         "stderr: {stderr}"
     );
 }


### PR DESCRIPTION


## Summary

The two W2 phase-2 items both #516 review rounds demanded before `sonda-action` can ship. **Range-query acquisition**: verdicts are no longer quantized by the polling loop — live polling only decides when each check has settled, then a `/api/v1/query_range` reconstruction of the stored `ALERTS` samples becomes the verdict timeline, so reported transition times are sample times at rule-evaluation resolution. This closes the correctness root that produced wrong verdicts in both review rounds (polling only sees what it looked at, when it happened to look). **Foreign-label warning** (from the #527 review): matched firing series are compared against the labels the scenario actually emits, and a value the scenario never produced prints a WARN naming it and prescribing `expect.labels` scoping.

The evaluator is untouched — this is precisely the acquisition swap its agnostic design was built for.

Proven live against VictoriaMetrics + vmalert v1.149.0 before opening:

```
# Coarse 20s polling, verdicts still at 5s sample resolution:
sonda test examples/alert-lifecycle-test.yaml --prometheus-url http://localhost:8428 \
  --interval 20s --query-step 5s
  PASS HighCpuUsage firing after 10s (within 90s)          ← sample time, not the 20s poll grid
  PASS HighCpuUsage resolved after 0s (within 2m of scenario end)   → exit 0

# Unscoped expectation + foreign HighCpuUsage firing from host=ci-test-node:
  WARN matched an ALERTS series with host="ci-test-node", which this scenario never
       emits — another series may have triggered the alert; scope `expect.labels` ...
  PASS HighCpuUsage firing after 0s (within 90s)           ← the foreign alert, flagged

# Scoped fixture under the same contamination: clean PASS, no warning   → exit 0
```

## Changes

- `sonda-core/src/verify/prometheus.rs` — `range_timeline()`: grid reconstruction over a window (one observation per step, absent sample = Inactive, anchored timestamps), plus `parse_range_timeline` (pure, 6 new unit tests) collecting distinct firing-series label sets.
- `sonda-core/src/verify/mod.rs` — feature-free `foreign_label_values()`: series labels vs. emitted label values; only keys the scenario actually sets are compared, so rule labels (`severity`) and dynamic-label keys can't false-positive (4 unit tests).
- `sonda/src/test_cmd.rs` — live polling demoted to settle-detection; verdict timelines acquired per check with the window clamped to *now* (future grid points can never fabricate coverage), up to 3 acquisition retries when range data lags what polling saw (remote-write flush), and a warned fallback to the live timeline when the range API is unavailable. Provenance warnings rendered before the report; zero durations print `0s`.
- `sonda/src/cli.rs` — new `--query-step` flag (default `5s`; match the rule evaluation interval).
- Integration tests — the mock became a time-consistent *world* answering instant and range queries from one clock. 15 tests: all previous semantics preserved, plus `firing_verdict_uses_sample_time_not_poll_time` (2s poll interval vs 1s deadline vs 300ms firing — passes only with sample-time verdicts; goes red if verdicts revert to the poll timeline) and `warns_when_matched_series_carries_foreign_label_values`.
- Docs: `cli-flags.md` (`--query-step` + how verdicts are acquired), both crate `CLAUDE.md`s.

## Test plan

- Live vmalert round trips quoted above (coarse-poll sample-time verdict; unscoped-with-contamination warning; scoped immunity).
- `cargo test --workspace`: 2,239 passed (the 2 known root-only `sink::file` failures excepted); no-default-features: 931 passed warning-free; doc tests pass; clippy `--all-targets -D warnings` and fmt clean.
- 25 core verify unit tests; 15 CLI integration tests; `mkdocs build --strict` clean; docs-command validator 153/153.
- The Live Infra UAT rows from #527 run these paths against real vmalert on this PR's CI.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)
