### PR TITLE
feat(site): a time cursor on the playground chart, with log correlation

### DIFF
--- a/docs/site/docs/javascripts/playground.js
+++ b/docs/site/docs/javascripts/playground.js
@@ -15,10 +15,16 @@ import {
   exportFilename,
   scheduleWindows,
   burstEmission,
+  cursorSecsAt,
+  cursorSamples,
+  logLinesNear,
 } from "./sonda-pure.js";
 
 const MAX_TICKS = 240;
 const DEBOUNCE_MS = 500;
+// How long a burst of edits stays open once typing stops. Longer than the
+// debounce on purpose, so the run that ends a burst is still inside it.
+const GHOST_IDLE_MS = 1500;
 
 const SERIES_COLORS = ["#f97316", "#3b82f6", "#10b981", "#8b5cf6", "#ec4899", "#eab308"];
 
@@ -230,6 +236,56 @@ scenarios:
 `,
   },
   {
+    /* The one preset carrying metrics AND logs in the same scenario file.
+     *
+     * It exists because WP9's log correlation needs one: hovering the chart
+     * highlights the log lines from that instant, and with a logs-only
+     * scenario there is no chart to hover. Found in UAT — every other preset
+     * is one signal type or the other, so the feature shipped unreachable
+     * and untestable until this landed.
+     *
+     * The spike and the error-weighted templates are deliberately the same
+     * story: sweep the cursor into a latency spike and the log lines beside
+     * it are the timeouts that caused it. */
+    name: "Latency spike + correlated logs",
+    yaml: `version: 2
+kind: runnable
+defaults:
+  rate: 4
+  duration: 60s
+  encoder: { type: json_lines }
+  sink: { type: stdout }
+scenarios:
+  - id: latency
+    signal_type: metrics
+    name: request_latency_ms
+    generator:
+      type: spike_event
+      baseline: 120.0
+      spike_height: 520.0
+      spike_duration: 4s
+      spike_interval: 20s
+    labels: { service: checkout }
+  - id: checkout_logs
+    signal_type: logs
+    name: checkout_logs
+    log_generator:
+      type: template
+      templates:
+        - message: "GET {endpoint} -> {status} in {latency}ms"
+          field_pools:
+            endpoint: ["/api/cart", "/api/checkout"]
+            status: ["200", "200", "503"]
+            latency: ["48", "121", "870"]
+        - message: "upstream payment-gw timed out after {timeout}s"
+          field_pools:
+            timeout: ["5", "10"]
+      severity_weights: { info: 0.7, warn: 0.15, error: 0.15 }
+      seed: 42
+    labels: { service: checkout }
+`,
+  },
+  {
     name: "Correlated pair (CPU + errors)",
     yaml: `version: 2
 kind: runnable
