### PR TITLE
feat(site): live widgets for the five remaining core generators

### DIFF
--- a/docs/site/docs/build/generators.md
+++ b/docs/site/docs/build/generators.md
@@ -47,6 +47,8 @@ for full editing. Without JavaScript you get the static shape drawings instead.
 
 ![The constant generator: a flat line at the configured value](img/generators/constant.svg)
 
+<div class="sonda-livegen" data-gen="constant" markdown="0"></div>
+
 Returns the same value on every tick. Use it for baseline testing or known-value verification (for example, recording rule validation).
 
 | Parameter | Type | Required | Default | Description |
@@ -151,6 +153,8 @@ cpu 100 1774279697110
 
 ![The sawtooth generator: a linear ramp from min to max that resets each period](img/generators/sawtooth.svg)
 
+<div class="sonda-livegen" data-gen="sawtooth" markdown="0"></div>
+
 Ramps linearly from `min` to `max` and resets to `min` at the start of each period.
 
 | Parameter | Type | Required | Default | Description |
@@ -203,6 +207,8 @@ ramp 25 1774279702399
 ### uniform
 
 ![The uniform generator: deterministic random values bounded between min and max](img/generators/uniform.svg)
+
+<div class="sonda-livegen" data-gen="uniform" markdown="0"></div>
 
 Produces uniformly distributed random values in the range `[min, max]`. Deterministic when seeded.
 
@@ -257,6 +263,8 @@ noise 27.068700996215277 1774279699731
 
 ![The sequence generator: explicit values stepped through in order, repeating](img/generators/sequence.svg)
 
+<div class="sonda-livegen" data-gen="sequence" markdown="0"></div>
+
 Steps through an explicit list of values. Use it to model specific incident patterns such as threshold crossings.
 
 | Parameter | Type | Required | Default | Description |
@@ -289,6 +297,8 @@ cpu_spike_test{instance="server-01",job="node"} 95 1774279709031
 ### step
 
 ![The step generator: a monotonic staircase that wraps at the configured max](img/generators/step.svg)
+
+<div class="sonda-livegen" data-gen="step" markdown="0"></div>
 
 Produces a monotonically increasing counter value: `start + tick * step_size`. With `max` set, the value wraps using modular arithmetic to simulate a counter reset. This is the standard generator for testing PromQL `rate()` and `increase()` queries.
 
@@ -368,6 +378,11 @@ cpu_spike_test{instance="server-01",job="node"} 250 1775195162888
     Set `magnitude` to a negative value to create periodic dips below the baseline. For example, `baseline: 100.0` with `magnitude: -50.0` produces values that drop from 100 to 50 during the spike window. This is useful for testing low-threshold alerts.
 
 ### csv_replay
+
+!!! note "Not live on this page"
+    `csv_replay` reads a file from disk, and there is no filesystem in the browser — so this
+    section stays static by design. The [examples gallery](../test/examples.md) shows the
+    scenarios that use it, and the [Grafana CSV Replay guide](../import/grafana-exports.md) walks the export workflow end to end.
 
 Replays numeric values from a CSV file. Use it to reproduce real production metric patterns captured from monitoring systems, including Grafana CSV exports with embedded labels. The replay rate is derived from the CSV's column-0 timestamps and the optional `timescale` multiplier, so a 5-minute incident plays back over 5 minutes without manual tuning. For a step-by-step walkthrough of the Grafana export workflow, see the [Grafana CSV Replay](../import/grafana-exports.md) guide.
 
