### PR TITLE
feat(ci): browser smoke suite for the docs site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,90 @@ jobs:
         env:
           SONDA_BIN: ./target/release/sonda
 
+  # The docs site's JS is exercised here and nowhere else. The pure-helper
+  # harness covers functions that are plain functions of their arguments; this
+  # job covers what only a browser can: the wasm engine actually loading, the
+  # canvas actually drawing, and the DOM wiring behaving under Material's
+  # instant navigation. Before it existed, every visual claim in a docs PR
+  # rested on the author having driven Chromium by hand — which a reviewer
+  # cannot reproduce.
+  docs-browser-smoke:
+    name: Docs site browser smoke suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docs/site/tools/browser/package-lock.json
+
+      - name: Install smoke-suite dependencies
+        working-directory: docs/site/tools/browser
+        run: npm ci
+
+      # Keyed on the resolved playwright version, so a lockfile bump fetches a
+      # matching browser instead of silently reusing an incompatible cached one.
+      - name: Resolve playwright version
+        id: pw
+        working-directory: docs/site/tools/browser
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache playwright browsers
+        id: pw-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
+
+      - name: Install Chromium
+        working-directory: docs/site/tools/browser
+        run: npx playwright install --with-deps chromium
+
+      # Same major and pin as the deploy workflow, so the site this job smokes
+      # is built by the toolchain that actually publishes it.
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: docs/site/requirements.txt
+
+      - name: Install MkDocs
+        run: pip install -r docs/site/requirements.txt
+
+      - name: Build the site
+        run: mkdocs build --strict -f docs/site/mkdocs.yml
+
+      # Served as static files, exactly as GitHub Pages serves it — the wasm
+      # needs a real HTTP origin, so file:// is not an option.
+      # nohup + setsid so the server outlives this step's shell — each `run`
+      # is its own shell, and the next step needs the port still open.
+      - name: Serve the built site
+        run: |
+          setsid nohup python3 -m http.server 8777 --directory docs/site/site \
+            > /tmp/http-server.log 2>&1 < /dev/null &
+          for _ in $(seq 1 30); do
+            if curl -sf -o /dev/null http://localhost:8777/playground/; then
+              echo "site is up on :8777"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::the site never came up on :8777"
+          cat /tmp/http-server.log
+          exit 1
+
+      - name: Browser smoke suite
+        working-directory: docs/site/tools/browser
+        run: node smoke.mjs
+        env:
+          SONDA_SITE_URL: http://localhost:8777
+
   release-pin-check:
     name: release.yml rust-toolchain pin matches rust-toolchain.toml
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,9 @@ jobs:
       # Served as static files, exactly as GitHub Pages serves it — the wasm
       # needs a real HTTP origin, so file:// is not an option.
       # nohup + setsid so the server outlives this step's shell — each `run`
-      # is its own shell, and the next step needs the port still open.
+      # is its own shell, and the next step needs the port still open. setsid
+      # is Linux-only and this runner is ubuntu; for local runs use
+      # `task site:smoke`, whose recipe is portable, rather than copying this.
       - name: Serve the built site
         run: |
           setsid nohup python3 -m http.server 8777 --directory docs/site/site \

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,12 @@ tests/e2e/.docker-volumes/
 # MkDocs site build output and Python venv
 docs/site/.venv/
 docs/site/site/
+
+# npm installs for the docs-site build tools (editor bundle, browser smoke
+# suite). Both are reproduced from their committed lockfiles with `npm ci`;
+# nothing under node_modules belongs in the repo.
+node_modules/
+
+# Playwright's browser downloads, when it manages them itself rather than
+# using a preinstalled Chromium via CHROMIUM_PATH.
+docs/site/tools/browser/.playwright/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -145,16 +145,26 @@ tasks:
 
       Set CHROMIUM_PATH to use a preinstalled browser instead of playwright's
       own download (this devcontainer has one at /opt/pw-browsers/chromium).
+
+      Use this rather than copying the CI job's serve step: that one uses
+      setsid, which is Linux-only, because each GitHub Actions `run` is a
+      separate shell and the server has to outlive it. Here the server is a
+      child of this recipe and is killed on exit, so it stays portable.
     cmds:
       - mkdocs build --strict -f docs/site/mkdocs.yml
       - |
         python3 -m http.server 8777 --directory docs/site/site >/dev/null 2>&1 &
         server=$!
         trap "kill $server 2>/dev/null" EXIT
