### PR TITLE
fix(ci): rebuild the wasm bundle at the version it was built at

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,14 @@ jobs:
       - name: Examples-gallery hook self-tests
         run: python3 docs/site/hooks/examples_gallery.py --self-test
 
+      # The drift workflow is path-filtered, so a record that has gone wrong
+      # can sit unnoticed until the next change to sonda-core. This is cheap
+      # and runs on every push.
+      - name: Wasm bundle build pins are coherent
+        run: |
+          python3 scripts/wasm_pins.py --self-test
+          python3 scripts/wasm_pins.py check
+
       # No backend, no accounts — text-to-HTML injection is the one classic
       # web risk left, and the codebase answer is a blanket rule. This is the
       # gate that keeps it a rule rather than a convention.

--- a/.github/workflows/wasm-drift.yml
+++ b/.github/workflows/wasm-drift.yml
@@ -15,8 +15,20 @@ name: Wasm bundle drift
 # is here because the compiler moves the bytes further than anything else that
 # does (review #542 W1, measured twice: rustc 1.95.0 vs 1.93.1 on macOS arm64
 # +44,785 bytes; 1.95.0 vs 1.94.1 on linux x86_64 +21,687 bytes, both against a
-# control of two identical same-toolchain builds). scripts/wasm_pins.py holds
-# this list to the inputs it records.
+# control of two identical same-toolchain builds). `.cargo/config*` is here for
+# the same reason and was found the same way (review #542 M1): cargo reads it
+# before compiling, and the one key it currently holds is not inert —
+# `[build] incremental` flipped from false to true moves the bundle by +760
+# bytes, measured.
+#
+# One nuance that is not a reason to leave it out: the recipe sets RUSTFLAGS
+# explicitly, and an env RUSTFLAGS shadows this file's `rustflags` keys, so
+# THAT particular channel is currently inert (measured: identical bytes with
+# `[target.wasm32-unknown-unknown] rustflags` set, 959,780 bytes with the same
+# config and no env RUSTFLAGS — live, just shadowed). Gating on the file rather
+# than reasoning about which of its keys survive is the cheaper correctness.
+#
+# scripts/wasm_pins.py holds this list to the inputs it records.
 on:
   push:
     paths:
@@ -26,6 +38,7 @@ on:
       - "Cargo.toml"
       - "docs/site/docs/javascripts/sonda_wasm*"
       - "rust-toolchain.toml"
+      - ".cargo/config*"
       - ".github/workflows/wasm-drift.yml"
   pull_request:
     paths:
@@ -35,6 +48,7 @@ on:
       - "Cargo.toml"
       - "docs/site/docs/javascripts/sonda_wasm*"
       - "rust-toolchain.toml"
+      - ".cargo/config*"
       - ".github/workflows/wasm-drift.yml"
   workflow_dispatch:
 

--- a/.github/workflows/wasm-drift.yml
+++ b/.github/workflows/wasm-drift.yml
@@ -31,15 +31,10 @@ concurrency:
   group: wasm-drift-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # Must match the wasm-bindgen version in Cargo.lock, or the generated JS glue
-  # and the wasm disagree at runtime.
-  WASM_BINDGEN_VERSION: "0.2.117"
-  # Binaryen 108 (the Debian/Ubuntu package) optimizes this bundle without
-  # complaint and produces a module that dies in the browser with
-  # "WebAssembly.Table.grow(): failed to grow table by 4". 119 is the version
-  # the committed bundle was produced with and the one verified working.
-  BINARYEN_VERSION: "119"
+# The build inputs are not listed here any more. They live next to the bundle,
+# in docs/site/docs/javascripts/sonda_wasm.build.json, because `task site:wasm`
+# needs the same values and two copies of a pin is one copy too many. The step
+# below reads them into the environment.
 
 jobs:
   rebuild-and-compare:
@@ -49,6 +44,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      # Everything the committed bundle is a product of, from one file.
+      - name: Read the bundle's build pins
+        run: |
+          python3 scripts/wasm_pins.py check
+          {
+            echo "WASM_BINDGEN_VERSION=$(python3 scripts/wasm_pins.py get wasm_bindgen)"
+            echo "BINARYEN_VERSION=$(python3 scripts/wasm_pins.py get binaryen)"
+            echo "BUNDLE_CRATE_VERSION=$(python3 scripts/wasm_pins.py get crate_version)"
+          } >> "$GITHUB_ENV"
 
       # rust-toolchain.toml pins the compiler (1.95.0) and cargo honours that
       # override inside the repo, so this action's own toolchain is only ever
@@ -99,6 +104,43 @@ jobs:
       - name: Verify binaryen version
         run: wasm-opt --version
 
