### PR TITLE
feat(site): export the tuned alert-lab rule as a sonda test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,11 @@ jobs:
       - name: Validate documented sonda commands
         run: python3 scripts/validate_docs_commands.py
 
+      # Zero-dependency node harness over the playground's pure JS helpers
+      # (sonda-pure.js) — the only automated coverage the docs-site JS has.
+      - name: Playground pure-helper tests
+        run: node docs/site/tools/tests/pure.test.mjs
+
   release-pin-check:
     name: release.yml rust-toolchain pin matches rust-toolchain.toml
     runs-on: ubuntu-latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -115,6 +115,11 @@ tasks:
       - npm install
       - npm run build
 
+  site:jstest:
+    desc: Run the playground pure-helper JS tests (node, zero dependencies)
+    cmds:
+      - node docs/site/tools/tests/pure.test.mjs
+
   # ---------------------------------------------------------------------------
   # E2E Stack
   # ---------------------------------------------------------------------------

--- a/docs/site/docs/javascripts/alert-lab.js
+++ b/docs/site/docs/javascripts/alert-lab.js
@@ -7,6 +7,13 @@
  * (inactive / pending / firing, with resolve markers).
  */
 import init, { sample_scenario } from "./sonda_wasm.js";
+import {
+  buildTestExport,
+  defaultThreshold,
+  evaluate,
+  fromBase64Url,
+  toBase64Url,
+} from "./sonda-pure.js";
 
 const MAX_TICKS = 240;
 const SWEEP_SECONDS = 11; // wall-clock length of one full playback sweep
@@ -133,31 +140,6 @@ function ensureWasm() {
   return wasmReady;
 }
 
