### PR TITLE
feat(site): runnable YAML fences site-wide, proven by a docs compile gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,24 @@ jobs:
       - name: Validate documented sonda commands
         run: python3 scripts/validate_docs_commands.py
 
+      # Every YAML fence the docs site offers a "Run in playground" button for
+      # must actually compile, or the button is a promise the page cannot
+      # keep. Same binary as above, so every documented sink/encoder parses.
+      - name: Compile every runnable scenario fence in the docs
+        run: python3 scripts/validate_docs_scenarios.py
+
+      # The detector behind those buttons lives in JS (sonda-pure.js) and in
+      # Python (the validator above). Both answer runnable-cases.json; this
+      # proves the Python half agrees with the table the node harness pins.
+      - name: Runnable-fence detector self-tests
+        run: python3 scripts/validate_docs_scenarios.py --self-test
+
+      # No backend, no accounts — text-to-HTML injection is the one classic
+      # web risk left, and the codebase answer is a blanket rule. This is the
+      # gate that keeps it a rule rather than a convention.
+      - name: No raw-markup assignment in hand-written docs JS
+        run: bash scripts/check_no_raw_html.sh
+
       # Zero-dependency node harness over the playground's pure JS helpers
       # (sonda-pure.js) — the only automated coverage the docs-site JS has.
       - name: Playground pure-helper tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-wasm"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -126,6 +126,17 @@ tasks:
     cmds:
       - SONDA_BIN=./target/release/sonda node docs/site/tools/tests/livegen-compile.mjs
 
+  site:scenario-check:
+    desc: Compile every runnable scenario fence in the docs through the real engine
+    deps: [build:release]
+    cmds:
+      - python3 scripts/validate_docs_scenarios.py
+
+  site:no-raw-html:
+    desc: "Fail if any hand-written docs JS assigns raw markup (XSS floor)"
+    cmds:
+      - bash scripts/check_no_raw_html.sh
+
   # ---------------------------------------------------------------------------
   # E2E Stack
   # ---------------------------------------------------------------------------

--- a/docs/site/docs/build/catalogs-and-packs.md
+++ b/docs/site/docs/build/catalogs-and-packs.md
@@ -98,7 +98,7 @@ sonda --catalog ~/sonda-catalog show @cpu-spike
 version: 2
 kind: runnable
 
-name: cpu-spike
+scenario_name: cpu-spike
 tags: [cpu, infrastructure]
 description: "Periodic CPU usage spikes above threshold"
 
@@ -139,7 +139,7 @@ A catalog entry is a scenario YAML with a top-level `kind:` field. For runnable 
 version: 2
 kind: runnable
 
-name: my-scenario
+scenario_name: my-scenario
 tags: [application, custom]
 description: "My custom scenario pattern"
 
