### PR TITLE
docs(site): bridge the playground and the alert lab

### DIFF
--- a/docs/site/docs/javascripts/alert-lab.js
+++ b/docs/site/docs/javascripts/alert-lab.js
@@ -218,6 +218,21 @@ function boot() {
     const isCustom = el.preset.value === "custom" && customYaml !== null;
     const preset = isCustom ? null : PRESETS[Number(el.preset.value)];
     const yaml = isCustom ? customYaml : preset.yaml;
+    // Everything that doesn't need the sampled series is assigned BEFORE
+    // sampling, so a scenario that fails to sample never shows rule fields
+    // belonging to a previously selected preset next to the error banner.
+    // Only the custom threshold has to wait — it is derived from the data.
+    if (isCustom) {
+      el.op.value = ">";
+      el.threshold.value = "";
+      el.forSel.value = "6";
+      el.story.textContent = "Your scenario from the playground.";
+    } else {
+      el.op.value = preset.op;
+      el.threshold.value = String(preset.threshold);
+      el.forSel.value = String(preset.forSecs);
+      el.story.textContent = preset.story;
+    }
     // Relative to /playground/alert-lab/, the playground index is one level
     // up — "./" would point the link back at this very page.
     el.open.href = "../#yaml=" + toBase64Url(yaml);
@@ -238,20 +253,13 @@ function boot() {
     if (isCustom) {
       // No preset rule to apply — start from a threshold the signal
       // actually crosses and let the user tune from there.
-      el.op.value = ">";
       el.threshold.value = String(defaultThreshold(entry.values));
-      el.forSel.value = "6";
       const extra =
         result.entries.length > 1 ? ` (first of ${result.entries.length} series)` : "";
       el.story.textContent =
         `Your scenario from the playground — tune the threshold and for: to see when ` +
         `an alert on ${entry.name}${extra} would fire. The same expectation runs for ` +
         `real with sonda test.`;
-    } else {
-      el.op.value = preset.op;
-      el.threshold.value = String(preset.threshold);
-      el.forSel.value = String(preset.forSecs);
-      el.story.textContent = preset.story;
     }
     hideError(el);
     reevaluate();
@@ -359,17 +367,28 @@ function fromLocationHash() {
 
 /* Starting threshold for a scenario the lab has never seen: a value the
  * signal actually crosses (60% up its range), rounded to a tidy number so
- * the input reads like something a human chose. */
+ * the input reads like something a human chose. A flat series has no range
+ * to cross, so the threshold seats just below the value instead — `>`
+ * fires immediately and tuning starts from a live alert rather than one
+ * that provably cannot fire (constant scenarios are common bridge
+ * traffic). */
 function defaultThreshold(values) {
   const min = Math.min(...values);
   const max = Math.max(...values);
   if (!Number.isFinite(min) || !Number.isFinite(max)) return 1;
+  if (max - min < Math.max(1e-9, Math.abs(max) * 1e-9)) {
+    if (max === 0) return -1;
+    return tidyNumber(max > 0 ? max * 0.9 : max * 1.1);
+  }
   const mid = min + (max - min) * 0.6;
   if (mid === 0) return 0;
-  const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(mid))) - 1);
-  const rounded = Math.round(mid / magnitude) * magnitude;
-  // Guard float dust like 60.000000000000004 from the multiply.
-  return Number(rounded.toPrecision(3));
+  return tidyNumber(mid);
+}
+
+/* Round to two leading digits; guards float dust like 60.000000000000004. */
+function tidyNumber(value) {
+  const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(value))) - 1);
+  return Number((Math.round(value / magnitude) * magnitude).toPrecision(3));
 }
 
 function palette() {

--- a/docs/site/docs/javascripts/alert-lab.js
+++ b/docs/site/docs/javascripts/alert-lab.js
@@ -176,6 +176,16 @@ function boot() {
     open: document.getElementById("al-open"),
   };
 
+  // A scenario carried over from the playground (#yaml=…) becomes a
+  // synthetic first preset, selected on load — the other half of the
+  // playground's "Test an alert →" bridge.
+  const customYaml = fromLocationHash();
+  if (customYaml !== null) {
+    const option = document.createElement("option");
+    option.value = "custom";
+    option.textContent = "Your scenario (from playground)";
+    el.preset.appendChild(option);
+  }
   PRESETS.forEach((preset, index) => {
     const option = document.createElement("option");
     option.value = String(index);
@@ -205,16 +215,14 @@ function boot() {
   };
 
   const loadPreset = async () => {
-    const preset = PRESETS[Number(el.preset.value)];
-    el.op.value = preset.op;
-    el.threshold.value = String(preset.threshold);
-    el.forSel.value = String(preset.forSecs);
-    el.story.textContent = preset.story;
+    const isCustom = el.preset.value === "custom" && customYaml !== null;
+    const preset = isCustom ? null : PRESETS[Number(el.preset.value)];
+    const yaml = isCustom ? customYaml : preset.yaml;
     // Relative to /playground/alert-lab/, the playground index is one level
     // up — "./" would point the link back at this very page.
-    el.open.href = "../#yaml=" + toBase64Url(preset.yaml);
+    el.open.href = "../#yaml=" + toBase64Url(yaml);
     await ensureWasm();
-    const result = JSON.parse(sample_scenario(preset.yaml, MAX_TICKS));
+    const result = JSON.parse(sample_scenario(yaml, MAX_TICKS));
     entry = result.ok && result.entries.length ? result.entries[0] : null;
     if (!entry) {
       // Surface the engine's own message instead of a silent blank chart —
@@ -226,6 +234,24 @@ function boot() {
           : "the scenario produced no metrics entries";
       showError(el, reason || "the scenario could not be sampled");
       return;
+    }
+    if (isCustom) {
+      // No preset rule to apply — start from a threshold the signal
+      // actually crosses and let the user tune from there.
+      el.op.value = ">";
+      el.threshold.value = String(defaultThreshold(entry.values));
+      el.forSel.value = "6";
+      const extra =
+        result.entries.length > 1 ? ` (first of ${result.entries.length} series)` : "";
+      el.story.textContent =
+        `Your scenario from the playground — tune the threshold and for: to see when ` +
+        `an alert on ${entry.name}${extra} would fire. The same expectation runs for ` +
+        `real with sonda test.`;
+    } else {
+      el.op.value = preset.op;
+      el.threshold.value = String(preset.threshold);
+      el.forSel.value = String(preset.forSecs);
+      el.story.textContent = preset.story;
     }
     hideError(el);
     reevaluate();
@@ -312,6 +338,38 @@ function toBase64Url(text) {
   let binary = "";
   bytes.forEach((b) => (binary += String.fromCharCode(b)));
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(encoded) {
+  const base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(base64);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function fromLocationHash() {
+  const match = window.location.hash.match(/^#yaml=(.+)$/);
+  if (!match) return null;
+  try {
+    return fromBase64Url(match[1]);
+  } catch {
+    return null;
+  }
+}
+
+/* Starting threshold for a scenario the lab has never seen: a value the
+ * signal actually crosses (60% up its range), rounded to a tidy number so
+ * the input reads like something a human chose. */
+function defaultThreshold(values) {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return 1;
+  const mid = min + (max - min) * 0.6;
+  if (mid === 0) return 0;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(mid))) - 1);
+  const rounded = Math.round(mid / magnitude) * magnitude;
+  // Guard float dust like 60.000000000000004 from the multiply.
+  return Number(rounded.toPrecision(3));
 }
 
 function palette() {

--- a/docs/site/docs/javascripts/playground.js
+++ b/docs/site/docs/javascripts/playground.js
@@ -284,6 +284,7 @@ async function boot() {
     preset: document.getElementById("sp-preset"),
     run: document.getElementById("sp-run"),
     share: document.getElementById("sp-share"),
+    testAlert: document.getElementById("sp-test-alert"),
     status: document.getElementById("sp-status"),
     editor: document.getElementById("sp-editor"),
     error: document.getElementById("sp-error"),
@@ -308,11 +309,15 @@ async function boot() {
     el.status.textContent = "compiling…";
     try {
       await ensureWasm();
-      const result = JSON.parse(sample_scenario(editor.getValue(), MAX_TICKS));
+      const yaml = editor.getValue();
+      const result = JSON.parse(sample_scenario(yaml, MAX_TICKS));
       lastResult = result;
       render(el, result);
       editor.setEngineError(result.ok ? null : result.error);
       el.status.textContent = result.ok ? "" : "compile error";
+      // Bridge to the alert lab: carry the current scenario across so a
+      // threshold + for: rule can be tuned against this exact signal.
+      if (el.testAlert) el.testAlert.href = "alert-lab/#yaml=" + toBase64Url(yaml);
     } catch (err) {
       el.status.textContent = "engine failed to load";
       showError(el, String(err));

--- a/docs/site/docs/playground/alert-lab.md
+++ b/docs/site/docs/playground/alert-lab.md
@@ -11,7 +11,9 @@ hide:
 
 # Watch an alert fire — before you page anyone
 
-Pick a failure pattern, set a threshold and a `for:` duration, and press play.
+Pick a failure pattern — or bring your own: the playground's
+**Test an alert →** button carries whatever scenario you're editing straight
+here. Set a threshold and a `for:` duration, and press play.
 The signal comes from the real Sonda engine (the same
 [WebAssembly build](index.md) as the playground); the lane below the chart
 shows the alert state the way Prometheus would walk it:

--- a/docs/site/docs/playground/index.md
+++ b/docs/site/docs/playground/index.md
@@ -23,6 +23,7 @@ jitter, and defaults behave exactly like `sonda run`.
     <select id="sp-preset" class="sonda-playground__select" aria-label="Load a preset scenario"></select>
     <button id="sp-run" type="button" class="md-button md-button--primary sonda-playground__run">Run</button>
     <button id="sp-share" type="button" class="md-button sonda-playground__share">Copy link</button>
+    <a id="sp-test-alert" class="md-button sonda-playground__share" href="alert-lab/">Test an alert →</a>
     <span id="sp-status" class="sonda-playground__status" role="status" aria-live="polite"></span>
   </div>
   <div class="sonda-playground__grid">
@@ -67,6 +68,8 @@ Two things do not run in a browser sandbox: `csv_replay` (no filesystem — use
 [`sonda new --from`](../import/from-csv.md) locally) and log entries, which
 are compiled and validated but not visualized yet.
 
-When the shape looks right, the same YAML runs unchanged with
-[`sonda run`](../deploy/cli.md) — or straight against a
+When the shape looks right, **Test an alert →** carries the scenario into the
+[alert lab](alert-lab.md) so you can tune a threshold + `for:` rule against
+this exact signal — and the same YAML runs unchanged with
+[`sonda run`](../deploy/cli.md) or straight against a
 [real backend](../get-started/send-to-a-backend.md).


### PR DESCRIPTION


## Summary

W1 next item: the playground and the alert lab stop being separate islands. A **Test an alert →** button in the playground carries the scenario you're editing straight into the alert lab (same base64url hash mechanism as the share link, refreshed on every run). The lab reads it into a synthetic **"Your scenario (from playground)"** preset, selected on load, with a starting rule the signal actually crosses — threshold at 60% of the series range rounded to a tidy number, `for: 6s` — and a story line naming the series. *Edit this scenario in the playground* completes the round trip with the same YAML.

## Changes

- `playground.js` — `sp-test-alert` link kept pointing at `alert-lab/#yaml=<current editor content>` on every successful run.
- `alert-lab.js` — `#yaml=` hash becomes a custom preset (first option, auto-selected); auto-threshold heuristic (`defaultThreshold`: 60% up the range, magnitude-rounded, float-dust guarded); multi-series scenarios note "first of N series"; hashless behavior unchanged.
- `playground/index.md`, `playground/alert-lab.md` — the button, and prose pointing both directions (plus the `sonda test` tie-in).

## Test plan

Chromium UAT, three paths:
- **Playground → lab**: memory-leak preset carried over; custom preset auto-selected, auto-threshold 62 on the 12→96 ramp, pending→firing lane renders, FIRING chip correct (screenshot attached to the session).
- **Lab → playground**: *Edit this scenario* returns with the same series (`process_memory_percent` in the encoded output).
- **Hashless lab regression**: normal presets, first option "Link blips, then a real outage", no phantom custom entry.
- `mkdocs build --strict` clean; docs-command validator 153/153. No Rust changes.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)
