### PR TITLE
feat(site): download the scenario YAML and the chart PNG from the playground

### DIFF
--- a/docs/site/docs/javascripts/playground.js
+++ b/docs/site/docs/javascripts/playground.js
@@ -8,7 +8,7 @@
  * fetched only when the playground container exists.
  */
 import init, { sample_scenario } from "./sonda_wasm.js";
-import { toBase64Url, fromBase64Url, hashPayloadTooLarge } from "./sonda-pure.js";
+import { toBase64Url, fromBase64Url, hashPayloadTooLarge, exportFilename } from "./sonda-pure.js";
 
 const MAX_TICKS = 240;
 const DEBOUNCE_MS = 500;
@@ -314,6 +314,8 @@ async function boot() {
     preset: document.getElementById("sp-preset"),
     run: document.getElementById("sp-run"),
     share: document.getElementById("sp-share"),
+    download: document.getElementById("sp-download"),
+    png: document.getElementById("sp-png"),
     testAlert: document.getElementById("sp-test-alert"),
     status: document.getElementById("sp-status"),
     editor: document.getElementById("sp-editor"),
@@ -368,6 +370,43 @@ async function boot() {
     editor.setValue(PRESETS[Number(el.preset.value)].yaml);
     run();
   });
+  // Download YAML: one gesture leaves the reader with both halves of the
+  // next step — the file on disk and the command that runs it on the
+  // clipboard. The status line always shows the command, so a browser that
+  // refuses clipboard access costs the convenience, not the information
+  // (same degradation the alert lab's "Copy below ↓" already uses).
+  el.download.addEventListener("click", () => {
+    const yaml = editor.getValue();
+    const filename = exportFilename(exportSource(lastResult), "yaml");
+    saveBlob(new Blob([yaml], { type: "text/yaml;charset=utf-8" }), filename);
+    const command = `sonda run ${filename}`;
+    const flash = (prefix) => flashStatus(el, `${prefix} ${command}`);
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(command).then(
+        () => flash("Saved — run:"),
+        () => flash("Saved — run (copy manually):")
+      );
+    } else {
+      flash("Saved — run (copy manually):");
+    }
+  });
+
+  // Chart PNG: whatever is on the canvas, at whatever DPR it was drawn for.
+  // toBlob can hand back null (a zero-size or otherwise untainted-but-empty
+  // canvas), so the null branch reports rather than silently doing nothing.
+  el.png.addEventListener("click", () => {
+    if (el.png.disabled) return;
+    const filename = exportFilename(exportSource(lastResult), "png");
+    el.chart.toBlob((blob) => {
+      if (!blob) {
+        flashStatus(el, "nothing to export — the chart is empty");
+        return;
+      }
+      saveBlob(blob, filename);
+      flashStatus(el, `Saved ${filename}`);
+    });
+  });
+
   el.share.addEventListener("click", () => {
     const url = new URL(window.location.href);
     url.hash = "yaml=" + toBase64Url(editor.getValue());
@@ -426,6 +465,58 @@ function showError(el, message) {
   el.error.textContent = message;
 }
 
+/* Which sampled entries should name the downloaded file.
+ *
+ * Metrics entries first, because they are what the chart shows. A logs-only
+ * scenario has an empty `entries` array but named log entries, and falling
+ * straight through to exportFilename's "scenario" default would hand every
+ * logs preset the same anonymous filename. */
+function exportSource(result) {
+  if (!result) return [];
+  if (result.entries && result.entries.length) return result.entries;
+  return result.logs || [];
+}
+
+/* Hand a Blob to the browser's download machinery.
+ *
+ * The object URL is revoked on the next frame rather than immediately: the
+ * click has to have been dispatched before the URL dies, and revoking in the
+ * same tick loses the download in some browsers. */
+function saveBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+/* Put a transient message on the status line without stomping on whatever a
+ * later run wants to say. The token guards against an earlier flash's timer
+ * clearing a newer message. */
+let statusToken = 0;
+function flashStatus(el, message, holdMs = 4000) {
+  el.status.textContent = message;
+  const token = ++statusToken;
+  window.setTimeout(() => {
+    if (statusToken === token) el.status.textContent = "";
+  }, holdMs);
+}
+
+/* The PNG button is only meaningful when the main chart is on screen — a
+ * logs-only scenario hides it (render() sets display:none), and exporting a
+ * blank canvas would be a worse answer than refusing. */
+function syncPngButton(el) {
+  if (!el.png) return;
+  const hidden = el.chart.style.display === "none";
+  el.png.disabled = hidden;
+  el.png.title = hidden
+    ? "This scenario has no line chart to export"
+    : "Download the chart as a PNG";
+}
+
 function render(el, result) {
   if (!result.ok) {
     showError(el, result.error || "unknown compile error");
@@ -443,6 +534,7 @@ function render(el, result) {
   const hasExtras = histograms.length || summaries.length || logs.length;
   el.chart.style.display = hasLines || !hasExtras ? "" : "none";
   if (hasLines || !hasExtras) drawChart(el.chart, result.entries);
+  syncPngButton(el);
 
   renderExtraCharts(el, histograms, summaries);
   renderLogs(el, logs);

--- a/docs/site/docs/javascripts/sonda-pure.js
+++ b/docs/site/docs/javascripts/sonda-pure.js
@@ -109,6 +109,38 @@ export function runnableScenario(text) {
   return /^scenarios:/m.test(body) || /^kind:/m.test(body);
 }
 
+/* Build a download filename from a sampled scenario.
+ *
+ * The name comes from the first entry, so a downloaded file is recognisable
+ * as the thing that was on screen — but an entry name is engine-validated,
+ * not filesystem-validated, and the two agree on much less than you would
+ * hope. `cpu usage %`, `../etc/passwd`, `.bashrc` and `東京` are all names the
+ * engine accepts and none of them may reach a Save dialog intact.
+ *
+ * So the stem is rebuilt rather than escaped: lowercase, every character
+ * outside [a-z0-9_-] becomes a hyphen (runs collapsing to one), repeated
+ * hyphens collapse, leading and trailing hyphens go, and the result is capped
+ * at 40 characters. Path separators and dots cannot survive that — `../x`
+ * reduces to `x` — so the return value is always a single bare filename with
+ * exactly one extension, never a path and never a dotfile.
+ *
+ * A name that sanitizes to nothing (all-CJK, punctuation-only, empty, or no
+ * entries at all) falls back to "scenario" rather than producing a file
+ * called ".yaml".
+ */
+export function exportFilename(entries, ext) {
+  const first = Array.isArray(entries) && entries.length ? entries[0] : null;
+  let stem = String((first && first.name) || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (stem.length > 40) stem = stem.slice(0, 40).replace(/-+$/g, "");
+  if (!stem) stem = "scenario";
+  const suffix = String(ext || "").replace(/^\.+/, "");
+  return suffix ? `${stem}.${suffix}` : stem;
+}
+
 /* Round to two leading digits; guards float dust like 60.000000000000004. */
 export function tidyNumber(value) {
   const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(value))) - 1);

--- a/docs/site/docs/playground/index.md
+++ b/docs/site/docs/playground/index.md
@@ -25,6 +25,8 @@ the signal reshape live.
     <select id="sp-preset" class="sonda-playground__select" aria-label="Load a preset scenario"></select>
     <button id="sp-run" type="button" class="md-button md-button--primary sonda-playground__run">Run</button>
     <button id="sp-share" type="button" class="md-button sonda-playground__share">Copy link</button>
+    <button id="sp-download" type="button" class="md-button sonda-playground__share">Download YAML</button>
+    <button id="sp-png" type="button" class="md-button sonda-playground__share">Chart PNG</button>
     <a id="sp-test-alert" class="md-button sonda-playground__share" href="alert-lab/">Test an alert →</a>
     <span id="sp-status" class="sonda-playground__status" role="status" aria-live="polite"></span>
   </div>

--- a/docs/site/docs/stylesheets/sonda.css
+++ b/docs/site/docs/stylesheets/sonda.css
@@ -814,6 +814,20 @@
   font-size: 0.72rem;
 }
 
+/* Chart PNG is disabled for scenarios with no line chart (logs-only). It
+   stays visible rather than disappearing, so the control row does not
+   reflow as the reader switches presets — the title attribute explains why
+   it is inert. */
+.md-typeset .sonda-playground__share:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.md-typeset .sonda-playground__share:disabled:hover {
+  background: transparent;
+  color: currentcolor;
+}
+
 .sonda-playground__status {
   font-family: "JetBrains Mono", ui-monospace, monospace;
   font-size: 0.72rem;

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -15,6 +15,7 @@ import {
   deriveAlertName,
   escapeQuoted,
   evaluate,
+  exportFilename,
   fromBase64Url,
   hashPayloadTooLarge,
   niceDeadlineSecs,
@@ -477,6 +478,76 @@ test("the cap is measured in payload characters, not decoded bytes", () => {
   // The point of the guard is to refuse work BEFORE decoding, so the check
   // must be a pure length test on the raw hash payload.
   assert.equal(MAX_HASH_PAYLOAD, 32 * 1024);
+});
+
+// --- exportFilename ----------------------------------------------------
+
+// An entry name is validated by the engine, not by any filesystem. Every
+// shape here is a name the engine accepts; none of them may reach a Save
+// dialog intact.
+const FILENAME_CASES = [
+  { name: "cpu_usage", want: "cpu_usage.yaml" },
+  { name: "web-01", want: "web-01.yaml" },
+  { name: "CPU_Usage", want: "cpu_usage.yaml", why: "lowercased" },
+  { name: "cpu usage %", want: "cpu-usage.yaml", why: "spaces and punctuation collapse, trailing trimmed" },
+  { name: "a//b", want: "a-b.yaml", why: "a run of separators becomes ONE hyphen" },
+  { name: "a--b", want: "a-b.yaml", why: "pre-existing repeats collapse too" },
+  { name: "../x", want: "x.yaml", why: "path traversal cannot survive" },
+  { name: "../../etc/passwd", want: "etc-passwd.yaml", why: "deep traversal flattens to a bare name" },
+  { name: "/abs/path", want: "abs-path.yaml", why: "absolute path flattens" },
+  { name: ".bashrc", want: "bashrc.yaml", why: "never produce a dotfile" },
+  { name: "report.tar.gz", want: "report-tar-gz.yaml", why: "exactly one extension, always ours" },
+  { name: "東京", want: "scenario.yaml", why: "sanitizes to nothing -> fallback, not '.yaml'" },
+  { name: "!!!", want: "scenario.yaml", why: "punctuation-only -> fallback" },
+  { name: "", want: "scenario.yaml" },
+  { name: "   ", want: "scenario.yaml" },
+  { name: "-lead-and-trail-", want: "lead-and-trail.yaml" },
+  { name: "café", want: "caf.yaml", why: "accented char is not in the allowed set" },
+];
+
+for (const testCase of FILENAME_CASES) {
+  const label = `exportFilename: ${JSON.stringify(testCase.name)}${testCase.why ? ` (${testCase.why})` : ""}`;
+  test(label, () => {
+    assert.equal(exportFilename([{ name: testCase.name }], "yaml"), testCase.want);
+  });
+}
+
+test("exportFilename never returns a path separator or a leading dot", () => {
+  for (const testCase of FILENAME_CASES) {
+    const out = exportFilename([{ name: testCase.name }], "yaml");
+    assert.ok(!out.includes("/"), `${out} contains /`);
+    assert.ok(!out.includes("\\"), `${out} contains backslash`);
+    assert.ok(!out.startsWith("."), `${out} is a dotfile`);
+    assert.equal(out.split(".").length, 2, `${out} must have exactly one extension`);
+  }
+});
+
+test("exportFilename falls back when there is nothing to name it after", () => {
+  assert.equal(exportFilename([], "yaml"), "scenario.yaml");
+  assert.equal(exportFilename(null, "yaml"), "scenario.yaml");
+  assert.equal(exportFilename(undefined, "yaml"), "scenario.yaml");
+  assert.equal(exportFilename([{}], "yaml"), "scenario.yaml");
+  assert.equal(exportFilename([{ name: null }], "yaml"), "scenario.yaml");
+});
+
+test("exportFilename caps the stem at 40 chars without a trailing hyphen", () => {
+  const long = exportFilename([{ name: "x".repeat(80) }], "yaml");
+  assert.equal(long, `${"x".repeat(40)}.yaml`);
+  // The cut must land ON a hyphen to exercise the post-cap trim: 39 x's then
+  // a space puts the separator at index 39, so slice(0, 40) ends with it.
+  const boundary = exportFilename([{ name: `${"x".repeat(39)} tail` }], "png");
+  assert.equal(boundary, `${"x".repeat(39)}.png`);
+  assert.ok(!boundary.includes("-."), "a capped stem must not end in a hyphen");
+});
+
+test("exportFilename takes the extension as given, dotted or bare", () => {
+  assert.equal(exportFilename([{ name: "cpu" }], "png"), "cpu.png");
+  assert.equal(exportFilename([{ name: "cpu" }], ".png"), "cpu.png");
+  assert.equal(exportFilename([{ name: "cpu" }], ""), "cpu");
+});
+
+test("exportFilename names the file after the FIRST entry", () => {
+  assert.equal(exportFilename([{ name: "first" }, { name: "second" }], "yaml"), "first.yaml");
 });
 
 console.log(`${passed} pure-helper tests passed`);


### PR DESCRIPTION
## Summary

Wave 1, WP3 — closes the original W1 export backlog. Two buttons in the playground's control row, styled like "Copy link".

**Download YAML** saves the editor's current buffer, then flashes `Saved — run: sonda run <file>` on the status line and puts that command on the clipboard. One gesture leaves the reader with both halves of the next step: the file on disk and the command that runs it.

**Chart PNG** saves the main chart via `toBlob`, and is disabled — with a title explaining why — for scenarios that have no line chart.

Filenames come from a new pure helper, `exportFilename(entries, ext)`, because an entry name is engine-validated, not filesystem-validated, and the two agree on much less than you would hope.

## Changes

**`exportFilename(entries, ext)` in `sonda-pure.js`**

`cpu usage %`, `../etc/passwd`, `.bashrc` and `東京` are all names the engine accepts and none of them may reach a Save dialog intact. The stem is therefore rebuilt rather than escaped: lowercase → anything outside `[a-z0-9_-]` becomes a hyphen (runs collapsing to one) → repeated hyphens collapse → leading/trailing hyphens trim → capped at 40 chars. The result is always a single bare filename with exactly one extension — never a path, never a dotfile. `../x` reduces to `x`. A name that sanitizes to nothing falls back to `scenario` rather than producing a file called `.yaml`.

**Download YAML (`#sp-download`)**

- Blob of `editor.getValue()`, anchor-download, object URL revoked on the next tick so the click is dispatched before the URL dies.
- Status flash + clipboard copy of `sonda run <file>`.
- Clipboard refusal degrades rather than half-failing: the file still saves, the status still shows the command, and the wording changes to "copy manually" so the refusal is signalled instead of silent. Same shape as the alert lab's existing "Copy below ↓" fallback.

**Chart PNG (`#sp-png`)**

- `chart.toBlob` → download. `toBlob` can hand back `null` (empty canvas), so that branch reports instead of doing nothing.
- Disabled when `render()` has hidden the canvas (logs-only scenarios). The button stays in place rather than disappearing, so the control row does not reflow as the reader switches presets; a `title` explains why it is inert.

**Filename source**

A logs-only scenario has no metrics entries, so `exportSource()` falls back to the first *log* entry before reaching the `scenario` default — otherwise every logs preset downloaded as the same anonymous `scenario.yaml`. Caught in UAT, now asserted.

The alert lab already has its own export; nothing was duplicated there.

## Test plan

Local gate suite, all green:

```
node docs/site/tools/tests/pure.test.mjs             80 pure-helper tests passed  (was 58)
python3 scripts/validate_docs_scenarios.py           75 fences, 74 compiled, 1 skipped, 0 failed
python3 scripts/validate_docs_scenarios.py --self-test  18 tests OK
python3 scripts/validate_docs_commands.py            153 commands checked, 0 failed
node docs/site/tools/tests/livegen-compile.mjs       477 slider combinations compile
bash scripts/check_no_raw_html.sh                    OK
mkdocs build --strict -f docs/site/mkdocs.yml        clean
```

**Law 3 — the 24 new filename cases were verified RED first.** Seven mutations each failed a specific named case before being reverted: dropping the trim, dropping the fallback, dropping the repeat collapse, dropping the lowercase, dropping the 40-char cap, dropping the post-cap hyphen trim, and allowing dots in the charset (which resurrects both the dotfile and `../`).

One of those mutations initially stayed **GREEN**, and the case was wrong rather than the code: the cap-trim boundary case used 40 `x`s, so `slice(0, 40)` never landed on the hyphen and the post-cap trim was never exercised. The case now uses 39 `x`s so the separator sits exactly at the cut, and the mutation goes red as it should.

**Browser UAT** (Chromium, 22 assertions, three consecutive clean runs, 0 same-origin page errors):

- Downloaded YAML matches the editor buffer; filename is a bare `[a-z0-9_-]+.yaml`.
- Status flashes `sonda run cpu_usage.yaml` and the clipboard holds exactly that.
- PNG carries real PNG magic bytes, 35 KB at DPR 1.
- **DPR 2** (reviewer attack): canvas backed at 1334×640, PNG 85 KB and non-blank.
- **Clipboard denial** (reviewer attack): `navigator.clipboard.writeText` stubbed to reject — file still downloads, status still shows the command, wording signals the refusal.
- PNG button disabled on the logs preset with the explanatory title, re-enabled on switching back to a metrics preset.
- Logs-only download is named `checkout_logs.yaml`, not `scenario.yaml`.

Light and dark screenshots of the control row reviewed, plus the disabled state on the logs preset.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)

No Rust changed in this PR — it is JS, CSS and the playground page markup only, so the workspace gates are unaffected (they were run green on this branch's base, `180b7a3`).

## Notes for the reviewer

- **Where bugs would hide:** `exportFilename` is pure and table-tested, so the interesting attacks are shapes the table lacks — Windows reserved stems (`con`, `nul`, `aux`) survive sanitization intact and would be awkward on that platform; a name that is all hyphens after sanitizing hits the fallback, but one that is a single character does not; and the 40-char cap counts UTF-16 code units, so an emoji name is measured in surrogate halves before it is stripped.
- `saveBlob` revokes on `setTimeout(…, 0)` — worth arguing if you think a slow download in a throttled tab could outlive that.
- `syncPngButton` is only called from the success path of `render()`; after a compile error the button keeps its previous state, which I judged correct (the chart still shows the last good render, so the PNG is still meaningful) but it is a judgement call.
- The `statusToken` guard exists so an earlier flash's timer cannot clear a newer message; the run path writes `el.status` directly and is deliberately not tokenised.
- **Pre-existing, not touched:** the playground reads `#yaml=` once at boot, so a hash-only change does not reload the scenario.