@@ -164,7 +164,7 @@ scenarios:
 |-------|----------|-------------|
 | `version` | yes | Must be `2`. |
 | `kind` | yes | `runnable` for runnable scenarios; `composable` for packs (see [Packs](#packs)). |
-| `name` | no | Catalog identifier. Defaults to the filename (without `.yaml`) if omitted. Used with `@name`. |
+| `scenario_name` | no | Catalog identifier. Defaults to the filename (without `.yaml`) if omitted. Used with `@name`. Packs (`kind: composable`) use a plain `name:` instead — see [Packs](#packs). |
 | `tags` | no | Optional list of strings. `sonda list --tag <t>` filters on this. |
 | `description` | no | One-line summary shown in the `sonda list` table and JSON output. |
 

--- a/docs/site/docs/build/scenario-files.md
+++ b/docs/site/docs/build/scenario-files.md
@@ -68,7 +68,7 @@ A scenario file can carry optional top-level metadata that drives the catalog vi
 version: 2
 kind: runnable
 
-name: steady-state
+scenario_name: steady-state
 tags: [infrastructure, baseline]
 description: "Normal oscillating baseline (sine + jitter)"
 
@@ -91,7 +91,7 @@ scenarios:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `kind` | yes | `runnable` for runnable scenarios; `composable` for packs. Required at the top level of every scenario file. |
-| `name` | no | Catalog identifier (kebab-case). Defaults to the filename (without `.yaml`, hyphens preserved) if omitted. Used by the `@name` shortcut and `sonda run @name`. When POSTed to a running `sonda-server`, this field also acts as a uniqueness key. POSTing two cascades that share an active `name` returns [`409 Conflict`](../deploy/http-api.md#duplicate-scenario_name-returns-409). |
+| `scenario_name` | no | Catalog identifier (kebab-case). Defaults to the filename (without `.yaml`, hyphens preserved) if omitted. Used by the `@name` shortcut and `sonda run @name`. When POSTed to a running `sonda-server`, this field also acts as a uniqueness key. POSTing two cascades that share an active `scenario_name` returns [`409 Conflict`](../deploy/http-api.md#duplicate-scenario_name-returns-409). |
 | `tags` | no | List of strings shown in the catalog table and filterable through `sonda list --tag <t>`. |
 | `description` | no | One-line summary shown in the catalog table and JSON output. Keep it under ~60 characters so it fits the table column. |
 
@@ -257,7 +257,7 @@ The built-in `link-failover` scenario is a worked example: a primary interface f
 version: 2
 kind: runnable
 
-name: link-failover
+scenario_name: link-failover
 tags: [network]
 description: "Edge router link failure with traffic shift to backup"
 
@@ -737,6 +737,7 @@ Re-resolution is event-driven, not polled. There is no periodic background sweep
 A baseline counter that you want running at full rate by default, but paused whenever an on-demand cascade declares a "link state" of 0. The baseline and the cascade emit **different series** (`requests_total` and `link_state`). The cascade only signals the baseline to stop emitting while it is firing.
 
 ```yaml title="baseline.yaml — POST first, runs immediately under if_unresolved: open"
+# sonda:static - cross-POST `while:` needs a running sonda-server; `sonda run` and the browser playground both reject it by design
 version: 2
 kind: runnable
 scenario_name: baseline_post
@@ -945,6 +946,7 @@ Some operational signals should freeze at their last value during an outage rath
 A single metric scenario with a `while:` clause and `delay.close.snap_to: <value>` does this without a separate baseline POST and without DELETE-and-replace orchestration. When the gate closes, the runner fires the one-shot recovery sample, the scenario transitions to the `held` lifecycle state, and `current_values` retains the frozen sample. Scrapers that pass `?include_state=running,unresolved,held` continue to see the frozen value on every scrape; scrapers that omit `held` from the allowlist see the series drop out for the duration of the outage.
 
 ```yaml title="held-counter.yaml — single scenario, frozen during outage"
+# sonda:static - cross-POST `while:` needs a running sonda-server; `sonda run` and the browser playground both reject it by design
 version: 2
 kind: runnable
 scenario_name: held_counter_post

--- a/docs/site/docs/build/scheduling.md
+++ b/docs/site/docs/build/scheduling.md
@@ -9,6 +9,9 @@ By default, a Sonda scenario emits at a steady rate for its full duration. This 
 
 Use these when you want test data that resembles real production traffic. Examples: services that go quiet during deploys, surges at peak hours, fleets that share a single scenario entry, and cascades where one signal triggers another.
 
+!!! tip "Run these examples as you read"
+    Complete scenarios on this page — the ones that open with `version: 2` — carry a **Run in playground →** link that opens them in the [playground](../playground/index.md) with the chart already drawn. The shorter fences show a single block in isolation, so they have nothing to run on their own.
+
 ## Gaps and bursts
 
 Gaps and bursts are recurring time windows that modulate emission. A **gap** suppresses output for a window: the metric goes silent, Prometheus treats it as stale, downstream alerts resolve. A **burst** temporarily raises the per-second event rate above the configured `rate:`.

--- a/docs/site/docs/build/sinks.md
+++ b/docs/site/docs/build/sinks.md
@@ -392,6 +392,18 @@ scenarios:
     labels:
       job: sonda
       env: dev
+    log_generator:
+      type: template
+      templates:
+        - message: "Request from {ip} to {endpoint} returned {status}"
+          field_pools:
+            ip: ["10.0.0.1", "10.0.0.2"]
+            endpoint: ["/api", "/health"]
+            status: ["200", "404", "500"]
+      severity_weights:
+        info: 0.8
+        warn: 0.15
+        error: 0.05
 ```
 
 **CLI override** — `sonda run` accepts `--sink loki`, `--endpoint <url>`, and `--label k=v` (repeatable) for stream labels:

--- a/docs/site/docs/deploy/http-api.md
+++ b/docs/site/docs/deploy/http-api.md
@@ -441,7 +441,6 @@ Each scenario gets its own ID and runs independently. You manage them individual
       - id: cpu_usage
         signal_type: metrics
         name: cpu_usage
-        phase_offset: "0s"
         clock_group: alert-test
         generator:
           type: sequence

--- a/docs/site/docs/get-started/index.md
+++ b/docs/site/docs/get-started/index.md
@@ -9,6 +9,10 @@ This section takes you from no Sonda installed to a synthetic metric reaching a 
 
 <div class="grid cards" markdown>
 
+-   :material-play-circle: __[Try it in your browser](../playground/index.md)__
+
+    The real engine, compiled to WebAssembly. Edit YAML, watch the signal, nothing to install.
+
 -   :material-rocket-launch: __[Quickstart](quickstart.md)__
 
     Install Sonda, generate a starter YAML file with `sonda new --template`, and stream a metric to stdout. Five minutes.
@@ -24,7 +28,7 @@ This section takes you from no Sonda installed to a synthetic metric reaching a 
 </div>
 
 !!! tip "Where to next"
-    After you finish here, read [Build scenarios](../build/index.md) to write YAML you can check into git. To produce data that drives your alert rules, see [Test pipelines](../test/index.md).
+    After you finish here, read [Build scenarios](../build/index.md) to write YAML you can check into git. To produce data that drives your alert rules, see [Test pipelines](../test/index.md). To try a change without installing anything first, the [playground](../playground/index.md) runs the same engine in your browser.
 
 <div class="sonda-nav-footer">
   <p></p>

--- a/docs/site/docs/get-started/quickstart.md
+++ b/docs/site/docs/get-started/quickstart.md
@@ -15,6 +15,9 @@ hide:
 
 </div>
 
+!!! tip "No install needed to explore"
+    The [playground](../playground/index.md) runs the same engine in your browser — edit scenario YAML and watch the signal it produces, with nothing on your machine. Come back here when you want it on your machine, emitting to a real backend.
+
 ## Installation
 
 Pick the option that matches your environment. Each tab shows a single command.

--- a/docs/site/docs/javascripts/alert-lab.js
+++ b/docs/site/docs/javascripts/alert-lab.js
@@ -12,6 +12,7 @@ import {
   defaultThreshold,
   evaluate,
   fromBase64Url,
+  hashPayloadTooLarge,
   toBase64Url,
 } from "./sonda-pure.js";
 
@@ -140,7 +141,7 @@ function ensureWasm() {
   return wasmReady;
 }
 
-function boot() {
+async function boot() {
   const root = document.getElementById("sonda-alert-lab");
   if (!root || root.dataset.ready) return;
   root.dataset.ready = "1";
@@ -163,7 +164,8 @@ function boot() {
   // A scenario carried over from the playground (#yaml=…) becomes a
   // synthetic first preset, selected on load — the other half of the
   // playground's "Test an alert →" bridge.
-  const customYaml = fromLocationHash();
+  const shared = fromLocationHash();
+  const customYaml = shared.yaml;
   if (customYaml !== null) {
     const option = document.createElement("option");
     option.value = "custom";
@@ -325,7 +327,15 @@ function boot() {
     }
   }).observe(document.body, { attributes: true, attributeFilter: ["data-md-color-scheme"] });
 
-  loadPreset();
+  // Awaited so a refused hash explains itself after the first preset has
+  // drawn, rather than being overwritten by it. The notice goes on the story
+  // line rather than through showError: the lab itself is fine — a preset is
+  // loaded and evaluating — and blanking its chart to report an ignored link
+  // would break more than it explains.
+  await loadPreset();
+  if (shared.status) {
+    el.story.textContent = `${shared.status} ${el.story.textContent}`.trim();
+  }
 }
 
 function showError(el, message) {
@@ -351,13 +361,27 @@ function setStateChip(chip, state) {
   chip.className = `sonda-lab-chip sonda-lab-chip--${state}`;
 }
 
+/* Read a scenario carried over from the playground via `#yaml=`.
+ *
+ * Returns `{ yaml, status }` — see the twin in playground.js. The size check
+ * runs before the decode so an oversized link costs a length comparison
+ * rather than a decode plus a compile; a malformed one falls back to the
+ * built-in presets in silence, since that is a broken link rather than a
+ * hostile one.
+ */
 function fromLocationHash() {
   const match = window.location.hash.match(/^#yaml=(.+)$/);
-  if (!match) return null;
+  if (!match) return { yaml: null, status: null };
+  if (hashPayloadTooLarge(match[1])) {
+    return {
+      yaml: null,
+      status: "The shared scenario is too large to load — showing the built-in presets instead.",
+    };
+  }
   try {
-    return fromBase64Url(match[1]);
+    return { yaml: fromBase64Url(match[1]), status: null };
   } catch {
-    return null;
+    return { yaml: null, status: null };
   }
 }
 

--- a/docs/site/docs/javascripts/playground.js
+++ b/docs/site/docs/javascripts/playground.js
@@ -8,7 +8,7 @@
  * fetched only when the playground container exists.
  */
 import init, { sample_scenario } from "./sonda_wasm.js";
-import { toBase64Url, fromBase64Url } from "./sonda-pure.js";
+import { toBase64Url, fromBase64Url, hashPayloadTooLarge } from "./sonda-pure.js";
 
 const MAX_TICKS = 240;
 const DEBOUNCE_MS = 500;
@@ -360,7 +360,7 @@ async function boot() {
   };
 
   const shared = fromLocationHash();
-  el.editor.value = shared !== null ? shared : PRESETS[0].yaml;
+  el.editor.value = shared.yaml !== null ? shared.yaml : PRESETS[0].yaml;
   editor = await mountEditor(el.editor, { onChange: scheduleRun, onRun: run });
 
   el.run.addEventListener("click", run);
@@ -390,16 +390,34 @@ async function boot() {
     attributeFilter: ["data-md-color-scheme"],
   });
 
-  run();
+  // Awaited so a refused hash reports AFTER the first run has settled the
+  // status line — otherwise the run's own "" would erase the explanation.
+  await run();
+  if (shared.status) el.status.textContent = shared.status;
 }
 
+/* Read a shared scenario out of the `#yaml=` hash.
+ *
+ * Returns `{ yaml, status }`: `yaml` is null when there is nothing usable to
+ * load, and `status` carries a message to show the reader when the hash was
+ * present but refused.
+ *
+ * The size check runs BEFORE the decode. A link is attacker-supplied input,
+ * and an unbounded one buys a base64 decode plus an engine compile of
+ * arbitrary size on page load; refusing by length is O(1) and cannot be
+ * talked out of. Malformed base64 still falls back to the default preset
+ * silently — that is a broken link, not a hostile one.
+ */
 function fromLocationHash() {
   const match = window.location.hash.match(/^#yaml=(.+)$/);
-  if (!match) return null;
+  if (!match) return { yaml: null, status: null };
+  if (hashPayloadTooLarge(match[1])) {
+    return { yaml: null, status: "shared scenario too large — showing the default preset" };
+  }
   try {
-    return fromBase64Url(match[1]);
+    return { yaml: fromBase64Url(match[1]), status: null };
   } catch {
-    return null;
+    return { yaml: null, status: null };
   }
 }
 

--- a/docs/site/docs/javascripts/runnable-fences.js
+++ b/docs/site/docs/javascripts/runnable-fences.js
@@ -1,0 +1,100 @@
+/* Sonda docs — "Run in playground" buttons on complete scenario fences.
+ *
+ * Progressive enhancement, site-wide: every YAML code fence that is a
+ * complete scenario gets a link that opens it in the playground, carried in
+ * the existing `#yaml=` hash. A reader who wants to see what a documented
+ * scenario actually does no longer has to copy, switch pages, and paste.
+ *
+ * Three properties are load-bearing:
+ *
+ * 1. The decision of what counts as runnable is NOT made here — it lives in
+ *    `runnableScenario` (sonda-pure.js) and is answered by the same case
+ *    table as the CI gate that compiles every buttoned fence
+ *    (scripts/validate_docs_scenarios.py). A button therefore cannot promise
+ *    something CI has not proven.
+ * 2. Nothing is ever built by assigning markup — createElement/textContent
+ *    only. Fence text is repo-authored and PR-reviewed, but the rule is
+ *    absolute (see the CI grep gate in the docs-commands job) precisely so it
+ *    never has to be re-argued per call site.
+ * 3. Failure is silent and total. If the playground cannot be located, no
+ *    buttons appear and the page is untouched — the fences are still
+ *    readable prose, which is the whole no-JS floor.
+ */
+import { runnableScenario, toBase64Url } from "./sonda-pure.js";
+
+const LINK_CLASS = "sonda-runnable";
+
+/* Resolve the playground's URL from the nav rather than hardcoding a path.
+ *
+ * The site is published under a project prefix (/sonda/), and these buttons
+ * appear at every depth of the tree, so neither a root-absolute path nor a
+ * fixed number of `../` hops is correct everywhere. The nav is rendered on
+ * every page and its hrefs are already correct relative to the current one;
+ * reading `.href` yields the resolved absolute URL.
+ *
+ * The `$=` match pins the playground index and excludes `playground/alert-lab/`,
+ * which a `*=` match would also hit — and which, being second in the nav,
+ * would otherwise win on some pages but not others.
+ */
+function playgroundHref() {
+  const exact = document.querySelector('.md-nav a[href$="playground/"]');
+  if (exact) return exact.href;
+  const loose = document.querySelector('.md-nav a[href*="playground/"]');
+  return loose ? loose.href : null;
+}
+
+function buildLink(href, yaml) {
+  const link = document.createElement("a");
+  link.className = LINK_CLASS;
+  link.href = `${href}#yaml=${toBase64Url(yaml)}`;
+  link.textContent = "Run in playground →";
+  // The fence right above says which scenario this is; screen readers reading
+  // the link out of context get the association spelled out.
+  link.setAttribute("aria-label", "Run this scenario in the Sonda playground");
+  return link;
+}
+
+function boot() {
+  // The playground page's own fences must not offer a link back to the page
+  // the reader is already on.
+  if (document.getElementById("sonda-playground")) return;
+
+  const content = document.querySelector(".md-content");
+  if (!content) return;
+
+  const href = playgroundHref();
+  if (!href) return; // nav missing or renamed — leave the page alone
+
+  for (const code of content.querySelectorAll("pre > code")) {
+    // `.highlight` is the wrapper pymdownx puts around the whole block
+    // (including a `title=` filename bar, when present); the link belongs
+    // after it, not between the title and its code.
+    const block = code.closest(".highlight") || code.parentElement;
+    if (!block || block.dataset.sondaRunnable) continue;
+
+    // Material tags the language on the wrapper (pygments_lang_class). When
+    // the fence carries no language at all, fall through to the detector on
+    // the text itself rather than skipping — an unclassed complete scenario
+    // is still a complete scenario.
+    const classed = block.className || "";
+    if (classed.includes("language-") && !classed.includes("language-yaml")) continue;
+
+    const yaml = code.textContent;
+    if (!runnableScenario(yaml)) continue;
+
+    block.dataset.sondaRunnable = "1";
+    block.insertAdjacentElement("afterend", buildLink(href, yaml));
+  }
+}
+
+/* Material's instant navigation swaps `.md-content` without a page load, so
+ * boot() re-runs per document. The `data-sonda-runnable` flag lives on the
+ * swapped-in DOM, so a re-run over the same document is a no-op rather than a
+ * source of duplicate links. */
+if (window.document$ && typeof window.document$.subscribe === "function") {
+  window.document$.subscribe(boot);
+} else if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", boot);
+} else {
+  boot();
+}

--- a/docs/site/docs/javascripts/sonda-pure.js
+++ b/docs/site/docs/javascripts/sonda-pure.js
@@ -24,6 +24,91 @@ export function fromBase64Url(encoded) {
   return new TextDecoder().decode(bytes);
 }
 
+/* Ceiling on a `#yaml=` hash payload, in characters of the encoded form.
+ *
+ * The playground and the alert lab will compile anything a link hands them.
+ * That is the point — but a link is attacker-supplied input, and an
+ * unbounded one buys a decode plus a compile of arbitrary size on page load.
+ * 32 KB of base64url is ~24 KB of YAML: far above any real scenario (the
+ * largest fence in the docs is under 2 KB) and far below a payload that can
+ * wedge the tab.
+ */
+export const MAX_HASH_PAYLOAD = 32 * 1024;
+
+/* True when a hash payload is too large to be worth decoding.
+ *
+ * A pure length test on the RAW payload, deliberately: the guard has to run
+ * before `fromBase64Url` allocates, so it cannot ask how big the decoded
+ * text would be. */
+export function hashPayloadTooLarge(payload) {
+  return String(payload).length > MAX_HASH_PAYLOAD;
+}
+
+/* Normalize a code fence's body before any structural test runs on it.
+ *
+ * The two callers see the same scenario through different lenses: the browser
+ * reads `code.textContent` out of the rendered DOM, while the CI extractor
+ * reads raw markdown where an admonition- or tab-nested fence carries four
+ * spaces of indentation on every line. Folding both to one shape here is what
+ * lets `runnableScenario` be a single rule with a single case table
+ * (docs/site/tools/tests/runnable-cases.json) rather than two implementations
+ * that drift.
+ *
+ * Strips a UTF-8 BOM, folds CRLF (a fence pasted from a Windows editor must
+ * not read as a different document), and removes the indentation common to
+ * every non-blank line.
+ */
+export function normalizeFence(text) {
+  const body = String(text).replace(/^\uFEFF/, "").replace(/\r\n?/g, "\n");
+  const lines = body.split("\n");
+  let common = Infinity;
+  for (const line of lines) {
+    if (!line.trim()) continue; // blank lines carry no indentation signal
+    const indent = line.length - line.replace(/^[ \t]+/, "").length;
+    if (indent < common) common = indent;
+  }
+  if (!Number.isFinite(common) || common === 0) return body;
+  return lines.map((line) => (line.trim() ? line.slice(common) : line)).join("\n");
+}
+
+/* True when a docs code fence is a complete, runnable Sonda scenario — the
+ * one rule behind both the "Run in playground →" buttons and the CI gate that
+ * compiles every buttoned fence.
+ *
+ * A fence qualifies when it declares `version: 2` (the engine rejects a
+ * scenario file without it — see ParseError::InvalidVersion, so this is the
+ * honest complete-vs-fragment line) AND carries a `scenarios:` list or the
+ * `kind:` shorthand header. Fragments — a bare `generator:` block quoted to
+ * explain one field — fail naturally and are never offered.
+ *
+ * A `pack:` reference disqualifies a fence no matter how complete it looks.
+ * Packs resolve against a catalog directory, and there is no catalog in the
+ * browser — sonda-wasm builds an empty InMemoryPackResolver, so a
+ * pack-backed scenario reaches the playground only to report "unknown pack".
+ * Offering a button that always lands on an error is worse than offering
+ * none, and the CI gate skips them for the same reason (`--catalog <dir>` is
+ * a runtime argument a fence cannot carry). The match is indentation-
+ * tolerant because `pack:` sits inside an entry; the cost is that a label
+ * literally keyed `pack` also opts a fence out, which only ever loses a
+ * button.
+ *
+ * The escape hatch is a `# sonda:static` comment line, visible in both the
+ * markdown source and the rendered page: it opts a fence out for cases where
+ * running it is not the point (a deliberately broken example whose error
+ * message IS the lesson, or a server-only shape the CLI cannot run).
+ *
+ * Anchors are line-local and use [ \t] rather than \s throughout: \s spans
+ * newlines, which would let `version:` on one line and `2` on the next read
+ * as a version declaration.
+ */
+export function runnableScenario(text) {
+  const body = normalizeFence(text);
+  if (/^#[ \t]*sonda:static\b/m.test(body)) return false;
+  if (!/^version:[ \t]*2[ \t]*$/m.test(body)) return false;
+  if (/^[ \t]*(?:-[ \t]+)?pack:/m.test(body)) return false;
+  return /^scenarios:/m.test(body) || /^kind:/m.test(body);
+}
+
 /* Round to two leading digits; guards float dust like 60.000000000000004. */
 export function tidyNumber(value) {
   const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(value))) - 1);

--- a/docs/site/docs/reference/scenario-fields.md
+++ b/docs/site/docs/reference/scenario-fields.md
@@ -463,7 +463,6 @@ scenarios:
   - id: cpu_usage
     signal_type: metrics
     name: cpu_usage
-    phase_offset: "0s"
     clock_group: alert-test
     generator:
       type: sequence
@@ -485,7 +484,7 @@ scenarios:
 sonda run multi-scenario.yaml
 ```
 
-The `phase_offset` on `memory_usage` delays it by 3 seconds, so CPU rises first and memory follows. Both entries share the `alert-test` clock group for synchronized timing. For declarative chains, use [`after:`](../build/scenario-files.md#temporal-chains-with-after) instead of hand-tuned offsets.
+The `phase_offset` on `memory_usage` delays it by 3 seconds, so CPU rises first and memory follows. `cpu_usage` omits the field entirely — that is how an entry says "start immediately"; a `phase_offset` must be greater than zero, so `"0s"` is a config error rather than a way to spell "no delay". Both entries share the `alert-test` clock group for synchronized timing. For declarative chains, use [`after:`](../build/scenario-files.md#temporal-chains-with-after) instead of hand-tuned offsets.
 
 ### Mixing all four signal types
 

--- a/docs/site/docs/stylesheets/sonda.css
+++ b/docs/site/docs/stylesheets/sonda.css
@@ -1011,6 +1011,25 @@
   font-weight: 600;
 }
 
+/* "Run in playground →" link appended after a complete scenario fence.
+ * Sits tight under the code block it belongs to and stays quiet until
+ * hovered — it is an offer, not a call to action competing with the prose. */
+.md-typeset .sonda-runnable {
+  display: inline-block;
+  margin: -0.6rem 0 1rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--md-default-fg-color--light);
+  text-decoration: none;
+}
+
+.md-typeset .sonda-runnable:hover,
+.md-typeset .sonda-runnable:focus-visible {
+  color: var(--md-accent-fg-color);
+  text-decoration: underline;
+}
+
 .md-typeset .sonda-livegen__open {
   margin-left: auto;
   font-size: 0.78rem;

--- a/docs/site/docs/test/capacity-planning.md
+++ b/docs/site/docs/test/capacity-planning.md
@@ -67,6 +67,7 @@ sonda run examples/capacity-throughput-test.yaml
 ```
 
 ```yaml title="examples/capacity-throughput-test.yaml (excerpt)"
+# sonda:static - excerpt only; the complete, runnable file is in the repo
 version: 2
 kind: runnable
 
@@ -159,6 +160,7 @@ sonda run examples/capacity-cardinality-stress.yaml
 ```
 
 ```yaml title="examples/capacity-cardinality-stress.yaml (excerpt)"
+# sonda:static - excerpt only; the complete, runnable file is in the repo
 version: 2
 kind: runnable
 
@@ -290,6 +292,7 @@ sonda run examples/capacity-burst-test.yaml
 ```
 
 ```yaml title="examples/capacity-burst-test.yaml (excerpt)"
+# sonda:static - excerpt only; the complete, runnable file is in the repo
 version: 2
 kind: runnable
 

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -66,6 +66,8 @@ extra_javascript:
     type: module
   - path: javascripts/livegen.js
     type: module
+  - path: javascripts/runnable-fences.js
+    type: module
 
 markdown_extensions:
   - abbr

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -7,15 +7,20 @@
 // playground JS has — keep every function under test free of DOM/wasm.
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
+  MAX_HASH_PAYLOAD,
   buildTestExport,
   defaultThreshold,
   deriveAlertName,
   escapeQuoted,
   evaluate,
   fromBase64Url,
+  hashPayloadTooLarge,
   niceDeadlineSecs,
+  normalizeFence,
   numberSpanAt,
+  runnableScenario,
   scrubNumber,
   toBase64Url,
 } from "../../docs/javascripts/sonda-pure.js";
@@ -411,6 +416,67 @@ test("corner and sweep enumeration cover what the compile gate feeds the engine"
   assert.equal(sweep[0].time_to_ceiling, WIDGETS.leak.durationSecs);
   assert.equal(sweep[sweep.length - 1].time_to_ceiling, 600);
   assert.equal(sweepParams(WIDGETS.leak, "nope").length, 0);
+});
+
+// --- runnableScenario (shared case table) ------------------------------
+
+// The browser module and the CI extractor are two implementations of one
+// rule. They answer the SAME table, loaded from disk — a case added for one
+// side is automatically demanded of the other, so the two cannot drift.
+const casesPath = new URL("./runnable-cases.json", import.meta.url);
+const { cases } = JSON.parse(readFileSync(casesPath, "utf8"));
+
+test("shared case table is non-trivial and covers both verdicts", () => {
+  assert.ok(cases.length >= 20, "table should be a real hostile-case table");
+  assert.ok(cases.some((c) => c.expected === true), "needs positive cases");
+  assert.ok(cases.some((c) => c.expected === false), "needs negative cases");
+});
+
+for (const testCase of cases) {
+  test(`runnableScenario: ${testCase.name}`, () => {
+    assert.equal(
+      runnableScenario(testCase.text),
+      testCase.expected,
+      `expected ${testCase.expected} for: ${JSON.stringify(testCase.text.slice(0, 60))}`
+    );
+  });
+}
+
+test("normalizeFence dedents uniformly and leaves flush text alone", () => {
+  assert.equal(normalizeFence("version: 2\nkind: runnable\n"), "version: 2\nkind: runnable\n");
+  assert.equal(normalizeFence("    a\n    b\n"), "a\nb\n");
+  // A blank line carries no indentation signal — it must not pin the dedent at 0.
+  assert.equal(normalizeFence("    a\n\n    b\n"), "a\n\nb\n");
+  // Ragged indentation dedents by the common prefix only.
+  assert.equal(normalizeFence("  a\n    b\n"), "a\n  b\n");
+  assert.equal(normalizeFence("﻿version: 2"), "version: 2");
+  assert.equal(normalizeFence("a\r\nb\rc"), "a\nb\nc");
+});
+
+// A fence rendered by Material carries the scenario in `code.textContent`.
+// The detector must survive that lens as well as the raw-markdown one.
+test("runnableScenario accepts a fence as textContent yields it", () => {
+  const rendered = "version: 2\nscenarios:\n  - signal_type: metrics\n    name: cpu_usage\n";
+  assert.equal(runnableScenario(rendered), true);
+});
+
+// --- hash size cap (§1b hardening) -------------------------------------
+
+test("hash payloads at and under the cap are accepted", () => {
+  assert.equal(hashPayloadTooLarge("a".repeat(MAX_HASH_PAYLOAD)), false);
+  assert.equal(hashPayloadTooLarge("a".repeat(MAX_HASH_PAYLOAD - 1)), false);
+  assert.equal(hashPayloadTooLarge(""), false);
+});
+
+test("one byte over the cap is rejected — before any decode happens", () => {
+  assert.equal(hashPayloadTooLarge("a".repeat(MAX_HASH_PAYLOAD + 1)), true);
+  assert.equal(hashPayloadTooLarge("a".repeat(MAX_HASH_PAYLOAD * 4)), true);
+});
+
+test("the cap is measured in payload characters, not decoded bytes", () => {
+  // The point of the guard is to refuse work BEFORE decoding, so the check
+  // must be a pure length test on the raw hash payload.
+  assert.equal(MAX_HASH_PAYLOAD, 32 * 1024);
 });
 
 console.log(`${passed} pure-helper tests passed`);

--- a/docs/site/tools/tests/runnable-cases.json
+++ b/docs/site/tools/tests/runnable-cases.json
@@ -1,0 +1,130 @@
+{
+  "_comment": "Shared case table for the runnable-scenario detector. Consumed by BOTH docs/site/tools/tests/pure.test.mjs (runnableScenario in sonda-pure.js, the browser side) and scripts/validate_docs_scenarios.py (is_runnable_scenario, the CI side). One rule decides which docs fences get a 'Run in playground' button and which fences the compile gate must prove; two implementations of it can only stay honest if they answer the same table. Add hostile cases here, never to one suite alone.",
+  "cases": [
+    {
+      "name": "complete scenario with scenarios: list",
+      "expected": true,
+      "text": "version: 2\nscenarios:\n  - signal_type: metrics\n    name: cpu_usage\n    generator:\n      type: sine\n      amplitude: 20\n"
+    },
+    {
+      "name": "v2 shorthand: kind: header without a scenarios: list",
+      "expected": true,
+      "text": "version: 2\nkind: runnable\nname: cpu_usage\ngenerator:\n  type: constant\n  value: 95.0\n"
+    },
+    {
+      "name": "generator-only fragment quoted to explain one field",
+      "expected": false,
+      "text": "generator:\n  type: sine\n  amplitude: 20\n  period: 60s\n"
+    },
+    {
+      "name": "scenarios: list without version: — the engine rejects it, so it is a fragment",
+      "expected": false,
+      "text": "scenarios:\n  - signal_type: metrics\n    name: cpu_usage\n    gaps:\n      every: 60s\n      for: 20s\n"
+    },
+    {
+      "name": "vmalert rules file",
+      "expected": false,
+      "text": "groups:\n  - name: sonda-lab\n    interval: 5s\n    rules:\n      - alert: CpuUsageHigh\n        expr: 'cpu_usage > 80'\n        for: 30s\n"
+    },
+    {
+      "name": "opted out with a first-line # sonda:static comment",
+      "expected": false,
+      "text": "# sonda:static\nversion: 2\nscenarios:\n  - signal_type: metrics\n    name: broken\n"
+    },
+    {
+      "name": "# sonda:static with a trailing explanation still opts out",
+      "expected": false,
+      "text": "# sonda:static - deliberately broken, the error message is the lesson\nversion: 2\nscenarios:\n  - signal_type: metrics\n    name: broken\n"
+    },
+    {
+      "name": "admonition-nested fence carries 4 spaces of indentation on every line",
+      "expected": true,
+      "text": "    version: 2\n    scenarios:\n      - signal_type: metrics\n        name: cpu_usage\n        generator:\n          type: constant\n          value: 95.0\n"
+    },
+    {
+      "name": "nested fence that is opted out — dedent must expose the marker",
+      "expected": false,
+      "text": "    # sonda:static\n    version: 2\n    scenarios:\n      - signal_type: metrics\n        name: broken\n"
+    },
+    {
+      "name": "UTF-8 BOM before the version line",
+      "expected": true,
+      "text": "﻿version: 2\nscenarios:\n  - signal_type: metrics\n    name: cpu_usage\n"
+    },
+    {
+      "name": "CRLF line endings",
+      "expected": true,
+      "text": "version: 2\r\nscenarios:\r\n  - signal_type: metrics\r\n    name: cpu_usage\r\n"
+    },
+    {
+      "name": "version: 2 appearing only inside a comment",
+      "expected": false,
+      "text": "# upgrade note: version: 2 replaced the old flat format\nscenarios:\n  - signal_type: metrics\n    name: cpu_usage\n"
+    },
+    {
+      "name": "version: 2 appearing only inside a log message template",
+      "expected": false,
+      "text": "generator:\n  type: log_template\n  message: \"config reloaded, version: 2 schema active\"\n"
+    },
+    {
+      "name": "version: 2 quoted as a YAML string value elsewhere in the doc",
+      "expected": false,
+      "text": "kind: runnable\nname: notes\nnote: \"version: 2\"\n"
+    },
+    {
+      "name": "Kubernetes manifest — kind: without a sonda version header",
+      "expected": false,
+      "text": "apiVersion: monitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: sonda\n"
+    },
+    {
+      "name": "docker-compose style version: 2 with no scenarios: or kind:",
+      "expected": false,
+      "text": "version: 2\nservices:\n  sonda:\n    image: ghcr.io/davidban77/sonda\n"
+    },
+    {
+      "name": "version: 1 is a different schema",
+      "expected": false,
+      "text": "version: 1\nscenarios:\n  - name: cpu_usage\n"
+    },
+    {
+      "name": "version: 20 must not prefix-match version: 2",
+      "expected": false,
+      "text": "version: 20\nscenarios:\n  - signal_type: metrics\n    name: cpu_usage\n"
+    },
+    {
+      "name": "trailing whitespace after the version value is tolerated",
+      "expected": true,
+      "text": "version: 2   \nscenarios:\n  - signal_type: metrics\n    name: cpu_usage\n"
+    },
+    {
+      "name": "version: and 2 on separate lines is not a version declaration",
+      "expected": false,
+      "text": "version:\n2\nscenarios:\n  - signal_type: metrics\n    name: cpu_usage\n"
+    },
+    {
+      "name": "kind: nested under a mapping is not the shorthand header",
+      "expected": false,
+      "text": "version: 2\nmetadata:\n  kind: Secret\n"
+    },
+    {
+      "name": "empty fence",
+      "expected": false,
+      "text": ""
+    },
+    {
+      "name": "pack-backed entry — no catalog exists in the browser or in a fence",
+      "expected": false,
+      "text": "version: 2\nkind: runnable\nscenarios:\n  - pack: telegraf_snmp_interface\n    signal_type: metrics\n"
+    },
+    {
+      "name": "pack: nested deeper in an entry still disqualifies",
+      "expected": false,
+      "text": "version: 2\nscenarios:\n  - signal_type: metrics\n    name: cpu_usage\n    generator:\n      type: sine\n  - signal_type: metrics\n    pack: node_exporter_cpu\n"
+    },
+    {
+      "name": "a metric named like a pack does not trip the pack rule",
+      "expected": true,
+      "text": "version: 2\nscenarios:\n  - signal_type: metrics\n    name: pack_queue_depth\n    generator:\n      type: constant\n      value: 3\n"
+    }
+  ]
+}

--- a/scripts/check_no_raw_html.sh
+++ b/scripts/check_no_raw_html.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Fail if any hand-written docs JS builds DOM from a markup string.
+#
+# The docs site has no backend and no accounts, so the one classic web risk
+# left is injecting text into HTML. The codebase answer is a blanket rule
+# rather than a per-call-site judgement: build DOM with createElement and
+# textContent, never by assigning markup. This turns that convention into a
+# gate (Law 2 — a claim in a comment becomes a check in CI).
+#
+# Scope is the hand-written sources only. sonda-editor.js and sonda_wasm.js
+# are committed BUILD OUTPUTS (esbuild and wasm-bindgen); their contents are
+# decided by upstream libraries, so policing them here would fail the build
+# on a dependency's internals rather than on anything a reviewer can fix.
+# They are covered instead by the rebuild-and-compare drift gates.
+#
+# Run directly or via `task site:no-raw-html`.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+# insertAdjacentElement is the SAFE sibling and must not match, so the pattern
+# names insertAdjacentHTML exactly rather than matching on "insertAdjacent".
+PATTERN='\.innerHTML|\.outerHTML|insertAdjacentHTML|document\.write\('
+
+GENERATED='docs/site/docs/javascripts/sonda-editor.js
+docs/site/docs/javascripts/sonda_wasm.js'
+
+status=0
+while IFS= read -r file; do
+  case "$GENERATED" in
+    *"$file"*) continue ;;
+  esac
+  if matches=$(grep -nE "$PATTERN" "$file"); then
+    if [ "$status" -eq 0 ]; then
+      echo "::error::raw-markup assignment found in hand-written docs JS." >&2
+      echo "Build DOM with createElement/textContent instead." >&2
+    fi
+    status=1
+    while IFS= read -r hit; do
+      echo "  $file:$hit" >&2
+    done <<<"$matches"
+  fi
+done < <(find docs/site/docs/javascripts docs/site/tools/editor/src -name '*.js' -type f | sort)
+
+if [ "$status" -eq 0 ]; then
+  echo "OK: no raw-markup assignment in hand-written docs JS"
+fi
+exit "$status"

--- a/scripts/validate_docs_scenarios.py
+++ b/scripts/validate_docs_scenarios.py
@@ -30,6 +30,18 @@ as a SKIP line:
   exports themselves. The scenario is well-formed but uncheckable here, so it
   is reported as SKIP with the offending path.
 
+One assumption is load-bearing enough to state. This gate compiles a fence with
+the NATIVE binary, built with ``http,kafka,remote-write,otlp`` — but the button
+it certifies opens that fence in the WASM build, which has none of those
+features, and ``SinkConfig`` gates its variants with ``#[cfg(feature = ...)]``
+at the enum level rather than only at construction. If a gated variant were
+unparseable under wasm, this gate would happily pass fences the browser then
+rejects, and 25 of the buttoned fences use gated sinks. Measured on the review
+of PR #536 by building a ``--target nodejs`` bundle and parsing one scenario per
+sink type: stdout, remote_write, http_push, loki, kafka, otlp_grpc, tcp and file
+all parse in the wasm build, so the divergence does not exist and the CLI's
+verdict transfers. Re-measure if sink parsing ever moves behind a feature gate.
+
 Stdlib-only. Run from the repo root::
 
     python3 scripts/validate_docs_scenarios.py

--- a/scripts/validate_docs_scenarios.py
+++ b/scripts/validate_docs_scenarios.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""Compile gate for every runnable scenario fence in the user-facing docs.
+
+Companion to :mod:`validate_docs_commands`, which checks the ``sonda`` command
+lines in ``bash`` fences. This script checks the *scenarios* in ``yaml`` fences:
+every fence the docs site offers a "Run in playground" button for must actually
+compile, or the button is a promise the page cannot keep.
+
+The rule that decides which fences are runnable lives in two places by
+necessity — here, and in ``runnableScenario`` in
+``docs/site/docs/javascripts/sonda-pure.js`` (the browser cannot import Python
+and CI cannot run the DOM). They are kept honest by a shared case table,
+``docs/site/tools/tests/runnable-cases.json``, which both sides answer:
+``--self-test`` here, and ``pure.test.mjs`` there. Add hostile cases to the
+table, never to one suite alone.
+
+Three classes of fence are deliberately not compiled here. None of them is
+silent — the first two are invisible to this gate because the shared rule
+excludes them from being buttoned in the first place, and the third is printed
+as a SKIP line:
+
+* ``# sonda:static`` — an explicit opt-out comment in the fence, for examples
+  whose failure IS the lesson, or shapes only ``sonda-server`` can run. The
+  detector treats these as not-runnable, so they get no button either: the
+  marker moves both gates at once.
+* ``pack:`` references — they need a ``--catalog`` directory that neither a
+  fence nor the browser can supply, so they are not runnable anywhere the
+  button would take the reader.
+* Missing input files — csv_replay tutorials that reference a CSV the reader
+  exports themselves. The scenario is well-formed but uncheckable here, so it
+  is reported as SKIP with the offending path.
+
+Stdlib-only. Run from the repo root::
+
+    python3 scripts/validate_docs_scenarios.py
+
+``--self-test`` runs the inline unit tests plus the shared case table without
+needing a ``sonda`` binary. ``--list`` prints what would be checked and exits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Iterable, Sequence
+
+# Reuse the docs-root walk from the sibling validator rather than restating it:
+# the "which markdown files are user-facing" rule (and its docs/site/site
+# exclusion) must not drift between the two gates.
+from validate_docs_commands import (
+    DEFAULT_SONDA_BINARY,
+    DOCS_GLOB_ROOT,
+    find_repo_root,
+    iter_markdown_files,
+)
+
+# --- Configuration -----------------------------------------------------------
+
+SHARED_CASE_TABLE = Path("docs/site/tools/tests/runnable-cases.json")
+
+DEFAULT_SUBPROCESS_TIMEOUT_S = 30.0
+
+# YAML keys whose value names an INPUT file the engine must read at compile
+# time (csv_replay and its log sibling). A file sink's `path:` is an output
+# and is deliberately not listed — it does not need to exist.
+_INPUT_FILE_KEY_RE = re.compile(r"^\s*file:\s*(?P<path>\S+)\s*$", re.MULTILINE)
+
+
+# --- Data model --------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ExtractedScenario:
+    """One ``yaml`` fence from a markdown file, dedented and ready to compile."""
+
+    file: Path
+    line: int  # 1-based, first content line inside the fence
+    body: str
+    info: str  # the fence's info string, e.g. 'yaml title="hello.yaml"'
+
+
+@dataclasses.dataclass
+class ScenarioResult:
+    """Outcome of validating one :class:`ExtractedScenario`."""
+
+    scenario: ExtractedScenario
+    ok: bool
+    message: str = ""
+    skipped_reason: str = ""
+
+
+# --- The shared rule ---------------------------------------------------------
+
+
+def normalize_fence(text: str) -> str:
+    """Mirror of ``normalizeFence`` in sonda-pure.js.
+
+    Strips a UTF-8 BOM, folds CRLF, and removes the indentation common to
+    every non-blank line — an admonition- or tab-nested fence carries four
+    spaces on every line in markdown source that the browser never sees.
+    """
+    body = text.lstrip("﻿").replace("\r\n", "\n").replace("\r", "\n")
+    lines = body.split("\n")
+    common: int | None = None
+    for line in lines:
+        if not line.strip():
+            continue  # blank lines carry no indentation signal
+        indent = len(line) - len(line.lstrip(" \t"))
+        if common is None or indent < common:
+            common = indent
+    if not common:
+        return body
+    return "\n".join(line[common:] if line.strip() else line for line in lines)
+
+
+def is_runnable_scenario(text: str) -> bool:
+    """Mirror of ``runnableScenario`` in sonda-pure.js — see that docstring.
+
+    Complete iff it declares ``version: 2`` (the engine rejects a scenario
+    file without one) AND carries a ``scenarios:`` list or the ``kind:``
+    shorthand header, is not opted out with ``# sonda:static``, and makes no
+    ``pack:`` reference (packs need a ``--catalog`` directory that neither a
+    fence nor the browser can supply).
+
+    Anchors are line-local and use ``[ \\t]`` rather than ``\\s``: in the JS
+    twin ``\\s`` spans newlines, which would read ``version:`` on one line and
+    ``2`` on the next as a version declaration. Python's ``\\s`` behaves the
+    same way under ``re.MULTILINE``, so the two stay character-for-character
+    comparable.
+    """
+    body = normalize_fence(text)
+    if re.search(r"^#[ \t]*sonda:static\b", body, re.MULTILINE):
+        return False
+    if not re.search(r"^version:[ \t]*2[ \t]*$", body, re.MULTILINE):
+        return False
+    if re.search(r"^[ \t]*(?:-[ \t]+)?pack:", body, re.MULTILINE):
+        return False
+    return bool(
+        re.search(r"^scenarios:", body, re.MULTILINE)
+        or re.search(r"^kind:", body, re.MULTILINE)
+    )
+
+
+# --- Markdown extraction -----------------------------------------------------
+
+# 3+ backticks, optionally indented (admonition/tabbed nesting), info string
+# up to the first space so `yaml title="x.yaml"` still reads as `yaml`.
+_FENCE_OPEN_RE = re.compile(r"^(?P<indent>[ \t]*)(?P<ticks>`{3,})(?P<info>[^\s`]*)")
+
+
+def extract_yaml_fences(markdown_text: str) -> list[tuple[int, str, str]]:
+    """Return ``(line_number, body, info)`` for every ``yaml`` fence.
+
+    The closing fence must carry at least as many backticks as the opener, so
+    a fence nested inside a longer-delimited block does not close it early.
+    The line number is 1-based and points at the first content line, matching
+    what the reader sees and what ``format_failure`` prints.
+    """
+    lines = markdown_text.splitlines()
+    fences: list[tuple[int, str, str]] = []
+    i = 0
+    while i < len(lines):
+        match = _FENCE_OPEN_RE.match(lines[i])
+        if not match:
+            i += 1
+            continue
+        ticks = match.group("ticks")
+        info = match.group("info") or ""
+        close_re = re.compile(r"^[ \t]*`{%d,}\s*$" % len(ticks))
+        start_body_line = i + 2
+        i += 1
+        body: list[str] = []
+        while i < len(lines):
+            if close_re.match(lines[i]):
+                i += 1
+                break
+            body.append(lines[i])
+            i += 1
+        if info.lower().startswith("yaml"):
+            tail = lines[start_body_line - 2][match.end() :]
+            fences.append((start_body_line, "\n".join(body), (info + tail).strip()))
+    return fences
+
+
+def extract_scenarios(md_path: Path, markdown_text: str) -> list[ExtractedScenario]:
+    """Return every runnable scenario fence in one markdown document."""
+    out: list[ExtractedScenario] = []
+    for line, body, info in extract_yaml_fences(markdown_text):
+        if not is_runnable_scenario(body):
+            continue
+        out.append(
+            ExtractedScenario(
+                file=md_path, line=line, body=normalize_fence(body), info=info
+            )
+        )
+    return out
+
+
+# --- Validation --------------------------------------------------------------
+
+
+def missing_input_files(body: str, repo_root: Path) -> list[str]:
+    """Return input paths the scenario reads that do not exist in the repo.
+
+    A csv_replay tutorial pointing at a CSV the reader exports from Grafana is
+    well-formed but uncheckable here — the scenario is skipped and the reason
+    reported, rather than failing the build or being silently dropped.
+    """
+    missing: list[str] = []
+    for match in _INPUT_FILE_KEY_RE.finditer(body):
+        raw = match.group("path").strip().strip("\"'")
+        if not raw or raw.startswith("<") or raw.startswith("$"):
+            continue  # metavar placeholder, not a path
+        if not (repo_root / raw).is_file():
+            missing.append(raw)
+    return missing
+
+
+def validate_scenario(
+    scenario: ExtractedScenario,
+    repo_root: Path,
+    sonda_bin: Path | None,
+    subprocess_timeout: float = DEFAULT_SUBPROCESS_TIMEOUT_S,
+) -> ScenarioResult:
+    """Compile one scenario with ``sonda --dry-run run``."""
+    missing = missing_input_files(scenario.body, repo_root)
+    if missing:
+        return ScenarioResult(
+            scenario,
+            ok=True,
+            skipped_reason=f"reads input file(s) not in the repo: {', '.join(missing)}",
+        )
+
+    if sonda_bin is None:
+        return ScenarioResult(scenario, ok=True, skipped_reason="no binary (--no-binary)")
+
+    # NamedTemporaryFile with a .yaml suffix: the CLI takes the path
+    # positionally and the scenario's own relative paths resolve against
+    # repo_root, which is why cwd is pinned below.
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".yaml", encoding="utf-8", delete=False
+    ) as handle:
+        handle.write(scenario.body)
+        temp_path = Path(handle.name)
+    try:
+        proc = subprocess.run(
+            [str(sonda_bin), "run", "--dry-run", str(temp_path)],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=subprocess_timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return ScenarioResult(
+            scenario, ok=False, message=f"timed out after {subprocess_timeout}s"
+        )
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+    if proc.returncode == 0:
+        return ScenarioResult(scenario, ok=True)
+    detail = (proc.stderr or proc.stdout or "").strip()
+    return ScenarioResult(
+        scenario, ok=False, message=f"exit {proc.returncode}: {_first_lines(detail)}"
+    )
+
+
+def _first_lines(text: str, limit: int = 6) -> str:
+    """Trim engine output to the first few lines for a readable CI log."""
+    lines = [line for line in text.splitlines() if line.strip()]
+    if len(lines) <= limit:
+        return "\n    ".join(lines)
+    return "\n    ".join(lines[:limit] + [f"... ({len(lines) - limit} more lines)"])
+
+
+# --- Orchestration -----------------------------------------------------------
+
+
+def run_validation(
+    repo_root: Path,
+    sonda_bin: Path | None,
+    subprocess_timeout: float = DEFAULT_SUBPROCESS_TIMEOUT_S,
+    skip_files: Iterable[str] = (),
+) -> tuple[list[ScenarioResult], list[ScenarioResult]]:
+    """Validate every runnable fence. Returns ``(all_results, failures)``."""
+    docs_root = repo_root / DOCS_GLOB_ROOT
+    if not docs_root.is_dir():
+        raise RuntimeError(f"docs root not found: {docs_root}")
+
+    skip_set = {str(s) for s in skip_files}
+    scenarios: list[ExtractedScenario] = []
+    for md in iter_markdown_files(docs_root):
+        rel = str(md.relative_to(repo_root)) if md.is_absolute() else str(md)
+        if rel in skip_set:
+            continue
+        scenarios.extend(extract_scenarios(md, md.read_text(encoding="utf-8")))
+
+    results = [
+        validate_scenario(
+            scenario,
+            repo_root=repo_root,
+            sonda_bin=sonda_bin,
+            subprocess_timeout=subprocess_timeout,
+        )
+        for scenario in scenarios
+    ]
+    return results, [r for r in results if not r.ok]
+
+
+def format_failure(result: ScenarioResult, repo_root: Path) -> str:
+    """Render one failure as a multi-line string suitable for CI logs."""
+    try:
+        rel = result.scenario.file.relative_to(repo_root)
+    except ValueError:
+        rel = result.scenario.file
+    head = result.scenario.body.strip().splitlines()[:3]
+    return (
+        f"FAIL {rel}:{result.scenario.line}\n"
+        + "".join(f"    | {line}\n" for line in head)
+        + f"    {result.message}"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Compile every runnable scenario fence in the docs.",
+    )
+    parser.add_argument(
+        "--sonda",
+        type=Path,
+        default=None,
+        help=(
+            f"Path to the sonda binary. Defaults to {DEFAULT_SONDA_BINARY} "
+            "relative to the repo root."
+        ),
+    )
+    parser.add_argument(
+        "--no-binary",
+        action="store_true",
+        help="Extract and report fences without compiling them.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_SUBPROCESS_TIMEOUT_S,
+        help="Per-invocation timeout in seconds.",
+    )
+    parser.add_argument(
+        "--skip-file",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help=(
+            "Repo-relative markdown path to skip entirely. Repeatable. "
+            "A temporary escape hatch — prefer fixing the fence or marking it "
+            "'# sonda:static'."
+        ),
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List the fences that would be checked, then exit.",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run inline unit tests plus the shared case table, and exit.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _run_self_tests()
+
+    repo_root = find_repo_root(Path(__file__).parent)
+
+    if args.list:
+        docs_root = repo_root / DOCS_GLOB_ROOT
+        total = 0
+        for md in iter_markdown_files(docs_root):
+            for scenario in extract_scenarios(md, md.read_text(encoding="utf-8")):
+                total += 1
+                print(f"{scenario.file.relative_to(repo_root)}:{scenario.line}")
+        print(f"{total} runnable scenario fences", file=sys.stderr)
+        return 0
+
+    sonda_bin: Path | None
+    if args.no_binary:
+        sonda_bin = None
+    else:
+        raw_bin = args.sonda or (repo_root / DEFAULT_SONDA_BINARY)
+        raw_bin = raw_bin if raw_bin.is_absolute() else (repo_root / raw_bin)
+        if not raw_bin.is_file():
+            print(
+                f"sonda binary not found at {raw_bin}. Build it first "
+                "(cargo build --release -p sonda) or pass --no-binary.",
+                file=sys.stderr,
+            )
+            return 2
+        sonda_bin = raw_bin
+
+    results, failures = run_validation(
+        repo_root=repo_root,
+        sonda_bin=sonda_bin,
+        subprocess_timeout=args.timeout,
+        skip_files=args.skip_file,
+    )
+
+    # Skips are reported, never silent: a gate that quietly stops checking
+    # things reads as "all green" when it is not.
+    for result in results:
+        if result.skipped_reason:
+            rel = result.scenario.file.relative_to(repo_root)
+            print(
+                f"SKIP {rel}:{result.scenario.line} — {result.skipped_reason}",
+                file=sys.stderr,
+            )
+    for failure in failures:
+        print(format_failure(failure, repo_root), file=sys.stderr)
+
+    skipped = sum(1 for r in results if r.skipped_reason)
+    print(
+        f"{len(results)} runnable scenario fences found, "
+        f"{len(results) - skipped - len(failures)} compiled, "
+        f"{skipped} skipped, {len(failures)} failed",
+        file=sys.stderr,
+    )
+    return 0 if not failures else 1
+
+
+# --- Self-tests --------------------------------------------------------------
+
+
+class _SharedCaseTableTests(unittest.TestCase):
+    """The other half of the contract with pure.test.mjs.
+
+    Every case in runnable-cases.json is answered by BOTH implementations.
+    A case added for the browser detector fails here until the Python twin
+    agrees, which is the whole point of the file.
+    """
+
+    def test_shared_case_table(self) -> None:
+        repo_root = find_repo_root(Path(__file__).parent)
+        table = json.loads(
+            (repo_root / SHARED_CASE_TABLE).read_text(encoding="utf-8")
+        )
+        cases = table["cases"]
+        self.assertGreaterEqual(len(cases), 20, "table should be a real case table")
+        self.assertTrue(any(c["expected"] for c in cases))
+        self.assertTrue(any(not c["expected"] for c in cases))
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                self.assertEqual(
+                    is_runnable_scenario(case["text"]),
+                    case["expected"],
+                    f"detector disagrees with the shared table on: {case['name']}",
+                )
+
+
+class _NormalizeFenceTests(unittest.TestCase):
+    def test_flush_text_is_untouched(self) -> None:
+        self.assertEqual(normalize_fence("version: 2\nkind: x\n"), "version: 2\nkind: x\n")
+
+    def test_uniform_indent_is_removed(self) -> None:
+        self.assertEqual(normalize_fence("    a\n    b\n"), "a\nb\n")
+
+    def test_blank_line_does_not_pin_dedent_at_zero(self) -> None:
+        self.assertEqual(normalize_fence("    a\n\n    b\n"), "a\n\nb\n")
+
+    def test_ragged_indent_removes_common_prefix_only(self) -> None:
+        self.assertEqual(normalize_fence("  a\n    b\n"), "a\n  b\n")
+
+    def test_bom_and_crlf(self) -> None:
+        self.assertEqual(normalize_fence("﻿version: 2"), "version: 2")
+        self.assertEqual(normalize_fence("a\r\nb\rc"), "a\nb\nc")
+
+
+class _ExtractYamlFencesTests(unittest.TestCase):
+    def test_only_yaml_fences_match(self) -> None:
+        md = (
+            "intro\n"
+            "```bash\n"
+            "sonda run x.yaml\n"
+            "```\n"
+            "```yaml\n"
+            "version: 2\n"
+            "```\n"
+        )
+        fences = extract_yaml_fences(md)
+        self.assertEqual(len(fences), 1)
+        self.assertEqual(fences[0][1], "version: 2")
+
+    def test_line_number_points_at_first_content_line(self) -> None:
+        md = "intro\n\n```yaml\nversion: 2\n```\n"
+        line, body, _ = extract_yaml_fences(md)[0]
+        self.assertEqual(md.splitlines()[line - 1], "version: 2")
+
+    def test_titled_fence_keeps_its_info_string(self) -> None:
+        md = '```yaml title="hello.yaml"\nversion: 2\n```\n'
+        _, _, info = extract_yaml_fences(md)[0]
+        self.assertIn('title="hello.yaml"', info)
+
+    def test_indented_fence_inside_a_tab_block(self) -> None:
+        md = '=== "Tab"\n\n    ```yaml\n    version: 2\n    scenarios: []\n    ```\n'
+        fences = extract_yaml_fences(md)
+        self.assertEqual(len(fences), 1)
+        self.assertEqual(normalize_fence(fences[0][1]), "version: 2\nscenarios: []")
+
+    def test_longer_delimiter_is_not_closed_by_a_shorter_inner_fence(self) -> None:
+        md = "````yaml\nversion: 2\n```\nstill inside\n````\n"
+        fences = extract_yaml_fences(md)
+        self.assertEqual(len(fences), 1)
+        self.assertIn("still inside", fences[0][1])
+
+
+class _ExtractScenariosTests(unittest.TestCase):
+    def test_fragments_are_not_extracted(self) -> None:
+        md = "```yaml\ngenerator:\n  type: sine\n```\n"
+        self.assertEqual(extract_scenarios(Path("x.md"), md), [])
+
+    def test_complete_scenario_is_extracted_dedented(self) -> None:
+        md = '=== "Tab"\n\n    ```yaml\n    version: 2\n    kind: runnable\n    ```\n'
+        found = extract_scenarios(Path("x.md"), md)
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].body, "version: 2\nkind: runnable")
+
+    def test_static_marked_fence_is_not_extracted(self) -> None:
+        md = "```yaml\n# sonda:static\nversion: 2\nkind: runnable\n```\n"
+        self.assertEqual(extract_scenarios(Path("x.md"), md), [])
+
+
+class _MissingInputFilesTests(unittest.TestCase):
+    def test_reports_a_path_that_does_not_exist(self) -> None:
+        repo_root = find_repo_root(Path(__file__).parent)
+        body = "version: 2\nkind: runnable\ngenerator:\n  file: nope/absent.csv\n"
+        self.assertEqual(missing_input_files(body, repo_root), ["nope/absent.csv"])
+
+    def test_existing_path_is_not_reported(self) -> None:
+        repo_root = find_repo_root(Path(__file__).parent)
+        body = "version: 2\nkind: runnable\ngenerator:\n  file: Cargo.toml\n"
+        self.assertEqual(missing_input_files(body, repo_root), [])
+
+    def test_metavar_placeholders_are_ignored(self) -> None:
+        repo_root = find_repo_root(Path(__file__).parent)
+        body = "generator:\n  file: <your-export>.csv\n"
+        self.assertEqual(missing_input_files(body, repo_root), [])
+
+    def test_output_sink_paths_are_not_treated_as_inputs(self) -> None:
+        repo_root = find_repo_root(Path(__file__).parent)
+        body = "sink:\n  type: file\n  path: /tmp/out.txt\n"
+        self.assertEqual(missing_input_files(body, repo_root), [])
+
+
+def _run_self_tests() -> int:
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(sys.modules[__name__])
+    runner = unittest.TextTestRunner(verbosity=2)
+    return 0 if runner.run(suite).wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Wave 1, WP1 + WP2 of the live-docs program.

Every complete scenario fence in the docs now carries a **Run in playground →** link that opens it in the playground with the chart already drawn, and CI compiles every fence that gets one — so a button cannot promise something CI has not proven. Alongside it, the getting-started funnel now leads with the playground instead of asking readers to install a binary before they can see what Sonda does.

Turning the gate on found **19 fences out of 87 that the engine rejects** — a reader copying any of them got an error, not a signal. Three were real doc bugs; the rest are honestly not runnable and are now marked as such. Fixing them is the feature's first payoff and is included here.

The rule deciding what is "runnable" necessarily exists twice (the browser cannot import Python, CI cannot run the DOM), so both implementations answer **one shared case table**, `docs/site/tools/tests/runnable-cases.json`, exercised from both sides. A case added for one is automatically demanded of the other — that is what stops them drifting.

## Changes

**The rule and the button**

- `runnableScenario` / `normalizeFence` in `sonda-pure.js`: complete iff the fence declares `version: 2` (the engine rejects a scenario file without one, making this the honest complete-vs-fragment line) and carries `scenarios:` or the `kind:` shorthand. Normalization folds BOM/CRLF and dedents, so the browser's `code.textContent` and CI's raw markdown resolve to one shape.
- Two structural exclusions: `# sonda:static`, an explicit opt-out visible in both the markdown source and the rendered page; and any `pack:` reference — packs resolve against a `--catalog` directory that neither a fence nor the browser has (sonda-wasm builds an empty resolver), so a button there would always land on "unknown pack".
- `runnable-fences.js`: scans `.md-content pre > code`, skips the playground page itself, resolves the playground URL from the nav (`a[href$="playground/"]` — never a hardcoded path, since the site lives under the `/sonda/` project prefix and these appear at every depth), and appends the link. `document$`-subscribed for instant navigation; DOM built with `createElement`/`textContent` only.
- `runnable-cases.json`: 25 cases, hostile on purpose — `version: 2` inside a comment and inside a log message, CRLF, BOM, a `version:`/`2` line split, `version: 20`, Kubernetes manifests, docker-compose, `- pack:` in list form, and admonition-nested fences carrying four spaces on every line.

**The gates**

- `scripts/validate_docs_scenarios.py`: extracts every runnable fence and compiles it with `sonda --dry-run run`, failing with `file:line`. Reuses the sibling validator's docs-root walk so "which files are user-facing" cannot drift between the two gates. Skips are reported, never silent. `--self-test` runs 18 unit tests including the shared table; `--list` prints what would be checked.
- `scripts/check_no_raw_html.sh`: fails on `.innerHTML` / `.outerHTML` / `insertAdjacentHTML` / `document.write` in hand-written docs JS, turning the no-raw-markup convention into a gate. The vendored esbuild and wasm-bindgen bundles are excluded — their contents are upstream's, and they are covered by rebuild-and-compare drift gates instead.
- Both wired into the `docs-commands` job (which already builds the release binary with `http,kafka,remote-write,otlp`, so every documented sink and encoder parses), plus `task site:scenario-check` and `task site:no-raw-html`.

**Hash hardening**

- `MAX_HASH_PAYLOAD` (32 KB) + `hashPayloadTooLarge`, applied in both `#yaml=` readers **before** the decode — a pure length test on the raw payload, because the guard has to run before `fromBase64Url` allocates. A refused link is explained (playground status line, lab story line) rather than swallowed; malformed base64 still falls back to the default preset silently, since that is a broken link rather than a hostile one.

**Doc bugs the gate exposed**

- **`name:` is not a scenario field.** Catalog metadata on a `kind: runnable` file is `scenario_name:`; `name:` is rejected by `deny_unknown_fields`. Five fences *and two field-reference tables* taught the wrong spelling. `kind: composable` packs genuinely do use a bare `name:`, which is where the confusion came from, so the catalogs table now says so explicitly. Verified both ways against the binary; `sonda show` echoes the file verbatim, so the "Output" fence changed with it.
- **`phase_offset: "0s"` is a config error**, not a way to spell "no delay" — the duration must exceed zero. Two fences used it to mean "starts immediately", which is expressed by omitting the field, exactly as the field reference already documented. Removed, with a sentence on the reference page so it is not reintroduced.
- **The Loki sink example** had a `signal_type: logs` entry with no generator at all and could never run. Given a `log_generator:` block matching the generators page.
- Marked `# sonda:static`: the three capacity-planning fences (explicitly titled "(excerpt)", truncated mid-entry) and the two cross-POST `while:` examples (rejected by the CLI by design — they need a running `sonda-server`).

**Funnel (WP2)**

- Get started gains a "Try it in your browser" card ahead of the install-shaped ones; Quickstart opens with a "No install needed to explore" admonition; Scheduling notes that its complete scenarios carry the link *and* that its shorter fences have nothing to run.
- Copy is deliberately literal: "the real engine, compiled to WebAssembly", never "every generator" — the CSV replays need a file from disk and are reported as skipped in the browser.
- The homepage already leads with a "Try it in your browser" button above the fold, so it is left alone.

**Unrelated, separated into its own commit**

- `Cargo.lock` synced to 1.19.0. The release-please commit bumped the three crates in their `Cargo.toml` files but left the lockfile at 1.18.0, so every local build regenerated it and showed a dirty tree. No dependency changed.

## Test plan

Local gate suite, all green:

```
node docs/site/tools/tests/pure.test.mjs            58 pure-helper tests passed
python3 scripts/validate_docs_scenarios.py --self-test   18 tests OK
python3 scripts/validate_docs_scenarios.py          75 fences, 74 compiled, 1 skipped, 0 failed
python3 scripts/validate_docs_commands.py           153 commands checked, 0 failed
node docs/site/tools/tests/livegen-compile.mjs      477 slider combinations compile
bash scripts/check_no_raw_html.sh                   OK
mkdocs build --strict -f docs/site/mkdocs.yml       built clean
```

The single skip is `import/log-files.md:167`, a csv_replay tutorial reading `incident.csv`, which the reader exports themselves — reported by path, not silently dropped.

**Law 3 — new invariants verified RED first.** Seven mutations of the detector were each confirmed to fail a specific named case, then reverted: `\s` for `[ \t]` (matches the split-line case), dropping the end anchor (`version: 20` prefix-matches), removing normalization and removing the BOM strip, ignoring `sonda:static`, dropping the `scenarios:`/`kind:` requirement, and letting blank lines pin the dedent at zero. The `- pack:` list form was caught this way too — the first regex missed it and the table failed until it was fixed. The compile gate itself was sabotage-checked by typo-ing a field in a real fence and confirming the right `file:line`; the no-raw-markup gate was checked against an injected assignment and confirmed not to trip on the safe `insertAdjacentElement` this PR actually uses.

**Browser UAT** (Chromium against the built site, 15 assertions, three consecutive clean runs):

- Buttons on both complete scenarios on `scheduling.md`, on none of its ten fragments, and on no non-YAML fence.
- `code.textContent` is clean YAML despite Material's `line_spans` wrapping — the line anchors are empty, so they contribute no text.
- Clicking a button lands in the playground with that scenario loaded and a non-blank chart.
- The playground page offers no buttons back to itself.
- An oversized hash reports "too large" and falls back to the default preset.
- A share link whose YAML contains a `<script>` tag renders as inert editor text and does not execute.
- The nav-derived playground URL resolves correctly from a deep page and returns 200.

Screenshots reviewed in both light and dark themes.

**CI:** all 18 checks green on `63a5f3b`.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)

No Rust source changed in this PR — the only non-docs change is the `Cargo.lock` version sync, so the workspace gates were run to confirm it still builds rather than because code moved. Locally `cargo test --workspace` is 1970 passed / 2 failed, both being the known root-only `sink::file` read-only-dir tests (`write_to_readonly_dir_returns_sink_error_with_path_in_message`, `sink_file_error_produces_sink_variant`); they pass in CI, as the green job on this branch shows.

## Notes for the reviewer

- **Where bugs would hide:** the detector's two implementations share a table, so the interesting attack is a case the table does not contain. Fence shapes worth trying: a block scalar whose content begins at column 0, a fence with mixed tab/space indentation (the dedent is character-count based, so a tab counts as one), a fence with Material `linenums` enabled (none exist today — `textContent` was verified clean under `line_spans` because the line anchors are empty, but `linenums` is a different code path), and `pack:` appearing as a label key rather than an entry field (a known, accepted false negative that only ever loses a button).
- Beyond the detector: the nav-derived playground URL (`a[href$="playground/"]` — the `$=` is load-bearing, since `*=` also matches `playground/alert-lab/`); double-buttoning under Material instant navigation (guarded by a `data-` flag on the swapped-in DOM); and the `await run()` / `await loadPreset()` reordering in playground.js and alert-lab.js, which was needed so a refused-hash message is not immediately overwritten — worth confirming nothing else depended on those being fire-and-forget.
- On the gate: `missing_input_files` only inspects `file:` keys (a file sink's `path:` is an output and is deliberately not checked) — argue with that if you think an input can arrive another way.
- **Spec delta, recorded not dropped:** `encoders.md` was slated for a WP2 pointer, but all ten of its YAML fences are bare `encoder:` blocks by design — the page has zero complete scenarios, so the sentence would have been false. WP8's live encoder widget is the real answer there.
- **Spec delta:** excluding `pack:` was added to the shared rule rather than marking six fences `# sonda:static`, because the browser has no catalog either — a doc-level marker would have fixed CI while leaving the buttons broken.
- **Pre-existing behavior noticed, not changed:** the playground reads `#yaml=` once at boot, so changing only the hash on an already-loaded page does not reload the scenario. Out of scope here.
- Branch is `claude/sonda-wp1-execution-p9biuu` (this session's assigned branch) rather than the playbook's shared review branch.