### PR TITLE
feat(site): warning/critical rule pairs and PromQL rule import in the alert lab

### DIFF
--- a/docs/site/docs/javascripts/alert-lab.js
+++ b/docs/site/docs/javascripts/alert-lab.js
@@ -13,11 +13,14 @@ import {
   evaluate,
   fromBase64Url,
   hashPayloadTooLarge,
+  parsePromQLRule,
+  tidyNumber,
   toBase64Url,
 } from "./sonda-pure.js";
 
 const MAX_TICKS = 240;
-const SWEEP_SECONDS = 11; // wall-clock length of one full playback sweep
+const SWEEP_SECONDS = 11;
+const LANE_STACK_GAP = 18; // vertical space between two rules' state lanes // wall-clock length of one full playback sweep
 
 const STATE_COLORS = {
   inactive: { light: "rgba(100, 116, 139, 0.25)", dark: "rgba(148, 163, 184, 0.25)" },
@@ -151,6 +154,16 @@ async function boot() {
     op: document.getElementById("al-op"),
     threshold: document.getElementById("al-threshold"),
     forSel: document.getElementById("al-for"),
+    severity: document.getElementById("al-severity"),
+    second: document.getElementById("al-second"),
+    op2: document.getElementById("al-op2"),
+    threshold2: document.getElementById("al-threshold2"),
+    forSel2: document.getElementById("al-for2"),
+    severity2: document.getElementById("al-severity2"),
+    state2: document.getElementById("al-state2"),
+    importBox: document.getElementById("al-import"),
+    importBtn: document.getElementById("al-import-btn"),
+    importNote: document.getElementById("al-import-note"),
     play: document.getElementById("al-play"),
     state: document.getElementById("al-state"),
     chart: document.getElementById("al-chart"),
@@ -181,24 +194,61 @@ async function boot() {
 
   const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   let entry = null; // sampled series from the engine
-  let evaled = null;
+  let evaled = null; // the FIRST rule's evaluation, for the sweep's pacing
+  let rules = []; // every enabled rule, each carrying its own evaluation
   let animation = 0;
   let currentYaml = null; // the scenario source behind `entry`
 
-  const currentRule = () => ({
-    op: el.op.value,
-    threshold: Number(el.threshold.value),
-    forSecs: Number(el.forSel.value),
-  });
+  /* The rules the lab is currently showing, in row order.
+   *
+   * A list since WP12. The second row is opt-in and starts disabled, so a
+   * reader who never touches it sees exactly the single-rule lab that was
+   * here before — the pair is available, not imposed. */
+  const currentRules = () => {
+    const rules = [
+      {
+        severity: el.severity.value,
+        op: el.op.value,
+        threshold: Number(el.threshold.value),
+        forSecs: Number(el.forSel.value),
+      },
+    ];
+    if (el.second && el.second.checked) {
+      rules.push({
+        severity: el.severity2.value,
+        op: el.op2.value,
+        threshold: Number(el.threshold2.value),
+        forSecs: Number(el.forSel2.value),
+      });
+    }
+    return rules.filter((rule) => Number.isFinite(rule.threshold));
+  };
 
   const reevaluate = () => {
     if (!entry) return;
-    const rule = currentRule();
-    evaled = evaluate(entry.values, entry.tick_secs, rule.op, rule.threshold, rule.forSecs);
+    rules = currentRules().map((rule) => ({
+      ...rule,
+      evaled: evaluate(entry.values, entry.tick_secs, rule.op, rule.threshold, rule.forSecs),
+    }));
+    evaled = rules.length ? rules[0].evaled : null;
     stopSweep();
-    draw(el, entry, evaled, rule, entry.values.length);
-    setStateChip(el.state, finalStateSummary(evaled));
+    draw(el, entry, rules, entry.values.length);
+    syncChips(entry.values.length);
     el.play.textContent = "Play";
+  };
+
+  /* One chip per rule. The second is hidden rather than emptied when the row
+   * is off, so an unused control does not sit there reading "inactive" as
+   * though it were reporting on something. */
+  const syncChips = (upTo) => {
+    const at = (rule) =>
+      upTo >= rule.evaled.states.length
+        ? finalStateSummary(rule.evaled)
+        : rule.evaled.states[Math.max(0, upTo - 1)];
+    if (rules[0]) setStateChip(el.state, at(rules[0]));
+    if (!el.state2) return;
+    el.state2.hidden = rules.length < 2;
+    if (rules[1]) setStateChip(el.state2, at(rules[1]));
   };
 
   const loadPreset = async () => {
@@ -263,43 +313,120 @@ async function boot() {
   }
 
   function startSweep() {
-    if (!entry || !evaled) return;
+    if (!entry || !rules.length) return;
     stopSweep();
-    const rule = currentRule();
     const total = entry.values.length;
     const start = performance.now();
     el.play.textContent = "Replay";
     const frame = (now) => {
       const progress = Math.min(1, (now - start) / (SWEEP_SECONDS * 1000));
       const upTo = Math.max(2, Math.round(progress * total));
-      draw(el, entry, evaled, rule, upTo);
-      setStateChip(el.state, evaled.states[upTo - 1]);
+      draw(el, entry, rules, upTo);
+      syncChips(upTo);
       if (progress < 1) {
         animation = window.requestAnimationFrame(frame);
       } else {
         animation = 0;
-        setStateChip(el.state, finalStateSummary(evaled));
+        syncChips(total);
       }
     };
     animation = window.requestAnimationFrame(frame);
   }
 
   el.preset.addEventListener("change", loadPreset);
-  el.op.addEventListener("change", reevaluate);
-  el.threshold.addEventListener("input", reevaluate);
-  el.forSel.addEventListener("change", reevaluate);
+  for (const control of [el.op, el.threshold, el.forSel, el.severity, el.op2, el.threshold2, el.forSel2, el.severity2]) {
+    if (!control) continue;
+    control.addEventListener(control.tagName === "INPUT" ? "input" : "change", reevaluate);
+  }
+  if (el.second) {
+    el.second.addEventListener("change", () => {
+      const on = el.second.checked;
+      for (const control of [el.op2, el.threshold2, el.forSel2, el.severity2]) {
+        if (control) control.disabled = !on;
+      }
+      // A second rule with no threshold is not a rule. Seed it below the
+      // first so the pair reads as warning-then-critical on first sight
+      // rather than as two lines on top of each other.
+      if (on && el.threshold2 && !el.threshold2.value && entry) {
+        const first = Number(el.threshold.value);
+        const span = Math.max(...entry.values) - Math.min(...entry.values);
+        el.threshold2.value = String(
+          tidyNumber(el.op.value === ">" ? first - span * 0.25 : first + span * 0.25)
+        );
+      }
+      reevaluate();
+    });
+  }
   el.play.addEventListener("click", () => {
     if (reducedMotion) reevaluate();
     else startSweep();
   });
+  /* Import a Prometheus rule into the controls.
+   *
+   * The parse is `parsePromQLRule` in sonda-pure.js, which accepts only
+   * `metric{labels} OP number` and refuses everything richer BY NAME. What
+   * happens here is the other half: the rule's op/threshold/for become the
+   * lab's, and the reader is told when the rule they pasted was written about
+   * a different series than the one on screen.
+   *
+   * That last part matters more than it looks. The lab always evaluates
+   * against the loaded scenario, so importing a rule for `http_errors_total`
+   * while `cpu_usage` is on the chart produces a perfectly working demo of
+   * the wrong thing — and nothing in the numbers would say so.
+   */
+  const importRule = () => {
+    if (!el.importBox || !el.importNote) return;
+    const result = parsePromQLRule(el.importBox.value);
+    const note = el.importNote;
+    if (!result.ok) {
+      note.dataset.kind = "error";
+      note.textContent = result.reason;
+      return;
+    }
+    // Into the SECOND row when it is already in use, so an import does not
+    // silently discard a pair the reader has been tuning.
+    const second = el.second && el.second.checked;
+    const target = second
+      ? { op: el.op2, threshold: el.threshold2, forSel: el.forSel2 }
+      : { op: el.op, threshold: el.threshold, forSel: el.forSel };
+    target.op.value = result.op === ">=" ? ">" : result.op === "<=" ? "<" : result.op;
+    target.threshold.value = String(result.threshold);
+    // `for:` is a fixed menu; land on the nearest option rather than adding
+    // one, and say so if the rule's duration is not on it.
+    const options = Array.from(target.forSel.options).map((option) => Number(option.value));
+    const nearest = options.reduce((best, value) =>
+      Math.abs(value - result.forSecs) < Math.abs(best - result.forSecs) ? value : best
+    );
+    target.forSel.value = String(nearest);
+
+    const notes = [];
+    if (result.op !== target.op.value) {
+      notes.push(`\`${result.op}\` shown as \`${target.op.value}\` — the lab evaluates strict comparisons`);
+    }
+    if (nearest !== result.forSecs) {
+      notes.push(`for: ${result.forSecs}s rounded to ${nearest}s`);
+    }
+    if (entry && result.metric !== entry.name) {
+      notes.push(
+        `this rule is about \`${result.metric}\`, but the chart is showing \`${entry.name}\` — ` +
+          `the lab evaluates against the loaded scenario`
+      );
+    }
+    note.dataset.kind = notes.length ? "warn" : "ok";
+    note.textContent = notes.length
+      ? `Imported${result.name ? ` ${result.name}` : ""} — ${notes.join("; ")}`
+      : `Imported${result.name ? ` ${result.name}` : ""}.`;
+    reevaluate();
+  };
+  if (el.importBtn) el.importBtn.addEventListener("click", importRule);
+
   if (el.exportBtn) {
     el.exportBtn.addEventListener("click", () => {
-      if (!entry || !evaled || currentYaml === null) return;
+      if (!entry || !rules.length || currentYaml === null) return;
       const text = buildTestExport({
         yaml: currentYaml,
         entry,
-        rule: currentRule(),
-        evaled,
+        rules,
       });
       el.exportOut.textContent = text;
       el.exportOut.hidden = false;
@@ -316,16 +443,18 @@ async function boot() {
     });
   }
 
-  new ResizeObserver(() => {
-    if (entry && evaled && !animation) {
-      draw(el, entry, evaled, currentRule(), entry.values.length);
-    }
-  }).observe(el.chart.parentElement);
-  new MutationObserver(() => {
-    if (entry && evaled && !animation) {
-      draw(el, entry, evaled, currentRule(), entry.values.length);
-    }
-  }).observe(document.body, { attributes: true, attributeFilter: ["data-md-color-scheme"] });
+  // Redraw from the CACHED rules on resize and theme flip. Re-reading the
+  // controls here would be a second source of truth for what is on screen,
+  // and these fire while a sweep is paused mid-way — `rules` is what was
+  // drawn, which is what has to be redrawn.
+  const redraw = () => {
+    if (entry && rules.length && !animation) draw(el, entry, rules, entry.values.length);
+  };
+  new ResizeObserver(redraw).observe(el.chart.parentElement);
+  new MutationObserver(redraw).observe(document.body, {
+    attributes: true,
+    attributeFilter: ["data-md-color-scheme"],
+  });
 
   // Awaited so a refused hash explains itself after the first preset has
   // drawn, rather than being overwritten by it. The notice goes on the story
@@ -398,12 +527,24 @@ function palette() {
   };
 }
 
-function draw(el, entry, evaled, rule, upTo) {
+/* Severity decides a rule's colour, so a reader can tell the pair apart on
+ * the chart without reading the numbers. Critical keeps the red the lab has
+ * always used; warning takes amber, which is also the `pending` colour in the
+ * state lane — deliberate, since a warning threshold IS the earlier, softer
+ * line. */
+const SEVERITY_COLORS = {
+  critical: { light: "#dc2626", dark: "#f87171" },
+  warning: { light: "#b45309", dark: "#fbbf24" },
+};
+
+function draw(el, entry, rules, upTo) {
   const colors = palette();
   const canvas = el.chart;
   const dpr = window.devicePixelRatio || 1;
   const cssWidth = canvas.parentElement.clientWidth;
-  const cssHeight = 380;
+  const laneH = 26;
+  const extraLanes = Math.max(0, rules.length - 1);
+  const cssHeight = 380 + extraLanes * (laneH + LANE_STACK_GAP);
   canvas.width = cssWidth * dpr;
   canvas.height = cssHeight * dpr;
   canvas.style.width = cssWidth + "px";
@@ -412,17 +553,25 @@ function draw(el, entry, evaled, rule, upTo) {
   ctx.scale(dpr, dpr);
   ctx.clearRect(0, 0, cssWidth, cssHeight);
 
-  const laneH = 26;
   const laneGap = 34;
-  const pad = { left: 48, right: 12, top: 12, bottom: 26 + laneH + laneGap };
+  // Every lane past the first extends the canvas rather than squeezing the
+  // plot: the trace is what the reader is reading, and a second rule must
+  // not shrink it.
+  const pad = {
+    left: 48,
+    right: 12,
+    top: 12,
+    bottom: 26 + laneH + laneGap + extraLanes * (laneH + LANE_STACK_GAP),
+  };
   const plotW = cssWidth - pad.left - pad.right;
   const plotH = cssHeight - pad.top - pad.bottom;
   const laneY = pad.top + plotH + laneGap;
 
   const values = entry.values;
   const spanSecs = (values.length - 1) * entry.tick_secs;
-  let min = Math.min(...values, rule.threshold);
-  let max = Math.max(...values, rule.threshold);
+  const thresholds = rules.map((rule) => rule.threshold).filter(Number.isFinite);
+  let min = Math.min(...values, ...thresholds);
+  let max = Math.max(...values, ...thresholds);
   if (max - min < 1e-9) {
     min -= 1;
     max += 1;
@@ -436,10 +585,15 @@ function draw(el, entry, evaled, rule, upTo) {
 
   // Firing bands behind the trace, only up to the sweep cursor. Consecutive
   // ticks are merged into one rect so bands render seamlessly at any DPR.
+  // Shaded for the FIRST rule only. Two overlapping washes would make the
+  // area where both fire a third colour that means nothing, and the second
+  // rule's firing is already legible in its own lane below.
   ctx.fillStyle = colors.firingBand;
-  for (const run of stateRuns(evaled.states, upTo)) {
-    if (run.state === "firing") {
-      ctx.fillRect(x(run.start), pad.top, x(run.end) - x(run.start), plotH);
+  if (rules[0]) {
+    for (const run of stateRuns(rules[0].evaled.states, upTo)) {
+      if (run.state === "firing") {
+        ctx.fillRect(x(run.start), pad.top, x(run.end) - x(run.start), plotH);
+      }
     }
   }
 
@@ -467,18 +621,28 @@ function draw(el, entry, evaled, rule, upTo) {
     ctx.fillText(formatSeconds(secs), pad.left + (secs / spanSecs) * plotW, pad.top + plotH + 16);
   }
 
-  // Threshold line.
-  ctx.strokeStyle = colors.thresholdLine;
-  ctx.setLineDash([6, 4]);
-  ctx.lineWidth = 1.5;
-  ctx.beginPath();
-  ctx.moveTo(pad.left, y(rule.threshold));
-  ctx.lineTo(cssWidth - pad.right, y(rule.threshold));
-  ctx.stroke();
-  ctx.setLineDash([]);
-  ctx.textAlign = "left";
-  ctx.fillStyle = colors.thresholdLine;
-  ctx.fillText(`${rule.op} ${rule.threshold}`, pad.left + 4, y(rule.threshold) - 5);
+  // One threshold line per rule, coloured by severity and labelled with its
+  // own severity so the pair is readable without counting lines.
+  for (const rule of rules) {
+    const stroke = (SEVERITY_COLORS[rule.severity] || SEVERITY_COLORS.critical)[
+      colors.dark ? "dark" : "light"
+    ];
+    ctx.strokeStyle = stroke;
+    ctx.setLineDash([6, 4]);
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(pad.left, y(rule.threshold));
+    ctx.lineTo(cssWidth - pad.right, y(rule.threshold));
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.textAlign = "left";
+    ctx.fillStyle = stroke;
+    const label =
+      rules.length > 1
+        ? `${rule.severity} ${rule.op} ${rule.threshold}`
+        : `${rule.op} ${rule.threshold}`;
+    ctx.fillText(label, pad.left + 4, y(rule.threshold) - 5);
+  }
 
   // Signal trace up to the sweep cursor.
   ctx.strokeStyle = colors.trace;
@@ -493,26 +657,41 @@ function draw(el, entry, evaled, rule, upTo) {
   }
   ctx.stroke();
 
-  // Alert-state lane, drawn as merged runs for seamless segments.
-  ctx.fillStyle = colors.text;
-  ctx.textAlign = "left";
+  // One alert-state lane per rule, drawn as merged runs for seamless
+  // segments. Stacked rather than overlaid: the whole point of a
+  // warning/critical pair is that the two fire at different times, and a
+  // single lane could only ever show one of them.
+  const stateColor = (state) => STATE_COLORS[state][colors.dark ? "dark" : "light"];
   ctx.font = "10px ui-monospace, monospace";
-  ctx.fillText("ALERT STATE", pad.left, laneY - 7);
-  const stateColor = (s) => STATE_COLORS[s][colors.dark ? "dark" : "light"];
-  for (const run of stateRuns(evaled.states, upTo)) {
-    ctx.fillStyle = stateColor(run.state);
-    ctx.fillRect(x(run.start), laneY, Math.max(1, x(run.end) - x(run.start)), laneH);
-  }
-  // Resolve markers.
-  ctx.strokeStyle = colors.resolve;
-  ctx.lineWidth = 2;
-  for (const idx of evaled.resolves) {
-    if (idx >= upTo) continue;
-    ctx.beginPath();
-    ctx.moveTo(x(idx), laneY - 4);
-    ctx.lineTo(x(idx), laneY + laneH + 4);
-    ctx.stroke();
-  }
+  rules.forEach((rule, index) => {
+    const top = laneY + index * (laneH + LANE_STACK_GAP);
+    ctx.fillStyle = colors.text;
+    ctx.textAlign = "left";
+    ctx.fillText(
+      rules.length > 1 ? `${rule.severity.toUpperCase()} STATE` : "ALERT STATE",
+      pad.left,
+      top - 7
+    );
+    for (const run of stateRuns(rule.evaled.states, upTo)) {
+      ctx.fillStyle = stateColor(run.state);
+      ctx.fillRect(x(run.start), top, Math.max(1, x(run.end) - x(run.start)), laneH);
+    }
+    ctx.strokeStyle = colors.resolve;
+    ctx.lineWidth = 2;
+    for (const idx of rule.evaled.resolves) {
+      if (idx >= upTo) continue;
+      ctx.beginPath();
+      ctx.moveTo(x(idx), top - 4);
+      ctx.lineTo(x(idx), top + laneH + 4);
+      ctx.stroke();
+    }
+  });
+
+  // What the chart is claiming, for the browser smoke suite — the lesson
+  // from review #543, which is that a canvas diff can say something moved
+  // but never what.
+  canvas.dataset.rules = String(rules.length);
+  canvas.dataset.thresholds = rules.map((rule) => `${rule.severity}:${rule.threshold}`).join(",");
 }
 
 /* Group consecutive same-state ticks into runs [start, end) for seamless

--- a/docs/site/docs/javascripts/alert-lab.js
+++ b/docs/site/docs/javascripts/alert-lab.js
@@ -19,8 +19,8 @@ import {
 } from "./sonda-pure.js";
 
 const MAX_TICKS = 240;
-const SWEEP_SECONDS = 11;
-const LANE_STACK_GAP = 18; // vertical space between two rules' state lanes // wall-clock length of one full playback sweep
+const SWEEP_SECONDS = 11; // wall-clock length of one full playback sweep
+const LANE_STACK_GAP = 18; // vertical space between two rules' state lanes
 
 const STATE_COLORS = {
   inactive: { light: "rgba(100, 116, 139, 0.25)", dark: "rgba(148, 163, 184, 0.25)" },
@@ -196,6 +196,16 @@ async function boot() {
   let entry = null; // sampled series from the engine
   let evaled = null; // the FIRST rule's evaluation, for the sweep's pacing
   let rules = []; // every enabled rule, each carrying its own evaluation
+  /* True when the second row is owed a seeded threshold.
+   *
+   * Seeding is an INTENTION, not a reflex on every keystroke. Set when the
+   * row is switched on or a preset replaces the scenario; consumed by the
+   * next reevaluate that has an `entry` to size it against. Without the
+   * flag, seeding from reevaluate refills the box the instant a reader
+   * empties it — so Backspace becomes impossible and clearing the row is a
+   * thing the UI will not let you do. Found while verifying the #546 B1 fix
+   * rather than by reading it. */
+  let secondNeedsSeed = false;
   let animation = 0;
   let currentYaml = null; // the scenario source behind `entry`
 
@@ -204,28 +214,44 @@ async function boot() {
    * A list since WP12. The second row is opt-in and starts disabled, so a
    * reader who never touches it sees exactly the single-rule lab that was
    * here before — the pair is available, not imposed. */
+  /* One row's controls as a rule, or null when the row has no threshold.
+   *
+   * The blank check is on the STRING, not on `Number.isFinite` (review #546
+   * B1). `Number("") === 0` and zero is perfectly finite, so a filter written
+   * as `Number.isFinite(rule.threshold)` says "a row with no threshold is not
+   * a rule" while doing the opposite: an empty box became a rule at 0 that
+   * fired on everything and — the part that made it a blocker — exported a
+   * warning rule the reader never wrote into their rules file and their
+   * expect: block.
+   *
+   * Reading the string also covers the route no load-timing fix reaches: a
+   * reader who clears the box by hand. */
+  const rowRule = (severitySel, opSel, thresholdInput, forSelect) => {
+    const raw = String(thresholdInput.value).trim();
+    if (raw === "") return null;
+    const threshold = Number(raw);
+    if (!Number.isFinite(threshold)) return null;
+    return {
+      severity: severitySel.value,
+      op: opSel.value,
+      threshold,
+      forSecs: Number(forSelect.value),
+    };
+  };
+
   const currentRules = () => {
-    const rules = [
-      {
-        severity: el.severity.value,
-        op: el.op.value,
-        threshold: Number(el.threshold.value),
-        forSecs: Number(el.forSel.value),
-      },
-    ];
+    const rules = [rowRule(el.severity, el.op, el.threshold, el.forSel)];
     if (el.second && el.second.checked) {
-      rules.push({
-        severity: el.severity2.value,
-        op: el.op2.value,
-        threshold: Number(el.threshold2.value),
-        forSecs: Number(el.forSel2.value),
-      });
+      rules.push(rowRule(el.severity2, el.op2, el.threshold2, el.forSel2));
     }
-    return rules.filter((rule) => Number.isFinite(rule.threshold));
+    return rules.filter(Boolean);
   };
 
   const reevaluate = () => {
     if (!entry) return;
+    // The second row may have been switched on while the engine was still
+    // loading, in which case this is the first moment it can be sized.
+    if (secondNeedsSeed) seedSecondRule();
     rules = currentRules().map((rule) => ({
       ...rule,
       evaled: evaluate(entry.values, entry.tick_secs, rule.op, rule.threshold, rule.forSecs),
@@ -251,11 +277,28 @@ async function boot() {
     if (rules[1]) setStateChip(el.state2, at(rules[1]));
   };
 
+  /* Re-seed the second row against the scenario now on screen.
+   *
+   * `loadPreset` reassigns the first rule's op/threshold/for on every preset
+   * change. Leaving the second row untouched left a warning line seeded a
+   * quarter-span below the OLD critical sitting on a completely different
+   * signal — 68 points below it in the case review #546 W5 measured, firing
+   * flat-out for the whole run, while still reading and exporting as a tuned
+   * policy. Clearing it lets the ordinary seeding path put it back in the
+   * relationship it was designed to have. */
+  const reseedSecondRule = () => {
+    if (el.second && el.second.checked && el.threshold2) {
+      el.threshold2.value = "";
+      secondNeedsSeed = true;
+    }
+  };
+
   const loadPreset = async () => {
     const isCustom = el.preset.value === "custom" && customYaml !== null;
     const preset = isCustom ? null : PRESETS[Number(el.preset.value)];
     const yaml = isCustom ? customYaml : preset.yaml;
     currentYaml = yaml;
+    reseedSecondRule();
     if (el.exportOut) el.exportOut.hidden = true;
     // Everything that doesn't need the sampled series is assigned BEFORE
     // sampling, so a scenario that fails to sample never shows rule fields
@@ -347,15 +390,29 @@ async function boot() {
       // A second rule with no threshold is not a rule. Seed it below the
       // first so the pair reads as warning-then-critical on first sight
       // rather than as two lines on top of each other.
-      if (on && el.threshold2 && !el.threshold2.value && entry) {
-        const first = Number(el.threshold.value);
-        const span = Math.max(...entry.values) - Math.min(...entry.values);
-        el.threshold2.value = String(
-          tidyNumber(el.op.value === ">" ? first - span * 0.25 : first + span * 0.25)
-        );
-      }
+      // `entry` may still be null: #al-second is the one second-row control
+      // the markup leaves enabled, so it is clickable from first paint while
+      // the wasm engine is still loading. `seedSecondRule` is therefore also
+      // called from reevaluate(), so the seed lands whichever order the two
+      // happen in rather than being silently skipped.
+      secondNeedsSeed = on;
+      if (on) seedSecondRule();
       reevaluate();
     });
+  }
+
+  /* Give the second row a threshold a quarter-span from the first, so the
+   * pair reads as warning-then-critical on first sight rather than as two
+   * lines on top of each other. No-op unless the row is on and empty. */
+  function seedSecondRule() {
+    if (!el.second || !el.second.checked || !el.threshold2 || !entry) return;
+    if (el.threshold2.value) return; // a reader's own number is never overwritten
+    const first = Number(el.threshold.value);
+    const span = Math.max(...entry.values) - Math.min(...entry.values);
+    el.threshold2.value = String(
+      tidyNumber(el.op.value === ">" ? first - span * 0.25 : first + span * 0.25)
+    );
+    secondNeedsSeed = false;
   }
   el.play.addEventListener("click", () => {
     if (reducedMotion) reevaluate();
@@ -401,10 +458,30 @@ async function boot() {
 
     const notes = [];
     if (result.op !== target.op.value) {
-      notes.push(`\`${result.op}\` shown as \`${target.op.value}\` — the lab evaluates strict comparisons`);
+      // Naming WHEN the two differ, not just that they were swapped (review
+      // #546 M2). At a plateau sitting exactly on the threshold — which step
+      // and constant generators produce — `>=` fires throughout and `>` never
+      // fires at all, so "they differ only where the signal lands exactly on
+      // the threshold" is the half-clause that makes this actionable rather
+      // than merely disclosed.
+      notes.push(
+        `\`${result.op}\` shown as \`${target.op.value}\` — the lab evaluates strict ` +
+          `comparisons, so they differ only where the signal lands exactly on the threshold`
+      );
     }
     if (nearest !== result.forSecs) {
-      notes.push(`for: ${result.forSecs}s rounded to ${nearest}s`);
+      // "Rounded" is honest for 15s -> 12s and badly understates 5m -> 30s,
+      // which is the duration most rules files actually carry (review #546
+      // M1). Naming the reason — the lab's timeline is seconds long — stops
+      // a reader concluding their tuning transferred.
+      const ratio = result.forSecs / nearest;
+      notes.push(
+        ratio >= 2
+          ? `for: ${result.forSecs}s does not fit this lab's ${Math.round(
+              (entry ? entry.values.length * entry.tick_secs : 60)
+            )}s timeline — showing ${nearest}s instead, so the timing here is not your rule's`
+          : `for: ${result.forSecs}s rounded to ${nearest}s`
+      );
     }
     if (entry && result.metric !== entry.name) {
       notes.push(

--- a/docs/site/docs/javascripts/sonda-pure.js
+++ b/docs/site/docs/javascripts/sonda-pure.js
@@ -315,58 +315,83 @@ export function niceDeadlineSecs(secs) {
   return Math.ceil(padded / 60) * 60;
 }
 
-/* Build the "run this for real" export: one clipboard-ready file — the
- * scenario YAML with an appended, label-scoped `expect:` block, headed by a
- * comment carrying the matching vmalert/Prometheus rule. Deadlines come
- * from the evaluated preview timeline, so the exported expectation is one
- * the tuned rule demonstrably meets. */
-export function buildTestExport({ yaml, entry, rule, evaled }) {
-  const alertName = deriveAlertName(entry.name, rule.op);
+/* The `sonda test` setup for one or more lab rules, as a copyable document.
+ *
+ * `rules` is an array of `{ severity, op, threshold, forSecs, evaled }` —
+ * plural since WP12, because a warning/critical pair is how these are written
+ * in practice and exporting only one of them would hand a reader half their
+ * alerting policy. A single-rule export is byte-identical to what this
+ * produced before the pair existed, so the common case did not get noisier to
+ * make room for the uncommon one.
+ *
+ * Each rule carries its OWN `evaled`, because the deadlines are per-rule: a
+ * warning at 60 fires earlier than a critical at 90 on the same series, and
+ * asserting the critical's timing against the warning's states would produce
+ * an expectation that passes for the wrong reason.
+ */
+export function buildTestExport({ yaml, entry, rules }) {
   const labels = entry.labels || {};
   const labelKeys = Object.keys(labels).sort();
   const selector = labelKeys.length
     ? `{${labelKeys.map((k) => `${k}="${escapeQuoted(labels[k])}"`).join(",")}}`
     : "";
-  const forSecs = rule.forSecs;
-
-  const firstFiring = evaled.states.indexOf("firing");
-  const fired = firstFiring >= 0;
   const offset = entry.offset_secs || 0;
-  const firingWithin = fired
-    ? niceDeadlineSecs(offset + firstFiring * entry.tick_secs)
-    : null;
-  const endsResolved = fired && evaled.states[evaled.states.length - 1] !== "firing";
+  const multiple = rules.length > 1;
 
-  // The expr is a YAML scalar containing PromQL: single-quote it at the
-  // YAML layer (apostrophes doubled, backslashes untouched) so PromQL's
-  // own escapes survive and label values with `: ` cannot break the rules
-  // file. escapeQuoted already handled the PromQL string-literal layer.
-  const expr = `${entry.name}${selector} ${rule.op} ${rule.threshold}`;
-  const ruleLines = [
-    "groups:",
-    "  - name: sonda-lab",
-    "    interval: 5s",
-    "    rules:",
-    `      - alert: ${alertName}`,
-    `        expr: '${expr.replace(/'/g, "''")}'`,
-    `        for: ${forSecs}s`,
-    "        labels:",
-    "          severity: critical",
-  ];
+  const prepared = rules.map((rule) => {
+    const severity = rule.severity || "critical";
+    // The severity suffix only appears when it has to. With one rule the
+    // name is what it always was; with two, two alerts sharing a name in one
+    // group is a rules file that does not mean what it looks like.
+    const alertName = deriveAlertName(entry.name, rule.op) +
+      (multiple ? severity.charAt(0).toUpperCase() + severity.slice(1) : "");
+    const states = (rule.evaled && rule.evaled.states) || [];
+    const firstFiring = states.indexOf("firing");
+    const fired = firstFiring >= 0;
+    return {
+      severity,
+      alertName,
+      op: rule.op,
+      threshold: rule.threshold,
+      forSecs: rule.forSecs,
+      fired,
+      firingWithin: fired ? niceDeadlineSecs(offset + firstFiring * entry.tick_secs) : null,
+      endsResolved: fired && states[states.length - 1] !== "firing",
+      expr: `${entry.name}${selector} ${rule.op} ${rule.threshold}`,
+    };
+  });
 
-  const expectLines = ["expect:", "  alerts:", `    - alert: ${alertName}`, "      labels:", "        severity: critical"];
-  for (const key of labelKeys) {
-    // Always double-quoted: a bare numeric, boolean, `{`, `*`, colon-space
-    // or empty value is invalid (or worse, retyped) YAML.
-    expectLines.push(`        ${key}: "${escapeQuoted(labels[key])}"`);
+  const ruleLines = ["groups:", "  - name: sonda-lab", "    interval: 5s", "    rules:"];
+  for (const rule of prepared) {
+    ruleLines.push(
+      `      - alert: ${rule.alertName}`,
+      // The expr is a YAML scalar containing PromQL: single-quote it at the
+      // YAML layer (apostrophes doubled, backslashes untouched) so PromQL's
+      // own escapes survive and label values with `: ` cannot break the
+      // rules file. escapeQuoted already handled the PromQL literal layer.
+      `        expr: '${rule.expr.replace(/'/g, "''")}'`,
+      `        for: ${rule.forSecs}s`,
+      "        labels:",
+      `          severity: ${rule.severity}`
+    );
   }
-  expectLines.push(
-    `      firing_within: ${firingWithin !== null ? `${firingWithin}s` : "60s # the rule never fired in the sampled preview — tune it in the lab first"}`
-  );
-  if (endsResolved) {
-    expectLines.push("      resolves_within: 2m");
-  } else if (fired) {
-    expectLines.push("      # still firing when the scenario ends — resolution not asserted");
+
+  const expectLines = ["expect:", "  alerts:"];
+  for (const rule of prepared) {
+    expectLines.push(`    - alert: ${rule.alertName}`, "      labels:", `        severity: ${rule.severity}`);
+    for (const key of labelKeys) {
+      // Always double-quoted: a bare numeric, boolean, `{`, `*`, colon-space
+      // or empty value is invalid (or worse, retyped) YAML.
+      expectLines.push(`        ${key}: "${escapeQuoted(labels[key])}"`);
+    }
+    expectLines.push(
+      `      firing_within: ${rule.firingWithin !== null ? `${rule.firingWithin}s` : "60s # the rule never fired in the sampled preview — tune it in the lab first"}`
+    );
+    if (rule.endsResolved) {
+      expectLines.push("      resolves_within: 2m");
+    } else if (rule.fired) {
+      expectLines.push("      # still firing when the scenario ends — resolution not asserted");
+    }
   }
 
   const hasExpect = /^expect:/m.test(yaml);
@@ -374,10 +399,14 @@ export function buildTestExport({ yaml, entry, rule, evaled }) {
     ? `${yaml.trimEnd()}\n\n# NOTE: this scenario already has an expect: block — merge the one below by hand.\n${expectLines.map((l) => `# ${l}`).join("\n")}\n`
     : `${yaml.trimEnd()}\n\n# Scope note: expect.labels pins this scenario's own labels — ALERTS is\n# global, and an unscoped expectation can match alerts other series caused.\n${expectLines.join("\n")}\n`;
 
+  const headline = prepared
+    .map((r) => `${entry.name}${selector} ${r.op} ${r.threshold} for ${r.forSecs}s (${r.severity})`)
+    .join("\n#   ");
+
   return (
-    `# Generated by the Sonda alert lab — ${entry.name}${selector} ${rule.op} ${rule.threshold} for ${forSecs}s\n` +
+    `# Generated by the Sonda alert lab — ${headline}\n` +
     `#\n` +
-    `# 1) Alert rule (vmalert / Prometheus) — add to your rules file:\n` +
+    `# 1) Alert rule${multiple ? "s" : ""} (vmalert / Prometheus) — add to your rules file:\n` +
     ruleLines.map((l) => `#    ${l}`).join("\n") +
     `\n#\n` +
     `# 2) This file — save as lab-scenario.yaml and run:\n` +
@@ -710,4 +739,226 @@ export function logLinesNear(log, cursorSecs) {
     if (Math.abs(secs - at) <= window) hits.push(i);
   }
   return hits;
+}
+
+/* ---- importing a Prometheus rule (WP12) ------------------------------- */
+
+/* The operators the lab can evaluate. `evaluate` implements `>` and `<`;
+ * the rest are accepted here and normalized, because a rule written with
+ * `>=` is a rule about the same threshold and refusing it would send a
+ * reader away to edit text by hand for no reason. */
+const _IMPORTABLE_OPS = new Set([">", ">=", "<", "<="]);
+
+/* A PromQL instant-vector selector and a scalar comparison, and nothing else:
+ *
+ *   metric_name{label="value",other!="x"} >= 12.5e3
+ *
+ * Anchored end to end on purpose. A partial match is how a parser accepts
+ * `rate(cpu[5m]) > 90` by reading only the tail — the class of leniency that
+ * makes an import feature lie about what it imported.
+ */
+const _PROMQL_RULE_RE = new RegExp(
+  "^\\s*(?<metric>[a-zA-Z_:][a-zA-Z0-9_:]*)\\s*" +
+    // The selector block: anything but a brace or quote, OR a complete
+    // string literal — which MAY contain braces. `[^{}]*` is the obvious
+    // version and it rejects `{msg="{braces}"}`, a legal matcher, because a
+    // brace inside a value is indistinguishable from the closing one to a
+    // rule that cannot see quoting.
+    '(?:\\{(?<selectors>(?:[^{}"]|"(?:[^"\\\\]|\\\\.)*")*)\\})?\\s*' +
+    "(?<op>>=|<=|==|!=|>|<)\\s*" +
+    "(?<value>[+-]?(?:\\d+\\.?\\d*|\\.\\d+)(?:[eE][+-]?\\d+)?)\\s*$"
+);
+
+/* One label matcher inside the braces. The value is a double-quoted PromQL
+ * string literal, so it may contain escaped quotes and backslashes — and
+ * `: ` , which is what broke the YAML layer in review #532. */
+const _SELECTOR_RE = new RegExp(
+  '^\\s*(?<label>[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?<match>=~|!~|!=|=)\\s*"(?<value>(?:[^"\\\\]|\\\\.)*)"\\s*$'
+);
+
+/* Duration suffixes Prometheus accepts on `for:`, in seconds. */
+const _DURATION_UNITS = { ms: 0.001, s: 1, m: 60, h: 3600, d: 86400, w: 604800, y: 31536000 };
+
+/* Parse a Prometheus duration (`5m`, `1h30m`, `90s`) into seconds, or null. */
+function _durationSecs(text) {
+  const raw = String(text).trim();
+  if (!raw) return null;
+  if (/^\d+(?:\.\d+)?$/.test(raw)) return Number(raw); // bare number = seconds
+  const parts = raw.match(/\d+(?:\.\d+)?(?:ms|[smhdwy])/g);
+  if (!parts || parts.join("") !== raw) return null;
+  let total = 0;
+  for (const part of parts) {
+    const match = part.match(/^(\d+(?:\.\d+)?)(ms|[smhdwy])$/);
+    if (!match) return null;
+    total += Number(match[1]) * _DURATION_UNITS[match[2]];
+  }
+  return total;
+}
+
+/* Split the inside of `{...}` on commas that are not inside a string. */
+function _splitSelectors(text) {
+  const out = [];
+  let current = "";
+  let inString = false;
+  let escaped = false;
+  for (const char of text) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === '"') inString = !inString;
+    if (char === "," && !inString) {
+      out.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  out.push(current);
+  return out;
+}
+
+/* Import one Prometheus alerting rule into the lab's controls.
+ *
+ * Accepts either a rules-file snippet — `alert:` / `expr:` / `for:`, with or
+ * without the `groups:` scaffolding around it — or a bare expression. Returns
+ * `{ ok: true, name, metric, selectors, op, threshold, forSecs }`, or
+ * `{ ok: false, reason }` where the reason names what was actually seen.
+ *
+ * THE GRAMMAR IS DELIBERATELY TINY: one instant-vector selector compared
+ * against one scalar. The lab evaluates a threshold against a single sampled
+ * series, so that is the whole of what it can honestly represent. A rule
+ * carrying `rate(...)`, `sum by (...)`, `unless`, an arithmetic expression or
+ * a comparison between two series is not a rule this lab could show — and
+ * importing "most of it" would put a reader in front of a chart that answers
+ * a different question than the rule they pasted. Those are refused by name.
+ *
+ * Selectors are parsed but do NOT drive evaluation: the lab always evaluates
+ * against the scenario currently loaded. They are validated so a well-formed
+ * rule is not rejected for having them, and returned so the caller can say
+ * which series the rule was written about.
+ */
+export function parsePromQLRule(text) {
+  const source = String(text == null ? "" : text);
+  if (!source.trim()) return { ok: false, reason: "nothing to import — paste a rule first" };
+
+  // Pull the fields out of a rules-file snippet if that is what this is.
+  // A bare expression has no `expr:` key and is used whole.
+  //
+  // The line prefix allows `#` as well as indentation and the list dash,
+  // because THIS LAB'S OWN EXPORT writes its rule inside a comment block —
+  // a reader who copies what the lab gave them and pastes it back would
+  // otherwise be told there is no `expr:` line. Found by round-tripping
+  // `buildTestExport` through this parser, which is now a test: if the two
+  // ever disagree again, the lab cannot read what it wrote.
+  let expr = source;
+  let name = null;
+  let forText = null;
+  const exprLine = source.match(/^[ \t#-]*expr:[ \t]*(?<value>.+?)[ \t]*$/m);
+  if (exprLine) {
+    expr = _unquoteScalar(exprLine.groups.value);
+    const nameLine = source.match(/^[ \t#-]*alert:[ \t]*(?<value>.+?)[ \t]*$/m);
+    if (nameLine) name = _unquoteScalar(nameLine.groups.value);
+    const forLine = source.match(/^[ \t#-]*for:[ \t]*(?<value>.+?)[ \t]*$/m);
+    if (forLine) forText = _unquoteScalar(forLine.groups.value);
+  } else if (/^[ \t#-]*(?:record|alert):/m.test(source)) {
+    // A rule block with no expr: is a rules file we failed to read, not a
+    // bare expression — saying so beats reporting a PromQL syntax error
+    // about YAML.
+    return { ok: false, reason: "found a rule block but no `expr:` line" };
+  }
+
+  expr = expr.trim();
+  if (!expr) return { ok: false, reason: "the rule has an empty `expr:`" };
+
+  // Name the unsupported constructs before the regex does, because
+  // "does not match" is a useless thing to tell someone holding a rule that
+  // is perfectly valid PromQL.
+  const unsupported = [
+    [/\b(?:rate|irate|increase|avg_over_time|max_over_time|min_over_time|sum_over_time|histogram_quantile|absent|delta|deriv|predict_linear)\s*\(/, "a function call"],
+    [/\b(?:sum|avg|min|max|count|topk|bottomk|quantile|stddev|group)\s*(?:by|without)?\s*[({]/, "an aggregation"],
+    [/\b(?:unless|and|or)\b/, "a set operator"],
+    [/\[[^\]]*\]/, "a range selector"],
+    [/\boffset\b|@/, "an offset or @ modifier"],
+  ];
+  for (const [pattern, what] of unsupported) {
+    if (pattern.test(expr)) {
+      return {
+        ok: false,
+        reason: `only simple threshold rules import; this one uses ${what}. Edit it by hand.`,
+      };
+    }
+  }
+
+  const match = _PROMQL_RULE_RE.exec(expr);
+  if (!match) {
+    return {
+      ok: false,
+      reason:
+        "only simple threshold rules import — expected `metric{labels} > number`. Edit it by hand.",
+    };
+  }
+  const { metric, selectors: selectorText, op, value } = match.groups;
+
+  if (!_IMPORTABLE_OPS.has(op)) {
+    return {
+      ok: false,
+      reason: `the lab evaluates \`>\`, \`>=\`, \`<\` and \`<=\`; this rule uses \`${op}\``,
+    };
+  }
+
+  const threshold = Number(value);
+  if (!Number.isFinite(threshold)) {
+    return { ok: false, reason: `\`${value}\` is not a finite number` };
+  }
+
+  const selectors = {};
+  if (selectorText !== undefined && selectorText.trim()) {
+    for (const part of _splitSelectors(selectorText)) {
+      const selector = _SELECTOR_RE.exec(part);
+      if (!selector) {
+        return { ok: false, reason: `could not read the label matcher \`${part.trim()}\`` };
+      }
+      const { label, match: matcher, value: raw } = selector.groups;
+      // Unescape the PromQL string literal so the value round-trips through
+      // `escapeQuoted` on the way back out to a rules file.
+      selectors[label] = { op: matcher, value: raw.replace(/\\(.)/g, "$1") };
+    }
+  }
+
+  let forSecs = 0;
+  if (forText !== null) {
+    const parsed = _durationSecs(forText);
+    if (parsed === null) {
+      return { ok: false, reason: `could not read the duration \`${forText}\`` };
+    }
+    forSecs = parsed;
+  }
+
+  return { ok: true, name, metric, selectors, op, threshold, forSecs };
+}
+
+/* Strip one layer of YAML scalar quoting from a value read off a line.
+ *
+ * `expr: 'cpu > 90'` and `expr: "cpu > 90"` are the same expression; the
+ * single-quoted form doubles its own apostrophes, which is how
+ * `buildTestExport` writes them. Trailing `#` comments are NOT stripped: a
+ * `#` inside an unquoted PromQL expression is not a comment, and guessing
+ * wrong would silently truncate the rule.
+ */
+function _unquoteScalar(value) {
+  const text = String(value).trim();
+  if (text.length >= 2 && text.startsWith("'") && text.endsWith("'")) {
+    return text.slice(1, -1).replace(/''/g, "'");
+  }
+  if (text.length >= 2 && text.startsWith('"') && text.endsWith('"')) {
+    return text.slice(1, -1).replace(/\\(.)/g, "$1");
+  }
+  return text;
 }

--- a/docs/site/docs/javascripts/sonda-pure.js
+++ b/docs/site/docs/javascripts/sonda-pure.js
@@ -5,6 +5,17 @@
  * property — docs/site/tools/tests/pure.test.mjs imports this file in node
  * and exercises the case tables in CI, which is the only automated coverage
  * the playground JS has.
+ *
+ * ONE CONSTRAINT THAT IS NOT OBVIOUS FROM HERE: this module is bundled into
+ * the CodeMirror editor (docs/site/tools/editor/src imports `numberSpanAt`
+ * and `scrubNumber`), and that bundle is committed under a byte-exact drift
+ * gate. Exported function declarations tree-shake cleanly, so adding one
+ * costs the editor nothing — but a module-level `new RegExp(...)`, `new
+ * Set(...)` or any other constructor call does NOT, because esbuild cannot
+ * prove it is side-effect-free. Such a value is compiled into a 494 KB bundle
+ * that never runs it, and turns the editor's gate red on a change that has
+ * nothing to do with the editor. Mark them `/* @__PURE__ *\/` — see the
+ * PromQL parser at the end of this file, which is where this was learned.
  */
 
 /* URL-safe base64 for the #yaml= hash. Encodes through TextEncoder so
@@ -743,11 +754,24 @@ export function logLinesNear(log, cursorSecs) {
 
 /* ---- importing a Prometheus rule (WP12) ------------------------------- */
 
+/* Every module-level value below carries `/* @__PURE__ *\/` because
+ * sonda-pure.js is BUNDLED INTO THE EDITOR (docs/site/tools/editor/src imports
+ * `numberSpanAt` and `scrubNumber` from it), and esbuild cannot prove a
+ * constructor call is side-effect-free on its own. Without the annotation the
+ * alert lab's PromQL parser is compiled into a 494 KB CodeMirror bundle that
+ * never runs it — and, more to the point, the editor's byte-exact drift gate
+ * fails on a change that has nothing to do with the editor. That is how this
+ * was found: CI red on #546 with a diff full of CodeMirror internals.
+ *
+ * Plain function declarations tree-shake without help, which is why WP9's
+ * additions to this module never showed up in that bundle.
+ */
+
 /* The operators the lab can evaluate. `evaluate` implements `>` and `<`;
  * the rest are accepted here and normalized, because a rule written with
  * `>=` is a rule about the same threshold and refusing it would send a
  * reader away to edit text by hand for no reason. */
-const _IMPORTABLE_OPS = new Set([">", ">=", "<", "<="]);
+const _IMPORTABLE_OPS = /* @__PURE__ */ new Set([">", ">=", "<", "<="]);
 
 /* A PromQL instant-vector selector and a scalar comparison, and nothing else:
  *
@@ -757,7 +781,7 @@ const _IMPORTABLE_OPS = new Set([">", ">=", "<", "<="]);
  * `rate(cpu[5m]) > 90` by reading only the tail — the class of leniency that
  * makes an import feature lie about what it imported.
  */
-const _PROMQL_RULE_RE = new RegExp(
+const _PROMQL_RULE_RE = /* @__PURE__ */ new RegExp(
   "^\\s*(?<metric>[a-zA-Z_:][a-zA-Z0-9_:]*)\\s*" +
     // The selector block: anything but a brace or quote, OR a complete
     // string literal — which MAY contain braces. `[^{}]*` is the obvious
@@ -772,7 +796,7 @@ const _PROMQL_RULE_RE = new RegExp(
 /* One label matcher inside the braces. The value is a double-quoted PromQL
  * string literal, so it may contain escaped quotes and backslashes — and
  * `: ` , which is what broke the YAML layer in review #532. */
-const _SELECTOR_RE = new RegExp(
+const _SELECTOR_RE = /* @__PURE__ */ new RegExp(
   '^\\s*(?<label>[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?<match>=~|!~|!=|=)\\s*"(?<value>(?:[^"\\\\]|\\\\.)*)"\\s*$'
 );
 

--- a/docs/site/docs/javascripts/sonda-pure.js
+++ b/docs/site/docs/javascripts/sonda-pure.js
@@ -349,13 +349,26 @@ export function buildTestExport({ yaml, entry, rules }) {
   const offset = entry.offset_secs || 0;
   const multiple = rules.length > 1;
 
-  const prepared = rules.map((rule) => {
-    const severity = rule.severity || "critical";
-    // The severity suffix only appears when it has to. With one rule the
-    // name is what it always was; with two, two alerts sharing a name in one
-    // group is a rules file that does not mean what it looks like.
-    const alertName = deriveAlertName(entry.name, rule.op) +
-      (multiple ? severity.charAt(0).toUpperCase() + severity.slice(1) : "");
+  // Both severity dropdowns offer BOTH severities, so a pair can be two
+  // criticals at different `for:` durations — a real pattern, and two clicks
+  // away. Suffixing by severity alone then produces two identical names with
+  // identical labels in one group, which is exactly the rules file the suffix
+  // exists to prevent (review #546 W2). When the severities collide the
+  // suffix falls back to the row's position, which cannot.
+  const severities = rules.map((rule) => rule.severity || "critical");
+  const severityIsUnique = new Set(severities).size === severities.length;
+
+  const prepared = rules.map((rule, index) => {
+    const severity = severities[index];
+    // The suffix only appears when it has to. With one rule the name is what
+    // it always was; with two, two alerts sharing a name in one group is a
+    // rules file that does not mean what it looks like.
+    const suffix = !multiple
+      ? ""
+      : severityIsUnique
+        ? severity.charAt(0).toUpperCase() + severity.slice(1)
+        : `Rule${index + 1}`;
+    const alertName = deriveAlertName(entry.name, rule.op) + suffix;
     const states = (rule.evaled && rule.evaled.states) || [];
     const firstFiring = states.indexOf("firing");
     const fired = firstFiring >= 0;
@@ -410,8 +423,17 @@ export function buildTestExport({ yaml, entry, rules }) {
     ? `${yaml.trimEnd()}\n\n# NOTE: this scenario already has an expect: block — merge the one below by hand.\n${expectLines.map((l) => `# ${l}`).join("\n")}\n`
     : `${yaml.trimEnd()}\n\n# Scope note: expect.labels pins this scenario's own labels — ALERTS is\n# global, and an unscoped expectation can match alerts other series caused.\n${expectLines.join("\n")}\n`;
 
+  // The severity is named only when there is more than one rule, for the same
+  // reason the alert-name suffix is: a single-rule export has to stay
+  // byte-identical to what it was before pairs existed. The docstring claims
+  // that, and review #546 W4 measured the claim false on exactly this line —
+  // the one place `multiple` had not been applied.
   const headline = prepared
-    .map((r) => `${entry.name}${selector} ${r.op} ${r.threshold} for ${r.forSecs}s (${r.severity})`)
+    .map(
+      (r) =>
+        `${entry.name}${selector} ${r.op} ${r.threshold} for ${r.forSecs}s` +
+        (multiple ? ` (${r.severity})` : "")
+    )
     .join("\n#   ");
 
   return (
@@ -901,35 +923,23 @@ export function parsePromQLRule(text) {
   expr = expr.trim();
   if (!expr) return { ok: false, reason: "the rule has an empty `expr:`" };
 
-  // Name the unsupported constructs before the regex does, because
-  // "does not match" is a useless thing to tell someone holding a rule that
-  // is perfectly valid PromQL.
-  const unsupported = [
-    [/\b(?:rate|irate|increase|avg_over_time|max_over_time|min_over_time|sum_over_time|histogram_quantile|absent|delta|deriv|predict_linear)\s*\(/, "a function call"],
-    [/\b(?:sum|avg|min|max|count|topk|bottomk|quantile|stddev|group)\s*(?:by|without)?\s*[({]/, "an aggregation"],
-    [/\b(?:unless|and|or)\b/, "a set operator"],
-    [/\[[^\]]*\]/, "a range selector"],
-    [/\boffset\b|@/, "an offset or @ modifier"],
-  ];
-  for (const [pattern, what] of unsupported) {
-    if (pattern.test(expr)) {
-      return {
-        ok: false,
-        reason: `only simple threshold rules import; this one uses ${what}. Edit it by hand.`,
-      };
-    }
-  }
-
+  // THE GRAMMAR RUNS FIRST, and the naming scan only when it fails.
+  //
+  // The scan is a set of substring patterns over the raw expression, so it
+  // cannot tell a PromQL token from the inside of a string literal. Running
+  // it first refused rules this lab represents perfectly and, worse, refused
+  // them by asserting a specific false fact about the reader's own rule —
+  // `{user="alice@example.com"}` was "an offset or @ modifier",
+  // `{msg="[error] disk"}` was "a range selector", `{msg="a or b"}` was "a
+  // set operator" (review #546 W1, which measured nine such rules).
+  //
+  // Anything the anchored grammar accepts is representable by construction,
+  // so trying it first cannot let an unsupported rule through — the scan
+  // still names every construct it named before, just for expressions that
+  // failed the grammar rather than for every expression.
   const match = _PROMQL_RULE_RE.exec(expr);
-  if (!match) {
-    return {
-      ok: false,
-      reason:
-        "only simple threshold rules import — expected `metric{labels} > number`. Edit it by hand.",
-    };
-  }
+  if (!match) return { ok: false, reason: _whyUnsupported(expr) };
   const { metric, selectors: selectorText, op, value } = match.groups;
-
   if (!_IMPORTABLE_OPS.has(op)) {
     return {
       ok: false,
@@ -966,6 +976,29 @@ export function parsePromQLRule(text) {
   }
 
   return { ok: true, name, metric, selectors, op, threshold, forSecs };
+}
+
+/* Why an expression the grammar rejected could not be imported.
+ *
+ * Substring patterns, so this is only sound on expressions the anchored
+ * grammar has ALREADY refused — see the note at the call site. Naming the
+ * construct beats "does not match", which is a useless thing to tell someone
+ * holding a rule that is perfectly valid PromQL.
+ */
+function _whyUnsupported(expr) {
+  const unsupported = [
+    [/\b(?:rate|irate|increase|avg_over_time|max_over_time|min_over_time|sum_over_time|histogram_quantile|absent|delta|deriv|predict_linear)\s*\(/, "a function call"],
+    [/\b(?:sum|avg|min|max|count|topk|bottomk|quantile|stddev|group)\s*(?:by|without)?\s*[({]/, "an aggregation"],
+    [/\b(?:unless|and|or)\b/, "a set operator"],
+    [/\[[^\]]*\]/, "a range selector"],
+    [/\boffset\b|@/, "an offset or @ modifier"],
+  ];
+  for (const [pattern, what] of unsupported) {
+    if (pattern.test(expr)) {
+      return `only simple threshold rules import; this one uses ${what}. Edit it by hand.`;
+    }
+  }
+  return "only simple threshold rules import — expected `metric{labels} > number`. Edit it by hand.";
 }
 
 /* Strip one layer of YAML scalar quoting from a value read off a line.

--- a/docs/site/docs/playground/alert-lab.md
+++ b/docs/site/docs/playground/alert-lab.md
@@ -41,9 +41,45 @@ shows the alert state the way Prometheus would walk it:
       <option value="20">20s</option>
       <option value="30">30s</option>
     </select>
+    <select id="al-severity" class="sonda-playground__select" aria-label="Severity of the first rule">
+      <option value="critical">critical</option>
+      <option value="warning">warning</option>
+    </select>
     <button id="al-play" type="button" class="md-button md-button--primary sonda-playground__run">Play</button>
     <button id="al-export" type="button" class="md-button sonda-playground__share">Copy sonda test setup</button>
     <span id="al-state" class="sonda-lab-chip sonda-lab-chip--inactive" role="status" aria-live="polite">inactive</span>
+  </div>
+  <div class="sonda-playground__controls">
+    <label class="sonda-playground__label sonda-lab-second" for="al-second">
+      <input id="al-second" type="checkbox"> Second rule
+    </label>
+    <select id="al-op2" class="sonda-playground__select" aria-label="Comparison operator, second rule" disabled>
+      <option value="&gt;">value &gt;</option>
+      <option value="&lt;">value &lt;</option>
+    </select>
+    <input id="al-threshold2" class="sonda-playground__select sonda-lab-number" type="number"
+      step="1" aria-label="Threshold value, second rule" disabled>
+    <label class="sonda-playground__label" for="al-for2">for:</label>
+    <select id="al-for2" class="sonda-playground__select" aria-label="For duration, second rule" disabled>
+      <option value="0">0s</option>
+      <option value="6">6s</option>
+      <option value="12">12s</option>
+      <option value="20">20s</option>
+      <option value="30">30s</option>
+    </select>
+    <select id="al-severity2" class="sonda-playground__select" aria-label="Severity of the second rule" disabled>
+      <option value="warning">warning</option>
+      <option value="critical">critical</option>
+    </select>
+    <span id="al-state2" class="sonda-lab-chip sonda-lab-chip--inactive" role="status" aria-live="polite" hidden>inactive</span>
+  </div>
+  <div class="sonda-playground__controls sonda-lab-import">
+    <label class="sonda-playground__label" for="al-import">Import a rule</label>
+    <textarea id="al-import" class="sonda-lab-importbox" rows="2" spellcheck="false"
+      aria-label="Paste a Prometheus alerting rule"
+      placeholder="Paste a Prometheus rule — alert:/expr:/for:, or just  cpu_usage{host=&quot;web-01&quot;} > 90"></textarea>
+    <button id="al-import-btn" type="button" class="md-button sonda-playground__share">Import</button>
+    <span id="al-import-note" class="sonda-lab-importnote" role="status" aria-live="polite"></span>
   </div>
   <div id="al-error" class="sonda-playground__error" hidden></div>
   <canvas id="al-chart" class="sonda-playground__chart" height="380"

--- a/docs/site/docs/stylesheets/sonda.css
+++ b/docs/site/docs/stylesheets/sonda.css
@@ -1063,6 +1063,58 @@
 
 /* ---------- Playground synthetic log stream ----------------------------- */
 
+/* The alert lab's second rule row and import box (WP12). */
+.sonda-lab-second {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+}
+
+.sonda-lab-import {
+  align-items: flex-start;
+}
+
+.sonda-lab-importbox {
+  flex: 1 1 22rem;
+  min-width: 12rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.74rem;
+  line-height: 1.5;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 6px;
+  background: var(--md-code-bg-color);
+  color: var(--md-default-fg-color);
+  resize: vertical;
+}
+
+.sonda-lab-importnote {
+  flex: 1 1 100%;
+  font-size: 0.74rem;
+  line-height: 1.5;
+}
+
+.sonda-lab-importnote[data-kind="error"] {
+  color: #b8241f;
+}
+
+[data-md-color-scheme="slate"] .sonda-lab-importnote[data-kind="error"] {
+  color: #ff8079;
+}
+
+.sonda-lab-importnote[data-kind="warn"] {
+  color: #8a5600;
+}
+
+[data-md-color-scheme="slate"] .sonda-lab-importnote[data-kind="warn"] {
+  color: #e0a445;
+}
+
+.sonda-lab-importnote[data-kind="ok"] {
+  opacity: 0.7;
+}
+
 /* The time cursor's readout (WP9): one strip under the chart, one chip per
    series. Wraps rather than scrolls — a scenario with six series on a narrow
    screen should grow downwards, not hide readings off the right edge. */

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -991,6 +991,44 @@ try {
   );
   check("and its state chip appears", !alPair.chipHidden);
 
+  // Review #546 B1: `Number("") === 0`, so a blank threshold used to become a
+  // rule at 0 that fired on everything AND exported a warning rule the reader
+  // never wrote. The reviewer reached it by racing the checkbox against the
+  // wasm load; clearing the box reaches the same place with no timing at all,
+  // which is why this is the version that belongs in a suite.
+  await alPage.fill("#al-threshold2", "");
+  let alCleared = true;
+  await alPage
+    .waitForFunction(
+      () => document.querySelector("#al-chart").dataset.rules === "1",
+      null,
+      { timeout: 15000 }
+    )
+    .catch(() => {
+      alCleared = false;
+    });
+  const alBlank = await alPage.evaluate(() => ({
+    rules: document.querySelector("#al-chart").dataset.rules,
+    thresholds: document.querySelector("#al-chart").dataset.thresholds,
+    value: document.querySelector("#al-threshold2").value,
+  }));
+  check(
+    "a blank threshold is not a rule at zero",
+    alCleared && !/warning:0\b/.test(alBlank.thresholds),
+    `rules=${alBlank.rules} thresholds=${alBlank.thresholds}`
+  );
+  // And the box stays empty: seeding is an intention, not a reflex on every
+  // keystroke, or a reader could never clear the field to type a new number.
+  check("and clearing it is not undone by the seeding", alBlank.value === "", `value="${alBlank.value}"`);
+  await alPage.fill("#al-threshold2", "0.4");
+  await alPage
+    .waitForFunction(
+      () => document.querySelector("#al-chart").dataset.rules === "2",
+      null,
+      { timeout: 15000 }
+    )
+    .catch(() => {});
+
   // Import. The lab evaluates against the LOADED scenario, so a rule about a
   // different metric produces a working demo of the wrong thing — saying so
   // is the assertion worth making.
@@ -1009,7 +1047,20 @@ try {
   const alNote = await alPage.evaluate(
     () => document.querySelector("#al-import-note").textContent
   );
-  check("a pasted rule imports its threshold", alImported, alNote.slice(0, 60));
+  // The THRESHOLD, not the note. Review #546 W3: this check waited on the
+  // note turning "warn", which happens because of the different-metric
+  // notice — computed from the parsed metric name and independent of the
+  // threshold ever reaching a control. Removing the assignment line left the
+  // whole suite green. The check's name promised this assertion; now it
+  // makes it. The import lands in the SECOND row because it is enabled above.
+  const alThreshold = await alPage.evaluate(
+    () => document.querySelector("#al-threshold2").value
+  );
+  check(
+    "a pasted rule imports its threshold",
+    alImported && Number(alThreshold) === 72,
+    `note kind ok=${alImported}, threshold control reads "${alThreshold}"`
+  );
   check(
     "and says when the rule is about a different series than the chart",
     /but the chart is showing/.test(alNote),

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -943,6 +943,129 @@ try {
     `scrollY ${scrollBefore} -> ${correlated.scrollY}`
   );
   await cursorPage.close();
+
+  // --- 13. The alert lab's rule pair and rule import ---------------------
+  //
+  // WP12. `draw` stamps how many rules it drew and at what thresholds, so
+  // these read the chart's own claim rather than diffing pixels — the lesson
+  // review #543 taught about the burst label.
+  section("[13] alert lab: warning/critical pair and rule import");
+  const alPage = watch(await context.newPage());
+  alPage.setDefaultTimeout(30000);
+  await alPage.goto(`${BASE}/playground/alert-lab/`, { waitUntil: "domcontentloaded" });
+  await alPage.waitForFunction(
+    () => document.querySelector("#al-chart") && document.querySelector("#al-chart").dataset.rules,
+    null,
+    { timeout: 90000 }
+  );
+  check(
+    "the lab starts as one rule, exactly as before the pair existed",
+    (await alPage.evaluate(() => document.querySelector("#al-chart").dataset.rules)) === "1"
+  );
+  check(
+    "and the second rule's chip is hidden rather than reporting on nothing",
+    await alPage.evaluate(() => document.querySelector("#al-state2").hidden)
+  );
+
+  await alPage.check("#al-second");
+  let alPaired = true;
+  await alPage
+    .waitForFunction(
+      () => document.querySelector("#al-chart").dataset.rules === "2",
+      null,
+      { timeout: 20000 }
+    )
+    .catch(() => {
+      alPaired = false;
+    });
+  const alPair = await alPage.evaluate(() => ({
+    thresholds: document.querySelector("#al-chart").dataset.thresholds,
+    chipHidden: document.querySelector("#al-state2").hidden,
+    seeded: document.querySelector("#al-threshold2").value,
+  }));
+  check("enabling the second rule draws two thresholds", alPaired, alPair.thresholds);
+  check(
+    "the second rule is seeded with a threshold rather than left empty",
+    alPair.seeded !== "" && Number.isFinite(Number(alPair.seeded)),
+    `seeded ${alPair.seeded}`
+  );
+  check("and its state chip appears", !alPair.chipHidden);
+
+  // Import. The lab evaluates against the LOADED scenario, so a rule about a
+  // different metric produces a working demo of the wrong thing — saying so
+  // is the assertion worth making.
+  await alPage.fill("#al-import", 'expr: some_other_metric{host="web-01"} >= 72\nfor: 15s');
+  await alPage.click("#al-import-btn");
+  let alImported = true;
+  await alPage
+    .waitForFunction(
+      () => document.querySelector("#al-import-note").dataset.kind === "warn",
+      null,
+      { timeout: 15000 }
+    )
+    .catch(() => {
+      alImported = false;
+    });
+  const alNote = await alPage.evaluate(
+    () => document.querySelector("#al-import-note").textContent
+  );
+  check("a pasted rule imports its threshold", alImported, alNote.slice(0, 60));
+  check(
+    "and says when the rule is about a different series than the chart",
+    /but the chart is showing/.test(alNote),
+    alNote.slice(0, 120)
+  );
+  check(
+    "and says when a strict comparison was substituted",
+    /`>=` shown as `>`/.test(alNote),
+    alNote.slice(0, 80)
+  );
+
+  // A rule the lab cannot represent must be refused BY NAME, not half-read.
+  await alPage.fill("#al-import", "rate(http_errors_total[5m]) > 10");
+  await alPage.click("#al-import-btn");
+  let alRefused = true;
+  await alPage
+    .waitForFunction(
+      () => document.querySelector("#al-import-note").dataset.kind === "error",
+      null,
+      { timeout: 15000 }
+    )
+    .catch(() => {
+      alRefused = false;
+    });
+  const alRefusal = await alPage.evaluate(
+    () => document.querySelector("#al-import-note").textContent
+  );
+  check(
+    "a rule the lab cannot represent is refused, naming what it saw",
+    alRefused && /function call/.test(alRefusal),
+    alRefusal.slice(0, 90)
+  );
+
+  await alPage.click("#al-export");
+  await alPage.waitForFunction(
+    () => !document.querySelector("#al-export-out").hidden,
+    null,
+    { timeout: 15000 }
+  );
+  const alExport = await alPage.evaluate(
+    () => document.querySelector("#al-export-out").textContent
+  );
+  const alNames = (alExport.match(/-\s*alert:\s*(\S+)/g) || []).map((line) =>
+    line.replace(/-\s*alert:\s*/, "")
+  );
+  check(
+    "the export carries both rules under distinct alert names",
+    new Set(alNames).size === 2,
+    [...new Set(alNames)].join(", ")
+  );
+  check(
+    "and one expectation per severity",
+    /severity: warning/.test(alExport) && /severity: critical/.test(alExport),
+    `${(alExport.match(/severity:/g) || []).length} severity lines`
+  );
+  await alPage.close();
 } catch (err) {
   failures.push(`threw: ${err && err.message ? err.message : err}`);
   console.log(`\n  FAIL threw: ${err && err.stack ? err.stack.split("\n")[0] : err}`);

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -26,6 +26,7 @@ import {
   MAX_SCHEDULE_CYCLES,
   niceDeadlineSecs,
   normalizeFence,
+  parsePromQLRule,
   numberSpanAt,
   runnableScenario,
   scheduleWindows,
@@ -154,8 +155,7 @@ test("export carries a label-scoped rule and expect block with derived deadlines
   const out = buildTestExport({
     yaml: YAML,
     entry: ENTRY,
-    rule: { op: ">", threshold: 64, forSecs: 12 },
-    evaled: { states, resolves: [200] },
+    rules: [{ severity: "critical", op: ">", threshold: 64, forSecs: 12, evaled: { states, resolves: [200] } }],
   });
   assert.match(out, /alert: CpuUsageHigh/);
   assert.match(out, /expr: 'cpu_usage\{host="web-01",service="api"\} > 64'/);
@@ -173,8 +173,7 @@ test("export omits resolution when still firing at the end", () => {
   const out = buildTestExport({
     yaml: YAML,
     entry: ENTRY,
-    rule: { op: ">", threshold: 64, forSecs: 12 },
-    evaled: { states, resolves: [] },
+    rules: [{ severity: "critical", op: ">", threshold: 64, forSecs: 12, evaled: { states, resolves: [] } }],
   });
   assert.doesNotMatch(out, /resolves_within:/);
   assert.match(out, /resolution not asserted/);
@@ -184,18 +183,69 @@ test("export flags a rule that never fired instead of inventing a deadline", () 
   const out = buildTestExport({
     yaml: YAML,
     entry: ENTRY,
-    rule: { op: ">", threshold: 9999, forSecs: 12 },
-    evaled: { states: Array(80).fill("inactive"), resolves: [] },
+    rules: [{ severity: "critical", op: ">", threshold: 9999, forSecs: 12, evaled: { states: Array(80).fill("inactive"), resolves: [] } }],
   });
   assert.match(out, /never fired in the sampled preview/);
+});
+
+test("a warning/critical pair exports two rules with distinct names", () => {
+  // Two alerts sharing one name in one group is a rules file that does not
+  // mean what it looks like — Prometheus keys alerts by name plus labels, so
+  // the pair would collapse in ways that depend on the labels rather than on
+  // anything the reader wrote.
+  const early = Array(240).fill("inactive");
+  for (let i = 40; i < 240; i++) early[i] = "firing";
+  const late = Array(240).fill("inactive");
+  for (let i = 120; i < 200; i++) late[i] = "firing";
+  const out = buildTestExport({
+    yaml: YAML,
+    entry: ENTRY,
+    rules: [
+      { severity: "warning", op: ">", threshold: 60, forSecs: 6, evaled: { states: early, resolves: [] } },
+      { severity: "critical", op: ">", threshold: 90, forSecs: 12, evaled: { states: late, resolves: [200] } },
+    ],
+  });
+  assert.match(out, /alert: CpuUsageHighWarning/);
+  assert.match(out, /alert: CpuUsageHighCritical/);
+  assert.match(out, /severity: warning/);
+  assert.match(out, /severity: critical/);
+  assert.match(out, /> 60/);
+  assert.match(out, /> 90/);
+  assert.match(out, /for: 6s/);
+  assert.match(out, /for: 12s/);
+  // Deadlines are PER RULE. tick_secs is 0.25, so the warning crosses at
+  // tick 40 (10s -> a 30s deadline) and the critical at tick 120 (30s -> 60s);
+  // asserting one against the other's states would produce an expectation
+  // that passes for the wrong reason.
+  assert.match(out, /firing_within: 30s/);
+  assert.match(out, /firing_within: 60s/);
+  // And only the critical recovers, so only it asserts resolution.
+  assert.equal((out.match(/resolves_within: 2m/g) || []).length, 1);
+  assert.equal((out.match(/resolution not asserted/g) || []).length, 1);
+});
+
+test("a single rule exports exactly what it always did", () => {
+  // The pair must not make the common case noisier: no severity suffix on
+  // the alert name, and one rule in the group.
+  const out = buildTestExport({
+    yaml: YAML,
+    entry: ENTRY,
+    rules: [
+      { severity: "critical", op: ">", threshold: 64, forSecs: 12, evaled: { states: Array(40).fill("firing"), resolves: [] } },
+    ],
+  });
+  assert.match(out, /alert: CpuUsageHigh$/m);
+  assert.doesNotMatch(out, /CpuUsageHighCritical/);
+  assert.equal((out.match(/^#\s+- alert:/gm) || []).length, 1, "one rule in the group");
+  assert.equal((out.match(/^    - alert:/gm) || []).length, 1, "one expectation");
+  assert.match(out, /# 1\) Alert rule \(vmalert/);
 });
 
 test("export comments the expect block when the scenario already has one", () => {
   const out = buildTestExport({
     yaml: "version: 2\nexpect:\n  alerts: []\n",
     entry: ENTRY,
-    rule: { op: ">", threshold: 64, forSecs: 12 },
-    evaled: { states: Array(40).fill("firing"), resolves: [] },
+    rules: [{ severity: "critical", op: ">", threshold: 64, forSecs: 12, evaled: { states: Array(40).fill("firing"), resolves: [] } }],
   });
   assert.match(out, /merge the one below by hand/);
   assert.match(out, /^# expect:/m); // our block arrives commented
@@ -330,8 +380,7 @@ test("exports stay well-formed for every hostile label value (review #532 table)
   const out = buildTestExport({
     yaml: YAML,
     entry: { ...ENTRY, labels: nasty },
-    rule: { op: ">", threshold: 64, forSecs: 12 },
-    evaled: { states, resolves: [] },
+    rules: [{ severity: "critical", op: ">", threshold: 64, forSecs: 12, evaled: { states, resolves: [] } }],
   });
   // Every YAML label line is a double-quoted scalar…
   for (const key of Object.keys(nasty)) {
@@ -1064,6 +1113,216 @@ test("a log stream with nothing to correlate yields no highlight", () => {
     assert.deepEqual(logLinesNear(bad, 1), [], `log=${JSON.stringify(bad)}`);
   }
   assert.deepEqual(logLinesNear(logEntry(), NaN), []);
+});
+// --- parsePromQLRule (WP12) --------------------------------------------
+//
+// An import feature's whole risk is accepting more than it can represent.
+// The lab evaluates one threshold against one sampled series, so the grammar
+// is one selector and one scalar — and every richer rule below is valid
+// PromQL that must be REFUSED BY NAME rather than half-read.
+//
+// Law 4: the selector value is the hostile surface. It is a PromQL string
+// literal nested inside a YAML scalar, and review #532 caught a `: ` in one
+// breaking the layer nobody was looking at.
+
+const ok = (text) => {
+  const result = parsePromQLRule(text);
+  assert.ok(result.ok, `expected accept, got: ${result.reason}`);
+  return result;
+};
+const no = (text) => {
+  const result = parsePromQLRule(text);
+  assert.ok(!result.ok, `expected reject, got ${JSON.stringify(result)}`);
+  return result.reason;
+};
+
+test("a bare threshold expression imports", () => {
+  const rule = ok("cpu_usage > 90");
+  assert.equal(rule.metric, "cpu_usage");
+  assert.equal(rule.op, ">");
+  assert.equal(rule.threshold, 90);
+  assert.equal(rule.forSecs, 0);
+  assert.deepEqual(rule.selectors, {});
+});
+
+test("a rules-file snippet imports its name, threshold and for:", () => {
+  const rule = ok(`
+groups:
+  - name: sonda-lab
+    rules:
+      - alert: CpuUsageHigh
+        expr: 'cpu_usage{host="web-01"} > 64'
+        for: 12s
+`);
+  assert.equal(rule.name, "CpuUsageHigh");
+  assert.equal(rule.metric, "cpu_usage");
+  assert.equal(rule.threshold, 64);
+  assert.equal(rule.forSecs, 12);
+  assert.deepEqual(rule.selectors, { host: { op: "=", value: "web-01" } });
+});
+
+test("the lab's own export round-trips back in", () => {
+  // The strongest case available: feed buildTestExport's output to the
+  // importer. If these two ever disagree the lab cannot read what it wrote.
+  const out = buildTestExport({
+    yaml: YAML,
+    entry: ENTRY,
+    rules: [{ severity: "critical", op: ">", threshold: 64, forSecs: 12, evaled: { states: Array(40).fill("firing"), resolves: [] } }],
+  });
+  const rule = ok(out);
+  assert.equal(rule.metric, "cpu_usage");
+  assert.equal(rule.op, ">");
+  assert.equal(rule.threshold, 64);
+  assert.equal(rule.forSecs, 12);
+  assert.deepEqual(rule.selectors, {
+    host: { op: "=", value: "web-01" },
+    service: { op: "=", value: "api" },
+  });
+});
+
+test("durations import in every unit Prometheus writes", () => {
+  const forOf = (text) => ok(`expr: cpu > 1\nfor: ${text}`).forSecs;
+  assert.equal(forOf("30s"), 30);
+  assert.equal(forOf("5m"), 300);
+  assert.equal(forOf("2h"), 7200);
+  assert.equal(forOf("1h30m"), 5400);
+  assert.equal(forOf("1d"), 86400);
+  assert.equal(forOf("500ms"), 0.5);
+  assert.equal(forOf("90"), 90, "a bare number is seconds");
+});
+
+test("scientific and signed thresholds import as written", () => {
+  assert.equal(ok("errors > 1e3").threshold, 1000);
+  assert.equal(ok("errors > 1.5e-2").threshold, 0.015);
+  assert.equal(ok("temp < -40").threshold, -40);
+  assert.equal(ok("ratio > .5").threshold, 0.5);
+  assert.equal(ok("ratio > +0.5").threshold, 0.5);
+});
+
+test("whitespace anywhere is not a syntax error", () => {
+  const rule = ok('   cpu_usage  {  host = "web-01" , az != "b"  }   >=   90.5   ');
+  assert.equal(rule.op, ">=");
+  assert.equal(rule.threshold, 90.5);
+  assert.deepEqual(rule.selectors, {
+    host: { op: "=", value: "web-01" },
+    az: { op: "!=", value: "b" },
+  });
+});
+
+test("hostile selector values survive intact", () => {
+  // Each of these is a legal PromQL string literal, and each has broken a
+  // layer of this stack before or is one comma away from doing so.
+  const cases = [
+    ['{msg="a: b"}', "a: b"], //         colon-space — the #532 shape
+    ['{msg="a,b"}', "a,b"], //           a comma inside a value, not a separator
+    ['{msg="say \\"hi\\""}', 'say "hi"'], // escaped quotes
+    ['{msg="C:\\\\tmp"}', "C:\\tmp"], // escaped backslash
+    ['{msg="{braces}"}', "{braces}"], //  braces inside the value
+    ['{msg="東京"}', "東京"], //           non-ASCII
+    ['{msg=""}', ""], //                  empty value
+    ['{msg="  "}', "  "], //              whitespace-only value
+    // The case that forces the splitter to track escapes. Without it the
+    // `\\"` reads as the end of the string, the comma after it looks like a
+    // separator, and the matcher is torn in half. Every other value above
+    // survives a broken splitter because none of them pairs an escaped quote
+    // with a comma — found by mutation, not by inspection.
+    ['{msg="a \\" , b"}', 'a " , b'],
+  ];
+  for (const [selector, expected] of cases) {
+    const rule = ok(`cpu${selector} > 1`);
+    assert.equal(rule.selectors.msg.value, expected, selector);
+  }
+});
+
+test("a backslash in one value does not swallow the next matcher", () => {
+  // The case that forces the splitter's escape tracking, and the second one
+  // mutation testing had to find: `{msg="a \\" , b"}` above does NOT
+  // discriminate, because a splitter that stops resetting its escape flag
+  // simply never splits — which still yields one correct selector there.
+  // Here the comma is a REAL separator sitting after a backslash, so a
+  // broken splitter loses the second matcher entirely.
+  const rule = ok('cpu{a="x\\\\",b="y"} > 1');
+  assert.deepEqual(rule.selectors, {
+    a: { op: "=", value: "x\\" },
+    b: { op: "=", value: "y" },
+  });
+});
+
+test("regex matchers are read, not mistaken for equality", () => {
+  const rule = ok('cpu{host=~"web-.*",az!~"eu-.*"} > 1');
+  assert.deepEqual(rule.selectors, {
+    host: { op: "=~", value: "web-.*" },
+    az: { op: "!~", value: "eu-.*" },
+  });
+});
+
+test("rules the lab cannot represent are refused BY NAME", () => {
+  // Every one of these is valid PromQL. Half-reading them would put a reader
+  // in front of a chart answering a different question than the rule they
+  // pasted, which is worse than refusing.
+  assert.match(no("rate(http_errors_total[5m]) > 10"), /function call/);
+  assert.match(no("sum by (host) (cpu_usage) > 90"), /aggregation/);
+  assert.match(no("histogram_quantile(0.99, foo) > 1"), /function call/);
+  assert.match(no("up == 1 unless cpu > 90"), /set operator/);
+  assert.match(no("cpu > 90 and mem > 90"), /set operator/);
+  assert.match(no("cpu_usage[5m] > 90"), /range selector/);
+  assert.match(no("cpu_usage offset 5m > 90"), /offset/);
+});
+
+test("a threshold the lab cannot evaluate is refused, not silently coerced", () => {
+  assert.match(no("cpu_usage == 90"), /`>`.*`==`/);
+  assert.match(no("cpu_usage != 90"), /`>`.*`!=`/);
+});
+
+test("a comparison against anything but a number is refused", () => {
+  // The tail-matching trap: a lenient parser reads `> 90` and ignores the
+  // left side entirely.
+  no("cpu_usage > other_metric");
+  no("cpu_usage > 90 * 2");
+  no("cpu_usage + 1 > 90");
+  no("cpu_usage");
+  no("cpu_usage >");
+  no("> 90");
+});
+
+test("the expression is read whole, not found inside a larger one", () => {
+  // This is the case that forces the leading anchor, and mutation testing is
+  // how it got written: unanchoring the regex left every other case in this
+  // file green. `100 * cpu_usage > 90` contains a substring that parses
+  // perfectly — a parser that scans for one would import a rule about a
+  // scaled metric as though it were about the raw one, and the threshold
+  // would be wrong by a factor of a hundred with nothing to show for it.
+  no("100 * cpu_usage > 90");
+  no("(cpu_usage / 2) > 90");
+  no("some junk then cpu_usage > 90");
+});
+
+test("empty and malformed input says what is wrong", () => {
+  assert.match(no(""), /nothing to import/);
+  assert.match(no("   \n  "), /nothing to import/);
+  assert.match(no(null), /nothing to import/);
+  assert.match(no(undefined), /nothing to import/);
+  assert.match(no("alert: NoExpr\n  for: 5m"), /no `expr:` line/);
+  assert.match(no("expr: cpu > 1\nfor: soon"), /could not read the duration/);
+  assert.match(no('cpu{host "web"} > 1'), /label matcher/);
+  assert.match(no("cpu{host=web} > 1"), /label matcher/);
+});
+
+test("a double-quoted expr is unescaped like YAML, not like PromQL", () => {
+  const rule = ok('expr: "cpu_usage{msg=\\"a: b\\"} > 5"');
+  assert.equal(rule.selectors.msg.value, "a: b");
+  assert.equal(rule.threshold, 5);
+});
+
+test("a # inside an expression is not treated as a comment", () => {
+  // Guessing wrong here silently truncates the rule to something that still
+  // parses, which is the worst available outcome.
+  assert.equal(parsePromQLRule('cpu{path="/a#b"} > 1').selectors.path.value, "/a#b");
+  // And through the YAML-scalar path, which is where the temptation to strip
+  // a trailing comment actually lives. The bare-expression case above does
+  // not reach `_unquoteScalar` at all, so it left that behaviour unpinned.
+  assert.equal(parsePromQLRule('expr: cpu{path="/a#b"} > 1').selectors.path.value, "/a#b");
+  assert.equal(parsePromQLRule("expr: cpu > 1 # a real trailing comment").ok, false);
 });
 
 console.log(`${passed} pure-helper tests passed`);

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -186,6 +186,11 @@ test("export flags a rule that never fired instead of inventing a deadline", () 
     rules: [{ severity: "critical", op: ">", threshold: 9999, forSecs: 12, evaled: { states: Array(80).fill("inactive"), resolves: [] } }],
   });
   assert.match(out, /never fired in the sampled preview/);
+  // Review #546 M3: dropping `fired &&` from `endsResolved` left all 146
+  // tests green, because this case checked the firing comment and never that
+  // a resolution deadline is absent. An export asserting that a rule which
+  // never fired nonetheless resolves is an expectation that cannot pass.
+  assert.doesNotMatch(out, /resolves_within/);
 });
 
 test("a warning/critical pair exports two rules with distinct names", () => {
@@ -222,6 +227,49 @@ test("a warning/critical pair exports two rules with distinct names", () => {
   // And only the critical recovers, so only it asserts resolution.
   assert.equal((out.match(/resolves_within: 2m/g) || []).length, 1);
   assert.equal((out.match(/resolution not asserted/g) || []).length, 1);
+});
+
+test("two rules of the SAME severity still get distinct names", () => {
+  // Review #546 W2. Both dropdowns offer both severities, so a critical pair
+  // at different `for:` durations is two clicks away — and suffixing by
+  // severity alone produced two identical names with identical labels in one
+  // group, which is precisely the rules file the suffix exists to prevent.
+  const evaled = { states: Array(40).fill("firing"), resolves: [] };
+  const out = buildTestExport({
+    yaml: YAML,
+    entry: ENTRY,
+    rules: [
+      { severity: "critical", op: ">", threshold: 70, forSecs: 6, evaled },
+      { severity: "critical", op: ">", threshold: 90, forSecs: 12, evaled },
+    ],
+  });
+  const names = [...out.matchAll(/alert: (\S+)/g)].map((m) => m[1]);
+  assert.ok(names.length >= 2, "expected at least two alert lines");
+  assert.equal(new Set(names).size, 2, `names collided: ${[...new Set(names)].join(", ")}`);
+});
+
+test("the headline names a severity only when there is more than one rule", () => {
+  // The docstring claims a single-rule export is byte-identical to what it
+  // was before pairs existed. Review #546 W4 measured that false on exactly
+  // this line — the one place the `multiple` gate had not been applied — and
+  // the test that was supposed to pin it read everything except the headline.
+  const evaled = { states: Array(40).fill("firing"), resolves: [] };
+  const one = buildTestExport({
+    yaml: YAML,
+    entry: ENTRY,
+    rules: [{ severity: "critical", op: ">", threshold: 64, forSecs: 12, evaled }],
+  });
+  assert.doesNotMatch(one.split("\n")[0], /\(critical\)/);
+  const two = buildTestExport({
+    yaml: YAML,
+    entry: ENTRY,
+    rules: [
+      { severity: "warning", op: ">", threshold: 60, forSecs: 6, evaled },
+      { severity: "critical", op: ">", threshold: 90, forSecs: 12, evaled },
+    ],
+  });
+  assert.match(two, /\(warning\)/);
+  assert.match(two, /\(critical\)/);
 });
 
 test("a single rule exports exactly what it always did", () => {
@@ -1189,6 +1237,23 @@ test("durations import in every unit Prometheus writes", () => {
   assert.equal(forOf("1d"), 86400);
   assert.equal(forOf("500ms"), 0.5);
   assert.equal(forOf("90"), 90, "a bare number is seconds");
+});
+
+test("a duration with trailing junk is refused, not read as its prefix", () => {
+  // Review #546 M3. `_durationSecs` rebuilds the string from the parts it
+  // matched and compares — without that, every one of these imports as 300s
+  // and the reader's `for:` is silently something they did not write.
+  // Deleting the guard left all 146 tests green; none of these was a case.
+  for (const bad of ["5m junk", "5mx", "5m5", "5 m", "m5", "5m,", "-5m"]) {
+    assert.match(
+      no(`expr: cpu > 1\nfor: ${bad}`),
+      /could not read the duration/,
+      `for: ${bad}`
+    );
+  }
+  // And the shapes that ARE complete still parse, so the guard is not simply
+  // refusing everything with more than one unit.
+  assert.equal(ok("expr: cpu > 1\nfor: 1h30m").forSecs, 5400);
 });
 
 test("scientific and signed thresholds import as written", () => {


### PR DESCRIPTION

## Summary

WP12 — the last item in wave 4. Two halves.

**A second rule.** The lab evaluated one threshold. A warning/critical pair is how alerting policy is actually written, and exporting only one of them hands a reader half of theirs. The second row is **opt-in and starts disabled**, so a reader who never touches it sees exactly the lab that was here before.

**PromQL import.** A paste box that takes a rules-file snippet or a bare expression and drives the lab's controls from it.

## The pair, and what it changed on the chart

Both thresholds are drawn, coloured and labelled by severity; each rule gets **its own state lane, stacked rather than overlaid** — the whole point of a pair is that the two fire at different times, and one lane could only ever show one of them. The canvas grows to make room rather than squeezing the plot: the trace is what the reader is reading.

Firing bands shade the **first** rule only. Two overlapping washes would make the region where both fire a third colour that means nothing, and the second rule's firing is already legible in its own lane.

`buildTestExport` now takes `rules[]`, each carrying **its own evaluation**, because the deadlines are per-rule: a warning at 60 fires earlier than a critical at 90 on the same series, and asserting one against the other's states produces an expectation that passes for the wrong reason. Alert names gain a severity suffix **only when there are two** — two alerts sharing a name in one group is a rules file that does not mean what it looks like. A single-rule export is byte-identical to what it was.

## The importer refuses more than it accepts

The grammar is deliberately tiny: `metric{selectors} OP number`, plus `for:`. Everything richer is refused **by name**, because the lab evaluates a threshold against one sampled series and half-reading a richer rule would put a reader in front of a chart answering a different question than the rule they pasted:

| pasted | response |
|---|---|
| `rate(http_errors_total[5m]) > 10` | *only simple threshold rules import; this one uses **a function call*** |
| `sum by (host) (cpu_usage) > 90` | …**an aggregation** |
| `up == 1 unless cpu > 90` | …**a set operator** |
| `cpu_usage offset 5m > 90` | …**an offset or @ modifier** |
| `cpu_usage == 90` | the lab evaluates `>`, `>=`, `<`, `<=`; this uses `==` |

It also says when the rule is about a **different metric than the chart**. The lab always evaluates the loaded scenario, so importing a rule for `http_errors_total` while `cpu_usage` is on screen otherwise produces a perfectly working demo of the wrong thing, and nothing in the numbers would say so.

## Found by round-tripping the lab through its own parser

The export writes its rule inside a **comment block**. A reader copying what the lab gave them and pasting it back was told there was no `expr:` line. The line prefix now allows `#`, and the round trip is a test — if the two ever disagree again, the lab cannot read what it wrote.

## Test plan

**146 pure tests** (was 128). The hostile-case table is the point: a selector value is a PromQL string literal nested inside a YAML scalar, and review #532 caught a `: ` in one breaking the layer nobody was looking at. Colon-space, embedded commas, escaped quotes, escaped backslashes, braces inside values, non-ASCII, empty and whitespace-only all round-trip.

**All 12 mutations RED.** Three of them were only caught after mutation testing showed my first table did not pin the claim — that part is worth reading:

| mutation | why the first table missed it |
|---|---|
| **unanchor the expression regex** | Every existing case stayed green. `100 * cpu_usage > 90` contains a substring that parses perfectly; a parser that scans for one imports a rule about a *scaled* metric as though it were about the raw one — the threshold wrong by a factor of a hundred, with nothing to show it. |
| **drop the selector splitter's escape tracking** | Also green. The obvious hostile case (`{msg="a \" , b"}`) does **not** discriminate: a splitter that stops resetting its escape flag simply never splits, which still yields one correct selector. The killing case is a backslash followed by a **real** separator comma. |
| **treat `#` as a trailing comment** | The `#`-in-a-path case went through the bare-expression path, which never reaches the YAML scalar unquoter where that temptation actually lives. |

**Smoke: section 13, 70 checks** (was 59). `draw` stamps how many rules it drew and at what thresholds, so the checks read the chart's own claim rather than diffing pixels.

**Gates:** 146 pure tests · 70 smoke checks · 522 slider combinations · 74 fences + 52 fragments · 153 commands · wasm size unchanged · `mkdocs build --strict` clean · no-raw-markup clean.

**Chromium UAT:** both themes, 0 page errors, screenshots reviewed — two labelled thresholds, two stacked lanes, warning firing visibly before critical.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)

No Rust changed and no bundle rebuilt.

## Notes for the reviewer

- **Worth attacking: the importer's `>=` → `>` substitution.** `evaluate` implements strict comparisons only, so an imported `>=` is shown as `>` and the note says so. At a threshold the signal lands on exactly, those differ. I judged a visible substitution better than refusing a rule that is 99% representable — but it is a judgement, and the note is the only thing making it honest.
- **`for:` rounds to the nearest menu option** and says so. A rule with `for: 15s` becomes `12s`. The alternative was adding options to the menu for arbitrary durations, which makes the common case worse.
- **The second rule's seeded threshold** is `first ∓ span/4`, direction chosen by the operator so the pair reads warning-then-critical. It is a feel judgement, not derived from anything.
- The severity suffix on alert names appears only with two rules. That keeps single-rule exports stable but means the same rule exports under two different names depending on whether a second row is enabled — deliberate, but say so if you disagree.
- I did **not** make firing bands per-rule. Overlapping washes seemed worse than one; the second lane carries the information. Attack that if the chart reads wrong to you.