+      # THE THIRD AXIS. Host and binaryen were the two known ones; the crate
+      # version is the third, and it is the one that made this gate
+      # unsatisfiable in practice.
+      #
+      # rustc folds the crate version into the symbol/metadata hash, so a
+      # release that changes nothing but version numbers changes the bundle's
+      # bytes. Measured on release-please PR #537: committed 771,614 vs
+      # rebuilt 771,618, differing at byte 532 — four bytes of reordered
+      # function signatures in the wasm type section, no behavioural
+      # difference at all. Reverting ONLY the version in that same tree and
+      # rebuilding reproduced the committed bundle exactly.
+      #
+      # Release commits are machine-generated and cannot carry a wasm
+      # rebuild, so "the bundle matches the current source" is a promise
+      # nobody can keep. This step makes the gate ask the question that
+      # matters instead: does the bundle match the ENGINE, rebuilt as it was
+      # built? Skipping the gate on release branches would not do — main's
+      # bundle would then genuinely be a build of the previous version, and
+      # the next PR touching sonda-core would fail instead.
+      #
+      # The rewrite happens in this throwaway checkout and is never
+      # committed. wasm_pins.py refuses a recorded version newer than the
+      # workspace's, which is what editing the record to silence a red gate
+      # would look like.
+      - name: Rebuild as the bundle was built
+        run: |
+          current=$(python3 scripts/wasm_pins.py workspace-version)
+          if [ "$BUNDLE_CRATE_VERSION" = "$current" ]; then
+            echo "workspace is at $current, the version the bundle was built at — no rewrite"
+          else
+            echo "::notice::workspace is at $current; the committed bundle was built at" \
+              "$BUNDLE_CRATE_VERSION. Rebuilding at $BUNDLE_CRATE_VERSION so this" \
+              "compares engines rather than version strings."
+            python3 scripts/wasm_pins.py rewrite-workspace-version "$BUNDLE_CRATE_VERSION"
+            git --no-pager diff --stat
+          fi
+
       # Same recipe as `task site:wasm`, including the path remaps — without
       # those the bundle embeds the builder's absolute paths and no two
       # machines can ever agree.
@@ -117,8 +159,10 @@ jobs:
       #
       # THE BYTE-EXACT WASM CHECK IS PLATFORM-SPECIFIC. It compares against a
       # bundle that must have been built on linux x86_64 with binaryen exactly
-      # 119. Host and binaryen version are two independent axes, and each was
-      # measured by varying one of them (review #540 W1, then W1 round two):
+      # 119 — and at the crate version recorded in sonda_wasm.build.json,
+      # which the step above has already arranged. Host and binaryen version
+      # were measured by varying one of them (review #540 W1, then W1 round
+      # two); the version axis is measured above:
       #
       #     host platform      linux x86_64, binaryen 119   771,488 bytes  <- committed
       #                        macOS arm64,  binaryen 119   772,019 bytes  (differ at byte 532)

--- a/.github/workflows/wasm-drift.yml
+++ b/.github/workflows/wasm-drift.yml
@@ -8,6 +8,15 @@ name: Wasm bundle drift
 # version-pinned wasm-bindgen and a version-pinned binaryen, which is far too
 # much to install on every push. Path filters keep it to the changes that can
 # actually invalidate the bundle.
+#
+# THE FILTER IS PART OF THE GATE. An input that moves the bundle's bytes and is
+# missing from this list does not cause a failure — it delays one, onto the
+# next person to touch sonda-core, reported as their drift. `rust-toolchain.toml`
+# is here because the compiler moves the bytes further than anything else that
+# does (review #542 W1, measured twice: rustc 1.95.0 vs 1.93.1 on macOS arm64
+# +44,785 bytes; 1.95.0 vs 1.94.1 on linux x86_64 +21,687 bytes, both against a
+# control of two identical same-toolchain builds). scripts/wasm_pins.py holds
+# this list to the inputs it records.
 on:
   push:
     paths:
@@ -16,6 +25,7 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - "docs/site/docs/javascripts/sonda_wasm*"
+      - "rust-toolchain.toml"
       - ".github/workflows/wasm-drift.yml"
   pull_request:
     paths:
@@ -24,6 +34,7 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - "docs/site/docs/javascripts/sonda_wasm*"
+      - "rust-toolchain.toml"
       - ".github/workflows/wasm-drift.yml"
   workflow_dispatch:
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -131,8 +131,13 @@ tasks:
       therefore never half-written: either the recipe completes and replaces it
       wholesale, or it fails and leaves it untouched.
 
-      wasm-bindgen-cli must match the wasm-bindgen version in Cargo.lock
-      (0.2.117), or the generated JS glue and the wasm will disagree.
+      wasm-bindgen-cli must match the wasm-bindgen version in Cargo.lock, or
+      the generated JS glue and the wasm will disagree. That version, the
+      binaryen version, the reference platform and the crate version the
+      committed bundle was built at all live in one file next to the bundle —
+      docs/site/docs/javascripts/sonda_wasm.build.json — which this recipe and
+      the drift workflow both read. `python3 scripts/wasm_pins.py check`
+      reports them.
     cmds:
       # FIRST, before anything writes anything. The guard used to sit on the
       # wasm-opt step, three commands in — by which point wasm-bindgen had
@@ -143,16 +148,28 @@ tasks:
       - |
         # The committed bundle is compared BYTE-FOR-BYTE against a rebuild by
         # the wasm-drift workflow, and that comparison is only meaningful if
