### PR TITLE
docs(site): live generator widgets on generators.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,16 @@ jobs:
       - name: Playground pure-helper tests
         run: node docs/site/tools/tests/pure.test.mjs
 
+      # Every slider combination of the generators.md live widgets must
+      # compile — the widget presets are pure data (livegen-presets.js),
+      # and this feeds their corner/sweep grid through the binary built
+      # above. Converts the presets' "ranges are compile-safe" comment
+      # into a gate (review #534).
+      - name: Live-widget slider combinations compile
+        run: node docs/site/tools/tests/livegen-compile.mjs
+        env:
+          SONDA_BIN: ./target/release/sonda
+
   release-pin-check:
     name: release.yml rust-toolchain pin matches rust-toolchain.toml
     runs-on: ubuntu-latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -120,6 +120,12 @@ tasks:
     cmds:
       - node docs/site/tools/tests/pure.test.mjs
 
+  site:livegen-check:
+    desc: Compile every live-widget slider combination through the real engine
+    deps: [build:release]
+    cmds:
+      - SONDA_BIN=./target/release/sonda node docs/site/tools/tests/livegen-compile.mjs
+
   # ---------------------------------------------------------------------------
   # E2E Stack
   # ---------------------------------------------------------------------------

--- a/docs/site/docs/build/generators.md
+++ b/docs/site/docs/build/generators.md
@@ -36,6 +36,11 @@ For [logs](#log-generators), choose `template` for synthesized messages with fie
 !!! tip "Aliases and core generators are interchangeable"
     Aliases are shortcuts. At parse time, each alias is translated into the core generators above. Use the alias when the operational meaning is clearer; use the core generator when you need a parameter the alias does not expose (for example, negative spike `magnitude` for dip testing).
 
+Charts with sliders below are **live**: they run the real engine in your browser — the same
+WebAssembly build behind the [playground](../playground/index.md) — so dragging a slider reshapes
+the actual signal Sonda would emit, and **Open in playground →** carries the tuned scenario over
+for full editing. Without JavaScript you get the static shape drawings instead.
+
 ## Metric generators
 
 ### constant
@@ -90,6 +95,8 @@ When no generator is configured, the default is `constant` with `value: 0.0`.
 ### sine
 
 ![The sine generator: a smooth wave oscillating around the offset](img/generators/sine.svg)
+
+<div class="sonda-livegen" data-gen="sine" markdown="0"></div>
 
 Produces a sine wave that oscillates between `offset - amplitude` and `offset + amplitude`.
 
@@ -323,6 +330,8 @@ request_count{instance="web-01",job="app"} 4 1775192672943
 
 ![The spike generator: a steady baseline with short periodic spikes](img/generators/spike.svg)
 
+<div class="sonda-livegen" data-gen="spike" markdown="0"></div>
+
 Outputs a constant baseline value with periodic spikes. During a spike window the value is `baseline + magnitude`; outside the window the value is `baseline`. Use it to test alert thresholds and anomaly detection rules that trigger on sudden value changes.
 
 | Parameter | Type | Required | Default | Description |
@@ -486,6 +495,8 @@ Aliases are shortcuts. At config load time, each alias is translated into a conc
 
 ![The steady generator: a healthy oscillation with realistic noise](img/generators/steady.svg)
 
+<div class="sonda-livegen" data-gen="steady" markdown="0"></div>
+
 Models a healthy "everything is fine" signal. Values oscillate gently around a center point with slight noise — the kind of metric you see on a server under normal load.
 
 | Parameter | Type | Default | Description |
@@ -514,6 +525,8 @@ Values oscillate between 63 and 87 (75 +/- 10, plus up to +/- 2 noise) on a 60-s
 ### flap
 
 ![The flap generator: a square wave alternating between up and down states](img/generators/flap.svg)
+
+<div class="sonda-livegen" data-gen="flap" markdown="0"></div>
 
 Models a binary signal toggling between two states — an interface going up and down, a service alternating between healthy and unhealthy.
 
@@ -572,6 +585,8 @@ generator:
 
 ![The saturation generator: a resource filling to its ceiling and resetting, repeatedly](img/generators/saturation.svg)
 
+<div class="sonda-livegen" data-gen="saturation" markdown="0"></div>
+
 Models a resource that fills up and resets on a repeating cycle — disk usage growing between log rotations, a buffer draining when a consumer catches up.
 
 | Parameter | Type | Default | Description |
@@ -593,6 +608,8 @@ Values ramp linearly from 20 to 95 over 5 minutes, then reset to 20 and repeat.
 ### leak
 
 ![The leak generator: a one-way climb from baseline to ceiling](img/generators/leak.svg)
+
+<div class="sonda-livegen" data-gen="leak" markdown="0"></div>
 
 Models a resource growing toward a ceiling without ever resetting — a memory leak, a connection pool that never releases, a queue that fills but never drains.
 
@@ -619,6 +636,8 @@ Values ramp linearly from 40 to 95 over 120 seconds with no reset.
 
 ![The degradation generator: a noisy upward drift from baseline toward the ceiling](img/generators/degradation.svg)
 
+<div class="sonda-livegen" data-gen="degradation" markdown="0"></div>
+
 Models gradual performance loss with realistic noise — latency increasing over time, error rates rising, throughput dropping.
 
 | Parameter | Type | Default | Description |
@@ -644,6 +663,8 @@ Values ramp from 50ms to 500ms over 60 seconds with +/- 20ms of noise on each ti
 ### spike_event
 
 ![The spike_event generator: a quiet baseline interrupted by brief high plateaus](img/generators/spike_event.svg)
+
+<div class="sonda-livegen" data-gen="spike_event" markdown="0"></div>
 
 Models periodic anomalous bursts above a baseline — CPU spikes, sudden request surges, momentary error floods.
 

--- a/docs/site/docs/javascripts/livegen-presets.js
+++ b/docs/site/docs/javascripts/livegen-presets.js
@@ -1,0 +1,214 @@
+/* Sonda docs — live generator widget presets (pure).
+ *
+ * Data + template functions only: no DOM, no wasm, no I/O — the same
+ * load-bearing property as sonda-pure.js, and for the same reason
+ * (review #534 W1): docs/site/tools/tests/pure.test.mjs pins the preset
+ * invariants in CI, and docs/site/tools/tests/livegen-compile.mjs runs
+ * every slider-corner combination through the real compiler. livegen.js
+ * imports this module and owns everything browser-shaped.
+ *
+ * Each widget declares `rate` and `durationSecs` as data so constraints
+ * that reference the scenario duration can be derived instead of
+ * hand-synchronized: the leak widget's time_to_ceiling floor IS the
+ * duration (the engine rejects a leak that resets mid-run), not a number
+ * that happens to match one inside a template string. Slider ranges are
+ * chosen so every combination compiles — baseline/ceiling ranges are
+ * disjoint where both exist — and the compile gate proves it on every CI
+ * run rather than trusting this comment.
+ */
+
+function head(rate, durationSecs) {
+  return `version: 2
+kind: runnable
+defaults:
+  rate: ${rate}
+  duration: ${durationSecs}s
+  encoder: { type: prometheus_text }
+  sink: { type: stdout }
+scenarios:`;
+}
+
+const LEAK_DURATION_SECS = 120;
+
+export const WIDGETS = {
+  sine: {
+    rate: 4,
+    durationSecs: 60,
+    sliders: [
+      { key: "amplitude", min: 0, max: 60, step: 1, value: 30 },
+      { key: "period_secs", min: 5, max: 60, step: 1, value: 20, unit: "s" },
+      { key: "offset", min: 0, max: 100, step: 1, value: 55 },
+    ],
+    yaml(p) {
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: cpu_usage
+    generator: { type: sine, amplitude: ${p.amplitude}, offset: ${p.offset}, period_secs: ${p.period_secs} }
+`;
+    },
+  },
+  spike: {
+    rate: 4,
+    durationSecs: 60,
+    sliders: [
+      { key: "baseline", min: 0, max: 100, step: 1, value: 10 },
+      { key: "magnitude", min: -80, max: 80, step: 1, value: 40 },
+      { key: "interval_secs", min: 5, max: 30, step: 1, value: 10, unit: "s" },
+    ],
+    yaml(p) {
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: http_errors_total
+    generator: { type: spike, baseline: ${p.baseline}, magnitude: ${p.magnitude}, duration_secs: 3, interval_secs: ${p.interval_secs} }
+`;
+    },
+  },
+  steady: {
+    rate: 4,
+    durationSecs: 60,
+    sliders: [
+      { key: "center", min: 0, max: 100, step: 1, value: 50 },
+      { key: "amplitude", min: 0, max: 30, step: 1, value: 8 },
+      { key: "noise", min: 0, max: 10, step: 0.5, value: 2.5 },
+    ],
+    yaml(p) {
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: cpu_usage
+    generator: { type: steady, center: ${p.center}, amplitude: ${p.amplitude}, period: 30s, noise: ${p.noise}, noise_seed: 7 }
+`;
+    },
+  },
+  flap: {
+    rate: 2,
+    durationSecs: 120,
+    sliders: [
+      { key: "up_duration", min: 5, max: 60, step: 1, value: 20, unit: "s" },
+      { key: "down_duration", min: 2, max: 30, step: 1, value: 8, unit: "s" },
+    ],
+    yaml(p) {
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: interface_up
+    generator: { type: flap, up_duration: ${p.up_duration}s, down_duration: ${p.down_duration}s }
+`;
+    },
+  },
+  saturation: {
+    rate: 2,
+    durationSecs: 120,
+    sliders: [
+      { key: "baseline", min: 0, max: 15, step: 1, value: 5 },
+      { key: "ceiling", min: 40, max: 100, step: 1, value: 95 },
+      { key: "time_to_saturate", min: 10, max: 120, step: 5, value: 40, unit: "s" },
+    ],
+    yaml(p) {
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: queue_fill_percent
+    generator: { type: saturation, baseline: ${p.baseline}, ceiling: ${p.ceiling}, time_to_saturate: ${p.time_to_saturate}s }
+`;
+    },
+  },
+  leak: {
+    rate: 2,
+    durationSecs: LEAK_DURATION_SECS,
+    sliders: [
+      { key: "baseline", min: 0, max: 40, step: 1, value: 10 },
+      { key: "ceiling", min: 50, max: 100, step: 1, value: 95 },
+      // The floor is the scenario duration by construction, not by
+      // coincidence: the engine requires time_to_ceiling >= duration.
+      { key: "time_to_ceiling", min: LEAK_DURATION_SECS, max: 600, step: 10, value: LEAK_DURATION_SECS, unit: "s" },
+    ],
+    yaml(p) {
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: process_memory_percent
+    generator: { type: leak, baseline: ${p.baseline}, ceiling: ${p.ceiling}, time_to_ceiling: ${p.time_to_ceiling}s }
+`;
+    },
+  },
+  degradation: {
+    rate: 4,
+    durationSecs: 60,
+    sliders: [
+      { key: "ceiling", min: 10, max: 100, step: 1, value: 60 },
+      { key: "time_to_degrade", min: 20, max: 120, step: 5, value: 60, unit: "s" },
+      { key: "noise", min: 0, max: 10, step: 0.5, value: 3 },
+    ],
+    yaml(p) {
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: request_latency_ms
+    generator: { type: degradation, baseline: 5, ceiling: ${p.ceiling}, time_to_degrade: ${p.time_to_degrade}s, noise: ${p.noise}, noise_seed: 42 }
+`;
+    },
+  },
+  spike_event: {
+    rate: 2,
+    durationSecs: 120,
+    sliders: [
+      { key: "baseline", min: 0, max: 100, step: 1, value: 35 },
+      { key: "spike_height", min: 10, max: 100, step: 1, value: 60 },
+      { key: "spike_interval", min: 15, max: 60, step: 1, value: 30, unit: "s" },
+    ],
+    yaml(p) {
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: cpu_usage
+    generator: { type: spike_event, baseline: ${p.baseline}, spike_height: ${p.spike_height}, spike_duration: 10s, spike_interval: ${p.spike_interval}s }
+`;
+    },
+  },
+};
+
+/* Default parameter values for a widget, keyed by slider. */
+export function defaultParams(widget) {
+  const params = {};
+  for (const slider of widget.sliders) params[slider.key] = slider.value;
+  return params;
+}
+
+/* Every {min, default, max} combination of a widget's sliders (up to 3^n
+ * objects — duplicate points per slider are deduped). This is the base set
+ * the compile gate feeds through the real engine: the documented
+ * constraints are linear in each parameter, so the range edges are the
+ * binding cases, and the default row is what every reader actually sees. */
+export function cornerParams(widget) {
+  let corners = [{}];
+  for (const slider of widget.sliders) {
+    const points = [...new Set([slider.min, slider.value, slider.max])];
+    corners = corners.flatMap((corner) => points.map((v) => ({ ...corner, [slider.key]: v })));
+  }
+  return corners;
+}
+
+/* Full sweep of one slider (every step) crossed with the min/max corners
+ * of the remaining sliders — used by the compile gate for the
+ * duration-coupled sliders, where "the corners pass" deserves a
+ * every-step check along the axis under the worst neighbors. */
+export function sweepParams(widget, key) {
+  const slider = widget.sliders.find((s) => s.key === key);
+  if (!slider) return [];
+  let others = [{}];
+  for (const other of widget.sliders) {
+    if (other.key === key) continue;
+    others = others.flatMap((corner) => [
+      { ...corner, [other.key]: other.min },
+      { ...corner, [other.key]: other.max },
+    ]);
+  }
+  const sweeps = [];
+  for (let v = slider.min; v <= slider.max; v += slider.step) {
+    for (const corner of others) sweeps.push({ ...corner, [key]: v });
+  }
+  return sweeps;
+}

--- a/docs/site/docs/javascripts/livegen.js
+++ b/docs/site/docs/javascripts/livegen.js
@@ -11,132 +11,10 @@
  */
 import init, { sample_scenario } from "./sonda_wasm.js";
 import { toBase64Url } from "./sonda-pure.js";
+import { WIDGETS, defaultParams } from "./livegen-presets.js";
 
 const MAX_TICKS = 240;
 const DEBOUNCE_MS = 150;
-
-/* One preset per widget. `yaml(params)` must produce a single-entry runnable
- * scenario; slider ranges are chosen so every combination compiles (e.g. the
- * leak widget keeps time_to_ceiling >= duration, and baseline/ceiling ranges
- * never cross). */
-const WIDGETS = {
-  sine: {
-    sliders: [
-      { key: "amplitude", min: 0, max: 60, step: 1, value: 30 },
-      { key: "period_secs", min: 5, max: 60, step: 1, value: 20, unit: "s" },
-      { key: "offset", min: 0, max: 100, step: 1, value: 55 },
-    ],
-    yaml: (p) => `${HEAD(4, "60s")}
-  - id: live
-    signal_type: metrics
-    name: cpu_usage
-    generator: { type: sine, amplitude: ${p.amplitude}, offset: ${p.offset}, period_secs: ${p.period_secs} }
-`,
-  },
-  spike: {
-    sliders: [
-      { key: "baseline", min: 0, max: 100, step: 1, value: 10 },
-      { key: "magnitude", min: -80, max: 80, step: 1, value: 40 },
-      { key: "interval_secs", min: 5, max: 30, step: 1, value: 10, unit: "s" },
-    ],
-    yaml: (p) => `${HEAD(4, "60s")}
-  - id: live
-    signal_type: metrics
-    name: http_errors_total
-    generator: { type: spike, baseline: ${p.baseline}, magnitude: ${p.magnitude}, duration_secs: 3, interval_secs: ${p.interval_secs} }
-`,
-  },
-  steady: {
-    sliders: [
-      { key: "center", min: 0, max: 100, step: 1, value: 50 },
-      { key: "amplitude", min: 0, max: 30, step: 1, value: 8 },
-      { key: "noise", min: 0, max: 10, step: 0.5, value: 2.5 },
-    ],
-    yaml: (p) => `${HEAD(4, "60s")}
-  - id: live
-    signal_type: metrics
-    name: cpu_usage
-    generator: { type: steady, center: ${p.center}, amplitude: ${p.amplitude}, period: 30s, noise: ${p.noise}, noise_seed: 7 }
-`,
-  },
-  flap: {
-    sliders: [
-      { key: "up_duration", min: 5, max: 60, step: 1, value: 20, unit: "s" },
-      { key: "down_duration", min: 2, max: 30, step: 1, value: 8, unit: "s" },
-    ],
-    yaml: (p) => `${HEAD(2, "120s")}
-  - id: live
-    signal_type: metrics
-    name: interface_up
-    generator: { type: flap, up_duration: ${p.up_duration}s, down_duration: ${p.down_duration}s }
-`,
-  },
-  saturation: {
-    sliders: [
-      { key: "baseline", min: 0, max: 15, step: 1, value: 5 },
-      { key: "ceiling", min: 40, max: 100, step: 1, value: 95 },
-      { key: "time_to_saturate", min: 10, max: 120, step: 5, value: 40, unit: "s" },
-    ],
-    yaml: (p) => `${HEAD(2, "120s")}
-  - id: live
-    signal_type: metrics
-    name: queue_fill_percent
-    generator: { type: saturation, baseline: ${p.baseline}, ceiling: ${p.ceiling}, time_to_saturate: ${p.time_to_saturate}s }
-`,
-  },
-  leak: {
-    sliders: [
-      { key: "baseline", min: 0, max: 40, step: 1, value: 10 },
-      { key: "ceiling", min: 50, max: 100, step: 1, value: 95 },
-      // A leak must not reset mid-run: the engine requires
-      // time_to_ceiling >= duration, so the slider floor is the duration.
-      { key: "time_to_ceiling", min: 120, max: 600, step: 10, value: 120, unit: "s" },
-    ],
-    yaml: (p) => `${HEAD(2, "120s")}
-  - id: live
-    signal_type: metrics
-    name: process_memory_percent
-    generator: { type: leak, baseline: ${p.baseline}, ceiling: ${p.ceiling}, time_to_ceiling: ${p.time_to_ceiling}s }
-`,
-  },
-  degradation: {
-    sliders: [
-      { key: "ceiling", min: 10, max: 100, step: 1, value: 60 },
-      { key: "time_to_degrade", min: 20, max: 120, step: 5, value: 60, unit: "s" },
-      { key: "noise", min: 0, max: 10, step: 0.5, value: 3 },
-    ],
-    yaml: (p) => `${HEAD(4, "60s")}
-  - id: live
-    signal_type: metrics
-    name: request_latency_ms
-    generator: { type: degradation, baseline: 5, ceiling: ${p.ceiling}, time_to_degrade: ${p.time_to_degrade}s, noise: ${p.noise}, noise_seed: 42 }
-`,
-  },
-  spike_event: {
-    sliders: [
-      { key: "baseline", min: 0, max: 100, step: 1, value: 35 },
-      { key: "spike_height", min: 10, max: 100, step: 1, value: 60 },
-      { key: "spike_interval", min: 15, max: 60, step: 1, value: 30, unit: "s" },
-    ],
-    yaml: (p) => `${HEAD(2, "120s")}
-  - id: live
-    signal_type: metrics
-    name: cpu_usage
-    generator: { type: spike_event, baseline: ${p.baseline}, spike_height: ${p.spike_height}, spike_duration: 10s, spike_interval: ${p.spike_interval}s }
-`,
-  },
-};
-
-function HEAD(rate, duration) {
-  return `version: 2
-kind: runnable
-defaults:
-  rate: ${rate}
-  duration: ${duration}
-  encoder: { type: prometheus_text }
-  sink: { type: stdout }
-scenarios:`;
-}
 
 let wasmReady = null;
 function ensureWasm() {
@@ -172,7 +50,7 @@ async function mount(root) {
   const preset = WIDGETS[root.dataset.gen];
   if (!preset) return;
 
-  const params = {};
+  const params = defaultParams(preset);
   const canvas = document.createElement("canvas");
   canvas.className = "sonda-livegen__chart";
   canvas.setAttribute("aria-label", `Live chart of the ${root.dataset.gen} generator`);
@@ -189,7 +67,6 @@ async function mount(root) {
   link.textContent = "Open in playground →";
 
   for (const slider of preset.sliders) {
-    params[slider.key] = slider.value;
     const row = document.createElement("label");
     row.className = "sonda-livegen__row";
     const name = document.createElement("span");

--- a/docs/site/docs/javascripts/livegen.js
+++ b/docs/site/docs/javascripts/livegen.js
@@ -1,0 +1,387 @@
+/* Sonda docs — live generator widgets.
+ *
+ * Progressive enhancement for generators.md: each `.sonda-livegen` placeholder
+ * becomes a mini-chart with parameter sliders, sampled by the same wasm engine
+ * that powers the playground (sonda_wasm.js). The static SVG above each widget
+ * is the no-JS fallback and is hidden once the live chart first renders.
+ *
+ * The wasm binary is fetched lazily — only when the first widget scrolls near
+ * the viewport — so pages without widgets (and readers who never scroll) pay
+ * nothing.
+ */
+import init, { sample_scenario } from "./sonda_wasm.js";
+import { toBase64Url } from "./sonda-pure.js";
+
+const MAX_TICKS = 240;
+const DEBOUNCE_MS = 150;
+
+/* One preset per widget. `yaml(params)` must produce a single-entry runnable
+ * scenario; slider ranges are chosen so every combination compiles (e.g. the
+ * leak widget keeps time_to_ceiling >= duration, and baseline/ceiling ranges
+ * never cross). */
+const WIDGETS = {
+  sine: {
+    sliders: [
+      { key: "amplitude", min: 0, max: 60, step: 1, value: 30 },
+      { key: "period_secs", min: 5, max: 60, step: 1, value: 20, unit: "s" },
+      { key: "offset", min: 0, max: 100, step: 1, value: 55 },
+    ],
+    yaml: (p) => `${HEAD(4, "60s")}
+  - id: live
+    signal_type: metrics
+    name: cpu_usage
+    generator: { type: sine, amplitude: ${p.amplitude}, offset: ${p.offset}, period_secs: ${p.period_secs} }
+`,
+  },
+  spike: {
+    sliders: [
+      { key: "baseline", min: 0, max: 100, step: 1, value: 10 },
+      { key: "magnitude", min: -80, max: 80, step: 1, value: 40 },
+      { key: "interval_secs", min: 5, max: 30, step: 1, value: 10, unit: "s" },
+    ],
+    yaml: (p) => `${HEAD(4, "60s")}
+  - id: live
+    signal_type: metrics
+    name: http_errors_total
+    generator: { type: spike, baseline: ${p.baseline}, magnitude: ${p.magnitude}, duration_secs: 3, interval_secs: ${p.interval_secs} }
+`,
+  },
+  steady: {
+    sliders: [
+      { key: "center", min: 0, max: 100, step: 1, value: 50 },
+      { key: "amplitude", min: 0, max: 30, step: 1, value: 8 },
+      { key: "noise", min: 0, max: 10, step: 0.5, value: 2.5 },
+    ],
+    yaml: (p) => `${HEAD(4, "60s")}
+  - id: live
+    signal_type: metrics
+    name: cpu_usage
+    generator: { type: steady, center: ${p.center}, amplitude: ${p.amplitude}, period: 30s, noise: ${p.noise}, noise_seed: 7 }
+`,
+  },
+  flap: {
+    sliders: [
+      { key: "up_duration", min: 5, max: 60, step: 1, value: 20, unit: "s" },
+      { key: "down_duration", min: 2, max: 30, step: 1, value: 8, unit: "s" },
+    ],
+    yaml: (p) => `${HEAD(2, "120s")}
+  - id: live
+    signal_type: metrics
+    name: interface_up
+    generator: { type: flap, up_duration: ${p.up_duration}s, down_duration: ${p.down_duration}s }
+`,
+  },
+  saturation: {
+    sliders: [
+      { key: "baseline", min: 0, max: 15, step: 1, value: 5 },
+      { key: "ceiling", min: 40, max: 100, step: 1, value: 95 },
+      { key: "time_to_saturate", min: 10, max: 120, step: 5, value: 40, unit: "s" },
+    ],
+    yaml: (p) => `${HEAD(2, "120s")}
+  - id: live
+    signal_type: metrics
+    name: queue_fill_percent
+    generator: { type: saturation, baseline: ${p.baseline}, ceiling: ${p.ceiling}, time_to_saturate: ${p.time_to_saturate}s }
+`,
+  },
+  leak: {
+    sliders: [
+      { key: "baseline", min: 0, max: 40, step: 1, value: 10 },
+      { key: "ceiling", min: 50, max: 100, step: 1, value: 95 },
+      // A leak must not reset mid-run: the engine requires
+      // time_to_ceiling >= duration, so the slider floor is the duration.
+      { key: "time_to_ceiling", min: 120, max: 600, step: 10, value: 120, unit: "s" },
+    ],
+    yaml: (p) => `${HEAD(2, "120s")}
+  - id: live
+    signal_type: metrics
+    name: process_memory_percent
+    generator: { type: leak, baseline: ${p.baseline}, ceiling: ${p.ceiling}, time_to_ceiling: ${p.time_to_ceiling}s }
+`,
+  },
+  degradation: {
+    sliders: [
+      { key: "ceiling", min: 10, max: 100, step: 1, value: 60 },
+      { key: "time_to_degrade", min: 20, max: 120, step: 5, value: 60, unit: "s" },
+      { key: "noise", min: 0, max: 10, step: 0.5, value: 3 },
+    ],
+    yaml: (p) => `${HEAD(4, "60s")}
+  - id: live
+    signal_type: metrics
+    name: request_latency_ms
+    generator: { type: degradation, baseline: 5, ceiling: ${p.ceiling}, time_to_degrade: ${p.time_to_degrade}s, noise: ${p.noise}, noise_seed: 42 }
+`,
+  },
+  spike_event: {
+    sliders: [
+      { key: "baseline", min: 0, max: 100, step: 1, value: 35 },
+      { key: "spike_height", min: 10, max: 100, step: 1, value: 60 },
+      { key: "spike_interval", min: 15, max: 60, step: 1, value: 30, unit: "s" },
+    ],
+    yaml: (p) => `${HEAD(2, "120s")}
+  - id: live
+    signal_type: metrics
+    name: cpu_usage
+    generator: { type: spike_event, baseline: ${p.baseline}, spike_height: ${p.spike_height}, spike_duration: 10s, spike_interval: ${p.spike_interval}s }
+`,
+  },
+};
+
+function HEAD(rate, duration) {
+  return `version: 2
+kind: runnable
+defaults:
+  rate: ${rate}
+  duration: ${duration}
+  encoder: { type: prometheus_text }
+  sink: { type: stdout }
+scenarios:`;
+}
+
+let wasmReady = null;
+function ensureWasm() {
+  if (!wasmReady) {
+    wasmReady = init({ module_or_path: new URL("./sonda_wasm_bg.wasm", import.meta.url) });
+  }
+  return wasmReady;
+}
+
+const live = new Set(); // initialized widgets, for theme redraws
+
+function boot() {
+  const placeholders = document.querySelectorAll(".sonda-livegen:not([data-ready])");
+  if (!placeholders.length) return;
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue;
+        observer.unobserve(entry.target);
+        mount(entry.target);
+      }
+    },
+    { rootMargin: "250px" }
+  );
+  placeholders.forEach((el) => {
+    el.dataset.ready = "1";
+    observer.observe(el);
+  });
+}
+
+async function mount(root) {
+  const preset = WIDGETS[root.dataset.gen];
+  if (!preset) return;
+
+  const params = {};
+  const canvas = document.createElement("canvas");
+  canvas.className = "sonda-livegen__chart";
+  canvas.setAttribute("aria-label", `Live chart of the ${root.dataset.gen} generator`);
+  const controls = document.createElement("div");
+  controls.className = "sonda-livegen__controls";
+  const error = document.createElement("p");
+  error.className = "sonda-livegen__error";
+  error.hidden = true;
+  root.append(canvas, controls, error);
+
+  let currentYaml = "";
+  const link = document.createElement("a");
+  link.className = "sonda-livegen__open";
+  link.textContent = "Open in playground →";
+
+  for (const slider of preset.sliders) {
+    params[slider.key] = slider.value;
+    const row = document.createElement("label");
+    row.className = "sonda-livegen__row";
+    const name = document.createElement("span");
+    name.className = "sonda-livegen__key";
+    name.textContent = slider.key;
+    const input = document.createElement("input");
+    input.type = "range";
+    input.min = String(slider.min);
+    input.max = String(slider.max);
+    input.step = String(slider.step);
+    input.value = String(slider.value);
+    const readout = document.createElement("span");
+    readout.className = "sonda-livegen__value";
+    const show = (v) => `${v}${slider.unit || ""}`;
+    readout.textContent = show(slider.value);
+    input.addEventListener("input", () => {
+      params[slider.key] = Number(input.value);
+      readout.textContent = show(input.value);
+      schedule();
+    });
+    row.append(name, input, readout);
+    controls.appendChild(row);
+  }
+  controls.appendChild(link);
+
+  let firstRender = true;
+  const render = async () => {
+    try {
+      await ensureWasm();
+      currentYaml = preset.yaml(params);
+      link.href = "../../playground/#yaml=" + toBase64Url(currentYaml);
+      const result = JSON.parse(sample_scenario(currentYaml, MAX_TICKS));
+      if (!result.ok) {
+        error.hidden = false;
+        error.textContent = result.error || "compile error";
+        return;
+      }
+      error.hidden = true;
+      const entry = result.entries[0];
+      root._draw = () => drawMini(canvas, entry);
+      root._draw();
+      live.add(root);
+      if (firstRender) {
+        firstRender = false;
+        hideStaticImage(root);
+      }
+    } catch (err) {
+      error.hidden = false;
+      error.textContent = String(err);
+    }
+  };
+
+  let timer = 0;
+  const schedule = () => {
+    window.clearTimeout(timer);
+    timer = window.setTimeout(render, DEBOUNCE_MS);
+  };
+
+  render();
+}
+
+/* The paragraph holding the static SVG sits directly above the widget; once
+ * the live chart is on screen the still image is redundant. Defensive walk —
+ * if the structure isn't what we expect, leave the page alone. */
+function hideStaticImage(root) {
+  let sibling = root.previousElementSibling;
+  for (let hops = 0; sibling && hops < 2; hops++) {
+    const img = sibling.querySelector && sibling.querySelector('img[src*="img/generators/"]');
+    if (img) {
+      sibling.hidden = true;
+      return;
+    }
+    sibling = sibling.previousElementSibling;
+  }
+}
+
+function palette() {
+  const dark = document.body.getAttribute("data-md-color-scheme") === "slate";
+  return {
+    grid: dark ? "rgba(148, 163, 184, 0.25)" : "rgba(100, 116, 139, 0.25)",
+    text: dark ? "#94a3b8" : "#64748b",
+    line: "#f97316",
+  };
+}
+
+function drawMini(canvas, entry) {
+  const colors = palette();
+  const dpr = window.devicePixelRatio || 1;
+  const cssWidth = canvas.parentElement.clientWidth;
+  const cssHeight = 150;
+  canvas.width = cssWidth * dpr;
+  canvas.height = cssHeight * dpr;
+  canvas.style.width = cssWidth + "px";
+  canvas.style.height = cssHeight + "px";
+  const ctx = canvas.getContext("2d");
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, cssWidth, cssHeight);
+
+  const values = entry.values;
+  if (!values.length) return;
+  const pad = { left: 42, right: 10, top: 8, bottom: 20 };
+  const plotW = cssWidth - pad.left - pad.right;
+  const plotH = cssHeight - pad.top - pad.bottom;
+
+  let min = Infinity;
+  let max = -Infinity;
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  if (!Number.isFinite(min)) return;
+  if (max - min < 1e-9) {
+    min -= 1;
+    max += 1;
+  }
+  const range = max - min;
+  min -= range * 0.1;
+  max += range * 0.1;
+
+  const x = (i) => pad.left + (i / (values.length - 1 || 1)) * plotW;
+  const y = (v) => pad.top + (1 - (v - min) / (max - min)) * plotH;
+
+  ctx.strokeStyle = colors.grid;
+  ctx.fillStyle = colors.text;
+  ctx.lineWidth = 1;
+  ctx.font = "10px ui-monospace, monospace";
+  ctx.setLineDash([2, 5]);
+  for (let row = 0; row <= 2; row++) {
+    const value = min + ((max - min) * row) / 2;
+    const gy = y(value);
+    ctx.beginPath();
+    ctx.moveTo(pad.left, gy);
+    ctx.lineTo(cssWidth - pad.right, gy);
+    ctx.stroke();
+    ctx.textAlign = "right";
+    ctx.fillText(fmt(value), pad.left - 5, gy + 3);
+  }
+  ctx.setLineDash([]);
+
+  const spanSecs = (entry.offset_secs || 0) + values.length * entry.tick_secs;
+  ctx.textAlign = "center";
+  for (let step = 0; step <= 3; step++) {
+    const secs = (spanSecs * step) / 3;
+    ctx.fillText(fmtSecs(secs), pad.left + (plotW * step) / 3, cssHeight - 6);
+  }
+
+  ctx.strokeStyle = colors.line;
+  ctx.lineWidth = 1.8;
+  ctx.lineJoin = "round";
+  ctx.beginPath();
+  values.forEach((v, i) => {
+    if (i === 0) ctx.moveTo(x(i), y(v));
+    else ctx.lineTo(x(i), y(v));
+  });
+  ctx.stroke();
+}
+
+function fmt(value) {
+  if (Math.abs(value) >= 1000) return value.toFixed(0);
+  if (Math.abs(value) >= 10) return value.toFixed(1);
+  return value.toFixed(2);
+}
+
+function fmtSecs(secs) {
+  const rounded = Math.round(secs);
+  if (rounded < 60) return `${rounded}s`;
+  const mins = Math.floor(rounded / 60);
+  const rest = rounded % 60;
+  return rest ? `${mins}m${rest}s` : `${mins}m`;
+}
+
+// Theme flips and resizes redraw every live widget from its cached samples;
+// widgets detached by instant navigation are pruned as we go.
+function redrawAll() {
+  live.forEach((root) => {
+    if (!root.isConnected) {
+      live.delete(root);
+      return;
+    }
+    if (root._draw) root._draw();
+  });
+}
+new MutationObserver(redrawAll).observe(document.body, {
+  attributes: true,
+  attributeFilter: ["data-md-color-scheme"],
+});
+window.addEventListener("resize", redrawAll);
+
+if (window.document$ && typeof window.document$.subscribe === "function") {
+  window.document$.subscribe(boot);
+} else if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", boot);
+} else {
+  boot();
+}

