### PR TITLE
feat(ci): compile the docs' scenario fragments, not just the complete ones

### DIFF
--- a/docs/site/docs/build/scenario-files.md
+++ b/docs/site/docs/build/scenario-files.md
@@ -1029,6 +1029,7 @@ The `pack:` field replaces the `name:` + `generator:` combo. Any fields you set 
 Scenarios with the same `clock_group` share a start-time reference, which keeps multi-signal scenarios phase-aligned. You can set `clock_group:` explicitly:
 
 ```yaml
+# sonda:static — an excerpt: `...` stands in for the rest of each entry.
 scenarios:
   - id: a
     clock_group: incident-1

--- a/docs/site/docs/build/scheduling.md
+++ b/docs/site/docs/build/scheduling.md
@@ -77,6 +77,7 @@ scenarios:
     generator:
       type: sine
       amplitude: 40.0
+      period_secs: 60
       offset: 50.0
     dynamic_labels:
       - key: hostname
@@ -403,7 +404,8 @@ scenarios:
     name: error_logs
     while:
       ref: cpu_usage
-      gt: 90.0
+      op: ">"
+      value: 90.0
     log_generator:
       type: template
       templates:

--- a/scripts/validate_docs_scenarios.py
+++ b/scripts/validate_docs_scenarios.py
@@ -96,6 +96,10 @@ class ExtractedScenario:
     line: int  # 1-based, first content line inside the fence
     body: str
     info: str  # the fence's info string, e.g. 'yaml title="hello.yaml"'
+    # True when `body` is not what the page shows: a fragment wrapped in a
+    # synthesized preamble. Reporting has to say so, or a reader chasing a
+    # failure looks for lines that are not in their file.
+    synthesized: bool = False
 
 
 @dataclasses.dataclass
@@ -165,6 +169,166 @@ def is_runnable_scenario(text: str) -> bool:
     )
 
 
+# --- Fragment synthesis ------------------------------------------------------
+#
+# The gate above only ever sees COMPLETE scenarios, because that is what a
+# "Run in playground" button needs. But three of the bugs this program has
+# found lived in fragments — `scenario_name` (PR #536), the pack fence (#541)
+# and `rate_multiplier` (#543) — and a fragment is invisible to a compile gate
+# precisely because it is a fragment.
+#
+# The insight is the reviewer's, from #543: a fragment is only a fragment
+# because it LACKS A PREAMBLE. The engine rejects unknown fields, so wrapping
+# a fragment in the minimal `version: 2 / kind: runnable / defaults /
+# scenarios:` shape and dry-running it catches exactly the class those three
+# bugs belong to — a misspelled or renamed field under `gaps:`, `bursts:`,
+# `generator:`, `while:`. It does not type-check values the way a schema would,
+# which is what leaves WP11 worth doing.
+#
+# The design constraint that shapes everything below: THE SYNTHESIZED PARTS
+# MUST NOT BE WHAT IS UNDER TEST. Every field this function invents is a field
+# whose errors would belong to the gate rather than to the docs, so it invents
+# as little as it can and only what the fragment has left out.
+#
+# Nothing is suppressed on the strength of that, though. Across today's corpus
+# no fragment fails for a field the scaffolding should have supplied, so
+# filtering out `missing field` errors would only hide real ones — the
+# `period_secs` bug this gate found on its first run is exactly that shape. If
+# a future fragment does fail because the scaffolding is too thin, the honest
+# fixes are to widen the scaffolding or mark the fence `# sonda:static`; both
+# are visible, where a suppressed error class is not.
+
+_FRAGMENT_PREAMBLE = """version: 2
+kind: runnable
+"""
+
+# Defaults, not content. Every key here is one the engine would otherwise
+# demand and that a prose fragment has no reason to carry.
+_FRAGMENT_DEFAULTS = """defaults:
+  rate: 1
+  duration: 10s
+  encoder: { type: json_lines }
+  sink: { type: stdout }
+"""
+
+
+def _scenarios_is_a_sequence(body: str) -> bool:
+    """True when a top-level ``scenarios:`` key introduces a LIST of entries.
+
+    The discriminator that keeps Helm values files out. ``deploy/kubernetes.md``
+    documents a chart whose ``scenarios:`` key maps FILENAMES to file contents:
+
+        scenarios:
+          cpu-metrics.yaml: |
+            name: cpu_usage
+
+    That is a valid document about Sonda which is not a Sonda scenario, and
+    wrapping it produces ``invalid type: map, expected a sequence`` — a failure
+    that says nothing about the docs. Reading whether the first non-blank line
+    under the key starts a sequence item separates the two exactly.
+    """
+    match = re.search(r"^scenarios:[ \t]*$", body, re.MULTILINE)
+    if not match:
+        return False
+    for line in body[match.end() :].splitlines():
+        if not line.strip():
+            continue
+        return line.lstrip().startswith("- ")
+    return False
+
+
+def _looks_like_a_scenario_entry(body: str) -> bool:
+    """True when a fragment is the body of one scenario entry.
+
+    Requires a key only a Sonda entry has. An earlier version accepted any
+    fence opening with ``name:``, which swept in three GITHUB ACTIONS
+    WORKFLOWS from ``test/end-to-end-pipelines.md`` — ``name: Alert Rule
+    Validation`` followed by ``on:`` — and reported ``unknown field `on` `` as
+    a docs bug. `name:` is the most common key in YAML; it discriminates
+    nothing.
+    """
+    if not re.match(
+        r"^(signal_type|name|id|generator|log_generator|distribution):",
+        body.strip().splitlines()[0] if body.strip() else "",
+    ):
+        return False
+    return bool(
+        re.search(r"^(signal_type|generator|log_generator|distribution):", body, re.MULTILINE)
+    )
+
+
+def synthesize_fragment(text: str) -> str | None:
+    """Wrap a docs fragment in the smallest preamble that makes it compilable.
+
+    Returns ``None`` for anything this gate cannot speak about honestly:
+    complete scenarios (the gate above already compiles those), ``sonda:static``
+    opt-outs, ``pack:`` references, Helm values maps, and any fence that is not
+    shaped like a scenario or a list of them.
+
+    Two shapes are handled, and the difference is how much has to be invented:
+
+    ``scenarios:`` already present
+        Only the version header is prepended — and ``defaults:`` too, unless
+        the fragment brought its own. Nothing structural is guessed, so a
+        failure here is the fragment's own.
+
+    a single entry's body
+        Wrapped under ``scenarios:`` at one indent, and ``signal_type:``/
+        ``name:`` are injected IF ABSENT, because a prose fragment showing a
+        `generator:` block has no reason to repeat them. `signal_type` is read
+        off the fragment: a `log_generator:` means logs. Those two injections
+        are the reason a caller must not report `missing field` errors from
+        this tier — see the module note above.
+    """
+    body = normalize_fence(text)
+    if is_runnable_scenario(body):
+        return None
+    if re.search(r"^#[ \t]*sonda:static\b", body, re.MULTILINE):
+        return None
+    if re.search(r"^[ \t]*(?:-[ \t]+)?pack:", body, re.MULTILINE):
+        return None
+    # A fence that already declares a version is either complete (handled
+    # above) or deliberately not v2; either way this gate has nothing to add.
+    if re.search(r"^version:", body, re.MULTILINE):
+        return None
+
+    if _scenarios_is_a_sequence(body):
+        head = _FRAGMENT_PREAMBLE
+        if not re.search(r"^defaults:", body, re.MULTILINE):
+            head += _FRAGMENT_DEFAULTS
+        return head + body if body.endswith("\n") else head + body + "\n"
+
+    if _looks_like_a_scenario_entry(body):
+        injected = []
+        if not re.search(r"^signal_type:", body, re.MULTILINE):
+            # Read off the fragment rather than defaulted, because the entry's
+            # required fields depend on it: a `distribution:` block belongs to
+            # a histogram (a metrics entry would then be asked for a
+            # `generator:` it never had), and a `log_generator:` to logs.
+            if re.search(r"^log_generator:", body, re.MULTILINE):
+                kind = "logs"
+            elif re.search(r"^distribution:", body, re.MULTILINE) and not re.search(
+                r"^generator:", body, re.MULTILINE
+            ):
+                kind = "histogram"
+            else:
+                kind = "metrics"
+            injected.append(f"signal_type: {kind}")
+        if not re.search(r"^name:", body, re.MULTILINE):
+            injected.append("name: doc_fragment")
+        entry = "\n".join(injected + [body.rstrip("\n")])
+        indented = "\n".join("    " + line if line.strip() else "" for line in entry.splitlines())
+        return (
+            _FRAGMENT_PREAMBLE
+            + _FRAGMENT_DEFAULTS
+            + "scenarios:\n"
+            + indented.replace("    ", "  - ", 1)
+            + "\n"
+        )
+
+    return None
+
+
 # --- Markdown extraction -----------------------------------------------------
 
 # 3+ backticks, optionally indented (admonition/tabbed nesting), info string