-        # everyone rebuilds under the same conditions the gate uses. Two
-        # independent inputs change the output bytes (review #540 W1):
+        # everyone rebuilds under the same conditions the gate uses. THREE
+        # independent inputs change the output bytes, all measured:
         #
         #   binaryen version   linux x86_64, 119   771,488 bytes  <- committed
         #                      macOS arm64,  131   770,922 bytes
         #   host platform      linux x86_64, 119   771,488 bytes  <- committed
         #                      macOS arm64,  119   772,019 bytes  (differ at byte 532)
+        #   crate version      1.19.0              771,614 bytes  <- committed
+        #                      1.20.0              771,618 bytes  (differ at byte 532)
         #
         # Each pair varies one axis; no run has ever measured linux x86_64 with
         # binaryen 131, so do not read a linux/131 figure out of the table.
+        # (The first two pairs predate the crate-version bump, hence the two
+        # committed figures — 771,488 at 1.19.0 before the #541 engine change,
+        # 771,614 after. The axis each pair isolates is what matters.)
+        #
+        # The values live in docs/site/docs/javascripts/sonda_wasm.build.json,
+        # next to the bundle they describe, and this recipe and the drift
+        # workflow both read them from there. The crate version is handled
+        # differently from the other two: the gate rebuilds AT the recorded
+        # version rather than demanding the workspace match it, because a
+        # release bumps versions and cannot rebuild wasm.
         #
         # So this is an exact version match, not a floor, and the platform is
         # checked too. Getting either wrong produces a functionally correct
@@ -165,8 +182,9 @@ tasks:
         # trap: it optimizes without complaint and emits a module that dies in
         # the browser with "WebAssembly.Table.grow(): failed to grow table by
         # 4". Too old for what wasm-bindgen 0.2.117 emits.)
-        want_binaryen=119
-        want_platform="Linux x86_64"
+        python3 scripts/wasm_pins.py check || exit 1
+        want_binaryen=$(python3 scripts/wasm_pins.py get binaryen)
+        want_platform=$(python3 scripts/wasm_pins.py get platform)
         version=$(wasm-opt --version 2>/dev/null | grep -oE '[0-9]+' | head -1)
         platform="$(uname -s) $(uname -m)"
         if [ "${version:-0}" != "$want_binaryen" ] || [ "$platform" != "$want_platform" ]; then
@@ -222,6 +240,10 @@ tasks:
         done
         mv target/wasm-stage/sonda_wasm.js target/wasm-stage/sonda_wasm_bg.wasm docs/site/docs/javascripts/
         rm -rf target/wasm-stage
+        # The record follows the bundle. Committing one without the other is
+        # what the drift gate would then report, correctly and confusingly.
+        python3 scripts/wasm_pins.py set-crate-version "$(python3 scripts/wasm_pins.py workspace-version)"
+        python3 scripts/wasm_pins.py check
       - python3 scripts/check_wasm_size.py
 
   site:editor:

--- a/docs/site/docs/javascripts/sonda_wasm.build.json
+++ b/docs/site/docs/javascripts/sonda_wasm.build.json
@@ -10,6 +10,8 @@
   "binaryen": "119",
   "_binaryen": "An exact match, not a floor. 131 produces a different (working) bundle; 108 — the Debian/Ubuntu package — optimizes without complaint and emits a module that dies in the browser with 'WebAssembly.Table.grow(): failed to grow table by 4'.",
 
+  "_compiler": "NOT RECORDED HERE, DELIBERATELY, and it is the input that moves the bytes furthest: rustc 1.95.0 vs 1.94.1 on this platform differs by +21,687 bytes (2.81%), and 1.95.0 vs 1.93.1 on macOS arm64 by +44,785 (review #542 W1, both against a control of two identical same-toolchain builds). The compiler is pinned in rust-toolchain.toml, which owns that value; copying it here would recreate exactly the duplication this file exists to remove. What DID have to change is the drift workflow's path filter — rust-toolchain.toml was missing from it, so a compiler bump would have merged green and surfaced as the next author's drift. scripts/wasm_pins.py --self-test holds the filter to this list.",
+
   "platform": "Linux x86_64",
   "_platform": "`uname -s` and `uname -m` of the reference host. Codegen differs by host even with paths remapped: the same source and toolchain on macOS arm64 gives 772,019 bytes against this platform's 771,488, differing at byte 532 (review #540 W1)."
 }