+        up=""
         for _ in $(seq 1 30); do
-          curl -sf -o /dev/null http://localhost:8777/playground/ && break
+          if curl -sf -o /dev/null http://localhost:8777/playground/; then up=1; break; fi
           sleep 1
         done
+        if [ -z "$up" ]; then
+          echo "the site never came up on :8777 — is docs/site/site built?" >&2
+          exit 1
+        fi
         node docs/site/tools/browser/smoke.mjs
 
   # ---------------------------------------------------------------------------

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -137,6 +137,26 @@ tasks:
     cmds:
       - bash scripts/check_no_raw_html.sh
 
+  site:smoke:
+    desc: Drive the built docs site in Chromium (playground, alert lab, widgets, fences)
+    summary: |
+      Builds the site, serves it on :8777, and runs the browser smoke suite
+      against it. Needs the npm deps once: cd docs/site/tools/browser && npm ci
+
+      Set CHROMIUM_PATH to use a preinstalled browser instead of playwright's
+      own download (this devcontainer has one at /opt/pw-browsers/chromium).
+    cmds:
+      - mkdocs build --strict -f docs/site/mkdocs.yml
+      - |
+        python3 -m http.server 8777 --directory docs/site/site >/dev/null 2>&1 &
+        server=$!
+        trap "kill $server 2>/dev/null" EXIT
+        for _ in $(seq 1 30); do
+          curl -sf -o /dev/null http://localhost:8777/playground/ && break
+          sleep 1
+        done
+        node docs/site/tools/browser/smoke.mjs
+
   # ---------------------------------------------------------------------------
   # E2E Stack
   # ---------------------------------------------------------------------------