@@ -708,6 +723,11 @@ Histograms and summaries are scenario entries with `signal_type: histogram` or `
 
 ### histogram
 
+!!! tip "See it move"
+    The playground's **Latency histogram + quantiles** preset renders these buckets as a live
+    heatmap — [open it there](../playground/index.md) and drag `mean_shift_per_sec` to watch mass
+    drift into the higher buckets. A live widget on this page is playbook WP14.
+
 A histogram answers the question: **"what is the distribution of observed values?"** It does this by sorting observations into buckets — ranges with upper boundaries you define. Each bucket counts how many observations fell at or below that boundary.
 
 For a metric named `http_request_duration_seconds` with buckets at 0.1, 0.25, and 0.5, each tick produces something like:
@@ -793,6 +813,10 @@ http_request_duration_seconds_sum{handler="/api/v1/query",method="GET"} 9.505 17
     Set `mean_shift_per_sec` to a positive value to make the distribution center move higher over time. More observations land in higher buckets, percentile estimates rise, and latency alerts eventually trigger. See the [alert testing walkthrough](../test/alert-testing.md#test-a-histogram_quantile-alert-with-sonda) for a complete example.
 
 ### summary
+
+!!! tip "See it move"
+    The same **Latency histogram + quantiles** preset in the [playground](../playground/index.md)
+    draws summaries as quantile bands. A live widget on this page is playbook WP14.
 
 Where a histogram stores raw bucket counts and lets Prometheus estimate percentiles server-side, a summary does the math upfront. It computes the actual percentile values on the client and reports them directly. The p50 *is* 98ms. The p99 *is* 148ms. No estimation, no bucket interpolation.
 
@@ -908,6 +932,10 @@ Log generators produce structured log events instead of numeric values. They liv
 
 ### template
 
+!!! tip "See it move"
+    The **Synthetic log stream** preset in the [playground](../playground/index.md) renders a live,
+    severity-coloured stream from this generator. A live widget on this page is playbook WP14.
+
 Generates log events from message templates with randomized field values.
 
 | Parameter | Type | Required | Default | Description |
@@ -937,6 +965,11 @@ log_generator:
 Templates are selected round-robin by tick. Placeholders are resolved by picking randomly from the corresponding field pool.
 
 ### csv_replay
+
+!!! note "Not live on this page"
+    `csv_replay` reads a file from disk, and there is no filesystem in the browser — so this
+    section stays static by design. The [examples gallery](../test/examples.md) shows the
+    scenarios that use it, and the [Log CSV Replay guide](../import/log-files.md) walks the export workflow end to end.
 
 Replays structured log events from a CSV file. The CSV has a `timestamp` column that drives the emission cadence, plus optional `severity` and `message` columns and any number of free-form field columns. The replay rate is derived from the median Δt of the timestamp column, the same model the metrics-side [`csv_replay`](#csv_replay) uses. A 10-minute window in the CSV plays back over 10 minutes of wall clock without manual rate tuning. For a full walkthrough including the Loki / `logcli` export pipeline, see the [Log CSV Replay](../import/log-files.md) guide.
 

--- a/docs/site/docs/javascripts/livegen-presets.js
+++ b/docs/site/docs/javascripts/livegen-presets.js
@@ -28,6 +28,33 @@ defaults:
 scenarios:`;
 }
 