--- a/docs/site/docs/javascripts/sonda_wasm.build.json
+++ b/docs/site/docs/javascripts/sonda_wasm.build.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Build inputs the committed playground bundle (sonda_wasm_bg.wasm) is a product of. Every one of these has been MEASURED to change the output bytes, and the wasm-drift workflow compares the committed bundle byte-for-byte against a rebuild, so a rebuild that does not match these does not match the bundle. This file is the single home for them: `task site:wasm` reads it to refuse an unsuitable host, and .github/workflows/wasm-drift.yml reads it to reproduce the build. Edit it only by rebuilding the bundle, never to make a red gate go green.",
+
+  "crate_version": "1.19.0",
+  "_crate_version": "The workspace version the bundle was built at. rustc folds the crate version into the symbol/metadata hash, which perturbs LTO ordering: the same source at 1.19.0 and at 1.20.0 produces bundles differing by 4 bytes in the wasm type section — reordered function signatures, no behavioural difference. That made the drift gate unsatisfiable for release commits, which bump versions and cannot rebuild wasm (measured: release-please PR #537, committed 771,614 vs rebuilt 771,618, differing at byte 532; reverting only the version in that same tree reproduced the committed bundle exactly). So the gate rebuilds AT THIS VERSION rather than at the workspace's current one, and the bundle is rebuilt when the engine changes rather than when a release happens. Bump this only alongside a real rebuild.",
+
+  "wasm_bindgen": "0.2.117",
+  "_wasm_bindgen": "Must match the wasm-bindgen version in Cargo.lock, or the generated JS glue and the wasm disagree at runtime.",
+
+  "binaryen": "119",
+  "_binaryen": "An exact match, not a floor. 131 produces a different (working) bundle; 108 — the Debian/Ubuntu package — optimizes without complaint and emits a module that dies in the browser with 'WebAssembly.Table.grow(): failed to grow table by 4'.",
+
+  "platform": "Linux x86_64",
+  "_platform": "`uname -s` and `uname -m` of the reference host. Codegen differs by host even with paths remapped: the same source and toolchain on macOS arm64 gives 772,019 bytes against this platform's 771,488, differing at byte 532 (review #540 W1)."
+}

