### PR TITLE
feat(test): verify alerts against Alertmanager, not just the rule evaluator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,6 +2563,7 @@ name = "sonda"
 version = "1.19.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "ctrlc",
  "dialoguer",

--- a/docs/site/docs/reference/cli-flags.md
+++ b/docs/site/docs/reference/cli-flags.md
@@ -278,10 +278,15 @@ sonda test examples/alert-expectation-test.yaml \
 
 | Flag | Description |
 |------|-------------|
-| `--prometheus-url <URL>` | Base URL of the Prometheus-compatible API evaluating the alert rules (e.g. `http://localhost:9090`). Required except with `--dry-run`; also read from `SONDA_PROMETHEUS_URL`. |
+| `--prometheus-url <URL>` | Base URL of the Prometheus-compatible API evaluating the alert rules (e.g. `http://localhost:9090`) — verifies that the **rule** fires. Also read from `SONDA_PROMETHEUS_URL`. |
+| `--alertmanager-url <URL>` | Base URL of the Alertmanager receiving the alerts (e.g. `http://localhost:9093`) — verifies that the **notification** arrived. Also read from `SONDA_ALERTMANAGER_URL`. |
 | `--interval <DUR>` | Poll interval for alert-state checks. Default `5s`. |
 | `--query-timeout <DUR>` | Overall timeout for each alert-state query (connect + read), so a stalled endpoint fails fast instead of hanging. Default `10s`. |
-| `--query-step <DUR>` | Grid resolution for the post-hoc range queries that produce the verdict timelines. Match your rule evaluation interval. Default `5s`. |
+| `--query-step <DUR>` | Grid resolution for the post-hoc range queries that produce the verdict timelines. Match your rule evaluation interval. Default `5s`. `--prometheus-url` only. |
+
+Exactly one of `--prometheus-url` / `--alertmanager-url` is required (except
+with `--dry-run`). Passing both is an error: they verify different hops of
+the alerting path, so there is no sensible way to merge their verdicts.
 
 The scenario runs exactly as `sonda run` would (no overrides). Firing
 deadlines are measured from scenario start; resolution deadlines from
@@ -297,9 +302,24 @@ times — independent of how often `sonda test` polled. If the range API is
 unavailable, the verdict falls back to the live poll timeline with a
 warning.
 
+Against `--alertmanager-url` the verdict is read from live polling alone.
+Alertmanager keeps no queryable history — there is no range API and no
+`time()` endpoint — so there is nothing to reconstruct after the fact.
+Transition times therefore carry `--interval` precision, sharpened by each
+alert's own `startsAt` stamp (about one second of clock resolution, measured
+from Alertmanager's `Date` header) and never pushed beyond what polling
+observed. The report says so on every run; do not read these numbers as the
+sample-accurate times the Prometheus path reports.
+
+Two more differences on the Alertmanager path: it has no `pending` state (an
+alert inside its rule's `for:` window has not been sent yet, so it is simply
+absent), and an alert that Alertmanager has **suppressed** — silenced or
+inhibited — still counts as firing, with a warning. A silence stops the
+notification, not the alert.
+
 Before the scenario starts, a preflight confirms the endpoint answers a
 query for every expectation. Only the first expectation is retried (3
-attempts, for a Prometheus still starting up in CI); the rest are probed
+attempts, for a backend still starting up in CI); the rest are probed
 once each, so preflight against a dead endpoint fails within about three
 query timeouts regardless of how many expectations the scenario declares.
 

--- a/docs/site/docs/test/alert-testing.md
+++ b/docs/site/docs/test/alert-testing.md
@@ -847,6 +847,63 @@ otherwise — which makes alert rules testable in CI. The
 or contacting Prometheus. The `expect:` block is pure metadata to `sonda run`
 — the same file works for both commands.
 
+### Verify the notification, not just the rule
+
+`--prometheus-url` asks the rule evaluator a question: *did the rule fire?*
+That leaves the rest of the path untested. A rule can evaluate perfectly and
+still never reach anyone — a wrong `-notifier.url`, a route that drops the
+alert, a receiver that was never configured. Every one of those is green on
+the `ALERTS` metric.
+
+`--alertmanager-url` asks the next hop instead: *did the notification
+arrive?* Same scenario, same `expect:` block, one flag different:
+
+```bash
+sonda test examples/alert-lifecycle-test.yaml \
+  --alertmanager-url http://localhost:9093
+```
+
+```text
+  PASS HighCpuUsage firing after 40s (within 90s)
+  PASS HighCpuUsage resolved after 10s (within 2m of scenario end)
+
+  note: Alertmanager keeps no queryable history, so these times come from live polling every 5s, sharpened by each alert's own startsAt stamp (~1s clock resolution) — not from stored samples
+  PASS 1 alert expectation(s) verified via Alertmanager (scenario ran 90s)
+```
+
+The alert shows up later here than on the `--prometheus-url` run of the same
+scenario, and that gap is the point: it is the extra hop — vmalert deciding
+the rule is firing, then notifying Alertmanager — that this path measures
+and the other one cannot see.
+
+Pick exactly one: passing both URLs is an error, because the two answer
+different questions and there is no sensible way to merge their verdicts.
+Run the same scenario twice — once per flag — when you want both hops
+covered, and the second run tells you which hop broke.
+
+Three things behave differently on this path, all of them consequences of
+Alertmanager not being a datastore:
+
+- **Times are poll-precise, not sample-precise.** There is no range API to
+  reconstruct history from, so the verdict is what polling saw, sharpened
+  (never extended) by the alert's own `startsAt`. Tighten `--interval` if
+  you need finer resolution.
+- **There is no `pending`.** An alert still inside its rule's `for:` window
+  has not been sent yet, so Alertmanager simply doesn't know about it.
+  `firing_within` still means what it says; there is just no intermediate
+  state to observe.
+- **Silenced alerts still count as firing**, with a warning. A silence stops
+  the notification, not the alert — but if your test is asserting on a
+  silenced alert, that warning is the thing to read.
+
+Resolution on this path means *the alert is no longer in Alertmanager* — a
+resolved alert is dropped from the API rather than kept around. That is only
+a safe signal because the notifier keeps re-announcing a still-firing alert:
+vmalert re-sends on every evaluation, each time pushing the alert's `endsAt`
+well past the next few evaluations, so a firing alert cannot briefly vanish
+and fake a resolution. Keep `--interval` comfortably below your rule
+evaluation interval and this stays true.
+
 Resolution above leans on series staleness (emission stops, the rule's
 query eventually empties out), which takes minutes. For a fast, explicit
 recovery, `examples/alert-lifecycle-test.yaml` adds a second phase that

--- a/docs/site/docs/test/alert-testing.md
+++ b/docs/site/docs/test/alert-testing.md
@@ -872,9 +872,17 @@ sonda test examples/alert-lifecycle-test.yaml \
 ```
 
 The alert shows up later here than on the `--prometheus-url` run of the same
-scenario, and that gap is the point: it is the extra hop — vmalert deciding
-the rule is firing, then notifying Alertmanager — that this path measures
-and the other one cannot see.
+scenario. Measured against one live VictoriaMetrics + vmalert + Alertmanager
+stack, same scenario, separate series so neither run could see the other's
+alerts: **10s on the Prometheus path, 35–40s on the Alertmanager path.**
+
+Most of that gap is real — it is the extra hop, vmalert deciding the rule is
+firing and then notifying Alertmanager, which is exactly what this path
+measures and the other one cannot see. Some of it is not: this path polls,
+so up to one `--interval` of the difference is just when Sonda happened to
+look. Do not read the two numbers as a latency measurement of the notifier;
+read them as "the rule fired here, the notification landed somewhere after
+there."
 
 Pick exactly one: passing both URLs is an error, because the two answer
 different questions and there is no sensible way to merge their verdicts.

--- a/docs/site/docs/test/end-to-end-pipelines.md
+++ b/docs/site/docs/test/end-to-end-pipelines.md
@@ -332,9 +332,11 @@ Pick the tab that matches your scenario.
     | Metrics | `influx_lp` | `file` | `examples/influx-file.yaml` | `wc -l < /tmp/sonda-influx-output.txt` |
     | Metrics | `remote_write` | `remote_write` (VM + vmalert) | `examples/alert-lifecycle-test.yaml` | `sonda test examples/alert-lifecycle-test.yaml --prometheus-url http://localhost:8428 --interval 5s` — self-verifying: exit 0 means the alert fired *and* resolved on deadline |
     | Metrics | `remote_write` | `remote_write` (VM + vmalert, negative control) | `tests/e2e/alert-negative-control.yaml` | Same `sonda test` shape — must exit 1 with `did not fire within`, proving the failure path fails |
+    | Metrics | `remote_write` | `remote_write` (VM + vmalert → Alertmanager) | `examples/alert-lifecycle-test.yaml` | `sonda test examples/alert-lifecycle-test.yaml --alertmanager-url http://localhost:9093 --interval 5s` — same scenario one hop further: exit 0 means the *notification* reached Alertmanager and cleared |
+    | Metrics | `remote_write` | `remote_write` (Alertmanager, negative control) | `tests/e2e/alert-negative-control.yaml` | Same `--alertmanager-url` shape — must exit 1 with `did not fire within` |
 
     !!! info "Compose profiles"