--- a/docs/site/tools/browser/package-lock.json
+++ b/docs/site/tools/browser/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "sonda-browser-smoke",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sonda-browser-smoke",
+      "devDependencies": {
+        "playwright": "1.58.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/docs/site/tools/browser/package.json
+++ b/docs/site/tools/browser/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sonda-browser-smoke",
+  "private": true,
+  "description": "Browser smoke suite for the docs site — the only automated coverage of the playground, alert lab and live widgets that exercises wasm, canvas and the DOM (task site:smoke)",
+  "type": "module",
+  "scripts": {
+    "smoke": "node smoke.mjs"
+  },
+  "devDependencies": {
+    "playwright": "1.58.1"
+  }
+}

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -76,21 +76,78 @@ function watch(page) {
 const chartSignature = () =>
   document.querySelector("#sp-chart")?.toDataURL().length ?? 0;
 
-/* The playground has rendered when the canvas holds a non-trivial image. An
- * empty canvas still produces a short data URL, so the threshold is the
- * assertion, not the presence of the element. */
-const CHART_DRAWN = 3000;
+/* Canvas thresholds, every number below MEASURED against this site rather
+ * than guessed — review #539 W1 caught the first version of this constant
+ * being 1,346 chars BELOW the floor it was supposed to exclude.
+ *
+ * Corrupting the committed wasm and reading each signal gives:
+ *
+ *                        healthy    engine dead
+ *   #sp-chart             47,754          4,346   <- axes and grid still draw
+ *   #sp-output (chars)       355              0   <- nothing without the engine
+ *   .sonda-livegen__chart 29,242          2,118
+ *
+ * The lesson is that the failed state is not a BLANK canvas, it is a
+ * chromed-but-empty one: the axes, gridlines and tick labels are drawn by
+ * plain canvas code that does not need the engine at all. A threshold picked
+ * against "blank" therefore cannot fail for the reason it exists.
+ *
+ * These sit roughly midway between the two measurements in log terms, so
+ * they survive ordinary chart-chrome drift in either direction.
+ */
+const CHART_WITH_DATA = 12000;
+const WIDGET_CHART_WITH_DATA = 8000;
 
+/* Readiness is gated on the ENGINE having produced output, not on the canvas
+ * having produced bytes.
+ *
+ * This predicate is the precondition for three of the nine sections, so it is
+ * the last place a check that cannot fail belongs. `#sp-output` holds the
+ * encoded events the wasm engine emitted: 355 chars healthy, exactly 0 with a
+ * dead engine. It tests the thing we actually care about and cannot be
+ * defeated by drawing more axes. The canvas conditions ride along so the
+ * chart is known-visible for the assertions that follow. */
 async function waitForPlayground(page) {
   await page.waitForSelector("#sonda-playground", { timeout: 30000 });
-  await page.waitForFunction(
-    (min) => {
-      const canvas = document.querySelector("#sp-chart");
-      return canvas && canvas.style.display !== "none" && canvas.toDataURL().length > min;
-    },
-    CHART_DRAWN,
-    { timeout: 60000 }
-  );
+  try {
+    await page.waitForFunction(
+      (min) => {
+        const canvas = document.querySelector("#sp-chart");
+        const output = document.querySelector("#sp-output");
+        return (
+          canvas &&
+          output &&
+          output.textContent.trim().length > 0 &&
+          canvas.style.display !== "none" &&
+          canvas.toDataURL().length > min
+        );
+      },
+      CHART_WITH_DATA,
+      { timeout: 60000 }
+    );
+  } catch (err) {
+    // A bare "waitForFunction: Timeout exceeded" says nothing about WHY the
+    // playground never became ready, and this gate now guards the whole run.
+    // Report what the page actually looked like — with a dead engine the
+    // status line and error banner both name the real cause.
+    const seen = await page
+      .evaluate((min) => {
+        const canvas = document.querySelector("#sp-chart");
+        const error = document.querySelector("#sp-error");
+        return {
+          chartChars: canvas ? canvas.toDataURL().length : null,
+          floor: min,
+          chartDisplay: canvas ? canvas.style.display || "(visible)" : null,
+          outputChars: (document.querySelector("#sp-output")?.textContent || "").trim().length,
+          status: (document.querySelector("#sp-status")?.textContent || "").trim() || null,
+          error: error && !error.hidden ? error.textContent.trim().slice(0, 200) : null,
+        };
+      }, CHART_WITH_DATA)
+      .catch(() => null);
+    throw new Error(
+      `playground never became ready — ${seen ? JSON.stringify(seen) : "page unreadable"}`
+    );
+  }
 }
 
 /* Two ways to find a browser, and they are mutually exclusive in Playwright:
@@ -118,8 +175,11 @@ try {
   await waitForPlayground(page);
 
   const firstSignature = await page.evaluate(chartSignature);
-  check("default preset renders a non-blank chart", firstSignature > CHART_DRAWN,
-    `dataURL ${firstSignature} chars`);
+  // "Non-blank" was the wrong bar: a dead engine still draws axes and grid.
+  // This threshold is above that measured floor, so it fails when the engine
+  // does (review #539 W1).
+  check("default preset renders a chart with data in it", firstSignature > CHART_WITH_DATA,
+    `dataURL ${firstSignature} chars, floor ${CHART_WITH_DATA}`);
   const output = await page.textContent("#sp-output");
   check("encoded output pane is populated", output.trim().length > 0,
     `${output.trim().length} chars`);
@@ -142,7 +202,7 @@ try {
   );
   const secondSignature = await page.evaluate(chartSignature);
   check("a different preset produces a different chart",
-    secondSignature !== firstSignature && secondSignature > CHART_DRAWN,
+    secondSignature !== firstSignature && secondSignature > CHART_WITH_DATA,
     `${firstSignature} -> ${secondSignature}`);
 
   // --- 3. Scrub decoration exists and dragging edits the document --------
@@ -304,10 +364,15 @@ try {
       const canvas = document.querySelector(".sonda-livegen__chart");
       return canvas && canvas.toDataURL().length > min;
     },
-    CHART_DRAWN,
+    WIDGET_CHART_WITH_DATA,
     { timeout: 60000 }
   );
-  check("the widget renders a live chart", true);
+  const widgetSignature = await widgets.evaluate(
+    () => document.querySelector(".sonda-livegen__chart").toDataURL().length
+  );
+  check("the widget renders a chart with data in it",
+    widgetSignature > WIDGET_CHART_WITH_DATA,
+    `dataURL ${widgetSignature} chars, floor ${WIDGET_CHART_WITH_DATA}`);
   const widgetError = await widgets.evaluate(() => {
     const err = document.querySelector(".sonda-livegen__error");
     return err && !err.hidden ? err.textContent : null;

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -1,0 +1,360 @@
+/* Sonda docs site — browser smoke suite.
+ *
+ * The docs site's JS is the only part of this repo with no automated coverage
+ * beyond the pure-helper harness: everything that touches wasm, the canvas or
+ * the DOM has, until now, been verified by a human driving Chromium once per
+ * PR and reporting what they saw. Reviewers cannot reproduce that, so every
+ * visual claim in the last several PRs rested on the author's word. This
+ * suite moves the load-bearing ones into CI.
+ *
+ * Run:
+ *   node docs/site/tools/browser/smoke.mjs
+ *
+ * Environment:
+ *   SONDA_SITE_URL  base URL of a served build   (default http://localhost:8777)
+ *   CHROMIUM_PATH   browser binary to launch     (default: playwright's own;
+ *                   locally /opt/pw-browsers/chromium)
+ *
+ * Conventions that keep this from becoming a flaky tax:
+ *
+ *   - Every wait is condition-based (waitForFunction / waitForSelector).
+ *     There is no bare waitForTimeout anywhere; the one place a debounce has
+ *     to settle is expressed as "wait until the value CHANGES", not "wait
+ *     500ms and hope".
+ *   - Silence is not success. Every check asserts a terminal state, and any
+ *     uncaught page error or same-origin request failure fails the run at the
+ *     end even if every assertion passed.
+ *   - Failures print what they saw, so a red CI log is diagnosable without
+ *     re-running locally.
+ */
+import { chromium } from "playwright";
+
+const BASE = (process.env.SONDA_SITE_URL || "http://localhost:8777").replace(/\/+$/, "");
+const CHROMIUM_PATH = process.env.CHROMIUM_PATH || undefined;
+const started = Date.now();
+
+const failures = [];
+const pageErrors = [];
+let checks = 0;
+
+function check(name, condition, detail = "") {
+  checks += 1;
+  const line = `${name}${detail ? ` — ${detail}` : ""}`;
+  if (condition) {
+    console.log(`  ok   ${line}`);
+  } else {
+    console.log(`  FAIL ${line}`);
+    failures.push(line);
+  }
+}
+
+function section(title) {
+  console.log(`\n${title}`);
+}
+
+/* Same-origin request failures are ours. ERR_ABORTED is not: it means this
+ * script navigated away while a request was in flight (the 1.2 MB wasm is the
+ * usual victim), which says nothing about the site. */
+function watch(page) {
+  page.on("pageerror", (err) => pageErrors.push(`${page.url()} :: ${err}`));
+  page.on("requestfailed", (req) => {
+    const reason = req.failure()?.errorText || "";
+    if (req.url().startsWith(BASE) && !reason.includes("ERR_ABORTED")) {
+      pageErrors.push(`request failed: ${req.url()} ${reason}`);
+    }
+  });
+  page.on("console", (msg) => {
+    // Uncaught errors already arrive via pageerror; this catches explicit
+    // console.error calls from the site's own code.
+    if (msg.type() === "error" && !/Failed to load resource/.test(msg.text())) {
+      pageErrors.push(`console.error: ${msg.text()}`);
+    }
+  });
+  return page;
+}
+
+const chartSignature = () =>
+  document.querySelector("#sp-chart")?.toDataURL().length ?? 0;
+
+/* The playground has rendered when the canvas holds a non-trivial image. An
+ * empty canvas still produces a short data URL, so the threshold is the
+ * assertion, not the presence of the element. */
+const CHART_DRAWN = 3000;
+
+async function waitForPlayground(page) {
+  await page.waitForSelector("#sonda-playground", { timeout: 30000 });
+  await page.waitForFunction(
+    (min) => {
+      const canvas = document.querySelector("#sp-chart");
+      return canvas && canvas.style.display !== "none" && canvas.toDataURL().length > min;
+    },
+    CHART_DRAWN,
+    { timeout: 60000 }
+  );
+}
+
+/* Two ways to find a browser, and they are mutually exclusive in Playwright:
+ *
+ *   - CHROMIUM_PATH set (dev containers with a preinstalled Chromium): launch
+ *     that binary directly.
+ *   - Otherwise (CI): ask for the `chromium` channel rather than letting
+ *     Playwright default to `chrome-headless-shell`. The shell is a SEPARATE
+ *     download from the browser, so a default launch can fail with
+ *     "Executable doesn't exist at .../chromium_headless_shell-<rev>" even
+ *     though `playwright install chromium` succeeded. Naming the channel
+ *     pins us to the full build, which that install always provides.
+ */
+const browser = await chromium.launch(
+  CHROMIUM_PATH ? { executablePath: CHROMIUM_PATH } : { channel: "chromium" }
+);
+const context = await browser.newContext();
+
+try {
+  // --- 1. The playground boots and draws the default preset --------------
+  section("[1] playground boots and renders the default preset");
+  const page = watch(await context.newPage());
+  page.setDefaultTimeout(30000);
+  await page.goto(`${BASE}/playground/`, { waitUntil: "domcontentloaded" });
+  await waitForPlayground(page);
+
+  const firstSignature = await page.evaluate(chartSignature);
+  check("default preset renders a non-blank chart", firstSignature > CHART_DRAWN,
+    `dataURL ${firstSignature} chars`);
+  const output = await page.textContent("#sp-output");
+  check("encoded output pane is populated", output.trim().length > 0,
+    `${output.trim().length} chars`);
+
+  // --- 2. Switching preset redraws ---------------------------------------
+  section("[2] switching preset redraws the chart");
+  const presetCount = await page.evaluate(
+    () => document.querySelector("#sp-preset").options.length
+  );
+  check("presets are populated", presetCount > 5, `${presetCount} presets`);
+  await page.selectOption("#sp-preset", "1");
+  // Condition-based: wait for the image to actually differ, not for a delay.
+  await page.waitForFunction(
+    (previous) => {
+      const canvas = document.querySelector("#sp-chart");
+      return canvas && canvas.toDataURL().length !== previous;
+    },
+    firstSignature,
+    { timeout: 30000 }
+  );
+  const secondSignature = await page.evaluate(chartSignature);
+  check("a different preset produces a different chart",
+    secondSignature !== firstSignature && secondSignature > CHART_DRAWN,
+    `${firstSignature} -> ${secondSignature}`);
+
+  // --- 3. Scrub decoration exists and dragging edits the document --------
+  section("[3] numeric literals are scrubbable");
+  await page.selectOption("#sp-preset", "0");
+  await waitForPlayground(page);
+  await page.waitForSelector(".cm-scrub-number", { timeout: 30000 });
+  const scrubCount = await page.evaluate(
+    () => document.querySelectorAll(".cm-scrub-number").length
+  );
+  check("scrub targets are decorated", scrubCount > 0, `${scrubCount} decorated literals`);
+
+  const docBefore = await page.evaluate(
+    () => document.querySelector("#sonda-playground .cm-content").textContent
+  );
+  const target = await page.$(".cm-scrub-number");
+  const box = await target.boundingBox();
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width / 2 + 40, box.y + box.height / 2, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForFunction(
+    (before) =>
+      document.querySelector("#sonda-playground .cm-content").textContent !== before,
+    docBefore,
+    { timeout: 15000 }
+  );
+  const docAfter = await page.evaluate(
+    () => document.querySelector("#sonda-playground .cm-content").textContent
+  );
+  check("dragging a literal rewrites the document", docAfter !== docBefore);
+
+  // --- 4. Logs preset renders a stream and hides the chart ---------------
+  section("[4] logs preset renders a stream and hides the chart");
+  const logPreset = await page.evaluate(() => {
+    const select = document.querySelector("#sp-preset");
+    const option = [...select.options].find((o) => /log/i.test(o.textContent));
+    return option ? option.value : null;
+  });
+  check("a logs preset is present", logPreset !== null);
+  await page.selectOption("#sp-preset", logPreset);
+  await page.waitForSelector("#sp-logs", { timeout: 30000 });
+  await page.waitForFunction(
+    () => document.querySelectorAll("#sp-logs .sonda-playground__logline").length > 0,
+    null,
+    { timeout: 30000 }
+  );
+  const logLines = await page.evaluate(
+    () => document.querySelectorAll("#sp-logs .sonda-playground__logline").length
+  );
+  check("log lines render", logLines > 0, `${logLines} lines`);
+  check("the line chart is hidden for a logs-only scenario",
+    await page.evaluate(() => document.querySelector("#sp-chart").style.display === "none"));
+
+  // --- 5. Export buttons produce real files ------------------------------
+  section("[5] exports produce real files");
+  await page.selectOption("#sp-preset", "0");
+  await waitForPlayground(page);
+  const [yamlDownload] = await Promise.all([
+    page.waitForEvent("download", { timeout: 30000 }),
+    page.click("#sp-download"),
+  ]);
+  check("Download YAML yields a sanitized bare filename",
+    /^[a-z0-9_-]+\.yaml$/.test(yamlDownload.suggestedFilename()),
+    yamlDownload.suggestedFilename());
+  const [pngDownload] = await Promise.all([
+    page.waitForEvent("download", { timeout: 30000 }),
+    page.click("#sp-png"),
+  ]);
+  check("Chart PNG yields a sanitized bare filename",
+    /^[a-z0-9_-]+\.png$/.test(pngDownload.suggestedFilename()),
+    pngDownload.suggestedFilename());
+
+  // --- 6. Hostile share links are inert ----------------------------------
+  section("[6] hostile share links are inert");
+  const scriptYaml = "version: 2\nkind: runnable\n# <script>window.__pwned = 1</script>\n";
+  const encoded = Buffer.from(scriptYaml, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  const hostile = watch(await context.newPage());
+  hostile.setDefaultTimeout(30000);
+  await hostile.goto(`${BASE}/playground/#yaml=${encoded}`, { waitUntil: "domcontentloaded" });
+  await hostile.waitForFunction(
+    () => document.querySelector("#sonda-playground .cm-content")?.textContent.includes("script"),
+    null,
+    { timeout: 60000 }
+  );
+  check("a script tag in shared YAML does not execute",
+    (await hostile.evaluate(() => window.__pwned)) === undefined);
+  check("it is shown as inert editor text",
+    await hostile.evaluate(() =>
+      document.querySelector("#sonda-playground .cm-content").textContent.includes("<script>")
+    ));
+
+  const oversized = "A".repeat(32 * 1024 + 1);
+  await hostile.goto(`${BASE}/playground/#yaml=${oversized}`, { waitUntil: "domcontentloaded" });
+  await hostile.waitForFunction(
+    () => document.querySelector("#sp-status")?.textContent.includes("too large"),
+    null,
+    { timeout: 60000 }
+  );
+  check("an oversized hash is refused with a status, not a hang",
+    (await hostile.textContent("#sp-status")).includes("too large"));
+  check("the page still works after refusing it",
+    await hostile.evaluate(() =>
+      document.querySelector("#sonda-playground .cm-content").textContent.includes("version: 2")
+    ));
+  await hostile.close();
+
+  // --- 7. Alert lab evaluates and exports --------------------------------
+  section("[7] alert lab evaluates and exports");
+  // The lab animates a playback sweep and, while it runs, the chip shows the
+  // state AT the sweep position — so asserting "the chip says something" would
+  // pass on a transient frame and prove nothing. The lab already skips the
+  // sweep under prefers-reduced-motion, so emulating that gives the settled
+  // verdict deterministically, and lets us assert the useful thing: the
+  // default preset is tuned to fire, so it must reach "firing".
+  const labContext = await browser.newContext({ reducedMotion: "reduce" });
+  const lab = watch(await labContext.newPage());
+  lab.setDefaultTimeout(30000);
+  await lab.goto(`${BASE}/playground/alert-lab/`, { waitUntil: "domcontentloaded" });
+  await lab.waitForSelector("#al-state", { timeout: 30000 });
+  await lab.waitForFunction(
+    () => document.querySelector("#al-state")?.textContent.trim() === "firing",
+    null,
+    { timeout: 60000 }
+  );
+  const chipText = (await lab.textContent("#al-state")).trim();
+  check("the default preset evaluates to a firing rule", chipText === "firing", chipText);
+  check("the lab reports no error banner",
+    await lab.evaluate(() => document.querySelector("#al-error").hidden));
+
+  await lab.click("#al-export");
+  await lab.waitForFunction(
+    () => {
+      const out = document.querySelector("#al-export-out");
+      return out && !out.hidden && out.textContent.includes("expect:");
+    },
+    null,
+    { timeout: 30000 }
+  );
+  const exported = await lab.textContent("#al-export-out");
+  check("export emits a scenario with an expect: block", exported.includes("expect:"),
+    `${exported.length} chars`);
+  await lab.close();
+  await labContext.close();
+
+  // --- 8. A generators.md widget mounts on scroll ------------------------
+  section("[8] a live generator widget mounts on scroll");
+  const widgets = watch(await context.newPage());
+  widgets.setDefaultTimeout(30000);
+  await widgets.goto(`${BASE}/build/generators/`, { waitUntil: "domcontentloaded" });
+  await widgets.waitForSelector(".sonda-livegen", { timeout: 30000 });
+  await widgets.evaluate(() => document.querySelector(".sonda-livegen").scrollIntoView());
+  await widgets.waitForFunction(
+    (min) => {
+      const canvas = document.querySelector(".sonda-livegen__chart");
+      return canvas && canvas.toDataURL().length > min;
+    },
+    CHART_DRAWN,
+    { timeout: 60000 }
+  );
+  check("the widget renders a live chart", true);
+  const widgetError = await widgets.evaluate(() => {
+    const err = document.querySelector(".sonda-livegen__error");
+    return err && !err.hidden ? err.textContent : null;
+  });
+  check("the widget reports no engine error", widgetError === null, widgetError || "");
+  await widgets.close();
+
+  // --- 9. A runnable-fence button carries its scenario -------------------
+  section("[9] a runnable-fence button carries its scenario to the playground");
+  const fences = watch(await context.newPage());
+  fences.setDefaultTimeout(30000);
+  await fences.goto(`${BASE}/build/scheduling/`, { waitUntil: "domcontentloaded" });
+  await fences.waitForSelector("a.sonda-runnable", { timeout: 30000 });
+  const buttonCount = await fences.evaluate(
+    () => document.querySelectorAll("a.sonda-runnable").length
+  );
+  check("fence buttons are present", buttonCount > 0, `${buttonCount} buttons`);
+  await fences.click("a.sonda-runnable");
+  await fences.waitForSelector("#sonda-playground", { timeout: 30000 });
+  await fences.waitForFunction(
+    () =>
+      document
+        .querySelector("#sonda-playground .cm-content")
+        ?.textContent.includes("version: 2"),
+    null,
+    { timeout: 60000 }
+  );
+  check("the fence's scenario arrives in the editor", true);
+  await fences.close();
+} catch (err) {
+  failures.push(`threw: ${err && err.message ? err.message : err}`);
+  console.log(`\n  FAIL threw: ${err && err.stack ? err.stack.split("\n")[0] : err}`);
+} finally {
+  await browser.close();
+}
+
+const elapsed = ((Date.now() - started) / 1000).toFixed(1);
+console.log(`\n${checks} checks in ${elapsed}s`);
+
+if (pageErrors.length) {
+  console.log(`\n${pageErrors.length} page error(s):`);
+  for (const err of pageErrors) console.log(`   ${err}`);
+}
+
+const bad = failures.length + pageErrors.length;
+if (bad) {
+  console.log(`\nSMOKE FAILED — ${failures.length} assertion(s), ${pageErrors.length} page error(s)`);
+  process.exit(1);
+}
+console.log("\nSMOKE PASSED");


### PR DESCRIPTION
## Summary

Wave 2, WP4 — and the direct answer to the caveat both wave 1 review verdicts ended on.

The docs site's JS is exercised in CI only by the pure-helper harness, which by construction covers just the functions that are plain functions of their arguments. Everything that touches **wasm, the canvas, or the DOM** has been verified by a human driving Chromium once per PR and reporting what they saw — which a reviewer cannot reproduce. As the #538 reviewer put it: *every finding still open in wave 1 sits on the far side of a browser check no reviewer can run.* This moves the load-bearing ones into CI.

New `docs/site/tools/browser/`: a pinned `playwright` devDependency with a committed lockfile, and `smoke.mjs` — a plain node script in the same style as the scratchpad UATs, reading `SONDA_SITE_URL` and `CHROMIUM_PATH`.

## Changes

**22 checks, covering what wave 1 built**

| # | Surface | Asserted |
|---|---|---|
| 1 | Playground boot | non-blank chart (`toDataURL` length), output pane populated |
| 2 | Preset switch | the image actually *changes* |
| 3 | Scrub | `.cm-scrub-number` decorations exist; a drag rewrites the document |
| 4 | Logs preset | log lines render, line chart hidden |
| 5 | Exports | both downloads yield sanitized bare filenames |
| 6 | Hostile share links | `<script>` stays inert text; oversized hash refused with a status, page still usable |
| 7 | Alert lab | settles to a **firing** rule; export emits an `expect:` block |
| 8 | Live widget | mounts on scroll, no engine error |
| 9 | Runnable fence | button carries its scenario into the playground |

**Anti-flake**, since a suite that cries wolf gets disabled:

- Every wait is condition-based. There is **no bare `waitForTimeout` anywhere** — the one place a debounce has to settle is written as "wait until the value *changes*", not a sleep.
- Uncaught page errors, same-origin request failures and `console.error` calls fail the run even when every assertion passed. Silence is not success.
- `ERR_ABORTED` on a same-origin asset is excluded by design: it means the script navigated away mid-request (the 1.2 MB wasm is the usual victim), not that the site failed.

**CI job `docs-browser-smoke`** — cached on npm and on the *resolved playwright version*, so a lockfile bump fetches a matching browser instead of silently reusing an incompatible cached one. The server is started with `setsid` + `nohup` because each `run` is its own shell and the next step needs the port still open, and the step polls until the site answers rather than assuming. Python is pinned to 3.12 on `setup-python@v7`, matching the deploy workflow, so the site this job smokes is built by the toolchain that publishes it.

`task site:smoke` runs the whole thing locally.

Also adds `node_modules/` to `.gitignore`. It was never listed, so `npm ci` in either `tools/` directory left an untracked ~40 MB tree one careless `git add -A` away from the repo.

## Test plan

**Law 3, applied to infrastructure.** A test suite is only worth its runtime if it fails when it should, so it was verified RED before being trusted — three sabotages, each reverted, baseline green after each:

| Sabotage | Result |
|---|---|
| Remove the wasm binary from the built site | **RED** — `FAIL encoded output pane is populated — 0 chars` |
| Neuter `runnable-fences.js` | **RED** — timed out waiting for `a.sonda-runnable` |
| Remove the 32 KB hash cap | **RED** — timed out waiting for the "too large" status |

**Flake + budget:** three consecutive clean runs at **81.3s / 80.5s / 80.8s** — spread under a second, comfortably inside the ~3 minute budget.

Full gate suite green: 80 pure-helper tests · 75 fences (74 compiled, 1 skipped) · 18 detector self-tests · 153 commands · 477 slider combinations · no-raw-markup · `mkdocs build --strict`.

**Two things the first draft got wrong, both caught by running it rather than reading it:**

1. **The alert-lab check was vacuous.** It asserted only that the state chip said *something*, and during playback the chip shows the state *at the sweep position* — so it read `inactive` on a transient frame and would have passed on a completely broken evaluation. The lab already skips the sweep under `prefers-reduced-motion`, so the suite now emulates that and asserts the settled verdict: the default preset is tuned to fire, so it must reach `firing`.

2. **A default launch would likely have failed in CI.** Playwright launches `chrome-headless-shell` by default, which is a *separate download* from the browser — so CI could have failed with `Executable doesn't exist at .../chromium_headless_shell-<rev>` despite a successful `playwright install chromium`. Verified locally that `channel: "chromium"` resolves to `chromium-<rev>` instead — the full build that install always provides — so the CI path names the channel and only `CHROMIUM_PATH` takes the `executablePath` branch.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)

No Rust changed — this is CI config, a Taskfile target, `.gitignore` and a new node-only test directory. The workspace gates are unaffected (last run green on this branch's base, `afd3239`).

## Notes for the reviewer

- **The honest limit of this PR:** I could not execute the CI job's own install path. This sandbox blocks Playwright's CDN, so `npx playwright install chromium` fails here and the suite runs locally only via `CHROMIUM_PATH`. The `channel: "chromium"` decision was derived by launching with each option and reading which executable path Playwright resolved — sound, but the first real CI run is the proof. **If anything in this PR is going to be red on arrival, it is that step.**
- **Where bugs would hide:** the 60s waits are generous for a cold wasm fetch on a slow runner, but a genuinely hung page burns the full timeout ×9 before failing — worth arguing the job needs a `timeout-minutes`. Check 8 scrolls one widget into view and asserts *a* chart; it does not prove the IntersectionObserver kept the other seven unmounted, so a regression to eager-loading would pass. Check 3's drag assumes the first `.cm-scrub-number` is draggable at its current position — long preset lines can clip under the result pane, which is a known rendering quirk from #533.
- **Deliberately not ported** from the scratchpad UATs: DPR-2 PNG size, clipboard-denial wording, and the byte-level YAML round-trip. They are slow or environment-sensitive and the playbook says migrate the best assertions rather than porting wholesale — the filename *shape* is what this suite pins.
- The suite does not assert PNG/YAML *content*, only that a download with a sanitized name fires. Content is covered by the pure tests plus the WP3 UAT.