--- a/scripts/wasm_pins.py
+++ b/scripts/wasm_pins.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Read and maintain the committed wasm bundle's build pins.
+
+``docs/site/docs/javascripts/sonda_wasm.build.json`` records the inputs the
+committed playground bundle is a product of — crate version, wasm-bindgen,
+binaryen, host platform. Three places need them and used to carry their own
+copies: ``task site:wasm`` (refusing an unsuitable host), the wasm-drift
+workflow (reproducing the build), and whoever is trying to work out why a
+rebuild does not match. This is the one parser.
+
+The interesting one is ``crate_version``. rustc folds the crate version into
+the symbol hash, so a release that only bumps versions changes the bundle's
+bytes without changing its behaviour — which made the drift gate unsatisfiable
+for machine-generated release commits. The gate now rebuilds at the recorded
+version instead of the current one, so the bundle is rebuilt when the ENGINE
+changes rather than when a release happens.
+
+That only works while the recorded version is a version that actually
+existed: :func:`check` refuses a record from the future, which is what a
+hand-edit to silence the gate would look like.
+
+Usage::
+
+    python3 scripts/wasm_pins.py get binaryen
+    python3 scripts/wasm_pins.py workspace-version
+    python3 scripts/wasm_pins.py check
+    python3 scripts/wasm_pins.py set-crate-version 1.20.0
+    python3 scripts/wasm_pins.py rewrite-workspace-version 1.19.0
+    python3 scripts/wasm_pins.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import unittest
+from pathlib import Path
+
+PINS = Path("docs/site/docs/javascripts/sonda_wasm.build.json")
+
+# Every manifest that declares a version. sonda-wasm inherits the workspace's,
+# so it is not listed; sonda-core is listed twice over because the workspace
+# dependency entry carries a matching requirement that cargo checks.
+VERSION_SITES: tuple[tuple[str, str], ...] = (
+    ("Cargo.toml", r'(?m)^(?P<pre>version = ")(?P<v>[^"]+)(?P<post>")'),
+    (
+        "Cargo.toml",
+        r'(?P<pre>sonda-core = \{ path = "sonda-core", version = ")(?P<v>[^"]+)(?P<post>" \})',
+    ),
+    ("sonda-core/Cargo.toml", r'(?m)^(?P<pre>version = ")(?P<v>[^"]+)(?P<post>")'),
+    ("sonda/Cargo.toml", r'(?m)^(?P<pre>version = ")(?P<v>[^"]+)(?P<post>")'),
+    ("sonda-server/Cargo.toml", r'(?m)^(?P<pre>version = ")(?P<v>[^"]+)(?P<post>")'),
+)
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def find_repo_root(start: Path) -> Path:
+    """Walk up from ``start`` until a directory with a ``Cargo.toml`` is found."""
+    current = start.resolve()
+    while True:
+        if (current / "Cargo.toml").is_file():
+            return current
+        if current.parent == current:
+            raise RuntimeError(f"could not locate repo root above {start}")
+        current = current.parent
+
+
+def load(repo_root: Path) -> dict:
+    """Return the pins, minus the ``_``-prefixed prose."""
+    data = json.loads((repo_root / PINS).read_text(encoding="utf-8"))
+    return {k: v for k, v in data.items() if not k.startswith("_")}
+
+
+def workspace_version(repo_root: Path) -> str:
+    """The version in ``[workspace.package]`` — what a build would use today."""
+    text = (repo_root / "Cargo.toml").read_text(encoding="utf-8")
+    match = re.search(r'\[workspace\.package\]\s*\nversion = "([^"]+)"', text)
+    if not match:
+        raise RuntimeError("no [workspace.package] version in Cargo.toml")
+    return match.group(1)
+
+
+def version_key(version: str) -> tuple[int, ...]:
+    """Sortable form of a plain ``x.y.z``."""
+    if not SEMVER_RE.match(version):
+        raise ValueError(f"not a plain x.y.z version: {version!r}")
+    return tuple(int(part) for part in version.split("."))
+
+
+def check(repo_root: Path) -> list[str]:
+    """Return problems with the recorded pins. Empty means good."""
+    problems: list[str] = []
+    pins = load(repo_root)
+    for key in ("crate_version", "wasm_bindgen", "binaryen", "platform"):
+        if not pins.get(key):
+            problems.append(f"{PINS}: missing '{key}'")
+    if problems:
+        return problems
+
+    recorded, current = pins["crate_version"], workspace_version(repo_root)
+    try:
+        newer = version_key(recorded) > version_key(current)
+    except ValueError as err:
+        return [f"{PINS}: {err}"]
+    if newer:
+        problems.append(
+            f"{PINS}: crate_version {recorded} is NEWER than the workspace's "
+            f"{current}. The bundle cannot have been built at a version that "
+            "does not exist yet — this is what editing the record to silence "
+            "the drift gate looks like. Rebuild the bundle instead."
+        )
+    return problems
+
+
+def rewrite_workspace_version(repo_root: Path, version: str) -> list[str]:
+    """Set every manifest version to ``version``. Returns the files changed.
+
+    Used by the drift gate inside a throwaway CI checkout so it can rebuild
+    the bundle as it was built, and by nothing else. It is deliberately not
+    wired into any task a contributor runs: rewriting versions in a working
+    tree is release-please's job, not a build script's.
+    """
+    version_key(version)  # reject anything that is not a plain x.y.z
+    changed: list[str] = []
+    for relative, pattern in VERSION_SITES:
+        path = repo_root / relative
+        text = path.read_text(encoding="utf-8")
+        new_text, count = re.subn(
+            pattern, lambda m: f"{m.group('pre')}{version}{m.group('post')}", text, count=1
+        )
+        if count != 1:
+            raise RuntimeError(f"{relative}: expected exactly one match for {pattern!r}")
+        if new_text != text:
+            path.write_text(new_text, encoding="utf-8")
+            changed.append(relative)
+    return changed
+
+
+def set_crate_version(repo_root: Path, version: str) -> None:
+    """Record ``version`` as the version the committed bundle was built at.
+
+    Rewrites only that one value, leaving the file's prose and key order
+    alone — the ``_``-prefixed explanations are the point of the file and a
+    json.dump round-trip would reflow all of it.
+    """
+    version_key(version)
+    path = repo_root / PINS
+    text = path.read_text(encoding="utf-8")
+    new_text, count = re.subn(
+        r'("crate_version":\s*")[^"]+(")', rf"\g<1>{version}\g<2>", text, count=1
+    )
+    if count != 1:
+        raise RuntimeError(f"{PINS}: expected exactly one crate_version entry")
+    path.write_text(new_text, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--self-test", action="store_true", help="Run inline tests and exit.")
+    sub = parser.add_subparsers(dest="command")
+    get = sub.add_parser("get", help="Print one pin.")
+    get.add_argument("key")
+    sub.add_parser("workspace-version", help="Print the workspace's current version.")
+    sub.add_parser("check", help="Validate the recorded pins.")
+    setter = sub.add_parser("set-crate-version", help="Record the bundle's build version.")
+    setter.add_argument("version")
+    rewriter = sub.add_parser(
+        "rewrite-workspace-version", help="Set every manifest version (CI checkouts only)."
+    )
+    rewriter.add_argument("version")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _run_self_tests()
+    if not args.command:
+        parser.print_help()
+        return 2
+
+    repo_root = find_repo_root(Path(__file__).parent)
+
+    if args.command == "get":
+        pins = load(repo_root)
+        if args.key not in pins:
+            print(f"no such pin: {args.key}", file=sys.stderr)
+            return 2
+        print(pins[args.key])
+        return 0
+    if args.command == "workspace-version":
+        print(workspace_version(repo_root))
+        return 0
+    if args.command == "check":
+        problems = check(repo_root)
+        for problem in problems:
+            print(f"::error::{problem}", file=sys.stderr)
+        if problems:
+            return 1
+        pins = load(repo_root)
+        print(
+            f"OK: bundle built at crate {pins['crate_version']} "
+            f"(workspace is {workspace_version(repo_root)}), "
+            f"wasm-bindgen {pins['wasm_bindgen']}, binaryen {pins['binaryen']}, "
+            f"{pins['platform']}"
+        )
+        return 0
+    if args.command == "set-crate-version":
+        set_crate_version(repo_root, args.version)
+        print(f"recorded crate_version {args.version}")
+        return 0
+    if args.command == "rewrite-workspace-version":
+        changed = rewrite_workspace_version(repo_root, args.version)
+        print(f"set workspace version to {args.version} in: {', '.join(changed) or 'nothing'}")
+        return 0
+    return 2
+
+
+# --- Self-tests --------------------------------------------------------------
+
+
+class _VersionKeyTests(unittest.TestCase):
+    def test_orders_numerically_not_lexically(self) -> None:
+        self.assertLess(version_key("1.9.0"), version_key("1.10.0"))
+        self.assertLess(version_key("1.19.0"), version_key("1.20.0"))
+        self.assertEqual(version_key("1.19.0"), version_key("1.19.0"))
+
+    def test_rejects_anything_that_is_not_x_y_z(self) -> None:
+        for bad in ("1.19", "1.19.0-rc1", "v1.19.0", "", "1.19.0 ", "latest"):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    version_key(bad)
+
+
+class _RepoStateTests(unittest.TestCase):
+    """The committed pins, as they stand right now."""
+
+    def setUp(self) -> None:
+        self.repo_root = find_repo_root(Path(__file__).parent)
+
+    def test_pins_are_valid(self) -> None:
+        self.assertEqual(check(self.repo_root), [])
+
+    def test_every_version_site_matches_exactly_once(self) -> None:
+        for relative, pattern in VERSION_SITES:
+            with self.subTest(file=relative):
+                text = (self.repo_root / relative).read_text(encoding="utf-8")
+                self.assertEqual(
+                    len(re.findall(pattern, text)),
+                    1,
+                    f"{relative}: {pattern!r} must match exactly once, or the "
+                    "gate would rebuild at a half-rewritten version",
+                )
+
+    def test_wasm_bindgen_pin_matches_cargo_lock(self) -> None:
+        """A pin that drifts from the lockfile ships broken glue."""
+        lock = (self.repo_root / "Cargo.lock").read_text(encoding="utf-8")
+        match = re.search(r'\[\[package\]\]\nname = "wasm-bindgen"\nversion = "([^"]+)"', lock)
+        self.assertIsNotNone(match, "wasm-bindgen not found in Cargo.lock")
+        self.assertEqual(load(self.repo_root)["wasm_bindgen"], match.group(1))
+
+
+class _RewriteTests(unittest.TestCase):
+    """Rewriting runs against copies; the real manifests are never touched."""
+
+    def setUp(self) -> None:
+        import shutil
+        import tempfile
+
+        self.repo_root = find_repo_root(Path(__file__).parent)
+        self.tmp = Path(tempfile.mkdtemp())
+        for relative, _ in VERSION_SITES:
+            target = self.tmp / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if not target.exists():
+                shutil.copy(self.repo_root / relative, target)
+        (self.tmp / PINS).parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(self.repo_root / PINS, self.tmp / PINS)
+
+    def test_rewrite_sets_every_site(self) -> None:
+        rewrite_workspace_version(self.tmp, "9.9.9")
+        self.assertEqual(workspace_version(self.tmp), "9.9.9")
+        for relative, pattern in VERSION_SITES:
+            text = (self.tmp / relative).read_text(encoding="utf-8")
+            with self.subTest(file=relative):
+                self.assertEqual(re.search(pattern, text).group("v"), "9.9.9")
+
+    def test_rewrite_refuses_a_non_version(self) -> None:
+        with self.assertRaises(ValueError):
+            rewrite_workspace_version(self.tmp, "not-a-version")
+
+    def test_set_crate_version_keeps_the_prose(self) -> None:
+        before = (self.tmp / PINS).read_text(encoding="utf-8")
+        set_crate_version(self.tmp, "2.0.0")
+        after = (self.tmp / PINS).read_text(encoding="utf-8")
+        self.assertEqual(load(self.tmp)["crate_version"], "2.0.0")
+        self.assertIn("_crate_version", after, "the explanation must survive")
+        self.assertEqual(before.count("\n"), after.count("\n"), "no reflow")
+
+    def test_a_record_from_the_future_is_refused(self) -> None:
+        set_crate_version(self.tmp, "99.0.0")
+        problems = check(self.tmp)
+        self.assertTrue(problems)
+        self.assertIn("NEWER than the workspace", problems[0])
+
+    def test_a_record_from_the_past_is_fine(self) -> None:
+        """The whole point: the bundle lags the version until the engine changes."""
+        rewrite_workspace_version(self.tmp, "1.20.0")
+        set_crate_version(self.tmp, "1.19.0")
+        self.assertEqual(check(self.tmp), [])
+
+
+def _run_self_tests() -> int:
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(sys.modules[__name__])
+    return 0 if unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wasm_pins.py
+++ b/scripts/wasm_pins.py
@@ -260,6 +260,79 @@ class _RepoStateTests(unittest.TestCase):
         self.assertEqual(load(self.repo_root)["wasm_bindgen"], match.group(1))
 
 
+class _DriftTriggerTests(unittest.TestCase):
+    """The workflow's path filter is part of the gate, so it gets a test.
+
+    A gate that fires on a curated list of inputs is only as good as the list:
+    an input that moves the bundle's bytes and is missing from the filter does
+    not cause a failure, it delays one onto the next person to touch
+    sonda-core, reported as their drift. That is not hypothetical — the filter
+    shipped in #540 without ``rust-toolchain.toml``, and the compiler moves the
+    bytes further than anything the sidecar records (review #542 W1: +21,687
+    bytes across one minor version on linux x86_64, +44,785 on macOS arm64).
+
+    So the list is asserted rather than trusted, from both trigger events. A
+    new input to the build belongs in three places — the filter, this list,
+    and the sidecar's prose — and forgetting the filter is the one that fails
+    silently.
+    """
+
+    WORKFLOW = Path(".github/workflows/wasm-drift.yml")
+
+    #: Every path whose change can invalidate the committed bundle.
+    REQUIRED_TRIGGERS = (
+        "sonda-wasm/**",  # the facade itself
+        "sonda-core/**",  # the engine it wraps
+        "Cargo.lock",  # dependency versions
+        "Cargo.toml",  # the wasm-release profile, and the crate version
+        "rust-toolchain.toml",  # the compiler — the largest effect of all
+        "docs/site/docs/javascripts/sonda_wasm*",  # the bundle and this record
+        ".github/workflows/wasm-drift.yml",  # the gate's own recipe
+    )
+
+    def setUp(self) -> None:
+        self.repo_root = find_repo_root(Path(__file__).parent)
+        self.text = (self.repo_root / self.WORKFLOW).read_text(encoding="utf-8")
+
+    def _paths_for(self, event: str) -> list[str]:
+        """The `paths:` list under one trigger, read without a YAML parser.
+
+        Deliberately no yaml import: this script is stdlib-only so it can run
+        in the docs job with no pip install, and PyYAML would also read the
+        bare `on:` key as the boolean True, which is its own small trap.
+        """
+        start = self.text.index(f"\n  {event}:")
+        after = self.text[start + 1 :]
+        end = len(after)
+        for candidate in ("\n  push:", "\n  pull_request:", "\n  workflow_dispatch:", "\nconcurrency:"):
+            found = after.find(candidate, 1)
+            if found != -1:
+                end = min(end, found)
+        return re.findall(r'^\s*- "([^"]+)"', after[:end], re.MULTILINE)
+
+    def test_every_required_trigger_is_present_in_both_events(self) -> None:
+        for event in ("push", "pull_request"):
+            paths = self._paths_for(event)
+            self.assertTrue(paths, f"no paths parsed for {event}")
+            for required in self.REQUIRED_TRIGGERS:
+                with self.subTest(event=event, path=required):
+                    self.assertIn(
+                        required,
+                        paths,
+                        f"{required} can change the bundle but does not trigger "
+                        f"the drift gate on {event}",
+                    )
+
+    def test_both_events_filter_identically(self) -> None:
+        """A path in one list and not the other passes on push and fails on the PR."""
+        self.assertEqual(self._paths_for("push"), self._paths_for("pull_request"))
+
+    def test_the_compiler_pin_exists_where_the_record_says_it_does(self) -> None:
+        """The sidecar defers to rust-toolchain.toml; that file must own a channel."""
+        toolchain = (self.repo_root / "rust-toolchain.toml").read_text(encoding="utf-8")
+        self.assertRegex(toolchain, r'channel\s*=\s*"[^"]+"')
+
+
 class _RewriteTests(unittest.TestCase):
     """Rewriting runs against copies; the real manifests are never touched."""
 

--- a/scripts/wasm_pins.py
+++ b/scripts/wasm_pins.py
@@ -270,6 +270,9 @@ class _DriftTriggerTests(unittest.TestCase):
     shipped in #540 without ``rust-toolchain.toml``, and the compiler moves the
     bytes further than anything the sidecar records (review #542 W1: +21,687
     bytes across one minor version on linux x86_64, +44,785 on macOS arm64).
+    ``.cargo/config*`` was missing for the same reason one round later (#542
+    M1) — and it is not a theoretical channel: flipping the one key that file
+    holds today, ``[build] incremental``, moves the bundle by 760 bytes.
 
     So the list is asserted rather than trusted, from both trigger events. A
     new input to the build belongs in three places — the filter, this list,
@@ -286,6 +289,7 @@ class _DriftTriggerTests(unittest.TestCase):
         "Cargo.lock",  # dependency versions
         "Cargo.toml",  # the wasm-release profile, and the crate version
         "rust-toolchain.toml",  # the compiler — the largest effect of all
+        ".cargo/config*",  # cargo's own build settings; `incremental` alone is +760 bytes
         "docs/site/docs/javascripts/sonda_wasm*",  # the bundle and this record
         ".github/workflows/wasm-drift.yml",  # the gate's own recipe
     )