--- a/docs/site/docs/stylesheets/sonda.css
+++ b/docs/site/docs/stylesheets/sonda.css
@@ -965,3 +965,65 @@
   z-index: 0;
   pointer-events: none;
 }
+
+/* ---------- Live generator widgets (generators.md) ---------------------- */
+
+.sonda-livegen {
+  margin: 0.9rem 0 1.4rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  padding: 0.75rem 0.9rem 0.6rem;
+  background: var(--md-default-bg-color);
+}
+
+.sonda-livegen__chart {
+  width: 100%;
+  display: block;
+}
+
+.sonda-livegen__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem 1.4rem;
+  margin-top: 0.4rem;
+}
+
+.sonda-livegen__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.72rem;
+}
+
+.sonda-livegen__row input[type="range"] {
+  width: 8.5rem;
+  accent-color: var(--sonda-accent, #f97316);
+}
+
+.sonda-livegen__key {
+  color: var(--md-default-fg-color--light);
+}
+
+.sonda-livegen__value {
+  min-width: 3.2rem;
+  font-weight: 600;
+}
+
+.md-typeset .sonda-livegen__open {
+  margin-left: auto;
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.md-typeset .sonda-livegen__error {
+  margin: 0.5rem 0 0;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.75rem;
+  color: #dc2626;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .sonda-livegen__error {
+  color: #f87171;
+}

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -64,6 +64,8 @@ extra_javascript:
     type: module
   - path: javascripts/alert-lab.js
     type: module
+  - path: javascripts/livegen.js
+    type: module
 
 markdown_extensions:
   - abbr

--- a/docs/site/tools/tests/livegen-compile.mjs
+++ b/docs/site/tools/tests/livegen-compile.mjs
@@ -1,0 +1,58 @@
+// Compile gate for the live generator widgets (review #534 W1/M1).
+//
+// The presets module claims every slider combination compiles; this script
+// proves it against the real engine on every CI run instead of trusting the
+// comment. For each widget it feeds every min/max corner combination (the
+// documented constraints are linear per parameter, so corners are the
+// binding cases) plus a full every-step sweep of the duration-coupled
+// sliders (leak.time_to_ceiling, saturation.time_to_saturate) through
+// `sonda --dry-run run`.
+//
+// Run from the repo root after building the binary:
+//   cargo build --release -p sonda
+//   node docs/site/tools/tests/livegen-compile.mjs
+// SONDA_BIN overrides the binary path. Zero npm dependencies.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WIDGETS, cornerParams, sweepParams } from "../../docs/javascripts/livegen-presets.js";
+
+const SONDA = process.env.SONDA_BIN || "./target/release/sonda";
+const SWEEPS = [
+  ["leak", "time_to_ceiling"],
+  ["saturation", "time_to_saturate"],
+];
+
+const cases = [];
+for (const [gen, widget] of Object.entries(WIDGETS)) {
+  for (const params of cornerParams(widget)) cases.push([gen, widget, params]);
+}
+for (const [gen, key] of SWEEPS) {
+  for (const params of sweepParams(WIDGETS[gen], key)) cases.push([gen, WIDGETS[gen], params]);
+}
+
+const dir = mkdtempSync(join(tmpdir(), "livegen-"));
+let failed = 0;
+try {
+  cases.forEach(([gen, widget, params], index) => {
+    const file = join(dir, `${gen}-${index}.yaml`);
+    writeFileSync(file, widget.yaml(params));
+    try {
+      execFileSync(SONDA, ["--dry-run", "run", file], { stdio: "pipe" });
+    } catch (err) {
+      failed += 1;
+      const stderr = err.stderr ? err.stderr.toString().trim() : String(err);
+      console.error(`FAIL ${gen} ${JSON.stringify(params)}\n  ${stderr}`);
+    }
+  });
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+if (failed) {
+  console.error(`${failed}/${cases.length} slider combinations failed to compile`);
+  process.exit(1);
+}
+console.log(`${cases.length} slider combinations compile`);

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -19,6 +19,7 @@ import {
   scrubNumber,
   toBase64Url,
 } from "../../docs/javascripts/sonda-pure.js";
+import { WIDGETS, cornerParams, defaultParams, sweepParams } from "../../docs/javascripts/livegen-presets.js";
 
 let passed = 0;
 function test(name, fn) {
@@ -335,6 +336,81 @@ test("exports stay well-formed for every hostile label value (review #532 table)
   // No label value ever lands as a raw unquoted YAML scalar.
   assert.doesNotMatch(out, /^\s+numeric: 12345$/m);
   assert.doesNotMatch(out, /^\s+boolish: true$/m);
+});
+
+// --- live-widget presets (review #534 W1/M1) ----------------------------
+
+test("widget sliders are well-formed and defaults sit inside their range", () => {
+  for (const [gen, widget] of Object.entries(WIDGETS)) {
+    assert.ok(widget.sliders.length >= 2 && widget.sliders.length <= 3, `${gen}: 2-3 sliders`);
+    for (const s of widget.sliders) {
+      assert.ok(s.step > 0, `${gen}.${s.key}: positive step`);
+      assert.ok(s.min < s.max, `${gen}.${s.key}: min < max`);
+      assert.ok(s.value >= s.min && s.value <= s.max, `${gen}.${s.key}: default in range`);
+    }
+  }
+});
+
+test("baseline and ceiling ranges are disjoint wherever both exist", () => {
+  // Disjoint ranges mean no slider combination can cross them — the
+  // compile gate then only has to confirm the engine agrees.
+  for (const [gen, widget] of Object.entries(WIDGETS)) {
+    const baseline = widget.sliders.find((s) => s.key === "baseline");
+    const ceiling = widget.sliders.find((s) => s.key === "ceiling");
+    if (baseline && ceiling) {
+      assert.ok(baseline.max < ceiling.min, `${gen}: baseline range must sit below ceiling range`);
+    }
+  }
+});
+
+test("duration-coupled slider floors cover the scenario duration (review #534 M1)", () => {
+  // The engine rejects a leak that resets mid-run (time_to_ceiling must be
+  // >= duration). The floor is derived from durationSecs in the presets;
+  // this pins the derivation so retuning the template cannot silently
+  // strand the slider below its own scenario length.
+  const leak = WIDGETS.leak;
+  const ttc = leak.sliders.find((s) => s.key === "time_to_ceiling");
+  assert.ok(ttc.min >= leak.durationSecs, "leak: time_to_ceiling floor must cover the duration");
+  // And every widget's YAML really carries the duration it declares.
+  for (const [gen, widget] of Object.entries(WIDGETS)) {
+    const yaml = widget.yaml(defaultParams(widget));
+    assert.match(yaml, new RegExp(`duration: ${widget.durationSecs}s`), `${gen}: durationSecs drives the template`);
+    assert.match(yaml, new RegExp(`rate: ${widget.rate}`), `${gen}: rate drives the template`);
+  }
+});
+
+test("preset sampling stays within the playground tick budget", () => {
+  for (const [gen, widget] of Object.entries(WIDGETS)) {
+    assert.ok(widget.rate * widget.durationSecs <= 240, `${gen}: rate*duration must fit MAX_TICKS`);
+  }
+});
+
+test("corner and sweep enumeration cover what the compile gate feeds the engine", () => {
+  for (const [gen, widget] of Object.entries(WIDGETS)) {
+    const corners = cornerParams(widget);
+    const expected = widget.sliders.reduce(
+      (n, s) => n * new Set([s.min, s.value, s.max]).size,
+      1
+    );
+    assert.equal(corners.length, expected, `${gen}: {min,default,max} grid`);
+    for (const corner of corners) {
+      for (const s of widget.sliders) {
+        assert.ok(
+          [s.min, s.value, s.max].includes(corner[s.key]),
+          `${gen}: corners use range edges or the default`
+        );
+      }
+      // Every corner must produce a single-scenario YAML mentioning the type.
+      assert.match(widget.yaml(corner), /signal_type: metrics/);
+    }
+  }
+  // Sweeps walk every step of the named slider under min/max neighbors.
+  const sweep = sweepParams(WIDGETS.leak, "time_to_ceiling");
+  const steps = (600 - WIDGETS.leak.durationSecs) / 10 + 1;
+  assert.equal(sweep.length, steps * 4); // 2 other sliders, min/max each
+  assert.equal(sweep[0].time_to_ceiling, WIDGETS.leak.durationSecs);
+  assert.equal(sweep[sweep.length - 1].time_to_ceiling, 600);
+  assert.equal(sweepParams(WIDGETS.leak, "nope").length, 0);
 });
 
 console.log(`${passed} pure-helper tests passed`);


### PR DESCRIPTION

## Summary

W1 (docs-site UX): the generators reference stops being a picture book. Eight generators (`sine`, `spike`, `steady`, `flap`, `saturation`, `leak`, `degradation`, `spike_event`) get a live mini-chart with parameter sliders in place of their static SVG — dragging a slider re-samples the scenario through the same WebAssembly engine the playground uses and redraws the shape, and **Open in playground →** carries the tuned YAML over via the existing `#yaml=` hash. Static SVGs remain as the no-JS fallback, hidden only after the live chart first renders.

## Changes

- **`javascripts/livegen.js`** (new, registered site-wide as a module) — per-widget presets own the scenario template and 2–3 slider definitions. Slider ranges are chosen so **every combination compiles**: `leak`'s `time_to_ceiling` floor equals the scenario duration (the engine rejects a leak that resets mid-run), and baseline/ceiling ranges never cross. The wasm binary loads lazily via `IntersectionObserver` (250 px margin) — readers who never scroll to a widget fetch nothing, and pages without widgets bail before observing anything.
- **Mini-chart renderer** — small canvas (150 px), 3 gridlines with value labels, time axis, light/dark palettes. Theme flips and window resizes redraw every live widget from its cached samples; widgets detached by Material's instant navigation are pruned from the redraw set.
- **`generators.md`** — 8 `<div class="sonda-livegen" data-gen="…">` placeholders after the static images, plus a short prose note that slider charts are live and degrade to the static drawings without JavaScript.
- **`stylesheets/sonda.css`** — widget frame, mono slider rows, accent-colored ranges, error line.
- No Rust, no bundle changes; reuses `toBase64Url` from `sonda-pure.js` for the handoff hash.

## Test plan

- Chromium UAT against the built site:
  - all 8 widgets mount on scroll with **no engine errors** (every preset + default slider position compiles);
  - dragging `amplitude` 30 → 60 reshapes the canvas and updates the readout;
  - the static SVG paragraph hides after the first successful render (and only then);
  - **Open in playground →** lands in the playground with the tuned YAML (`amplitude: 60` carried over);
  - dark-mode redraw screenshot-verified.
- `mkdocs build --strict` clean; `node docs/site/tools/tests/pure.test.mjs` 22/22 (no helper changes — regression only).
- No Rust changes; cargo gates run in CI.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)