@@ -215,6 +379,27 @@ def extract_scenarios(md_path: Path, markdown_text: str) -> list[ExtractedScenar
         out.append(
             ExtractedScenario(
                 file=md_path, line=line, body=normalize_fence(body), info=info
+            )
+        )
+    return out
+
+
+def extract_fragments(md_path: Path, markdown_text: str) -> list[ExtractedScenario]:
+    """Return every FRAGMENT fence, wrapped so the engine can parse it.
+
+    The complement of :func:`extract_scenarios`: these fences carry no button
+    and no gate could previously reach them, which is where three of this
+    program's field-name bugs were found. See the module note above
+    :func:`synthesize_fragment` for why the wrapping is kept minimal.
+    """
+    out: list[ExtractedScenario] = []
+    for line, body, info in extract_yaml_fences(markdown_text):
+        document = synthesize_fragment(body)
+        if document is None:
+            continue
+        out.append(
+            ExtractedScenario(
+                file=md_path, line=line, body=document, info=info, synthesized=True
             )
         )
     return out
@@ -422,7 +607,9 @@ def run_validation(
         rel = str(md.relative_to(repo_root)) if md.is_absolute() else str(md)
         if rel in skip_set:
             continue
-        scenarios.extend(extract_scenarios(md, md.read_text(encoding="utf-8")))
+        text = md.read_text(encoding="utf-8")
+        scenarios.extend(extract_scenarios(md, text))
+        scenarios.extend(extract_fragments(md, text))
 
     results = [
         validate_scenario(
@@ -443,8 +630,18 @@ def format_failure(result: ScenarioResult, repo_root: Path) -> str:
     except ValueError:
         rel = result.scenario.file
     head = result.scenario.body.strip().splitlines()[:3]
+    # A synthesized body starts with lines that are not in the reader's file.
+    # Saying so is the difference between a diagnosable failure and a hunt for
+    # a `version: 2` that the page does not contain.
+    note = (
+        "    (fragment, compiled under a synthesized preamble — the lines below "
+        "are the wrapper, not the page)\n"
+        if result.scenario.synthesized
+        else ""
+    )
     return (
         f"FAIL {rel}:{result.scenario.line}\n"
+        + note
         + "".join(f"    | {line}\n" for line in head)
         + f"    {result.message}"
     )
@@ -547,8 +744,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(format_failure(failure, repo_root), file=sys.stderr)
 
     skipped = sum(1 for r in results if r.skipped_reason)
+    fragments = sum(1 for r in results if r.scenario.synthesized)
     print(
-        f"{len(results)} runnable scenario fences found, "
+        f"{len(results) - fragments} runnable scenario fences and {fragments} "
+        f"fragments found, "
         f"{len(results) - skipped - len(failures)} compiled, "
         f"{skipped} skipped, {len(failures)} failed",
         file=sys.stderr,
@@ -662,6 +861,94 @@ class _ExtractScenariosTests(unittest.TestCase):
     def test_static_marked_fence_is_not_extracted(self) -> None:
         md = "```yaml\n# sonda:static\nversion: 2\nkind: runnable\n```\n"
         self.assertEqual(extract_scenarios(Path("x.md"), md), [])
+
+
+class _SynthesizeFragmentTests(unittest.TestCase):
+    """The fragment wrapper, and every shape that must NOT be wrapped.
+
+    Each refusal below is a false positive this gate actually produced on the
+    first run against the real corpus. They are named rather than counted,
+    because "the gate reports 3 failures" is only useful if none of them is
+    the gate misreading a file about something else entirely.
+    """
+
+    def test_scenarios_sequence_only_gets_a_preamble(self) -> None:
+        out = synthesize_fragment(
+            "scenarios:\n  - signal_type: metrics\n    name: x\n"
+            "    generator: { type: constant, value: 1.0 }\n"
+        )
+        self.assertIsNotNone(out)
+        assert out is not None
+        self.assertTrue(out.startswith("version: 2\nkind: runnable\n"))
+        # Nothing structural invented: the fragment's own text survives whole.
+        self.assertIn("  - signal_type: metrics\n    name: x\n", out)
+
+    def test_a_fragments_own_defaults_are_not_duplicated(self) -> None:
+        out = synthesize_fragment(
+            "defaults:\n  rate: 9\nscenarios:\n  - signal_type: metrics\n"
+            "    name: x\n    generator: { type: constant, value: 1.0 }\n"
+        )
+        assert out is not None
+        self.assertEqual(out.count("defaults:"), 1, "a second defaults: is a YAML duplicate key")
+        self.assertIn("rate: 9", out)
+
+    def test_helm_values_map_is_refused(self) -> None:
+        # deploy/kubernetes.md documents a chart whose `scenarios:` maps
+        # FILENAMES to file bodies. Wrapping it yields "invalid type: map,
+        # expected a sequence" — a failure that says nothing about the docs.
+        self.assertIsNone(
+            synthesize_fragment("scenarios:\n  cpu-metrics.yaml: |\n    name: cpu_usage\n")
+        )
+
+    def test_github_actions_workflow_is_refused(self) -> None:
+        # Three of these live in test/end-to-end-pipelines.md. An earlier rule
+        # accepted any fence opening with `name:` and reported `unknown field
+        # 'on'` as a docs bug. `name:` is the most common key in YAML.
+        self.assertIsNone(
+            synthesize_fragment("name: Alert Rule Validation\non:\n  pull_request:\n")
+        )
+
+    def test_bare_encoder_block_is_refused(self) -> None:
+        # Not an entry: it carries no key that only a scenario entry has.
+        self.assertIsNone(synthesize_fragment("encoder:\n  type: prometheus_text\n"))
+
+    def test_static_and_pack_and_complete_are_refused(self) -> None:
+        self.assertIsNone(
+            synthesize_fragment("# sonda:static\nscenarios:\n  - signal_type: metrics\n")
+        )
+        self.assertIsNone(synthesize_fragment("scenarios:\n  - pack: node-exporter\n"))
+        self.assertIsNone(
+            synthesize_fragment("version: 2\nkind: runnable\nscenarios:\n  - id: a\n")
+        )
+
+    def test_signal_type_is_read_off_the_fragment(self) -> None:
+        # The entry's REQUIRED fields depend on this, so guessing `metrics`
+        # for everything makes the gate report its own wrapper's errors: a
+        # bare `distribution:` block would be asked for a `generator:`.
+        logs = synthesize_fragment("log_generator:\n  type: template\n")
+        assert logs is not None
+        self.assertIn("signal_type: logs", logs)
+        hist = synthesize_fragment("distribution:\n  type: exponential\n  rate: 10.0\n")
+        assert hist is not None
+        self.assertIn("signal_type: histogram", hist)
+        metric = synthesize_fragment("generator:\n  type: constant\n  value: 1.0\n")
+        assert metric is not None
+        self.assertIn("signal_type: metrics", metric)
+
+    def test_present_scaffolding_is_not_overwritten(self) -> None:
+        out = synthesize_fragment("signal_type: logs\nname: mine\nlog_generator:\n  type: template\n")
+        assert out is not None
+        self.assertEqual(out.count("signal_type:"), 1)
+        self.assertIn("name: mine", out)
+        self.assertNotIn("doc_fragment", out)
+
+    def test_the_entry_is_indented_under_a_sequence_item(self) -> None:
+        out = synthesize_fragment("generator:\n  type: constant\n  value: 1.0\n")
+        assert out is not None
+        self.assertIn("scenarios:\n  - signal_type: metrics", out)
+        # Continuation lines sit at the item's indent, not the item's dash.
+        self.assertIn("\n    generator:\n", out)
+        self.assertIn("\n      type: constant\n", out)
 
 
 class _MissingInputFilesTests(unittest.TestCase):

--- a/scripts/validate_docs_scenarios.py
+++ b/scripts/validate_docs_scenarios.py
@@ -172,10 +172,19 @@ def is_runnable_scenario(text: str) -> bool:
 # --- Fragment synthesis ------------------------------------------------------
 #
 # The gate above only ever sees COMPLETE scenarios, because that is what a
-# "Run in playground" button needs. But three of the bugs this program has
-# found lived in fragments — `scenario_name` (PR #536), the pack fence (#541)
-# and `rate_multiplier` (#543) — and a fragment is invisible to a compile gate
-# precisely because it is a fragment.
+# "Run in playground" button needs. TWO of the bugs this program has found
+# lived in fragments — `scenario_name` (PR #536) and `rate_multiplier` (#543)
+# — and a fragment is invisible to a compile gate precisely because it is a
+# fragment.
+#
+# The third bug of that family, the pack fence (#541), is NOT one of them, and
+# this gate cannot see it either (review #545 M1). A pack carries `version: 2`
+# and `kind: composable`, so it was never a fragment; it was invisible because
+# the ORACLE accepts it — `sonda --dry-run run` reports `OK (0 scenarios)` for
+# a pack and exits 0. Compiling one here would report green and prove nothing,
+# which is why `synthesize_fragment` refuses anything carrying `pack:`. The
+# scenario-count assertion in `validate_scenario` is the piece that would have
+# to grow for this gate to ever speak about packs.
 #
 # The insight is the reviewer's, from #543: a fragment is only a fragment
 # because it LACKS A PREAMBLE. The engine rejects unknown fields, so wrapping
@@ -276,9 +285,16 @@ def synthesize_fragment(text: str) -> str | None:
         Wrapped under ``scenarios:`` at one indent, and ``signal_type:``/
         ``name:`` are injected IF ABSENT, because a prose fragment showing a
         `generator:` block has no reason to repeat them. `signal_type` is read
-        off the fragment: a `log_generator:` means logs. Those two injections
-        are the reason a caller must not report `missing field` errors from
-        this tier — see the module note above.
+        off the fragment: a `log_generator:` means logs.
+
+    Those two injections are why suppressing `missing field` errors from this
+    tier is TEMPTING — and they are not a reason to do it. The filter was
+    considered and refused; see the module note above. An earlier draft of
+    this docstring said a caller "must not report" that class, which is the
+    opposite of what the code does and would have talked a future maintainer
+    into deleting the check that found the `period_secs` bug (review #545 W1,
+    which settled it by removing `period_secs` from a tier-2 fragment and
+    confirming the gate still reports it).
     """
     body = normalize_fence(text)
     if is_runnable_scenario(body):
@@ -466,12 +482,54 @@ def validate_scenario(
     finally:
         temp_path.unlink(missing_ok=True)
 
-    if proc.returncode == 0:
-        return ScenarioResult(scenario, ok=True)
     detail = (proc.stderr or proc.stdout or "").strip()
-    return ScenarioResult(
-        scenario, ok=False, message=f"exit {proc.returncode}: {_first_lines(detail)}"
+    if proc.returncode != 0:
+        return ScenarioResult(
+            scenario, ok=False, message=f"exit {proc.returncode}: {_first_lines(detail)}"
+        )
+    return _check_scenario_count(scenario, proc.stdout, proc.stderr)
+
+
+# `Validation: OK (2 scenarios)` — the CLI's own count, and the only part of a
+# successful run that says the file did anything.
+_VALIDATION_COUNT_RE = re.compile(r"Validation:\s*OK\s*\((?P<count>\d+)\s+scenarios?\)")
+
+
+def _check_scenario_count(
+    scenario: ExtractedScenario, stdout: str, stderr: str
+) -> ScenarioResult:
+    """Exit 0 is necessary but not sufficient: require at least one scenario.
+
+    Review #545 M2. Until this existed the oracle was the exit code alone, and
+    ``Validation: OK (0 scenarios)`` — a file the engine parses and then emits
+    nothing from — was indistinguishable from success.
+
+    That is not a hypothetical shape, it is the #541 bug exactly: a metric pack
+    compiles clean and produces no scenarios, which is how a "Run in
+    playground" button came to point at an empty chart while every gate stayed
+    green. Leaving the hole unguarded inside the gate built to answer that
+    family would have been the joke writing itself.
+
+    A missing count is not treated as a failure. The assertion is about what
+    the CLI reported, not about parsing its output successfully, and a future
+    change to that banner should not turn every fence red at once — the
+    self-tests pin the phrasing so such a change is visible instead.
+    """
+    match = _VALIDATION_COUNT_RE.search(stdout or "") or _VALIDATION_COUNT_RE.search(
+        stderr or ""
     )
+    if match is None:
+        return ScenarioResult(scenario, ok=True)
+    if int(match.group("count")) == 0:
+        return ScenarioResult(
+            scenario,
+            ok=False,
+            message=(
+                "compiled clean but produced 0 scenarios — the engine parsed this "
+                "file and would emit nothing from it"
+            ),
+        )
+    return ScenarioResult(scenario, ok=True)
 
 
 def _first_lines(text: str, limit: int = 6) -> str:
@@ -595,19 +653,29 @@ def run_validation(
     sonda_bin: Path | None,
     subprocess_timeout: float = DEFAULT_SUBPROCESS_TIMEOUT_S,
     skip_files: Iterable[str] = (),
-) -> tuple[list[ScenarioResult], list[ScenarioResult]]:
-    """Validate every runnable fence. Returns ``(all_results, failures)``."""
+) -> tuple[list[ScenarioResult], list[ScenarioResult], int]:
+    """Validate every reachable fence.
+
+    Returns ``(all_results, failures, declined)``, where ``declined`` counts the
+    yaml fences neither tier could speak about — Helm values, workflow files,
+    Alertmanager and vmalert configs, bare ``encoder:`` blocks. Reported rather
+    than inferred (review #545 M3): "52 fragments compiled" invites the
+    question "out of how many?", and a reader of the run cannot tell 45
+    declines from 5 without a script of their own.
+    """
     docs_root = repo_root / DOCS_GLOB_ROOT
     if not docs_root.is_dir():
         raise RuntimeError(f"docs root not found: {docs_root}")
 
     skip_set = {str(s) for s in skip_files}
     scenarios: list[ExtractedScenario] = []
+    fences = 0  # every yaml fence seen, so declines can be counted rather than inferred
     for md in iter_markdown_files(docs_root):
         rel = str(md.relative_to(repo_root)) if md.is_absolute() else str(md)
         if rel in skip_set:
             continue
         text = md.read_text(encoding="utf-8")
+        fences += len(extract_yaml_fences(text))
         scenarios.extend(extract_scenarios(md, text))
         scenarios.extend(extract_fragments(md, text))
 
@@ -620,7 +688,7 @@ def run_validation(
         )
         for scenario in scenarios
     ]
-    return results, [r for r in results if not r.ok]
+    return results, [r for r in results if not r.ok], fences - len(scenarios)
 
 
 def format_failure(result: ScenarioResult, repo_root: Path) -> str:
@@ -724,7 +792,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 2
         sonda_bin = raw_bin
 
-    results, failures = run_validation(
+    results, failures, declined = run_validation(
         repo_root=repo_root,
         sonda_bin=sonda_bin,
         subprocess_timeout=args.timeout,
@@ -749,7 +817,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"{len(results) - fragments} runnable scenario fences and {fragments} "
         f"fragments found, "
         f"{len(results) - skipped - len(failures)} compiled, "
-        f"{skipped} skipped, {len(failures)} failed",
+        f"{skipped} skipped, {len(failures)} failed; "
+        f"{declined} yaml fences declined (not Sonda scenarios)",
         file=sys.stderr,
     )
 
@@ -949,6 +1018,39 @@ class _SynthesizeFragmentTests(unittest.TestCase):
         # Continuation lines sit at the item's indent, not the item's dash.
         self.assertIn("\n    generator:\n", out)
         self.assertIn("\n      type: constant\n", out)
+
+
+class _ScenarioCountTests(unittest.TestCase):
+    """The success oracle. Review #545 M2: exit 0 alone was the whole test.
+
+    These pin the CLI's banner phrasing on purpose. If it ever changes, a
+    parse miss degrades to "assume fine" rather than turning every fence red —
+    so the failing test here is the only thing that would say so.
+    """
+
+    def _result(self, stdout: str = "", stderr: str = "") -> ScenarioResult:
+        scenario = ExtractedScenario(file=Path("x.md"), line=1, body="", info="yaml")
+        return _check_scenario_count(scenario, stdout, stderr)
+
+    def test_zero_scenarios_is_a_failure(self) -> None:
+        # The #541 shape: a pack parses clean and emits nothing.
+        result = self._result("Validation: OK (0 scenarios)\n")
+        self.assertFalse(result.ok)
+        self.assertIn("0 scenarios", result.message)
+
+    def test_one_or_more_passes(self) -> None:
+        self.assertTrue(self._result("Validation: OK (1 scenario)\n").ok)
+        self.assertTrue(self._result("Validation: OK (2 scenarios)\n").ok)
+        self.assertTrue(self._result("Validation: OK (12 scenarios)\n").ok)
+
+    def test_the_count_is_read_from_either_stream(self) -> None:
+        self.assertFalse(self._result(stderr="Validation: OK (0 scenarios)\n").ok)
+
+    def test_an_unrecognised_banner_does_not_fail_every_fence(self) -> None:
+        # Deliberately permissive: this assertion is about what the CLI
+        # reported, not about parsing its output successfully.
+        self.assertTrue(self._result("something else entirely\n").ok)
+        self.assertTrue(self._result("").ok)
 
 
 class _MissingInputFilesTests(unittest.TestCase):


### PR DESCRIPTION


## Summary

The idea is the #543 reviewer's, and it found two real bugs on its first run.

Three of this program's docs bugs lived in **fragments** — `scenario_name` (#536), the pack fence (#541), `rate_multiplier` (#543) — and every one was invisible to the compile gate for the same reason: a fragment carries no `version: 2`, so nothing offers it a button and nothing compiles it.

Their insight was that **a fragment is only a fragment because it lacks a preamble**. Wrap it in the minimal `version: 2 / kind: runnable / defaults / scenarios:` shape, dry-run it, and the engine's unknown-field rejection catches exactly that class. It does not type-check values the way a schema would, which is what leaves WP11 worth doing.

**52 fragments now compile that no gate could previously reach**, in two tiers that differ by how much has to be invented:

| shape | what is synthesized |
|---|---|
| `scenarios:` already present | Only the version header, plus `defaults:` unless the fragment brought its own. **Nothing structural is guessed**, so a failure is the fragment's own. |
| a single entry's body | Wrapped under `scenarios:` at one indent, with `signal_type:`/`name:` injected **only if absent**. |

## Two real bugs, both copy-and-fail

Both on `scheduling.md`, both in examples a reader could copy straight into a file:

- **A `sine` with no `period_secs`.** The "10-node fleet, one entry" example shows `amplitude` and `offset`; the engine requires `period_secs` and rejects the file.
- **`while: { ref: cpu_usage, gt: 90.0 }`.** The field is `op:` + `value:`. Introduced in the docs as "a minimal example", and it never compiled. Same shape as `rate_multiplier`.

## The false positives are the design

Every refusal below is one this gate **actually produced** against the real corpus before the rule was tightened. Each is now a named self-test rather than a number, because "the gate reports 3 failures" is only useful if none of them is the gate misreading a file about something else:

| refused | why it was reaching the gate |
|---|---|
| **Helm values maps** | `deploy/kubernetes.md` documents a chart whose `scenarios:` key maps *filenames* to file bodies. Wrapping it yields `invalid type: map, expected a sequence` — a failure that says nothing about the docs. Now refused by reading whether the key introduces a sequence. |
| **GitHub Actions workflows** | Three of them in `end-to-end-pipelines.md`. An earlier rule accepted any fence opening with `name:` and reported `unknown field 'on'` as a docs bug. **`name:` is the most common key in YAML; it discriminates nothing.** A fragment must now carry a key only a Sonda entry has. |
| **bare `distribution:` blocks** | Guessing `signal_type: metrics` made the engine demand a `generator:` the fragment never had — the gate reporting its own wrapper's error. `signal_type` is now read off the fragment: `log_generator` → logs, a lone `distribution` → histogram. |

## Nothing is suppressed to make the run clean

Filtering out `missing field` errors would have been the easy way to quiet the wrapper's noise — and it would have hidden the `period_secs` bug, which is exactly that shape. The module note says what to do instead if the scaffolding ever proves too thin: widen it, or mark the fence. Both are visible; a suppressed error class is not.

One fence is marked `# sonda:static` rather than fixed — a `clock_group` excerpt using YAML's `...` document-end marker as an ellipsis. It is truncated on purpose and its point is the key, not a runnable file.

## Test plan

Verified RED by reintroducing each bug shape, **including the historical one**:

```
rate_multiplier   ->  FAIL scheduling.md:46    (the exact line #543 found)
while gt:         ->  FAIL scheduling.md:392   unknown field `gt`, expected `ref`, `op`, `value`…
no period_secs    ->  FAIL scheduling.md:74    missing field `period_secs`
```

Failures announce when the compiled body is not what the page shows, so nobody hunts for a `version: 2` their file does not contain:

```
FAIL docs/site/docs/build/scheduling.md:392
    (fragment, compiled under a synthesized preamble — the lines below are the wrapper, not the page)
    | version: 2
```

**Gates:** 32 validator self-tests (was 23) · 74 fences + 52 fragments compiled, 0 failed · 153 commands · 60 carded examples · 128 pure tests · `mkdocs build --strict` clean.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)

No Rust changed; the diff is one Python gate and two markdown fixes.

## Notes for the reviewer

- **The scope line is where I'd push.** The two tiers cover fences that carry `scenarios:` or open a scenario entry. Bare `encoder:`/`sink:`/`gaps:` blocks (46 + 21 of them) are still unreachable, because wrapping a lone `gaps:` block means inventing an entire entry around it — at which point the gate is testing my wrapper. I judged that line correct; it is a judgement, not a fact.
- **`signal_type` inference is the part most likely to be wrong.** `log_generator → logs` and `lone distribution → histogram` are the two rules. A `distribution:` alongside a `generator:` falls through to metrics, which is right today but is exactly the kind of assumption that ages badly.
- The `# sonda:static` marker now does double duty — it opts a fence out of *buttoning* and out of *fragment-compiling*. That felt right (one marker, one meaning: "this fence is not meant to run") but it is a widening of an existing convention.
- Worth attacking: feed the wrapper a fragment with a tab-indented body, or one whose first line is a comment. I tested BOM/CRLF via the shared `normalize_fence`, not those two.