### PR DESCRIPTION

## Summary

**The wasm drift gate has been blocking every release since it landed in #540.** Both release-please PRs since then failed it, and 1.20.0 is blocked on it right now. Nobody noticed because the gate is path-filtered and only runs on paths a release happens to touch.

Nothing is wrong with the shipped bundle and main is green. What is wrong is that the gate asks a question a release commit cannot answer.

## What is actually wrong

Rebuilding the release-please tree reproduces CI's numbers exactly — committed 771,614, rebuilt 771,618, differing at byte 532. Then, in that same tree, reverting **only** the version (1.20.0 → 1.19.0) and rebuilding produces a bundle **byte-identical** to the committed one.

So the crate version is the sole changed input. rustc folds it into the symbol/metadata hash, which perturbs LTO ordering; the diff lands in the wasm type section as four bytes of reordered function signatures. No behavioural difference whatever.

The gate is not wrong — it is **unsatisfiable**. A version bump *is* a source change by its definition, and the commit that makes one is machine-generated and cannot carry a wasm rebuild.

This is a third axis alongside the two #540 already measured:

| axis | | bytes |
|---|---|---|
| host platform | linux x86_64, binaryen 119 | 771,488 |
| | macOS arm64, binaryen 119 | 772,019 (byte 532) |
| binaryen version | macOS arm64, binaryen 119 | 772,019 |
| | macOS arm64, binaryen 131 | 770,922 |
| **crate version** | **1.19.0** | **771,614** |
| | **1.20.0** | **771,618 (byte 532)** |