-        Loki, Kafka, Prometheus, the OTel Collector, and the alerting stack (vmalert + Alertmanager, needed by the two `sonda test` rows) are behind profiles to keep the base stack lean. Bring up only what each row needs. The vmagent row uses the default stack — no extra profile.
+        Loki, Kafka, Prometheus, the OTel Collector, and the alerting stack (vmalert + Alertmanager, needed by the four `sonda test` rows) are behind profiles to keep the base stack lean. Bring up only what each row needs. The vmagent row uses the default stack — no extra profile.
         ```bash
         docker compose -f examples/docker-compose-victoriametrics.yml \
           --profile loki --profile kafka --profile prometheus --profile otel-collector up -d

--- a/scripts/live_infra_uat.py
+++ b/scripts/live_infra_uat.py
@@ -196,6 +196,49 @@ MATRIX: tuple[MatrixRow, ...] = (
         # 90s scenario + firing/resolution polling; observed ~105s live.
         timeout_s=300.0,
     ),
+    # -- The same two rows one hop further down: Alertmanager acquisition.
+    # These prove the *notification* path, not just rule evaluation. A
+    # vmalert whose --notifier.url is wrong (or an Alertmanager route that
+    # drops the alert) is green on the rows above and red on these.
+    MatrixRow(
+        name="alert-test-fail-control-am",
+        profiles=("alerting",),
+        subcommand="metrics",
+        scenario=Path("tests/e2e/alert-negative-control.yaml"),
+        verify_url="",
+        failure_log_containers=("alertmanager", "vmalert", "victoriametrics"),
+        verb="test",
+        extra_args=(
+            "--alertmanager-url",
+            "http://localhost:9093",
+            "--interval",
+            "5s",
+        ),
+        expect_exit=1,
+        expect_stderr="did not fire within",
+        timeout_s=120.0,
+    ),
+    MatrixRow(
+        name="alert-test-pass-am",
+        profiles=("alerting",),
+        subcommand="metrics",
+        scenario=Path("examples/alert-lifecycle-test.yaml"),
+        verify_url="",
+        failure_log_containers=("alertmanager", "vmalert", "victoriametrics"),
+        verb="test",
+        extra_args=(
+            "--alertmanager-url",
+            "http://localhost:9093",
+            "--interval",
+            "5s",
+        ),
+        # "resolved after" is the half this scenario exists to exercise, and
+        # on this path it is also the proof that Alertmanager's own expiry
+        # semantics were read correctly rather than the alert merely
+        # vanishing from the API.
+        expect_stderr="resolved after",
+        timeout_s=300.0,
+    ),
 )
 
 # Backends keyed by compose profile. The empty-tuple key is for the default

--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -140,14 +140,24 @@ src/
 │   ├── evaluator.rs    ← pure, feature-free verdicts: Observation timelines + a deadline
 │   │                      → Outcome (Pass | Late | Missed | Undecided). Owns EVERY deadline
 │   │                      comparison — acquisition layers must never decide pass/fail.
+│   ├── alertmanager.rs ← acquisition (feature = "http"): blocking AlertmanagerClient over
+│   │                      GET /api/v2/alerts — verifies the *notification*, one hop past the
+│   │                      rule evaluator. Live polling only (no range API, no time()):
+│   │                      parse_alerts maps matched, unexpired alerts to Firing (never
+│   │                      Pending — AM has no such state), collects their labels for the
+│   │                      provenance check, and reports suppression. refine_firing_timeline
+│   │                      sharpens the first firing observation with the alert's own startsAt,
+│   │                      clamped between the last successful non-firing poll and the poll
+│   │                      that saw it — so a skewed clock can never rewrite observed history.
+│   │                      Clock offset comes from the HTTP Date header (1s granularity);
+│   │                      do NOT describe these verdicts with the prometheus.rs guarantees.
 │   └── prometheus.rs   ← acquisition (feature = "http"): blocking PrometheusClient with a
 │                          mandatory per-request timeout. Instant queries (alert_state) drive
 │                          live settling; range queries (range_timeline) reconstruct verdict
 │                          timelines from the stored ALERTS samples — grid parse in
 │                          parse_range_timeline, firing-series labels collected for the
 │                          foreign_label_values provenance check (verify/mod.rs). Errors are
-│                          SondaError::Verify, retryable by polling loops. Alertmanager
-│                          acquisition is planned as a sibling.
+│                          SondaError::Verify, retryable by polling loops.
 └── config/
     ├── mod.rs          ← BaseScheduleConfig (shared schedule/delivery fields: name, rate, duration,
     │                      gaps, bursts, cardinality_spikes, dynamic_labels, labels, sink,

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -17,7 +17,10 @@ config = ["dep:serde_yaml_ng", "dep:chrono", "chrono/serde"]
 # The async scheduling and delivery layer (tokio). Disable for pure-engine
 # consumers — e.g. compiling generators/encoders/compiler to WebAssembly.
 runtime = ["dep:tokio", "dep:tokio-util"]
-http = ["dep:ureq", "runtime"]
+# chrono: the Alertmanager acquisition parses RFC 3339 alert stamps and the
+# RFC 7231 `Date` header it measures the server clock from. Already a
+# dependency of the default `config` feature — no new supply chain.
+http = ["dep:ureq", "dep:chrono", "runtime"]
 kafka = ["dep:rskafka", "dep:chrono", "chrono/clock", "dep:rustls", "dep:rustls-pki-types", "dep:webpki-roots", "runtime"]
 remote-write = ["dep:prost", "dep:snap", "dep:ureq", "runtime"]
 otlp = ["dep:tonic", "dep:prost", "dep:bytes", "dep:http", "runtime"]

--- a/sonda-core/src/verify/alertmanager.rs
+++ b/sonda-core/src/verify/alertmanager.rs
@@ -365,8 +365,16 @@ pub fn parse_alerts(
 ///
 /// Both bounds matter because refinement moves verdicts in exactly one
 /// direction (towards `Pass`); an unbounded stamp from a skewed clock would
-/// be a false-pass channel. Returns the timeline unchanged when there is no
-/// stamp or nothing fired.
+/// be a false-pass channel.
+///
+/// When there is **no** successful earlier observation — every earlier poll
+/// errored, or the first poll already found the alert firing — the lower
+/// bound does not exist and the timeline is returned unchanged. Falling
+/// back to zero there would hand the stamp the most Pass-favourable value
+/// in the range at exactly the moment nothing corroborates it, which is the
+/// false-pass channel this function exists to close (#552 review W1).
+///
+/// Returns the timeline unchanged when there is no stamp or nothing fired.
 pub fn refine_firing_timeline(
     observations: &[Observation],
     starts_at_local: Option<f64>,
@@ -382,12 +390,19 @@ pub fn refine_firing_timeline(
     else {
         return refined;
     };
-    let floor = refined[..index]
+    // No successful earlier observation means no evidence to bound the
+    // stamp below, and the only available fallback — zero — is the most
+    // Pass-favourable value in the range. Refusing to refine is the
+    // correct answer: refinement is a sharpening of evidence we have, not
+    // a substitute for evidence we lack.
+    let Some(floor) = refined[..index]
         .iter()
         .rev()
         .find(|o| o.state.is_ok())
         .map(|o| o.at)
-        .unwrap_or(Duration::ZERO);
+    else {
+        return refined;
+    };
     let ceiling = refined[index].at;
     if floor >= ceiling {
         return refined;
@@ -756,9 +771,58 @@ mod tests {
     fn a_first_poll_that_is_already_firing_cannot_be_refined() {
         // No earlier evidence and no room below zero: the stamp has
         // nothing to sharpen, so the timeline must survive untouched.
+        //
+        // NOTE: this case alone is NOT discriminating — floor and ceiling
+        // coincide at 0s, so it passes whether or not the no-evidence path
+        // is handled (#552 review W1). The two tests below are the ones
+        // with teeth; this one stays for the boundary itself.
         let observations = timeline(&[(0, Some(AlertState::Firing))]);
         let refined = refine_firing_timeline(&observations, Some(500.0), 1000.0);
         assert_eq!(refined[0].at, Duration::ZERO);
+    }
+
+    #[test]
+    fn a_stamp_with_no_successful_earlier_poll_is_refused() {
+        // Every earlier poll errored, so nothing we observed can bound the
+        // stamp from below. A stale stamp (unix 900 against a 1000 anchor)
+        // would otherwise be clamped to zero — the most Pass-favourable
+        // value in the range — and flip a missed deadline into a pass.
+        let observations = timeline(&[
+            (0, None),
+            (10, None),
+            (20, None),
+            (30, Some(AlertState::Firing)),
+        ]);
+        let refined = refine_firing_timeline(&observations, Some(900.0), 1000.0);
+        assert_eq!(
+            refined[3].at,
+            Duration::from_secs(30),
+            "a stamp nothing corroborates must not move the firing time"
+        );
+    }
+
+    #[test]
+    fn a_late_first_poll_that_is_already_firing_is_refused() {
+        // Same hole, reached the other way: the very first observation is
+        // firing, but at 30s rather than 0s, so floor and ceiling do NOT
+        // coincide and a zero fallback would be a 30s jump to Pass.
+        let observations = timeline(&[(30, Some(AlertState::Firing))]);
+        let refined = refine_firing_timeline(&observations, Some(900.0), 1000.0);
+        assert_eq!(refined[0].at, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn one_successful_earlier_poll_is_enough_to_refine_again() {
+        // The refusal must be scoped to "no evidence", not to "some polls
+        // failed" — a single successful earlier observation restores the
+        // floor and the sharpening resumes.
+        let observations = timeline(&[
+            (0, None),
+            (10, Some(AlertState::Inactive)),
+            (30, Some(AlertState::Firing)),
+        ]);
+        let refined = refine_firing_timeline(&observations, Some(1020.0), 1000.0);
+        assert_eq!(refined[2].at, Duration::from_secs(20));
     }
 
     #[test]

--- a/sonda-core/src/verify/alertmanager.rs
+++ b/sonda-core/src/verify/alertmanager.rs
@@ -1,0 +1,790 @@
+//! Alertmanager acquisition for alert-state polling.
+//!
+//! The sibling of [`crate::verify::prometheus`], one hop further down the
+//! alerting path. The Prometheus path asks the *rule evaluator* whether a
+//! rule is firing; this one asks **Alertmanager** whether the notification
+//! actually arrived. A rule that evaluates correctly but never reaches
+//! Alertmanager — wrong `-notifier.url`, a dropped route, a broken relabel
+//! — is green on the Prometheus path and red here. That is the whole
+//! reason this module exists.
+//!
+//! Only `GET /api/v2/alerts` is used, filtered server-side with
+//! `filter=key="value"` matchers built from the expectation.
+//!
+//! # What this path can and cannot promise
+//!
+//! Alertmanager has **no range API and no `time()` endpoint**. There is no
+//! stored history to reconstruct after the fact: acquisition here is
+//! *live polling only*, and a state change between two polls is invisible.
+//! Verdict times therefore carry poll-interval precision, refined — never
+//! extended — by the alert's own `startsAt` stamp.
+//!
+//! "Absent" is the resolution signal, which is only trustworthy because a
+//! notifier keeps re-sending a still-firing alert. Measured live against
+//! vmalert v1.149.0 at a 5s evaluation interval: every evaluation re-posts
+//! the alert with `endsAt` 20s in the future, so a firing alert is never
+//! less than ~15s from expiry and would have to miss four consecutive
+//! evaluations to vanish between polls. Keep `--interval` well inside that
+//! window. The `alert-test-pass-am` UAT row is the standing check that this
+//! still holds end to end.
+//!
+//! `startsAt` is written by Alertmanager's clock, so comparing it against a
+//! local anchor would bake clock skew straight into the verdict. The offset
+//! is measured from the HTTP `Date` header of Alertmanager's own responses
+//! ([`AlertmanagerClient::measure_clock_offset`]), which is **one-second
+//! granular** — deliberately weaker than the `time()`-derived
+//! [`crate::verify::prometheus::ServerClock`], and reported as such. Do not
+//! describe Alertmanager verdicts as server-anchored to sample resolution;
+//! they are not.
+//!
+//! # State mapping
+//!
+//! Alertmanager has no `pending` concept — a rule in its `for:` window has
+//! not been sent yet, so it is simply absent. This module therefore never
+//! produces [`AlertState::Pending`]; every matched, unexpired alert is
+//! [`AlertState::Firing`] and everything else is [`AlertState::Inactive`].
+//! The evaluator only ever asks "is this Firing?", so the missing middle
+//! state changes no verdict.
+//!
+//! This module only *acquires* state — deadline decisions belong to
+//! [`crate::verify::evaluator`].
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::time::Duration;
+
+use crate::verify::evaluator::Observation;
+use crate::verify::{AlertExpectation, AlertState};
+use crate::{SondaError, VerifyError};
+
+/// One poll of Alertmanager for a single expectation.
+#[derive(Debug, Clone)]
+pub struct AlertSnapshot {
+    /// [`AlertState::Firing`] when at least one unexpired alert matched,
+    /// [`AlertState::Inactive`] otherwise. Never `Pending` — see the module
+    /// docs.
+    pub state: AlertState,
+    /// Label sets of the matched firing alerts — input for
+    /// [`crate::verify::foreign_label_values`] provenance checks, exactly
+    /// as the Prometheus path feeds them from its range series.
+    pub series: Vec<BTreeMap<String, String>>,
+    /// Earliest `startsAt` across the matched alerts, in **Alertmanager**
+    /// unix seconds. `None` when nothing matched or no stamp parsed.
+    pub started_at: Option<f64>,
+    /// Whether any matched alert was silenced or inhibited
+    /// (`status.state == "suppressed"`). Suppressed alerts still count as
+    /// firing — a silence stops the notification, not the alert — but the
+    /// report says so, because a silenced alert is rarely what a test
+    /// author meant to assert.
+    pub suppressed: bool,
+}
+
+/// Minimal blocking client for the Alertmanager v2 alerts API.
+///
+/// Every request carries an overall timeout, so a stalled Alertmanager
+/// returns a [`VerifyError::Query`] instead of parking the polling thread.
+pub struct AlertmanagerClient {
+    alerts_url: String,
+    agent: ureq::Agent,
+    clock_offset_secs: f64,
+}
+
+impl AlertmanagerClient {
+    /// Create a client for an Alertmanager base URL
+    /// (e.g. `http://localhost:9093`), with an overall per-request timeout
+    /// covering connect, write, and read. The clock offset starts at zero;
+    /// see [`Self::measure_clock_offset`] and [`Self::with_clock_offset`].
+    pub fn new(base_url: &str, timeout: Duration) -> Self {
+        let base = base_url.trim_end_matches('/');
+        Self {
+            alerts_url: format!("{base}/api/v2/alerts"),
+            agent: ureq::AgentBuilder::new().timeout(timeout).build(),
+            clock_offset_secs: 0.0,
+        }
+    }
+
+    /// Adopt a measured server-minus-local clock offset in seconds.
+    pub fn with_clock_offset(mut self, offset_secs: f64) -> Self {
+        self.clock_offset_secs = offset_secs;
+        self
+    }
+
+    /// The offset this client applies to Alertmanager-stamped timestamps.
+    pub fn clock_offset_secs(&self) -> f64 {
+        self.clock_offset_secs
+    }
+
+    /// Measure Alertmanager's clock from the `Date` header of a real
+    /// response, bracketing the request with local readings so the offset
+    /// is taken against the request's midpoint.
+    ///
+    /// HTTP dates have **one-second** resolution, so the result is only
+    /// good to about ±1s plus half the round trip. That is enough to keep
+    /// host clock skew out of a verdict and nowhere near enough to claim
+    /// sample-level precision.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SondaError::Verify`] when the endpoint is unreachable or
+    /// sends no parseable `Date` header — callers should fall back to a
+    /// zero offset with a warning rather than abort.
+    pub fn measure_clock_offset(&self) -> Result<f64, SondaError> {
+        let local_before = local_unix_now();
+        let response = self
+            .agent
+            .get(&self.alerts_url)
+            .query("filter", "alertname=\"sonda-clock-probe\"")
+            .call()
+            .map_err(|e| {
+                SondaError::Verify(VerifyError::Query {
+                    url: self.alerts_url.clone(),
+                    reason: e.to_string(),
+                })
+            })?;
+        let local_after = local_unix_now();
+        let header = response.header("date").ok_or_else(|| {
+            SondaError::Verify(VerifyError::BadResponse {
+                url: self.alerts_url.clone(),
+                reason: "response carries no Date header to measure the clock from".to_string(),
+            })
+        })?;
+        let server = parse_http_date(header).ok_or_else(|| {
+            SondaError::Verify(VerifyError::BadResponse {
+                url: self.alerts_url.clone(),
+                reason: format!("Date header {header:?} is not an HTTP date"),
+            })
+        })?;
+        Ok(server - (local_before + local_after) / 2.0)
+    }
+
+    /// Poll the current state of an expected alert.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SondaError::Verify`] when the endpoint is unreachable,
+    /// times out, or responds with an unusable payload — callers polling in
+    /// a loop treat these as retryable until their deadline.
+    pub fn alerts(&self, expectation: &AlertExpectation) -> Result<AlertSnapshot, SondaError> {
+        let mut request = self.agent.get(&self.alerts_url);
+        for filter in alert_filters(expectation) {
+            // ureq percent-encodes each query value; the matcher quoting
+            // below is the *other* half of the escaping contract.
+            request = request.query("filter", &filter);
+        }
+        let body = request
+            .call()
+            .map_err(|e| {
+                SondaError::Verify(VerifyError::Query {
+                    url: self.alerts_url.clone(),
+                    reason: e.to_string(),
+                })
+            })?
+            .into_string()
+            .map_err(|e| {
+                SondaError::Verify(VerifyError::BadResponse {
+                    url: self.alerts_url.clone(),
+                    reason: format!("response could not be read: {e}"),
+                })
+            })?;
+        let now = local_unix_now() + self.clock_offset_secs;
+        parse_alerts(&body, expectation, now).map_err(|reason| {
+            SondaError::Verify(VerifyError::BadResponse {
+                url: self.alerts_url.clone(),
+                reason,
+            })
+        })
+    }
+
+    /// [`Self::alerts`] reduced to just the state, for polling loops that
+    /// do not need the matched labels.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::alerts`].
+    pub fn alert_state(&self, expectation: &AlertExpectation) -> Result<AlertState, SondaError> {
+        Ok(self.alerts(expectation)?.state)
+    }
+}
+
+/// Local wall clock in unix seconds.
+fn local_unix_now() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+/// Build the `filter=` matchers for an expectation: `alertname` plus every
+/// declared label, each as a quoted equality matcher.
+///
+/// Alertmanager ANDs repeated `filter` params, so one matcher per param is
+/// both the documented shape and the one that cannot be broken by a comma
+/// inside a label value.
+pub fn alert_filters(expectation: &AlertExpectation) -> Vec<String> {
+    let mut filters = vec![matcher("alertname", &expectation.alert)];
+    if let Some(labels) = &expectation.labels {
+        for (key, value) in labels {
+            filters.push(matcher(key, value));
+        }
+    }
+    filters
+}
+
+/// One `key="value"` equality matcher with the value quoted.
+fn matcher(key: &str, value: &str) -> String {
+    let mut out = String::with_capacity(key.len() + value.len() + 3);
+    let _ = write!(out, "{key}=\"{}\"", escape_matcher_value(value));
+    out
+}
+
+/// Escape a matcher value for Alertmanager's quoted-string syntax.
+///
+/// Alertmanager parses matcher values with Go-style escapes inside double
+/// quotes, the same alphabet PromQL uses. An unescaped quote or backslash
+/// silently changes which alerts the filter selects, which is the exact
+/// class of bug percent-encoding alone does **not** prevent: the transport
+/// layer would faithfully deliver a broken matcher.
+fn escape_matcher_value(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
+}
+
+/// Parse a `GET /api/v2/alerts` response into an [`AlertSnapshot`].
+///
+/// `now_unix` is the current moment **on Alertmanager's clock** (local time
+/// plus the measured offset); it decides which alerts have expired.
+///
+/// Three things are checked per alert, and all three must hold for it to
+/// count as firing:
+///
+/// 1. Its labels satisfy the expectation — re-checked here even though the
+///    server already filtered, so a mis-escaped matcher can only ever lose
+///    a match, never invent one. Escaping correctness is proven separately
+///    by asserting the request line the client sends.
+/// 2. `status.state` is not a state Alertmanager treats as gone. `active`,
+///    `suppressed` and `unprocessed` all mean the notification exists;
+///    `suppressed` is reported but still counts (a silence stops the
+///    notification, not the alert).
+/// 3. `endsAt` has not passed. Measured against Alertmanager 0.28.1, a
+///    resolved alert is *removed* from `/api/v2/alerts` rather than lingering
+///    with a past `endsAt`, so absence is the resolution signal in practice
+///    and this check is the second line of defence: it covers a producer
+///    that posts an already-expired alert, and it keeps the verdict correct
+///    if that retention behaviour ever changes.
+///
+/// Returns a human-readable reason on failure; the caller wraps it with the
+/// query URL into a [`VerifyError::BadResponse`].
+pub fn parse_alerts(
+    body: &str,
+    expectation: &AlertExpectation,
+    now_unix: f64,
+) -> Result<AlertSnapshot, String> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(body).map_err(|e| format!("not valid JSON: {e}"))?;
+    let alerts = parsed
+        .as_array()
+        .ok_or_else(|| "expected a JSON array of alerts".to_string())?;
+
+    let mut series: Vec<BTreeMap<String, String>> = Vec::new();
+    let mut started_at: Option<f64> = None;
+    let mut suppressed = false;
+
+    for alert in alerts {
+        let labels: BTreeMap<String, String> = alert["labels"]
+            .as_object()
+            .map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !labels_match(&labels, expectation) {
+            continue;
+        }
+        let state = alert["status"]["state"].as_str().unwrap_or("active");
+        if !matches!(state, "active" | "suppressed" | "unprocessed") {
+            continue;
+        }
+        // A zero/absent endsAt means "no end declared" — still firing.
+        if let Some(ends_at) = parse_rfc3339(alert["endsAt"].as_str().unwrap_or_default()) {
+            if ends_at <= now_unix {
+                continue;
+            }
+        }
+        if state == "suppressed" {
+            suppressed = true;
+        }
+        if let Some(starts) = parse_rfc3339(alert["startsAt"].as_str().unwrap_or_default()) {
+            started_at = Some(started_at.map_or(starts, |current: f64| current.min(starts)));
+        }
+        if !series.contains(&labels) {
+            series.push(labels);
+        }
+    }
+
+    Ok(AlertSnapshot {
+        state: if series.is_empty() {
+            AlertState::Inactive
+        } else {
+            AlertState::Firing
+        },
+        series,
+        started_at,
+        suppressed,
+    })
+}
+
+/// Sharpen a firing timeline with Alertmanager's own `startsAt` stamp.
+///
+/// Live polling can only ever say "it was already firing when I asked", so
+/// the observed firing time is late by up to one poll interval. The alert
+/// carries the moment Alertmanager considers it to have started;
+/// `starts_at_local` is that stamp already translated to the local clock
+/// (Alertmanager stamp minus the measured offset), and `anchor_unix` is the
+/// scenario-start anchor the timeline's durations are measured from.
+///
+/// The stamp is **bounded on both sides by evidence we gathered ourselves**:
+///
+/// - It can only move the firing observation *earlier* — a stamp later than
+///   the poll that saw the alert would claim the alert had not yet started
+///   when we watched it firing.
+/// - It can never move earlier than the last successful *non*-firing poll —
+///   a stamp behind that would contradict a state we observed directly, and
+///   is evidence of clock error or of a previous, since-resolved episode of
+///   the same alert.
+///
+/// Both bounds matter because refinement moves verdicts in exactly one
+/// direction (towards `Pass`); an unbounded stamp from a skewed clock would
+/// be a false-pass channel. Returns the timeline unchanged when there is no
+/// stamp or nothing fired.
+pub fn refine_firing_timeline(
+    observations: &[Observation],
+    starts_at_local: Option<f64>,
+    anchor_unix: f64,
+) -> Vec<Observation> {
+    let mut refined = observations.to_vec();
+    let Some(starts_at) = starts_at_local.filter(|s| s.is_finite()) else {
+        return refined;
+    };
+    let Some(index) = refined
+        .iter()
+        .position(|o| matches!(o.state, Ok(AlertState::Firing)))
+    else {
+        return refined;
+    };
+    let floor = refined[..index]
+        .iter()
+        .rev()
+        .find(|o| o.state.is_ok())
+        .map(|o| o.at)
+        .unwrap_or(Duration::ZERO);
+    let ceiling = refined[index].at;
+    if floor >= ceiling {
+        return refined;
+    }
+    let raw = starts_at - anchor_unix;
+    let stamped = if raw <= 0.0 {
+        Duration::ZERO
+    } else {
+        Duration::from_secs_f64(raw)
+    };
+    refined[index].at = stamped.clamp(floor, ceiling);
+    refined
+}
+
+/// Whether an alert's labels satisfy the expectation's matchers.
+fn labels_match(labels: &BTreeMap<String, String>, expectation: &AlertExpectation) -> bool {
+    if labels.get("alertname").map(String::as_str) != Some(expectation.alert.as_str()) {
+        return false;
+    }
+    expectation.labels.as_ref().is_none_or(|wanted| {
+        wanted
+            .iter()
+            .all(|(key, value)| labels.get(key) == Some(value))
+    })
+}
+
+/// Parse an RFC 3339 timestamp into unix seconds, or `None` when it is
+/// absent, unparseable, or Go's zero time (which Alertmanager sends for
+/// "unset").
+pub fn parse_rfc3339(value: &str) -> Option<f64> {
+    if value.is_empty() || value.starts_with("0001-01-01") {
+        return None;
+    }
+    let parsed = chrono::DateTime::parse_from_rfc3339(value).ok()?;
+    Some(parsed.timestamp() as f64 + f64::from(parsed.timestamp_subsec_nanos()) / 1e9)
+}
+
+/// Parse an HTTP `Date` header (RFC 7231 IMF-fixdate) into unix seconds.
+///
+/// Returns `None` for anything unparseable — the caller warns and falls
+/// back to a zero offset rather than trusting a guess.
+pub fn parse_http_date(value: &str) -> Option<f64> {
+    let parsed = chrono::DateTime::parse_from_rfc2822(value.trim()).ok()?;
+    Some(parsed.timestamp() as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn expectation(labels: Option<BTreeMap<String, String>>) -> AlertExpectation {
+        AlertExpectation {
+            alert: "HighCpuUsage".into(),
+            labels,
+            firing_within: "1m".into(),
+            resolves_within: None,
+        }
+    }
+
+    fn labels(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    /// One `gettableAlert` as Alertmanager v2 renders it.
+    fn alert_json(state: &str, ends_at: &str, extra: &str) -> String {
+        format!(
+            r#"{{"labels":{{"alertname":"HighCpuUsage","host":"sonda-test"{extra}}},
+                "startsAt":"2026-08-15T12:00:00.000Z","endsAt":"{ends_at}",
+                "status":{{"state":"{state}","silencedBy":[],"inhibitedBy":[]}}}}"#
+        )
+    }
+
+    /// Unix seconds for 2026-08-15T12:00:00Z, the fixtures' start stamp.
+    const START_UNIX: f64 = 1_786_795_200.0;
+
+    #[test]
+    fn filters_cover_alertname_and_every_label() {
+        let filters = alert_filters(&expectation(Some(labels(&[
+            ("severity", "critical"),
+            ("host", "sonda-test"),
+        ]))));
+        assert_eq!(
+            filters,
+            vec![
+                "alertname=\"HighCpuUsage\"",
+                "host=\"sonda-test\"",
+                "severity=\"critical\"",
+            ]
+        );
+    }
+
+    #[rustfmt::skip]
+    #[rstest::rstest]
+    // Hostile label values: the matcher must stay one well-formed quoted
+    // string. Percent-encoding happens a layer later (ureq) and cannot
+    // rescue a value that broke out of its quotes here.
+    #[case::plain(       "critical",      "team=\"critical\"")]
+    #[case::double_quote("net\"ops",      "team=\"net\\\"ops\"")]
+    #[case::backslash(   "a\\b",          "team=\"a\\\\b\"")]
+    #[case::quote_escape("a\\\"b",        "team=\"a\\\\\\\"b\"")]
+    #[case::spaces(      "on call",       "team=\"on call\"")]
+    #[case::comma(       "a,b",           "team=\"a,b\"")]
+    #[case::brace(       "a}b{c",         "team=\"a}b{c\"")]
+    #[case::newline(     "a\nb",          "team=\"a\\nb\"")]
+    #[case::carriage(    "a\rb",          "team=\"a\\rb\"")]
+    #[case::tab(         "a\tb",          "team=\"a\\tb\"")]
+    #[case::utf8(        "café-ñoño-日本", "team=\"café-ñoño-日本\"")]
+    #[case::emoji(       "🔥",            "team=\"🔥\"")]
+    #[case::empty(       "",              "team=\"\"")]
+    fn hostile_label_values_stay_quoted(#[case] value: &str, #[case] expected: &str) {
+        let filters = alert_filters(&expectation(Some(labels(&[("team", value)]))));
+        assert_eq!(filters[1], expected);
+    }
+
+    #[test]
+    fn active_alert_is_firing_with_labels_and_start() {
+        let body = format!("[{}]", alert_json("active", "2026-08-15T12:10:00.000Z", ""));
+        let snapshot = parse_alerts(&body, &expectation(None), START_UNIX + 60.0).expect("parse");
+        assert_eq!(snapshot.state, AlertState::Firing);
+        assert_eq!(snapshot.series.len(), 1);
+        assert_eq!(
+            snapshot.series[0].get("host").map(String::as_str),
+            Some("sonda-test")
+        );
+        assert_eq!(snapshot.started_at, Some(START_UNIX));
+        assert!(!snapshot.suppressed);
+    }
+
+    #[test]
+    fn empty_array_is_inactive() {
+        let snapshot = parse_alerts("[]", &expectation(None), START_UNIX).expect("parse");
+        assert_eq!(snapshot.state, AlertState::Inactive);
+        assert!(snapshot.series.is_empty());
+        assert_eq!(snapshot.started_at, None);
+    }
+
+    #[test]
+    fn suppressed_alert_still_counts_as_firing_and_is_flagged() {
+        // A silence stops the notification, not the alert: the rule did
+        // fire, so firing_within is satisfied — but the caller is told.
+        let body = format!(
+            "[{}]",
+            alert_json("suppressed", "2026-08-15T12:10:00.000Z", "")
+        );
+        let snapshot = parse_alerts(&body, &expectation(None), START_UNIX + 60.0).expect("parse");
+        assert_eq!(snapshot.state, AlertState::Firing);
+        assert!(snapshot.suppressed);
+    }
+
+    #[test]
+    fn expired_alert_is_not_firing() {
+        // Alertmanager 0.28.1 drops resolved alerts from the API, so this
+        // payload is the hostile case rather than the common one: a
+        // producer posting an already-expired alert must not read as
+        // firing just because it is present.
+        let body = format!("[{}]", alert_json("active", "2026-08-15T12:05:00.000Z", ""));
+        let snapshot = parse_alerts(&body, &expectation(None), START_UNIX + 600.0).expect("parse");
+        assert_eq!(snapshot.state, AlertState::Inactive);
+        assert!(snapshot.series.is_empty());
+    }
+
+    #[test]
+    fn alert_expiring_exactly_now_is_not_firing() {
+        let body = format!("[{}]", alert_json("active", "2026-08-15T12:05:00.000Z", ""));
+        let snapshot = parse_alerts(&body, &expectation(None), START_UNIX + 300.0).expect("parse");
+        assert_eq!(snapshot.state, AlertState::Inactive);
+    }
+
+    #[test]
+    fn zero_ends_at_means_no_expiry() {
+        let body = format!("[{}]", alert_json("active", "0001-01-01T00:00:00.000Z", ""));
+        let snapshot = parse_alerts(&body, &expectation(None), START_UNIX + 600.0).expect("parse");
+        assert_eq!(snapshot.state, AlertState::Firing);
+    }
+
+    #[test]
+    fn label_recheck_rejects_an_alert_the_expectation_did_not_ask_for() {
+        // Defence in depth against a mis-escaped filter: the server is not
+        // trusted to have applied the matchers we meant to send, so a bad
+        // matcher can lose a match but never fabricate one.
+        let body = format!("[{}]", alert_json("active", "2026-08-15T12:10:00.000Z", ""));
+        let wanted = expectation(Some(labels(&[("host", "other-host")])));
+        let snapshot = parse_alerts(&body, &wanted, START_UNIX + 60.0).expect("parse");
+        assert_eq!(snapshot.state, AlertState::Inactive);
+    }
+
+    #[test]
+    fn label_recheck_rejects_a_different_alertname() {
+        let body = r#"[{"labels":{"alertname":"OtherAlert","host":"sonda-test"},
+            "startsAt":"2026-08-15T12:00:00.000Z","endsAt":"2026-08-15T12:10:00.000Z",
+            "status":{"state":"active"}}]"#;
+        let snapshot = parse_alerts(body, &expectation(None), START_UNIX + 60.0).expect("parse");
+        assert_eq!(snapshot.state, AlertState::Inactive);
+    }
+
+    #[test]
+    fn earliest_start_wins_across_matched_alerts() {
+        let body = r#"[
+            {"labels":{"alertname":"HighCpuUsage","host":"a"},
+             "startsAt":"2026-08-15T12:02:00.000Z","endsAt":"2026-08-15T12:10:00.000Z",
+             "status":{"state":"active"}},
+            {"labels":{"alertname":"HighCpuUsage","host":"b"},
+             "startsAt":"2026-08-15T12:00:30.000Z","endsAt":"2026-08-15T12:10:00.000Z",
+             "status":{"state":"active"}}
+        ]"#;
+        let snapshot = parse_alerts(body, &expectation(None), START_UNIX + 180.0).expect("parse");
+        assert_eq!(snapshot.started_at, Some(START_UNIX + 30.0));
+        assert_eq!(snapshot.series.len(), 2);
+    }
+
+    #[test]
+    fn expired_alert_does_not_contribute_its_start_stamp() {
+        // An alert that already ended must not drag `started_at` earlier —
+        // otherwise a stale notification would refine a later alert's
+        // firing time backwards and could turn Late into Pass.
+        let body = r#"[
+            {"labels":{"alertname":"HighCpuUsage","host":"a"},
+             "startsAt":"2026-08-15T11:00:00.000Z","endsAt":"2026-08-15T11:30:00.000Z",
+             "status":{"state":"active"}},
+            {"labels":{"alertname":"HighCpuUsage","host":"a"},
+             "startsAt":"2026-08-15T12:05:00.000Z","endsAt":"2026-08-15T12:20:00.000Z",
+             "status":{"state":"active"}}
+        ]"#;
+        let snapshot = parse_alerts(body, &expectation(None), START_UNIX + 400.0).expect("parse");
+        assert_eq!(snapshot.started_at, Some(START_UNIX + 300.0));
+    }
+
+    #[test]
+    fn unknown_status_state_is_ignored() {
+        let body = format!(
+            "[{}]",
+            alert_json("resolved", "2026-08-15T12:10:00.000Z", "")
+        );
+        let snapshot = parse_alerts(&body, &expectation(None), START_UNIX + 60.0).expect("parse");
+        assert_eq!(snapshot.state, AlertState::Inactive);
+    }
+
+    #[test]
+    fn non_array_payload_is_rejected() {
+        let err = parse_alerts(r#"{"status":"success"}"#, &expectation(None), 0.0)
+            .expect_err("must reject");
+        assert!(err.contains("array"), "{err}");
+    }
+
+    #[test]
+    fn invalid_json_is_rejected() {
+        assert!(parse_alerts("not json", &expectation(None), 0.0).is_err());
+    }
+
+    #[rustfmt::skip]
+    #[rstest::rstest]
+    #[case::zulu(       "2026-08-15T12:00:00Z",        Some(1_786_795_200.0))]
+    #[case::millis(     "2026-08-15T12:00:00.500Z",    Some(1_786_795_200.5))]
+    #[case::offset(     "2026-08-15T13:00:00+01:00",   Some(1_786_795_200.0))]
+    #[case::go_zero(    "0001-01-01T00:00:00Z",        None)]
+    #[case::empty(      "",                            None)]
+    #[case::garbage(    "not a time",                  None)]
+    #[case::date_only(  "2026-08-15",                  None)]
+    fn rfc3339_parsing(#[case] value: &str, #[case] expected: Option<f64>) {
+        match (parse_rfc3339(value), expected) {
+            (Some(got), Some(want)) => assert!((got - want).abs() < 1e-6, "{got} vs {want}"),
+            (got, want) => assert_eq!(got.is_none(), want.is_none(), "{value:?}"),
+        }
+    }
+
+    #[test]
+    fn http_date_parses_imf_fixdate() {
+        let ts = parse_http_date("Sat, 15 Aug 2026 12:00:00 GMT").expect("parse");
+        assert!((ts - 1_786_795_200.0).abs() < 1e-6, "{ts}");
+    }
+
+    #[test]
+    fn http_date_rejects_garbage() {
+        assert!(parse_http_date("").is_none());
+        assert!(parse_http_date("yesterday").is_none());
+        assert!(parse_http_date("2026-08-15T12:00:00Z").is_none());
+    }
+
+    fn timeline(points: &[(u64, Option<AlertState>)]) -> Vec<Observation> {
+        points
+            .iter()
+            .map(|(secs, state)| {
+                Observation::new(
+                    Duration::from_secs(*secs),
+                    state.ok_or_else(|| "query failed".to_string()),
+                )
+            })
+            .collect()
+    }
+
+    /// A three-poll firing timeline anchored at unix 1000: inactive at 0s
+    /// and 10s, firing first seen at 20s.
+    fn late_notice() -> Vec<Observation> {
+        timeline(&[
+            (0, Some(AlertState::Inactive)),
+            (10, Some(AlertState::Inactive)),
+            (20, Some(AlertState::Firing)),
+        ])
+    }
+
+    #[test]
+    fn starts_at_pulls_the_firing_observation_back_to_the_stamp() {
+        let refined = refine_firing_timeline(&late_notice(), Some(1015.0), 1000.0);
+        assert_eq!(refined[2].at, Duration::from_secs(15));
+        // Everything else is untouched.
+        assert_eq!(refined[0].at, Duration::ZERO);
+        assert_eq!(refined[1].at, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn starts_at_never_moves_the_observation_later() {
+        // A stamp after the poll would claim the alert had not started
+        // when we watched it firing.
+        let refined = refine_firing_timeline(&late_notice(), Some(1030.0), 1000.0);
+        assert_eq!(refined[2].at, Duration::from_secs(20));
+    }
+
+    #[test]
+    fn starts_at_never_contradicts_an_observed_inactive_poll() {
+        // 1005 is before the 10s poll that successfully saw Inactive: a
+        // skewed clock (or a previous episode's stamp) must not rewrite
+        // history we watched happen.
+        let refined = refine_firing_timeline(&late_notice(), Some(1005.0), 1000.0);
+        assert_eq!(refined[2].at, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn a_failed_poll_is_not_a_floor() {
+        // Only successful observations bound the stamp — a query error
+        // proves nothing about the alert's state.
+        let observations = timeline(&[
+            (0, Some(AlertState::Inactive)),
+            (10, None),
+            (20, Some(AlertState::Firing)),
+        ]);
+        let refined = refine_firing_timeline(&observations, Some(1005.0), 1000.0);
+        assert_eq!(refined[2].at, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn stamp_before_the_anchor_clamps_to_the_first_observation() {
+        // An alert that predates the scenario: floor is the 0s poll, so
+        // the refinement cannot invent negative time.
+        let refined = refine_firing_timeline(&late_notice(), Some(900.0), 1000.0);
+        assert_eq!(refined[2].at, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn no_stamp_and_no_firing_leave_the_timeline_alone() {
+        assert_eq!(
+            refine_firing_timeline(&late_notice(), None, 1000.0)[2].at,
+            Duration::from_secs(20)
+        );
+        let never = timeline(&[(0, Some(AlertState::Inactive))]);
+        assert_eq!(
+            refine_firing_timeline(&never, Some(1000.0), 1000.0)[0].at,
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn a_first_poll_that_is_already_firing_cannot_be_refined() {
+        // No earlier evidence and no room below zero: the stamp has
+        // nothing to sharpen, so the timeline must survive untouched.
+        let observations = timeline(&[(0, Some(AlertState::Firing))]);
+        let refined = refine_firing_timeline(&observations, Some(500.0), 1000.0);
+        assert_eq!(refined[0].at, Duration::ZERO);
+    }
+
+    #[test]
+    fn a_nan_stamp_is_ignored() {
+        let refined = refine_firing_timeline(&late_notice(), Some(f64::NAN), 1000.0);
+        assert_eq!(refined[2].at, Duration::from_secs(20));
+    }
+
+    #[test]
+    fn stalled_endpoint_times_out_with_verify_error() {
+        // A listener that accepts but never answers must produce a bounded
+        // Verify::Query error, not a parked polling thread — same contract
+        // the Prometheus client holds.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let _keep_alive = std::thread::spawn(move || {
+            let _streams: Vec<_> = listener.incoming().take(1).collect();
+            std::thread::sleep(Duration::from_secs(30));
+        });
+        let client = AlertmanagerClient::new(&format!("http://{addr}"), Duration::from_millis(300));
+        let started = std::time::Instant::now();
+        let result = client.alert_state(&expectation(None));
+        assert!(started.elapsed() < Duration::from_secs(5));
+        match result {
+            Err(SondaError::Verify(VerifyError::Query { .. })) => {}
+            other => panic!("expected Verify::Query error, got {other:?}"),
+        }
+    }
+}

--- a/sonda-core/src/verify/mod.rs
+++ b/sonda-core/src/verify/mod.rs
@@ -14,9 +14,14 @@
 //!
 //! The block is pure metadata to the compiler and runtime — scenarios run
 //! identically with or without it. [`parse_expectations`] extracts it, and
-//! the [`prometheus`] client (feature `http`) polls a Prometheus-compatible
-//! API's `ALERTS` metric to check each expectation.
+//! one of two acquisition layers (feature `http`) checks each expectation:
+//! the [`prometheus`] client polls a Prometheus-compatible API's `ALERTS`
+//! metric — did the *rule* fire? — while the [`alertmanager`] client polls
+//! `GET /api/v2/alerts` — did the *notification* arrive? The same
+//! `expect:` block drives both; the caller picks exactly one.
 
+#[cfg(feature = "http")]
+pub mod alertmanager;
 pub mod evaluator;
 #[cfg(feature = "http")]
 pub mod prometheus;
@@ -28,8 +33,10 @@ use crate::SondaError;
 
 /// Observed state of one alert at a single poll.
 ///
-/// Produced by acquisition (the [`prometheus`] client today, Alertmanager
-/// sampling in a later phase) and consumed by the [`evaluator`].
+/// Produced by acquisition (the [`prometheus`] or [`alertmanager`] client)
+/// and consumed by the [`evaluator`]. Not every acquisition can produce
+/// every variant: Alertmanager has no `pending` concept, so that path only
+/// ever reports `Firing` or `Inactive`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AlertState {
     /// No alert series matched the expectation's selector.

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -110,7 +110,13 @@ the single discovery surface. The verbosity model is captured in the `Verbosity`
   otherwise the YAML is printed to stdout.
 
 - **`sonda test`** — run a scenario and verify its top-level `expect:` alert expectations
-  against a Prometheus-compatible API (`--prometheus-url`, env `SONDA_PROMETHEUS_URL`).
+  against **exactly one** acquisition source: a Prometheus-compatible API
+  (`--prometheus-url`, env `SONDA_PROMETHEUS_URL`) or an Alertmanager
+  (`--alertmanager-url`, env `SONDA_ALERTMANAGER_URL`). Passing both is an error — they
+  verify different hops (did the *rule* fire vs. did the *notification* arrive) and
+  their verdicts cannot be merged. The Alertmanager path has no range API and no
+  `time()`, so it is live-polling only; its report states that precision explicitly
+  rather than borrowing the Prometheus path's sample-time guarantees.
   Live polling of the `ALERTS` metric (a poller thread beside the same run machinery as
   `sonda run`) only decides when each check has *settled*; the verdict timeline is then
   reconstructed by a range query over the stored samples at `--query-step` resolution, so

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -39,6 +39,9 @@ tokio-util = { version = "0.7", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"
+# The mock Alertmanager stamps alerts (RFC 3339) and its own Date header
+# (RFC 7231), both of which the acquisition layer parses for real.
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 insta = { workspace = true, features = ["filters"] }
 rstest = { workspace = true }
 

--- a/sonda/src/cli.rs
+++ b/sonda/src/cli.rs
@@ -130,9 +130,18 @@ pub struct TestArgs {
     pub scenario: String,
 
     /// Base URL of the Prometheus-compatible API evaluating the alert rules
-    /// (e.g. `http://localhost:9090`). Required except with `--dry-run`.
+    /// (e.g. `http://localhost:9090`) — verifies that the *rule* fires.
+    /// Exactly one of `--prometheus-url` / `--alertmanager-url` is required,
+    /// except with `--dry-run`.
     #[arg(long, env = "SONDA_PROMETHEUS_URL")]
     pub prometheus_url: Option<String>,
+
+    /// Base URL of the Alertmanager receiving the alerts
+    /// (e.g. `http://localhost:9093`) — verifies that the *notification*
+    /// arrived, one hop further down the alerting path. Mutually exclusive
+    /// with `--prometheus-url`.
+    #[arg(long, env = "SONDA_ALERTMANAGER_URL")]
+    pub alertmanager_url: Option<String>,
 
     /// Poll interval for alert-state checks (e.g. `5s`).
     #[arg(long, default_value = "5s")]
@@ -143,7 +152,9 @@ pub struct TestArgs {
     pub query_timeout: String,
 
     /// Grid resolution for the post-hoc range queries that produce the
-    /// verdict timelines. Match your rule evaluation interval.
+    /// verdict timelines. Match your rule evaluation interval. Applies to
+    /// `--prometheus-url` only: Alertmanager has no range API, so that path
+    /// is live-polling only and its resolution is `--interval`.
     #[arg(long, default_value = "5s")]
     pub query_step: String,
 }

--- a/sonda/src/test_cmd.rs
+++ b/sonda/src/test_cmd.rs
@@ -1,8 +1,15 @@
 //! `sonda test` — run a scenario and verify its `expect:` alert expectations.
 //!
 //! Orchestration and rendering only: every deadline decision is made by
-//! `sonda_core::verify::evaluator` over [`Observation`] timelines. Two
-//! acquisition layers feed it:
+//! `sonda_core::verify::evaluator` over [`Observation`] timelines.
+//!
+//! Exactly one **acquisition source** supplies those timelines, chosen by
+//! the caller with `--prometheus-url` or `--alertmanager-url`. They answer
+//! different questions about the same `expect:` block — *did the rule
+//! fire?* versus *did the notification arrive?* — so the same expectations
+//! verify two different hops of the alerting path.
+//!
+//! **Prometheus** (`--prometheus-url`) acquires in two stages:
 //!
 //! - **Live polling** (instant queries) runs while the scenario does and
 //!   only decides *when each check has settled* — firing observed, resolved,
@@ -13,6 +20,15 @@
 //!   skewed by time spent polling other expectations. When range
 //!   acquisition fails or disagrees with what live polling saw (remote-
 //!   write lag), the live timeline is the warned-about fallback.
+//!
+//! **Alertmanager** (`--alertmanager-url`) has no range API and no stored
+//! history, so it is live polling only. Its verdict timeline is the poll
+//! timeline, with the first firing observation sharpened by the alert's own
+//! `startsAt` stamp — bounded by our own observations, never beyond them
+//! (`verify::alertmanager::refine_firing_timeline`). Verdict times on this
+//! path therefore carry `--interval` precision, not sample precision, and
+//! the report says so rather than borrowing the Prometheus path's
+//! guarantees.
 //!
 //! Firing deadlines are measured from scenario start, resolution deadlines
 //! from scenario end. The process exits non-zero when any expectation
@@ -26,9 +42,12 @@ use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{bail, Context};
 use owo_colors::{OwoColorize, Stream::Stderr};
+use sonda_core::verify::alertmanager::{refine_firing_timeline, AlertmanagerClient};
 use sonda_core::verify::evaluator::{evaluate_firing, evaluate_resolution, Observation, Outcome};
 use sonda_core::verify::prometheus::{PrometheusClient, ServerClock};
-use sonda_core::verify::{foreign_label_values, parse_expectations, AlertState, ExpectConfig};
+use sonda_core::verify::{
+    foreign_label_values, parse_expectations, AlertExpectation, AlertState, ExpectConfig,
+};
 use sonda_core::CancellationToken;
 
 use crate::cli::{self, Cli, Verbosity};
@@ -39,6 +58,148 @@ use crate::cli::{self, Cli, Verbosity};
 enum Check {
     Firing,
     Resolution,
+}
+
+/// The acquisition source the caller chose, before any client is built —
+/// so the same choice can be reconnected for the poller thread.
+#[derive(Clone, Copy)]
+enum Target<'a> {
+    Prometheus(&'a str),
+    Alertmanager(&'a str),
+}
+
+impl Target<'_> {
+    fn url(&self) -> &str {
+        match self {
+            Target::Prometheus(url) | Target::Alertmanager(url) => url,
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            Target::Prometheus(_) => "Prometheus",
+            Target::Alertmanager(_) => "Alertmanager",
+        }
+    }
+
+    /// Build a client. `am_offset` is ignored by the Prometheus variant.
+    fn connect(&self, timeout: Duration, am_offset: f64) -> Source {
+        match self {
+            Target::Prometheus(url) => Source::Prometheus(PrometheusClient::new(url, timeout)),
+            Target::Alertmanager(url) => Source::Alertmanager(
+                AlertmanagerClient::new(url, timeout).with_clock_offset(am_offset),
+            ),
+        }
+    }
+}
+
+/// The one acquisition source this run verifies against.
+///
+/// Both variants answer "is this expectation firing right now?"; only the
+/// Prometheus one can also reconstruct history after the fact.
+enum Source {
+    Prometheus(PrometheusClient),
+    Alertmanager(AlertmanagerClient),
+}
+
+/// What one poll of one expectation yielded, in the shape both acquisitions
+/// can produce. The Prometheus path leaves `series` and `started_at` empty
+/// — it recovers matched series from its range query instead.
+#[derive(Default)]
+struct Poll {
+    series: Vec<BTreeMap<String, String>>,
+    started_at: Option<f64>,
+    suppressed: bool,
+}
+
+/// Everything the live poller learned about one expectation beyond its
+/// timeline: matched label sets (provenance) and Alertmanager's own view of
+/// when the alert started.
+#[derive(Default, Clone)]
+struct Evidence {
+    series: Vec<BTreeMap<String, String>>,
+    started_at: Option<f64>,
+    suppressed: bool,
+}
+
+/// What the live firing poller hands back: one timeline and one evidence
+/// bundle per expectation, in expectation order.
+struct FiringPoll {
+    timelines: Vec<Vec<Observation>>,
+    evidence: Vec<Evidence>,
+}
+
+impl FiringPoll {
+    fn empty(alerts: usize) -> Self {
+        Self {
+            timelines: vec![Vec::new(); alerts],
+            evidence: vec![Evidence::default(); alerts],
+        }
+    }
+}
+
+impl Evidence {
+    fn absorb(&mut self, poll: Poll) {
+        for labels in poll.series {
+            if !self.series.contains(&labels) {
+                self.series.push(labels);
+            }
+        }
+        if let Some(starts) = poll.started_at {
+            self.started_at = Some(self.started_at.map_or(starts, |cur: f64| cur.min(starts)));
+        }
+        self.suppressed |= poll.suppressed;
+    }
+}
+
+impl Source {
+    /// Poll one expectation. The state is the poller's settling signal; the
+    /// rest is evidence the caller accumulates.
+    fn poll(&self, expectation: &AlertExpectation) -> (Result<AlertState, String>, Poll) {
+        match self {
+            Source::Prometheus(client) => (
+                client.alert_state(expectation).map_err(|e| e.to_string()),
+                Poll::default(),
+            ),
+            Source::Alertmanager(client) => match client.alerts(expectation) {
+                Ok(snapshot) => (
+                    Ok(snapshot.state),
+                    Poll {
+                        series: snapshot.series,
+                        started_at: snapshot.started_at,
+                        suppressed: snapshot.suppressed,
+                    },
+                ),
+                Err(e) => (Err(e.to_string()), Poll::default()),
+            },
+        }
+    }
+
+    /// Reachability + selector probe, used by the preflight gate.
+    fn probe(&self, expectation: &AlertExpectation) -> anyhow::Result<()> {
+        match self {
+            Source::Prometheus(client) => client.alert_state(expectation).map(|_| ()),
+            Source::Alertmanager(client) => client.alert_state(expectation).map(|_| ()),
+        }
+        .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    /// How the report names this source.
+    fn label(&self) -> &'static str {
+        match self {
+            Source::Prometheus(_) => "Prometheus",
+            Source::Alertmanager(_) => "Alertmanager",
+        }
+    }
+
+    /// Alertmanager stamps live on its own clock; this is the measured
+    /// server-minus-local offset used to translate them back.
+    fn clock_offset_secs(&self) -> f64 {
+        match self {
+            Source::Prometheus(_) => 0.0,
+            Source::Alertmanager(client) => client.clock_offset_secs(),
+        }
+    }
 }
 
 /// Per-expectation live resolution polling result: `None` when the check
@@ -83,25 +244,67 @@ pub fn run(
         return Ok(());
     }
 
-    let Some(prometheus_url) = args.prometheus_url.as_deref() else {
-        bail!("--prometheus-url is required (or set SONDA_PROMETHEUS_URL); only --dry-run works without it");
+    // Exactly one acquisition source. Both is a contradiction (which
+    // verdict would win?), neither leaves nothing to ask.
+    let target = match (
+        args.prometheus_url.as_deref(),
+        args.alertmanager_url.as_deref(),
+    ) {
+        (Some(_), Some(_)) => bail!(
+            "--prometheus-url and --alertmanager-url are mutually exclusive — \
+             `sonda test` verifies against exactly one acquisition source \
+             (the rule evaluator or Alertmanager), so pick the hop you mean to test"
+        ),
+        (Some(url), None) => Target::Prometheus(url),
+        (None, Some(url)) => Target::Alertmanager(url),
+        (None, None) => bail!(
+            "one of --prometheus-url (env SONDA_PROMETHEUS_URL) or --alertmanager-url \
+             (env SONDA_ALERTMANAGER_URL) is required; only --dry-run works without one"
+        ),
     };
+    let url = target.url().to_string();
 
-    let client = PrometheusClient::new(prometheus_url, query_timeout);
-    preflight(&client, &expect, cancel)
-        .with_context(|| format!("prometheus preflight against {prometheus_url} failed"))?;
+    preflight(&target.connect(query_timeout, 0.0), &expect, cancel).with_context(|| {
+        format!(
+            "{} preflight against {url} failed",
+            target.label().to_lowercase()
+        )
+    })?;
+
+    // Alertmanager's alert stamps come from *its* clock, measured from the
+    // Date header — one-second granular, and only ever used to sharpen a
+    // firing time within bounds we observed ourselves.
+    let am_offset = match target {
+        Target::Prometheus(_) => 0.0,
+        Target::Alertmanager(_) => AlertmanagerClient::new(&url, query_timeout)
+            .measure_clock_offset()
+            .unwrap_or_else(|e| {
+                eprintln!(
+                    "  {} could not measure the Alertmanager clock ({e}); assuming zero offset \
+                     — firing times refined from `startsAt` may be skewed by any clock difference",
+                    warn_marker()
+                );
+                0.0
+            }),
+    };
+    let client = target.connect(query_timeout, am_offset);
 
     // Verdict anchors must live on the *server's* clock — range samples
     // carry server timestamps, and subtracting a local anchor from them
-    // bakes any clock skew straight into the verdicts.
-    let clock = client.server_clock().unwrap_or_else(|e| {
-        eprintln!(
-            "  {} could not measure the server clock ({e}); assuming zero offset — \
-             verdict times may be skewed by any clock difference",
-            warn_marker()
-        );
-        ServerClock::identity()
-    });
+    // bakes any clock skew straight into the verdicts. Alertmanager has no
+    // `time()` endpoint and no range API, so this stays the identity there;
+    // its own offset is applied to `startsAt` stamps instead.
+    let clock = match &client {
+        Source::Prometheus(prometheus) => prometheus.server_clock().unwrap_or_else(|e| {
+            eprintln!(
+                "  {} could not measure the server clock ({e}); assuming zero offset — \
+                 verdict times may be skewed by any clock difference",
+                warn_marker()
+            );
+            ServerClock::identity()
+        }),
+        Source::Alertmanager(_) => ServerClock::identity(),
+    };
 
     // The firing poller runs alongside the scenario. `stop` cuts it short
     // when the scenario itself fails — no point waiting out deadlines to
@@ -111,9 +314,9 @@ pub fn run(
     let started_wall = SystemTime::now();
     let started_at = Instant::now();
     let stop = Arc::new(AtomicBool::new(false));
-    let (timeline_tx, timeline_rx) = mpsc::channel::<Vec<Vec<Observation>>>();
+    let (timeline_tx, timeline_rx) = mpsc::channel::<FiringPoll>();
     let poller = spawn_firing_poller(
-        PrometheusClient::new(prometheus_url, query_timeout),
+        target.connect(query_timeout, am_offset),
         expect.clone(),
         started_at,
         interval,
@@ -134,7 +337,7 @@ pub fn run(
 
     let ended_wall = started_wall + ended_at.duration_since(started_at);
     let poller_died = poller.join().is_err();
-    let firing_timelines = timeline_rx.try_recv().ok();
+    let firing_poll = timeline_rx.try_recv().ok();
     if cancel.is_cancelled() {
         bail!("interrupted before alert expectations could be verified");
     }
@@ -143,12 +346,18 @@ pub fn run(
     // acquisition below can still recover a verdict from the datastore,
     // and when it can't, the evaluator maps the empty timeline to
     // Undecided and the report says why (review W4).
-    let live_firing = firing_timelines.unwrap_or_else(|| vec![Vec::new(); expect.alerts.len()]);
+    let FiringPoll {
+        timelines: live_firing,
+        evidence,
+    } = firing_poll.unwrap_or_else(|| FiringPoll::empty(expect.alerts.len()));
 
     // One settling pause before the verdict queries: the rule evaluator
     // remote-writes ALERTS on its own cadence, and the freshest samples
-    // need a beat to land.
-    std::thread::sleep(query_step.min(Duration::from_secs(5)));
+    // need a beat to land. Alertmanager holds no history for a later query
+    // to find, so there is nothing to wait for on that path.
+    if matches!(client, Source::Prometheus(_)) {
+        std::thread::sleep(query_step.min(Duration::from_secs(5)));
+    }
     if cancel.is_cancelled() {
         bail!("interrupted before alert expectations could be verified");
     }
@@ -157,6 +366,9 @@ pub fn run(
     let mut matched_firing_series: Vec<BTreeMap<String, String>> = Vec::new();
 
     let anchor_start = clock.at(started_wall);
+    // Alertmanager stamps are translated back to the local clock the
+    // scenario anchors live on; `local_unix(started_wall)` is that anchor.
+    let local_start = unix_secs(started_wall);
     let mut firing_outcomes: Vec<Outcome> = Vec::with_capacity(expect.alerts.len());
     for (index, expectation) in expect.alerts.iter().enumerate() {
         if cancel.is_cancelled() {
@@ -165,17 +377,31 @@ pub fn run(
         let deadline = expectation
             .firing_within()
             .map_err(|e| anyhow::anyhow!("{e}"))?;
-        let (timeline, series) = verdict_timeline(
-            &client,
-            &clock,
-            expectation,
-            &live_firing[index],
-            deadline,
-            anchor_start,
-            query_step,
-            Check::Firing,
-            &mut warnings,
-        );
+        let (timeline, series) = match &client {
+            Source::Prometheus(prometheus) => verdict_timeline(
+                prometheus,
+                &clock,
+                expectation,
+                &live_firing[index],
+                deadline,
+                anchor_start,
+                query_step,
+                Check::Firing,
+                &mut warnings,
+            ),
+            // No stored history to query: the poll timeline *is* the
+            // verdict timeline, sharpened by the alert's own startsAt.
+            Source::Alertmanager(_) => (
+                refine_firing_timeline(
+                    &live_firing[index],
+                    evidence[index]
+                        .started_at
+                        .map(|stamp| stamp - client.clock_offset_secs()),
+                    local_start,
+                ),
+                evidence[index].series.clone(),
+            ),
+        };
         matched_firing_series.extend(series);
         firing_outcomes.push(evaluate_firing(&timeline, deadline));
     }
@@ -199,19 +425,42 @@ pub fn run(
             resolution_outcomes.push(None);
             continue;
         };
-        let (timeline, series) = verdict_timeline(
-            &client,
-            &clock,
-            expectation,
-            live,
-            *deadline,
-            anchor_end,
-            query_step,
-            Check::Resolution,
-            &mut warnings,
-        );
-        matched_firing_series.extend(series);
-        resolution_outcomes.push(Some(evaluate_resolution(&timeline, *deadline)));
+        let outcome = match &client {
+            Source::Prometheus(prometheus) => {
+                let (timeline, series) = verdict_timeline(
+                    prometheus,
+                    &clock,
+                    expectation,
+                    live,
+                    *deadline,
+                    anchor_end,
+                    query_step,
+                    Check::Resolution,
+                    &mut warnings,
+                );
+                matched_firing_series.extend(series);
+                evaluate_resolution(&timeline, *deadline)
+            }
+            // `startsAt` says nothing about when an alert ended, and the
+            // stamp an expiring alert carries (`endsAt`) is a *deadline*
+            // Alertmanager set in advance, not an observation — so the
+            // resolution verdict stays exactly what polling saw.
+            Source::Alertmanager(_) => evaluate_resolution(live, *deadline),
+        };
+        resolution_outcomes.push(Some(outcome));
+    }
+
+    // A silence stops the notification, not the alert: the expectation is
+    // satisfied, but a test author asserting on a silenced alert is very
+    // likely asserting on the wrong thing.
+    for (expectation, found) in expect.alerts.iter().zip(&evidence) {
+        if found.suppressed {
+            warnings.push(format!(
+                "{} matched an alert Alertmanager has suppressed (silenced or inhibited) — \
+                 it still counts as firing, but no notification was delivered for it",
+                expectation.alert
+            ));
+        }
     }
 
     // Provenance: an expectation that matched an alert carrying label
@@ -242,6 +491,8 @@ pub fn run(
         poller_died,
         started_at,
         ended_at,
+        client.label(),
+        matches!(client, Source::Alertmanager(_)).then_some(interval),
     )
 }
 
@@ -367,7 +618,7 @@ fn emitted_label_values(
 /// exactly once each. Against a dead endpoint the total cost is therefore
 /// bounded by 3 query timeouts, independent of expectation count (review M4).
 fn preflight(
-    client: &PrometheusClient,
+    client: &Source,
     expect: &ExpectConfig,
     cancel: &CancellationToken,
 ) -> anyhow::Result<()> {
@@ -380,8 +631,8 @@ fn preflight(
         if cancel.is_cancelled() {
             bail!("interrupted");
         }
-        match client.alert_state(first) {
-            Ok(_) => {
+        match client.probe(first) {
+            Ok(()) => {
                 gate = None;
                 break;
             }
@@ -398,9 +649,7 @@ fn preflight(
         if cancel.is_cancelled() {
             bail!("interrupted");
         }
-        client
-            .alert_state(expectation)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        client.probe(expectation)?;
     }
     Ok(())
 }
@@ -411,13 +660,13 @@ fn preflight(
 /// returns, never reused across queries (review blocker 1).
 #[allow(clippy::too_many_arguments)]
 fn spawn_firing_poller(
-    client: PrometheusClient,
+    client: Source,
     expect: ExpectConfig,
     started_at: Instant,
     interval: Duration,
     cancel: CancellationToken,
     stop: Arc<AtomicBool>,
-    timelines_out: mpsc::Sender<Vec<Vec<Observation>>>,
+    timelines_out: mpsc::Sender<FiringPoll>,
 ) -> anyhow::Result<std::thread::JoinHandle<()>> {
     let deadlines: Vec<Duration> = expect
         .alerts
@@ -429,16 +678,15 @@ fn spawn_firing_poller(
     let handle = std::thread::Builder::new()
         .name("sonda-test-poller".into())
         .spawn(move || {
-            let mut timelines: Vec<Vec<Observation>> = vec![Vec::new(); expect.alerts.len()];
+            let mut poll = FiringPoll::empty(expect.alerts.len());
             let mut pending: Vec<usize> = (0..expect.alerts.len()).collect();
             while !pending.is_empty() && !cancel.is_cancelled() && !stop.load(Ordering::SeqCst) {
                 pending.retain(|&index| {
-                    let state = client
-                        .alert_state(&expect.alerts[index])
-                        .map_err(|e| e.to_string());
+                    let (state, extra) = client.poll(&expect.alerts[index]);
                     let at = started_at.elapsed();
                     let fired = matches!(state, Ok(AlertState::Firing));
-                    timelines[index].push(Observation::new(at, state));
+                    poll.evidence[index].absorb(extra);
+                    poll.timelines[index].push(Observation::new(at, state));
                     // Settled once firing is seen or coverage of the
                     // deadline is recorded; the evaluator makes the verdict.
                     !(fired || at >= deadlines[index])
@@ -447,7 +695,7 @@ fn spawn_firing_poller(
                     std::thread::sleep(interval);
                 }
             }
-            let _ = timelines_out.send(timelines);
+            let _ = timelines_out.send(poll);
         })?;
     Ok(handle)
 }
@@ -464,7 +712,7 @@ fn spawn_firing_poller(
 /// another's first query past its own deadline, leaving that window
 /// unobserved (round-2 review blocker).
 fn poll_resolutions(
-    client: &PrometheusClient,
+    client: &Source,
     expect: &ExpectConfig,
     firing_outcomes: &[Outcome],
     ended_at: Instant,
@@ -503,9 +751,7 @@ fn poll_resolutions(
             let Some((deadline, timeline)) = &mut timelines[index] else {
                 return false;
             };
-            let state = client
-                .alert_state(&expect.alerts[index])
-                .map_err(|e| e.to_string());
+            let (state, _) = client.poll(&expect.alerts[index]);
             let at = ended_at.elapsed();
             let resolved = matches!(state, Ok(ref s) if !matches!(s, AlertState::Firing));
             timeline.push(Observation::new(at, state));
@@ -519,6 +765,14 @@ fn poll_resolutions(
     Ok(timelines)
 }
 
+/// Render the verdicts.
+///
+/// `poll_precision` is `Some` only for acquisitions with no stored history
+/// to query — Alertmanager — and states the resolution their transition
+/// times actually carry. The Prometheus path's times come from stored
+/// samples on a measured server clock (#528); saying the same thing about
+/// a live-polled path would be a claim the data does not support.
+#[allow(clippy::too_many_arguments)]
 fn report(
     expect: &ExpectConfig,
     firing: &[Outcome],
@@ -526,6 +780,8 @@ fn report(
     poller_died: bool,
     started_at: Instant,
     ended_at: Instant,
+    source: &str,
+    poll_precision: Option<Duration>,
 ) -> anyhow::Result<()> {
     let mut failures = 0usize;
     eprintln!();
@@ -636,15 +892,22 @@ fn report(
     let total = expect.alerts.len();
     let elapsed = ended_at.duration_since(started_at);
     eprintln!();
+    if let Some(interval) = poll_precision {
+        eprintln!(
+            "  note: {source} keeps no queryable history, so these times come from live polling \
+             every {interval:.0?}, sharpened by each alert's own startsAt stamp \
+             (~1s clock resolution) — not from stored samples"
+        );
+    }
     if failures == 0 {
         eprintln!(
-            "  {} {total} alert expectation(s) verified (scenario ran {:.0?})",
+            "  {} {total} alert expectation(s) verified via {source} (scenario ran {:.0?})",
             pass_marker(),
             elapsed
         );
         Ok(())
     } else {
-        bail!("{failures} alert expectation(s) failed");
+        bail!("{failures} alert expectation(s) failed (verified via {source})");
     }
 }
 
@@ -674,6 +937,13 @@ fn fmt_after(at: Duration) -> String {
     } else {
         format!("{at:.0?}")
     }
+}
+
+/// A wall-clock instant as unix seconds.
+fn unix_secs(t: SystemTime) -> f64 {
+    t.duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
 }
 
 fn pass_marker() -> String {

--- a/sonda/src/test_cmd.rs
+++ b/sonda/src/test_cmd.rs
@@ -192,6 +192,18 @@ impl Source {
         }
     }
 
+    /// What a matched thing *is* on this source, for messages that point a
+    /// reader at something to go and look at. The provenance check is
+    /// acquisition-independent, but its warning is not much use if it names
+    /// a metric this path never queried — and this path exists precisely
+    /// for people whose two systems disagree (#552 review M1).
+    fn matched_noun(&self) -> &'static str {
+        match self {
+            Source::Prometheus(_) => "ALERTS series",
+            Source::Alertmanager(_) => "Alertmanager alert",
+        }
+    }
+
     /// Alertmanager stamps live on its own clock; this is the measured
     /// server-minus-local offset used to translate them back.
     fn clock_offset_secs(&self) -> f64 {
@@ -464,17 +476,20 @@ pub fn run(
     }
 
     // Provenance: an expectation that matched an alert carrying label
-    // values this scenario never emitted is probably under-scoped —
-    // ALERTS is global (#527 review).
+    // values this scenario never emitted is probably under-scoped — both
+    // sources are global (`ALERTS` is a shared metric; Alertmanager holds
+    // every alert anyone sent it). The check is acquisition-independent;
+    // only the noun in the message follows the source (#527, #552 M1).
     let emitted = emitted_label_values(&args.scenario, catalog);
     let mut foreign_seen: BTreeSet<(String, String)> = BTreeSet::new();
     for series in &matched_firing_series {
         for (key, value) in foreign_label_values(series, &emitted) {
             if foreign_seen.insert((key.clone(), value.clone())) {
                 warnings.push(format!(
-                    "matched an ALERTS series with {key}=\"{value}\", which this scenario \
-                     never emits — another series may have triggered the alert; scope \
-                     `expect.labels` to something unique to this scenario"
+                    "matched an {} with {key}=\"{value}\", which this scenario \
+                     never emits — something outside this scenario may have triggered the \
+                     alert; scope `expect.labels` to something unique to this scenario",
+                    client.matched_noun()
                 ));
             }
         }

--- a/sonda/tests/cli_test_cmd.rs
+++ b/sonda/tests/cli_test_cmd.rs
@@ -898,6 +898,63 @@ expect:
             && stderr.contains("scope `expect.labels`"),
         "stderr: {stderr}"
     );
+    // The noun names what this source actually holds — a reader chasing
+    // the warning must be pointed at the system that was queried.
+    assert!(
+        stderr.contains("matched an ALERTS series"),
+        "the Prometheus path must name the ALERTS series\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn alertmanager_provenance_warning_names_alertmanager_not_alerts() {
+    // #552 review M1: the provenance check is acquisition-independent, but
+    // its message was not — it told an Alertmanager user to go look at a
+    // metric this path never queries. This path exists for people whose
+    // two systems disagree, so pointing them at the wrong one is worse
+    // here than anywhere else.
+    let (url, _log) = mock_alertmanager(Some(0.0), None, "intruder-host", "active");
+    let dir = TempDir::new().expect("tempdir");
+    let yaml = "version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 300ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: memory
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 95.0
+    labels:
+      host: sonda-test
+expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 5s
+";
+    let path = write_scenario(&dir, yaml);
+
+    let output = run_against_alertmanager(&path, &url);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("WARN") && stderr.contains("host=\"intruder-host\""),
+        "the provenance check must still fire on this path\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("matched an Alertmanager alert"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("ALERTS series"),
+        "the Alertmanager path must not name a metric it never queried\nstderr: {stderr}"
+    );
 }
 
 #[test]

--- a/sonda/tests/cli_test_cmd.rs
+++ b/sonda/tests/cli_test_cmd.rs
@@ -28,7 +28,22 @@ const FIRING_RESULT: &str = r#"{"status":"success","data":{"resultType":"vector"
 fn mock_prometheus(
     respond: impl Fn(usize, &str) -> (String, std::time::Duration) + Send + Sync + 'static,
 ) -> (String, Arc<AtomicUsize>) {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock prometheus");
+    mock_server(move |n, line| {
+        let (body, stall) = respond(n, line);
+        (body, Vec::new(), stall)
+    })
+}
+
+/// The shared scripted-HTTP responder behind [`mock_prometheus`] and
+/// [`mock_alertmanager`]. `respond` returns the body, any extra response
+/// headers, and an artificial delay.
+fn mock_server(
+    respond: impl Fn(usize, &str) -> (String, Vec<(String, String)>, std::time::Duration)
+        + Send
+        + Sync
+        + 'static,
+) -> (String, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
     let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
     let hits = Arc::new(AtomicUsize::new(0));
     let hits_clone = Arc::clone(&hits);
@@ -50,10 +65,14 @@ fn mock_prometheus(
                     }
                     line.clear();
                 }
-                let (body, stall) = respond(n, &request_line);
+                let (body, headers, stall) = respond(n, &request_line);
                 std::thread::sleep(stall);
+                let extra: String = headers
+                    .iter()
+                    .map(|(name, value)| format!("{name}: {value}\r\n"))
+                    .collect();
                 let response = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{extra}Connection: close\r\n\r\n{}",
                     body.len(),
                     body
                 );
@@ -182,6 +201,176 @@ fn skewed_alert_world(
             )
         }
     }
+}
+
+// --- Mock Alertmanager -------------------------------------------------
+//
+// The Alertmanager acquisition asks a different question of the same alert
+// world: not "is the rule firing?" but "did the notification arrive?".
+// These fixtures speak the v2 `GET /api/v2/alerts` shape and are driven by
+// the same clock as [`alert_world`], so the parity test can put one world
+// through both acquisitions and demand the same verdict.
+
+/// Every request line the mock received, in order — so tests can assert on
+/// the *wire* form of the filters, which is the only place a mis-escaped or
+/// mis-encoded matcher is visible.
+type RequestLog = Arc<std::sync::Mutex<Vec<String>>>;
+
+/// A scripted responder: request index and request line in, body + extra
+/// response headers + artificial delay out.
+type Responder =
+    dyn Fn(usize, &str) -> (String, Vec<(String, String)>, std::time::Duration) + Send + Sync;
+
+/// Format an instant as Alertmanager renders `startsAt` / `endsAt`.
+fn rfc3339(unix: f64) -> String {
+    chrono::DateTime::from_timestamp(unix.trunc() as i64, (unix.fract() * 1e9) as u32)
+        .expect("representable timestamp")
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+/// An Alertmanager whose alert is present from `fire_at` and carries an
+/// `endsAt` of `resolve_at` — deliberately *keeping* the resolved alert in
+/// the response. A real Alertmanager (measured: 0.28.1) removes it instead,
+/// which makes this the harder fixture of the two: resolution here can only
+/// be detected by reading `endsAt`, not by the alert disappearing.
+///
+/// `extra_labels` is appended verbatim inside the label object (leading
+/// comma included) and `state` names the `status.state` to report.
+///
+/// `keep_after_resolve == false` models what a real Alertmanager does —
+/// drop the alert once it resolves — so both resolution shapes are covered.
+fn am_world(
+    fire_at: Option<f64>,
+    resolve_at: Option<f64>,
+    host: &'static str,
+    state: &'static str,
+    keep_after_resolve: bool,
+) -> (Box<Responder>, RequestLog) {
+    let log: RequestLog = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen = Arc::clone(&log);
+    let anchor: Arc<std::sync::OnceLock<(std::time::Instant, f64)>> =
+        Arc::new(std::sync::OnceLock::new());
+    let responder = Box::new(move |_: usize, request_line: &str| {
+        if let Ok(mut lines) = seen.lock() {
+            lines.push(request_line.to_string());
+        }
+        let (mono0, unix0) = *anchor.get_or_init(|| {
+            (
+                std::time::Instant::now(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .expect("epoch")
+                    .as_secs_f64(),
+            )
+        });
+        let offset = mono0.elapsed().as_secs_f64();
+        let headers = vec![(
+            "Date".to_string(),
+            chrono::Utc::now()
+                .format("%a, %d %b %Y %H:%M:%S GMT")
+                .to_string(),
+        )];
+        let gone = !keep_after_resolve && resolve_at.is_some_and(|r| offset >= r);
+        let body = match fire_at {
+            Some(fire) if offset >= fire && !gone => {
+                // Alertmanager gives a live alert an endsAt in the future
+                // (the resend deadline) and rewrites it to the resolution
+                // time when the alert ends.
+                let ends = resolve_at.map_or(unix0 + offset + 300.0, |r| unix0 + r);
+                format!(
+                    r#"[{{"labels":{{"alertname":"HighCpuUsage","host":"{host}"}},
+                        "annotations":{{}},
+                        "startsAt":"{}","endsAt":"{}","updatedAt":"{}",
+                        "status":{{"state":"{state}","silencedBy":[],"inhibitedBy":[]}},
+                        "receivers":[{{"name":"webhook"}}],"fingerprint":"deadbeef"}}]"#,
+                    rfc3339(unix0 + fire),
+                    rfc3339(ends),
+                    rfc3339(unix0 + offset),
+                )
+            }
+            _ => "[]".to_string(),
+        };
+        (body, headers, NO_STALL)
+    });
+    (responder, log)
+}
+
+/// An Alertmanager that keeps the resolved alert with a past `endsAt`.
+fn mock_alertmanager(
+    fire_at: Option<f64>,
+    resolve_at: Option<f64>,
+    host: &'static str,
+    state: &'static str,
+) -> (String, RequestLog) {
+    let (responder, log) = am_world(fire_at, resolve_at, host, state, true);
+    let (url, _hits) = mock_server(responder);
+    (url, log)
+}
+
+/// An Alertmanager that drops the alert on resolution, as real ones do.
+fn mock_alertmanager_dropping(
+    fire_at: Option<f64>,
+    resolve_at: Option<f64>,
+    host: &'static str,
+) -> (String, RequestLog) {
+    let (responder, log) = am_world(fire_at, resolve_at, host, "active", false);
+    let (url, _hits) = mock_server(responder);
+    (url, log)
+}
+
+/// The `filter=` values the mock actually received, percent-decoded.
+fn filters_seen(log: &RequestLog) -> Vec<String> {
+    let lines = log.lock().expect("request log");
+    let mut filters = Vec::new();
+    for line in lines.iter() {
+        let Some(target) = line.split_whitespace().nth(1) else {
+            continue;
+        };
+        let Some((_, params)) = target.split_once('?') else {
+            continue;
+        };
+        for pair in params.split('&') {
+            if let Some(value) = pair.strip_prefix("filter=") {
+                filters.push(percent_decode(value));
+            }
+        }
+    }
+    filters
+}
+
+/// Decode a percent-encoded query value. Deliberately hand-rolled: the
+/// point of the escaping tests is to read exactly what went on the wire,
+/// not to trust the same library that put it there.
+fn percent_decode(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'%' if index + 2 < bytes.len() => {
+                let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).unwrap_or("");
+                match u8::from_str_radix(hex, 16) {
+                    Ok(byte) => {
+                        out.push(byte);
+                        index += 3;
+                    }
+                    Err(_) => {
+                        out.push(bytes[index]);
+                        index += 1;
+                    }
+                }
+            }
+            b'+' => {
+                out.push(b' ');
+                index += 1;
+            }
+            byte => {
+                out.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 fn scenario_with_expect(expect_block: &str) -> String {
@@ -740,32 +929,11 @@ fn dry_run_works_without_prometheus_url() {
     );
 }
 
-#[test]
-fn missing_prometheus_url_is_rejected_outside_dry_run() {
-    let dir = TempDir::new().expect("tempdir");
-    let path = write_scenario(
-        &dir,
-        &scenario_with_expect(
-            "expect:
-  alerts:
-    - alert: HighCpuUsage
-      firing_within: 2m
-",
-        ),
-    );
-
-    let output = Command::new(sonda_bin())
-        .args(["test", path.to_str().expect("utf8 path")])
-        .env_remove("SONDA_PROMETHEUS_URL")
-        .output()
-        .expect("run sonda test");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(!output.status.success());
-    assert!(
-        stderr.contains("--prometheus-url is required"),
-        "stderr: {stderr}"
-    );
-}
+// `missing_prometheus_url_is_rejected_outside_dry_run` lived here until
+// `--alertmanager-url` arrived. It is superseded by
+// `neither_acquisition_url_names_both_options`, which clears *both* env
+// vars and asserts the message names both flags — the weaker version could
+// pass while the new flag's env var silently supplied a URL.
 
 #[test]
 fn failed_scenario_reports_immediately_without_waiting_out_deadlines() {
@@ -836,5 +1004,271 @@ fn run_still_accepts_files_with_expect_blocks() {
         output.status.success(),
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// --- Alertmanager acquisition ------------------------------------------
+
+/// Standard expect block for the Alertmanager tests.
+fn am_expect(firing_within: &str, resolves_within: Option<&str>) -> String {
+    let resolves = resolves_within
+        .map(|d| format!("      resolves_within: {d}\n"))
+        .unwrap_or_default();
+    format!(
+        "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: {firing_within}
+{resolves}"
+    )
+}
+
+fn run_against_alertmanager(path: &std::path::Path, url: &str) -> std::process::Output {
+    Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--alertmanager-url", url, "--interval", "100ms"])
+        .output()
+        .expect("run sonda test")
+}
+
+#[test]
+fn alertmanager_passes_when_the_notification_arrives_and_clears() {
+    // Firing from first contact, ending one second in — just after the
+    // 300ms scenario. The mock keeps the ended alert in the response with
+    // a past endsAt, so resolution is detected by the expiry check, not by
+    // the alert disappearing.
+    let (url, _log) = mock_alertmanager(Some(0.0), Some(1.0), "sonda-test", "active");
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(&dir, &scenario_with_expect(&am_expect("5s", Some("5s"))));
+
+    let output = run_against_alertmanager(&path, &url);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}\nstderr: {stderr}",
+        output.status
+    );
+    assert!(stderr.contains("firing after"), "stderr: {stderr}");
+    assert!(stderr.contains("resolved after"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("verified via Alertmanager"),
+        "the report must name the acquisition path\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn alertmanager_detects_resolution_when_the_alert_disappears() {
+    // The shape a real Alertmanager produces: a resolved alert is dropped
+    // from /api/v2/alerts rather than lingering with a past endsAt. Both
+    // shapes must reach the same verdict, because which one you get is the
+    // Alertmanager's choice, not the test author's.
+    let (url, _log) = mock_alertmanager_dropping(Some(0.0), Some(1.0), "sonda-test");
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(&dir, &scenario_with_expect(&am_expect("5s", Some("5s"))));
+
+    let output = run_against_alertmanager(&path, &url);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(stderr.contains("resolved after"), "stderr: {stderr}");
+}
+
+#[test]
+fn alertmanager_report_states_its_precision_instead_of_borrowing_prometheus_guarantees() {
+    // The likeliest wrong claim on this path is implying the sample-time
+    // precision the range-query path earned. The note must be present and
+    // must say where the numbers come from.
+    let (url, _log) = mock_alertmanager(Some(0.0), None, "sonda-test", "active");
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(&dir, &scenario_with_expect(&am_expect("5s", None)));
+
+    let output = run_against_alertmanager(&path, &url);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("keeps no queryable history"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("live polling every"), "stderr: {stderr}");
+    assert!(
+        !stderr.contains("range"),
+        "the Alertmanager path must not mention range acquisition\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn alertmanager_fails_when_no_notification_arrives() {
+    let (url, _log) = mock_alertmanager(None, None, "sonda-test", "active");
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(&dir, &scenario_with_expect(&am_expect("1s", None)));
+
+    let output = run_against_alertmanager(&path, &url);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "must exit non-zero\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("did not fire within 1s"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("verified via Alertmanager"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn alertmanager_and_prometheus_agree_on_the_same_alert_world() {
+    // Parity: one alert world, two acquisitions, one verdict. The point of
+    // the Alertmanager path is that it asks a *different question* — it
+    // must not answer a different *answer* when both hops are healthy.
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(&dir, &scenario_with_expect(&am_expect("5s", Some("5s"))));
+
+    let (prom_url, _hits) = mock_prometheus(alert_world(Some(0.0), Some(1.0), "sonda-test"));
+    let prometheus = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &prom_url, "--interval", "100ms"])
+        .args(["--query-step", "200ms"])
+        .output()
+        .expect("run sonda test");
+
+    let (am_url, _log) = mock_alertmanager(Some(0.0), Some(1.0), "sonda-test", "active");
+    let alertmanager = run_against_alertmanager(&path, &am_url);
+
+    let prom_err = String::from_utf8_lossy(&prometheus.stderr);
+    let am_err = String::from_utf8_lossy(&alertmanager.stderr);
+    assert_eq!(
+        prometheus.status.success(),
+        alertmanager.status.success(),
+        "acquisitions disagreed on the same world\nprometheus: {prom_err}\nalertmanager: {am_err}"
+    );
+    for expected in [
+        "firing after",
+        "resolved after",
+        "1 alert expectation(s) verified",
+    ] {
+        assert!(prom_err.contains(expected), "prometheus: {prom_err}");
+        assert!(am_err.contains(expected), "alertmanager: {am_err}");
+    }
+}
+
+#[test]
+fn alertmanager_suppressed_alert_counts_as_firing_and_warns() {
+    // A silence stops the notification, not the alert. The expectation is
+    // satisfied — and the operator is told, because asserting on a
+    // silenced alert is almost never what was meant.
+    let (url, _log) = mock_alertmanager(Some(0.0), None, "sonda-test", "suppressed");
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(&dir, &scenario_with_expect(&am_expect("5s", None)));
+
+    let output = run_against_alertmanager(&path, &url);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("suppressed (silenced or inhibited)"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn alertmanager_down_is_a_preflight_failure_not_a_silent_pass() {
+    // No listener at all: the preflight gate must name the failure rather
+    // than let the run proceed to an unprovable verdict.
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(&dir, &scenario_with_expect(&am_expect("1s", None)));
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args([
+            "--alertmanager-url",
+            "http://127.0.0.1:1",
+            "--interval",
+            "100ms",
+        ])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("alertmanager preflight against http://127.0.0.1:1 failed"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn both_acquisition_urls_is_a_config_error() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(&dir, &scenario_with_expect(&am_expect("1s", None)));
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", "http://127.0.0.1:1"])
+        .args(["--alertmanager-url", "http://127.0.0.1:2"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(stderr.contains("mutually exclusive"), "stderr: {stderr}");
+}
+
+#[test]
+fn neither_acquisition_url_names_both_options() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_scenario(&dir, &scenario_with_expect(&am_expect("1s", None)));
+
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .env_remove("SONDA_PROMETHEUS_URL")
+        .env_remove("SONDA_ALERTMANAGER_URL")
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(stderr.contains("--prometheus-url"), "stderr: {stderr}");
+    assert!(stderr.contains("--alertmanager-url"), "stderr: {stderr}");
+}
+
+#[rustfmt::skip]
+#[rstest::rstest]
+// Hostile expectation label values must survive TWO layers on the wire:
+// Alertmanager matcher quoting (done by sonda) and percent-encoding (done
+// by the HTTP layer). Decoding the request line back proves both — a value
+// that broke out of its quotes, or one that was never encoded, shows up
+// here as a filter that is not the one we meant to send.
+#[case::spaces(      "on call",        r#"team="on call""#)]
+#[case::double_quote("net\"ops",       r#"team="net\"ops""#)]
+#[case::backslash(   "a\\b",           r#"team="a\\b""#)]
+#[case::comma(       "a,b",            r#"team="a,b""#)]
+#[case::ampersand(   "a&b=c",          r#"team="a&b=c""#)]
+#[case::braces(      "{a}",            r#"team="{a}""#)]
+#[case::percent(     "100%",           r#"team="100%""#)]
+#[case::utf8(        "café-日本",       r#"team="café-日本""#)]
+fn alertmanager_filters_survive_the_wire(#[case] value: &str, #[case] expected: &str) {
+    let (url, log) = mock_alertmanager(None, None, "sonda-test", "active");
+    let dir = TempDir::new().expect("tempdir");
+    let expect_block = format!(
+        "expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 300ms
+      labels:
+        team: {}
+",
+        serde_json::to_string(value).expect("json string")
+    );
+    let path = write_scenario(&dir, &scenario_with_expect(&expect_block));
+
+    let output = run_against_alertmanager(&path, &url);
+    // The alert never fires here; the verdict is beside the point.
+    let _ = output.status;
+    let filters = filters_seen(&log);
+    assert!(
+        filters.contains(&r#"alertname="HighCpuUsage""#.to_string()),
+        "alertname filter missing from {filters:?}"
+    );
+    assert!(
+        filters.contains(&expected.to_string()),
+        "expected filter {expected:?} on the wire, saw {filters:?}"
     );
 }


### PR DESCRIPTION
## Summary

`sonda test --prometheus-url` asks the rule evaluator whether a rule fired. That leaves the rest of the alerting path untested: a wrong `-notifier.url`, a route that drops the alert, a receiver that was never configured — all green on the `ALERTS` metric, all invisible.

`--alertmanager-url` asks the next hop instead, from the same `expect:` block. Same scenario, one flag different, and the answer is *did the notification arrive?* rather than *did the rule fire?*

Exactly one URL is required. **Passing both is an error** — they answer different questions about different hops and there is no sensible way to merge their verdicts. Run the scenario twice when you want both covered; the second run then tells you which hop broke.

This is WP15 of Program 2. No `expect:` schema change — Alertmanager enters as an alternate acquisition against the existing `firing_within` / `resolves_within` deadlines, per the recorded decision.

## Changes

- **`sonda-core/src/verify/alertmanager.rs`** (new, `feature = "http"`) — sibling of `prometheus.rs`. Blocking `AlertmanagerClient` with a mandatory per-request timeout over `GET /api/v2/alerts`. Pure, separately tested parsers: `alert_filters`, `parse_alerts`, `refine_firing_timeline`, `parse_rfc3339`, `parse_http_date`.
- **The evaluator is untouched.** This module produces `Observation` timelines only; every deadline comparison stays where #516 B3 put it.
- **CLI** — `--alertmanager-url` (env `SONDA_ALERTMANAGER_URL`) on `TestArgs`; `test_cmd.rs` becomes acquisition-agnostic behind a `Source` enum, keeping its orchestration-and-rendering-only contract. `--query-step` is documented as Prometheus-only.
- **Provenance carries over** — matched Alertmanager alerts' labels feed the same `foreign_label_values` check; the WARN contract is acquisition-independent.
- Two Live Infra UAT rows (`alert-test-pass-am`, `alert-test-fail-control-am`), matching e2e coverage-table rows, and docs on `alert-testing.md` + `cli-flags.md`.

### What this path can and cannot claim

Overclaiming is the easy mistake here, so it is stated in the module docs, the report, and the docs page:

- **No range API, no `time()`** → live polling only. Times carry `--interval` precision, sharpened by the alert's own `startsAt`. The report prints that on every run rather than borrowing the sample-time guarantee #528 earned for the Prometheus path.
- **`startsAt` is bounded on both sides by evidence we gathered ourselves**: it can only move the firing observation *earlier*, and never earlier than the last successful non-firing poll. Refinement moves verdicts in one direction only (towards `Pass`), so an unbounded stamp from a skewed clock would be a false-pass channel. Clock offset comes from Alertmanager's `Date` header — one-second granular, documented as such, deliberately weaker than `ServerClock`.
- **No `pending` state** — an alert inside its rule's `for:` window has not been sent. The evaluator only asks "is this Firing?", so no verdict changes.
- **Suppressed counts as firing, with a warning.** Stated here for you to argue: a silence stops the notification, not the alert, so `firing_within` is satisfied. The alternative would make creating a silence turn a working alert rule into a test failure.

## Test plan

**Red-verified first, 8 sabotages, 8 red** (Law 3):

| Sabotage | Went red |
|---|---|
| `escape_matcher_value` as a no-op | 6 core + 2 wire failures |
| refinement without its floor | `starts_at_never_contradicts_an_observed_inactive_poll`, `stamp_before_the_anchor_clamps_to_the_first_observation` |
| refinement without its ceiling | `starts_at_never_moves_the_observation_later` |
| `endsAt` expiry check removed | 3 core failures |
| client-side label re-check removed | 2 core failures |
| suppressed no longer firing | `alertmanager_suppressed_alert_counts_as_firing_and_warns` |
| precision note dropped from the report | `alertmanager_report_states_its_precision_instead_of_borrowing_prometheus_guarantees` |

**Proven against a live stack, not only mocks** — VictoriaMetrics + vmalert v1.149.0 + Alertmanager 0.28.1, native binaries (no Docker in that environment). Every one of the four "attack here" points was exercised against the real binaries:

| Attack point | Result |
|---|---|
| Filter escaping vs. a real Alertmanager | **9 hostile label values** posted into the real AM and matched exactly by expectation: `net"ops`, `a\b`, `on call`, `a,b`, `a&b=c`, `{a}`, `100%`, `café-日本`, `🔥`. **Three near-miss values** (`net"ops-nope`, `a\c`, `on  call`) correctly did **not** match — the half that proves the filter is not merely over-matching. |
| Grouping hiding an active alert | Not hidden. With `group_by: [alertname, severity]` and `group_wait: 10s`, the alert is visible to the filter query immediately — grouping gates notification, not API visibility. |
| Silences | A real silence created through the API → `status.state: suppressed`, `silencedBy` populated; expectation passes, WARN fires. |
| Inhibition | A real `inhibit_rules` block with `equal: ['host']` → target reports `suppressed` with `inhibitedBy` populated; expectation passes, same WARN. Both suppression mechanisms land on one state, which is what the code assumes. |
| Resolution semantics | See below. |

Plus the end-to-end rows: `examples/alert-lifecycle-test.yaml --alertmanager-url` → PASS (firing 35–40s, resolved 5–10s); `tests/e2e/alert-negative-control.yaml --alertmanager-url` → exit 1, `did not fire within 20s`.

**Three measurements corrected claims I had written from assumption:**

1. Alertmanager 0.28.1 **removes** a resolved alert from `/api/v2/alerts` rather than keeping it with a past `endsAt`. So absence is the resolution signal in practice, and the `endsAt` check is the *second* line of defence — for a producer posting an already-expired alert, and for the day that retention behaviour changes. Docs and test comments now say what was measured, and a second integration fixture covers the disappearing shape alongside the lingering one.
2. Absence is only trustworthy because the notifier re-announces. Measured at **3.3s sampling — deliberately not a multiple of the 5s evaluation interval, so a frozen stamp cannot alias as a fresh one**: vmalert re-sends every evaluation with `endsAt` 20s ahead, so a firing alert never sits less than ~15s from expiry and would have to miss four consecutive evaluations to fake a resolution.
3. The docs claimed this path sees the alert later than the Prometheus path and blamed the whole gap on the extra hop. **My first attempt to measure that was invalid** — both paths ran against the same `host` label, so the Prometheus run matched `ALERTS` residue from earlier runs and reported firing at 1ms (exactly the provenance hazard this feature warns about). Re-measured with a separate series per path: **10s vs 35s**, reproduced in a paired run. `0c68373` replaces the assertion with the measurement and notes that up to one `--interval` of the gap is poll timing, not notifier latency.

**Gates:** all 21 CI checks green on `0c68373`, including **Live Infra UAT with both new Alertmanager rows against the real Docker stack**. Locally: `cargo test --workspace` (only the two known root-only `sink::file` failures, pre-existing and unrelated), `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all -- --check` clean, `validate_docs_commands.py` 155/155, `validate_docs_scenarios.py` 118 compiled / 0 failed, `mkdocs build --strict` clean, `pure.test.mjs` 197/197. Browser smoke not run locally: no JS or CSS changed (it is green in CI regardless).

## Where to attack it

1. **The clock-precision claims.** The report, module docs, and `alert-testing.md` all describe this path's precision. Check none of them imply server-anchored sample precision. The `Date`-header offset is the piece most worth arguing about — is measuring it at all better than not, given ±1s?
2. **The suppressed decision**, whichever way you think it should go. Note it now covers silences *and* inhibition identically.
3. **Filter escaping** — the two-layer test (quoted matcher in core, decoded request line in integration) is meant to make a broken escape visible at whichever layer breaks. Check I am crediting the layer that actually catches it.
4. **Resolution semantics.** The ~15s floor is one notifier at one interval. Ask whether the guard survives a longer resend delay, or `--interval` set carelessly large.
5. **`refine_firing_timeline`'s bounds.** It only moves verdicts towards `Pass`. Try to construct a case where the floor/ceiling still permits a false pass.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)