### PR TITLE
feat(site): gallery cards draw histogram, summary and log signals

### DIFF
--- a/docs/site/docs/javascripts/livegen.js
+++ b/docs/site/docs/javascripts/livegen.js
@@ -69,6 +69,12 @@ const SIGNAL_SOURCE = {
  */
 const LOG_LINES_SHOWN = 40;
 
+/* The same cap for a gallery CARD, which is a thumbnail in a grid rather than
+ * a section of a reference page — so it is shorter than the widget's 40. Both
+ * name what they withheld; a pane that stops silently tells a reader the
+ * scenario produced that many events (review #550 M2). */
+const GALLERY_LOG_LINES = 12;
+
 const SIGNAL_DRAW = {
   metrics: (canvas, sample) => drawMini(canvas, sample),
   histogram: drawHistogramHeatmap,
@@ -367,23 +373,52 @@ async function mountScenario(root) {
     state = { mode: "error", message: String(err) };
   }
 
-  if (state.mode !== "chart") {
+  // `chart` is metrics; `logs`/`histogram`/`summary` are the three the gallery
+  // used to answer with prose. Everything else — error, skipped, empty — is
+  // still a sentence, because those cards genuinely have nothing to draw.
+  const SIGNAL_FOR_MODE = { chart: "metrics", logs: "logs", histogram: "histogram", summary: "summary" };
+  const signal = SIGNAL_FOR_MODE[state.mode];
+  if (!signal) {
     say(state.message, state.mode);
     return;
   }
 
-  const entry = result.entries[0];
+  const sample = SIGNAL_SOURCE[signal](result)[0];
+  if (!sample) {
+    // `galleryCardState` said this signal was present, so an empty read here
+    // means the two disagree — a bug in one of them, not a fact about the
+    // scenario, and the card says so rather than rendering a blank frame.
+    say(`The engine reported ${signal} but produced none.`, "error");
+    return;
+  }
+
+  const title = sample.name || root.dataset.title || "this scenario";
+
+  if (signal === "logs") {
+    // Elements, not pixels — the same reason the log widget renders as DOM.
+    // The card is a thumbnail, so it shows fewer lines than the page widget
+    // and says how many it withheld.
+    canvas.remove();
+    const pane = document.createElement("div");
+    pane.className = "sonda-livegen__logs";
+    pane.append(logStream(sample, { prefix: "sonda-livegen", limit: GALLERY_LOG_LINES }));
+    root.insertBefore(pane, note);
+    const total = sample.lines.length;
+    if (total > GALLERY_LOG_LINES) {
+      say(`Showing ${GALLERY_LOG_LINES} of ${total} events.`, "more");
+    }
+    return;
+  }
+
   canvas.hidden = false;
-  canvas.setAttribute(
-    "aria-label",
-    `Live chart of ${entry.name || root.dataset.title || "this scenario"}`
-  );
-  root._draw = () => drawMini(canvas, entry);
+  canvas.setAttribute("aria-label", `Live chart of ${title}`);
+  const draw = SIGNAL_DRAW[signal];
+  root._draw = () => draw(canvas, sample);
   root._draw();
   live.add(root);
   if (state.extraSeries > 0) {
     const n = state.extraSeries;
-    say(`Showing ${entry.name} — ${n} more ${n === 1 ? "series" : "series"} here.`, "more");
+    say(`Showing ${title} — ${n} more ${n === 1 ? "series" : "series"} here.`, "more");
   }
 }
 

--- a/docs/site/docs/javascripts/sonda-pure.js
+++ b/docs/site/docs/javascripts/sonda-pure.js
@@ -509,14 +509,29 @@ export function galleryCardState(result) {
     };
   }
 
+  // These three used to be `note` — "open it in the playground for the bucket
+  // heatmap" — because the gallery had no renderer for them. WP14 gave the
+  // widget layer those renderers (signal-render.js) and said in its own spec
+  // that the gallery would be upgraded "for free"; that half did not ship,
+  // and eight example files stayed as prose telling a reader to go elsewhere
+  // for a picture this page can now draw.
+  //
+  // The mode NAMES the signal rather than being a generic "renderable", so
+  // the caller looks up a renderer instead of re-deriving which array to
+  // read. A signal type with no row in the caller's table is then a loud
+  // undefined at mount, not a card that silently falls back to prose.
+  // Precedence is unchanged from when these were notes: logs, then
+  // histograms, then summaries. Nothing pinned that order before, so it is
+  // pinned now — a mixed scenario showing a different signal than it used to
+  // would be a behaviour change this package has no reason to make.
   if (arrayOf(result.logs).length) {
-    return { mode: "note", message: "Log stream — open it in the playground to read the lines." };
+    return { mode: "logs" };
   }
   if (arrayOf(result.histograms).length) {
-    return { mode: "note", message: "Histogram — open it in the playground for the bucket heatmap." };
+    return { mode: "histogram" };
   }
   if (arrayOf(result.summaries).length) {
-    return { mode: "note", message: "Summary — open it in the playground for the quantile bands." };
+    return { mode: "summary" };
   }
 
   return { mode: "empty", message: "Nothing to sample — this file defines metrics for other scenarios to use." };

--- a/docs/site/tools/browser/smoke.mjs
+++ b/docs/site/tools/browser/smoke.mjs
@@ -790,7 +790,12 @@ try {
       return cards.every((card) => {
         const canvas = card.querySelector("canvas");
         const note = card.querySelector(".sonda-livegen__note");
-        return (canvas && !canvas.hidden) || (note && !note.hidden);
+        // A logs card has neither: its canvas is removed and its note only
+        // appears when the stream was truncated. Without this branch a short
+        // log example never satisfies the condition and the suite waits out
+        // its whole timeout on a card that rendered correctly.
+        const stream = card.querySelector(".sonda-livegen__logstream");
+        return (canvas && !canvas.hidden) || (note && !note.hidden) || stream;
       });
     },
     null,
@@ -798,12 +803,17 @@ try {
   );
 
   const tally = await gallery.evaluate(() => {
-    const out = { cards: 0, charts: 0, skipped: 0, notes: 0, errors: 0, linkless: 0, reason: "" };
+    const out = { cards: 0, charts: 0, logs: 0, skipped: 0, notes: 0, errors: 0, linkless: 0, reason: "", prose: [] };
     for (const card of document.querySelectorAll(".sonda-gallery__live")) {
       out.cards += 1;
       if (!card.querySelector(".sonda-livegen__open")) out.linkless += 1;
       const canvas = card.querySelector("canvas");
       const note = card.querySelector(".sonda-livegen__note");
+      const stream = card.querySelector(".sonda-livegen__logstream");
+      if (stream) {
+        out.logs += 1;
+        continue;
+      }
       if (canvas && !canvas.hidden) {
         out.charts += 1;
         continue;
@@ -813,7 +823,10 @@ try {
         out.skipped += 1;
         if (!out.reason) out.reason = note.textContent.trim();
       } else if (kind === "error") out.errors += 1;
-      else out.notes += 1;
+      else {
+        out.notes += 1;
+        if (note) out.prose.push(note.textContent.trim().slice(0, 60));
+      }
     }
     return out;
   });
@@ -827,6 +840,35 @@ try {
     tally.skipped > 0 && /csv_replay|feature|file/.test(tally.reason),
     `${tally.skipped} skipped — ${tally.reason.slice(0, 70)}`
   );
+
+  // The half of WP14 that did not ship with it: the gallery had renderers for
+  // these three signals and answered with prose anyway — "Histogram — open it
+  // in the playground for the bucket heatmap" — on a page that could draw it.
+  check("log-stream examples render their stream rather than describing it",
+    tally.logs > 0, `${tally.logs} log card(s)`);
+  check("no card still answers a drawable signal with prose",
+    tally.notes === 0, tally.prose.join(" | ") || "none");
+
+  // Named, so the check reports which signal broke rather than a count.
+  for (const [file, expect] of [["histogram", "canvas"], ["summary", "canvas"], ["log-template", "stream"]]) {
+    const shown = await gallery.evaluate(
+      ([f, want]) => {
+        const card = [...document.querySelectorAll(".sonda-gallery__live")].find((c) =>
+          (c.dataset.title || "").includes(f)
+        );
+        if (!card) return "no card";
+        if (want === "stream") {
+          const pane = card.querySelector(".sonda-livegen__logstream");
+          return pane ? `${pane.children.length} rows` : "no stream";
+        }
+        const canvas = card.querySelector("canvas:not([hidden])");
+        return canvas && canvas.height > 0 ? `${canvas.height}px canvas` : "no canvas";
+      },
+      [file, expect]
+    );
+    check(`the ${file} example draws its signal on the card`,
+      /rows|px canvas/.test(shown), shown);
+  }
 
   const galleryLink = await gallery.getAttribute(
     ".sonda-gallery__live .sonda-livegen__open",

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -648,11 +648,32 @@ test("the distribution widgets bound their per-tick observation volume", () => {
 function encodersNamedIn(yaml, gen) {
   const declared = [...yaml.matchAll(/^[ \t]*encoder:/gm)].length;
   const named = [...yaml.matchAll(/encoder:\s*\{\s*type:\s*(\w+)/g)].map((m) => m[1]);
+  // The message branches on the DIRECTION of the mismatch (review #550 round
+  // 5 M1). The two halves measure differently on purpose — declarations are
+  // line-anchored, values are read anywhere — so both directions can happen
+  // and they mean opposite things:
+  //
+  //   more keys than values   a key in a syntax the pattern cannot read
+  //   more values than keys   a value the pattern read but the count missed,
+  //                           e.g. a legal one-line `defaults: { … }`
+  //
+  // Telling an author "a syntax this test does not parse" when it parsed the
+  // encoder perfectly well sends them after a bug that is not there. Both
+  // directions still fail closed; only the wording differs.
+  //
+  // Note a mention counts as a declaration: a commented-out `# encoder:` or a
+  // log line whose CONTENT begins `encoder:` is counted. That is the safe
+  // direction for a gate, and it is why the message says "accounted for"
+  // rather than "declared".
   assert.equal(
     named.length,
     declared,
-    `${gen}: ${declared} encoder key(s) in the YAML but ${named.length} the checker could read — ` +
-      "an encoder written in a syntax this test does not parse is not an encoder it has checked"
+    named.length < declared
+      ? `${gen}: ${declared} encoder key(s) in the YAML but only ${named.length} the checker could read — ` +
+        "an encoder written in a syntax this test does not parse is not an encoder it has checked"
+      : `${gen}: the checker read ${named.length} encoder(s) but could only account for ${declared} — ` +
+        "the values parsed; the key count did not match them (an inline mapping, or an `encoder:` " +
+        "inside a comment or a log message)"
   );
   assert.ok(declared > 0, `${gen}: no encoder named in the widget's YAML`);
   return named;
@@ -1004,10 +1025,36 @@ test("a skipped entry with no reason still says it was skipped", () => {
   assert.match(state.message, /Not sampled in the browser/);
 });
 
-test("logs, histograms and summaries each get their own note", () => {
-  assert.match(galleryCardState(okWith({ logs: [{ lines: [] }] })).message, /Log stream/);
-  assert.match(galleryCardState(okWith({ histograms: [{}] })).message, /Histogram/);
-  assert.match(galleryCardState(okWith({ summaries: [{}] })).message, /Summary/);
+test("logs, histograms and summaries are named so the caller can render them", () => {
+  // These were `note` modes carrying prose that sent the reader to the
+  // playground for a picture. The widget layer can draw all three now, so the
+  // state names WHICH signal rather than apologising for not having one.
+  assert.equal(galleryCardState(okWith({ logs: [{ lines: [] }] })).mode, "logs");
+  assert.equal(galleryCardState(okWith({ histograms: [{}] })).mode, "histogram");
+  assert.equal(galleryCardState(okWith({ summaries: [{}] })).mode, "summary");
+});
+
+test("the renderable modes carry no message — there is nothing to apologise for", () => {
+  // A message on a mode the caller renders would be dead prose, and the kind
+  // that survives a refactor and starts being displayed again by accident.
+  for (const result of [
+    okWith({ logs: [{ lines: [] }] }),
+    okWith({ histograms: [{}] }),
+    okWith({ summaries: [{}] }),
+  ]) {
+    assert.equal(galleryCardState(result).message, undefined);
+  }
+});
+
+test("precedence among the non-metric signals is logs, then histogram, then summary", () => {
+  // Unchanged from when these were notes. Nothing pinned it before; a mixed
+  // scenario quietly changing which signal its card shows would be a
+  // behaviour change this package has no reason to make.
+  assert.equal(
+    galleryCardState(okWith({ logs: [{ lines: [] }], histograms: [{}], summaries: [{}] })).mode,
+    "logs"
+  );
+  assert.equal(galleryCardState(okWith({ histograms: [{}], summaries: [{}] })).mode, "histogram");
 });
 
 test("entries win over logs — a mixed scenario shows its chart", () => {


### PR DESCRIPTION


## Summary

The half of WP14 that **its own spec promised and that did not ship**:

> livegen's `mountScenario` / `mount` then render whichever signal type the sample result carries — *which also upgrades the non-chart gallery cards for free.*

#550 changed `mount()`, the preset path. `mountScenario()`, the gallery path, still only ever read `result.entries[0]`. Neither the five review rounds nor I caught it, because every check aimed at the widgets.

Measured on the built site: **eight example files are entirely non-metric**, and six of them answered a reader with prose on a page that could now draw the thing — `Histogram — open it in the playground for the bucket heatmap` sitting exactly where the heatmap goes.

```
before   41 charts · 0 streams · 6 prose notes
after    52 charts · 4 streams · 0 prose notes
         histogram.yaml 274px heatmap · summary.yaml 220px bands
         log-template.yaml 13 rows
```

## Changes

- **`sonda-pure.js`** — `galleryCardState` **names** the signal (`logs` / `histogram` / `summary`) instead of returning a note that points elsewhere. The three prose branches become live modes.
- **`livegen.js`** — `mountScenario` dispatches through the same `SIGNAL_SOURCE` / `SIGNAL_DRAW` tables and `logStream` as `mount()`. One dispatch, not a second copy; a signal with no row is a loud `undefined` at mount rather than a card that quietly falls back to prose.

**Precedence is pinned rather than changed.** Logs still win over histograms, which still win over summaries — the order those branches happened to have when they were notes. Nothing tested it before, so a mixed scenario silently changing which signal its card shows would have been a behaviour change this has no reason to make. I reordered them while writing this and put them back.

Cards cap their stream at **12** lines against the widget's 40, because a card is a thumbnail in a grid rather than a section of a reference page — and they say what they withheld, for the reason review #550 M2 gave: a pane that stops silently tells a reader the scenario produced that many events.

**Two harness gaps this exposed in the suite itself**, both fixed here:

- the gallery's settle condition was *"a visible canvas or a visible note"*. A logs card has **neither** — its canvas is removed and its note only appears when the stream was truncated — so a *short* log example would have waited out the whole 120s timeout on a card that rendered correctly.
- the tally had no bucket for a rendered stream, so log cards would have counted as prose notes.

## Test plan

Three new browser checks, plus one per named example so a failure reports *which* signal broke rather than a count:

```
ok  log-stream examples render their stream rather than describing it — 4 log card(s)
ok  no card still answers a drawable signal with prose — none
ok  the histogram example draws its signal on the card — 274px canvas
ok  the summary example draws its signal on the card — 220px canvas
ok  the log-template example draws its signal on the card — 13 rows
```

New pure cases: the three modes; that a renderable mode carries **no** message (dead prose is the kind that survives a refactor and starts displaying again by accident); and the precedence order.

**Sabotage-verified in the built site alone**, so the pure layer is not involved and the browser layer is measured by itself. Reverting the `logs` mode to its old note turns exactly the three new checks red, and the prose check *names* the regression rather than counting it:

```
FAIL log-stream examples render their stream rather than describing it — 0 log card(s)
FAIL no card still answers a drawable signal with prose — Log stream — open it in the
     playground to read the lines. | …x4
FAIL the log-template example draws its signal on the card — no stream
106 checks, SMOKE FAILED — 3 assertion(s)
```

**Also here, the carried round-5 minor from #550:** `encodersNamedIn` branches its mismatch message on the **direction** of the mismatch. More keys than values is a syntax the pattern cannot read; more values than keys is a value it read but the count missed (a legal inline mapping, or an `encoder:` inside a comment or a log body). Both still fail closed — telling an author *"a syntax this test does not parse"* when it parsed fine sent them after a bug that wasn't there. Both messages measured.

**The editor bundle is untouched.** `galleryCardState` is tree-shaken out of it — verified by actually rebuilding rather than assumed, md5 `d1ba8921…` before and after.

```bash
node docs/site/tools/tests/pure.test.mjs                 # 197 pure-helper tests passed
SONDA_BIN=./target/release/sonda \
  node docs/site/tools/tests/livegen-compile.mjs         # 648 slider combinations compile
python3 scripts/validate_docs_scenarios.py               # 118 compiled, 0 failed
python3 scripts/validate_docs_commands.py                # 154 commands, 0 failed
python3 docs/site/hooks/examples_gallery.py --self-test  # OK
bash scripts/check_no_raw_html.sh                        # OK
python3 scripts/check_editor_size.py                     # OK
mkdocs build --strict -f docs/site/mkdocs.yml            # clean
node docs/site/tools/browser/smoke.mjs                   # 106 checks, SMOKE PASSED
```

## Checklist

- [ ] `cargo test --workspace` passes — **not re-run: this PR touches no Rust.** Four files, all under `docs/site/`.
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable) — this PR *is* the documentation change.