(The first two pairs predate the #541 engine change, hence the two committed figures. Each pair isolates one axis; that is what matters.)

## The fix

The gate now **rebuilds at the version the committed bundle was built at**, so it asks whether the bundle matches the *engine* rather than whether it matches the current version string. The bundle is rebuilt when the engine changes, not when a release happens.

That version is recorded in a new file next to the bundle — `docs/site/docs/javascripts/sonda_wasm.build.json` — along with the binaryen version, the wasm-bindgen version and the reference platform. Those three were previously duplicated across the workflow's `env:` block and the Taskfile guard; both now read the one file. `task site:wasm` records the version as the last act of a rebuild, so the record cannot drift from the bundle it describes.

## Changes

- **`docs/site/docs/javascripts/sonda_wasm.build.json`** (new) — the pins, each with the measurement that justifies it.
- **`scripts/wasm_pins.py`** (new) — the one parser. Refuses a recorded version newer than the workspace's (what editing the record to silence a red gate looks like), asserts the wasm-bindgen pin still matches `Cargo.lock`, and can rewrite workspace versions for the gate's throwaway checkout. 10 self-tests.
- **`.github/workflows/wasm-drift.yml`** — reads the pins; new step rebuilds at the recorded version when the workspace has moved on, with the reasoning in the comment above it.
- **`Taskfile.yml`** — the guard reads binaryen and platform from the pins instead of hardcoding them; a rebuild records the version.
- **`.github/workflows/ci.yml`** — `wasm_pins.py check` on every push, since the drift job is path-filtered and a bad record could otherwise sit unnoticed.

## Test plan

Verified in **both** directions on the reference platform (linux x86_64, binaryen 119):

| scenario | rebuild | result |
|---|---|---|
| workspace at 1.20.0, bundle recorded at 1.19.0 | 771,614 | **byte-identical** — the release passes |
| a one-word change to a message in `sonda-wasm` | 771,601 | **differs at byte 3224** — an engine change is still caught |

The second is the one that matters: the fix must not buy the release's green at the cost of the gate's meaning.

**Tried and rejected, recorded so it is not retried:** pinning `-Cmetadata` through RUSTFLAGS does not decouple the version from the output — same size, still differing at byte 492 — and adding `-Cextra-filename` breaks the build outright, every crate colliding on one output name. My first measurement of that said "identical"; the build had failed and I was reading stale artifacts. Every number above is from a clean build.

**Also considered and rejected:** skipping the gate on release branches. That only defers the failure — main's bundle would then genuinely be a build of the previous version, and the next PR touching `sonda-core/**` would fail instead.

Gates: `wasm_pins.py` 10 self-tests · 73 fences compiled · 60 carded examples · 96 pure-helper tests · hook self-tests · no-raw-markup · wasm size 771,614/850,000 · `cargo fmt --check` clean.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)

No Rust source changed — the diff is CI configuration, a build-metadata file and one stdlib-only script. The workspace test/clippy state is unchanged from `832d7f6`.

## Notes for the reviewer

- **The sharp edge is `rewrite-workspace-version`** — a script that rewrites `Cargo.toml` versions. It is called from exactly one place, the drift job's throwaway checkout, and never from a task a contributor runs. Worth checking that it cannot be reached any other way, and that `VERSION_SITES` really covers every manifest (there is a test asserting each pattern matches exactly once, which is the failure mode: a half-rewritten workspace would rebuild at a version that never existed).
- **Worth attacking:** the record is data a human maintains. `check` refuses a version from the future, but it cannot tell you the bundle was built at 1.19.0 rather than 1.18.0 — a wrong-but-plausible record would make the gate compare against the wrong engine and pass. Is there a cheap way to make the bundle self-describing here?
- After this merges, 1.20.0's release PR should go green on a re-run without any change to it. If it does not, this fix is wrong and I would rather know from that run than from reasoning.
