### PR TITLE
feat(site): live histogram, summary and log widgets on generators.md

### DIFF
--- a/docs/site/docs/build/generators.md
+++ b/docs/site/docs/build/generators.md
@@ -723,10 +723,7 @@ Histograms and summaries are scenario entries with `signal_type: histogram` or `
 
 ### histogram
 
-!!! tip "See it move"
-    The playground's **Latency histogram + quantiles** preset renders these buckets as a live
-    heatmap — [open it there](../playground/index.md) and drag `mean_shift_per_sec` to watch mass
-    drift into the higher buckets. A live widget on this page is playbook WP14.
+<div class="sonda-livegen" data-gen="histogram" markdown="0"></div>
 
 A histogram answers the question: **"what is the distribution of observed values?"** It does this by sorting observations into buckets — ranges with upper boundaries you define. Each bucket counts how many observations fell at or below that boundary.
 
@@ -814,9 +811,7 @@ http_request_duration_seconds_sum{handler="/api/v1/query",method="GET"} 9.505 17
 
 ### summary
 
-!!! tip "See it move"
-    The same **Latency histogram + quantiles** preset in the [playground](../playground/index.md)
-    draws summaries as quantile bands. A live widget on this page is playbook WP14.
+<div class="sonda-livegen" data-gen="summary" markdown="0"></div>
 
 Where a histogram stores raw bucket counts and lets Prometheus estimate percentiles server-side, a summary does the math upfront. It computes the actual percentile values on the client and reports them directly. The p50 *is* 98ms. The p99 *is* 148ms. No estimation, no bucket interpolation.
 
@@ -932,9 +927,7 @@ Log generators produce structured log events instead of numeric values. They liv
 
 ### template
 
-!!! tip "See it move"
-    The **Synthetic log stream** preset in the [playground](../playground/index.md) renders a live,
-    severity-coloured stream from this generator. A live widget on this page is playbook WP14.
+<div class="sonda-livegen" data-gen="log_template" markdown="0"></div>
 
 Generates log events from message templates with randomized field values.
 

--- a/docs/site/docs/javascripts/livegen-presets.js
+++ b/docs/site/docs/javascripts/livegen-presets.js
@@ -17,13 +17,22 @@
  * run rather than trusting this comment.
  */
 
-function head(rate, durationSecs) {
+/* The shared scenario preamble.
+ *
+ * `encoder` is a parameter because it is not universal: `prometheus_text`
+ * cannot encode a log event, and a logs widget built on this default fails at
+ * SAMPLING with "log encoding not supported by this encoder" rather than at
+ * compile — so `sonda --dry-run run` accepts it and the compile gate stays
+ * green while the widget shows a reader an error. Found in browser UAT, which
+ * is the only gate that runs the sampler.
+ */
+function head(rate, durationSecs, encoder = "prometheus_text") {
   return `version: 2
 kind: runnable
 defaults:
   rate: ${rate}
   duration: ${durationSecs}s