@@ -344,6 +400,32 @@ async function boot() {
   let debounceTimer = 0;
   let editor = null;
 
+  /* The cursor's position on the timeline, in scenario seconds, or null.
+   * Lives here rather than on the element because it survives a re-render:
+   * a resize or a theme flip should not drop the reading under the pointer. */
+  let cursorSecs = null;
+
+  /* The ghost baseline, and whether an edit burst is currently open.
+   *
+   * David's call, over the spec's "previous run": the ghost is the scenario
+   * as it was BEFORE the current burst of edits, not one debounce step back.
+   * With a 500 ms debounce, dragging a scrubbable number produces a run every
+   * half second, and a ghost of the previous run is a faint near-copy of the
+   * live trace — it carries no information exactly when you are looking for
+   * some. Pinned to the pre-burst state, dragging amplitude 30 -> 50 shows
+   * the 30 curve the whole way down.
+   *
+   * The burst closes after GHOST_IDLE_MS of no edits, which only re-arms the
+   * baseline for the NEXT burst — the ghost itself stays on screen until then,
+   * so nothing vanishes on a timer while the reader is looking at it. The
+   * idle window is deliberately longer than the debounce, so the run that
+   * ends a burst is still inside it. */
+  let ghostEntries = null;
+  let burstOpen = false;
+  let burstIdleTimer = 0;
+
+  const view = () => ({ cursorSecs, ghost: ghostEntries });
+
   const run = async () => {
     el.status.textContent = "compiling…";
     try {
@@ -351,7 +433,7 @@ async function boot() {
       const yaml = editor.getValue();
       const result = JSON.parse(sample_scenario(yaml, MAX_TICKS));
       lastResult = result;
-      render(el, result);
+      render(el, result, view());
       editor.setEngineError(result.ok ? null : result.error);
       el.status.textContent = result.ok ? "" : "compile error";
       // Bridge to the alert lab: carry the current scenario across so a
@@ -364,8 +446,28 @@ async function boot() {
   };
 
   const scheduleRun = () => {
+    // The first edit of a burst pins the ghost. `lastResult.entries` is safe
+    // to hold by reference: every run parses fresh JSON, so the previous
+    // run's entries are never mutated under us.
+    if (!burstOpen) {
+      burstOpen = true;
+      ghostEntries = lastResult && lastResult.ok ? lastResult.entries : null;
+    }
+    window.clearTimeout(burstIdleTimer);
+    burstIdleTimer = window.setTimeout(() => {
+      burstOpen = false;
+    }, GHOST_IDLE_MS);
     window.clearTimeout(debounceTimer);
     debounceTimer = window.setTimeout(run, DEBOUNCE_MS);
+  };
+
+  /* A different scenario has nothing to be compared with. Preset changes and
+   * shared links replace the whole document, so a ghost of the old one would
+   * be two unrelated curves on one pair of axes. */
+  const dropGhost = () => {
+    window.clearTimeout(burstIdleTimer);
+    burstOpen = false;
+    ghostEntries = null;
   };
 
   const shared = fromLocationHash();
@@ -375,6 +477,8 @@ async function boot() {
   el.run.addEventListener("click", run);
   el.preset.addEventListener("change", () => {
     editor.setValue(PRESETS[Number(el.preset.value)].yaml);
+    dropGhost();
+    clearCursor();
     run();
   });
   // Download YAML: one gesture leaves the reader with both halves of the
@@ -425,11 +529,66 @@ async function boot() {
     });
   });
 
+  /* The time cursor.
+   *
+   * Repaints through `paintCursor` rather than `render`, because moving a
+   * pointer must not rebuild the log pane, the legend and the extra charts
+   * sixty times a second — and rebuilding the log rows would throw away the
+   * highlight this is trying to set. rAF-coalesced, so a burst of pointer
+   * events costs one redraw per frame however fast the device reports them.
+   */
+  let cursorFrame = 0;
+  const paintCursor = () => {
+    if (cursorFrame) return;
+    cursorFrame = window.requestAnimationFrame(() => {
+      cursorFrame = 0;
+      if (!lastResult || !lastResult.ok) return;
+      if (el.chart.style.display !== "none") {
+        drawChart(el.chart, lastResult.entries, view());
+      }
+      renderReadout(el, lastResult.entries, cursorSecs);
+      highlightLogs(lastResult.logs || [], cursorSecs);
+    });
+  };
+
+  const clearCursor = () => {
+    if (cursorSecs === null) return;
+    cursorSecs = null;
+    paintCursor();
+  };
+
+  const moveCursor = (event) => {
+    const at = cursorSecsAt(el.chart._geom, event.offsetX);
+    if (at === cursorSecs) return;
+    cursorSecs = at;
+    paintCursor();
+  };
+
+  el.chart.addEventListener("pointermove", (event) => {
+    // Touch reaches here too, but a finger's "move" is a drag, and treating
+    // it as hover would make the cursor follow a scroll gesture. Touch is
+    // handled by pointerdown below, as tap-to-set / tap-again-to-clear.
+    if (event.pointerType === "touch") return;
+    moveCursor(event);
+  });
+  el.chart.addEventListener("pointerleave", clearCursor);
+  el.chart.addEventListener("pointerdown", (event) => {
+    if (event.pointerType !== "touch") return;
+    // Second tap in the same place clears, so a reader on a phone can put the
+    // chart back the way they found it without a control to explain.
+    const at = cursorSecsAt(el.chart._geom, event.offsetX);
+    if (at === null || (cursorSecs !== null && Math.abs(at - cursorSecs) < 1e-9)) clearCursor();
+    else {
+      cursorSecs = at;
+      paintCursor();
+    }
+  });
+
   // Redraw on container resize; re-render chart and editor theme on
   // light/dark scheme change.
-  new ResizeObserver(() => lastResult && render(el, lastResult)).observe(el.chart.parentElement);
+  new ResizeObserver(() => lastResult && render(el, lastResult, view())).observe(el.chart.parentElement);
   new MutationObserver(() => {
-    if (lastResult) render(el, lastResult);
+    if (lastResult) render(el, lastResult, view());
     editor.setDark(document.body.getAttribute("data-md-color-scheme") === "slate");
   }).observe(document.body, {
     attributes: true,
@@ -524,7 +683,7 @@ function syncPngButton(el) {
     : "Download the chart as a PNG";
 }
 
-function render(el, result) {
+function render(el, result, view = {}) {
   if (!result.ok) {
     showError(el, result.error || "unknown compile error");
     return;
@@ -540,11 +699,17 @@ function render(el, result) {
   const hasLines = result.entries.length > 0;
   const hasExtras = histograms.length || summaries.length || logs.length;
   el.chart.style.display = hasLines || !hasExtras ? "" : "none";
-  if (hasLines || !hasExtras) drawChart(el.chart, result.entries);
+  if (hasLines || !hasExtras) drawChart(el.chart, result.entries, view);
   syncPngButton(el);
 
   renderExtraCharts(el, histograms, summaries);
   renderLogs(el, logs);
+  // The cursor's two readers, refreshed with the chart: a re-render on
+  // resize or theme flip must not leave a readout describing the old scales
+  // or a highlight on a log pane that was just rebuilt from scratch.
+  const cursorSecs = typeof view.cursorSecs === "number" ? view.cursorSecs : null;
+  renderReadout(el, result.entries, cursorSecs);
+  highlightLogs(logs, cursorSecs);
 
   el.legend.replaceChildren(
     ...result.entries.map((entry, index) => {
@@ -640,6 +805,110 @@ function renderLogs(el, logs) {
     }
     pane.append(caption, stream);
   }
+}
+
+/* The cursor's reading, as DOM rather than canvas text.
+ *
+ * Spec said a readout box; making it real elements rather than `fillText` is
+ * a deliberate delta and it buys three things: the numbers are selectable and
+ * copyable, a screen reader can announce them (`aria-live="polite"`), and the
+ * browser smoke suite can assert the exact strings instead of diffing pixels
+ * — the lesson review #543 taught about the burst label.
+ *
+ * It sits UNDER the chart rather than floating at the pointer: a tooltip
+ * would cover the trace it is describing, and at the moment you want to
+ * compare two series you want to see both.
+ */
+function renderReadout(el, entries, cursorSecs) {
+  let box = document.getElementById("sp-readout");
+  if (!box) {
+    box = document.createElement("div");
+    box.id = "sp-readout";
+    box.className = "sonda-playground__readout";
+    box.setAttribute("aria-live", "polite");
+    el.chart.insertAdjacentElement("afterend", box);
+  }
+  const rows = cursorSecs === null ? [] : cursorSamples(entries, cursorSecs);
+  // Hidden rather than removed: the element is rebuilt on every pointer move,
+  // and adding/removing a block on each one would reflow the page under the
+  // pointer.
+  box.hidden = !rows.length;
+  if (!rows.length) {
+    box.replaceChildren();
+    delete box.dataset.secs;
+    return;
+  }
+  box.dataset.secs = String(Math.round(cursorSecs * 100) / 100);
+
+  const at = document.createElement("span");
+  at.className = "sonda-playground__readat";
+  at.textContent = formatSeconds(cursorSecs);
+  const children = [at];
+  for (const row of rows) {
+    const index = entries.findIndex((entry) => entry.id === row.id);
+    const chip = document.createElement("span");
+    chip.className = "sonda-playground__readrow";
+    const swatch = document.createElement("i");
+    swatch.style.background = SERIES_COLORS[Math.max(0, index) % SERIES_COLORS.length];
+    const label = document.createElement("b");
+    label.textContent = row.name;
+    chip.append(swatch, label, document.createTextNode(formatNumber(row.value)));
+    children.push(chip);
+  }
+  box.replaceChildren(...children);
+}
+
+/* Highlight the log lines belonging to the cursor's instant.
+ *
+ * Which lines is `logLinesNear`; this walks the rendered rows and toggles a
+ * class. The rows are in the same order as `log.lines` because renderLogs
+ * appends them in order — stated because it is the assumption that makes the
+ * index lookup valid, and it would break silently if that loop ever filtered.
+ *
+ * The first hit is scrolled into view WITHIN ITS OWN PANE — a deliberate
+ * delta from the spec, which named `scrollIntoView({ block: "nearest" })`.
+ * That API walks every scrollable ancestor, so bringing a log line into view
+ * also scrolls the PAGE; the chart then slides out from under the pointer,
+ * the browser fires pointerleave, and the cursor that asked for the scroll
+ * is cleared. The highlight flashed and vanished on every hover. Adjusting
+ * only `stream.scrollTop` confines the movement to the pane, which is what
+ * the spec wanted the flag to mean.
+ *
+ * Nothing moves when the line is already visible: sweeping the cursor across
+ * a chart should not yank a pane that is already showing the right lines.
+ */
+function highlightLogs(logs, cursorSecs) {
+  const pane = document.getElementById("sp-logs");
+  if (!pane) return;
+  const streams = pane.querySelectorAll(".sonda-playground__logstream");
+  let scrolled = false;
+  streams.forEach((stream, streamIndex) => {
+    const log = logs[streamIndex];
+    const hits = cursorSecs === null || !log ? [] : logLinesNear(log, cursorSecs);
+    const wanted = new Set(hits);
+    const rows = stream.children;
+    for (let i = 0; i < rows.length; i++) {
+      rows[i].classList.toggle("sonda-playground__logline--at", wanted.has(i));
+    }
+    if (!scrolled && hits.length && rows[hits[0]]) {
+      scrollRowIntoPane(stream, rows[hits[0]]);
+      scrolled = true;
+    }
+  });
+}
+
+/* Bring one row into view inside its scroll container and nowhere else.
+ *
+ * Rect arithmetic rather than `offsetTop`, because the row's offsetParent is
+ * not necessarily the stream — the pane is statically positioned, so the
+ * offsets would be measured against whichever ancestor happens to establish
+ * the containing block. Rects are always in the same coordinate space.
+ */
+function scrollRowIntoPane(stream, row) {
+  const pane = stream.getBoundingClientRect();
+  const rect = row.getBoundingClientRect();
+  if (rect.top < pane.top) stream.scrollTop -= pane.top - rect.top;
+  else if (rect.bottom > pane.bottom) stream.scrollTop += rect.bottom - pane.bottom;
 }
 
 function drawHistogramHeatmap(canvas, histogram) {
@@ -814,7 +1083,18 @@ function palette() {
   };
 }
 
-function drawChart(canvas, entries) {
+/* The line chart.
+ *
+ * `opts.cursorSecs` is a point on the timeline to read out (null for none)
+ * and `opts.ghost` is the previous shape of the same scenario, drawn faintly
+ * underneath. Both are pure decoration over the same scales — WP9 added them
+ * without an overlay canvas because a full redraw here is a few hundred
+ * lineTo calls, and one drawing path is easier to keep honest than two that
+ * must agree on geometry.
+ */
+function drawChart(canvas, entries, opts = {}) {
+  const cursorSecs = typeof opts.cursorSecs === "number" ? opts.cursorSecs : null;
+  const ghost = Array.isArray(opts.ghost) ? opts.ghost : null;
   const colors = palette();
   const dpr = window.devicePixelRatio || 1;
   const cssWidth = canvas.parentElement.clientWidth;
@@ -826,6 +1106,14 @@ function drawChart(canvas, entries) {
   const ctx = canvas.getContext("2d");
   ctx.scale(dpr, dpr);
   ctx.clearRect(0, 0, cssWidth, cssHeight);
+  // A stale geometry would let the pointer read a chart that is no longer
+  // drawn, so every early return clears it rather than leaving the last
+  // scenario's mapping in place.
+  canvas._geom = null;
+  canvas.dataset.ghosts = "0";
+  canvas.dataset.cursor = "";
+  canvas.dataset.ghostPeak = "";
+  canvas.dataset.peak = "";
   if (!entries.length) return;
 
   const pad = { left: 48, right: 12, top: 12, bottom: 26 };
@@ -835,6 +1123,28 @@ function drawChart(canvas, entries) {
   let min = Infinity;
   let max = -Infinity;
   let spanSecs = 0;
+  // The ghost is inside BOTH domains, not clipped against them. A comparison
+  // the reader cannot see both halves of is not a comparison, and clamping an
+  // off-scale ghost to the plot edge would draw a flat line that never
+  // existed. The cost is that the live trace re-scales when a ghost appears —
+  // which is honest, because the chart is answering a different question at
+  // that moment.
+  //
+  // The x-span matters as much as the y-domain, and it is the one that bites:
+  // an edit to `rate` or `duration` changes how much time the samples cover,
+  // so a ghost sized only by the live entries runs off the right edge and the
+  // feature looks broken rather than wrong. Found by driving a scrub drag in
+  // Chromium, not by reading the code.
+  for (const entry of ghost || []) {
+    if (!entry || !Array.isArray(entry.values) || !entry.values.length) continue;
+    for (const value of entry.values) {
+      if (value < min) min = value;
+      if (value > max) max = value;
+    }
+    const tick = Number(entry.tick_secs);
+    if (!Number.isFinite(tick) || tick <= 0) continue;
+    spanSecs = Math.max(spanSecs, (entry.offset_secs || 0) + (entry.values.length - 1) * tick);
+  }
   for (const entry of entries) {
     for (const value of entry.values) {
       if (value < min) min = value;
@@ -917,6 +1227,40 @@ function drawChart(canvas, entries) {
     ctx.fillText(formatSeconds(secs), x(secs), cssHeight - 8);
   }
 
+  // The ghost: the same scenario as it was before this burst of edits,
+  // underneath the live trace in its own colour at low alpha. Matched by
+  // ENTRY ID, not by position — adding a scenario above an existing one
+  // would otherwise re-pair every ghost with the wrong series and show a
+  // change nobody made. An id present only in the ghost is dropped: a
+  // scenario that no longer exists has no live trace to be compared with.
+  let ghostsDrawn = 0;
+  let ghostPeak = null;
+  for (const before of ghost || []) {
+    if (!before || !Array.isArray(before.values) || !before.values.length) continue;
+    const index = entries.findIndex((entry) => entry.id === before.id);
+    if (index < 0) continue;
+    ghostsDrawn += 1;
+    for (const value of before.values) {
+      if (Number.isFinite(value) && (ghostPeak === null || value > ghostPeak)) ghostPeak = value;
+    }
+    const offset = before.offset_secs || 0;
+    ctx.save();
+    ctx.globalAlpha = 0.3;
+    ctx.strokeStyle = SERIES_COLORS[index % SERIES_COLORS.length];
+    ctx.lineWidth = 2;
+    ctx.lineJoin = "round";
+    ctx.setLineDash([5, 4]);
+    ctx.beginPath();
+    before.values.forEach((value, tick) => {
+      const px = x(offset + tick * before.tick_secs);
+      const py = y(value);
+      if (tick === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    });
+    ctx.stroke();
+    ctx.restore();
+  }
+
   entries.forEach((entry, index) => {
     const offset = entry.offset_secs || 0;
     ctx.strokeStyle = SERIES_COLORS[index % SERIES_COLORS.length];
@@ -974,6 +1318,62 @@ function drawChart(canvas, entries) {
       ctx.fillText(entry.while_label, x(offset) + 6, y(entry.values[0]) - 8);
     }
   });
+
+  // The time cursor, last so it sits over everything it is reading.
+  //
+  // The dots are drawn at the SNAPPED sample, not under the pointer: the
+  // chart is a sampled signal, and a dot that slid smoothly along the line
+  // would claim a resolution the engine never produced. At coarse rates the
+  // gap between the rule and the dot is visible, and that gap is the truth.
+  if (cursorSecs !== null) {
+    const rows = cursorSamples(entries, cursorSecs);
+    ctx.save();
+    ctx.strokeStyle = colors.text;
+    ctx.globalAlpha = 0.6;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath();
+    ctx.moveTo(x(cursorSecs), pad.top);
+    ctx.lineTo(x(cursorSecs), pad.top + plotH);
+    ctx.stroke();
+    ctx.restore();
+    for (const row of rows) {
+      const index = entries.findIndex((entry) => entry.id === row.id);
+      if (index < 0) continue;
+      ctx.fillStyle = SERIES_COLORS[index % SERIES_COLORS.length];
+      ctx.beginPath();
+      ctx.arc(x(row.secs), y(row.value), 3.5, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  // The mapping the pointer handler inverts. Stashed rather than recomputed
+  // because a second copy of this arithmetic is a second place for it to be
+  // wrong: `pad.left` and the span both depend on the entries and the
+  // container width, and the cursor has to agree with the axis exactly.
+  canvas._geom = { padLeft: pad.left, plotW, spanSecs };
+
+  // What the chart is claiming, in a form a test can read exactly. The
+  // browser suite cannot see a dashed line or a 3.5px dot, and a canvas
+  // diff can only say that SOMETHING moved — the distinction review #543
+  // was about.
+  canvas.dataset.ghosts = String(ghostsDrawn);
+  canvas.dataset.cursor = cursorSecs === null ? "" : String(Math.round(cursorSecs * 100) / 100);
+  // The ghost's peak, which is what makes "pinned to the pre-edit state"
+  // testable at all: a count alone cannot tell that baseline apart from the
+  // spec's previous-run one, because both draw exactly one ghost. Under
+  // previous-run semantics this number creeps toward the live trace on every
+  // debounce; pinned, it does not move until the burst ends.
+  canvas.dataset.ghostPeak = ghostPeak === null ? "" : String(Math.round(ghostPeak * 100) / 100);
+  // The live peak, in the same units, so the two can be compared without the
+  // test needing a window global to reach the entries.
+  let peak = null;
+  for (const entry of entries) {
+    for (const value of entry.values) {
+      if (Number.isFinite(value) && (peak === null || value > peak)) peak = value;
+    }
+  }
+  canvas.dataset.peak = peak === null ? "" : String(Math.round(peak * 100) / 100);
 }
 
 /* Bucket bounds need more precision than axis ticks — 0.005 and 0.01 are

--- a/docs/site/docs/javascripts/playground.js
+++ b/docs/site/docs/javascripts/playground.js
@@ -545,6 +545,18 @@ async function boot() {
       if (!lastResult || !lastResult.ok) return;
       if (el.chart.style.display !== "none") {
         drawChart(el.chart, lastResult.entries, view());
+      } else {
+        // The stamps live inside drawChart, which a hidden chart never
+        // reaches — so a logs-only scenario would keep advertising the cursor
+        // from the metrics scenario before it (review #544 M1). The BEHAVIOUR
+        // was already right, since the readout empties and no log line is
+        // spuriously highlighted; what went stale was the smoke suite's
+        // oracle for where the cursor is, which is worse than a wrong pixel
+        // because a future check would read it and believe it.
+        el.chart.dataset.cursor = "";
+        el.chart.dataset.ghosts = "0";
+        el.chart.dataset.ghostPeak = "";
+        el.chart.dataset.peak = "";
       }
       renderReadout(el, lastResult.entries, cursorSecs);
       highlightLogs(lastResult.logs || [], cursorSecs);
@@ -700,10 +712,19 @@ function render(el, result, view = {}) {
   const hasExtras = histograms.length || summaries.length || logs.length;
   el.chart.style.display = hasLines || !hasExtras ? "" : "none";
   if (hasLines || !hasExtras) drawChart(el.chart, result.entries, view);
+  // Same reason as the hidden branch of paintCursor: render() reaches here on
+  // a preset change too, and a hidden chart must not keep the last visible
+  // scenario's stamps.
+  else {
+    el.chart.dataset.cursor = "";
+    el.chart.dataset.ghosts = "0";
+    el.chart.dataset.ghostPeak = "";
+    el.chart.dataset.peak = "";
+  }
   syncPngButton(el);
 
   renderExtraCharts(el, histograms, summaries);
-  renderLogs(el, logs);
+  renderLogs(el, logs, el.chart.style.display !== "none");
   // The cursor's two readers, refreshed with the chart: a re-render on
   // resize or theme flip must not leave a readout describing the old scales
   // or a highlight on a log pane that was just rebuilt from scratch.
@@ -772,7 +793,7 @@ function renderExtraCharts(el, histograms, summaries) {
 /* Synthetic log stream pane: one scrollable block per log entry, each line
  * stamped with its offset on the scenario timeline and colored by severity.
  * Rebuilt per render, same lifecycle as the extra charts. */
-function renderLogs(el, logs) {
+function renderLogs(el, logs, correlatable) {
   let pane = document.getElementById("sp-logs");
   if (!logs.length) {
     if (pane) pane.remove();
@@ -784,6 +805,21 @@ function renderLogs(el, logs) {
     el.chart.parentElement.appendChild(pane);
   }
   pane.replaceChildren();
+
+  // Said here because here is where the question arises (review #544).
+  // Correlation hangs off the chart cursor, and a logs-only scenario has no
+  // chart — so the preset most about logs is the one place the log feature
+  // does nothing. That is a real consequence of the design rather than a bug,
+  // and the honest response is to name it rather than let a reader hunt for a
+  // control that was never there. A scrubber over the pane itself would be
+  // the other answer; that is a second instrument, not a sentence.
+  if (!correlatable) {
+    const note = document.createElement("p");
+    note.className = "sonda-playground__lognote";
+    note.textContent =
+      "Hovering a chart highlights the events at that moment — this scenario has no metrics series to hover.";
+    pane.appendChild(note);
+  }
 
   for (const log of logs) {
     const caption = document.createElement("p");

--- a/docs/site/docs/javascripts/sonda-pure.js
+++ b/docs/site/docs/javascripts/sonda-pure.js
@@ -603,3 +603,111 @@ export function burstEmission(entry) {
     label: `${tidyNumber(base)}/s → ${tidyNumber(during)}/s`,
   };
 }
+
+/* ---- the time cursor (WP9) -------------------------------------------
+ *
+ * Three plain functions between a pointer position and what the page should
+ * say about it. The chart's own geometry stays in playground.js; what lives
+ * here is every decision that can be wrong: where the cursor lands in
+ * scenario seconds, which sample each series was actually emitting then, and
+ * which log lines belong to that instant.
+ */
+
+/* Where a pointer sits on the chart, in scenario seconds — or null.
+ *
+ * `geom` is the mapping drawChart already computed: `{ padLeft, plotW,
+ * spanSecs }`. The chart's forward map is
+ * `secs -> padLeft + (secs / spanSecs) * plotW`, so this is its inverse.
+ *
+ * Returns null rather than a clamped value when the pointer is outside the
+ * plot area — the axis gutter is not second zero, and a cursor pinned to the
+ * left edge whenever the pointer strays into the y-axis labels would report a
+ * reading the reader never asked for. Callers treat null as "no cursor",
+ * which is also what a pointer leaving the canvas produces, so the two paths
+ * agree by construction.
+ */
+export function cursorSecsAt(geom, offsetX) {
+  if (!geom || typeof geom !== "object") return null;
+  const padLeft = Number(geom.padLeft);
+  const plotW = Number(geom.plotW);
+  const spanSecs = Number(geom.spanSecs);
+  const x = Number(offsetX);
+  if (!Number.isFinite(padLeft) || !Number.isFinite(x)) return null;
+  if (!Number.isFinite(plotW) || plotW <= 0) return null;
+  if (!Number.isFinite(spanSecs) || spanSecs <= 0) return null;
+  const fraction = (x - padLeft) / plotW;
+  if (fraction < 0 || fraction > 1) return null;
+  return fraction * spanSecs;
+}
+
+/* What each series was emitting at the cursor, as readout rows.
+ *
+ * Snapped to the nearest TICK rather than interpolated, because the chart is
+ * a sampled signal and an interpolated reading would be a number the engine
+ * never produced. The row carries the snapped `secs` as well as the value, so
+ * the readout can show where it actually read from — at a coarse rate the
+ * difference between the pointer and the sample is visible, and hiding it
+ * would make the cursor look more precise than it is.
+ *
+ * An entry contributes NOTHING when the cursor falls outside its own window.
+ * Scenarios chain (`after:`), so a 30-second entry starting at second 60 has
+ * no value at second 10 — and reporting its first sample there would invent
+ * data for a scenario that had not started. That is the case worth the
+ * function existing: clamping the index, which is the obvious implementation,
+ * gets it exactly wrong.
+ */
+export function cursorSamples(entries, cursorSecs) {
+  const at = Number(cursorSecs);
+  if (!Array.isArray(entries) || !Number.isFinite(at)) return [];
+  const rows = [];
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    const values = entry.values;
+    if (!Array.isArray(values) || !values.length) continue;
+    const tick = Number(entry.tick_secs);
+    if (!Number.isFinite(tick) || tick <= 0) continue;
+    const offset = Number(entry.offset_secs) || 0;
+    if (!Number.isFinite(offset)) continue;
+    const index = Math.round((at - offset) / tick);
+    // Outside this entry's own window — not clamped. See above.
+    if (index < 0 || index >= values.length) continue;
+    const value = Number(values[index]);
+    if (!Number.isFinite(value)) continue;
+    rows.push({ id: entry.id, name: entry.name, value, secs: offset + index * tick });
+  }
+  return rows;
+}
+
+/* Indices of the log lines belonging to the cursor's instant.
+ *
+ * Half a tick either side, so every instant on the timeline belongs to
+ * exactly one emission — the same rule the chart's nearest-tick snap uses,
+ * which is what keeps the highlighted lines and the highlighted sample
+ * describing the same moment.
+ *
+ * `line.secs` is already on the shared timeline (sonda-wasm stamps it as
+ * `offset_secs + tick * tick_secs`), so there is deliberately no offset
+ * arithmetic here; adding it again would push the highlight off by the
+ * entry's start on any chained scenario.
+ *
+ * The bound is inclusive, so a cursor exactly between two lines highlights
+ * both. That is the honest answer at a boundary and it is stable — an
+ * exclusive bound would flicker between the two as the pointer moved by
+ * sub-pixel amounts.
+ */
+export function logLinesNear(log, cursorSecs) {
+  const at = Number(cursorSecs);
+  if (!log || typeof log !== "object" || !Number.isFinite(at)) return [];
+  const lines = log.lines;
+  if (!Array.isArray(lines) || !lines.length) return [];
+  const tick = Number(log.tick_secs);
+  if (!Number.isFinite(tick) || tick <= 0) return [];
+  const window = tick / 2;
+  const hits = [];
+  for (let i = 0; i < lines.length; i++) {
+    const secs = Number(lines[i] && lines[i].secs);
+    if (!Number.isFinite(secs)) continue;
+    if (Math.abs(secs - at) <= window) hits.push(i);
+  }
+  return hits;
+}

--- a/docs/site/docs/stylesheets/sonda.css
+++ b/docs/site/docs/stylesheets/sonda.css
@@ -1063,6 +1063,58 @@
 
 /* ---------- Playground synthetic log stream ----------------------------- */
 
+/* The time cursor's readout (WP9): one strip under the chart, one chip per
+   series. Wraps rather than scrolls — a scenario with six series on a narrow
+   screen should grow downwards, not hide readings off the right edge. */
+.sonda-playground__readout {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem 0.9rem;
+  margin-top: 0.4rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.72rem;
+  line-height: 1.6;
+  min-height: 1.6em;
+}
+
+.sonda-playground__readat {
+  font-weight: 700;
+  opacity: 0.7;
+}
+
+.sonda-playground__readrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.sonda-playground__readrow i {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 2px;
+  flex: 0 0 auto;
+}
+
+.sonda-playground__readrow b {
+  font-weight: 400;
+  opacity: 0.72;
+}
+
+/* The log line under the cursor. Background rather than colour, so it stacks
+   with the severity colouring instead of overriding it — an error line at the
+   cursor must still read as an error. */
+.sonda-playground__logline--at {
+  background: rgba(249, 115, 22, 0.16);
+  box-shadow: -0.35rem 0 0 rgba(249, 115, 22, 0.16), 0.35rem 0 0 rgba(249, 115, 22, 0.16);
+  border-radius: 2px;
+}
+
+[data-md-color-scheme="slate"] .sonda-playground__logline--at {
+  background: rgba(253, 186, 116, 0.2);
+  box-shadow: -0.35rem 0 0 rgba(253, 186, 116, 0.2), 0.35rem 0 0 rgba(253, 186, 116, 0.2);
+}
+
 .sonda-playground__logstream {
   max-height: 16rem;
   overflow-y: auto;

--- a/docs/site/docs/stylesheets/sonda.css
+++ b/docs/site/docs/stylesheets/sonda.css
@@ -1115,6 +1115,13 @@
   box-shadow: -0.35rem 0 0 rgba(253, 186, 116, 0.2), 0.35rem 0 0 rgba(253, 186, 116, 0.2);
 }
 
+/* Why the log pane has no cursor when the scenario has no chart. */
+.sonda-playground__lognote {
+  margin: 0.6rem 0 0;
+  font-size: 0.74rem;
+  opacity: 0.7;
+}
+
 .sonda-playground__logstream {
   max-height: 16rem;
   overflow-y: auto;

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -17,10 +17,11 @@
  *
  * Conventions that keep this from becoming a flaky tax:
  *
- *   - Every wait is condition-based (waitForFunction / waitForSelector).
- *     There is no bare waitForTimeout anywhere; the one place a debounce has
- *     to settle is expressed as "wait until the value CHANGES", not "wait
- *     500ms and hope".
+ *   - Every wait for STATE is condition-based (waitForFunction /
+ *     waitForSelector): "wait until the value CHANGES", never "wait 500ms and
+ *     hope". The single waitForTimeout in this file is not waiting for state
+ *     at all — it paces a synthetic drag across debounce windows, because
+ *     spanning several of them is the behaviour section 12 is testing.
  *   - Silence is not success. Every check asserts a terminal state, and any
  *     uncaught page error or same-origin request failure fails the run at the
  *     end even if every assertion passed.
@@ -640,6 +641,218 @@ try {
     check(`${encoder} reports no engine error`, state.error === "", state.error);
   }
   await widgets2.close();
+
+  // --- 12. The time cursor, log correlation and the ghost trace ----------
+  //
+  // WP9. Three things a canvas diff cannot distinguish, so `drawChart`
+  // stamps what it drew and these read the stamps: whether there is a
+  // cursor, how many ghost series were matched and drawn, and which log
+  // lines the cursor claims.
+  section("[12] time cursor, log correlation and ghost trace");
+  const cursorPage = watch(await context.newPage());
+  cursorPage.setDefaultTimeout(30000);
+  await cursorPage.goto(`${BASE}/playground/`, { waitUntil: "domcontentloaded" });
+  await waitForPlayground(cursorPage);
+
+  // Scrolled into view before measuring: this suite's viewport is 720 tall and
+  // the chart's centre sits below the fold, so a mouse.move to its bounding
+  // box would land outside the viewport and never reach the canvas. Measuring
+  // before scrolling is the mistake that looks like "the cursor is broken".
+  await cursorPage.locator("#sp-chart").scrollIntoViewIfNeeded();
+  const chartBox = await cursorPage.locator("#sp-chart").boundingBox();
+  // Condition-based like everything else here: the repaint is rAF-driven, so
+  // wait for the chart to STAMP a cursor rather than for a duration.
+  const hover = async (fraction) => {
+    await cursorPage.mouse.move(
+      chartBox.x + chartBox.width * fraction,
+      chartBox.y + chartBox.height * 0.5
+    );
+    await cursorPage.waitForFunction(
+      () => document.getElementById("sp-chart").dataset.cursor !== "",
+      null,
+      { timeout: 15000 }
+    );
+  };
+
+  await hover(0.5);
+  const reading = await cursorPage.evaluate(() => {
+    const box = document.getElementById("sp-readout");
+    return {
+      cursor: document.getElementById("sp-chart").dataset.cursor,
+      secs: box.dataset.secs,
+      rows: box.querySelectorAll(".sonda-playground__readrow").length,
+      hidden: box.hidden,
+    };
+  });
+  check(
+    "hovering the chart reads out a value at that instant",
+    !reading.hidden && reading.rows === 1 && Number(reading.secs) > 0,
+    `secs=${reading.secs} rows=${reading.rows}`
+  );
+  check(
+    "the chart and the readout agree on where the cursor is",
+    reading.cursor === reading.secs,
+    `chart=${reading.cursor} readout=${reading.secs}`
+  );
+
+  // The discriminating case. The y-axis gutter is not second zero, and an
+  // implementation that clamps the pointer into the plot — the obvious one —
+  // reports a reading here that nobody asked for.
+  await cursorPage.mouse.move(chartBox.x + 8, chartBox.y + chartBox.height * 0.5);
+  await cursorPage
+    .waitForFunction(() => document.getElementById("sp-chart").dataset.cursor === "", null, {
+      timeout: 15000,
+    })
+    .catch(() => {}); // the check below reports what it actually saw
+  const gutter = await cursorPage.evaluate(() => ({
+    cursor: document.getElementById("sp-chart").dataset.cursor,
+    hidden: document.getElementById("sp-readout").hidden,
+  }));
+  check(
+    "the axis gutter is not second zero — no reading there",
+    gutter.hidden && gutter.cursor === "",
+    `cursor="${gutter.cursor}" hidden=${gutter.hidden}`
+  );
+
+  await hover(0.5);
+  await cursorPage.mouse.move(chartBox.x + chartBox.width * 0.5, chartBox.y - 80);
+  let cleared = true;
+  await cursorPage
+    .waitForFunction(() => document.getElementById("sp-readout").hidden, null, { timeout: 15000 })
+    .catch(() => {
+      cleared = false;
+    });
+  check("leaving the chart clears the reading", cleared);
+
+  // The ghost. A scrub drag is what it was built for, so drive that rather
+  // than a synthetic edit: the drag spans several debounce windows, and the
+  // ghost must stay pinned to the pre-drag curve for all of them instead of
+  // following one step behind.
+  const beforeDrag = await cursorPage.evaluate(
+    () => document.getElementById("sp-chart").dataset.peak
+  );
+
+  const scrub = (await cursorPage.$$(".cm-scrub-number"))[2]; // amplitude on the sine preset
+  await scrub.scrollIntoViewIfNeeded();
+  const scrubBox = await scrub.boundingBox();
+  await cursorPage.mouse.move(scrubBox.x + scrubBox.width / 2, scrubBox.y + scrubBox.height / 2);
+  await cursorPage.mouse.down();
+  const peaksDuring = [];
+  for (let step = 1; step <= 5; step++) {
+    await cursorPage.mouse.move(
+      scrubBox.x + scrubBox.width / 2 + step * 14,
+      scrubBox.y + scrubBox.height / 2,
+      { steps: 4 }
+    );
+    // The ONE deliberate dwell in this suite, and it is the behaviour under
+    // test rather than a wait for state. The number is bounded on both sides
+    // by playground.js and neither bound is arbitrary:
+    //
+    //   > DEBOUNCE_MS (500)     or no run fires mid-drag at all — every move
+    //                           resets the debounce, the whole drag collapses
+    //                           into one run after mouse-up, and the two
+    //                           possible ghost baselines are indistinguishable
+    //                           because neither has anything to be one step
+    //                           behind. (This suite asserted exactly that by
+    //                           mistake first, and reported a ghost that was
+    //                           never drawn.)
+    //   < GHOST_IDLE_MS (1500)  or each step is its own burst, which re-pins
+    //                           the baseline every time and tests nothing.
+    //
+    // 700ms sits in that window, so the drag is one burst containing several
+    // runs — the only shape in which "pinned" and "one run behind" differ.
+    await cursorPage.waitForTimeout(700);
+    peaksDuring.push(
+      await cursorPage.evaluate(() => document.getElementById("sp-chart").dataset.ghostPeak)
+    );
+  }
+  await cursorPage.mouse.up();
+  let ghosted = true;
+  await cursorPage
+    .waitForFunction(() => document.getElementById("sp-chart").dataset.ghosts === "1", null, {
+      timeout: 20000,
+    })
+    .catch(() => {
+      ghosted = false;
+    });
+  check(
+    "a scrub drag leaves the pre-drag curve on the chart as a ghost",
+    ghosted,
+    `ghosts=${await cursorPage.evaluate(() => document.getElementById("sp-chart").dataset.ghosts)}`
+  );
+  // The finding this exists for. A count cannot distinguish the two possible
+  // baselines — both draw one ghost. The PEAK can: pinned to the pre-drag
+  // state it never moves, while a ghost of the previous run creeps toward the
+  // live trace on every debounce.
+  const settled = peaksDuring.filter((p) => p !== "");
+  check(
+    "the ghost stays pinned to the pre-drag curve for the whole drag",
+    settled.length >= 2 && new Set(settled).size === 1 && settled[0] === beforeDrag,
+    `pre-drag peak ${beforeDrag}, ghost peaks seen ${JSON.stringify(peaksDuring)}`
+  );
+
+  // Changing preset replaces the whole document, so the old curve is not a
+  // comparison — it is an unrelated scenario sharing a pair of axes.
+  await cursorPage.selectOption("#sp-preset", { label: "Latency spike + correlated logs" });
+  await cursorPage.waitForFunction(
+    () =>
+      document.querySelectorAll("#sp-logs .sonda-playground__logline").length > 0 &&
+      document.querySelector("#sp-chart")?._geom,
+    null,
+    { timeout: 60000 }
+  );
+  check(
+    "switching preset drops the ghost rather than comparing two scenarios",
+    (await cursorPage.evaluate(() => document.getElementById("sp-chart").dataset.ghosts)) === "0"
+  );
+
+  // Log correlation needs a scenario with BOTH signals — the reason this
+  // preset exists. Every other one is metrics or logs, never both, so the
+  // feature had nothing to run against.
+  await cursorPage.locator("#sp-chart").scrollIntoViewIfNeeded();
+  const logBox = await cursorPage.locator("#sp-chart").boundingBox();
+  // Sampled after the deliberate scroll above, so this measures what the
+  // CURSOR does to the page and not what the test itself did.
+  const scrollBefore = await cursorPage.evaluate(() => window.scrollY);
+  await cursorPage.mouse.move(logBox.x + logBox.width * 0.5, logBox.y + logBox.height * 0.5);
+  await cursorPage
+    .waitForFunction(
+      () => document.querySelectorAll(".sonda-playground__logline--at").length > 0,
+      null,
+      { timeout: 15000 }
+    )
+    .catch(() => {}); // the checks below report what they actually saw
+  const correlated = await cursorPage.evaluate(() => {
+    const hit = document.querySelector(".sonda-playground__logline--at");
+    return {
+      hits: document.querySelectorAll(".sonda-playground__logline--at").length,
+      at: hit ? hit.querySelector(".sonda-playground__logat").textContent : null,
+      cursor: Number(document.getElementById("sp-chart").dataset.cursor),
+      scrollY: window.scrollY,
+    };
+  });
+  check(
+    "the cursor highlights the log lines from that instant",
+    correlated.hits >= 1 && correlated.at !== null,
+    `${correlated.hits} line(s), first at ${correlated.at}, cursor ${correlated.cursor}s`
+  );
+  // The highlighted line must be within half a tick of the cursor — the rule
+  // `logLinesNear` implements. A highlight on the wrong line would still be
+  // "a highlight", which is why this asserts the arithmetic and not presence.
+  const stampSecs = Number(String(correlated.at || "").replace(/[+s]/g, ""));
+  check(
+    "the highlighted line is the one at the cursor, within half a tick",
+    Math.abs(stampSecs - correlated.cursor) <= 0.125 + 1e-9,
+    `line +${stampSecs}s vs cursor ${correlated.cursor}s`
+  );
+  // scrollIntoView would have scrolled the page out from under the pointer,
+  // cancelling the very cursor that asked for it. It flashed and vanished.
+  check(
+    "correlating a log line scrolls its pane, never the page",
+    correlated.scrollY === scrollBefore,
+    `scrollY ${scrollBefore} -> ${correlated.scrollY}`
+  );
+  await cursorPage.close();
 } catch (err) {
   failures.push(`threw: ${err && err.message ? err.message : err}`);
   console.log(`\n  FAIL threw: ${err && err.stack ? err.stack.split("\n")[0] : err}`);

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -393,15 +393,32 @@ try {
   check("fence buttons are present", buttonCount > 0, `${buttonCount} buttons`);
   await fences.click("a.sonda-runnable");
   await fences.waitForSelector("#sonda-playground", { timeout: 30000 });
-  await fences.waitForFunction(
-    () =>
-      document
-        .querySelector("#sonda-playground .cm-content")
-        ?.textContent.includes("version: 2"),
-    null,
-    { timeout: 60000 }
+  // The waited-for condition is asserted here rather than relied on
+  // implicitly (review #544 M2). A `check(..., true)` after a wait is not
+  // vacuous today — the wait throws and fails the run — but it READS as an
+  // assertion while depending entirely on a line above it, so loosening that
+  // wait later would turn it decorative with nothing noticing.
+  let fenceArrived = true;
+  await fences
+    .waitForFunction(
+      () =>
+        document
+          .querySelector("#sonda-playground .cm-content")
+          ?.textContent.includes("version: 2"),
+      null,
+      { timeout: 60000 }
+    )
+    .catch(() => {
+      fenceArrived = false;
+    });
+  check(
+    "the fence's scenario arrives in the editor",
+    fenceArrived &&
+      (await fences.evaluate(() =>
+        document.querySelector("#sonda-playground .cm-content")?.textContent.includes("version: 2")
+      )),
+    `${(await fences.evaluate(() => document.querySelector("#sonda-playground .cm-content")?.textContent || "")).trim().slice(0, 40)}…`
   );
-  check("the fence's scenario arrives in the editor", true);
   await fences.close();
 
   // --- 10. The examples gallery ------------------------------------------
@@ -483,12 +500,21 @@ try {
     "href"
   );
   await gallery.goto(galleryLink, { waitUntil: "domcontentloaded" });
-  await gallery.waitForFunction(
-    () => document.querySelector("#sp-output")?.textContent.trim().length > 0,
-    null,
-    { timeout: 60000 }
+  await gallery
+    .waitForFunction(
+      () => document.querySelector("#sp-output")?.textContent.trim().length > 0,
+      null,
+      { timeout: 60000 }
+    )
+    .catch(() => {}); // the check below reports what it actually saw
+  const carried = await gallery.evaluate(
+    () => (document.querySelector("#sp-output")?.textContent || "").trim().length
   );
-  check("a card's link carries its example into the playground", true);
+  check(
+    "a card's link carries its example into the playground",
+    carried > 0,
+    `${carried} chars of encoded output`
+  );
   await gallery.close();
 
   // --- 11. Scheduling and encoder widgets --------------------------------
@@ -804,6 +830,70 @@ try {
   check(
     "switching preset drops the ghost rather than comparing two scenarios",
     (await cursorPage.evaluate(() => document.getElementById("sp-chart").dataset.ghosts)) === "0"
+  );
+
+  // Review #544 M1. The stamps are written inside drawChart, which a hidden
+  // chart never reaches — so a logs-only scenario used to keep advertising
+  // the cursor from whatever metrics scenario preceded it. The behaviour was
+  // already right; the stamp was not, and the stamp is what this suite reads.
+  // Hover first, so there is a cursor to go stale.
+  await cursorPage.locator("#sp-chart").scrollIntoViewIfNeeded();
+  const mixedBox = await cursorPage.locator("#sp-chart").boundingBox();
+  await cursorPage.mouse.move(
+    mixedBox.x + mixedBox.width * 0.5,
+    mixedBox.y + mixedBox.height * 0.5
+  );
+  await cursorPage
+    .waitForFunction(() => document.getElementById("sp-chart").dataset.cursor !== "", null, {
+      timeout: 15000,
+    })
+    .catch(() => {});
+  const hadCursor = await cursorPage.evaluate(
+    () => document.getElementById("sp-chart").dataset.cursor
+  );
+  await cursorPage.selectOption("#sp-preset", { label: "Synthetic log stream" });
+  await cursorPage.waitForFunction(
+    () => document.getElementById("sp-chart").style.display === "none",
+    null,
+    { timeout: 60000 }
+  );
+  const hiddenState = await cursorPage.evaluate(() => ({
+    cursor: document.getElementById("sp-chart").dataset.cursor,
+    readoutHidden: document.getElementById("sp-readout").hidden,
+    highlighted: document.querySelectorAll(".sonda-playground__logline--at").length,
+  }));
+  check(
+    "a hidden chart stops advertising a cursor from the scenario before it",
+    hadCursor !== "" && hiddenState.cursor === "",
+    `was "${hadCursor}", now "${hiddenState.cursor}"`
+  );
+  check(
+    "and nothing is left highlighted or read out on a logs-only scenario",
+    hiddenState.readoutHidden && hiddenState.highlighted === 0,
+    `readoutHidden=${hiddenState.readoutHidden} highlighted=${hiddenState.highlighted}`
+  );
+  check(
+    "a logs-only scenario says why it has no cursor, rather than leaving a reader hunting",
+    (await cursorPage.evaluate(
+      () => document.querySelector("#sp-logs .sonda-playground__lognote")?.textContent || ""
+    )).includes("no metrics series"),
+    await cursorPage.evaluate(
+      () => document.querySelector("#sp-logs .sonda-playground__lognote")?.textContent || "(absent)"
+    )
+  );
+
+  // Back to the mixed preset for the correlation checks below. The block
+  // above deliberately leaves the page on a logs-only scenario, which has no
+  // visible chart to hover — restoring it here rather than reordering keeps
+  // each block reading as one idea.
+  await cursorPage.selectOption("#sp-preset", { label: "Latency spike + correlated logs" });
+  await cursorPage.waitForFunction(
+    () =>
+      document.getElementById("sp-chart").style.display !== "none" &&
+      document.querySelectorAll("#sp-logs .sonda-playground__logline").length > 0 &&
+      document.querySelector("#sp-chart")?._geom,
+    null,
+    { timeout: 60000 }
   );
 
   // Log correlation needs a scenario with BOTH signals — the reason this

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -12,6 +12,8 @@ import {
   MAX_HASH_PAYLOAD,
   buildTestExport,
   burstEmission,
+  cursorSamples,
+  cursorSecsAt,
   defaultThreshold,
   deriveAlertName,
   escapeQuoted,
@@ -20,6 +22,7 @@ import {
   fromBase64Url,
   galleryCardState,
   hashPayloadTooLarge,
+  logLinesNear,
   MAX_SCHEDULE_CYCLES,
   niceDeadlineSecs,
   normalizeFence,
@@ -919,6 +922,148 @@ test("a preview widget carries no chart-only assumptions", () => {
     if (!widget.preview) continue;
     assert.match(widget.yaml(defaultParams(widget)), /encoder: \{ type: /, `${gen}: names an encoder`);
   }
+});
+
+
+// --- the time cursor (WP9) ---------------------------------------------
+//
+// Three helpers between a pointer and a reading. The cases that matter are
+// the ones where the obvious implementation is wrong: the axis gutter is not
+// second zero, a chained scenario has no value before it starts, and a log
+// line's `secs` is already timeline-absolute.
+
+const GEOM = { padLeft: 48, plotW: 400, spanSecs: 60 };
+
+test("the cursor inverts the chart's own seconds-to-pixels map", () => {
+  assert.equal(cursorSecsAt(GEOM, 48), 0);
+  assert.equal(cursorSecsAt(GEOM, 448), 60);
+  assert.equal(cursorSecsAt(GEOM, 248), 30);
+});
+
+test("a pointer outside the plot has no reading, rather than a clamped one", () => {
+  // The y-axis gutter is the case this is about: pixels 0..47 are labels, and
+  // reporting second zero there would answer a question nobody asked.
+  assert.equal(cursorSecsAt(GEOM, 47.9), null);
+  assert.equal(cursorSecsAt(GEOM, 0), null);
+  assert.equal(cursorSecsAt(GEOM, 448.1), null);
+  assert.equal(cursorSecsAt(GEOM, 900), null);
+});
+
+test("a degenerate chart geometry yields no cursor instead of NaN seconds", () => {
+  for (const bad of [null, undefined, "geom", 42, []]) {
+    assert.equal(cursorSecsAt(bad, 100), null, `geom=${JSON.stringify(bad)}`);
+  }
+  assert.equal(cursorSecsAt({ ...GEOM, plotW: 0 }, 100), null, "zero-width plot");
+  assert.equal(cursorSecsAt({ ...GEOM, spanSecs: 0 }, 100), null, "zero-length span");
+  assert.equal(cursorSecsAt({ ...GEOM, spanSecs: Infinity }, 100), null);
+  assert.equal(cursorSecsAt(GEOM, NaN), null);
+  assert.equal(cursorSecsAt(GEOM, "left"), null);
+});
+
+const series = (extra) => ({
+  id: "cpu",
+  name: "cpu_usage",
+  tick_secs: 0.5,
+  offset_secs: 0,
+  values: [10, 20, 30, 40, 50],
+  ...extra,
+});
+
+test("a reading snaps to the nearest tick and says which tick it read", () => {
+  // tick 0.5s: 1.1s is nearer index 2 (1.0s) than index 3 (1.5s).
+  assert.deepEqual(cursorSamples([series()], 1.1), [
+    { id: "cpu", name: "cpu_usage", value: 30, secs: 1 },
+  ]);
+  // Exactly between two ticks — Math.round settles it upward, consistently.
+  assert.equal(cursorSamples([series()], 1.25)[0].value, 40);
+});
+
+test("an entry that has not started yet contributes nothing", () => {
+  // The case clamping gets wrong. A chained scenario (`after:`) starting at
+  // 60s has no value at 10s, and reporting its first sample would invent
+  // data for a scenario the engine had not begun.
+  const late = series({ offset_secs: 60 });
+  assert.deepEqual(cursorSamples([late], 10), []);
+  assert.deepEqual(cursorSamples([late], 59.7), [], "just before its start");
+  assert.equal(cursorSamples([late], 60)[0].value, 10, "its own first tick");
+  assert.equal(cursorSamples([late], 62)[0].value, 50, "its own last tick");
+  assert.deepEqual(cursorSamples([late], 62.3), [], "past its end");
+});
+
+test("a series shorter than the span drops out past its end", () => {
+  // Two entries on one chart: the short one stops at 2s, the long one runs on.
+  const short = series({ id: "short", values: [1, 2, 3] }); // ends at 1.0s
+  const long = series({ id: "long", tick_secs: 1, values: [5, 6, 7, 8, 9] });
+  assert.deepEqual(cursorSamples([short, long], 0.5).map((r) => r.id), ["short", "long"]);
+  assert.deepEqual(cursorSamples([short, long], 3).map((r) => r.id), ["long"]);
+  assert.deepEqual(cursorSamples([short, long], 30), []);
+});
+
+test("rows come back in entry order, so the readout matches the legend", () => {
+  const a = series({ id: "a", tick_secs: 1, values: [1, 1, 1] });
+  const b = series({ id: "b", tick_secs: 1, values: [2, 2, 2] });
+  assert.deepEqual(cursorSamples([a, b], 1).map((r) => r.id), ["a", "b"]);
+  assert.deepEqual(cursorSamples([b, a], 1).map((r) => r.id), ["b", "a"]);
+});
+
+test("entries the readout cannot describe are skipped, not guessed at", () => {
+  assert.deepEqual(cursorSamples([series({ values: [] })], 1), [], "no samples");
+  assert.deepEqual(cursorSamples([series({ values: "10,20" })], 1), [], "values not an array");
+  assert.deepEqual(cursorSamples([series({ tick_secs: 0 })], 1), [], "zero tick");
+  assert.deepEqual(cursorSamples([series({ tick_secs: -1 })], 1), [], "negative tick");
+  assert.deepEqual(cursorSamples([series({ tick_secs: NaN })], 1), [], "non-numeric tick");
+  assert.deepEqual(cursorSamples([series({ offset_secs: -Infinity })], 1), [], "infinite offset");
+  assert.deepEqual(cursorSamples([series({ values: [NaN, NaN, NaN] })], 1), [], "non-finite value");
+  for (const bad of [null, undefined, 0, "entry", []]) {
+    assert.deepEqual(cursorSamples([bad], 1), [], `entry=${JSON.stringify(bad)}`);
+  }
+  for (const bad of [null, undefined, "entries", 5]) {
+    assert.deepEqual(cursorSamples(bad, 1), [], `entries=${JSON.stringify(bad)}`);
+  }
+  assert.deepEqual(cursorSamples([series()], NaN), [], "no cursor");
+  assert.deepEqual(cursorSamples([series()], Infinity), []);
+});
+
+const logEntry = (extra) => ({
+  tick_secs: 1,
+  lines: [{ secs: 0 }, { secs: 1 }, { secs: 2 }, { secs: 3 }],
+  ...extra,
+});
+
+test("a log line is highlighted within half a tick of the cursor", () => {
+  assert.deepEqual(logLinesNear(logEntry(), 2), [2]);
+  assert.deepEqual(logLinesNear(logEntry(), 2.3), [2]);
+  assert.deepEqual(logLinesNear(logEntry(), 1.7), [2]);
+  assert.deepEqual(logLinesNear(logEntry(), 10), [], "past the stream");
+});
+
+test("a cursor exactly between two lines highlights both", () => {
+  // Inclusive on purpose: an exclusive bound flickers between the two as the
+  // pointer moves by sub-pixel amounts.
+  assert.deepEqual(logLinesNear(logEntry(), 1.5), [1, 2]);
+});
+
+test("log correlation reads the shared timeline, not the entry's own clock", () => {
+  // sonda-wasm stamps line.secs as offset_secs + tick * tick_secs, so a
+  // chained log entry's lines are already absolute. Subtracting the offset
+  // again would push the highlight off by the entry's start.
+  const chained = logEntry({
+    offset_secs: 60,
+    lines: [{ secs: 60 }, { secs: 61 }, { secs: 62 }],
+  });
+  assert.deepEqual(logLinesNear(chained, 61), [1]);
+  assert.deepEqual(logLinesNear(chained, 1), [], "no line at the un-offset time");
+});
+
+test("a log stream with nothing to correlate yields no highlight", () => {
+  assert.deepEqual(logLinesNear(logEntry({ lines: [] }), 1), []);
+  assert.deepEqual(logLinesNear(logEntry({ tick_secs: 0 }), 1), []);
+  assert.deepEqual(logLinesNear(logEntry({ tick_secs: NaN }), 1), []);
+  assert.deepEqual(logLinesNear(logEntry({ lines: [{ secs: "soon" }, { secs: 1 }] }), 1), [1]);
+  for (const bad of [null, undefined, 0, "log", []]) {
+    assert.deepEqual(logLinesNear(bad, 1), [], `log=${JSON.stringify(bad)}`);
+  }
+  assert.deepEqual(logLinesNear(logEntry(), NaN), []);
 });
 
 console.log(`${passed} pure-helper tests passed`);


### PR DESCRIPTION

## Summary

Wave 4, WP9 — the first of the depth instruments. Three things over one timeline:

- **Time cursor.** Hover the chart and read what every series was emitting at that instant, snapped to the nearest tick.
- **Log correlation.** With the cursor active, the log lines from that same instant are highlighted beside it.
- **Ghost trace.** The shape the scenario had before your last burst of edits, drawn faintly underneath.

## The pure part, and why each function exists

Three plain functions in `sonda-pure.js`. Each one is there because the obvious implementation is wrong somewhere specific:

| helper | the mistake it avoids |
|---|---|
| `cursorSecsAt` | Returns `null` outside the plot rather than a clamped value. **The y-axis gutter is not second zero** — clamping reports a reading nobody asked for whenever the pointer strays into the labels. |
| `cursorSamples` | Snaps to the nearest **tick**, and contributes **nothing** for an entry whose window doesn't contain the cursor. A chained scenario (`after:`) starting at 60s has no value at 10s; clamping the index — which is what you write first — reports its first sample there, inventing data for a scenario the engine hadn't started. |
| `logLinesNear` | Reads `line.secs` as-is. `sonda-wasm` already stamps those absolute (`offset_secs + tick * tick_secs`), so re-basing by `offset_secs` — the natural-looking thing — puts the highlight off by the entry's start on every chained scenario. |

The cursor's dots are drawn at the **snapped sample**, not under the pointer: a dot sliding smoothly along the line would claim a resolution the engine never produced. At coarse rates the gap between the rule and the dot is visible, and that gap is the truth.

## Two bugs found by driving it, not by reading it

**The ghost was drawn off the right edge.** It was in the y-domain but not the x-span, so any edit to `rate` or `duration` — which changes how much *time* the samples cover — pushed it past the plot. It looked like the feature simply didn't work. Both domains now include it, because a comparison the reader can't see both halves of is not a comparison.

**`scrollIntoView({block:"nearest"})` cancels its own cursor.** The spec names that API. It walks *every* scrollable ancestor, so pulling a log line into view scrolls the **page**, which slides the chart out from under the pointer, which fires `pointerleave`, which clears the cursor that asked for the scroll. The highlight flashed and vanished on every hover. Replaced with pane-local `scrollTop` arithmetic; the suite now asserts `window.scrollY` is unchanged by a correlation.

## A gap in the spec: the feature had nothing to run against

Log correlation needs a scenario carrying **both** metrics and logs. A logs-only scenario hides the chart entirely, and every shipped preset was one signal type or the other — so the feature would have shipped **unreachable and untestable**. Added `Latency spike + correlated logs`, verified through `sonda --dry-run run`. The spike and the error-weighted templates are deliberately the same story: sweep into a latency spike and the lines beside it are the timeouts that caused it.

## The ghost's baseline — David's call, and the measurement behind it

The spec said "the previous run". With a 500 ms debounce that means a ghost one step behind, which during an edit is a faint near-copy of the live trace — it carries no information exactly when you're looking for some. David chose **pinned to the state before the current burst of edits**, re-baselining only once editing stops.

That distinction is not decorative, and the numbers below are the proof.

## Test plan

**Pure harness: 128 tests** (was 116). Five mutations, each caught by the one case that names it:

| mutation | assertion that goes red |
|---|---|
| clamp the sample index | *an entry that has not started yet contributes nothing* |
| clamp the pointer into the plot | *the axis gutter is not second zero* |
| exclusive correlation bound | *a cursor exactly between two lines highlights both* |
| a whole tick either side | *a log line is highlighted within half a tick* |
| re-base log secs by the offset | *reads the shared timeline, not the entry's own clock* |

**Smoke suite: section 12, 56 checks** (was 46). A count of ghosts cannot distinguish the two candidate baselines — both draw exactly one — so `drawChart` stamps the ghost's peak next to the live peak, and the suite asserts it never moves across a five-step drag:

```
  pinned (shipped)          ghost peaks: ["85","85","85","85","85"]
  sabotaged to previous-run ghost peaks: ["85","89","92","96","99"]   <- exactly one assertion red
```

The sabotage is the ghost chasing the live trace one debounce behind — which is what the pinning decision was made to avoid, now measured rather than argued.

**Two errors in the test itself, both caught by running it and both worth naming:**

1. Measuring the chart's bounding box *before* scrolling it into view put the pointer outside a 720-tall viewport, so the cursor never engaged. My local UAT used a 1200px window and hid it.
2. The first drag used 300 ms dwells against a 500 ms debounce — every move reset it, no run fired mid-drag at all, and the suite reported a ghost that was never drawn. The dwell is now bounded on **both** sides by playground.js's own constants (`> DEBOUNCE_MS` or nothing runs; `< GHOST_IDLE_MS` or every step is its own burst), with the reasoning written down.

**Gates:** 128 pure tests · 56 smoke checks · 522 slider combinations compile · 73 fences · 60 carded examples · 153 commands · hook/validator/pins self-tests · no-raw-markup · wasm size unchanged (771,614/850,000) · `mkdocs build --strict` clean. No Rust changed and no bundle rebuilt.

**Chromium UAT:** cursor and readout in both themes; ghost across a scrub drag; correlation on the new preset at three points on the timeline; leaving the chart clears everything.

## Deltas from the spec, all noted in code

- **The readout is DOM, not canvas text.** Selectable, announced by a screen reader via `aria-live`, and assertable without pixels — review #543's lesson about the burst label. It sits *under* the chart rather than floating at the pointer, because a tooltip covers the trace it's describing.
- **The correlation scroll is pane-local**, for the cancel-its-own-cursor reason above.
- **A tenth preset**, because the feature had nothing to run against otherwise.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)

## Notes for the reviewer

- **Worth attacking:** the readout's per-entry lookup does `entries.findIndex` inside a loop over rows, once per pointer frame. Fine at six series; I judged the clarity worth more than the asymptotics, but say so if you disagree.
- **The ghost changes the chart's scales.** Adding one re-fits both axes so the comparison is fully visible, which means the live trace *moves* when a ghost appears. I think that's honest — the chart is answering a different question at that moment — but it's a judgement call and the alternative (clip the ghost) has a real argument too.
- **Touch is tap-to-set / tap-again-to-clear**, and `pointermove` deliberately ignores `pointerType === "touch"` so a scroll gesture doesn't drag a cursor along with it. I could not test this on real hardware — only Chromium's synthetic touch — so it's the least-verified corner of the PR.
- `GHOST_IDLE_MS` (1500) is the one number I picked rather than derived. It has to exceed `DEBOUNCE_MS` so the run that ends a burst is still inside it; beyond that constraint it's a feel judgement.