-/* Walk the series the way a Prometheus rule walks scrape samples: pending
- * while the condition holds but hasn't lasted `for:` yet, firing once it
- * has, back to inactive (recording a resolve) when it goes false. */
-function evaluate(values, tickSecs, op, threshold, forSecs) {
-  const states = new Array(values.length);
-  const resolves = [];
-  let run = 0;
-  let wasFiring = false;
-  for (let i = 0; i < values.length; i++) {
-    const cond = op === ">" ? values[i] > threshold : values[i] < threshold;
-    if (!cond) {
-      if (wasFiring) resolves.push(i);
-      run = 0;
-      wasFiring = false;
-      states[i] = "inactive";
-    } else {
-      run += 1;
-      const heldSecs = (run - 1) * tickSecs;
-      states[i] = heldSecs >= forSecs ? "firing" : "pending";
-      wasFiring = states[i] === "firing";
-    }
-  }
-  return { states, resolves };
-}
-
 function boot() {
   const root = document.getElementById("sonda-alert-lab");
   if (!root || root.dataset.ready) return;
@@ -174,6 +156,8 @@ function boot() {
     error: document.getElementById("al-error"),
     story: document.getElementById("al-story"),
     open: document.getElementById("al-open"),
+    exportBtn: document.getElementById("al-export"),
+    exportOut: document.getElementById("al-export-out"),
   };
 
   // A scenario carried over from the playground (#yaml=…) becomes a
@@ -197,6 +181,7 @@ function boot() {
   let entry = null; // sampled series from the engine
   let evaled = null;
   let animation = 0;
+  let currentYaml = null; // the scenario source behind `entry`
 
   const currentRule = () => ({
     op: el.op.value,
@@ -218,6 +203,8 @@ function boot() {
     const isCustom = el.preset.value === "custom" && customYaml !== null;
     const preset = isCustom ? null : PRESETS[Number(el.preset.value)];
     const yaml = isCustom ? customYaml : preset.yaml;
+    currentYaml = yaml;
+    if (el.exportOut) el.exportOut.hidden = true;
     // Everything that doesn't need the sampled series is assigned BEFORE
     // sampling, so a scenario that fails to sample never shows rule fields
     // belonging to a previously selected preset next to the error banner.
@@ -303,6 +290,29 @@ function boot() {
     if (reducedMotion) reevaluate();
     else startSweep();
   });
+  if (el.exportBtn) {
+    el.exportBtn.addEventListener("click", () => {
+      if (!entry || !evaled || currentYaml === null) return;
+      const text = buildTestExport({
+        yaml: currentYaml,
+        entry,
+        rule: currentRule(),
+        evaled,
+      });
+      el.exportOut.textContent = text;
+      el.exportOut.hidden = false;
+      const done = (label) => {
+        el.exportBtn.textContent = label;
+        window.setTimeout(() => {
+          el.exportBtn.textContent = "Copy sonda test setup";
+        }, 1600);
+      };
+      navigator.clipboard.writeText(text).then(
+        () => done("Copied!"),
+        () => done("Copy below ↓")
+      );
+    });
+  }
 
   new ResizeObserver(() => {
     if (entry && evaled && !animation) {
@@ -341,20 +351,6 @@ function setStateChip(chip, state) {
   chip.className = `sonda-lab-chip sonda-lab-chip--${state}`;
 }
 
-function toBase64Url(text) {
-  const bytes = new TextEncoder().encode(text);
-  let binary = "";
-  bytes.forEach((b) => (binary += String.fromCharCode(b)));
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function fromBase64Url(encoded) {
-  const base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
-  const binary = atob(base64);
-  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
-}
-
 function fromLocationHash() {
   const match = window.location.hash.match(/^#yaml=(.+)$/);
   if (!match) return null;
@@ -363,32 +359,6 @@ function fromLocationHash() {
   } catch {
     return null;
   }
-}
-
-/* Starting threshold for a scenario the lab has never seen: a value the
- * signal actually crosses (60% up its range), rounded to a tidy number so
- * the input reads like something a human chose. A flat series has no range
- * to cross, so the threshold seats just below the value instead — `>`
- * fires immediately and tuning starts from a live alert rather than one
- * that provably cannot fire (constant scenarios are common bridge
- * traffic). */
-function defaultThreshold(values) {
-  const min = Math.min(...values);
-  const max = Math.max(...values);
-  if (!Number.isFinite(min) || !Number.isFinite(max)) return 1;
-  if (max - min < Math.max(1e-9, Math.abs(max) * 1e-9)) {
-    if (max === 0) return -1;
-    return tidyNumber(max > 0 ? max * 0.9 : max * 1.1);
-  }
-  const mid = min + (max - min) * 0.6;
-  if (mid === 0) return 0;
-  return tidyNumber(mid);
-}
-
-/* Round to two leading digits; guards float dust like 60.000000000000004. */
-function tidyNumber(value) {
-  const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(value))) - 1);
-  return Number((Math.round(value / magnitude) * magnitude).toPrecision(3));
 }
 
 function palette() {

--- a/docs/site/docs/javascripts/playground.js
+++ b/docs/site/docs/javascripts/playground.js
@@ -8,6 +8,7 @@
  * fetched only when the playground container exists.
  */
 import init, { sample_scenario } from "./sonda_wasm.js";
+import { toBase64Url, fromBase64Url } from "./sonda-pure.js";
 
 const MAX_TICKS = 240;
 const DEBOUNCE_MS = 500;
@@ -371,20 +372,6 @@ function fromLocationHash() {
   } catch {
     return null;
   }
-}
-
-function toBase64Url(text) {
-  const bytes = new TextEncoder().encode(text);
-  let binary = "";
-  bytes.forEach((b) => (binary += String.fromCharCode(b)));
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function fromBase64Url(encoded) {
-  const base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
-  const binary = atob(base64);
-  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
 }
 
 function showError(el, message) {

--- a/docs/site/docs/javascripts/sonda-pure.js
+++ b/docs/site/docs/javascripts/sonda-pure.js
@@ -75,6 +75,23 @@ export function evaluate(values, tickSecs, op, threshold, forSecs) {
   return { states, resolves };
 }
 
+/* Escape a label value for interpolation into a double-quoted context.
+ * PromQL string literals and YAML double-quoted scalars share these rules
+ * for the characters that matter here: backslash and quote must be
+ * escaped, newlines and tabs become escape sequences. Label KEYS need no
+ * treatment — they reached this code through the engine's label
+ * validation, so they match the Prometheus name charset; VALUES are
+ * arbitrary user strings and always pass through here (review #532:
+ * a numeric or empty value emitted bare breaks the generated YAML, and a
+ * quote breaks the generated PromQL). */
+export function escapeQuoted(value) {
+  return String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t");
+}
+
 /* PascalCase alert name from a metric name and a direction:
  * cpu_usage + ">" → CpuUsageHigh. */
 export function deriveAlertName(metricName, op) {
@@ -105,7 +122,7 @@ export function buildTestExport({ yaml, entry, rule, evaled }) {
   const labels = entry.labels || {};
   const labelKeys = Object.keys(labels).sort();
   const selector = labelKeys.length
-    ? `{${labelKeys.map((k) => `${k}="${labels[k]}"`).join(",")}}`
+    ? `{${labelKeys.map((k) => `${k}="${escapeQuoted(labels[k])}"`).join(",")}}`
     : "";
   const forSecs = rule.forSecs;
 
@@ -117,13 +134,18 @@ export function buildTestExport({ yaml, entry, rule, evaled }) {
     : null;
   const endsResolved = fired && evaled.states[evaled.states.length - 1] !== "firing";
 
+  // The expr is a YAML scalar containing PromQL: single-quote it at the
+  // YAML layer (apostrophes doubled, backslashes untouched) so PromQL's
+  // own escapes survive and label values with `: ` cannot break the rules
+  // file. escapeQuoted already handled the PromQL string-literal layer.
+  const expr = `${entry.name}${selector} ${rule.op} ${rule.threshold}`;
   const ruleLines = [
     "groups:",
     "  - name: sonda-lab",
     "    interval: 5s",
     "    rules:",
     `      - alert: ${alertName}`,
-    `        expr: ${entry.name}${selector} ${rule.op} ${rule.threshold}`,
+    `        expr: '${expr.replace(/'/g, "''")}'`,
     `        for: ${forSecs}s`,
     "        labels:",
     "          severity: critical",
@@ -131,7 +153,9 @@ export function buildTestExport({ yaml, entry, rule, evaled }) {
 
   const expectLines = ["expect:", "  alerts:", `    - alert: ${alertName}`, "      labels:", "        severity: critical"];
   for (const key of labelKeys) {
-    expectLines.push(`        ${key}: ${labels[key]}`);
+    // Always double-quoted: a bare numeric, boolean, `{`, `*`, colon-space
+    // or empty value is invalid (or worse, retyped) YAML.
+    expectLines.push(`        ${key}: "${escapeQuoted(labels[key])}"`);
   }
   expectLines.push(
     `      firing_within: ${firingWithin !== null ? `${firingWithin}s` : "60s # the rule never fired in the sampled preview — tune it in the lab first"}`

--- a/docs/site/docs/javascripts/sonda-pure.js
+++ b/docs/site/docs/javascripts/sonda-pure.js
@@ -1,0 +1,161 @@
+/* Sonda docs — pure helpers shared by the playground and the alert lab.
+ *
+ * Nothing in this module touches the DOM, the wasm engine, or the clock:
+ * every export is a plain function of its arguments. That is a load-bearing
+ * property — docs/site/tools/tests/pure.test.mjs imports this file in node
+ * and exercises the case tables in CI, which is the only automated coverage
+ * the playground JS has.
+ */
+
+/* URL-safe base64 for the #yaml= hash. Encodes through TextEncoder so
+ * arbitrary user-typed YAML (accents, CJK) round-trips — a naive btoa()
+ * throws on anything outside latin-1. */
+export function toBase64Url(text) {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  bytes.forEach((b) => (binary += String.fromCharCode(b)));
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function fromBase64Url(encoded) {
+  const base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(base64);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+/* Round to two leading digits; guards float dust like 60.000000000000004. */
+export function tidyNumber(value) {
+  const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(value))) - 1);
+  return Number((Math.round(value / magnitude) * magnitude).toPrecision(3));
+}
+
+/* Starting threshold for a scenario the lab has never seen: a value the
+ * signal actually crosses (60% up its range), rounded to a tidy number so
+ * the input reads like something a human chose. A flat series has no range
+ * to cross, so the threshold seats just below the value instead — `>`
+ * fires immediately and tuning starts from a live alert rather than one
+ * that provably cannot fire (constant scenarios are common bridge
+ * traffic). */
+export function defaultThreshold(values) {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return 1;
+  if (max - min < Math.max(1e-9, Math.abs(max) * 1e-9)) {
+    if (max === 0) return -1;
+    return tidyNumber(max > 0 ? max * 0.9 : max * 1.1);
+  }
+  const mid = min + (max - min) * 0.6;
+  if (mid === 0) return 0;
+  return tidyNumber(mid);
+}
+
+/* Walk the series the way a Prometheus rule walks scrape samples: pending
+ * while the condition holds but hasn't lasted `for:` yet, firing once it
+ * has, back to inactive (recording a resolve) when it goes false. */
+export function evaluate(values, tickSecs, op, threshold, forSecs) {
+  const states = new Array(values.length);
+  const resolves = [];
+  let run = 0;
+  let wasFiring = false;
+  for (let i = 0; i < values.length; i++) {
+    const cond = op === ">" ? values[i] > threshold : values[i] < threshold;
+    if (!cond) {
+      if (wasFiring) resolves.push(i);
+      run = 0;
+      wasFiring = false;
+      states[i] = "inactive";
+    } else {
+      run += 1;
+      const heldSecs = (run - 1) * tickSecs;
+      states[i] = heldSecs >= forSecs ? "firing" : "pending";
+      wasFiring = states[i] === "firing";
+    }
+  }
+  return { states, resolves };
+}
+
+/* PascalCase alert name from a metric name and a direction:
+ * cpu_usage + ">" → CpuUsageHigh. */
+export function deriveAlertName(metricName, op) {
+  const words = String(metricName)
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((w) => w[0].toUpperCase() + w.slice(1));
+  const base = words.join("") || "LabAlert";
+  const prefixed = /^[a-zA-Z]/.test(base) ? base : `Lab${base}`;
+  return prefixed + (op === ">" ? "High" : "Low");
+}
+
+/* Round a deadline up to a human-looking number of seconds. */
+export function niceDeadlineSecs(secs) {
+  const padded = secs * 1.25 + 10;
+  const steps = [15, 30, 45, 60, 90, 120, 180, 300, 600];
+  for (const step of steps) if (padded <= step) return step;
+  return Math.ceil(padded / 60) * 60;
+}
+
+/* Build the "run this for real" export: one clipboard-ready file — the
+ * scenario YAML with an appended, label-scoped `expect:` block, headed by a
+ * comment carrying the matching vmalert/Prometheus rule. Deadlines come
+ * from the evaluated preview timeline, so the exported expectation is one
+ * the tuned rule demonstrably meets. */
+export function buildTestExport({ yaml, entry, rule, evaled }) {
+  const alertName = deriveAlertName(entry.name, rule.op);
+  const labels = entry.labels || {};
+  const labelKeys = Object.keys(labels).sort();
+  const selector = labelKeys.length
+    ? `{${labelKeys.map((k) => `${k}="${labels[k]}"`).join(",")}}`
+    : "";
+  const forSecs = rule.forSecs;
+
+  const firstFiring = evaled.states.indexOf("firing");
+  const fired = firstFiring >= 0;
+  const offset = entry.offset_secs || 0;
+  const firingWithin = fired
+    ? niceDeadlineSecs(offset + firstFiring * entry.tick_secs)
+    : null;
+  const endsResolved = fired && evaled.states[evaled.states.length - 1] !== "firing";
+
+  const ruleLines = [
+    "groups:",
+    "  - name: sonda-lab",
+    "    interval: 5s",
+    "    rules:",
+    `      - alert: ${alertName}`,
+    `        expr: ${entry.name}${selector} ${rule.op} ${rule.threshold}`,
+    `        for: ${forSecs}s`,
+    "        labels:",
+    "          severity: critical",
+  ];
+
+  const expectLines = ["expect:", "  alerts:", `    - alert: ${alertName}`, "      labels:", "        severity: critical"];
+  for (const key of labelKeys) {
+    expectLines.push(`        ${key}: ${labels[key]}`);
+  }
+  expectLines.push(
+    `      firing_within: ${firingWithin !== null ? `${firingWithin}s` : "60s # the rule never fired in the sampled preview — tune it in the lab first"}`
+  );
+  if (endsResolved) {
+    expectLines.push("      resolves_within: 2m");
+  } else if (fired) {
+    expectLines.push("      # still firing when the scenario ends — resolution not asserted");
+  }
+
+  const hasExpect = /^expect:/m.test(yaml);
+  const body = hasExpect
+    ? `${yaml.trimEnd()}\n\n# NOTE: this scenario already has an expect: block — merge the one below by hand.\n${expectLines.map((l) => `# ${l}`).join("\n")}\n`
+    : `${yaml.trimEnd()}\n\n# Scope note: expect.labels pins this scenario's own labels — ALERTS is\n# global, and an unscoped expectation can match alerts other series caused.\n${expectLines.join("\n")}\n`;
+
+  return (
+    `# Generated by the Sonda alert lab — ${entry.name}${selector} ${rule.op} ${rule.threshold} for ${forSecs}s\n` +
+    `#\n` +
+    `# 1) Alert rule (vmalert / Prometheus) — add to your rules file:\n` +
+    ruleLines.map((l) => `#    ${l}`).join("\n") +
+    `\n#\n` +
+    `# 2) This file — save as lab-scenario.yaml and run:\n` +
+    `#\n` +
+    `#    sonda test lab-scenario.yaml --prometheus-url http://localhost:8428\n` +
+    `\n${body}`
+  );
+}

--- a/docs/site/docs/playground/alert-lab.md
+++ b/docs/site/docs/playground/alert-lab.md
@@ -42,6 +42,7 @@ shows the alert state the way Prometheus would walk it:
       <option value="30">30s</option>
     </select>
     <button id="al-play" type="button" class="md-button md-button--primary sonda-playground__run">Play</button>
+    <button id="al-export" type="button" class="md-button sonda-playground__share">Copy sonda test setup</button>
     <span id="al-state" class="sonda-lab-chip sonda-lab-chip--inactive" role="status" aria-live="polite">inactive</span>
   </div>
   <div id="al-error" class="sonda-playground__error" hidden></div>
@@ -49,6 +50,8 @@ shows the alert state the way Prometheus would walk it:
     aria-label="Signal chart with alert-state lane"></canvas>
   <p id="al-story" class="sonda-lab-story"></p>
   <p class="sonda-lab-open-link"><a id="al-open" href="index.md">Edit this scenario in the playground →</a></p>
+  <pre id="al-export-out" class="sonda-playground__output" hidden
+    aria-label="Generated sonda test scenario and alert rule"></pre>
   <noscript><p><strong>The alert lab needs JavaScript</strong> — it runs the Sonda engine
   in your browser via WebAssembly.</p></noscript>
 </div>
@@ -74,9 +77,13 @@ to prevent.
 
 ## Run it for real
 
-The lab simulates rule evaluation; the real thing is one config file away.
-[Alert testing](../test/alert-testing.md) walks the same patterns against a
-live Prometheus + Alertmanager stack (the repository ships a
+The lab simulates rule evaluation; the real thing is one button away.
+**Copy sonda test setup** exports the rule you just tuned as a ready-to-run
+package: the scenario YAML with a label-scoped `expect:` block appended
+(`firing_within` derived from when the rule actually fired in the preview),
+headed by the matching vmalert/Prometheus alert rule. Save it, add the rule
+to your rules file, and `sonda test` turns what you watched here into an
+exit code. [Alert testing](../test/alert-testing.md) walks the same patterns
+against a live Prometheus + Alertmanager stack (the repository ships a
 [Compose stack](../deploy/docker.md) with vmalert wired up), and
-[CI validation](../test/end-to-end-pipelines.md) turns them into exit codes
-for your pipeline.
+[CI validation](../test/end-to-end-pipelines.md) covers the pipeline side.

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -1,0 +1,188 @@
+// Node test harness for the playground's pure helpers (sonda-pure.js).
+//
+// Run: node docs/site/tools/tests/pure.test.mjs  (from the repo root; any
+// cwd works — the import is relative to this file). Zero dependencies; uses
+// node's built-in assert and exits non-zero on the first failure. Wired
+// into the docs CI workflow, this is the only automated coverage the
+// playground JS has — keep every function under test free of DOM/wasm.
+
+import assert from "node:assert/strict";
+import {
+  buildTestExport,
+  defaultThreshold,
+  deriveAlertName,
+  evaluate,
+  fromBase64Url,
+  niceDeadlineSecs,
+  toBase64Url,
+} from "../../docs/javascripts/sonda-pure.js";
+
+let passed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+  } catch (err) {
+    console.error(`FAIL ${name}`);
+    console.error(err && err.message ? err.message : err);
+    process.exit(1);
+  }
+}
+
+// --- base64url ---------------------------------------------------------
+
+test("base64url round-trips ASCII YAML", () => {
+  const yaml = "version: 2\nkind: runnable\n";
+  assert.equal(fromBase64Url(toBase64Url(yaml)), yaml);
+});
+
+test("base64url round-trips UTF-8 (accents + CJK)", () => {
+  const yaml = "labels: { service: café, region: 東京 }\n";
+  assert.equal(fromBase64Url(toBase64Url(yaml)), yaml);
+});
+
+test("base64url output is URL-safe", () => {
+  // Enough binary-ish variety to hit +, / and padding in plain base64.
+  const text = Array.from({ length: 64 }, (_, i) => String.fromCharCode(i * 3 + 1)).join("");
+  const encoded = toBase64Url(text);
+  assert.match(encoded, /^[A-Za-z0-9_-]+$/);
+  assert.equal(fromBase64Url(encoded), text);
+});
+
+// --- defaultThreshold --------------------------------------------------
+
+const range = (a, b, n = 50) => Array.from({ length: n }, (_, i) => a + ((b - a) * i) / (n - 1));
+const fires = (values, t) => values.some((v) => v > t);
+
+test("threshold is crossable across magnitudes and signs", () => {
+  for (const values of [
+    range(0, 100),
+    range(-100, -50),
+    range(-30, 30),
+    range(0.0001, 0.001),
+    range(1e9, 1e10),
+  ]) {
+    const t = defaultThreshold(values);
+    assert.ok(Number.isFinite(t));
+    assert.ok(fires(values, t), `threshold ${t} never fires`);
+    assert.ok(values.some((v) => v <= t), `threshold ${t} fires everywhere — nothing to watch`);
+  }
+});
+
+test("flat series seat the threshold below the value (review #531 W1)", () => {
+  for (const values of [Array(50).fill(42), Array(50).fill(0), Array(50).fill(-50), [7], Array(50).fill(0.005)]) {
+    const t = defaultThreshold(values);
+    assert.ok(Number.isFinite(t));
+    assert.ok(fires(values, t), `flat series with threshold ${t} must fire`);
+  }
+});
+
+test("degenerate inputs return a finite fallback", () => {
+  assert.ok(Number.isFinite(defaultThreshold([])));
+  assert.ok(Number.isFinite(defaultThreshold([NaN, NaN])));
+  assert.ok(Number.isFinite(defaultThreshold([Infinity])));
+});
+
+// --- evaluate ----------------------------------------------------------
+
+test("for: swallows short excursions, sustains long ones", () => {
+  // tick = 1s; two ticks above threshold then recovery, later six ticks.
+  const values = [0, 5, 5, 0, 0, 5, 5, 5, 5, 5, 5, 0];
+  const { states, resolves } = evaluate(values, 1, ">", 3, 3);
+  assert.equal(states[1], "pending");
+  assert.equal(states[2], "pending"); // held 1s < 3s
+  assert.equal(states[3], "inactive");
+  assert.equal(states[8], "firing"); // held 3s at index 8 (run started at 5)
+  assert.deepEqual(resolves, [11]); // resolved when it dropped while firing
+});
+
+test("for: 0 fires immediately and < operator works", () => {
+  const { states } = evaluate([5, 1, 5], 1, "<", 3, 0);
+  assert.deepEqual(states, ["inactive", "firing", "inactive"]);
+});
+
+// --- deriveAlertName / niceDeadlineSecs --------------------------------
+
+test("alert names are PascalCase with a direction suffix", () => {
+  assert.equal(deriveAlertName("cpu_usage", ">"), "CpuUsageHigh");
+  assert.equal(deriveAlertName("link_up", "<"), "LinkUpLow");
+  assert.equal(deriveAlertName("http.request-latency", ">"), "HttpRequestLatencyHigh");
+  assert.equal(deriveAlertName("", ">"), "LabAlertHigh");
+  assert.equal(deriveAlertName("9lives", ">"), "Lab9livesHigh");
+});
+
+test("deadlines round up to human numbers and never undercut the firing time", () => {
+  for (const secs of [0, 3, 20, 44, 100, 500, 1000]) {
+    const d = niceDeadlineSecs(secs);
+    assert.ok(d > secs, `deadline ${d} must exceed firing time ${secs}`);
+  }
+  assert.equal(niceDeadlineSecs(0), 15);
+  assert.equal(niceDeadlineSecs(30), 60);
+});
+
+// --- buildTestExport ---------------------------------------------------
+
+const ENTRY = {
+  name: "cpu_usage",
+  tick_secs: 0.25,
+  offset_secs: 0,
+  labels: { host: "web-01", service: "api" },
+};
+const YAML = "version: 2\nkind: runnable\nscenarios: []\n";
+
+test("export carries a label-scoped rule and expect block with derived deadlines", () => {
+  // Fires at index 80 → 20s → nice deadline 45s; ends resolved.
+  const states = Array(240).fill("inactive");
+  for (let i = 80; i < 200; i++) states[i] = "firing";
+  const out = buildTestExport({
+    yaml: YAML,
+    entry: ENTRY,
+    rule: { op: ">", threshold: 64, forSecs: 12 },
+    evaled: { states, resolves: [200] },
+  });
+  assert.match(out, /alert: CpuUsageHigh/);
+  assert.match(out, /expr: cpu_usage\{host="web-01",service="api"\} > 64/);
+  assert.match(out, /for: 12s/);
+  assert.match(out, /firing_within: 45s/);
+  assert.match(out, /resolves_within: 2m/);
+  assert.match(out, /host: web-01/); // expect.labels scoping
+  assert.match(out, /severity: critical/);
+  assert.match(out, /sonda test lab-scenario\.yaml/);
+  assert.ok(out.includes(YAML.trimEnd()), "scenario YAML embedded verbatim");
+});
+
+test("export omits resolution when still firing at the end", () => {
+  const states = Array(40).fill("inactive").concat(Array(40).fill("firing"));
+  const out = buildTestExport({
+    yaml: YAML,
+    entry: ENTRY,
+    rule: { op: ">", threshold: 64, forSecs: 12 },
+    evaled: { states, resolves: [] },
+  });
+  assert.doesNotMatch(out, /resolves_within:/);
+  assert.match(out, /resolution not asserted/);
+});
+
+test("export flags a rule that never fired instead of inventing a deadline", () => {
+  const out = buildTestExport({
+    yaml: YAML,
+    entry: ENTRY,
+    rule: { op: ">", threshold: 9999, forSecs: 12 },
+    evaled: { states: Array(80).fill("inactive"), resolves: [] },
+  });
+  assert.match(out, /never fired in the sampled preview/);
+});
+
+test("export comments the expect block when the scenario already has one", () => {
+  const out = buildTestExport({
+    yaml: "version: 2\nexpect:\n  alerts: []\n",
+    entry: ENTRY,
+    rule: { op: ">", threshold: 64, forSecs: 12 },
+    evaled: { states: Array(40).fill("firing"), resolves: [] },
+  });
+  assert.match(out, /merge the one below by hand/);
+  assert.match(out, /^# expect:/m); // our block arrives commented
+  assert.match(out, /^#\s+alerts:/m);
+});
+
+console.log(`${passed} pure-helper tests passed`);

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -11,6 +11,7 @@ import {
   buildTestExport,
   defaultThreshold,
   deriveAlertName,
+  escapeQuoted,
   evaluate,
   fromBase64Url,
   niceDeadlineSecs,
@@ -141,11 +142,11 @@ test("export carries a label-scoped rule and expect block with derived deadlines
     evaled: { states, resolves: [200] },
   });
   assert.match(out, /alert: CpuUsageHigh/);
-  assert.match(out, /expr: cpu_usage\{host="web-01",service="api"\} > 64/);
+  assert.match(out, /expr: 'cpu_usage\{host="web-01",service="api"\} > 64'/);
   assert.match(out, /for: 12s/);
   assert.match(out, /firing_within: 45s/);
   assert.match(out, /resolves_within: 2m/);
-  assert.match(out, /host: web-01/); // expect.labels scoping
+  assert.match(out, /host: "web-01"/); // expect.labels scoping, always quoted
   assert.match(out, /severity: critical/);
   assert.match(out, /sonda test lab-scenario\.yaml/);
   assert.ok(out.includes(YAML.trimEnd()), "scenario YAML embedded verbatim");
@@ -183,6 +184,56 @@ test("export comments the expect block when the scenario already has one", () =>
   assert.match(out, /merge the one below by hand/);
   assert.match(out, /^# expect:/m); // our block arrives commented
   assert.match(out, /^#\s+alerts:/m);
+});
+
+// --- label-value escaping (review #532 blocker) ------------------------
+
+test("escapeQuoted handles quotes, backslashes, and control characters", () => {
+  assert.equal(escapeQuoted('net"ops'), 'net\\"ops');
+  assert.equal(escapeQuoted("a\\b"), "a\\\\b");
+  assert.equal(escapeQuoted("a\nb"), "a\\nb");
+  assert.equal(escapeQuoted("a\tb"), "a\\tb");
+  assert.equal(escapeQuoted("plain"), "plain");
+  assert.equal(escapeQuoted(""), "");
+});
+
+test("exports stay well-formed for every hostile label value (review #532 table)", () => {
+  // The reviewer's case table: each of these, emitted bare, produced a
+  // file the export's own instructions reject — or silently-broken PromQL.
+  const nasty = {
+    quote: 'net"ops',
+    backslash: "a\\b",
+    colon_space: "a: b",
+    numeric: "12345",
+    boolish: "true",
+    brace: "{x}",
+    asterisk: "*ref",
+    newline: "a\nb",
+    empty: "",
+  };
+  const states = Array(40).fill("inactive").concat(Array(40).fill("firing"));
+  const out = buildTestExport({
+    yaml: YAML,
+    entry: { ...ENTRY, labels: nasty },
+    rule: { op: ">", threshold: 64, forSecs: 12 },
+    evaled: { states, resolves: [] },
+  });
+  // Every YAML label line is a double-quoted scalar…
+  for (const key of Object.keys(nasty)) {
+    assert.match(out, new RegExp(`^\\s+${key}: ".*"$`, "m"), `label ${key} must be quoted`);
+  }
+  // …with quotes/backslashes escaped, so the quoting cannot be broken out of.
+  assert.match(out, /quote: "net\\"ops"/);
+  assert.match(out, /backslash: "a\\\\b"/);
+  assert.match(out, /newline: "a\\nb"/);
+  assert.match(out, /empty: ""/);
+  // The PromQL matcher gets the same treatment.
+  assert.match(out, /quote="net\\"ops"/);
+  assert.match(out, /backslash="a\\\\b"/);
+  assert.match(out, /empty=""/);
+  // No label value ever lands as a raw unquoted YAML scalar.
+  assert.doesNotMatch(out, /^\s+numeric: 12345$/m);
+  assert.doesNotMatch(out, /^\s+boolish: true$/m);
 });
 
 console.log(`${passed} pure-helper tests passed`);


### PR DESCRIPTION


## Summary

Closes the loop the #531 review's product note called out: the lab said "the same expectation runs for real with `sonda test`" but left the user to hand-write both halves. A new **Copy sonda test setup** button exports the rule you just tuned as one clipboard-ready file — the scenario YAML with a **label-scoped `expect:` block** appended, headed by the matching vmalert/Prometheus alert rule as a comment block. The deadlines aren't invented: `firing_within` comes from where the tuned rule *actually fired* in the evaluated preview (rounded up to a human number), resolution is asserted only when the preview ends resolved, a never-firing rule is flagged rather than given a fake deadline, and a scenario that already carries an `expect:` block gets ours commented with a merge note.

**Proof the loop closes:** a file exported from the real browser passes `sonda --dry-run test` verbatim —

```
Validation: OK (1 scenario)
  expect: 1 alert expectation(s) parsed OK
```

with `expect.labels` correctly pinning the scenario's own labels (the #527 lesson baked into the generated output, with a scope-note comment explaining why).

Also lands the #531 review's other suggestion: the playground JS gets its first automated coverage.

## Changes

- `sonda-pure.js` (new) — the shared pure-helper module: base64url pair, `defaultThreshold`, `evaluate`, `deriveAlertName`, `niceDeadlineSecs`, and `buildTestExport`. No DOM, no wasm — import-safe in node by construction.
- `playground.js` / `alert-lab.js` — import from the shared module instead of duplicating helpers; the lab gains the export button handler (clipboard + always-visible output pane, so it works without clipboard permission).
- `alert-lab.md` — the button, the output pane, and a rewritten "Run it for real" section.
- `docs/site/tools/tests/pure.test.mjs` (new) — zero-dependency node harness, 14 tests: UTF-8/URL-safe round-trip, the reviewer's full threshold case table (incl. the flat-series regression), `for:` semantics, alert-name derivation, deadline rounding, and four export-shape cases.
- CI: the harness runs in the `docs-commands` job; `task site:jstest` locally.

## Test plan

- `node docs/site/tools/tests/pure.test.mjs` — 14/14.
- Chromium UAT: bridge the memory-leak preset over, click export → button flips to "Copied!", output pane shows the generated file; that exact browser-captured text fed to `sonda --dry-run test` validates cleanly (quoted above).
- `mkdocs build --strict` clean; docs-command validator 153/153. No Rust changes.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)