-  encoder: { type: prometheus_text }
+  encoder: { type: ${encoder} }
   sink: { type: stdout }
 scenarios:`;
 }
@@ -389,6 +398,114 @@ export const WIDGETS = {
     signal_type: metrics
     name: error_rate
     generator: { type: sequence, values: [${values.join(", ")}], repeat: ${p.repeat === "on"} }
+`;
+    },
+  },
+  /* --- WP14: the three sections that are not metrics ---------------------
+   *
+   * These carry `signal`, which the other widgets omit and default to
+   * "metrics". It selects which array of `sample_scenario`'s result the
+   * widget reads and which renderer draws it — the same three renderers the
+   * playground uses, now shared rather than copied (signal-render.js).
+   *
+   * The tick budget bites differently here. A metrics entry costs one number
+   * per tick; a histogram costs one number per BUCKET per tick, and the
+   * heatmap has to carry all of them. `histogramCells` in pure.test.mjs
+   * bounds that product at every slider corner, because the failure mode is
+   * not an error — it is a page that quietly gets heavy.
+   */
+  histogram: {
+    rate: 2,
+    durationSecs: 120,
+    signal: "histogram",
+    sliders: [
+      // The teaching slider: drift the distribution's mean and watch mass
+      // climb out of the low buckets into the high ones. 0 is a legal and
+      // meaningful setting — a stationary distribution — so the floor is 0
+      // rather than a small positive number.
+      { key: "shift", min: 0, max: 12, step: 1, value: 4 },
+      { key: "observations", min: 5, max: 60, step: 5, value: 40 },
+    ],
+    yaml(p) {
+      // `shift` is per-mille per second: the useful range for a 120s window
+      // is thousandths, and a slider that reads 0.004 is a slider nobody
+      // drags. The label says what the reader is setting; the template does
+      // the conversion.
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: histogram
+    name: http_request_duration_seconds
+    distribution: { type: exponential, rate: 10.0 }
+    observations_per_tick: ${p.observations}
+    mean_shift_per_sec: ${(p.shift / 1000).toFixed(3)}
+    seed: 42
+    labels: { service: api }
+`;
+    },
+  },
+  summary: {
+    rate: 2,
+    durationSecs: 120,
+    signal: "summary",
+    sliders: [
+      { key: "stddev", min: 1, max: 40, step: 1, value: 20 },
+      { key: "shift", min: 0, max: 12, step: 1, value: 2 },
+      { key: "observations", min: 5, max: 60, step: 5, value: 40 },
+    ],
+    yaml(p) {
+      // stddev is per-mille of a second for the same reason as `shift`, and
+      // its floor is 1 rather than 0: a zero-width normal makes every
+      // quantile equal, which draws a single line where the widget's whole
+      // subject is the SPREAD between them.
+      return `${head(this.rate, this.durationSecs)}
+  - id: live
+    signal_type: summary
+    name: rpc_duration_seconds
+    distribution: { type: normal, mean: 0.1, stddev: ${(p.stddev / 1000).toFixed(3)} }
+    observations_per_tick: ${p.observations}
+    mean_shift_per_sec: ${(p.shift / 1000).toFixed(3)}
+    seed: 7
+    labels: { service: api }
+`;
+    },
+  },
+  log_template: {
+    rate: 4,
+    durationSecs: 60,
+    signal: "logs",
+    sliders: [
+      // Severity weights the engine normalises, so these are RATIOS, not
+      // percentages, and every corner is legal. error at 0 is the ordinary
+      // healthy service and must render — a stream of nothing but info — and
+      // error at max with info at min is the incident. Both are corners the
+      // compile gate visits.
+      { key: "error_weight", min: 0, max: 10, step: 1, value: 1 },
+      { key: "warn_weight", min: 0, max: 10, step: 1, value: 2 },
+    ],
+    yaml(p) {
+      // info is pinned at 8 rather than being a third slider: with all three
+      // free, the all-zero corner is reachable, and severity_weights summing
+      // to zero is a scenario with no severities to pick from. One fixed
+      // weight makes the sum positive by construction — the same "unreachable
+      // rather than merely untested" move the min/max ranges make.
+      return `${head(this.rate, this.durationSecs, "json_lines")}
+  - id: live
+    signal_type: logs
+    name: checkout_logs
+    log_generator:
+      type: template
+      templates:
+        - message: "Request from {ip} to {endpoint} took {latency}ms"
+          field_pools:
+            ip: ["10.0.0.1", "10.0.0.2", "10.0.0.7"]
+            endpoint: ["/api/cart", "/api/checkout", "/api/health"]
+            latency: ["12", "48", "230", "870"]
+        - message: "payment gateway timeout after {timeout}s"
+          field_pools:
+            timeout: ["5", "10"]
+      severity_weights: { info: 8, warn: ${p.warn_weight}, error: ${p.error_weight} }
+      seed: 42
+    labels: { service: checkout }
 `;
     },
   },

--- a/docs/site/docs/javascripts/livegen.js
+++ b/docs/site/docs/javascripts/livegen.js
@@ -26,6 +26,37 @@ import {
   burstEmission,
 } from "./sonda-pure.js";
 import { playgroundHref } from "./playground-link.js";
+// `fmt`/`fmtSecs`/`palette` used to live here as character-identical copies of
+// playground.js's. Names differ from the originals in this file only; bodies
+// were unchanged by the extraction.
+import {
+  palette,
+  formatNumber,
+  formatSeconds,
+  drawHistogramHeatmap,
+  drawSummaryBands,
+  logStream,
+} from "./signal-render.js";
+
+/* Which array of the sample result a widget reads, and what draws it.
+ *
+ * Tables rather than a chain of ifs, for the reason the gallery's
+ * `galleryCardState` exists: adding a signal type should be a row, and a
+ * missing row should be a loud undefined at mount rather than a silent
+ * fall-through to the metrics path that then reads `.values` off a histogram.
+ */
+const SIGNAL_SOURCE = {
+  metrics: (result) => result.entries || [],
+  histogram: (result) => result.histograms || [],
+  summary: (result) => result.summaries || [],
+  logs: (result) => result.logs || [],
+};
+
+const SIGNAL_DRAW = {
+  metrics: (canvas, sample) => drawMini(canvas, sample),
+  histogram: drawHistogramHeatmap,
+  summary: drawSummaryBands,
+};
 // MAX_TICKS comes from the preset module rather than being declared here: it
 // constrains what a preset may ask for, so the pure invariants need it too,
 // and two definitions that agree by inspection are one edit away from not.
@@ -79,19 +110,28 @@ async function mount(root) {
   if (!preset) return;
 
   const params = defaultParams(preset);
-  // A preset either draws a chart or shows the encoded bytes. The encoders
-  // widget is the second kind: the same sine encodes three ways and the line
-  // is identical in all of them, so a chart there would answer a question
-  // nobody asked.
-  const output = preset.preview ? document.createElement("pre") : document.createElement("canvas");
-  output.className = preset.preview ? "sonda-livegen__preview" : "sonda-livegen__chart";
+  // Three output shapes, chosen by the preset rather than sniffed from the
+  // result. `preview` shows the engine's encoded bytes (the encoders widget:
+  // the same sine encodes three ways and the LINE is identical in all of
+  // them, so a chart there would answer a question nobody asked). A logs
+  // widget renders elements, because a log line is text and drawing text into
+  // a canvas would make it unselectable and invisible to a screen reader.
+  // Everything else is a canvas.
+  const signal = preset.signal || "metrics";
+  const kind = preset.preview ? "preview" : signal === "logs" ? "logs" : "chart";
+  const output = document.createElement(
+    kind === "preview" ? "pre" : kind === "logs" ? "div" : "canvas"
+  );
+  output.className = `sonda-livegen__${kind}`;
   output.setAttribute(
     "aria-label",
-    preset.preview
+    kind === "preview"
       ? `Encoded output of the ${root.dataset.gen} example`
-      : `Live chart of the ${root.dataset.gen} generator`
+      : kind === "logs"
+        ? `Live log stream from the ${root.dataset.gen} generator`
+        : `Live chart of the ${root.dataset.gen} generator`
   );
-  const canvas = preset.preview ? null : output;
+  const canvas = kind === "chart" ? output : null;
   const controls = document.createElement("div");
   controls.className = "sonda-livegen__controls";
   const error = document.createElement("p");
@@ -180,14 +220,31 @@ async function mount(root) {
         return;
       }
       error.hidden = true;
-      const entry = result.entries[0];
-      if (preset.preview) {
+      // `ok` from the engine does not mean this widget's signal is present:
+      // a scenario the compiler accepts can still be SKIPPED at sampling (a
+      // csv_replay reaching for a file, an encoder built out of this wasm).
+      // Saying so beats an empty frame the reader has to interpret.
+      const sample = SIGNAL_SOURCE[signal](result)[0];
+      if (!sample) {
+        error.hidden = false;
+        error.textContent =
+          result.skipped?.[0]?.reason || `the engine produced no ${signal} to draw`;
+        return;
+      }
+      if (kind === "preview") {
         // The engine's own encoded bytes, verbatim and as text — never as
         // markup. Trailing newline trimmed so the block does not carry an
         // empty last line.
-        output.textContent = (entry.encoded_preview || "").replace(/\n+$/, "");
+        output.textContent = (sample.encoded_preview || "").replace(/\n+$/, "");
+      } else if (kind === "logs") {
+        // Not registered for redraw: the stream is elements, so a theme flip
+        // is restyled by CSS and a resize reflows it. Only canvases need to
+        // be repainted, and adding this root to `live` would rebuild the
+        // whole pane — losing the reader's scroll position — for nothing.
+        output.replaceChildren(logStream(sample, { prefix: "sonda-livegen" }));
       } else {
-        root._draw = () => drawMini(canvas, entry);
+        const draw = SIGNAL_DRAW[signal];
+        root._draw = () => draw(canvas, sample);
         root._draw();
         live.add(root);
       }
@@ -312,23 +369,6 @@ function hideStaticImage(root) {
   }
 }
 
-function palette() {
-  const dark = document.body.getAttribute("data-md-color-scheme") === "slate";
-  return {
-    grid: dark ? "rgba(148, 163, 184, 0.25)" : "rgba(100, 116, 139, 0.25)",
-    text: dark ? "#94a3b8" : "#64748b",
-    line: "#f97316",
-    // Same two washes as the playground chart, for the same reason: a reader
-    // who learns what the grey band means on one page should not have to
-    // learn it again on the other.
-    gap: dark ? "rgba(148, 163, 184, 0.14)" : "rgba(100, 116, 139, 0.12)",
-    burst: dark ? "rgba(253, 186, 116, 0.14)" : "rgba(249, 115, 22, 0.10)",
-    // Backing plate for the burst label, which is drawn INSIDE the plot
-    // and would otherwise be read through whatever trace passes behind it.
-    plate: dark ? "rgba(15, 23, 42, 0.82)" : "rgba(255, 255, 255, 0.82)",
-  };
-}
-
 function drawMini(canvas, entry) {
   const colors = palette();
   const dpr = window.devicePixelRatio || 1;
@@ -379,7 +419,7 @@ function drawMini(canvas, entry) {
     ctx.lineTo(cssWidth - pad.right, gy);
     ctx.stroke();
     ctx.textAlign = "right";
-    ctx.fillText(fmt(value), pad.left - 5, gy + 3);
+    ctx.fillText(formatNumber(value), pad.left - 5, gy + 3);
   }
   ctx.setLineDash([]);
 
@@ -444,7 +484,7 @@ function drawMini(canvas, entry) {
   ctx.textAlign = "center";
   for (let step = 0; step <= 3; step++) {
     const secs = (spanSecs * step) / 3;
-    ctx.fillText(fmtSecs(secs), pad.left + (plotW * step) / 3, cssHeight - 6);
+    ctx.fillText(formatSeconds(secs), pad.left + (plotW * step) / 3, cssHeight - 6);
   }
 
   ctx.strokeStyle = colors.line;
@@ -456,20 +496,6 @@ function drawMini(canvas, entry) {
     else ctx.lineTo(x(i), y(v));
   });
   ctx.stroke();
-}
-
-function fmt(value) {
-  if (Math.abs(value) >= 1000) return value.toFixed(0);
-  if (Math.abs(value) >= 10) return value.toFixed(1);
-  return value.toFixed(2);
-}
-
-function fmtSecs(secs) {
-  const rounded = Math.round(secs);
-  if (rounded < 60) return `${rounded}s`;
-  const mins = Math.floor(rounded / 60);
-  const rest = rounded % 60;
-  return rest ? `${mins}m${rest}s` : `${mins}m`;
 }
 
 // Theme flips and resizes redraw every live widget from its cached samples;

--- a/docs/site/docs/javascripts/livegen.js
+++ b/docs/site/docs/javascripts/livegen.js
@@ -52,6 +52,23 @@ const SIGNAL_SOURCE = {
   logs: (result) => result.logs || [],
 };
 
+/* How many log lines a widget renders before saying how many it withheld.
+ *
+ * The playground renders the stream ENTIRE and should: it has a preset
+ * picker, a cursor that correlates a chart instant to a line, and a reader
+ * who came to look at logs. A reference-page demo has none of that, and at
+ * `rate: 4` over 60s the same renderer produced 240 lines — a 5,379px scroll
+ * inside a 318px pane, seventeen screens of nested scrolling in the middle of
+ * a page someone is reading top to bottom (review #550 M2).
+ *
+ * 40 keeps the pane about three of its own heights, which is enough to see
+ * the severity mix the widget's sliders control and short enough not to trap
+ * a scroll. The cap lives here rather than in `logStream` so the playground
+ * keeps its unbounded default rather than inheriting a limit aimed at a
+ * different page.
+ */
+const LOG_LINES_SHOWN = 40;
+
 const SIGNAL_DRAW = {
   metrics: (canvas, sample) => drawMini(canvas, sample),
   histogram: drawHistogramHeatmap,
@@ -241,7 +258,9 @@ async function mount(root) {
         // is restyled by CSS and a resize reflows it. Only canvases need to
         // be repainted, and adding this root to `live` would rebuild the
         // whole pane — losing the reader's scroll position — for nothing.
-        output.replaceChildren(logStream(sample, { prefix: "sonda-livegen" }));
+        output.replaceChildren(
+          logStream(sample, { prefix: "sonda-livegen", limit: LOG_LINES_SHOWN })
+        );
       } else {
         const draw = SIGNAL_DRAW[signal];
         root._draw = () => draw(canvas, sample);

--- a/docs/site/docs/javascripts/livegen.js
+++ b/docs/site/docs/javascripts/livegen.js
@@ -258,7 +258,21 @@ async function mount(root) {
         // is restyled by CSS and a resize reflows it. Only canvases need to
         // be repainted, and adding this root to `live` would rebuild the
         // whole pane — losing the reader's scroll position — for nothing.
+        // The count goes ABOVE the pane, not only in its footer. The footer
+        // sat 911px down a 318px window, so the view at rest was 40 lines
+        // ending at +9.75s of a 60s scenario with nothing saying 200 were
+        // withheld — the exact state the cap's own rationale says must not
+        // exist (review #550 round 2 M1). The footer stays as the link; this
+        // is the part that has to be true without scrolling.
+        const total = sample.lines.length;
+        const tally = document.createElement("p");
+        tally.className = "sonda-livegen__logtally";
+        tally.textContent =
+          total > LOG_LINES_SHOWN
+            ? `Showing the first ${LOG_LINES_SHOWN} of ${total} events`
+            : `${total} events`;
         output.replaceChildren(
+          tally,
           logStream(sample, { prefix: "sonda-livegen", limit: LOG_LINES_SHOWN })
         );
       } else {

--- a/docs/site/docs/javascripts/playground.js
+++ b/docs/site/docs/javascripts/playground.js
@@ -19,6 +19,16 @@ import {
   cursorSamples,
   logLinesNear,
 } from "./sonda-pure.js";
+// Shared with livegen.js so the two pages cannot drift on what a histogram,
+// a summary or a log line looks like. Extracted verbatim — see signal-render.js.
+import {
+  palette,
+  formatNumber,
+  formatSeconds,
+  drawHistogramHeatmap,
+  drawSummaryBands,
+  logStream,
+} from "./signal-render.js";
 
 const MAX_TICKS = 240;
 const DEBOUNCE_MS = 500;
@@ -825,20 +835,10 @@ function renderLogs(el, logs, correlatable) {
     const caption = document.createElement("p");
     caption.textContent = `${log.name} — synthetic log stream (${log.lines.length} events)`;
     caption.style.cssText = "font: 12px ui-monospace, monospace; opacity: .75; margin: 10px 0 2px;";
-    const stream = document.createElement("div");
-    stream.className = "sonda-playground__logstream";
-    for (const line of log.lines) {
-      const row = document.createElement("div");
-      row.className = `sonda-playground__logline sonda-playground__logline--${line.severity}`;
-      const at = document.createElement("span");
-      at.className = "sonda-playground__logat";
-      at.textContent = `+${line.secs.toFixed(line.secs % 1 ? 2 : 0)}s`;
-      const sev = document.createElement("span");
-      sev.className = "sonda-playground__logsev";
-      sev.textContent = line.severity.toUpperCase().padEnd(5);
-      row.append(at, sev, document.createTextNode(line.message));
-      stream.appendChild(row);
-    }
+    // Same element tree as before, built in signal-render.js. The prefix keeps
+    // the class names this page's stylesheet, its cursor correlation
+    // (`highlightLogs`) and its smoke assertions already depend on.
+    const stream = logStream(log, { prefix: "sonda-playground" });
     pane.append(caption, stream);
   }
 }
@@ -945,178 +945,6 @@ function scrollRowIntoPane(stream, row) {
   const rect = row.getBoundingClientRect();
   if (rect.top < pane.top) stream.scrollTop -= pane.top - rect.top;
   else if (rect.bottom > pane.bottom) stream.scrollTop += rect.bottom - pane.bottom;
-}
-
-function drawHistogramHeatmap(canvas, histogram) {
-  const colors = palette();
-  const dpr = window.devicePixelRatio || 1;
-  const cssWidth = canvas.parentElement.clientWidth;
-  const rows = histogram.bucket_bounds.length + 1; // +Inf row on top
-  const rowHeight = Math.max(12, Math.min(20, Math.floor(240 / rows)));
-  const pad = { left: 64, right: 12, top: 8, bottom: 26 };
-  const cssHeight = pad.top + rows * rowHeight + pad.bottom;
-  canvas.width = cssWidth * dpr;
-  canvas.height = cssHeight * dpr;
-  canvas.style.width = cssWidth + "px";
-  canvas.style.height = cssHeight + "px";
-  const ctx = canvas.getContext("2d");
-  ctx.scale(dpr, dpr);
-  ctx.clearRect(0, 0, cssWidth, cssHeight);
-
-  const ticks = histogram.counts.length;
-  if (!ticks) return;
-  const offset = histogram.offset_secs || 0;
-  const spanSecs = offset + ticks * histogram.tick_secs;
-  const plotW = cssWidth - pad.left - pad.right;
-  const x = (secs) => pad.left + (secs / spanSecs) * plotW;
-  // Row 0 (lowest bucket) sits at the bottom, like a latency axis.
-  const rowY = (row) => pad.top + (rows - 1 - row) * rowHeight;
-
-  let maxCount = 1;
-  for (const row of histogram.counts) {
-    for (const count of row) if (count > maxCount) maxCount = count;
-  }
-
-  const cellW = Math.max(1, (histogram.tick_secs / spanSecs) * plotW);
-  histogram.counts.forEach((rowCounts, tick) => {
-    const px = x(offset + tick * histogram.tick_secs);
-    rowCounts.forEach((count, row) => {
-      if (!count) return;
-      const alpha = 0.12 + 0.88 * (count / maxCount);
-      ctx.fillStyle = `rgba(249, 115, 22, ${alpha.toFixed(3)})`;
-      ctx.fillRect(px, rowY(row), cellW + 0.5, rowHeight - 1);
-    });
-  });
-
-  ctx.fillStyle = colors.text;
-  ctx.font = "10px ui-monospace, monospace";
-  ctx.textAlign = "right";
-  const labelEvery = Math.ceil(rows / 12);
-  for (let row = 0; row < rows; row++) {
-    if (row % labelEvery !== 0 && row !== rows - 1) continue;
-    const label = row === rows - 1 ? "+Inf" : `≤${formatBound(histogram.bucket_bounds[row])}`;
-    ctx.fillText(label, pad.left - 6, rowY(row) + rowHeight / 2 + 3);
-  }
-  ctx.textAlign = "center";
-  const xSteps = Math.min(6, Math.max(2, Math.floor(plotW / 110)));
-  for (let step = 0; step <= xSteps; step++) {
-    const secs = (spanSecs * step) / xSteps;
-    ctx.fillText(formatSeconds(secs), x(secs), cssHeight - 8);
-  }
-}
-
-function drawSummaryBands(canvas, summary) {
-  const colors = palette();
-  const dpr = window.devicePixelRatio || 1;
-  const cssWidth = canvas.parentElement.clientWidth;
-  const cssHeight = 220;
-  canvas.width = cssWidth * dpr;
-  canvas.height = cssHeight * dpr;
-  canvas.style.width = cssWidth + "px";
-  canvas.style.height = cssHeight + "px";
-  const ctx = canvas.getContext("2d");
-  ctx.scale(dpr, dpr);
-  ctx.clearRect(0, 0, cssWidth, cssHeight);
-
-  const ticks = summary.values.length;
-  const quantileCount = summary.quantiles.length;
-  if (!ticks || !quantileCount) return;
-
-  const pad = { left: 48, right: 46, top: 12, bottom: 26 };
-  const plotW = cssWidth - pad.left - pad.right;
-  const plotH = cssHeight - pad.top - pad.bottom;
-  const offset = summary.offset_secs || 0;
-  const spanSecs = offset + (ticks - 1) * summary.tick_secs;
-
-  let min = Infinity;
-  let max = -Infinity;
-  for (const row of summary.values) {
-    for (const value of row) {
-      if (value < min) min = value;
-      if (value > max) max = value;
-    }
-  }
-  if (!Number.isFinite(min)) return;
-  if (max - min < 1e-12) {
-    min -= 1;
-    max += 1;
-  }
-  const range = max - min;
-  min -= range * 0.08;
-  max += range * 0.08;
-  const x = (tick) => pad.left + ((offset + tick * summary.tick_secs) / spanSecs) * plotW;
-  const y = (value) => pad.top + (1 - (value - min) / (max - min)) * plotH;
-
-  ctx.strokeStyle = colors.grid;
-  ctx.fillStyle = colors.text;
-  ctx.lineWidth = 1;
-  ctx.font = "10px ui-monospace, monospace";
-  ctx.setLineDash([2, 5]);
-  for (let row = 0; row <= 3; row++) {
-    const value = min + ((max - min) * row) / 3;
-    const gy = y(value);
-    ctx.beginPath();
-    ctx.moveTo(pad.left, gy);
-    ctx.lineTo(cssWidth - pad.right, gy);
-    ctx.stroke();
-    ctx.textAlign = "right";
-    ctx.fillText(formatNumber(value), pad.left - 6, gy + 3);
-  }
-  ctx.setLineDash([]);
-
-  // Envelope between the lowest and highest quantile, then one line per
-  // quantile, brightest at the median end.
-  ctx.fillStyle = "rgba(59, 130, 246, 0.14)";
-  ctx.beginPath();
-  summary.values.forEach((row, tick) => {
-    const py = y(row[0]);
-    if (tick === 0) ctx.moveTo(x(tick), py);
-    else ctx.lineTo(x(tick), py);
-  });
-  for (let tick = ticks - 1; tick >= 0; tick--) {
-    ctx.lineTo(x(tick), y(summary.values[tick][quantileCount - 1]));
-  }
-  ctx.closePath();
-  ctx.fill();
-
-  for (let q = 0; q < quantileCount; q++) {
-    const alpha = 0.35 + 0.65 * (1 - q / Math.max(1, quantileCount - 1));
-    ctx.strokeStyle = `rgba(59, 130, 246, ${alpha.toFixed(3)})`;
-    ctx.lineWidth = q === 0 ? 2 : 1.4;
-    ctx.beginPath();
-    summary.values.forEach((row, tick) => {
-      const py = y(row[q]);
-      if (tick === 0) ctx.moveTo(x(tick), py);
-      else ctx.lineTo(x(tick), py);
-    });
-    ctx.stroke();
-    ctx.fillStyle = colors.text;
-    ctx.textAlign = "left";
-    const lastY = y(summary.values[ticks - 1][q]);
-    ctx.fillText(`p${Math.round(summary.quantiles[q] * 100)}`, cssWidth - pad.right + 4, lastY + 3);
-  }
-
-  ctx.fillStyle = colors.text;
-  ctx.textAlign = "center";
-  const xSteps = Math.min(6, Math.max(2, Math.floor(plotW / 110)));
-  for (let step = 0; step <= xSteps; step++) {
-    const secs = (spanSecs * step) / xSteps;
-    const px = pad.left + (secs / spanSecs) * plotW;
-    ctx.fillText(formatSeconds(secs), px, cssHeight - 8);
-  }
-}
-
-function palette() {
-  const dark = document.body.getAttribute("data-md-color-scheme") === "slate";
-  return {
-    grid: dark ? "rgba(148, 163, 184, 0.25)" : "rgba(100, 116, 139, 0.25)",
-    text: dark ? "#94a3b8" : "#64748b",
-    gap: dark ? "rgba(148, 163, 184, 0.14)" : "rgba(100, 116, 139, 0.12)",
-    burst: dark ? "rgba(253, 186, 116, 0.14)" : "rgba(249, 115, 22, 0.10)",
-    // Backing plate for the burst label, which is drawn INSIDE the plot
-    // and would otherwise be read through whatever trace passes behind it.
-    plate: dark ? "rgba(15, 23, 42, 0.82)" : "rgba(255, 255, 255, 0.82)",
-  };
 }
 
 /* The line chart.
@@ -1414,25 +1242,6 @@ function drawChart(canvas, entries, opts = {}) {
 
 /* Bucket bounds need more precision than axis ticks — 0.005 and 0.01 are
  * distinct buckets and must not round to the same label. */
-function formatBound(value) {
-  if (value !== 0 && Math.abs(value) < 0.01) return value.toPrecision(1);
-  return formatNumber(value);
-}
-
-function formatNumber(value) {
-  if (Math.abs(value) >= 1000) return value.toFixed(0);
-  if (Math.abs(value) >= 10) return value.toFixed(1);
-  return value.toFixed(2);
-}
-
-function formatSeconds(secs) {
-  const rounded = Math.round(secs);
-  if (rounded < 60) return `${rounded}s`;
-  const mins = Math.floor(rounded / 60);
-  const rest = rounded % 60;
-  return rest ? `${mins}m${rest}s` : `${mins}m`;
-}
-
 if (window.document$ && typeof window.document$.subscribe === "function") {
   window.document$.subscribe(boot);
 } else if (document.readyState === "loading") {

--- a/docs/site/docs/javascripts/signal-render.js
+++ b/docs/site/docs/javascripts/signal-render.js
@@ -19,10 +19,18 @@
 
 /* Chart colors for the current Material color scheme.
  *
- * The union of what both callers had: playground.js never read `line` and
- * livegen.js never read `plate`, and the six keys they shared were identical
- * strings. Keeping the union means neither caller changed behaviour when its
- * own copy was deleted.
+ * The union of what both callers had. Measured against origin/main before the
+ * deletions rather than remembered (review #550 M1 corrected the first
+ * version of this sentence, which had it backwards):
+ *
+ *   playground.js palette()  grid text      gap burst plate   (5 keys)
+ *   livegen.js    palette()  grid text line gap burst plate   (6 keys)
+ *
+ * So livegen read BOTH `line` and `plate`; playground was the file that never
+ * had `line` at all, and the genuinely shared set is FIVE keys, not six. All
+ * five were byte-equal strings in the two copies, which is why keeping the
+ * union left neither caller's behaviour changed when its own copy was
+ * deleted.
  */
 export function palette() {
   const dark = document.body.getAttribute("data-md-color-scheme") === "slate";
@@ -236,10 +244,11 @@ export function drawSummaryBands(canvas, summary) {
  * Text goes in via `textContent` and `createTextNode`, never markup: a log
  * message is generated content and `check_no_raw_html.sh` holds the floor.
  */
-export function logStream(log, { prefix }) {
+export function logStream(log, { prefix, limit = Infinity }) {
   const stream = document.createElement("div");
   stream.className = `${prefix}__logstream`;
-  for (const line of log.lines) {
+  const shown = log.lines.length > limit ? log.lines.slice(0, limit) : log.lines;
+  for (const line of shown) {
     const row = document.createElement("div");
     row.className = `${prefix}__logline ${prefix}__logline--${line.severity}`;
     const at = document.createElement("span");
@@ -250,6 +259,15 @@ export function logStream(log, { prefix }) {
     sev.textContent = line.severity.toUpperCase().padEnd(5);
     row.append(at, sev, document.createTextNode(line.message));
     stream.appendChild(row);
+  }
+  // Say what was withheld rather than just stopping. A pane that silently
+  // ends at line 40 of 240 tells the reader the scenario produced 40 events,
+  // which is the one thing it must not do on a page teaching `rate`.
+  if (shown.length < log.lines.length) {
+    const more = document.createElement("div");
+    more.className = `${prefix}__logmore`;
+    more.textContent = `… ${log.lines.length - shown.length} more events — open in the playground for the whole stream`;
+    stream.appendChild(more);
   }
   return stream;
 }

--- a/docs/site/docs/javascripts/signal-render.js
+++ b/docs/site/docs/javascripts/signal-render.js
@@ -1,0 +1,255 @@
+/* Sonda docs — rendering shared between the playground and the live widgets.
+ *
+ * Extracted rather than copied (the #543 precedent). Everything here already
+ * existed twice or was about to: `palette`, `formatNumber` and `formatSeconds`
+ * were duplicated character-for-character between playground.js and
+ * livegen.js, and WP14 needed the histogram, summary and log renderers on
+ * generators.md as well as on the playground. Two identical definitions that
+ * nothing holds together are one edit away from disagreeing, and the thing
+ * they would disagree about is what a reader sees on two pages that are
+ * supposed to be teaching the same signal.
+ *
+ * No wasm and no scenario knowledge: these functions take an already-sampled
+ * entry from `sample_scenario` and put pixels or elements on the page. What to
+ * sample, and whether there is anything worth drawing, stays with the caller.
+ *
+ * NOT bundle-coupled. Only sonda-pure.js is compiled into the editor bundle,
+ * so changes here do not move the drift gate.
+ */
+
+/* Chart colors for the current Material color scheme.
+ *
+ * The union of what both callers had: playground.js never read `line` and
+ * livegen.js never read `plate`, and the six keys they shared were identical
+ * strings. Keeping the union means neither caller changed behaviour when its
+ * own copy was deleted.
+ */
+export function palette() {
+  const dark = document.body.getAttribute("data-md-color-scheme") === "slate";
+  return {
+    grid: dark ? "rgba(148, 163, 184, 0.25)" : "rgba(100, 116, 139, 0.25)",
+    text: dark ? "#94a3b8" : "#64748b",
+    line: "#f97316",
+    // Same two washes on both pages, for the same reason: a reader who learns
+    // what the grey band means on one page should not have to learn it again
+    // on the other.
+    gap: dark ? "rgba(148, 163, 184, 0.14)" : "rgba(100, 116, 139, 0.12)",
+    burst: dark ? "rgba(253, 186, 116, 0.14)" : "rgba(249, 115, 22, 0.10)",
+    // Backing plate for the burst label, which is drawn INSIDE the plot
+    // and would otherwise be read through whatever trace passes behind it.
+    plate: dark ? "rgba(15, 23, 42, 0.82)" : "rgba(255, 255, 255, 0.82)",
+  };
+}
+
+export function formatNumber(value) {
+  if (Math.abs(value) >= 1000) return value.toFixed(0);
+  if (Math.abs(value) >= 10) return value.toFixed(1);
+  return value.toFixed(2);
+}
+
+export function formatSeconds(secs) {
+  const rounded = Math.round(secs);
+  if (rounded < 60) return `${rounded}s`;
+  const mins = Math.floor(rounded / 60);
+  const rest = rounded % 60;
+  return rest ? `${mins}m${rest}s` : `${mins}m`;
+}
+
+/* Bucket bounds go small: a latency histogram's lowest bucket is routinely
+ * 0.005, and `formatNumber` floors at two decimals, so it would render that as
+ * "0.01" — the same string as the 0.01 bucket above it. Two axis rows reading
+ * the same number is worse than one long row, hence the significant-figure
+ * escape hatch below 0.01. */
+export function formatBound(value) {
+  if (value !== 0 && Math.abs(value) < 0.01) return value.toPrecision(1);
+  return formatNumber(value);
+}
+
+export function drawHistogramHeatmap(canvas, histogram) {
+  const colors = palette();
+  const dpr = window.devicePixelRatio || 1;
+  const cssWidth = canvas.parentElement.clientWidth;
+  const rows = histogram.bucket_bounds.length + 1; // +Inf row on top
+  const rowHeight = Math.max(12, Math.min(20, Math.floor(240 / rows)));
+  const pad = { left: 64, right: 12, top: 8, bottom: 26 };
+  const cssHeight = pad.top + rows * rowHeight + pad.bottom;
+  canvas.width = cssWidth * dpr;
+  canvas.height = cssHeight * dpr;
+  canvas.style.width = cssWidth + "px";
+  canvas.style.height = cssHeight + "px";
+  const ctx = canvas.getContext("2d");
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, cssWidth, cssHeight);
+
+  const ticks = histogram.counts.length;
+  if (!ticks) return;
+  const offset = histogram.offset_secs || 0;
+  const spanSecs = offset + ticks * histogram.tick_secs;
+  const plotW = cssWidth - pad.left - pad.right;
+  const x = (secs) => pad.left + (secs / spanSecs) * plotW;
+  // Row 0 (lowest bucket) sits at the bottom, like a latency axis.
+  const rowY = (row) => pad.top + (rows - 1 - row) * rowHeight;
+
+  let maxCount = 1;
+  for (const row of histogram.counts) {
+    for (const count of row) if (count > maxCount) maxCount = count;
+  }
+
+  const cellW = Math.max(1, (histogram.tick_secs / spanSecs) * plotW);
+  histogram.counts.forEach((rowCounts, tick) => {
+    const px = x(offset + tick * histogram.tick_secs);
+    rowCounts.forEach((count, row) => {
+      if (!count) return;
+      const alpha = 0.12 + 0.88 * (count / maxCount);
+      ctx.fillStyle = `rgba(249, 115, 22, ${alpha.toFixed(3)})`;
+      ctx.fillRect(px, rowY(row), cellW + 0.5, rowHeight - 1);
+    });
+  });
+
+  ctx.fillStyle = colors.text;
+  ctx.font = "10px ui-monospace, monospace";
+  ctx.textAlign = "right";
+  const labelEvery = Math.ceil(rows / 12);
+  for (let row = 0; row < rows; row++) {
+    if (row % labelEvery !== 0 && row !== rows - 1) continue;
+    const label = row === rows - 1 ? "+Inf" : `≤${formatBound(histogram.bucket_bounds[row])}`;
+    ctx.fillText(label, pad.left - 6, rowY(row) + rowHeight / 2 + 3);
+  }
+  ctx.textAlign = "center";
+  const xSteps = Math.min(6, Math.max(2, Math.floor(plotW / 110)));
+  for (let step = 0; step <= xSteps; step++) {
+    const secs = (spanSecs * step) / xSteps;
+    ctx.fillText(formatSeconds(secs), x(secs), cssHeight - 8);
+  }
+}
+
+export function drawSummaryBands(canvas, summary) {
+  const colors = palette();
+  const dpr = window.devicePixelRatio || 1;
+  const cssWidth = canvas.parentElement.clientWidth;
+  const cssHeight = 220;
+  canvas.width = cssWidth * dpr;
+  canvas.height = cssHeight * dpr;
+  canvas.style.width = cssWidth + "px";
+  canvas.style.height = cssHeight + "px";
+  const ctx = canvas.getContext("2d");
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, cssWidth, cssHeight);
+
+  const ticks = summary.values.length;
+  const quantileCount = summary.quantiles.length;
+  if (!ticks || !quantileCount) return;
+
+  const pad = { left: 48, right: 46, top: 12, bottom: 26 };
+  const plotW = cssWidth - pad.left - pad.right;
+  const plotH = cssHeight - pad.top - pad.bottom;
+  const offset = summary.offset_secs || 0;
+  const spanSecs = offset + (ticks - 1) * summary.tick_secs;
+
+  let min = Infinity;
+  let max = -Infinity;
+  for (const row of summary.values) {
+    for (const value of row) {
+      if (value < min) min = value;
+      if (value > max) max = value;
+    }
+  }
+  if (!Number.isFinite(min)) return;
+  if (max - min < 1e-12) {
+    min -= 1;
+    max += 1;
+  }
+  const range = max - min;
+  min -= range * 0.08;
+  max += range * 0.08;
+  const x = (tick) => pad.left + ((offset + tick * summary.tick_secs) / spanSecs) * plotW;
+  const y = (value) => pad.top + (1 - (value - min) / (max - min)) * plotH;
+
+  ctx.strokeStyle = colors.grid;
+  ctx.fillStyle = colors.text;
+  ctx.lineWidth = 1;
+  ctx.font = "10px ui-monospace, monospace";
+  ctx.setLineDash([2, 5]);
+  for (let row = 0; row <= 3; row++) {
+    const value = min + ((max - min) * row) / 3;
+    const gy = y(value);
+    ctx.beginPath();
+    ctx.moveTo(pad.left, gy);
+    ctx.lineTo(cssWidth - pad.right, gy);
+    ctx.stroke();
+    ctx.textAlign = "right";
+    ctx.fillText(formatNumber(value), pad.left - 6, gy + 3);
+  }
+  ctx.setLineDash([]);
+
+  // Envelope between the lowest and highest quantile, then one line per
+  // quantile, brightest at the median end.
+  ctx.fillStyle = "rgba(59, 130, 246, 0.14)";
+  ctx.beginPath();
+  summary.values.forEach((row, tick) => {
+    const py = y(row[0]);
+    if (tick === 0) ctx.moveTo(x(tick), py);
+    else ctx.lineTo(x(tick), py);
+  });
+  for (let tick = ticks - 1; tick >= 0; tick--) {
+    ctx.lineTo(x(tick), y(summary.values[tick][quantileCount - 1]));
+  }
+  ctx.closePath();
+  ctx.fill();
+
+  for (let q = 0; q < quantileCount; q++) {
+    const alpha = 0.35 + 0.65 * (1 - q / Math.max(1, quantileCount - 1));
+    ctx.strokeStyle = `rgba(59, 130, 246, ${alpha.toFixed(3)})`;
+    ctx.lineWidth = q === 0 ? 2 : 1.4;
+    ctx.beginPath();
+    summary.values.forEach((row, tick) => {
+      const py = y(row[q]);
+      if (tick === 0) ctx.moveTo(x(tick), py);
+      else ctx.lineTo(x(tick), py);
+    });
+    ctx.stroke();
+    ctx.fillStyle = colors.text;
+    ctx.textAlign = "left";
+    const lastY = y(summary.values[ticks - 1][q]);
+    ctx.fillText(`p${Math.round(summary.quantiles[q] * 100)}`, cssWidth - pad.right + 4, lastY + 3);
+  }
+
+  ctx.fillStyle = colors.text;
+  ctx.textAlign = "center";
+  const xSteps = Math.min(6, Math.max(2, Math.floor(plotW / 110)));
+  for (let step = 0; step <= xSteps; step++) {
+    const secs = (spanSecs * step) / xSteps;
+    const px = pad.left + (secs / spanSecs) * plotW;
+    ctx.fillText(formatSeconds(secs), px, cssHeight - 8);
+  }
+}
+
+/* One scrollable block of log lines, each stamped with its offset on the
+ * scenario timeline and colored by severity.
+ *
+ * `prefix` names the BEM block the CSS hangs off, because the two callers are
+ * on different pages with different surrounding type. It is a parameter rather
+ * than a hard-coded string so the playground keeps the exact class names its
+ * stylesheet and its smoke assertions already use — an extraction that renames
+ * things is a rewrite wearing an extraction's clothes.
+ *
+ * Text goes in via `textContent` and `createTextNode`, never markup: a log
+ * message is generated content and `check_no_raw_html.sh` holds the floor.
+ */
+export function logStream(log, { prefix }) {
+  const stream = document.createElement("div");
+  stream.className = `${prefix}__logstream`;
+  for (const line of log.lines) {
+    const row = document.createElement("div");
+    row.className = `${prefix}__logline ${prefix}__logline--${line.severity}`;
+    const at = document.createElement("span");
+    at.className = `${prefix}__logat`;
+    at.textContent = `+${line.secs.toFixed(line.secs % 1 ? 2 : 0)}s`;
+    const sev = document.createElement("span");
+    sev.className = `${prefix}__logsev`;
+    sev.textContent = line.severity.toUpperCase().padEnd(5);
+    row.append(at, sev, document.createTextNode(line.message));
+    stream.appendChild(row);
+  }
+  return stream;
+}

--- a/docs/site/docs/stylesheets/sonda.css
+++ b/docs/site/docs/stylesheets/sonda.css
@@ -1200,6 +1200,15 @@
   white-space: nowrap;
 }
 
+/* How many events the pane is showing, and of how many. Sits above the
+   stream so it is true at rest rather than only after a scroll. */
+.md-typeset .sonda-livegen__logtally {
+  margin: 0 0 0.35rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.68rem;
+  opacity: 0.7;
+}
+
 /* The "and N more" footer on a capped stream. Livegen-only by construction:
    the playground renders its stream entire, so this row never appears there. */
 .sonda-livegen__logmore {

--- a/docs/site/docs/stylesheets/sonda.css
+++ b/docs/site/docs/stylesheets/sonda.css
@@ -1200,6 +1200,17 @@
   white-space: nowrap;
 }
 
+/* The "and N more" footer on a capped stream. Livegen-only by construction:
+   the playground renders its stream entire, so this row never appears there. */
+.sonda-livegen__logmore {
+  margin-top: 0.35rem;
+  padding-top: 0.35rem;
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+  opacity: 0.65;
+  font-style: italic;
+  white-space: normal;
+}
+
 .sonda-playground__logat,
 .sonda-livegen__logat {
   display: inline-block;

--- a/docs/site/docs/stylesheets/sonda.css
+++ b/docs/site/docs/stylesheets/sonda.css
@@ -995,6 +995,14 @@
   display: block;
 }
 
+/* The logs widget's output slot. The stream inside it carries its own border
+   and scroll (shared with the playground pane), so this is only a block-level
+   wrapper — a second border here would draw a box inside a box. */
+.sonda-livegen__logs {
+  width: 100%;
+  display: block;
+}
+
 .sonda-livegen__controls {
   display: flex;
   flex-wrap: wrap;
@@ -1174,7 +1182,8 @@
   opacity: 0.7;
 }
 
-.sonda-playground__logstream {
+.sonda-playground__logstream,
+.sonda-livegen__logstream {
   max-height: 16rem;
   overflow-y: auto;
   border: 1px solid var(--md-default-fg-color--lightest);
@@ -1186,50 +1195,63 @@
   background: var(--md-code-bg-color);
 }
 
-.sonda-playground__logline {
+.sonda-playground__logline,
+.sonda-livegen__logline {
   white-space: nowrap;
 }
 
-.sonda-playground__logat {
+.sonda-playground__logat,
+.sonda-livegen__logat {
   display: inline-block;
   min-width: 3.6rem;
   opacity: 0.55;
 }
 
-.sonda-playground__logsev {
+.sonda-playground__logsev,
+.sonda-livegen__logsev {
   display: inline-block;
   min-width: 3.6rem;
   font-weight: 700;
 }
 
 .sonda-playground__logline--trace .sonda-playground__logsev,
-.sonda-playground__logline--debug .sonda-playground__logsev {
+.sonda-playground__logline--debug .sonda-playground__logsev,
+.sonda-livegen__logline--trace .sonda-livegen__logsev,
+.sonda-livegen__logline--debug .sonda-livegen__logsev {
   color: var(--md-default-fg-color--light);
 }
 
-.sonda-playground__logline--info .sonda-playground__logsev {
+.sonda-playground__logline--info .sonda-playground__logsev,
+.sonda-livegen__logline--info .sonda-livegen__logsev {
   color: #2563eb;
 }
 
-.sonda-playground__logline--warn .sonda-playground__logsev {
+.sonda-playground__logline--warn .sonda-playground__logsev,
+.sonda-livegen__logline--warn .sonda-livegen__logsev {
   color: #a16207;
 }
 
-[data-md-color-scheme="slate"] .sonda-playground__logline--warn .sonda-playground__logsev {
+[data-md-color-scheme="slate"] .sonda-playground__logline--warn .sonda-playground__logsev,
+[data-md-color-scheme="slate"] .sonda-livegen__logline--warn .sonda-livegen__logsev {
   color: #facc15;
 }
 
 .sonda-playground__logline--error .sonda-playground__logsev,
-.sonda-playground__logline--fatal .sonda-playground__logsev {
+.sonda-playground__logline--fatal .sonda-playground__logsev,
+.sonda-livegen__logline--error .sonda-livegen__logsev,
+.sonda-livegen__logline--fatal .sonda-livegen__logsev {
   color: #dc2626;
 }
 
 [data-md-color-scheme="slate"] .sonda-playground__logline--error .sonda-playground__logsev,
-[data-md-color-scheme="slate"] .sonda-playground__logline--fatal .sonda-playground__logsev {
+[data-md-color-scheme="slate"] .sonda-playground__logline--fatal .sonda-playground__logsev,
+[data-md-color-scheme="slate"] .sonda-livegen__logline--error .sonda-livegen__logsev,
+[data-md-color-scheme="slate"] .sonda-livegen__logline--fatal .sonda-livegen__logsev {
   color: #f87171;
 }
 
-[data-md-color-scheme="slate"] .sonda-playground__logline--info .sonda-playground__logsev {
+[data-md-color-scheme="slate"] .sonda-playground__logline--info .sonda-playground__logsev,
+[data-md-color-scheme="slate"] .sonda-livegen__logline--info .sonda-livegen__logsev {
   color: #60a5fa;
 }
 

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -380,6 +380,18 @@ try {
   });
   check("the widget reports no engine error", widgetError === null, widgetError || "");
 
+  // Widgets mount on intersection, so each one has to be scrolled to before it
+  // exists. Shared by the WP13 and WP14 loops below rather than written twice.
+  const scrollAndMount = (page, sel) =>
+    page
+      .evaluate((s) => {
+        const host = document.querySelector(s);
+        if (!host) return { found: false };
+        host.scrollIntoView();
+        return { found: true };
+      }, sel)
+      .catch(() => ({ found: false }));
+
   // WP13 completed the core-generator set, so the page now carries widgets of
   // two SHAPES: slider-driven, and the choice-driven `sequence` whose whole
   // input is a <select>. Section 8 above only ever mounted whichever widget
@@ -391,14 +403,7 @@ try {
   // page where five placeholders rendered five empty boxes.
   for (const gen of ["constant", "sawtooth", "uniform", "step", "sequence"]) {
     const selector = `.sonda-livegen[data-gen="${gen}"]`;
-    const mounted = await widgets
-      .evaluate(async (sel) => {
-        const host = document.querySelector(sel);
-        if (!host) return { found: false };
-        host.scrollIntoView();
-        return { found: true };
-      }, selector)
-      .catch(() => ({ found: false }));
+    const mounted = await scrollAndMount(widgets, selector);
 
     let drew = false;
     if (mounted.found) {
@@ -455,6 +460,133 @@ try {
     : false;
   check("choosing a different sequence pattern redraws the chart", seqChanged,
     seqSelect ? `was ${seqBefore} chars` : 'no <select data-key="pattern"> rendered');
+
+  // --- 8b. WP14: the three sections that are not metrics -----------------
+  //
+  // These exercise the renderers extracted out of playground.js. The engine
+  // error check is not decoration here: a logs widget on the metrics default
+  // encoder COMPILES and fails at sampling, so the compile gate is green and
+  // only this sees it.
+  for (const gen of ["histogram", "summary"]) {
+    const sel = `.sonda-livegen[data-gen="${gen}"]`;
+    const mounted = await scrollAndMount(widgets, sel);
+    // Condition-based: mounting is asynchronous (intersection observer, then
+    // the lazily-fetched wasm), so reading the DOM straight after scrolling
+    // reads it before the widget exists.
+    const shot = await widgets
+      .waitForFunction(
+        ([s, min]) => {
+          const el = document.querySelector(s);
+          const err = el?.querySelector(".sonda-livegen__error");
+          if (err && !err.hidden) return { pixels: 0, height: 0, error: err.textContent };
+          const canvas = el?.querySelector("canvas");
+          if (!canvas) return false;
+          const pixels = canvas.toDataURL().length;
+          return pixels > min ? { pixels, height: canvas.height, error: null } : false;
+        },
+        [sel, WIDGET_CHART_WITH_DATA],
+        { timeout: 60000 }
+      )
+      .then((h) => h.jsonValue())
+      .catch(() => ({ pixels: 0, height: 0, error: "never drew" }));
+    check(`the ${gen} widget mounts and draws`,
+      mounted.found && shot.pixels > WIDGET_CHART_WITH_DATA && shot.error === null,
+      shot.error || (mounted.found ? `dataURL ${shot.pixels}` : "no placeholder on the page"));
+  }
+
+  // The half the pure module cannot check: it bounds ticks x observations,
+  // but the heatmap's ROW count comes from the engine's default bucket ladder
+  // for the named distribution, which no JS in this repo knows. Measured here
+  // against the real sampler, at the corner where both sliders are at max.
+  const histSel = '.sonda-livegen[data-gen="histogram"]';
+  await widgets.evaluate((s) => {
+    for (const input of document.querySelectorAll(`${s} input[type="range"]`)) {
+      input.value = input.max;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+  }, histSel);
+  const histAtMax = await widgets
+    .waitForFunction(
+      (s) => {
+        const c = document.querySelector(s)?.querySelector("canvas");
+        // rows are the only thing that sets height: pad(8+26) + rows*rowHeight
+        return c && c.height > 0 ? { height: c.height, pixels: c.toDataURL().length } : false;
+      },
+      histSel,
+      { timeout: 30000 }
+    )
+    .then((h) => h.jsonValue())
+    .catch(() => null);
+  // 34px of padding plus at most 40 rows at the 20px maximum row height. A
+  // ladder that outgrows this is one a reader has to scroll a chart to read.
+  const HEATMAP_MAX_HEIGHT = 34 + 40 * 20;
+  check("the heatmap stays bounded with both sliders at maximum",
+    histAtMax !== null && histAtMax.height <= HEATMAP_MAX_HEIGHT && histAtMax.pixels > WIDGET_CHART_WITH_DATA,
+    histAtMax ? `canvas ${histAtMax.height}px, ceiling ${HEATMAP_MAX_HEIGHT}px` : "never redrew");
+
+  // The logs widget renders ELEMENTS, not pixels — a log line is text, and
+  // drawing it into a canvas would make it unselectable and invisible to a
+  // screen reader. So it is checked as DOM.
+  const logSel = '.sonda-livegen[data-gen="log_template"]';
+  const logMounted = await scrollAndMount(widgets, logSel);
+  const stream = await widgets
+    .waitForFunction(
+      (s) => {
+        const el = document.querySelector(s);
+        const err = el?.querySelector(".sonda-livegen__error");
+        if (err && !err.hidden)
+          return { lines: 0, severities: [], stamped: 0, error: err.textContent };
+        const pane = el?.querySelector(".sonda-livegen__logstream");
+        if (!pane || !pane.children.length) return false;
+        const rows = [...pane.children];
+        return {
+          lines: rows.length,
+          severities: [...new Set(rows.map((r) => (r.className.match(/logline--(\w+)/) || [])[1]))],
+          stamped: rows.filter((r) => /^\+\d/.test(r.textContent)).length,
+          error: null,
+        };
+      },
+      logSel,
+      { timeout: 60000 }
+    )
+    .then((h) => h.jsonValue())
+    .catch(() => ({ lines: 0, severities: [], stamped: 0, error: "never rendered" }));
+  check("the log_template widget renders a severity-coloured stream",
+    logMounted.found && stream.lines > 0 && stream.error === null,
+    stream.error || `${stream.lines} line(s)`);
+  check("every log line is stamped with its offset on the timeline",
+    stream.lines > 0 && stream.stamped === stream.lines,
+    `${stream.stamped}/${stream.lines} stamped`);
+  check("the stream carries more than one severity, so the colouring means something",
+    stream.severities.filter(Boolean).length > 1,
+    stream.severities.join(" · ") || "none");
+
+  // The reviewer's other named corner: error weight at 0 is the ordinary
+  // healthy service, and it must still render rather than producing an empty
+  // pane or a division by zero in the engine's weighting.
+  await widgets.evaluate((s) => {
+    for (const input of document.querySelectorAll(`${s} input[type="range"]`)) {
+      input.value = input.min;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+  }, logSel);
+  const atZero = await widgets
+    .waitForFunction(
+      (s) => {
+        const el = document.querySelector(s);
+        const err = el?.querySelector(".sonda-livegen__error");
+        if (err && !err.hidden) return { lines: 0, error: err.textContent };
+        const pane = el?.querySelector(".sonda-livegen__logstream");
+        return pane && pane.children.length ? { lines: pane.children.length, error: null } : false;
+      },
+      logSel,
+      { timeout: 30000 }
+    )
+    .then((h) => h.jsonValue())
+    .catch(() => null);
+  check("all severity weights at minimum still produces a stream",
+    atZero !== null && atZero.error === null && atZero.lines > 0,
+    atZero ? atZero.error || `${atZero.lines} line(s)` : "never settled");
 
   await widgets.close();
 

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -659,40 +659,58 @@ try {
   // could have reached the page behind a green suite. This one enumerates
   // whatever the PAGE actually carries, so a new placeholder is covered the
   // day it lands rather than the day someone remembers to add it here.
-  const everyWidget = await widgets.evaluate(() =>
-    [...document.querySelectorAll(".sonda-livegen[data-gen]")].map((el) => el.dataset.gen)
-  );
-  // One at a time, each scrolled and then WAITED FOR before moving on. The
-  // first version scrolled all of them in a loop with no await, so only the
-  // last one ever intersected and the rest never mounted — the check timed
-  // out on its own harness rather than on the page.
-  const complaints = [];
-  for (const gen of everyWidget) {
-    const sel = `.sonda-livegen[data-gen="${gen}"]`;
-    await scrollAndMount(widgets, sel);
-    const outcome = await widgets
-      .waitForFunction(
-        (s) => {
-          const el = document.querySelector(s);
-          if (!el) return { gen: null, error: "no placeholder" };
-          const err = el.querySelector(".sonda-livegen__error");
-          if (err && !err.hidden) return { error: err.textContent.trim().slice(0, 80) };
-          const canvas = el.querySelector("canvas");
-          if (canvas && canvas.height > 0) return { error: null };
-          return el.querySelector(".sonda-livegen__logstream, .sonda-livegen__preview")
-            ? { error: null }
-            : false;
-        },
-        sel,
-        { timeout: 30000 }
-      )
-      .then((h) => h.jsonValue())
-      .catch(() => ({ error: "never settled" }));
-    if (outcome.error) complaints.push(`${gen}: ${outcome.error}`);
-  }
-  check("every widget on the page samples without an engine error",
-    complaints.length === 0,
-    complaints.length ? complaints.join(" | ") : `${everyWidget.length} widget(s) clean`);
+  // Review #550 round 3 W1 found two holes in the round-2 version of this:
+  // it ran on ONE of the three pages that carry widgets, and it could not see
+  // a preview widget's failure at all, because `encode_preview(...)
+  // .unwrap_or_else(|reason| reason)` folds the engine's complaint into the
+  // preview STRING — the entry renders, no error box appears, and a check
+  // asking "is there an error box" reports clean while the pane labelled as
+  // the engine's bytes shows "requires the 'otlp' feature".
+  //
+  // So: every page that carries widgets, and a preview counts as failed when
+  // its own text is an engine complaint.
+  const auditWidgets = async (page, label) => {
+    const names = await page.evaluate(() =>
+      [...document.querySelectorAll(".sonda-livegen[data-gen]")].map((el) => el.dataset.gen)
+    );
+    const complaints = [];
+    for (const gen of names) {
+      const sel = `.sonda-livegen[data-gen="${gen}"]`;
+      await scrollAndMount(page, sel);
+      const outcome = await page
+        .waitForFunction(
+          (s) => {
+            const el = document.querySelector(s);
+            if (!el) return { error: "no placeholder" };
+            const err = el.querySelector(".sonda-livegen__error");
+            if (err && !err.hidden) return { error: err.textContent.trim().slice(0, 80) };
+            const preview = el.querySelector(".sonda-livegen__preview");
+            if (preview) {
+              const text = preview.textContent.trim();
+              if (!text) return false;
+              // The engine's own error vocabulary, anchored at the start: a
+              // metric line never begins this way.
+              return /^(configuration|encoder|compile|validation) error:/i.test(text)
+                ? { error: text.slice(0, 80) }
+                : { error: null };
+            }
+            const canvas = el.querySelector("canvas");
+            if (canvas && canvas.height > 0) return { error: null };
+            return el.querySelector(".sonda-livegen__logstream") ? { error: null } : false;
+          },
+          sel,
+          { timeout: 30000 }
+        )
+        .then((h) => h.jsonValue())
+        .catch(() => ({ error: "never settled" }));
+      if (outcome.error) complaints.push(`${gen}: ${outcome.error}`);
+    }
+    check(`every widget on ${label} samples without an engine error`,
+      complaints.length === 0,
+      complaints.length ? complaints.join(" | ") : `${names.length} widget(s) clean`);
+    return names.length;
+  };
+  await auditWidgets(widgets, "build/generators");
 
   await widgets.close();
 
@@ -845,6 +863,7 @@ try {
   const widgets2 = watch(await context.newPage());
   widgets2.setDefaultTimeout(30000);
   await widgets2.goto(`${BASE}/build/scheduling/`, { waitUntil: "domcontentloaded" });
+  await auditWidgets(widgets2, "build/scheduling");
 
   for (const gen of ["gaps", "bursts"]) {
     await widgets2.evaluate((g) => document.querySelector(`[data-gen="${g}"]`)?.scrollIntoView(), gen);
@@ -948,15 +967,29 @@ try {
     null,
     { timeout: 90000 }
   );
+  await auditWidgets(widgets2, "build/encoders");
+
   // Each option must produce output SHAPED like the format it names. A
   // widget that offered an encoder the wasm build lacks would show the
   // engine's "requires the 'otlp' feature" here instead.
-  const SHAPES = [
+  const SHAPES = new Map([
     ["prometheus_text", /^cpu_usage\{/],
     ["influx_lp", /^cpu_usage,/],
     ["json_lines", /^\{/],
-  ];
-  for (const [encoder, shape] of SHAPES) {
+  ]);
+  // Driven off the widget's OWN <option> list rather than the table, so a
+  // fourth encoder is exercised the day it is offered instead of the day
+  // someone remembers this loop exists (review #550 round 3 W1). The table
+  // still supplies the expected shape, and an option missing from it fails
+  // rather than being silently checked more weakly.
+  const offered = await widgets2.evaluate(() =>
+    [...document.querySelectorAll('[data-gen="encoders"] select option')].map((o) => o.value)
+  );
+  check("every encoder the widget offers has an expected output shape",
+    offered.length > 0 && offered.every((e) => SHAPES.has(e)),
+    offered.filter((e) => !SHAPES.has(e)).join(", ") || `${offered.length} option(s) covered`);
+  for (const encoder of offered) {
+    const shape = SHAPES.get(encoder) || /$^/;
     await widgets2.selectOption('[data-gen="encoders"] select', encoder);
     let matched = true;
     await widgets2

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -599,6 +599,29 @@ try {
     Number.isFinite(stream.withheld) && stream.withheld > 0,
     stream.withheld === null ? "no footer" : `${stream.withheld} withheld`);
 
+  // Review #550 round 2 M1. The footer sat 911px down a 318px window, so the
+  // view AT REST was 40 lines ending at +9.75s with nothing saying 200 were
+  // dropped — the state the cap's own rationale says must not exist. The
+  // count now sits above the pane; this asserts it is outside the scroll
+  // container rather than merely present in the DOM.
+  const logTally = await widgets.evaluate((s) => {
+    const el = document.querySelector(s);
+    const node = el?.querySelector(".sonda-livegen__logtally");
+    const pane = el?.querySelector(".sonda-livegen__logstream");
+    if (!node || !pane) return null;
+    return {
+      text: node.textContent.trim(),
+      aboveThePane: node.getBoundingClientRect().bottom <= pane.getBoundingClientRect().top + 1,
+      insidePane: pane.contains(node),
+    };
+  }, logSel);
+  check("the withheld count is readable without scrolling the pane",
+    logTally !== null &&
+      logTally.aboveThePane &&
+      !logTally.insidePane &&
+      /\b40\b.*\b240\b/.test(logTally.text),
+    logTally ? logTally.text : "no tally element");
+
   // The reviewer's other named corner: error weight at 0 is the ordinary
   // healthy service, and it must still render rather than producing an empty
   // pane or a division by zero in the engine's weighting.
@@ -629,6 +652,47 @@ try {
   check("all severity weights at minimum still produces a stream",
     atZero !== null && atZero.error === null && atZero.lines > 0,
     atZero ? atZero.error || `${atZero.lines} line(s)` : "never settled");
+
+  // Review #550 round 2 W1 named the structural hole: every check above
+  // enumerates widgets by NAME, so a widget added later is invisible to all
+  // of them — which is how an encoder that compiles and then fails to sample
+  // could have reached the page behind a green suite. This one enumerates
+  // whatever the PAGE actually carries, so a new placeholder is covered the
+  // day it lands rather than the day someone remembers to add it here.
+  const everyWidget = await widgets.evaluate(() =>
+    [...document.querySelectorAll(".sonda-livegen[data-gen]")].map((el) => el.dataset.gen)
+  );
+  // One at a time, each scrolled and then WAITED FOR before moving on. The
+  // first version scrolled all of them in a loop with no await, so only the
+  // last one ever intersected and the rest never mounted — the check timed
+  // out on its own harness rather than on the page.
+  const complaints = [];
+  for (const gen of everyWidget) {
+    const sel = `.sonda-livegen[data-gen="${gen}"]`;
+    await scrollAndMount(widgets, sel);
+    const outcome = await widgets
+      .waitForFunction(
+        (s) => {
+          const el = document.querySelector(s);
+          if (!el) return { gen: null, error: "no placeholder" };
+          const err = el.querySelector(".sonda-livegen__error");
+          if (err && !err.hidden) return { error: err.textContent.trim().slice(0, 80) };
+          const canvas = el.querySelector("canvas");
+          if (canvas && canvas.height > 0) return { error: null };
+          return el.querySelector(".sonda-livegen__logstream, .sonda-livegen__preview")
+            ? { error: null }
+            : false;
+        },
+        sel,
+        { timeout: 30000 }
+      )
+      .then((h) => h.jsonValue())
+      .catch(() => ({ error: "never settled" }));
+    if (outcome.error) complaints.push(`${gen}: ${outcome.error}`);
+  }
+  check("every widget on the page samples without an engine error",
+    complaints.length === 0,
+    complaints.length ? complaints.join(" | ") : `${everyWidget.length} widget(s) clean`);
 
   await widgets.close();
 

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -509,20 +509,41 @@ try {
     .waitForFunction(
       (s) => {
         const c = document.querySelector(s)?.querySelector("canvas");
-        // rows are the only thing that sets height: pad(8+26) + rows*rowHeight
-        return c && c.height > 0 ? { height: c.height, pixels: c.toDataURL().length } : false;
+        if (!c || !c.height) return false;
+        // CSS pixels, not device pixels. `canvas.height` is cssHeight * dpr,
+        // and the ceiling below is a CSS-pixel quantity — comparing them
+        // directly made the gate's strictness depend on the display of
+        // whoever ran it (review #550 W1): identical at CI's dpr 1, twice as
+        // strict at dpr 2. `style.height` is what the renderer sets in CSS px.
+        return {
+          cssHeight: parseFloat(c.style.height),
+          devicePixels: c.height,
+          pixels: c.toDataURL().length,
+        };
       },
       histSel,
       { timeout: 30000 }
     )
     .then((h) => h.jsonValue())
     .catch(() => null);
-  // 34px of padding plus at most 40 rows at the 20px maximum row height. A
-  // ladder that outgrows this is one a reader has to scroll a chart to read.
-  const HEATMAP_MAX_HEIGHT = 34 + 40 * 20;
+  // Derived from the arithmetic the renderer can actually produce.
+  // `rowHeight = max(12, min(20, floor(240 / rows)))`, so 20px rows happen
+  // only while rows <= 12 — the tallest 20px heatmap is 8 + 12*20 + 26 = 274.
+  // Every row past that costs the 12px FLOOR, so a ladder of N > 20 rows is
+  // 34 + 12N. 40 rows is already more buckets than a reader can scan, and
+  // that is the bound: 34 + 40*12 = 514.
+  //
+  // The first version of this said "40 rows at the 20px maximum row height",
+  // a configuration the formula cannot reach, and so admitted 66 rows while
+  // claiming to admit 40.
+  const HEATMAP_MAX_CSS_HEIGHT = 34 + 40 * 12;
   check("the heatmap stays bounded with both sliders at maximum",
-    histAtMax !== null && histAtMax.height <= HEATMAP_MAX_HEIGHT && histAtMax.pixels > WIDGET_CHART_WITH_DATA,
-    histAtMax ? `canvas ${histAtMax.height}px, ceiling ${HEATMAP_MAX_HEIGHT}px` : "never redrew");
+    histAtMax !== null &&
+      histAtMax.cssHeight <= HEATMAP_MAX_CSS_HEIGHT &&
+      histAtMax.pixels > WIDGET_CHART_WITH_DATA,
+    histAtMax
+      ? `${histAtMax.cssHeight}css px (${histAtMax.devicePixels} device), ceiling ${HEATMAP_MAX_CSS_HEIGHT}`
+      : "never redrew");
 
   // The logs widget renders ELEMENTS, not pixels — a log line is text, and
   // drawing it into a canvas would make it unselectable and invisible to a
@@ -538,11 +559,16 @@ try {
           return { lines: 0, severities: [], stamped: 0, error: err.textContent };
         const pane = el?.querySelector(".sonda-livegen__logstream");
         if (!pane || !pane.children.length) return false;
-        const rows = [...pane.children];
+        // The trailing "… N more events" footer is not a log line and must be
+        // excluded from every count below, or the stamped check fails on it.
+        const footer = pane.querySelector(".sonda-livegen__logmore");
+        const rows = [...pane.children].filter((r) => r !== footer);
         return {
           lines: rows.length,
           severities: [...new Set(rows.map((r) => (r.className.match(/logline--(\w+)/) || [])[1]))],
           stamped: rows.filter((r) => /^\+\d/.test(r.textContent)).length,
+          withheld: footer ? Number((footer.textContent.match(/(\d+) more/) || [])[1]) : null,
+          screens: Math.round((pane.scrollHeight / pane.clientHeight) * 10) / 10,
           error: null,
         };
       },
@@ -561,6 +587,18 @@ try {
     stream.severities.filter(Boolean).length > 1,
     stream.severities.join(" · ") || "none");
 
+  // Review #550 M2. The renderer showed all 240 events inside a 318px pane —
+  // seventeen screens of nested scroll in the middle of a reference page,
+  // while the heatmap beside it was gated on exactly this kind of reader
+  // effort. The cap has to be visible AND honest: a pane that silently stops
+  // at 40 tells a reader the scenario produced 40 events.
+  check("the log pane is capped rather than becoming a scroll trap",
+    stream.lines <= 40 && stream.screens <= 4,
+    `${stream.lines} line(s), ${stream.screens} screens of scroll`);
+  check("and says how many events it withheld, rather than just stopping",
+    Number.isFinite(stream.withheld) && stream.withheld > 0,
+    stream.withheld === null ? "no footer" : `${stream.withheld} withheld`);
+
   // The reviewer's other named corner: error weight at 0 is the ordinary
   // healthy service, and it must still render rather than producing an empty
   // pane or a division by zero in the engine's weighting.
@@ -577,7 +615,11 @@ try {
         const err = el?.querySelector(".sonda-livegen__error");
         if (err && !err.hidden) return { lines: 0, error: err.textContent };
         const pane = el?.querySelector(".sonda-livegen__logstream");
-        return pane && pane.children.length ? { lines: pane.children.length, error: null } : false;
+        if (!pane || !pane.children.length) return false;
+        // Excludes the "… N more" footer, same as the counts above, so the
+        // two checks report the same quantity rather than differing by one.
+        const footer = pane.querySelector(".sonda-livegen__logmore");
+        return { lines: pane.children.length - (footer ? 1 : 0), error: null };
       },
       logSel,
       { timeout: 30000 }

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -619,6 +619,46 @@ test("the distribution widgets bound their per-tick observation volume", () => {
   }
 });
 
+test("a widget may only name encoders the browser's engine carries", () => {
+  // The sibling of the logs check below, and the general form of it (review
+  // #550 round 3 W1). That one is logs-only, so the widget whose entire
+  // subject IS the encoder — `encoders`, offering its choice as a <select> —
+  // had nothing saying its options must exist in the wasm build. Adding
+  // `otlp` there passed the pure suite, passed 651 compile corners, passed
+  // 98 browser checks, and put "configuration error: encoder type 'otlp'
+  // requires the 'otlp' feature" in the pane labelled as the engine's bytes.
+  //
+  // Same root cause as round 2, one widget further out: `sonda-wasm` takes
+  // sonda-core with `default-features = false, features = ["config"]`, so
+  // `otlp` and `remote_write` — both feature-gated in encoder/mod.rs — are
+  // absent, while ci.yml builds the CLI the compile gate uses WITH them.
+  //
+  // Checked over cornerParams so it sees every <select> option, not just the
+  // default: the corner grid enumerates choices, which is what makes an
+  // offered-but-broken option reachable here at all.
+  //
+  // EVERY occurrence, not the first. A widget's YAML names an encoder twice —
+  // once in the `defaults:` preamble and once on the entry that overrides it —
+  // and `String.match` returns only the first, which is always the preamble's.
+  // The first version of this check read that one and passed the very
+  // mutation it was written for.
+  const WASM_ENCODERS = new Set(["prometheus_text", "influx_lp", "json_lines", "syslog"]);
+  for (const [gen, widget] of Object.entries(WIDGETS)) {
+    for (const corner of cornerParams(widget)) {
+      const named = [...widget.yaml(corner).matchAll(/encoder:\s*\{\s*type:\s*(\w+)/g)].map(
+        (m) => m[1]
+      );
+      assert.ok(named.length > 0, `${gen}: no encoder named in the widget's YAML`);
+      for (const encoder of named) {
+        assert.ok(
+          WASM_ENCODERS.has(encoder),
+          `${gen}: encoder "${encoder}" is not in the wasm build — the widget would compile and then fail to sample`
+        );
+      }
+    }
+  }
+});
+
 test("a logs widget declares an encoder that can encode a log", () => {
   // The compile gate cannot see this. `encoder: { type: prometheus_text }`
   // with `signal_type: logs` COMPILES — `sonda --dry-run run` accepts it —
@@ -656,11 +696,19 @@ test("a logs widget declares an encoder that can encode a log", () => {
   for (const [gen, widget] of Object.entries(WIDGETS)) {
     if (widget.signal !== "logs") continue;
     for (const corner of cornerParams(widget)) {
-      const encoder = widget.yaml(corner).match(/encoder:\s*\{\s*type:\s*(\w+)/)?.[1];
-      assert.ok(
-        encoder && LOG_CAPABLE.has(encoder),
-        `${gen}: encoder "${encoder}" cannot encode a log event — the widget would compile and then fail to sample`
+      // matchAll for the same reason as the check above: the preamble and the
+      // entry each name an encoder, and only reading the first would miss an
+      // entry-level override.
+      const named = [...widget.yaml(corner).matchAll(/encoder:\s*\{\s*type:\s*(\w+)/g)].map(
+        (m) => m[1]
       );
+      assert.ok(named.length > 0, `${gen}: no encoder named in the widget's YAML`);
+      for (const encoder of named) {
+        assert.ok(
+          LOG_CAPABLE.has(encoder),
+          `${gen}: encoder "${encoder}" cannot encode a log event — the widget would compile and then fail to sample`
+        );
+      }
     }
   }
 });

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -628,11 +628,31 @@ test("a logs widget declares an encoder that can encode a log", () => {
   // that runs the sampler, and pinned here so the next logs widget cannot
   // inherit the metrics default silently.
   //
-  // The list is the set of encoders implementing `encode_log`, read from
-  // sonda-core/src/encoder/: json.rs, syslog.rs and otlp.rs override it;
-  // prometheus_text, influx_lp and remote_write take the trait's default,
-  // which is the NotSupported error above.
-  const LOG_CAPABLE = new Set(["json_lines", "syslog", "otlp"]);
+  // The list is an INTERSECTION, and the second half is the half that bites
+  // (review #550 round 2 W1). The first version listed the three encoders
+  // implementing `encode_log` — json.rs, syslog.rs, otlp.rs — and that is a
+  // true statement about sonda-core which is nevertheless the wrong list for
+  // a browser widget.
+  //
+  //   1. implements `encode_log`      json_lines, syslog, otlp
+  //   2. present in the wasm build    json_lines, syslog
+  //
+  // `sonda-wasm` depends on sonda-core with `default-features = false,
+  // features = ["config"]` (sonda-wasm/Cargo.toml), and `otlp` pulls in
+  // `runtime` plus four crates, so it is absent from the engine these widgets
+  // actually run on. `create_encoder` then returns "encoder type 'otlp'
+  // requires the 'otlp' feature" — at SAMPLING, exactly the failure this
+  // whole invariant exists to prevent.
+  //
+  // And the other two nets would not have caught it: this suite would pass
+  // because otlp was on the list, and the compile gate would pass because
+  // ci.yml builds the release binary with `-F otlp` even though the wasm has
+  // no such feature. An invariant written to close the compile-vs-sample gap
+  // that permits a value reopening it is worse than no invariant, because it
+  // is read as coverage.
+  //
+  // `syslog` is not feature-gated in sonda-core at all, so it stays.
+  const LOG_CAPABLE = new Set(["json_lines", "syslog"]);
   for (const [gen, widget] of Object.entries(WIDGETS)) {
     if (widget.signal !== "logs") continue;
     for (const corner of cornerParams(widget)) {

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -590,6 +590,61 @@ test("preset sampling stays within the playground tick budget", () => {
   }
 });
 
+test("the distribution widgets bound their per-tick observation volume", () => {
+  // A metrics entry costs one number per tick. A histogram or summary entry
+  // costs `observations_per_tick` DRAWS per tick, and the engine does that
+  // work for every tick in the window — so the tick budget above, which
+  // bounds ticks alone, says nothing about the quantity these two widgets
+  // actually scale. The failure mode is not an error: the page gets heavy,
+  // which is invisible to every other gate here and to a reader on a fast
+  // machine.
+  //
+  // This is the half a pure module can check. It CANNOT check the heatmap's
+  // cell count, because the bucket ladder is the engine's default for the
+  // named distribution and nothing in this file knows it — asserting a
+  // remembered number here would be a comment pretending to be a gate. The
+  // real rendered row count is measured against the real sampler in the
+  // browser suite instead.
+  const DRAW_BUDGET = 15_000;
+  for (const gen of ["histogram", "summary"]) {
+    const widget = WIDGETS[gen];
+    const ticks = sampledTicks(widget);
+    const observations = (widget.sliders || []).find((s) => s.key === "observations");
+    assert.ok(observations, `${gen}: expected an observations slider to bound`);
+    const worst = ticks * observations.max;
+    assert.ok(
+      worst <= DRAW_BUDGET,
+      `${gen}: ${ticks} ticks x ${observations.max} observations = ${worst} draws exceeds ${DRAW_BUDGET}`
+    );
+  }
+});
+
+test("a logs widget declares an encoder that can encode a log", () => {
+  // The compile gate cannot see this. `encoder: { type: prometheus_text }`
+  // with `signal_type: logs` COMPILES — `sonda --dry-run run` accepts it —
+  // and fails at sampling with "log encoding not supported by this encoder"
+  // (encoder/mod.rs). So the widget passes 648 corner compilations and shows
+  // every reader an error box. Caught in browser UAT, which is the only gate
+  // that runs the sampler, and pinned here so the next logs widget cannot
+  // inherit the metrics default silently.
+  //
+  // The list is the set of encoders implementing `encode_log`, read from
+  // sonda-core/src/encoder/: json.rs, syslog.rs and otlp.rs override it;
+  // prometheus_text, influx_lp and remote_write take the trait's default,
+  // which is the NotSupported error above.
+  const LOG_CAPABLE = new Set(["json_lines", "syslog", "otlp"]);
+  for (const [gen, widget] of Object.entries(WIDGETS)) {
+    if (widget.signal !== "logs") continue;
+    for (const corner of cornerParams(widget)) {
+      const encoder = widget.yaml(corner).match(/encoder:\s*\{\s*type:\s*(\w+)/)?.[1];
+      assert.ok(
+        encoder && LOG_CAPABLE.has(encoder),
+        `${gen}: encoder "${encoder}" cannot encode a log event — the widget would compile and then fail to sample`
+      );
+    }
+  }
+});
+
 test("every control reaches its widget's template (review #549 W2)", () => {
   // The generalisation of the hand-written `sequence` pattern check above.
   // That one covered ONE of sequence's two controls, and an inert `repeat`
@@ -643,8 +698,12 @@ test("corner and sweep enumeration cover what the compile gate feeds the engine"
           `${gen}: corners use range edges or the default`
         );
       }
-      // Every corner must produce a single-scenario YAML mentioning the type.
-      assert.match(widget.yaml(corner), /signal_type: metrics/);
+      // Every corner must produce a single-scenario YAML declaring the
+      // widget's own signal type. Hard-coded to `metrics` until WP14, which
+      // is the same shape of assumption WP13's slider-less widget broke: an
+      // assertion that reads as general and is really about the one case that
+      // existed when it was written.
+      assert.match(widget.yaml(corner), new RegExp(`signal_type: ${widget.signal || "metrics"}\\b`));
     }
   }
   // Sweeps walk every step of the named slider under min/max neighbors.

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -619,6 +619,45 @@ test("the distribution widgets bound their per-tick observation volume", () => {
   }
 });
 
+/* Every encoder a widget's YAML NAMES, or a loud failure if the reader cannot
+ * account for all of them.
+ *
+ * Fails CLOSED, which is the whole point (review #550 round 4 W1). Four rounds
+ * of this PR found the same family of defect four times — wrong allow-list,
+ * wrong widget class, wrong YAML syntax — and the answer to that is not a
+ * fifth correct list. The pattern understands FLOW style; block style
+ *
+ *     encoder:
+ *       type: otlp
+ *
+ * is the form anyone reaches for the moment an encoder needs a second field,
+ * and the previous version read straight past it and passed. So: count the
+ * `encoder:` keys, and require the pattern to have explained every one. A
+ * syntax this cannot read is now a red gate rather than a silent pass.
+ *
+ * The `named.length > 0` guard it replaces could never fire, because the
+ * shared `head()` preamble always contributes one flow-style match. A guard
+ * that cannot fail is not a guard.
+ *
+ * Note what this returns: every encoder NAMED, not the one that takes effect.
+ * A preamble naming X with an entry overriding it to Y samples as Y, and both
+ * are reported. That is deliberately conservative — it rejects a widget the
+ * engine would have run fine — and it is the safe direction for a gate whose
+ * job is to keep a broken encoder off the page.
+ */
+function encodersNamedIn(yaml, gen) {
+  const declared = [...yaml.matchAll(/^[ \t]*encoder:/gm)].length;
+  const named = [...yaml.matchAll(/encoder:\s*\{\s*type:\s*(\w+)/g)].map((m) => m[1]);
+  assert.equal(
+    named.length,
+    declared,
+    `${gen}: ${declared} encoder key(s) in the YAML but ${named.length} the checker could read — ` +
+      "an encoder written in a syntax this test does not parse is not an encoder it has checked"
+  );
+  assert.ok(declared > 0, `${gen}: no encoder named in the widget's YAML`);
+  return named;
+}
+
 test("a widget may only name encoders the browser's engine carries", () => {
   // The sibling of the logs check below, and the general form of it (review
   // #550 round 3 W1). That one is logs-only, so the widget whose entire
@@ -645,11 +684,7 @@ test("a widget may only name encoders the browser's engine carries", () => {
   const WASM_ENCODERS = new Set(["prometheus_text", "influx_lp", "json_lines", "syslog"]);
   for (const [gen, widget] of Object.entries(WIDGETS)) {
     for (const corner of cornerParams(widget)) {
-      const named = [...widget.yaml(corner).matchAll(/encoder:\s*\{\s*type:\s*(\w+)/g)].map(
-        (m) => m[1]
-      );
-      assert.ok(named.length > 0, `${gen}: no encoder named in the widget's YAML`);
-      for (const encoder of named) {
+      for (const encoder of encodersNamedIn(widget.yaml(corner), gen)) {
         assert.ok(
           WASM_ENCODERS.has(encoder),
           `${gen}: encoder "${encoder}" is not in the wasm build — the widget would compile and then fail to sample`
@@ -696,14 +731,9 @@ test("a logs widget declares an encoder that can encode a log", () => {
   for (const [gen, widget] of Object.entries(WIDGETS)) {
     if (widget.signal !== "logs") continue;
     for (const corner of cornerParams(widget)) {
-      // matchAll for the same reason as the check above: the preamble and the
-      // entry each name an encoder, and only reading the first would miss an
-      // entry-level override.
-      const named = [...widget.yaml(corner).matchAll(/encoder:\s*\{\s*type:\s*(\w+)/g)].map(
-        (m) => m[1]
-      );
-      assert.ok(named.length > 0, `${gen}: no encoder named in the widget's YAML`);
-      for (const encoder of named) {
+      // Shared reader, so both encoder invariants fail closed on a syntax it
+      // cannot parse rather than one of them silently passing.
+      for (const encoder of encodersNamedIn(widget.yaml(corner), gen)) {
         assert.ok(
           LOG_CAPABLE.has(encoder),
           `${gen}: encoder "${encoder}" cannot encode a log event — the widget would compile and then fail to sample`


### PR DESCRIPTION

## Summary

The last three sections carrying a *"see it in the playground"* note now carry the thing itself. That retires the WP13 stopgaps and finishes the generator reference: **every generator a browser can sample is now draggable where it is documented.**

**Extracted, not copied** (the #543 precedent). `docs/site/docs/javascripts/signal-render.js` now owns `drawHistogramHeatmap`, `drawSummaryBands`, a `logStream` element builder, `palette`, `formatNumber`, `formatSeconds` and `formatBound`. `playground.js` and `livegen.js` import them; their own copies are gone.

Three of those were **already duplicated character-for-character** between the two files — `palette`, and `formatNumber`/`formatSeconds` under the names `fmt`/`fmtSecs` — held together by nothing but the fact that nobody had edited one of them yet. What they would have disagreed about is what a reader sees on two pages teaching the same signal.

## The extraction was verified mechanically, before the originals were deleted

Brace-matched each function body out of both files and compared them as strings:

```
drawHistogramHeatmap  vs playground.js          IDENTICAL
drawSummaryBands      vs playground.js          IDENTICAL
formatBound           vs playground.js          IDENTICAL
formatNumber          vs playground.js          IDENTICAL
formatSeconds         vs playground.js          IDENTICAL
formatNumber          vs livegen.js:fmt         IDENTICAL
formatSeconds         vs livegen.js:fmtSecs     IDENTICAL
palette vs playground: 5 keys, none missing, none changed
palette vs livegen:    6 keys, none missing, none changed
```

The shared `palette` is the strict **union**: playground never read `line`, livegen never read `plate`, and the six keys they shared were identical strings — so neither caller changed behaviour when its copy went. The playground's own smoke sections are the end-to-end half of that evidence and are green.

`logStream` takes a class `prefix` rather than hard-coding one, so the playground keeps the exact class names its stylesheet, its cursor correlation (`highlightLogs`) and its smoke assertions already depend on. *An extraction that renames things is a rewrite wearing an extraction's clothes.* The log-stream CSS gained the livegen prefix as a second selector on the existing rules rather than a duplicated block — same reason as the module.

## One real bug, found in browser UAT, and it's the interesting one

```yaml
encoder: { type: prometheus_text }   # with signal_type: logs
```

**This compiles.** `sonda --dry-run run` accepts it. It fails at *sampling* with `log encoding not supported by this encoder` (`encoder/mod.rs`) — so the widget passed all 648 corner compilations and showed every reader an error box. The shared preamble helper defaulted to `prometheus_text` because until now every widget was metrics.

That gap is now a gate rather than a comment: **a logs widget must declare an encoder implementing `encode_log`.** The list — `json_lines`, `syslog`, `otlp` — was read out of `sonda-core/src/encoder/`, not remembered; `prometheus_text`, `influx_lp` and `remote_write` take the trait default, which is the error above. Mutation (revert the logs widget to the metrics default): **RED**.

## Changes

- **`signal-render.js`** (new) — the shared renderers and formatters. Not bundle-coupled; only `sonda-pure.js` is compiled into the editor bundle, so the drift gate does not move.
- **`livegen.js`** — dispatches on a new `signal` field through two tables rather than a chain of ifs, so adding a signal type is a row and a missing row is a loud `undefined` at mount instead of a silent fall-through that reads `.values` off a histogram. It also now says **why** there is nothing to draw, using the engine's own skip reason: `ok` from the compiler does not mean this widget's signal is present.
- **`livegen-presets.js`** — three presets; `head()` takes an encoder.
- **`generators.md`** — the three stopgap tips become widgets.
- **`sonda.css`** — log-stream rules extended to the livegen prefix.

## Test plan

Two new invariants, and one existing one generalised:

| Invariant | Note |
| --- | --- |
| a logs widget declares a log-capable encoder | mutation RED; the compile gate is structurally blind to this |
| histogram/summary bound `ticks × observations_per_tick` | deliberately does **not** assert a bucket count — see below |
| corner enumeration checks each widget's **own** `signal_type` | was hard-coded to `metrics`; same shape of assumption WP13's slider-less widget broke |

The observation-volume check deliberately stops short of the heatmap's row count, because the bucket ladder is the engine's default for the named distribution and **nothing in this repo's JS knows it** — asserting a remembered number there would be a comment pretending to be a gate. The real rendered row count is measured against the real sampler in the browser suite instead.

Seven new browser checks:

```
ok   the histogram widget mounts and draws — dataURL 32490
ok   the summary widget mounts and draws — dataURL 76678
ok   the heatmap stays bounded with both sliders at maximum — canvas 274px, ceiling 834px
ok   the log_template widget renders a severity-coloured stream — 240 line(s)
ok   every log line is stamped with its offset on the timeline — 240/240 stamped
ok   the stream carries more than one severity — info · error · warn
ok   all severity weights at minimum still produces a stream — 240 line(s)
```

That last one is the corner worth naming: **error weight at 0 is the ordinary healthy service**, and it must render. `info` is pinned at 8 rather than being a third slider, so `severity_weights` summing to zero is unreachable by construction rather than merely untested.

**Sabotage-verified:** pinning `severity_weights` to `info` alone turns exactly one check red — `FAIL the stream carries more than one severity, so the colouring means something — info` — with the other six green.

**Also fixed before it shipped:** the first version of these checks read the DOM straight after `scrollIntoView`, so all six failed against widgets a manual probe showed working. Mounting is asynchronous. They are condition-based now, like the rest of the suite.

```bash
node docs/site/tools/tests/pure.test.mjs                 # 194 pure-helper tests passed
SONDA_BIN=./target/release/sonda \
  node docs/site/tools/tests/livegen-compile.mjs         # 648 slider combinations compile (was 603)
python3 scripts/validate_docs_scenarios.py               # 118 compiled, 0 failed
python3 scripts/validate_docs_commands.py                # 154 commands, 0 failed
python3 docs/site/hooks/examples_gallery.py --self-test  # OK; two builds byte-identical
bash scripts/check_no_raw_html.sh                        # OK
mkdocs build --strict -f docs/site/mkdocs.yml            # clean
node docs/site/tools/browser/smoke.mjs                   # 94 checks, SMOKE PASSED
```

## Checklist

- [ ] `cargo test --workspace` passes — **not re-run: this PR touches no Rust.** `git diff origin/main --stat` is eight files, all under `docs/site/`. (For the record, two `sink::file` tests fail in this container for an environment reason — both `chmod 0o555` a tempdir and this container runs as uid 0, so root bypasses the permission. CI runs non-root, which is why `main` is green.)
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable) — this PR *is* the documentation change.