+/* The sampling window every widget is drawn in, in ticks.
+ *
+ * This lives here rather than in livegen.js because it is a property of the
+ * WIDGET CONTRACT, not of the renderer: a preset whose interesting behaviour
+ * happens past tick 240 is misconfigured no matter what draws it, and the
+ * pure invariants have to be able to say so. livegen.js imports it from here
+ * so there is one definition rather than two that agree by inspection.
+ *
+ * Review #549 W1 is why it is exported at all — see `sampledTicks`. */
+export const MAX_TICKS = 240;
+
+/* How many ticks a widget's chart actually covers.
+ *
+ * NOT `rate * durationSecs`. The wasm sampler computes
+ * `min(MAX_TICKS, ceil(duration * rate))` (`bounded_ticks`, sonda-wasm), so
+ * the requested product is an upper bound the window need not reach. The two
+ * coincide for every widget shipped today — the tick-budget invariant in
+ * pure.test.mjs holds `rate * durationSecs <= MAX_TICKS`, and under that
+ * constraint the min is always the product — which is exactly the problem:
+ * any invariant phrased in ticks that multiplies instead of calling this is
+ * correct only for as long as its NEIGHBOUR keeps holding, and silently
+ * wrong the moment that one is relaxed. Review #549 W1 found the step wrap
+ * guard doing the multiplication. */
+export function sampledTicks(widget) {
+  return Math.min(MAX_TICKS, Math.ceil(widget.rate * widget.durationSecs));
+}
+
 const LEAK_DURATION_SECS = 120;
 
 export const WIDGETS = {

--- a/docs/site/docs/javascripts/livegen-presets.js
+++ b/docs/site/docs/javascripts/livegen-presets.js
@@ -244,6 +244,127 @@ export const WIDGETS = {
 `;
     },
   },
+  /* --- WP13: the five core generators that had a static SVG and no widget ---
+   *
+   * Post-programme audit (playbook Wave 5): eight generator sections invited
+   * dragging and five did not, which reads as an unfinished pattern rather
+   * than a deliberate line. These complete the set.
+   *
+   * Every min/max pair below is DISJOINT by range construction, not by
+   * validation: the engine rejects `min >= max` (config/validate.rs), and a
+   * slider pair that can cross produces a widget that compiles at rest and
+   * fails under the reader's hand. The leak widget set this precedent and
+   * the compile gate proves it at every corner.
+   */
+  constant: {
+    rate: 2,
+    durationSecs: 60,
+    sliders: [{ key: "value", min: 0, max: 100, step: 1, value: 42 }],
+    yaml(p) {
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: queue_depth
+    generator: { type: constant, value: ${p.value} }
+`;
+    },
+  },
+  sawtooth: {
+    rate: 4,
+    durationSecs: 60,
+    sliders: [
+      // Disjoint: min tops out at 40, max starts at 50. They cannot cross.
+      { key: "min", min: 0, max: 40, step: 1, value: 10 },
+      { key: "max", min: 50, max: 100, step: 1, value: 90 },
+      { key: "period_secs", min: 5, max: 60, step: 1, value: 20, unit: "s" },
+    ],
+    yaml(p) {
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: buffer_fill
+    generator: { type: sawtooth, min: ${p.min}, max: ${p.max}, period_secs: ${p.period_secs} }
+`;
+    },
+  },
+  uniform: {
+    rate: 4,
+    durationSecs: 60,
+    sliders: [
+      { key: "min", min: 0, max: 40, step: 1, value: 20 },
+      { key: "max", min: 50, max: 100, step: 1, value: 80 },
+      // The teaching slider: uniform is SEEDED, so dragging back to the same
+      // seed reproduces the trace exactly. That is the property a static SVG
+      // cannot show and the reason this widget is worth more than its size.
+      { key: "seed", min: 0, max: 20, step: 1, value: 7 },
+    ],
+    yaml(p) {
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: request_latency_ms
+    generator: { type: uniform, min: ${p.min}, max: ${p.max}, seed: ${p.seed} }
+`;
+    },
+  },
+  step: {
+    rate: 4,
+    durationSecs: 60,
+    sliders: [
+      { key: "start", min: 0, max: 50, step: 1, value: 0 },
+      { key: "step_size", min: 1, max: 20, step: 1, value: 8 },
+      // The wrap has to be VISIBLE, which is the whole point of the widget:
+      // a `max` the counter never reaches inside the sampled window draws a
+      // plain ramp and teaches the wrong shape. The window is
+      // rate * durationSecs = 240 ticks, so the smallest climb per window is
+      // step_size(1) * 240 = 240 — above the largest max below. Every corner
+      // wraps at least once. `stepWrapsInWindow` in the harness is what holds
+      // this, because the arithmetic is exactly the kind that rots silently.
+      { key: "max", min: 100, max: 200, step: 50, value: 150 },
+    ],
+    yaml(p) {
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: bytes_sent_total
+    generator: { type: step, start: ${p.start}, step_size: ${p.step_size}, max: ${p.max} }
+`;
+    },
+  },
+  /* `sequence` is not slider-shaped — its input is a LIST — so it uses the
+   * `choices` mechanism #543 added for the encoder switcher. The lists live
+   * here as data rather than in the markup, which is what puts every option
+   * through the compile gate. */
+  sequence: {
+    rate: 2,
+    durationSecs: 60,
+    choices: [
+      {
+        key: "pattern",
+        label: "pattern",
+        options: ["incident ramp", "spike train", "staircase"],
+        value: "incident ramp",
+      },
+      { key: "repeat", label: "repeat", options: ["on", "off"], value: "on" },
+    ],
+    // Kept beside the choices they belong to. `sequence` with `repeat: false`
+    // holds its LAST value once the list is exhausted rather than stopping,
+    // which is why the off option still fills the window.
+    patterns: {
+      "incident ramp": [10, 12, 15, 22, 40, 65, 80, 85, 70, 45, 25, 14],
+      "spike train": [5, 5, 5, 90, 5, 5, 5, 90, 5, 5, 5, 90],
+      staircase: [10, 10, 30, 30, 50, 50, 70, 70, 90, 90],
+    },
+    yaml(p) {
+      const values = this.patterns[p.pattern] || this.patterns["incident ramp"];
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: metrics
+    name: error_rate
+    generator: { type: sequence, values: [${values.join(", ")}], repeat: ${p.repeat === "on"} }
+`;
+    },
+  },
   spike_event: {
     rate: 2,
     durationSecs: 120,
@@ -266,7 +387,7 @@ export const WIDGETS = {
 /* Default parameter values for a widget, keyed by slider. */
 export function defaultParams(widget) {
   const params = {};
-  for (const slider of widget.sliders) params[slider.key] = slider.value;
+  for (const slider of widget.sliders || []) params[slider.key] = slider.value;
   for (const choice of widget.choices || []) params[choice.key] = choice.value;
   return params;
 }
@@ -278,7 +399,10 @@ export function defaultParams(widget) {
  * binding cases, and the default row is what every reader actually sees. */
 export function cornerParams(widget) {
   let corners = [{}];
-  for (const slider of widget.sliders) {
+  // `sliders` is optional: a widget whose whole input is a <select>
+  // (`sequence`, whose parameter is a LIST and has no range to drag) is a
+  // legitimate shape, not a malformed preset.
+  for (const slider of widget.sliders || []) {
     const points = [...new Set([slider.min, slider.value, slider.max])];
     corners = corners.flatMap((corner) => points.map((v) => ({ ...corner, [slider.key]: v })));
   }
@@ -298,10 +422,10 @@ export function cornerParams(widget) {
  * duration-coupled sliders, where "the corners pass" deserves a
  * every-step check along the axis under the worst neighbors. */
 export function sweepParams(widget, key) {
-  const slider = widget.sliders.find((s) => s.key === key);
+  const slider = (widget.sliders || []).find((s) => s.key === key);
   if (!slider) return [];
   let others = [{}];
-  for (const other of widget.sliders) {
+  for (const other of widget.sliders || []) {
     if (other.key === key) continue;
     others = others.flatMap((corner) => [
       { ...corner, [other.key]: other.min },

--- a/docs/site/docs/javascripts/livegen.js
+++ b/docs/site/docs/javascripts/livegen.js
@@ -102,7 +102,13 @@ async function mount(root) {
   link.className = "sonda-livegen__open";
   link.textContent = "Open in playground →";
 
-  for (const slider of preset.sliders) {
+  // `sliders` is optional. A widget whose entire input is a <select> is a
+  // legitimate shape — `sequence`'s parameter is a LIST, with no range to
+  // drag — and dereferencing it unguarded threw before the choices below
+  // were ever rendered, so the widget mounted with no controls and no chart.
+  // The pure module's `cornerParams` carried the same assumption; both were
+  // written when every widget happened to have sliders.
+  for (const slider of preset.sliders || []) {
     const row = document.createElement("label");
     row.className = "sonda-livegen__row";
     const name = document.createElement("span");

--- a/docs/site/docs/javascripts/livegen.js
+++ b/docs/site/docs/javascripts/livegen.js
@@ -26,9 +26,11 @@ import {
   burstEmission,
 } from "./sonda-pure.js";
 import { playgroundHref } from "./playground-link.js";
-import { WIDGETS, defaultParams } from "./livegen-presets.js";
+// MAX_TICKS comes from the preset module rather than being declared here: it
+// constrains what a preset may ask for, so the pure invariants need it too,
+// and two definitions that agree by inspection are one edit away from not.
+import { WIDGETS, defaultParams, MAX_TICKS } from "./livegen-presets.js";
 
-const MAX_TICKS = 240;
 const DEBOUNCE_MS = 150;
 
 let wasmReady = null;
@@ -140,6 +142,12 @@ async function mount(root) {
     name.textContent = choice.label || choice.key;
     const select = document.createElement("select");
     select.className = "sonda-livegen__select";
+    // Names which control this is, so a test can drive a specific one. The
+    // browser suite resolved its target as "the first <select> in the widget"
+    // (review #549 M1); that is correct only until a widget's choices are
+    // reordered, at which point the check silently exercises a different
+    // control and stays green.
+    select.dataset.key = choice.key;
     for (const option of choice.options) {
       const el = document.createElement("option");
       el.value = option;

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -430,12 +430,17 @@ try {
   // The sequence widget's control is a <select>, and choosing a different
   // pattern must redraw. A widget whose control is inert renders perfectly
   // and teaches nothing.
+  // Addressed by key, not by position: `[data-gen="sequence"] select` resolves
+  // the FIRST <select>, which is `pattern` only until someone reorders the
+  // widget's choices (review #549 M1). `repeat`, the other control, is covered
+  // by the control-reaches-template invariant in the pure suite.
   const seqSelector = '.sonda-livegen[data-gen="sequence"]';
+  const seqSelectSelector = `${seqSelector} select[data-key="pattern"]`;
   const seqBefore = await widgets.evaluate(
     (sel) => document.querySelector(sel)?.querySelector(".sonda-livegen__chart")?.toDataURL().length ?? 0,
     seqSelector
   );
-  const seqSelect = await widgets.$(`${seqSelector} select`);
+  const seqSelect = await widgets.$(seqSelectSelector);
   if (seqSelect) await seqSelect.selectOption({ index: 1 });
   const seqChanged = seqSelect
     ? await widgets
@@ -449,7 +454,7 @@ try {
         .catch(() => false)
     : false;
   check("choosing a different sequence pattern redraws the chart", seqChanged,
-    seqSelect ? `was ${seqBefore} chars` : "no <select> rendered");
+    seqSelect ? `was ${seqBefore} chars` : 'no <select data-key="pattern"> rendered');
 
   await widgets.close();
 

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -379,6 +379,78 @@ try {
     return err && !err.hidden ? err.textContent : null;
   });
   check("the widget reports no engine error", widgetError === null, widgetError || "");
+
+  // WP13 completed the core-generator set, so the page now carries widgets of
+  // two SHAPES: slider-driven, and the choice-driven `sequence` whose whole
+  // input is a <select>. Section 8 above only ever mounted whichever widget
+  // came first in the document, which is a slider one — a choice-only widget
+  // could ship broken behind a green suite.
+  //
+  // Each new kind is asserted by mounting it specifically and reading its own
+  // canvas, rather than by counting widgets on the page: a count passes on a
+  // page where five placeholders rendered five empty boxes.
+  for (const gen of ["constant", "sawtooth", "uniform", "step", "sequence"]) {
+    const selector = `.sonda-livegen[data-gen="${gen}"]`;
+    const mounted = await widgets
+      .evaluate(async (sel) => {
+        const host = document.querySelector(sel);
+        if (!host) return { found: false };
+        host.scrollIntoView();
+        return { found: true };
+      }, selector)
+      .catch(() => ({ found: false }));
+
+    let drew = false;
+    if (mounted.found) {
+      drew = await widgets
+        .waitForFunction(
+          ([sel, min]) => {
+            const canvas = document.querySelector(sel)?.querySelector(".sonda-livegen__chart");
+            return Boolean(canvas && canvas.toDataURL().length > min);
+          },
+          [selector, WIDGET_CHART_WITH_DATA],
+          { timeout: 60000 }
+        )
+        .then(() => true)
+        .catch(() => false);
+    }
+
+    const err = await widgets.evaluate((sel) => {
+      const e = document.querySelector(sel)?.querySelector(".sonda-livegen__error");
+      return e && !e.hidden ? e.textContent.trim().slice(0, 120) : null;
+    }, selector);
+
+    check(
+      `the ${gen} widget mounts and draws`,
+      mounted.found && drew && err === null,
+      mounted.found ? err || (drew ? "" : "no chart data") : "no placeholder on the page"
+    );
+  }
+
+  // The sequence widget's control is a <select>, and choosing a different
+  // pattern must redraw. A widget whose control is inert renders perfectly
+  // and teaches nothing.
+  const seqSelector = '.sonda-livegen[data-gen="sequence"]';
+  const seqBefore = await widgets.evaluate(
+    (sel) => document.querySelector(sel)?.querySelector(".sonda-livegen__chart")?.toDataURL().length ?? 0,
+    seqSelector
+  );
+  const seqSelect = await widgets.$(`${seqSelector} select`);
+  if (seqSelect) await seqSelect.selectOption({ index: 1 });
+  const seqChanged = seqSelect
+    ? await widgets
+        .waitForFunction(
+          ([sel, before]) =>
+            (document.querySelector(sel)?.querySelector(".sonda-livegen__chart")?.toDataURL().length ?? 0) !== before,
+          [seqSelector, seqBefore],
+          { timeout: 30000 }
+        )
+        .then(() => true)
+        .catch(() => false)
+    : false;
+  check("choosing a different sequence pattern redraws the chart", seqChanged,
+    seqSelect ? `was ${seqBefore} chars` : "no <select> rendered");
+
   await widgets.close();
 
   // --- 9. A runnable-fence button carries its scenario -------------------

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -35,7 +35,14 @@ import {
   scrubNumber,
   toBase64Url,
 } from "../../docs/javascripts/sonda-pure.js";
-import { WIDGETS, cornerParams, defaultParams, sweepParams } from "../../docs/javascripts/livegen-presets.js";
+import {
+  WIDGETS,
+  cornerParams,
+  defaultParams,
+  sweepParams,
+  sampledTicks,
+  MAX_TICKS,
+} from "../../docs/javascripts/livegen-presets.js";
 
 let passed = 0;
 function test(name, fn) {
@@ -523,11 +530,21 @@ test("the step widget wraps inside the sampled window at every corner", () => {
   // wrong shape — a widget that is wrong in the most confident way, since it
   // renders perfectly.
   //
-  // The window is rate * durationSecs ticks. The counter climbs step_size per
-  // tick from `start`, so the worst case is the smallest step_size with the
-  // largest max and the lowest start.
+  // The window is `sampledTicks`, NOT rate * durationSecs (review #549 W1).
+  // The sampler clamps to MAX_TICKS, so the product is an upper bound the
+  // real window need not reach, and the multiplication grows more permissive
+  // exactly where the window stops growing. The two agree for every widget
+  // today only because the tick-budget invariant below holds the product at
+  // or under MAX_TICKS — which made this check correct on the strength of a
+  // NEIGHBOURING assertion rather than its own. Calling sampledTicks makes it
+  // self-sufficient; the reviewer's demonstration edit is caught by that
+  // neighbour today, so this is a latent coupling closed rather than a live
+  // defect fixed.
+  //
+  // The counter climbs step_size per tick from `start`, so the worst case is
+  // the smallest step_size with the largest max and the lowest start.
   const step = WIDGETS.step;
-  const ticks = step.rate * step.durationSecs;
+  const ticks = sampledTicks(step);
   const stepSize = step.sliders.find((s) => s.key === "step_size");
   const max = step.sliders.find((s) => s.key === "max");
   const start = step.sliders.find((s) => s.key === "start");
@@ -561,8 +578,53 @@ test("the sequence widget's patterns are real, non-empty value lists", () => {
 });
 
 test("preset sampling stays within the playground tick budget", () => {
+  // Reads MAX_TICKS from the preset module rather than repeating 240, so this
+  // and `sampledTicks` cannot drift apart. This assertion is what makes the
+  // product and the real window coincide today — see the wrap guard above,
+  // which no longer depends on that.
   for (const [gen, widget] of Object.entries(WIDGETS)) {
-    assert.ok(widget.rate * widget.durationSecs <= 240, `${gen}: rate*duration must fit MAX_TICKS`);
+    assert.ok(
+      widget.rate * widget.durationSecs <= MAX_TICKS,
+      `${gen}: rate*duration must fit MAX_TICKS`
+    );
+  }
+});
+
+test("every control reaches its widget's template (review #549 W2)", () => {
+  // The generalisation of the hand-written `sequence` pattern check above.
+  // That one covered ONE of sequence's two controls, and an inert `repeat`
+  // — `repeat: true` hard-coded in place of `${p.repeat === "on"}` — shipped
+  // green through the whole suite AND the browser suite, whose redraw check
+  // resolves the FIRST <select> and so never touches it. Measured, not
+  // assumed: 191 tests passed with the control dead.
+  //
+  // Differential rather than textual: render the widget twice, changing one
+  // control and nothing else, and require the YAML to differ. That makes no
+  // assumption about interpolation syntax, so it keeps working for a control
+  // the template consumes rather than pastes — `repeat` maps "on"/"off" to a
+  // boolean, and a substring search for the option string would miss it.
+  //
+  // Only this direction needs a test. The reverse — a template referencing a
+  // parameter no control supplies — interpolates `undefined` into the YAML
+  // and the compile gate rejects it.
+  for (const [gen, widget] of Object.entries(WIDGETS)) {
+    const base = defaultParams(widget);
+    for (const slider of widget.sliders || []) {
+      const lo = widget.yaml({ ...base, [slider.key]: slider.min });
+      const hi = widget.yaml({ ...base, [slider.key]: slider.max });
+      assert.notEqual(lo, hi, `${gen}.${slider.key}: a slider the template ignores does nothing`);
+    }
+    for (const choice of widget.choices || []) {
+      assert.ok(choice.options.length >= 2, `${gen}.${choice.key}: a one-option <select> is not a control`);
+      const first = widget.yaml({ ...base, [choice.key]: choice.options[0] });
+      const rest = choice.options
+        .slice(1)
+        .map((option) => widget.yaml({ ...base, [choice.key]: option }));
+      assert.ok(
+        rest.some((yaml) => yaml !== first),
+        `${gen}.${choice.key}: a <select> the template ignores does nothing`
+      );
+    }
   }
 });
 

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -457,9 +457,15 @@ test("widget controls are well-formed and defaults sit inside their range", () =
     // Counted as CONTROLS, not sliders: the encoders widget carries one
     // slider and one <select>, and the invariant being defended is "enough
     // to play with, few enough to take in", not the input element used.
-    const controls = widget.sliders.length + (widget.choices || []).length;
-    assert.ok(controls >= 2 && controls <= 3, `${gen}: 2-3 controls, got ${controls}`);
-    for (const s of widget.sliders) {
+    //
+    // The floor is 1, not 2. It was 2 until WP13 added `constant`, which has
+    // exactly one parameter — there is no second knob to offer and inventing
+    // one would be worse than a short widget. The floor exists to catch a
+    // widget shipped with NOTHING to drag, and 1 still catches that; the
+    // ceiling is where the real judgement lives.
+    const controls = (widget.sliders || []).length + (widget.choices || []).length;
+    assert.ok(controls >= 1 && controls <= 3, `${gen}: 1-3 controls, got ${controls}`);
+    for (const s of widget.sliders || []) {
       assert.ok(s.step > 0, `${gen}.${s.key}: positive step`);
       assert.ok(s.min < s.max, `${gen}.${s.key}: min < max`);
       assert.ok(s.value >= s.min && s.value <= s.max, `${gen}.${s.key}: default in range`);
@@ -471,8 +477,8 @@ test("baseline and ceiling ranges are disjoint wherever both exist", () => {
   // Disjoint ranges mean no slider combination can cross them — the
   // compile gate then only has to confirm the engine agrees.
   for (const [gen, widget] of Object.entries(WIDGETS)) {
-    const baseline = widget.sliders.find((s) => s.key === "baseline");
-    const ceiling = widget.sliders.find((s) => s.key === "ceiling");
+    const baseline = (widget.sliders || []).find((s) => s.key === "baseline");
+    const ceiling = (widget.sliders || []).find((s) => s.key === "ceiling");
     if (baseline && ceiling) {
       assert.ok(baseline.max < ceiling.min, `${gen}: baseline range must sit below ceiling range`);
     }
@@ -495,6 +501,65 @@ test("duration-coupled slider floors cover the scenario duration (review #534 M1
   }
 });
 
+test("every min/max slider pair is non-crossable by range construction", () => {
+  // Generalises the baseline/ceiling rule above to the pairs WP13 added.
+  // The engine rejects `min >= max`, so a pair whose ranges OVERLAP ships a
+  // widget that compiles at rest and throws under the reader's hand — the
+  // failure only appears for the readers who actually play with it, which is
+  // everyone the widget is for. Disjoint ranges make it unreachable rather
+  // than merely untested.
+  for (const [gen, widget] of Object.entries(WIDGETS)) {
+    const lo = (widget.sliders || []).find((s) => s.key === "min");
+    const hi = (widget.sliders || []).find((s) => s.key === "max");
+    if (lo && hi) {
+      assert.ok(lo.max < hi.min, `${gen}: min range [${lo.min},${lo.max}] must sit below max range [${hi.min},${hi.max}]`);
+    }
+  }
+});
+
+test("the step widget wraps inside the sampled window at every corner", () => {
+  // The `step` widget exists to show WRAP-AROUND. A `max` the counter never
+  // reaches inside the sampled window draws a plain ramp and teaches the
+  // wrong shape — a widget that is wrong in the most confident way, since it
+  // renders perfectly.
+  //
+  // The window is rate * durationSecs ticks. The counter climbs step_size per
+  // tick from `start`, so the worst case is the smallest step_size with the
+  // largest max and the lowest start.
+  const step = WIDGETS.step;
+  const ticks = step.rate * step.durationSecs;
+  const stepSize = step.sliders.find((s) => s.key === "step_size");
+  const max = step.sliders.find((s) => s.key === "max");
+  const start = step.sliders.find((s) => s.key === "start");
+  const worstClimb = stepSize.min * ticks;
+  assert.ok(
+    worstClimb > max.max - start.min,
+    `step: slowest climb ${worstClimb} must exceed the widest span ${max.max - start.min}, ` +
+      "or the widget shows a ramp and calls it a wrap"
+  );
+});
+
+test("the sequence widget's patterns are real, non-empty value lists", () => {
+  // `sequence` carries its option data in the preset rather than the markup,
+  // which is what puts every option through the compile gate. That only holds
+  // if every offered option resolves to a list the engine accepts.
+  const sequence = WIDGETS.sequence;
+  const pattern = sequence.choices.find((c) => c.key === "pattern");
+  for (const option of pattern.options) {
+    const values = sequence.patterns[option];
+    assert.ok(Array.isArray(values) && values.length > 0, `sequence: "${option}" must name a value list`);
+    for (const v of values) assert.ok(Number.isFinite(v), `sequence: "${option}" values must be finite`);
+    // And the option must reach the YAML — a pattern the template ignores is
+    // a control that does nothing.
+    assert.match(
+      sequence.yaml({ ...defaultParams(sequence), pattern: option }),
+      new RegExp(`values: \\[${values.join(", ").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\]`),
+      `sequence: "${option}" must reach the template`
+    );
+  }
+  assert.ok(pattern.options.includes(pattern.value), "the default pattern must be an offered option");
+});
+
 test("preset sampling stays within the playground tick budget", () => {
   for (const [gen, widget] of Object.entries(WIDGETS)) {
     assert.ok(widget.rate * widget.durationSecs <= 240, `${gen}: rate*duration must fit MAX_TICKS`);
@@ -506,11 +571,11 @@ test("corner and sweep enumeration cover what the compile gate feeds the engine"
     const corners = cornerParams(widget);
     const expected = (widget.choices || []).reduce(
       (n, c) => n * c.options.length,
-      widget.sliders.reduce((n, s) => n * new Set([s.min, s.value, s.max]).size, 1)
+      (widget.sliders || []).reduce((n, s) => n * new Set([s.min, s.value, s.max]).size, 1)
     );
     assert.equal(corners.length, expected, `${gen}: {min,default,max} grid`);
     for (const corner of corners) {
-      for (const s of widget.sliders) {
+      for (const s of widget.sliders || []) {
         assert.ok(
           [s.min, s.value, s.max].includes(corner[s.key]),
           `${gen}: corners use range edges or the default`


### PR DESCRIPTION


## Summary

`build/generators.md` invited dragging on eight sections and not on five. The five without widgets — `constant`, `sawtooth`, `uniform`, `step`, `sequence` — are the ones a reader meets first, so the gap reads as an unfinished pattern rather than a line drawn on purpose. All five now carry live widgets, and the sections that stay static say **why** instead of trailing off.

**The one structurally new thing is a widget with no sliders.** `sequence`'s parameter is a LIST — there is no range to drag — so it uses the `choices`/`<select>` mechanism #543 added for the encoder switcher, with its three patterns held as data in the preset rather than in the markup. That is what puts every option through the compile gate.

That shape broke four call sites which had assumed every widget has sliders, because until this PR every widget did. `livegen.js` dereferenced `preset.sliders` unguarded and threw *before* the choices below it were ever rendered, so the widget mounted with no controls and no chart; `defaultParams`, `cornerParams` and `sweepParams` carried the same assumption. The browser check found it — written first, RED for exactly this reason ("no chart data", "no `<select>` rendered") before the guard went in.

**The no-JS floor is unchanged.** Every placeholder sits *after* the static SVG it accompanies, so a reader without JavaScript loses nothing they had.

## Changes

- **`docs/site/docs/javascripts/livegen-presets.js`** — five new presets. Every `min`/`max` pair is disjoint by *range construction* rather than by validation, the precedent the leak widget set. `defaultParams` / `cornerParams` / `sweepParams` now treat `sliders` as optional.
- **`docs/site/docs/javascripts/livegen.js`** — the same guard at the mount site, with a comment naming why a slider-less widget is a legitimate shape.
- **`docs/site/docs/build/generators.md`** — five widget placeholders; `csv_replay` (metrics and logs) gains a "not live on this page" note explaining that it reads a file from disk and there is no filesystem in the browser, pointing at the examples gallery and the matching import guide; `histogram`, `summary` and `template` each point at the playground preset that renders them live today, pending WP14.
- **`docs/site/tools/tests/pure.test.mjs`** — three new invariants, and one existing invariant widened (below).
- **`docs/site/tools/browser/smoke.mjs`** — six new checks: each of the five widgets mounts and draws, and choosing a different `sequence` pattern redraws the chart.

**One existing invariant was WIDENED, which is the thing worth arguing about.** "2-3 controls" became 1-3. `constant` has exactly one parameter; there is no second knob to offer, and inventing one would be worse than a short widget. The floor exists to catch a widget shipped with NOTHING to drag, and 1 still catches that; the ceiling is where the judgement lives. Flagged here rather than buried, since a loosened assertion is the shape a reviewer should be suspicious of by default.

**Comment claims backed by tests that already exist:** `sequence` with `repeat: false` holds its last value (`no_repeat_beyond_length_clamps_to_last`), and `uniform` is seeded so dragging back to the same seed reproduces the trace exactly (`same_seed_and_tick_returns_same_value`) — the property a static SVG cannot show, and the reason that widget earns its size.

## Test plan

Three new pure invariants, each verified RED by mutating the preset it guards:

| Invariant | Mutation | Result |
| --- | --- | --- |
| every `min`/`max` slider pair is non-crossable by range construction | widen `sawtooth`'s `min` range to 60 so it can cross `max`'s floor of 50 | RED |
| the `step` widget wraps inside the sampled window at every corner | raise `max`'s ceiling to 500 | RED |
| every `sequence` pattern names a real, non-empty, finite list **and** reaches the template | offer a `flatline` option with no list | RED |
| (same) | make `yaml()` ignore `p.pattern` | RED |

The first invariant matters because the engine rejects `min >= max`: an overlapping pair ships a widget that compiles at rest and throws under the reader's hand — a failure only the readers who actually play with it will see, which is everyone the widget is for. The second matters because a `max` the counter never reaches draws a plain ramp and calls it a wrap — wrong in the most confident way, since it renders perfectly. Its check does the arithmetic explicitly (`step_size.min * rate * durationSecs` must exceed `max.max - start.min`) because that is exactly the kind that rots silently when a range is nudged.

The `sequence` redraw check was **sabotage-verified on its own terms**: dropping the `schedule()` call from the `<select>` handler leaves the widget rendering perfectly and turns exactly one check red — `FAIL choosing a different sequence pattern redraws the chart — was 41050 chars` — with all five mount checks still green. An inert control is the failure mode a mount check cannot see.

Gates run:

```bash
node docs/site/tools/tests/pure.test.mjs                 # 191 pure-helper tests passed
SONDA_BIN=./target/release/sonda \
  node docs/site/tools/tests/livegen-compile.mjs         # 603 slider combinations compile (was 522)
python3 scripts/validate_docs_scenarios.py               # 118 compiled, 9 skipped, 0 failed
python3 scripts/validate_docs_commands.py                # 154 commands checked, 0 failed
python3 docs/site/hooks/examples_gallery.py --self-test  # 16 tests, OK
bash scripts/check_no_raw_html.sh                        # OK
mkdocs build --strict -f docs/site/mkdocs.yml            # clean
node docs/site/tools/browser/smoke.mjs                   # 87 checks, SMOKE PASSED (two clean runs)
```

## Checklist

- [ ] `cargo test --workspace` passes — **1970 passed, 2 failed, and the 2 are an artifact of this container rather than the diff.** `sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message` and `tests::sink_file_error_produces_sink_variant` both `chmod 0o555` a tempdir and assert the write is refused. This container runs as uid 0, and root bypasses directory permissions — measured directly: creating a file inside a fresh `0o555` directory here **succeeds**, so `FileSink::new` returns `Ok` and the assertion cannot hold for any state of the code. CI runs as a non-root user, which is why `main` is green. This PR touches **no Rust at all** (`git diff origin/main --stat` is five files, all under `docs/site/`), so it cannot reach either test. Flagged rather than ticked.
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable) — this PR *is* the documentation change.

