### PR TITLE
feat(ci): sonda-action — run alert expectations as a GitHub Action

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -1,0 +1,138 @@
+# The action's own live proof.
+#
+# `uses: ./` runs the composite action exactly as a consumer would — it
+# resolves a release, downloads that release's binary, verifies it against
+# the release's SHA256SUMS, and runs `sonda test` against a live vmalert +
+# Alertmanager stack. Nothing here is mocked: a broken tag→asset mapping, a
+# checksum mismatch, or an argv bug all fail this job.
+#
+# Note what that means: this job tests the *published* binary, not the code
+# in the PR. That is the point — the action's contract is "install a release
+# and run it", and the failure mode it exists to catch is that contract
+# breaking. Changes to `sonda test` itself are covered by ci.yml and the
+# Live Infra UAT.
+#
+# Path-filtered: the action, its resolver, the installer it reuses, and the
+# release workflow that produces what it downloads. A docs push does not
+# need to pay for a compose stack.
+name: Action self-test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'action.yml'
+      - 'install.sh'
+      - 'scripts/resolve_release.py'
+      - 'scripts/tests/action_argv_test.sh'
+      - 'scripts/live_infra_uat.py'
+      - '.github/workflows/action-selftest.yml'
+      - '.github/workflows/release.yml'
+      - 'examples/docker-compose-victoriametrics.yml'
+      - 'examples/alertmanager/**'
+      - 'examples/alert-lifecycle-test.yaml'
+      - 'tests/e2e/alert-negative-control.yaml'
+  pull_request:
+    branches: ["**"]
+    paths:
+      - 'action.yml'
+      - 'install.sh'
+      - 'scripts/resolve_release.py'
+      - 'scripts/tests/action_argv_test.sh'
+      - 'scripts/live_infra_uat.py'
+      - '.github/workflows/action-selftest.yml'
+      - '.github/workflows/release.yml'
+      - 'examples/docker-compose-victoriametrics.yml'
+      - 'examples/alertmanager/**'
+      - 'examples/alert-lifecycle-test.yaml'
+      - 'tests/e2e/alert-negative-control.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: action-selftest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  selftest:
+    name: sonda-action self-test (live)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Reuses the Live Infra UAT's own bootstrap rather than a second copy
+      # of "which backends exist and how long they get to start".
+      - name: Boot the alerting stack
+        run: python3 scripts/live_infra_uat.py --boot-only alerting
+
+      # The positive case. `uses: ./` is the action as published: resolve,
+      # download, checksum, run. Exit 0 means the alert fired and resolved
+      # on deadline, end to end.
+      - name: Action must pass on a scenario whose alert fires
+        uses: ./
+        with:
+          scenario: examples/alert-lifecycle-test.yaml
+          prometheus-url: http://localhost:8428
+          extra-args: --interval 5s
+
+      # The negative control. Without it, an action that silently exits 0 —
+      # a swallowed exit code, a binary that never ran — passes the job
+      # above and looks healthy.
+      - name: Action must fail on a scenario whose alert cannot fire
+        id: control
+        continue-on-error: true
+        uses: ./
+        with:
+          scenario: tests/e2e/alert-negative-control.yaml
+          prometheus-url: http://localhost:8428
+          extra-args: --interval 5s
+
+      - name: Assert the negative control actually failed
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.control.outcome }}" != "failure" ]; then
+            echo "::error::the negative control did not fail (outcome=${{ steps.control.outcome }}). The action's exit code is not reaching the workflow, so a real alert regression would pass silently." >&2
+            exit 1
+          fi
+          echo "negative control failed as required"
+
+      # A version floor the action must refuse rather than install past.
+      # `alertmanager-url` is newer than some releases this action can be
+      # pinned to; installing one of those would produce a clap error that
+      # reads like a bug in the action.
+      - name: Action must refuse alertmanager-url on a release that predates it
+        id: floor
+        continue-on-error: true
+        uses: ./
+        with:
+          scenario: examples/alert-lifecycle-test.yaml
+          alertmanager-url: http://localhost:9093
+          version: v1.20.0
+
+      - name: Assert the version floor was enforced
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.floor.outcome }}" != "failure" ]; then
+            echo "::error::pinning v1.20.0 with alertmanager-url should have been refused before download." >&2
+            exit 1
+          fi
+          echo "version floor enforced as required"
+
+      - name: Collect stack logs (on failure)
+        if: failure()
+        run: |
+          mkdir -p action-logs
+          docker compose -f examples/docker-compose-victoriametrics.yml \
+            --profile alerting logs --no-color --tail 300 \
+            > action-logs/stack.log 2>&1 || true
+
+      - name: Upload stack logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: action-selftest-logs
+          path: action-logs/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,3 +470,27 @@ jobs:
             exit 1
           fi
           echo "OK: both pinned to ${pinned}"
+
+  action-contract:
+    name: sonda-action contract (argv safety + release resolution)
+    runs-on: ubuntu-latest
+
+    # Deliberately NOT path-filtered, unlike the live self-test. These are
+    # seconds of pure shell and Python with no network and no containers,
+    # and they guard the two things a broken action would leak quietly:
+    # a workflow input reaching a shell, and a moving tag resolving to the
+    # wrong release. Cheap enough to run on every PR, so they do.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Argv construction under hostile inputs (spaces, ;, $(…), globs,
+      # newlines), plus drift checks asserting action.yml and release.yml
+      # still contain the constructions the harness exercises.
+      - name: Action argv safety
+        run: bash scripts/tests/action_argv_test.sh
+
+      # Tag -> concrete release resolution: major-tag selection, the
+      # release-please no-assets window, missing checksums, version floors.
+      - name: Release resolver unit tests
+        run: python3 scripts/resolve_release.py --self-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,10 +476,15 @@ jobs:
     runs-on: ubuntu-latest
 
     # Deliberately NOT path-filtered, unlike the live self-test. These are
-    # seconds of pure shell and Python with no network and no containers,
-    # and they guard the two things a broken action would leak quietly:
-    # a workflow input reaching a shell, and a moving tag resolving to the
-    # wrong release. Cheap enough to run on every PR, so they do.
+    # seconds of shell and Python with no containers, and they guard the
+    # two things a broken action would leak quietly: a workflow input
+    # reaching a shell, and a moving tag resolving to the wrong release.
+    # Cheap enough to run on every PR, so they do.
+    #
+    # One step makes a single GitHub API call (the floor-staleness check).
+    # It cannot fail this job on an unreachable or rate-limited API — only
+    # on a genuinely stale constant — because every other PR in the repo
+    # would otherwise go red on a question none of them asked.
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -497,7 +502,9 @@ jobs:
 
       # The alertmanager-url version floor is a constant someone must
       # remember to revisit. This goes red on the release that makes it
-      # stale, which is exactly when it needs revisiting.
+      # stale, which is exactly when it needs revisiting — and stays green
+      # when the API is simply unreachable, since "could not ask" is not
+      # "is stale".
       - name: Version floor is not stale
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,3 +494,11 @@ jobs:
       # release-please no-assets window, missing checksums, version floors.
       - name: Release resolver unit tests
         run: python3 scripts/resolve_release.py --self-test
+
+      # The alertmanager-url version floor is a constant someone must
+      # remember to revisit. This goes red on the release that makes it
+      # stale, which is exactly when it needs revisiting.
+      - name: Version floor is not stale
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 scripts/resolve_release.py --check-floor-staleness

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,10 @@ jobs:
       # the repo out, so there would be no git to tag with.
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # The major-tag step compares this release against every existing
+          # vN.* tag, so it needs them all — a shallow checkout has none.
+          fetch-depth: 0
 
       - name: Download all tarball artifacts
         uses: actions/download-artifact@v8
@@ -170,6 +174,21 @@ jobs:
             exit 0
           fi
           major="${RELEASE_TAG%%.*}"          # v1.20.0 -> v1
+
+          # Never move the major tag BACKWARDS. A patch backported onto an
+          # older line — 1.19.1 cut after 1.20.0 — is a normal thing to do
+          # precisely once a newer line exists, and moving `v1` onto it
+          # would silently downgrade everyone pinned to `@v1`
+          # (#554 review W3). Compare by version, not by what was released
+          # most recently, and not as strings (v1.9.0 > v1.20.0 as text).
+          highest="$(git tag -l "${major}.*" \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V | tail -1)"
+          if [ -n "$highest" ] && [ "$highest" != "$RELEASE_TAG" ]; then
+            echo "note: ${highest} is newer than ${RELEASE_TAG}; leaving ${major} where it is"
+            exit 0
+          fi
+
           echo "moving ${major} to ${RELEASE_TAG} ($(git rev-parse --short HEAD))"
           git tag -f "$major"
           git push --force origin "refs/tags/${major}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,11 @@ jobs:
     needs: binaries
     runs-on: ubuntu-latest
     steps:
+      # Needed by the major-tag step below: this job otherwise never checks
+      # the repo out, so there would be no git to tag with.
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Download all tarball artifacts
         uses: actions/download-artifact@v8
         with:
@@ -141,6 +146,34 @@ jobs:
           files: |
             sonda-*.tar.gz
             SHA256SUMS
+
+      # Actions users pin `uses: davidban77/sonda@v1` and expect it to track
+      # the newest 1.x. That only works if a `v1` tag is moved onto each
+      # release — GitHub does not maintain major tags for you.
+      #
+      # Runs after the release is published, so `v1` only ever points at a
+      # tag whose assets exist. Moving it earlier would make `@v1` resolve
+      # to a release the installer cannot download yet.
+      #
+      # Guarded three ways, because a major tag that moves when it should
+      # not is worse than one that never moves: pre-releases are skipped,
+      # non-`vX.Y.Z` tags are skipped, and the tag moved is derived from
+      # THIS release's own major — so cutting v2.0.0 creates/moves `v2` and
+      # leaves `v1` pointing where it was, for everyone still pinned to it.
+      - name: Move the major-version tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "note: ${RELEASE_TAG} is not a plain vX.Y.Z tag; leaving major tags untouched"
+            exit 0
+          fi
+          major="${RELEASE_TAG%%.*}"          # v1.20.0 -> v1
+          echo "moving ${major} to ${RELEASE_TAG} ($(git rev-parse --short HEAD))"
+          git tag -f "$major"
+          git push --force origin "refs/tags/${major}"
+          echo "${major} now points at ${RELEASE_TAG}"
 
   docker:
     name: Build & Push Multi-arch Docker Image

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,21 @@ Full design rationale is in `docs/architecture.md`. Key decisions:
 To add a generator, encoder, or sink: use the matching skill in `.claude/skills/` (add-generator,
 add-encoder, add-sink). Each crate's `CLAUDE.md` also has step-by-step guidance.
 
+## The published GitHub Action
+
+`action.yml` at the repo root is a composite action wrapping `sonda test` for CI. It resolves the
+ref it was pinned at to a concrete release (`scripts/resolve_release.py`), installs that release
+with the repo's own `install.sh` — reused, not reimplemented, so the checksum verification has one
+definition — and runs `sonda test`.
+
+- **Inputs never reach a shell.** Every input is passed through `env:`, never interpolated into a
+  `run:` body, and argv is built as a quoted array. `scripts/tests/action_argv_test.sh` drives that
+  construction with hostile values and fails if `action.yml` stops containing it.
+- **`release.yml` moves a `vN` tag** onto each release so `uses: davidban77/sonda@v1` tracks the
+  newest `1.x`. Guarded so a pre-release or a `2.0.0` never moves `v1`.
+- **Two workflows:** `action-contract` in `ci.yml` (fast, always) and `action-selftest.yml`
+  (live stack, path-filtered) which runs `uses: ./` against real vmalert + Alertmanager.
+
 ## Phase Plans
 
 Completed development phases are documented in `docs/phase-{0..9}-*.md` for historical reference.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.19.0"
+version = "1.20.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.19.0"
+version = "1.20.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2615,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.19.0"
+version = "1.20.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-wasm"
-version = "1.19.0"
+version = "1.20.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,136 @@
+name: 'Sonda alert test'
+description: >-
+  Run a Sonda scenario and verify its expect: alert expectations against a
+  Prometheus-compatible API or an Alertmanager. Exits non-zero when an alert
+  does not fire, or resolve, on deadline.
+author: 'davidban77'
+
+branding:
+  icon: 'activity'
+  color: 'purple'
+
+inputs:
+  scenario:
+    description: >-
+      Path to a v2 scenario YAML with an expect: block, relative to the
+      workspace.
+    required: true
+  prometheus-url:
+    description: >-
+      Base URL of the Prometheus-compatible API evaluating the alert rules —
+      verifies that the rule fires. Exactly one of prometheus-url /
+      alertmanager-url is required.
+    required: false
+    default: ''
+  alertmanager-url:
+    description: >-
+      Base URL of the Alertmanager receiving the alerts — verifies that the
+      notification arrived, one hop further down the path. Mutually exclusive
+      with prometheus-url.
+    required: false
+    default: ''
+  version:
+    description: >-
+      Sonda version to install (e.g. v1.20.0), or "latest". Defaults to the
+      ref this action was called with, resolved to a concrete release so a
+      moving tag like @v1 still installs a determinate binary.
+    required: false
+    default: ''
+  extra-args:
+    description: >-
+      Additional arguments appended to `sonda test`, split on whitespace
+      (e.g. "--interval 5s --query-step 5s"). Never passed through a shell.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    # Every input reaches bash through env:, never through ${{ }}
+    # interpolation into a run: body. Interpolation happens before bash
+    # parses the script, so a scenario name containing $(...) or a quote
+    # would become part of the program rather than a value handed to it.
+    - name: Resolve the release to install
+      id: resolve
+      shell: bash
+      env:
+        SONDA_VERSION_INPUT: ${{ inputs.version }}
+        ACTION_REF: ${{ github.action_ref }}
+        SONDA_AM_URL: ${{ inputs.alertmanager-url }}
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        ref="${SONDA_VERSION_INPUT:-${ACTION_REF:-latest}}"
+        # The alertmanager-url input has a version floor: it is newer than
+        # some releases this action can legitimately be pinned to. Checking
+        # before download turns "unexpected argument" — which reads as an
+        # action bug — into a message naming the floor.
+        guard=()
+        if [ -n "$SONDA_AM_URL" ]; then
+          guard=(--needs-alertmanager)
+        fi
+        tag="$(python3 "${GITHUB_ACTION_PATH}/scripts/resolve_release.py" --ref "$ref" "${guard[@]+"${guard[@]}"}")"
+        echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+        echo "Resolved '${ref}' to ${tag}"
+
+    - name: Install sonda
+      shell: bash
+      env:
+        # The installer is the repo's own published install path, reused
+        # rather than reimplemented: it already maps uname to the release's
+        # target-triple asset names and verifies the download against the
+        # release's SHA256SUMS. A second implementation here would be a
+        # second thing to keep correct, and a second thing to drift.
+        SONDA_VERSION: ${{ steps.resolve.outputs.tag }}
+        SONDA_INSTALL_DIR: ${{ runner.temp }}/sonda-bin
+      run: |
+        set -euo pipefail
+        mkdir -p "$SONDA_INSTALL_DIR"
+        sh "${GITHUB_ACTION_PATH}/install.sh"
+        echo "$SONDA_INSTALL_DIR" >> "$GITHUB_PATH"
+
+    - name: Verify alert expectations
+      shell: bash
+      env:
+        SONDA_SCENARIO: ${{ inputs.scenario }}
+        SONDA_PROM_URL: ${{ inputs.prometheus-url }}
+        SONDA_AM_URL: ${{ inputs.alertmanager-url }}
+        SONDA_EXTRA_ARGS: ${{ inputs.extra-args }}
+      run: |
+        set -euo pipefail
+
+        # Mirror the CLI's own rule here so the error names the *input* the
+        # workflow author wrote, not the flag the action derived from it.
+        if [ -n "$SONDA_PROM_URL" ] && [ -n "$SONDA_AM_URL" ]; then
+          echo "::error::prometheus-url and alertmanager-url are mutually exclusive — they verify different hops of the alerting path, so pick the one you mean to test." >&2
+          exit 1
+        fi
+        if [ -z "$SONDA_PROM_URL" ] && [ -z "$SONDA_AM_URL" ]; then
+          echo "::error::one of prometheus-url or alertmanager-url is required." >&2
+          exit 1
+        fi
+
+        # Build argv as an array. Quoting each expansion keeps a value with
+        # spaces, semicolons or $(...) as exactly one argument — the shell
+        # never re-parses it, so there is nothing to inject into.
+        args=(test "$SONDA_SCENARIO")
+        if [ -n "$SONDA_PROM_URL" ]; then
+          args+=(--prometheus-url "$SONDA_PROM_URL")
+        else
+          args+=(--alertmanager-url "$SONDA_AM_URL")
+        fi
+
+        # extra-args is the one input that must split into several
+        # arguments, so it is the one that needs care. `set -f` disables
+        # globbing first: without it a bare `*` would expand against the
+        # workspace. Word splitting is all that remains — command
+        # substitution is not re-run on an expanded value.
+        if [ -n "$SONDA_EXTRA_ARGS" ]; then
+          set -f
+          # shellcheck disable=SC2206
+          extra=($SONDA_EXTRA_ARGS)
+          set +f
+          args+=("${extra[@]}")
+        fi
+
+        sonda "${args[@]}"

--- a/action.yml
+++ b/action.yml
@@ -137,7 +137,7 @@ runs:
           # downstream (#554 review M1).
           for arg in "${extra[@]}"; do
             if [ "$arg" = "--dry-run" ]; then
-              echo "::error::--dry-run in extra-args would make this step pass without verifying any alert expectation. Remove it, or use `sonda test --dry-run` locally." >&2
+              echo "::error::--dry-run in extra-args would make this step pass without verifying any alert expectation. Remove it, or run sonda test --dry-run locally." >&2
               exit 1
             fi
           done

--- a/action.yml
+++ b/action.yml
@@ -130,6 +130,17 @@ runs:
           # shellcheck disable=SC2206
           extra=($SONDA_EXTRA_ARGS)
           set +f
+          # --dry-run validates and returns before verifying anything, so a
+          # step carrying it exits 0 having checked nothing — a green
+          # required check that is not checking. Refused by name, like the
+          # other two cases whose failure would otherwise confuse
+          # downstream (#554 review M1).
+          for arg in "${extra[@]}"; do
+            if [ "$arg" = "--dry-run" ]; then
+              echo "::error::--dry-run in extra-args would make this step pass without verifying any alert expectation. Remove it, or use `sonda test --dry-run` locally." >&2
+              exit 1
+            fi
+          done
           args+=("${extra[@]}")
         fi
 

--- a/docs/site/docs/test/alert-testing.md
+++ b/docs/site/docs/test/alert-testing.md
@@ -842,7 +842,9 @@ sonda test examples/alert-expectation-test.yaml \
 
 The exit code is the contract: `0` when every expectation holds, non-zero
 otherwise — which makes alert rules testable in CI. The
-[CI validation walkthrough](end-to-end-pipelines.md) shows the full pipeline;
+[GitHub Action](ci-github-action.md) wraps exactly this into three lines of
+workflow YAML; the [CI validation walkthrough](end-to-end-pipelines.md)
+shows the full pipeline;
 `--dry-run` validates the scenario and its `expect:` block without emitting
 or contacting Prometheus. The `expect:` block is pure metadata to `sonda run`
 — the same file works for both commands.

--- a/docs/site/docs/test/ci-github-action.md
+++ b/docs/site/docs/test/ci-github-action.md
@@ -1,0 +1,101 @@
+# Run it in CI with the GitHub Action
+
+`sonda test` turns alert rules into a test suite. The action turns that into
+three lines of workflow YAML — it installs a pinned Sonda release, verifies
+the download against the release's published checksums, and runs your
+scenario. The exit code is the check.
+
+```yaml title=".github/workflows/alert-rules.yml"
+name: Alert rules
+on: [pull_request]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # ... start your Prometheus/vmalert stack here ...
+      - uses: davidban77/sonda@v1
+        with:
+          scenario: examples/alert-lifecycle-test.yaml
+          prometheus-url: http://localhost:8428
+```
+
+The job fails when an alert does not fire, or does not resolve, on deadline
+— the same contract `sonda test` has on your laptop.
+
+## Inputs
+
+| Input | Required | Description |
+|---|---|---|
+| `scenario` | yes | Path to a v2 scenario YAML with an `expect:` block, relative to the workspace. |
+| `prometheus-url` | one of | Base URL of the Prometheus-compatible API evaluating the rules — verifies the **rule** fires. |
+| `alertmanager-url` | one of | Base URL of the Alertmanager receiving the alerts — verifies the **notification** arrived. |
+| `version` | no | Release to install (e.g. `v1.20.0`), or `latest`. Defaults to the ref you pinned the action at. |
+| `extra-args` | no | Extra arguments for `sonda test`, split on whitespace (e.g. `--interval 5s`). |
+
+**Exactly one of `prometheus-url` / `alertmanager-url`**, mirroring the CLI.
+Passing both is an error: they verify different hops of the alerting path,
+so there is no sensible way to merge their verdicts. To cover both, add two
+steps — and the one that fails tells you which hop broke.
+
+!!! note "`alertmanager-url` has a version floor"
+    That input needs a Sonda release that has it. If you pin an older
+    version, the action refuses **before** downloading anything and names
+    the floor, rather than installing a binary that would reject the flag
+    with a confusing `unexpected argument`.
+
+## What the action does
+
+1. **Resolves your ref to a concrete release.** `@v1` is a tag that moves
+   with every release, so it is resolved to the newest published `1.x`
+   before anything is downloaded — a run always installs a determinate
+   version, and the log says which.
+2. **Installs that release**, reusing the same `install.sh` the docs point
+   humans at: it maps the runner's OS and architecture to the release
+   asset, downloads it, and **verifies it against the release's
+   `SHA256SUMS`**. A mismatch aborts.
+3. **Runs `sonda test`** with your scenario and URL.
+
+Two failure modes get named rather than left to guesswork:
+
+- **A tag whose release has no assets yet.** The version bump merges and
+  tags before the binary build finishes uploading, so for a few minutes a
+  real tag has nothing to download. The action says so and suggests
+  re-running or pinning the previous version.
+- **A release with assets but no checksums.** The action refuses instead of
+  installing something it cannot verify.
+
+## Pinning
+
+```yaml
+- uses: davidban77/sonda@v1        # newest 1.x, moves with each release
+- uses: davidban77/sonda@v1.20.0   # exactly this release, forever
+```
+
+`@v1` is maintained by the release workflow, which moves the `v1` tag onto
+each new `1.x` release. A future `2.0.0` creates and moves `v2` and leaves
+`v1` where it is, so pinning `@v1` never carries you across a major version.
+
+## Verifying the notification path
+
+Swap the flag to check the hop past the rule evaluator — did the alert
+actually reach Alertmanager?
+
+```yaml
+- uses: davidban77/sonda@v1
+  with:
+    scenario: examples/alert-lifecycle-test.yaml
+    alertmanager-url: http://localhost:9093
+```
+
+A rule that evaluates correctly but never reaches Alertmanager — a wrong
+`-notifier.url`, a route that drops it — is green on `prometheus-url` and
+red here. See [Alert testing](alert-testing.md#verify-the-notification-not-just-the-rule)
+for what that path can and cannot promise.
+
+## Where to next
+
+- [Alert testing](alert-testing.md) — writing the `expect:` block itself.
+- [End-to-end pipelines](end-to-end-pipelines.md) — the full CI walkthrough,
+  including bringing up the backend stack the action runs against.

--- a/docs/site/docs/test/index.md
+++ b/docs/site/docs/test/index.md
@@ -15,6 +15,10 @@ This section covers the patterns. Each page starts from a real failure mode you'
 
     Six patterns in one page: thresholds, resolution, compound `A AND B`, cardinality explosion, incident replay, histogram-based latency alerts.
 
+-   :material-github: __[Run it in CI](ci-github-action.md)__
+
+    The `sonda` GitHub Action: pin a release, verify the download against its published checksums, and make an alert rule a required check in three lines of workflow YAML.
+
 -   :material-calculator-variant: __[Recording rules](recording-rules.md)__
 
     Test that precomputed PromQL series produce the right values — sum rules, rate-based rules, multi-rule chains.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -221,6 +221,7 @@ nav:
   - Test pipelines:
       - test/index.md
       - Alert testing: test/alert-testing.md
+      - Run it in CI (GitHub Action): test/ci-github-action.md
       - Recording rules: test/recording-rules.md
       - End-to-end pipelines: test/end-to-end-pipelines.md
       - Synthetic monitoring: test/synthetic-monitoring.md

--- a/scripts/live_infra_uat.py
+++ b/scripts/live_infra_uat.py
@@ -632,6 +632,53 @@ def attribute_failure(
 # --- Orchestration -----------------------------------------------------------
 
 
+def boot_only(repo_root: Path, profiles: Sequence[str]) -> int:
+    """Bring the stack up for ``profiles``, wait for readiness, leave it running.
+
+    The ``sonda-action`` self-test needs the same live stack this matrix
+    uses, but runs its assertions through the action rather than through
+    :func:`run_all`. Exposing the bootstrap here keeps one definition of
+    "which backends exist, where their health endpoints are, and how long
+    they get to start" — duplicating that in workflow YAML is how the two
+    drift apart.
+
+    Deliberately does **not** tear down: the caller is mid-job and still
+    needs the stack. The runner reclaims it.
+    """
+    ordered = tuple(sorted(set(profiles)))
+    print(
+        f"==> compose up (profiles: {','.join(ordered) or '<default>'})",
+        file=sys.stderr,
+    )
+    up = compose_up(repo_root, ordered)
+    if up.returncode != 0:
+        print(up.stdout, file=sys.stderr)
+        print(up.stderr, file=sys.stderr)
+        print(f"docker compose up failed (exit {up.returncode})", file=sys.stderr)
+        return 1
+
+    backends: list[Backend] = []
+    seen: set[str] = set()
+    for prof in ("",) + ordered:
+        for backend in BACKENDS_BY_PROFILE.get(prof, ()):
+            if backend.name not in seen:
+                seen.add(backend.name)
+                backends.append(backend)
+
+    for backend in backends:
+        print(f"==> waiting for {backend.name} ({backend.health_url})", file=sys.stderr)
+        if not wait_for_backend_ready(backend):
+            print(
+                f"{backend.name} never became ready at {backend.health_url} "
+                f"within {READINESS_TIMEOUT_S:.0f}s",
+                file=sys.stderr,
+            )
+            return 1
+
+    print(f"==> stack ready ({len(backends)} backend(s))", file=sys.stderr)
+    return 0
+
+
 def find_repo_root(start: Path) -> Path:
     """Walk up from ``start`` until a directory with a ``Cargo.toml`` is found."""
     current = start.resolve()
@@ -767,6 +814,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--boot-only",
+        action="append",
+        default=None,
+        metavar="PROFILE",
+        help=(
+            "Bring the compose stack up for this profile, wait until every "
+            "backend is ready, then exit 0 leaving it running. Repeatable. "
+            "No matrix rows run and nothing is torn down. Used by the "
+            "sonda-action self-test so it boots the same stack this matrix "
+            "does instead of duplicating the bootstrap in workflow YAML."
+        ),
+    )
+    parser.add_argument(
         "--self-test",
         action="store_true",
         help="Run inline unit tests and exit. No Docker required.",
@@ -777,6 +837,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _run_self_tests()
 
     repo_root = find_repo_root(Path(__file__).parent)
+
+    # Bootstrap-only mode needs no sonda binary — it starts containers.
+    if args.boot_only is not None:
+        return boot_only(repo_root, args.boot_only)
 
     raw_bin = args.sonda or (repo_root / DEFAULT_SONDA_BINARY)
     raw_bin = raw_bin if raw_bin.is_absolute() else (repo_root / raw_bin)

--- a/scripts/resolve_release.py
+++ b/scripts/resolve_release.py
@@ -92,11 +92,21 @@ def highest(tags: Iterable[str]) -> str | None:
     everyone pinned to it (#554 review W3). Compare numerically instead:
     string order would also get this wrong, since ``"v1.9.0" > "v1.20.0"``.
     """
-    ranked = [(parse_version(tag), tag) for tag in tags]
-    ranked = [(version, tag) for version, tag in ranked if version is not None]
+    ranked = []
+    for tag in tags:
+        version = parse_version(tag)
+        if version is None:
+            continue
+        # `parse_version` drops pre-release metadata, so v2.0.0-rc.1 and
+        # v2.0.0 both rank (2, 0, 0) and max() would fall through to the
+        # tag STRING — where the longer one wins and the release candidate
+        # beats the release (#554 round 2, M1). Break that tie explicitly:
+        # a tag with no pre-release suffix is the final one.
+        is_final = "-" not in tag[1:]
+        ranked.append((version, is_final, tag))
     if not ranked:
         return None
-    return max(ranked)[1]
+    return max(ranked)[2]
 
 
 def newest_in_major(releases: Iterable[dict[str, Any]], major: str) -> str | None:
@@ -327,11 +337,25 @@ def main(argv: Sequence[str] | None = None) -> int:
         # means downloading first, which is the thing the floor exists to
         # avoid.
         floor = "v" + ".".join(str(p) for p in MIN_ALERTMANAGER_VERSION)
+        # Deliberately NOT via resolve(): that ends in check_downloadable,
+        # so during the release-please window — tag created, assets still
+        # uploading, which this module documents as normal and transient —
+        # every open PR in the repo would go red on a question about a
+        # constant (#554 round 2, W3). Staleness needs the newest published
+        # *tag*, not something downloadable.
         try:
-            newest = resolve("latest", args.repo, os.environ.get("GITHUB_TOKEN"))
-        except (ResolveError, urllib.error.URLError, TimeoutError) as e:
-            print(f"error: could not check floor staleness: {e}", file=sys.stderr)
-            return 1
+            token = os.environ.get("GITHUB_TOKEN")
+            newest = newest_published(_api_get(f"{GITHUB_API}/repos/{args.repo}/releases", token))
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
+            # "Could not ask" is not "is stale". Failing here would take
+            # every open PR down with a GitHub 5xx or a rate limit, and
+            # protect nothing: the constant is either stale or it is not,
+            # and this run simply does not know.
+            print(f"note: could not check floor staleness ({e}); skipping", file=sys.stderr)
+            return 0
+        if newest is None:
+            print("note: no published releases to compare the floor against; skipping")
+            return 0
         if at_least(newest, MIN_ALERTMANAGER_VERSION):
             print(
                 f"error: MIN_ALERTMANAGER_VERSION ({floor}) is stale — {newest} is "
@@ -468,6 +492,26 @@ class SelectionTests(unittest.TestCase):
     def test_no_match_returns_none(self):
         self.assertIsNone(newest_in_major([_release("v2.0.0")], "3"))
         self.assertIsNone(newest_published([]))
+
+
+class PreReleaseTieTests(unittest.TestCase):
+    def test_a_final_release_beats_its_own_candidate(self):
+        # parse_version drops the suffix, so both rank (2,0,0); a string
+        # tiebreak would hand it to the longer tag — the rc (#554 rd2 M1).
+        self.assertEqual(highest(["v2.0.0", "v2.0.0-rc.1"]), "v2.0.0")
+        self.assertEqual(highest(["v2.0.0-rc.1", "v2.0.0"]), "v2.0.0")
+
+    def test_a_candidate_still_wins_when_it_is_the_highest(self):
+        self.assertEqual(highest(["v1.20.0", "v2.0.0-rc.1"]), "v2.0.0-rc.1")
+
+    def test_the_tie_does_not_disturb_ordinary_ordering(self):
+        self.assertEqual(highest(["v1.9.0", "v1.20.0", "v1.20.1"]), "v1.20.1")
+
+    def test_newest_published_inherits_the_tiebreak(self):
+        # Reachable only if a maintainer publishes an rc without ticking
+        # "pre-release", since _published_tags filters on the API flag.
+        releases = [_release("v2.0.0-rc.1"), _release("v2.0.0")]
+        self.assertEqual(newest_published(releases), "v2.0.0")
 
 
 class PaginationTests(unittest.TestCase):

--- a/scripts/resolve_release.py
+++ b/scripts/resolve_release.py
@@ -69,35 +69,49 @@ def major_of(ref: str) -> str | None:
     return match.group(1) if match else None
 
 
-def newest_in_major(releases: Iterable[dict[str, Any]], major: str) -> str | None:
-    """Newest published release tag within one major version.
-
-    ``releases`` is the GitHub API payload order (newest first). Drafts and
-    pre-releases are skipped: pinning ``@v1`` must never select something
-    the maintainer has not published.
-    """
-    prefix = f"v{major}."
-    for release in releases:
-        tag = release.get("tag_name", "")
-        if not isinstance(tag, str) or not tag.startswith(prefix):
-            continue
-        if release.get("draft") or release.get("prerelease"):
-            continue
-        if is_full_tag(tag):
-            return tag
-    return None
-
-
-def newest_published(releases: Iterable[dict[str, Any]]) -> str | None:
-    """Newest published, non-pre-release tag of any major version."""
+def _published_tags(releases: Iterable[dict[str, Any]]) -> list[str]:
+    """Full release tags that are published (not drafts, not pre-releases)."""
+    tags = []
     for release in releases:
         tag = release.get("tag_name", "")
         if not isinstance(tag, str) or not is_full_tag(tag):
             continue
         if release.get("draft") or release.get("prerelease"):
             continue
-        return tag
-    return None
+        tags.append(tag)
+    return tags
+
+
+def highest(tags: Iterable[str]) -> str | None:
+    """The highest tag by *version*, not by position or by string order.
+
+    The releases endpoint is ordered by creation time, so the first entry
+    is the most recently *cut* release — which is not the highest version
+    the moment a patch is backported onto an older line. Taking position
+    for version there resolves ``@v1`` backwards and silently downgrades
+    everyone pinned to it (#554 review W3). Compare numerically instead:
+    string order would also get this wrong, since ``"v1.9.0" > "v1.20.0"``.
+    """
+    ranked = [(parse_version(tag), tag) for tag in tags]
+    ranked = [(version, tag) for version, tag in ranked if version is not None]
+    if not ranked:
+        return None
+    return max(ranked)[1]
+
+
+def newest_in_major(releases: Iterable[dict[str, Any]], major: str) -> str | None:
+    """Highest published release tag within one major version.
+
+    Drafts and pre-releases are skipped: pinning ``@v1`` must never select
+    something the maintainer has not published.
+    """
+    prefix = f"v{major}."
+    return highest(tag for tag in _published_tags(releases) if tag.startswith(prefix))
+
+
+def newest_published(releases: Iterable[dict[str, Any]]) -> str | None:
+    """Highest published, non-pre-release tag of any major version."""
+    return highest(_published_tags(releases))
 
 
 def parse_version(tag: str) -> tuple[int, int, int] | None:
@@ -161,14 +175,50 @@ def check_downloadable(tag: str, release: dict[str, Any] | None) -> None:
         )
 
 
+def _next_link(header: str | None) -> str | None:
+    """The ``rel="next"`` URL from a GitHub ``Link`` header, if present."""
+    if not header:
+        return None
+    for part in header.split(","):
+        chunks = part.split(";")
+        if len(chunks) < 2:
+            continue
+        url = chunks[0].strip()
+        if url.startswith("<") and url.endswith(">"):
+            if any(c.strip() in ('rel="next"', "rel=next") for c in chunks[1:]):
+                return url[1:-1]
+    return None
+
+
 def _api_get(url: str, token: str | None) -> Any:
-    request = urllib.request.Request(url)
-    request.add_header("Accept", "application/vnd.github+json")
-    request.add_header("User-Agent", "sonda-action")
-    if token:
-        request.add_header("Authorization", f"Bearer {token}")
-    with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_S) as response:
-        return json.loads(response.read().decode("utf-8"))
+    """GET a GitHub API URL, following pagination for list responses.
+
+    The releases endpoint pages at 30 by default and this repo already has
+    more than that, so one page is not the release list — it is the newest
+    slice of it. Asking `@v0` for a resolution today already fails with
+    "no published release found" while eighteen v0.x releases exist, and
+    `@v1` inherits that the moment ~30 newer releases sit in front of it
+    (#554 review M2). Ask for the maximum page size, then follow
+    ``Link: rel="next"`` so the answer does not depend on how many
+    releases have happened since.
+    """
+    if "?" not in url:
+        url = f"{url}?per_page=100"
+    collected: list[Any] | None = None
+    while url:
+        request = urllib.request.Request(url)
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("User-Agent", "sonda-action")
+        if token:
+            request.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_S) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            link = response.headers.get("Link")
+        if not isinstance(payload, list):
+            return payload
+        collected = payload if collected is None else collected + payload
+        url = _next_link(link)
+    return collected if collected is not None else []
 
 
 def resolve(
@@ -240,6 +290,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--ref", default="", help="Version input, or github.action_ref.")
     parser.add_argument("--repo", default=DEFAULT_REPO, help="owner/repo to resolve against.")
     parser.add_argument(
+        "--check-floor-staleness",
+        action="store_true",
+        help=(
+            "Network check for CI: fail once MIN_ALERTMANAGER_VERSION is "
+            "stale — i.e. once a release at or above the floor exists, at "
+            "which point the constant no longer needs to gate anything and "
+            "someone must revisit it."
+        ),
+    )
+    parser.add_argument(
         "--needs-alertmanager",
         action="store_true",
         help=(
@@ -257,6 +317,32 @@ def main(argv: Sequence[str] | None = None) -> int:
         suite = unittest.defaultTestLoader.loadTestsFromModule(sys.modules[__name__])
         result = unittest.TextTestRunner(verbosity=2).run(suite)
         return 0 if result.wasSuccessful() else 1
+
+    if args.check_floor_staleness:
+        # The floor is a constant someone has to remember to revisit. This
+        # turns that into a red check at exactly the moment it matters —
+        # the release that makes it stale — rather than relying on memory
+        # (#554 review, question 3). Deriving it from the binary is not an
+        # option: the only honest source is the installed `--help`, which
+        # means downloading first, which is the thing the floor exists to
+        # avoid.
+        floor = "v" + ".".join(str(p) for p in MIN_ALERTMANAGER_VERSION)
+        try:
+            newest = resolve("latest", args.repo, os.environ.get("GITHUB_TOKEN"))
+        except (ResolveError, urllib.error.URLError, TimeoutError) as e:
+            print(f"error: could not check floor staleness: {e}", file=sys.stderr)
+            return 1
+        if at_least(newest, MIN_ALERTMANAGER_VERSION):
+            print(
+                f"error: MIN_ALERTMANAGER_VERSION ({floor}) is stale — {newest} is "
+                "released and at or above it, so the floor no longer gates "
+                "anything. Confirm `--alertmanager-url` shipped in that release "
+                "and either drop the guard or move the floor.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"floor {floor} still ahead of the newest release ({newest})")
+        return 0
 
     try:
         tag = resolve(args.ref, args.repo, os.environ.get("GITHUB_TOKEN"))
@@ -359,9 +445,43 @@ class SelectionTests(unittest.TestCase):
         self.assertEqual(newest_in_major(releases, "1"), "v1.20.0")
         self.assertEqual(newest_published(releases), "v1.20.0")
 
+    def test_a_backport_cut_later_does_not_win(self):
+        # The releases endpoint is ordered by CREATION time. A 1.19.1
+        # backport cut after 1.20.0 therefore sits first in the payload,
+        # and taking position for version resolves @v1 backwards —
+        # silently downgrading everyone pinned to it (#554 review W3).
+        api_order = [_release("v1.19.1"), _release("v1.20.0"), _release("v1.19.0")]
+        self.assertEqual(newest_in_major(api_order, "1"), "v1.20.0")
+        self.assertEqual(newest_published(api_order), "v1.20.0")
+
+    def test_selection_is_numeric_not_lexical(self):
+        # The other way to get this wrong: "v1.9.0" > "v1.20.0" as strings.
+        api_order = [_release("v1.9.0"), _release("v1.20.0")]
+        self.assertEqual(newest_in_major(api_order, "1"), "v1.20.0")
+
+    def test_highest_across_majors(self):
+        self.assertEqual(highest(["v1.20.0", "v2.0.0", "v1.9.0"]), "v2.0.0")
+        self.assertEqual(highest(["v1.2.3"]), "v1.2.3")
+        self.assertIsNone(highest([]))
+        self.assertIsNone(highest(["main", "v1"]))
+
     def test_no_match_returns_none(self):
         self.assertIsNone(newest_in_major([_release("v2.0.0")], "3"))
         self.assertIsNone(newest_published([]))
+
+
+class PaginationTests(unittest.TestCase):
+    def test_next_link_is_extracted(self):
+        header = '<https://api/x?page=2>; rel="next", <https://api/x?page=3>; rel="last"'
+        self.assertEqual(_next_link(header), "https://api/x?page=2")
+
+    def test_last_page_has_no_next(self):
+        header = '<https://api/x?page=1>; rel="prev", <https://api/x?page=1>; rel="first"'
+        self.assertIsNone(_next_link(header))
+
+    def test_absent_or_malformed_headers(self):
+        for header in (None, "", "garbage", "<no-rel>"):
+            self.assertIsNone(_next_link(header), repr(header))
 
 
 class DownloadableTests(unittest.TestCase):

--- a/scripts/resolve_release.py
+++ b/scripts/resolve_release.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Resolve a sonda-action version reference to a concrete, downloadable release.
+
+The action must not hand a moving reference to the installer. ``@v1`` is a
+tag that moves with every release, ``latest`` is a query, and
+``github.action_ref`` can be any of a full tag, a major tag, a branch, or a
+commit SHA. All of them have to become one concrete ``vX.Y.Z`` that has
+assets attached, or a named failure — never a silent wrong version.
+
+Two failure modes matter enough to name separately:
+
+* **The release-please window.** ``release-please`` merges the version bump
+  and creates the tag *before* the binary build finishes uploading. A tag
+  that exists with no assets is therefore normal and transient, not
+  corruption, and the message has to say so — otherwise the next person
+  reads a 404 from the installer and goes looking for a bug.
+* **A reference that resolves to nothing.** A typo'd tag and a real tag
+  whose release was deleted look identical from the installer's side. Both
+  fail here, before anything is downloaded.
+
+Stdlib-only, mirroring ``live_infra_uat.py``. ``--self-test`` runs the
+inline unit tests with no network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import unittest
+import urllib.error
+import urllib.request
+from typing import Any, Iterable, Sequence
+
+GITHUB_API = "https://api.github.com"
+DEFAULT_REPO = "davidban77/sonda"
+HTTP_TIMEOUT_S = 15.0
+
+# A concrete, immutable release tag: vMAJOR.MINOR.PATCH (with optional
+# pre-release/build metadata, which release-please does not currently emit
+# but which must not be silently mistaken for a major tag).
+FULL_TAG = re.compile(r"^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+
+# A moving major tag: v1, v2 — the shape Actions users expect to pin.
+MAJOR_TAG = re.compile(r"^v(\d+)$")
+
+# `sonda test --alertmanager-url` landed in #552, after v1.20.0 shipped. The
+# action installs *released* binaries, so an older pin cannot serve that
+# input — and the failure it would otherwise produce is clap's "unexpected
+# argument", which reads like a bug in the action rather than a version
+# floor. Bump this when the flag's release changes.
+MIN_ALERTMANAGER_VERSION = (1, 21, 0)
+
+
+class ResolveError(Exception):
+    """A reference that cannot be turned into a downloadable release."""
+
+
+def is_full_tag(ref: str) -> bool:
+    """Whether ``ref`` already names one immutable release."""
+    return bool(FULL_TAG.match(ref))
+
+
+def major_of(ref: str) -> str | None:
+    """The major number of a moving major tag (``v1`` -> ``1``), else None."""
+    match = MAJOR_TAG.match(ref)
+    return match.group(1) if match else None
+
+
+def newest_in_major(releases: Iterable[dict[str, Any]], major: str) -> str | None:
+    """Newest published release tag within one major version.
+
+    ``releases`` is the GitHub API payload order (newest first). Drafts and
+    pre-releases are skipped: pinning ``@v1`` must never select something
+    the maintainer has not published.
+    """
+    prefix = f"v{major}."
+    for release in releases:
+        tag = release.get("tag_name", "")
+        if not isinstance(tag, str) or not tag.startswith(prefix):
+            continue
+        if release.get("draft") or release.get("prerelease"):
+            continue
+        if is_full_tag(tag):
+            return tag
+    return None
+
+
+def newest_published(releases: Iterable[dict[str, Any]]) -> str | None:
+    """Newest published, non-pre-release tag of any major version."""
+    for release in releases:
+        tag = release.get("tag_name", "")
+        if not isinstance(tag, str) or not is_full_tag(tag):
+            continue
+        if release.get("draft") or release.get("prerelease"):
+            continue
+        return tag
+    return None
+
+
+def parse_version(tag: str) -> tuple[int, int, int] | None:
+    """``v1.20.0`` -> ``(1, 20, 0)``. None when the tag is not a full tag.
+
+    Pre-release metadata is dropped for comparison: a ``v2.0.0-rc.1`` is
+    treated as ``2.0.0``, which is deliberately generous — the alternative
+    is refusing to run against a release candidate someone chose on purpose.
+    """
+    if not is_full_tag(tag):
+        return None
+    core = re.split(r"[-+]", tag[1:], maxsplit=1)[0]
+    major, minor, patch = core.split(".")
+    return (int(major), int(minor), int(patch))
+
+
+def at_least(tag: str, minimum: tuple[int, int, int]) -> bool:
+    """Whether ``tag`` is at or above ``minimum``.
+
+    An unparseable tag returns True: the caller has already resolved it to
+    something installable, and blocking on a shape this function does not
+    recognize would fail closed against the user rather than the risk.
+    """
+    parsed = parse_version(tag)
+    return True if parsed is None else parsed >= minimum
+
+
+def asset_names(release: dict[str, Any]) -> list[str]:
+    """Names of the assets attached to a release payload."""
+    assets = release.get("assets")
+    if not isinstance(assets, list):
+        return []
+    return [a.get("name", "") for a in assets if isinstance(a, dict)]
+
+
+def check_downloadable(tag: str, release: dict[str, Any] | None) -> None:
+    """Raise unless ``release`` is a real release with assets to download.
+
+    # Raises
+
+    [`ResolveError`] naming which of the two failure modes happened.
+    """
+    if release is None:
+        raise ResolveError(
+            f"no release found for {tag!r}. Check the version input, or pin a "
+            f"released version: https://github.com/{DEFAULT_REPO}/releases"
+        )
+    names = asset_names(release)
+    if not names:
+        raise ResolveError(
+            f"release {tag} exists but has no assets attached yet. This is "
+            "normal for a few minutes after a release: the tag is created "
+            "when the version bump merges, and the binaries upload once the "
+            "build finishes. Re-run this job, or pin the previous version."
+        )
+    if "SHA256SUMS" not in names:
+        raise ResolveError(
+            f"release {tag} has assets but no SHA256SUMS, so the download "
+            "cannot be integrity-checked. Refusing to install an unverified "
+            f"binary. Assets present: {', '.join(sorted(names))}"
+        )
+
+
+def _api_get(url: str, token: str | None) -> Any:
+    request = urllib.request.Request(url)
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("User-Agent", "sonda-action")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_S) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def resolve(
+    ref: str,
+    repo: str,
+    token: str | None,
+    fetch=None,
+) -> str:
+    """Turn ``ref`` into a concrete release tag with downloadable assets.
+
+    ``fetch(path)`` is injected in tests; it defaults to the GitHub API.
+
+    # Raises
+
+    [`ResolveError`] when the reference names nothing installable.
+    """
+    get = fetch or (lambda path: _api_get(f"{GITHUB_API}{path}", token))
+    ref = ref.strip()
+    if not ref:
+        raise ResolveError("empty version reference")
+
+    if is_full_tag(ref):
+        tag = ref
+    elif ref == "latest":
+        tag = newest_published(get(f"/repos/{repo}/releases"))
+        if tag is None:
+            raise ResolveError(f"{repo} has no published releases to resolve 'latest' to")
+    elif (major := major_of(ref)) is not None:
+        tag = newest_in_major(get(f"/repos/{repo}/releases"), major)
+        if tag is None:
+            raise ResolveError(
+                f"no published release found for major version {ref}. "
+                f"Pin a concrete version instead: "
+                f"https://github.com/{repo}/releases"
+            )
+    else:
+        # A branch or a commit SHA: the action is being used from a ref that
+        # is not a release at all (`uses: owner/repo@main`, or `uses: ./`).
+        # There is no honest mapping from that to a release, so fall back to
+        # the newest published one and say which was chosen.
+        tag = newest_published(get(f"/repos/{repo}/releases"))
+        if tag is None:
+            raise ResolveError(
+                f"{ref!r} is not a release tag and {repo} has no published "
+                "releases to fall back to"
+            )
+        print(
+            f"note: {ref!r} is not a release tag, so the newest published "
+            f"release ({tag}) will be installed",
+            file=sys.stderr,
+        )
+
+    release: dict[str, Any] | None
+    try:
+        release = get(f"/repos/{repo}/releases/tags/{tag}")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            release = None
+        else:
+            raise ResolveError(f"GitHub API error resolving {tag}: {e}") from e
+    check_downloadable(tag, release)
+    return tag
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve a sonda-action version reference to a concrete release tag.",
+    )
+    parser.add_argument("--ref", default="", help="Version input, or github.action_ref.")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="owner/repo to resolve against.")
+    parser.add_argument(
+        "--needs-alertmanager",
+        action="store_true",
+        help=(
+            "Fail if the resolved release predates `sonda test "
+            "--alertmanager-url`, instead of installing a binary that will "
+            "reject the flag."
+        ),
+    )
+    parser.add_argument(
+        "--self-test", action="store_true", help="Run inline unit tests and exit. No network."
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        suite = unittest.defaultTestLoader.loadTestsFromModule(sys.modules[__name__])
+        result = unittest.TextTestRunner(verbosity=2).run(suite)
+        return 0 if result.wasSuccessful() else 1
+
+    try:
+        tag = resolve(args.ref, args.repo, os.environ.get("GITHUB_TOKEN"))
+        if args.needs_alertmanager and not at_least(tag, MIN_ALERTMANAGER_VERSION):
+            floor = "v" + ".".join(str(p) for p in MIN_ALERTMANAGER_VERSION)
+            raise ResolveError(
+                f"the alertmanager-url input needs sonda {floor} or newer, but "
+                f"this run resolved to {tag}. `sonda test --alertmanager-url` "
+                f"does not exist in {tag}, so the run would fail with an "
+                "'unexpected argument' error that looks like an action bug. "
+                f"Pin version: {floor} once it is released, or use "
+                "prometheus-url."
+            )
+        print(tag)
+    except ResolveError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
+        print(f"error: could not reach the GitHub release API: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+# --- Inline tests ------------------------------------------------------------
+
+
+def _release(tag: str, assets: Sequence[str] = ("SHA256SUMS",), **kw: Any) -> dict[str, Any]:
+    return {
+        "tag_name": tag,
+        "assets": [{"name": n} for n in assets],
+        "draft": kw.get("draft", False),
+        "prerelease": kw.get("prerelease", False),
+    }
+
+
+class TagShapeTests(unittest.TestCase):
+    def test_full_tags_are_recognized(self):
+        for tag in ("v1.20.0", "v0.1.0", "v10.2.30", "v2.0.0-rc.1"):
+            self.assertTrue(is_full_tag(tag), tag)
+
+    def test_non_full_tags_are_rejected(self):
+        # `v1` is the case that matters: treating it as concrete would pin
+        # every user of @v1 to a tag that moves under them.
+        for tag in ("v1", "v", "1.2.3", "main", "latest", "vX.Y.Z", ""):
+            self.assertFalse(is_full_tag(tag), tag)
+
+    def test_major_tags(self):
+        self.assertEqual(major_of("v1"), "1")
+        self.assertEqual(major_of("v22"), "22")
+        for tag in ("v1.2.3", "main", "v", ""):
+            self.assertIsNone(major_of(tag), tag)
+
+
+class VersionFloorTests(unittest.TestCase):
+    def test_parses_full_tags(self):
+        self.assertEqual(parse_version("v1.20.0"), (1, 20, 0))
+        self.assertEqual(parse_version("v10.2.30"), (10, 2, 30))
+        self.assertEqual(parse_version("v2.0.0-rc.1"), (2, 0, 0))
+
+    def test_non_full_tags_have_no_version(self):
+        for tag in ("v1", "main", "", "1.2.3"):
+            self.assertIsNone(parse_version(tag), tag)
+
+    def test_ordering_is_numeric_not_lexical(self):
+        # "v1.9.0" > "v1.20.0" as strings; the floor must not agree.
+        self.assertTrue(at_least("v1.20.0", (1, 9, 0)))
+        self.assertFalse(at_least("v1.9.0", (1, 20, 0)))
+
+    def test_the_alertmanager_floor(self):
+        self.assertFalse(at_least("v1.20.0", MIN_ALERTMANAGER_VERSION))
+        self.assertTrue(at_least("v1.21.0", MIN_ALERTMANAGER_VERSION))
+        self.assertTrue(at_least("v2.0.0", MIN_ALERTMANAGER_VERSION))
+
+    def test_equality_satisfies_the_floor(self):
+        self.assertTrue(at_least("v1.21.0", (1, 21, 0)))
+
+    def test_an_unrecognized_shape_does_not_block(self):
+        # Fail open against the user, not closed: the tag already resolved
+        # to something installable.
+        self.assertTrue(at_least("weird", (1, 21, 0)))
+
+
+class SelectionTests(unittest.TestCase):
+    def test_newest_in_major_respects_the_major(self):
+        releases = [_release("v2.0.0"), _release("v1.20.0"), _release("v1.19.0")]
+        self.assertEqual(newest_in_major(releases, "1"), "v1.20.0")
+        self.assertEqual(newest_in_major(releases, "2"), "v2.0.0")
+
+    def test_major_prefix_is_not_a_substring_match(self):
+        # v11.x must never satisfy @v1.
+        releases = [_release("v11.0.0"), _release("v1.5.0")]
+        self.assertEqual(newest_in_major(releases, "1"), "v1.5.0")
+
+    def test_drafts_and_prereleases_are_skipped(self):
+        releases = [
+            _release("v1.21.0", draft=True),
+            _release("v1.20.1", prerelease=True),
+            _release("v1.20.0"),
+        ]
+        self.assertEqual(newest_in_major(releases, "1"), "v1.20.0")
+        self.assertEqual(newest_published(releases), "v1.20.0")
+
+    def test_no_match_returns_none(self):
+        self.assertIsNone(newest_in_major([_release("v2.0.0")], "3"))
+        self.assertIsNone(newest_published([]))
+
+
+class DownloadableTests(unittest.TestCase):
+    def test_a_release_with_checksums_is_downloadable(self):
+        check_downloadable("v1.20.0", _release("v1.20.0", ["SHA256SUMS", "sonda-x.tar.gz"]))
+
+    def test_missing_release_is_named(self):
+        with self.assertRaises(ResolveError) as ctx:
+            check_downloadable("v9.9.9", None)
+        self.assertIn("no release found", str(ctx.exception))
+
+    def test_the_release_please_window_is_named_as_transient(self):
+        # The tag exists before the binaries upload. A bare 404 from the
+        # installer sends the reader hunting for a bug that is not there.
+        with self.assertRaises(ResolveError) as ctx:
+            check_downloadable("v1.21.0", _release("v1.21.0", []))
+        message = str(ctx.exception)
+        self.assertIn("no assets attached yet", message)
+        self.assertIn("Re-run this job", message)
+
+    def test_assets_without_checksums_are_refused(self):
+        with self.assertRaises(ResolveError) as ctx:
+            check_downloadable("v1.20.0", _release("v1.20.0", ["sonda-x.tar.gz"]))
+        self.assertIn("no SHA256SUMS", str(ctx.exception))
+
+
+class ResolveTests(unittest.TestCase):
+    def _fetch(self, releases: Sequence[dict[str, Any]]):
+        by_tag = {r["tag_name"]: r for r in releases}
+
+        def fetch(path: str):
+            if path.endswith("/releases"):
+                return list(releases)
+            tag = path.rsplit("/", 1)[-1]
+            if tag not in by_tag:
+                raise urllib.error.HTTPError(path, 404, "Not Found", {}, None)  # type: ignore[arg-type]
+            return by_tag[tag]
+
+        return fetch
+
+    def test_a_full_tag_passes_through(self):
+        releases = [_release("v1.20.0")]
+        self.assertEqual(resolve("v1.20.0", "o/r", None, self._fetch(releases)), "v1.20.0")
+
+    def test_a_major_tag_resolves_within_its_major(self):
+        releases = [_release("v2.0.0"), _release("v1.20.0")]
+        self.assertEqual(resolve("v1", "o/r", None, self._fetch(releases)), "v1.20.0")
+
+    def test_latest_resolves_to_the_newest_published(self):
+        releases = [_release("v2.0.0"), _release("v1.20.0")]
+        self.assertEqual(resolve("latest", "o/r", None, self._fetch(releases)), "v2.0.0")
+
+    def test_a_branch_or_sha_falls_back_to_newest(self):
+        releases = [_release("v1.20.0")]
+        for ref in ("main", "0c68373", "claude/some-branch"):
+            self.assertEqual(resolve(ref, "o/r", None, self._fetch(releases)), "v1.20.0")
+
+    def test_a_tag_with_no_assets_fails_rather_than_installing(self):
+        releases = [_release("v1.21.0", [])]
+        with self.assertRaises(ResolveError) as ctx:
+            resolve("v1.21.0", "o/r", None, self._fetch(releases))
+        self.assertIn("no assets attached yet", str(ctx.exception))
+
+    def test_an_unknown_full_tag_fails(self):
+        with self.assertRaises(ResolveError) as ctx:
+            resolve("v9.9.9", "o/r", None, self._fetch([_release("v1.20.0")]))
+        self.assertIn("no release found", str(ctx.exception))
+
+    def test_an_empty_ref_fails(self):
+        with self.assertRaises(ResolveError):
+            resolve("   ", "o/r", None, self._fetch([]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/action_argv_test.sh
+++ b/scripts/tests/action_argv_test.sh
@@ -231,13 +231,24 @@ ACTION="$(dirname "$0")/../../action.yml"
 ACTION_CODE="$(run_bodies "$ACTION" code)"
 ACTION_RAW="$(run_bodies "$ACTION" raw)"
 
-# The extractor is now load-bearing for every check below it, so it gets
-# its own check: an extractor that silently returns nothing would make all
-# of them pass vacuously.
+# The extractor is load-bearing for every check below it, so it gets its
+# own checks — and they must test COMPLETENESS, not presence. Round 2
+# showed why: the extractor recognised only `run: |` with exactly one
+# space, so a single-line `run:` or a re-indented `run:  |` vanished, every
+# check below inherited the blindness, and a non-empty result kept the
+# guard green. "Some" is not "all".
+counts="$(python3 "$(dirname "$0")/extract_run_bodies.py" "$ACTION" count)"
+keys_in_file="${counts%% *}"
+keys_opened="${counts##* }"
 if [ -n "$ACTION_CODE" ]; then
   pass "run: bodies extracted from action.yml ($(printf '%s\n' "$ACTION_CODE" | grep -c .) code lines)"
 else
   fail "run: bodies extracted from action.yml" "extractor produced nothing — every check below would pass vacuously"
+fi
+if [ "$keys_in_file" = "$keys_opened" ] && [ "$keys_in_file" -gt 0 ]; then
+  pass "every run: key in action.yml was opened by the extractor (${keys_opened}/${keys_in_file})"
+else
+  fail "every run: key in action.yml was opened by the extractor" "file has ${keys_in_file} run: keys, extractor opened ${keys_opened} — the difference is invisible to every check below"
 fi
 
 missing=()
@@ -268,6 +279,18 @@ if printf '%s\n' "$ACTION_RAW" | grep -q '\${{'; then
   fail "no expression is interpolated into a run: body" "$(printf '%s\n' "$ACTION_RAW" | grep -n '\${{' | head -5)"
 else
   pass "no expression is interpolated into a run: body"
+fi
+
+# No unescaped backtick may survive in a run: body. Round 2 found one in
+# the --dry-run refusal message, where it ran `sonda test --dry-run` while
+# claiming to refuse it AND deleted the actionable half of the message.
+# A general guard rather than a needle for that one line: the class is
+# "shell metacharacter evaluated in the file whose thesis is that nothing
+# is evaluated by the shell".
+if printf '%s\n' "$ACTION_CODE" | grep -q '`'; then
+  fail "no unescaped backtick in a run: body" "$(printf '%s\n' "$ACTION_CODE" | grep -n '`' | head -3)"
+else
+  pass "no unescaped backtick in a run: body"
 fi
 
 # …and the inputs must therefore arrive through env:, which is where the

--- a/scripts/tests/action_argv_test.sh
+++ b/scripts/tests/action_argv_test.sh
@@ -55,6 +55,12 @@ run_action_step() {
     # shellcheck disable=SC2206
     extra=($SONDA_EXTRA_ARGS)
     set +f
+    for arg in "${extra[@]}"; do
+      if [ "$arg" = "--dry-run" ]; then
+        echo "--dry-run in extra-args would make this step pass without verifying" >&2
+        exit 1
+      fi
+    done
     args+=("${extra[@]}")
   fi
   sonda "${args[@]}"
@@ -188,12 +194,52 @@ else
   fail "alertmanager-url selects the alertmanager flag" "$(show)"
 fi
 
+dry="$(SONDA_SCENARIO=s.yaml SONDA_PROM_URL=http://p SONDA_AM_URL="" SONDA_EXTRA_ARGS="--interval 5s --dry-run" \
+  bash -c "$(declare -f run_action_step); run_action_step" 2>&1 >/dev/null; echo "rc=$?")"
+case "$dry" in
+  *"without verifying"*rc=1*) pass "--dry-run in extra-args is refused" ;;
+  *) fail "--dry-run in extra-args is refused" "$dry" ;;
+esac
+
+invoke "s.yaml" "--interval 5s"
+if [ "$ARGC" -eq 6 ]; then
+  pass "a normal extra-arg is still accepted"
+else
+  fail "a normal extra-arg is still accepted" "argc=${ARGC}: $(show)"
+fi
+
 echo
 echo "== the harness still mirrors action.yml =="
-# A copy of production code in a test rots silently. Pin the pieces that
-# carry the safety property; if action.yml stops containing them, this
-# harness is testing something the action no longer does.
+# A copy of production code in a test rots silently, so the copy is only
+# defensible if these checks pin it to production. Round 1 of #554 broke
+# safety in action.yml TWICE with every check green, both times because the
+# checks read the whole file as flat text:
+#
+#   - the `set -f` needle was satisfied by a COMMENT mentioning it, so
+#     deleting the real line changed nothing here while globs expanded;
+#   - the "no interpolation" check allowed any `:` before the expression,
+#     so `echo "scenario:<expr>"` inside a run: body passed — which is
+#     arbitrary command execution from a workflow input.
+#
+# Both are fixed by looking at the right text: the bodies of `run:` blocks,
+# with comment lines removed, rather than the whole file.
+run_bodies() {
+  python3 "$(dirname "$0")/extract_run_bodies.py" "$1" "${2:-code}"
+}
+
 ACTION="$(dirname "$0")/../../action.yml"
+ACTION_CODE="$(run_bodies "$ACTION" code)"
+ACTION_RAW="$(run_bodies "$ACTION" raw)"
+
+# The extractor is now load-bearing for every check below it, so it gets
+# its own check: an extractor that silently returns nothing would make all
+# of them pass vacuously.
+if [ -n "$ACTION_CODE" ]; then
+  pass "run: bodies extracted from action.yml ($(printf '%s\n' "$ACTION_CODE" | grep -c .) code lines)"
+else
+  fail "run: bodies extracted from action.yml" "extractor produced nothing — every check below would pass vacuously"
+fi
+
 missing=()
 for needle in \
   'args=(test "$SONDA_SCENARIO")' \
@@ -201,20 +247,44 @@ for needle in \
   'args+=(--alertmanager-url "$SONDA_AM_URL")' \
   'extra=($SONDA_EXTRA_ARGS)' \
   'sonda "${args[@]}"' \
-  'set -f'
+  'set -f' \
+  'set +f' \
+  'if [ "$arg" = "--dry-run" ]; then'
 do
-  grep -qF -- "$needle" "$ACTION" || missing+=("$needle")
+  printf '%s\n' "$ACTION_CODE" | grep -qF -- "$needle" || missing+=("$needle")
 done
 if [ ${#missing[@]} -eq 0 ]; then
-  pass "every construction under test is present in action.yml"
+  pass "every construction under test is real code in action.yml, not a comment"
 else
-  fail "every construction under test is present in action.yml" "absent: ${missing[*]}"
+  fail "every construction under test is real code in action.yml, not a comment" "absent: ${missing[*]}"
 fi
-# And the inverse: the action must not interpolate inputs into a run: body.
-if grep -nE '\$\{\{ *inputs\.' "$ACTION" | grep -qv ': *\${{'; then
-  fail "no input is interpolated into a run: body" "$(grep -nE '\$\{\{ *inputs\.' "$ACTION")"
+
+# The inverse, and the one that matters most: NOTHING may be interpolated
+# into a run: body — not an input, not any other expression. GitHub
+# substitutes them textually before bash parses the script, so the value
+# becomes program text. Checked against the raw bodies (comments included,
+# since those are substituted too) with no allow-list to have a hole in.
+if printf '%s\n' "$ACTION_RAW" | grep -q '\${{'; then
+  fail "no expression is interpolated into a run: body" "$(printf '%s\n' "$ACTION_RAW" | grep -n '\${{' | head -5)"
 else
-  pass "inputs reach bash only through env:"
+  pass "no expression is interpolated into a run: body"
+fi
+
+# …and the inputs must therefore arrive through env:, which is where the
+# run: bodies read them from.
+env_bound=0
+for binding in \
+  'SONDA_SCENARIO: ${{ inputs.scenario }}' \
+  'SONDA_PROM_URL: ${{ inputs.prometheus-url }}' \
+  'SONDA_AM_URL: ${{ inputs.alertmanager-url }}' \
+  'SONDA_EXTRA_ARGS: ${{ inputs.extra-args }}'
+do
+  grep -qF -- "$binding" "$ACTION" && env_bound=$((env_bound + 1))
+done
+if [ "$env_bound" -eq 4 ]; then
+  pass "all four inputs reach bash through env: bindings"
+else
+  fail "all four inputs reach bash through env: bindings" "found ${env_bound}/4"
 fi
 
 echo
@@ -253,11 +323,46 @@ check_major "v1.20"       "SKIP"
 check_major "nightly"     "SKIP"
 check_major "v1"          "SKIP"   # the major tag itself must not recurse
 
+# The backward-move guard, run against a REAL git repo rather than a
+# reimplementation of it — `sort -V` and `git tag -l` are the parts most
+# likely to behave differently from what the shell here assumes.
+moves_to() {
+  local release_tag="$1"; shift
+  local repo="$TMP/tagrepo"
+  rm -rf "$repo"; mkdir -p "$repo"
+  (
+    cd "$repo"
+    git init -q .; git config user.email t@t; git config user.name t
+    git commit -q --allow-empty -m x
+    for t in "$@"; do git tag "$t"; done
+    major="${release_tag%%.*}"
+    highest="$(git tag -l "${major}.*" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)"
+    if [ -n "$highest" ] && [ "$highest" != "$release_tag" ]; then
+      printf 'SKIP(%s)' "$highest"
+    else
+      printf '%s' "$major"
+    fi
+  )
+}
+
+check_move() {
+  local label="$1" want="$2" got; shift 2
+  got="$(moves_to "$@")"
+  if [ "$got" = "$want" ]; then pass "$label"; else fail "$label" "got ${got}, want ${want}"; fi
+}
+
+check_move "newest release moves v1"          "v1"            "v1.20.0" v1.19.0 v1.20.0
+check_move "a backport does NOT move v1 back" "SKIP(v1.20.0)" "v1.19.1" v1.19.0 v1.19.1 v1.20.0
+check_move "v1.9.0 vs v1.20.0 is numeric"     "SKIP(v1.20.0)" "v1.9.0"  v1.9.0 v1.20.0
+check_move "a 2.0 release moves v2 only"      "v2"            "v2.0.0"  v1.20.0 v2.0.0
+check_move "first release of a line moves it" "v1"            "v1.0.0"  v1.0.0
+
 RELEASE_YML="$(dirname "$0")/../../.github/workflows/release.yml"
 release_missing=()
 for needle in \
   '^v[0-9]+\.[0-9]+\.[0-9]+$' \
   'major="${RELEASE_TAG%%.*}"' \
+  'sort -V | tail -1)"' \
   'git push --force origin "refs/tags/${major}"'
 do
   grep -qF -- "$needle" "$RELEASE_YML" || release_missing+=("$needle")

--- a/scripts/tests/action_argv_test.sh
+++ b/scripts/tests/action_argv_test.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Injection tests for the argv the composite action builds.
+#
+# The action's "Verify alert expectations" step is bash, so its argument
+# handling cannot be covered by cargo tests. This harness extracts the same
+# construction and drives it with hostile inputs, asserting on the *argv*
+# a fake `sonda` receives — the only place where a value that escaped its
+# quoting becomes visible.
+#
+# The contract under test:
+#   1. scenario reaches the CLI as exactly one argument, whatever is in it
+#   2. no input is ever evaluated by the shell (no command substitution,
+#      no glob expansion against the workspace)
+#   3. extra-args, and only extra-args, splits on whitespace
+#
+# Run: bash scripts/tests/action_argv_test.sh
+set -uo pipefail
+
+FAILURES=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# A stand-in for the real binary. Argument boundaries are reported with NUL
+# separators and the count is reported separately: a newline *inside* an
+# argument is a case under test here, so a line-per-argument format would
+# make a correct single argument look like two.
+cat > "$TMP/sonda" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s' "$#" > "$SONDA_ARGC_FILE"
+for a in "$@"; do printf '%s\0' "$a"; done > "$SONDA_ARGV_FILE"
+FAKE
+chmod +x "$TMP/sonda"
+PATH="$TMP:$PATH"
+
+# Verbatim from action.yml's "Verify alert expectations" step. Kept in sync
+# by `assert_matches_action` below, which fails if the action drifts.
+run_action_step() {
+  set -euo pipefail
+  if [ -n "$SONDA_PROM_URL" ] && [ -n "$SONDA_AM_URL" ]; then
+    echo "mutually exclusive" >&2
+    exit 1
+  fi
+  if [ -z "$SONDA_PROM_URL" ] && [ -z "$SONDA_AM_URL" ]; then
+    echo "one of prometheus-url or alertmanager-url is required" >&2
+    exit 1
+  fi
+  args=(test "$SONDA_SCENARIO")
+  if [ -n "$SONDA_PROM_URL" ]; then
+    args+=(--prometheus-url "$SONDA_PROM_URL")
+  else
+    args+=(--alertmanager-url "$SONDA_AM_URL")
+  fi
+  if [ -n "$SONDA_EXTRA_ARGS" ]; then
+    set -f
+    # shellcheck disable=SC2206
+    extra=($SONDA_EXTRA_ARGS)
+    set +f
+    args+=("${extra[@]}")
+  fi
+  sonda "${args[@]}"
+}
+
+export SONDA_ARGC_FILE="$TMP/argc" SONDA_ARGV_FILE="$TMP/argv"
+
+# Runs the step; leaves the observed argv in $ARGV (array) and $ARGC.
+declare -a ARGV=()
+ARGC=0
+invoke() {
+  : > "$SONDA_ARGC_FILE"; : > "$SONDA_ARGV_FILE"
+  SONDA_SCENARIO="$1" \
+  SONDA_PROM_URL="${3-http://localhost:9090}" \
+  SONDA_AM_URL="${4-}" \
+  SONDA_EXTRA_ARGS="${2:-}" \
+  bash -c "$(declare -f run_action_step); run_action_step" 2>/dev/null
+  ARGC="$(cat "$SONDA_ARGC_FILE" 2>/dev/null || echo 0)"
+  ARGV=()
+  while IFS= read -r -d '' item; do ARGV+=("$item"); done < "$SONDA_ARGV_FILE"
+}
+
+pass() { printf '  ok   %s\n' "$1"; }
+fail() { printf '  FAIL %s\n     %s\n' "$1" "$2"; FAILURES=$((FAILURES + 1)); }
+
+show() { local a; for a in "${ARGV[@]}"; do printf '<%s>' "$a"; done; }
+
+check_scenario_is_one_arg() {
+  local label="$1" scenario="$2"
+  invoke "$scenario"
+  # argv = [test, scenario, --prometheus-url, url]
+  if [ "$ARGC" -eq 4 ] && [ "${ARGV[1]-}" = "$scenario" ]; then
+    pass "$label"
+  else
+    fail "$label" "expected argc 4 with argv[1] intact, got argc=${ARGC}: $(show)"
+  fi
+}
+
+echo "== scenario survives as exactly one argument =="
+check_scenario_is_one_arg "plain path"            "examples/alert.yaml"
+check_scenario_is_one_arg "spaces"                "my scenarios/alert test.yaml"
+check_scenario_is_one_arg "semicolon"             "a.yaml; echo pwned"
+check_scenario_is_one_arg "command substitution"  'a$(echo pwned).yaml'
+check_scenario_is_one_arg "backticks"             'a`echo pwned`.yaml'
+check_scenario_is_one_arg "pipe and redirect"     "a.yaml | tee /tmp/x > /dev/null"
+check_scenario_is_one_arg "ampersands"            "a.yaml && rm -rf /"
+check_scenario_is_one_arg "double quote"          'a"b.yaml'
+check_scenario_is_one_arg "single quote"          "a'b.yaml"
+check_scenario_is_one_arg "dollar var"            'a$HOME.yaml'
+check_scenario_is_one_arg "newline"               'a.yaml
+echo pwned'
+check_scenario_is_one_arg "glob"                  "*.yaml"
+check_scenario_is_one_arg "utf8 and emoji"        "café-日本-🔥.yaml"
+check_scenario_is_one_arg "leading dash"          "--not-a-flag.yaml"
+
+echo
+echo "== nothing is evaluated by the shell =="
+# A command substitution that would create a file if it ever ran.
+CANARY="$TMP/canary"
+invoke "a\$(touch $CANARY).yaml"
+if [ -e "$CANARY" ]; then
+  fail "command substitution never executes" "canary file was created"
+else
+  pass "command substitution never executes"
+fi
+
+invoke "x.yaml" "\$(touch $CANARY.extra)"
+if [ -e "$CANARY.extra" ]; then
+  fail "extra-args substitution never executes" "canary file was created"
+else
+  pass "extra-args substitution never executes"
+fi
+
+# A glob in extra-args must not expand against the working directory.
+#
+# This check is only meaningful from a directory where the glob HAS
+# matches — run from the repo root, where nothing matches `*.yaml`, an
+# unexpanded glob and a broken one look identical and the test passes
+# vacuously. So: create matches, run from there, and assert the count the
+# glob would have produced had it expanded (5 args, not 6).
+( cd "$TMP" && touch one.yaml two.yaml )
+matches=$(cd "$TMP" && ls *.yaml 2>/dev/null | wc -l)
+if [ "$matches" -lt 2 ]; then
+  fail "glob fixture is real" "expected >=2 matching files in the cwd, found ${matches}"
+fi
+cd "$TMP"
+invoke "s.yaml" "*.yaml"
+cd - >/dev/null
+if [ "$ARGC" -eq 5 ] && [ "${ARGV[4]-}" = "*.yaml" ]; then
+  pass "glob in extra-args is not expanded (${matches} files would have matched)"
+else
+  fail "glob in extra-args is not expanded" "argc=${ARGC}: $(show)"
+fi
+
+echo
+echo "== extra-args, and only extra-args, splits =="
+invoke "s.yaml" "--interval 5s --query-step 10s"
+if [ "$ARGC" -eq 8 ]; then
+  pass "four extra tokens become four arguments"
+else
+  fail "four extra tokens become four arguments" "argc=${ARGC}: $(show)"
+fi
+
+invoke "s.yaml" ""
+if [ "$ARGC" -eq 4 ]; then
+  pass "empty extra-args adds nothing"
+else
+  fail "empty extra-args adds nothing" "argc=${ARGC}"
+fi
+
+echo
+echo "== the one-of rule =="
+neither="$(SONDA_SCENARIO=s.yaml SONDA_PROM_URL="" SONDA_AM_URL="" SONDA_EXTRA_ARGS="" \
+  bash -c "$(declare -f run_action_step); run_action_step" 2>&1 >/dev/null; echo "rc=$?")"
+case "$neither" in
+  *"one of prometheus-url or alertmanager-url is required"*rc=1*) pass "neither URL is rejected" ;;
+  *) fail "neither URL is rejected" "$neither" ;;
+esac
+
+both="$(SONDA_SCENARIO=s.yaml SONDA_PROM_URL=http://p SONDA_AM_URL=http://a SONDA_EXTRA_ARGS="" \
+  bash -c "$(declare -f run_action_step); run_action_step" 2>&1 >/dev/null; echo "rc=$?")"
+case "$both" in
+  *"mutually exclusive"*rc=1*) pass "both URLs are rejected" ;;
+  *) fail "both URLs are rejected" "$both" ;;
+esac
+
+invoke "s.yaml" "" "" "http://am:9093"
+if [ "${ARGV[2]-}" = "--alertmanager-url" ] && [ "${ARGV[3]-}" = "http://am:9093" ]; then
+  pass "alertmanager-url selects the alertmanager flag"
+else
+  fail "alertmanager-url selects the alertmanager flag" "$(show)"
+fi
+
+echo
+echo "== the harness still mirrors action.yml =="
+# A copy of production code in a test rots silently. Pin the pieces that
+# carry the safety property; if action.yml stops containing them, this
+# harness is testing something the action no longer does.
+ACTION="$(dirname "$0")/../../action.yml"
+missing=()
+for needle in \
+  'args=(test "$SONDA_SCENARIO")' \
+  'args+=(--prometheus-url "$SONDA_PROM_URL")' \
+  'args+=(--alertmanager-url "$SONDA_AM_URL")' \
+  'extra=($SONDA_EXTRA_ARGS)' \
+  'sonda "${args[@]}"' \
+  'set -f'
+do
+  grep -qF -- "$needle" "$ACTION" || missing+=("$needle")
+done
+if [ ${#missing[@]} -eq 0 ]; then
+  pass "every construction under test is present in action.yml"
+else
+  fail "every construction under test is present in action.yml" "absent: ${missing[*]}"
+fi
+# And the inverse: the action must not interpolate inputs into a run: body.
+if grep -nE '\$\{\{ *inputs\.' "$ACTION" | grep -qv ': *\${{'; then
+  fail "no input is interpolated into a run: body" "$(grep -nE '\$\{\{ *inputs\.' "$ACTION")"
+else
+  pass "inputs reach bash only through env:"
+fi
+
+echo
+echo "== the major-version tag moves only where it should =="
+# release.yml force-moves `vN` onto each release so `uses: …@v1` tracks the
+# newest 1.x. A major tag that moves when it should not is worse than one
+# that never moves — it silently reassigns every consumer pinned to it — so
+# the guard gets a table.
+major_for() {
+  # Verbatim derivation from release.yml's "Move the major-version tag".
+  local RELEASE_TAG="$1"
+  if ! printf '%s' "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    printf 'SKIP'
+    return
+  fi
+  printf '%s' "${RELEASE_TAG%%.*}"
+}
+
+check_major() {
+  local tag="$1" want="$2" got
+  got="$(major_for "$tag")"
+  if [ "$got" = "$want" ]; then
+    pass "${tag} -> ${want}"
+  else
+    fail "${tag} -> ${want}" "got ${got}"
+  fi
+}
+
+check_major "v1.20.0"    "v1"
+check_major "v1.0.0"     "v1"
+check_major "v2.0.0"     "v2"      # a 2.0 release must NOT touch v1
+check_major "v10.3.1"    "v10"
+# Anything that is not a plain release tag leaves major tags alone.
+check_major "v2.0.0-rc.1" "SKIP"
+check_major "v1.20"       "SKIP"
+check_major "nightly"     "SKIP"
+check_major "v1"          "SKIP"   # the major tag itself must not recurse
+
+RELEASE_YML="$(dirname "$0")/../../.github/workflows/release.yml"
+release_missing=()
+for needle in \
+  '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+  'major="${RELEASE_TAG%%.*}"' \
+  'git push --force origin "refs/tags/${major}"'
+do
+  grep -qF -- "$needle" "$RELEASE_YML" || release_missing+=("$needle")
+done
+if [ ${#release_missing[@]} -eq 0 ]; then
+  pass "the derivation under test is present in release.yml"
+else
+  fail "the derivation under test is present in release.yml" "absent: ${release_missing[*]}"
+fi
+# The move must happen after the release exists, or @v1 can point at a tag
+# whose assets have not uploaded yet.
+if awk '/name: Create release/{r=NR} /name: Move the major-version tag/{m=NR} END{exit !(r && m && m > r)}' "$RELEASE_YML"; then
+  pass "the major tag moves after the release is created"
+else
+  fail "the major tag moves after the release is created" "ordering in release.yml is wrong or a step was renamed"
+fi
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "action argv: all checks passed"
+  exit 0
+fi
+echo "action argv: ${FAILURES} check(s) failed"
+exit 1

--- a/scripts/tests/action_argv_test.sh
+++ b/scripts/tests/action_argv_test.sh
@@ -27,44 +27,37 @@ trap 'rm -rf "$TMP"' EXIT
 cat > "$TMP/sonda" <<'FAKE'
 #!/usr/bin/env bash
 printf '%s' "$#" > "$SONDA_ARGC_FILE"
+# Any invocation at all is recorded, so a test can assert the step ran
+# nothing — which is how a command substitution in a message is caught
+# regardless of how it was spelled.
+[ -n "${SONDA_INVOKE_LOG:-}" ] && printf 'INVOKED: %s\n' "$*" >> "$SONDA_INVOKE_LOG"
 for a in "$@"; do printf '%s\0' "$a"; done > "$SONDA_ARGV_FILE"
 FAKE
 chmod +x "$TMP/sonda"
 PATH="$TMP:$PATH"
 
-# Verbatim from action.yml's "Verify alert expectations" step. Kept in sync
-# by `assert_matches_action` below, which fails if the action drifts.
-run_action_step() {
-  set -euo pipefail
-  if [ -n "$SONDA_PROM_URL" ] && [ -n "$SONDA_AM_URL" ]; then
-    echo "mutually exclusive" >&2
-    exit 1
-  fi
-  if [ -z "$SONDA_PROM_URL" ] && [ -z "$SONDA_AM_URL" ]; then
-    echo "one of prometheus-url or alertmanager-url is required" >&2
-    exit 1
-  fi
-  args=(test "$SONDA_SCENARIO")
-  if [ -n "$SONDA_PROM_URL" ]; then
-    args+=(--prometheus-url "$SONDA_PROM_URL")
-  else
-    args+=(--alertmanager-url "$SONDA_AM_URL")
-  fi
-  if [ -n "$SONDA_EXTRA_ARGS" ]; then
-    set -f
-    # shellcheck disable=SC2206
-    extra=($SONDA_EXTRA_ARGS)
-    set +f
-    for arg in "${extra[@]}"; do
-      if [ "$arg" = "--dry-run" ]; then
-        echo "--dry-run in extra-args would make this step pass without verifying" >&2
-        exit 1
-      fi
-    done
-    args+=("${extra[@]}")
-  fi
-  sonda "${args[@]}"
-}
+# THE REAL STEP, NOT A COPY.
+#
+# Every previous round of this PR found a defect the harness could not see
+# because it drove a copy of action.yml's shell: the copy diverged on
+# exactly the line a bug was on, twice, and a backtick that executed a
+# command sat in production while the copy carried a clean message. So the
+# copy is gone. `block:3` extracts the "Verify alert expectations" body
+# from action.yml itself and every check below runs THAT.
+#
+# This also retires a whole class of finding: there is no longer a second
+# copy that can drift, so the drift needles guard the remaining blocks
+# (resolve, install) rather than the one under test.
+ACTION_FILE="$(cd "$(dirname "$0")/../.." && pwd)/action.yml"
+VERIFY_STEP="$TMP/verify_step.sh"
+if ! python3 "$(dirname "$0")/extract_run_bodies.py" "$ACTION_FILE" block:3 > "$VERIFY_STEP"; then
+  echo "could not extract the verify step from action.yml" >&2
+  exit 1
+fi
+if ! grep -q 'sonda "${args\[@\]}"' "$VERIFY_STEP"; then
+  echo "extracted block 3 does not look like the verify step — refusing to test the wrong thing" >&2
+  exit 1
+fi
 
 export SONDA_ARGC_FILE="$TMP/argc" SONDA_ARGV_FILE="$TMP/argv"
 
@@ -77,7 +70,7 @@ invoke() {
   SONDA_PROM_URL="${3-http://localhost:9090}" \
   SONDA_AM_URL="${4-}" \
   SONDA_EXTRA_ARGS="${2:-}" \
-  bash -c "$(declare -f run_action_step); run_action_step" 2>/dev/null
+  bash "$VERIFY_STEP" 2>/dev/null
   ARGC="$(cat "$SONDA_ARGC_FILE" 2>/dev/null || echo 0)"
   ARGV=()
   while IFS= read -r -d '' item; do ARGV+=("$item"); done < "$SONDA_ARGV_FILE"
@@ -174,14 +167,14 @@ fi
 echo
 echo "== the one-of rule =="
 neither="$(SONDA_SCENARIO=s.yaml SONDA_PROM_URL="" SONDA_AM_URL="" SONDA_EXTRA_ARGS="" \
-  bash -c "$(declare -f run_action_step); run_action_step" 2>&1 >/dev/null; echo "rc=$?")"
+  bash "$VERIFY_STEP" 2>&1 >/dev/null; echo "rc=$?")"
 case "$neither" in
   *"one of prometheus-url or alertmanager-url is required"*rc=1*) pass "neither URL is rejected" ;;
   *) fail "neither URL is rejected" "$neither" ;;
 esac
 
 both="$(SONDA_SCENARIO=s.yaml SONDA_PROM_URL=http://p SONDA_AM_URL=http://a SONDA_EXTRA_ARGS="" \
-  bash -c "$(declare -f run_action_step); run_action_step" 2>&1 >/dev/null; echo "rc=$?")"
+  bash "$VERIFY_STEP" 2>&1 >/dev/null; echo "rc=$?")"
 case "$both" in
   *"mutually exclusive"*rc=1*) pass "both URLs are rejected" ;;
   *) fail "both URLs are rejected" "$both" ;;
@@ -195,7 +188,7 @@ else
 fi
 
 dry="$(SONDA_SCENARIO=s.yaml SONDA_PROM_URL=http://p SONDA_AM_URL="" SONDA_EXTRA_ARGS="--interval 5s --dry-run" \
-  bash -c "$(declare -f run_action_step); run_action_step" 2>&1 >/dev/null; echo "rc=$?")"
+  bash "$VERIFY_STEP" 2>&1 >/dev/null; echo "rc=$?")"
 case "$dry" in
   *"without verifying"*rc=1*) pass "--dry-run in extra-args is refused" ;;
   *) fail "--dry-run in extra-args is refused" "$dry" ;;
@@ -280,6 +273,39 @@ if printf '%s\n' "$ACTION_RAW" | grep -q '\${{'; then
 else
   pass "no expression is interpolated into a run: body"
 fi
+
+# W1, the behavioural half: refusing --dry-run must not RUN anything.
+#
+# Round 2 shipped a backtick in the refusal message, which executed
+# `sonda test --dry-run` while claiming to refuse it. Round 3 rewrote the
+# same bug as $(…) and the backtick check missed it — and banning $(…)
+# syntactically is not available, since the run bodies use it legitimately
+# three times. A syntactic guard would have to become an allow-list, which
+# is the shape round 1 deleted.
+#
+# So assert the behaviour instead: drive the real step and require that the
+# fake binary was never invoked. That covers every spelling, present and
+# future, because it tests what the shell DID rather than how it was
+# written.
+: > "$TMP/invoked.log"
+SONDA_SCENARIO=s.yaml SONDA_PROM_URL=http://p SONDA_AM_URL="" \
+  SONDA_EXTRA_ARGS="--dry-run" SONDA_INVOKE_LOG="$TMP/invoked.log" \
+  bash "$VERIFY_STEP" >/dev/null 2>&1
+if [ -s "$TMP/invoked.log" ]; then
+  fail "refusing --dry-run executes nothing" "the step invoked sonda while refusing: $(cat "$TMP/invoked.log")"
+else
+  pass "refusing --dry-run executes nothing"
+fi
+
+# …and the refusal must still say something useful. A substitution that
+# runs also swallows its own output, deleting the actionable half of the
+# message — which is how round 2's bug hid in plain sight.
+dry_msg="$(SONDA_SCENARIO=s.yaml SONDA_PROM_URL=http://p SONDA_AM_URL="" \
+  SONDA_EXTRA_ARGS="--dry-run" bash "$VERIFY_STEP" 2>&1 >/dev/null)"
+case "$dry_msg" in
+  *"sonda test --dry-run locally"*) pass "the refusal message survives intact" ;;
+  *) fail "the refusal message survives intact" "message was: ${dry_msg}" ;;
+esac
 
 # No unescaped backtick may survive in a run: body. Round 2 found one in
 # the --dry-run refusal message, where it ran `sonda test --dry-run` while
@@ -381,6 +407,37 @@ check_move "a 2.0 release moves v2 only"      "v2"            "v2.0.0"  v1.20.0 
 check_move "first release of a line moves it" "v1"            "v1.0.0"  v1.0.0
 
 RELEASE_YML="$(dirname "$0")/../../.github/workflows/release.yml"
+# Read release.yml the way action.yml is read. Round 1's fix — needles
+# against run: bodies with comments dropped — went to action.yml only, so
+# the ORIGINAL defect stayed reachable in the file that decides where @v1
+# points: commenting the tag move out, quoting it verbatim, kept every
+# check green while the workflow logged "moving v1" and moved nothing
+# (#554 round 3, W2).
+RELEASE_CODE="$(run_bodies "$RELEASE_YML" code)"
+RELEASE_RAW="$(run_bodies "$RELEASE_YML" raw)"
+rel_counts="$(python3 "$(dirname "$0")/extract_run_bodies.py" "$RELEASE_YML" count)"
+if [ "${rel_counts%% *}" = "${rel_counts##* }" ] && [ "${rel_counts%% *}" -gt 0 ]; then
+  pass "every run: key in release.yml was opened by the extractor (${rel_counts##* }/${rel_counts%% *})"
+else
+  fail "every run: key in release.yml was opened by the extractor" "counts: ${rel_counts}"
+fi
+# release.yml cannot hold action.yml's absolute rule: its build steps
+# legitimately interpolate `matrix.target`, a value defined literally in
+# the same file. So the assertion is an INVENTORY rather than a ban —
+# every interpolation reaching a run: body is pinned by name, and anything
+# new goes red until a human decides whether its value can be influenced
+# from outside the repo. That fails closed on change without becoming an
+# allow-list that permits by syntactic accident.
+release_exprs="$(printf '%s\n' "$RELEASE_RAW" \
+  | grep -o '\${{[^}]*}}' \
+  | sed -e 's/\${{ *//' -e 's/ *}}//' \
+  | sort -u | tr '\n' ' ' | sed 's/ $//')"
+expected_exprs="matrix.target"
+if [ "$release_exprs" = "$expected_exprs" ]; then
+  pass "release.yml run: bodies interpolate only the pinned expressions (${release_exprs})"
+else
+  fail "release.yml run: bodies interpolate only the pinned expressions" "expected '${expected_exprs}', found '${release_exprs}' — a new interpolation must be reviewed for whether its value is controlled from outside the repo, then pinned here"
+fi
 release_missing=()
 for needle in \
   '^v[0-9]+\.[0-9]+\.[0-9]+$' \
@@ -388,7 +445,7 @@ for needle in \
   'sort -V | tail -1)"' \
   'git push --force origin "refs/tags/${major}"'
 do
-  grep -qF -- "$needle" "$RELEASE_YML" || release_missing+=("$needle")
+  printf '%s\n' "$RELEASE_CODE" | grep -qF -- "$needle" || release_missing+=("$needle")
 done
 if [ ${#release_missing[@]} -eq 0 ]; then
   pass "the derivation under test is present in release.yml"

--- a/scripts/tests/action_argv_test.sh
+++ b/scripts/tests/action_argv_test.sh
@@ -166,19 +166,34 @@ fi
 
 echo
 echo "== the one-of rule =="
-neither="$(SONDA_SCENARIO=s.yaml SONDA_PROM_URL="" SONDA_AM_URL="" SONDA_EXTRA_ARGS="" \
-  bash "$VERIFY_STEP" 2>&1 >/dev/null; echo "rc=$?")"
-case "$neither" in
-  *"one of prometheus-url or alertmanager-url is required"*rc=1*) pass "neither URL is rejected" ;;
-  *) fail "neither URL is rejected" "$neither" ;;
-esac
+# Every bail path is checked for BOTH things: that it refuses, and that
+# refusing executes nothing. The step has three message paths, and the
+# substitution bug has now shipped twice — as a backtick in round 2 and as
+# $(…) in round 3 — both times inside an ::error:: string in this step.
+# Guarding only the path where it happened would be guarding the instance
+# instead of the class (#554 round 4, W1).
+check_bail() {
+  local label="$1" want="$2"; shift 2
+  local out
+  : > "$TMP/invoked.log"
+  out="$(env "$@" SONDA_SCENARIO=s.yaml SONDA_EXTRA_ARGS="" \
+    SONDA_INVOKE_LOG="$TMP/invoked.log" \
+    bash "$VERIFY_STEP" 2>&1 >/dev/null; echo "rc=$?")"
+  case "$out" in
+    *"$want"*rc=1*) pass "$label" ;;
+    *) fail "$label" "$out" ;;
+  esac
+  if [ -s "$TMP/invoked.log" ]; then
+    fail "$label executes nothing" "the step invoked sonda while refusing: $(cat "$TMP/invoked.log")"
+  else
+    pass "$label executes nothing"
+  fi
+}
 
-both="$(SONDA_SCENARIO=s.yaml SONDA_PROM_URL=http://p SONDA_AM_URL=http://a SONDA_EXTRA_ARGS="" \
-  bash "$VERIFY_STEP" 2>&1 >/dev/null; echo "rc=$?")"
-case "$both" in
-  *"mutually exclusive"*rc=1*) pass "both URLs are rejected" ;;
-  *) fail "both URLs are rejected" "$both" ;;
-esac
+check_bail "neither URL is rejected" "one of prometheus-url or alertmanager-url is required" \
+  SONDA_PROM_URL="" SONDA_AM_URL=""
+check_bail "both URLs are rejected" "mutually exclusive" \
+  SONDA_PROM_URL=http://p SONDA_AM_URL=http://a
 
 invoke "s.yaml" "" "" "http://am:9093"
 if [ "${ARGV[2]-}" = "--alertmanager-url" ] && [ "${ARGV[3]-}" = "http://am:9093" ]; then
@@ -284,9 +299,11 @@ fi
 # is the shape round 1 deleted.
 #
 # So assert the behaviour instead: drive the real step and require that the
-# fake binary was never invoked. That covers every spelling, present and
-# future, because it tests what the shell DID rather than how it was
-# written.
+# fake binary was never invoked. That covers every SPELLING, present and
+# future, because it tests what the shell did rather than how it was
+# written — but only on the paths actually driven, which is why the two
+# bail paths below carry the same assertion rather than trusting this one
+# to speak for the file.
 : > "$TMP/invoked.log"
 SONDA_SCENARIO=s.yaml SONDA_PROM_URL=http://p SONDA_AM_URL="" \
   SONDA_EXTRA_ARGS="--dry-run" SONDA_INVOKE_LOG="$TMP/invoked.log" \

--- a/scripts/tests/extract_run_bodies.py
+++ b/scripts/tests/extract_run_bodies.py
@@ -1,19 +1,25 @@
 #!/usr/bin/env python3
-"""Print the bodies of a workflow file's ``run:`` blocks.
+"""Print the bodies of a workflow file's ``run:`` steps.
 
 The action's safety properties live inside `run:` scripts, and checking
 them against the whole file is how #554 round 1 shipped two holes: a
 `set -f` needle satisfied by a comment that merely mentioned `set -f`, and
 an interpolation check whose allow-list matched any colon. Both go away
-once the checks read the block bodies instead of the file.
+once the checks read step bodies instead of the file.
+
+Round 2 found the next layer of the same mistake: the extractor recognised
+only ``run: |`` with exactly one space, so a single-line ``run: echo …``
+and a re-indented ``run:  |`` were both invisible — and every check
+underneath inherited that blindness while staying green. Hence
+:func:`run_key_count`, which lets a caller assert the extractor accounted
+for *every* ``run:`` in the file rather than merely finding *some*.
 
 Modes:
 
-* ``code`` — block bodies with whole-line comments dropped. Use when
-  asserting that a construction is *really there*, so a comment quoting it
-  cannot stand in for it.
-* ``raw`` — block bodies verbatim, comments included. Use when asserting
-  something must be *absent*: GitHub substitutes ``${{ }}`` before bash
+* ``code`` — bodies with whole-line comments dropped. Use when asserting a
+  construction is really there, so a comment quoting it cannot stand in.
+* ``raw`` — bodies verbatim, comments included. Use when asserting
+  something must be absent: GitHub substitutes ``${{ }}`` before bash
   parses the script, and it does that inside comments too.
 """
 
@@ -22,42 +28,82 @@ from __future__ import annotations
 import re
 import sys
 
-BLOCK = re.compile(r"^(\s*)run: [|>]")
+# Any indentation, any spacing, and a block scalar with any chomping or
+# indentation indicator (`|`, `|-`, `>+`, `|2`, …).
+RUN_KEY = re.compile(r"^(\s*)run:(\s*)(.*)$")
+BLOCK_SCALAR = re.compile(r"^[|>][+-]?\d*$")
 
 
-def run_bodies(text: str, mode: str) -> list[str]:
-    """Lines belonging to `run:` block scalars, in file order."""
+def run_key_count(text: str) -> int:
+    """How many ``run:`` step keys the file contains.
+
+    Counted independently of the extraction walk, so a caller can compare
+    the two and notice a body the walk failed to open.
+    """
+    return sum(1 for line in text.split("\n") if RUN_KEY.match(line))
+
+
+def run_bodies(text: str, mode: str = "code") -> tuple[list[str], int]:
+    """Lines belonging to `run:` step bodies, and how many keys were opened.
+
+    Both block scalars (``run: |``) and single-line values (``run: echo x``)
+    are returned: a single-line body is shell too, and an interpolation in
+    one is just as executable.
+    """
     out: list[str] = []
+    opened = 0
     indent: int | None = None
+
     for line in text.split("\n"):
-        opened = BLOCK.match(line)
-        if indent is None:
-            if opened:
-                indent = len(opened.group(1))
+        key = RUN_KEY.match(line)
+
+        # Inside a block scalar: it ends at the first non-blank line
+        # indented no further than the key that introduced it.
+        if indent is not None:
+            if line.strip() == "":
+                continue
+            if len(line) - len(line.lstrip()) > indent:
+                if not (mode == "code" and line.lstrip().startswith("#")):
+                    out.append(line)
+                continue
+            indent = None  # fell out; reconsider this line as a key below
+
+        if not key:
             continue
-        if line.strip() == "":
-            continue
-        # A block scalar ends at the first non-blank line indented no
-        # further than the key that introduced it.
-        if len(line) - len(line.lstrip()) <= indent:
-            indent = len(opened.group(1)) if opened else None
-            continue
-        if mode == "code" and line.lstrip().startswith("#"):
-            continue
-        out.append(line)
-    return out
+        rest = key.group(3).strip()
+        if BLOCK_SCALAR.match(rest):
+            indent = len(key.group(1))
+            opened += 1
+        elif rest:
+            opened += 1
+            if not (mode == "code" and rest.startswith("#")):
+                out.append(line)
+        else:
+            # `run:` with nothing after it is not valid on its own; count it
+            # so the completeness check notices rather than skipping it.
+            opened += 1
+
+    return out, opened
 
 
 def main(argv: list[str]) -> int:
     if len(argv) < 2:
-        print("usage: extract_run_bodies.py <file> [code|raw]", file=sys.stderr)
+        print("usage: extract_run_bodies.py <file> [code|raw|count]", file=sys.stderr)
         return 2
     mode = argv[2] if len(argv) > 2 else "code"
-    if mode not in ("code", "raw"):
-        print(f"unknown mode {mode!r}: expected 'code' or 'raw'", file=sys.stderr)
+    if mode not in ("code", "raw", "count"):
+        print(f"unknown mode {mode!r}: expected 'code', 'raw' or 'count'", file=sys.stderr)
         return 2
     with open(argv[1], encoding="utf-8") as handle:
-        print("\n".join(run_bodies(handle.read(), mode)))
+        text = handle.read()
+    if mode == "count":
+        # "<keys in file> <keys the walk opened>" — equal means the walk saw
+        # everything; unequal means some body is invisible to every check.
+        _, opened = run_bodies(text, "raw")
+        print(f"{run_key_count(text)} {opened}")
+        return 0
+    lines, _ = run_bodies(text, mode)
+    print("\n".join(lines))
     return 0
 
 

--- a/scripts/tests/extract_run_bodies.py
+++ b/scripts/tests/extract_run_bodies.py
@@ -78,21 +78,47 @@ def run_bodies(text: str, mode: str = "code") -> tuple[list[str], int]:
             opened += 1
             if not (mode == "code" and rest.startswith("#")):
                 out.append(line)
-        else:
-            # `run:` with nothing after it is not valid on its own; count it
-            # so the completeness check notices rather than skipping it.
-            opened += 1
+        # else: `run:` with the block scalar on the NEXT line. That is
+        # valid YAML and this walk does not follow it, so it must NOT be
+        # counted as opened — counting it is what keeps the completeness
+        # check equal and therefore silent, which is the guard defeating
+        # itself (#554 round 3, W3). Left uncounted, `run_key_count` sees
+        # the key, `opened` does not, and the caller goes red.
 
     return out, opened
 
 
+def run_blocks(text: str) -> list[str]:
+    """Each block-scalar `run:` body as one dedented, executable script."""
+    blocks: list[str] = []
+    current: list[str] | None = None
+    indent = 0
+    for line in text.split("\n"):
+        key = RUN_KEY.match(line)
+        if current is not None:
+            if line.strip() == "" or len(line) - len(line.lstrip()) > indent:
+                current.append(line[indent + 2 :] if len(line) > indent else "")
+                continue
+            blocks.append("\n".join(current))
+            current = None
+        if key and BLOCK_SCALAR.match(key.group(3).strip()):
+            indent = len(key.group(1))
+            current = []
+    if current is not None:
+        blocks.append("\n".join(current))
+    return blocks
+
+
 def main(argv: list[str]) -> int:
     if len(argv) < 2:
-        print("usage: extract_run_bodies.py <file> [code|raw|count]", file=sys.stderr)
+        print("usage: extract_run_bodies.py <file> [code|raw|count|block:N]", file=sys.stderr)
         return 2
     mode = argv[2] if len(argv) > 2 else "code"
-    if mode not in ("code", "raw", "count"):
-        print(f"unknown mode {mode!r}: expected 'code', 'raw' or 'count'", file=sys.stderr)
+    if not (mode in ("code", "raw", "count") or mode.startswith("block:")):
+        print(
+            f"unknown mode {mode!r}: expected 'code', 'raw', 'count' or 'block:N'",
+            file=sys.stderr,
+        )
         return 2
     with open(argv[1], encoding="utf-8") as handle:
         text = handle.read()
@@ -101,6 +127,20 @@ def main(argv: list[str]) -> int:
         # everything; unequal means some body is invisible to every check.
         _, opened = run_bodies(text, "raw")
         print(f"{run_key_count(text)} {opened}")
+        return 0
+    if mode.startswith("block:"):
+        # One step's body, dedented, ready to execute. This is what lets a
+        # test drive PRODUCTION shell instead of a copy of it — the copy is
+        # what diverged on exactly the line a bug was on, twice.
+        wanted = int(mode.split(":", 1)[1])
+        blocks = run_blocks(text)
+        if wanted < 1 or wanted > len(blocks):
+            print(
+                f"block {wanted} out of range: file has {len(blocks)} run: blocks",
+                file=sys.stderr,
+            )
+            return 2
+        print(blocks[wanted - 1])
         return 0
     lines, _ = run_bodies(text, mode)
     print("\n".join(lines))

--- a/scripts/tests/extract_run_bodies.py
+++ b/scripts/tests/extract_run_bodies.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Print the bodies of a workflow file's ``run:`` blocks.
+
+The action's safety properties live inside `run:` scripts, and checking
+them against the whole file is how #554 round 1 shipped two holes: a
+`set -f` needle satisfied by a comment that merely mentioned `set -f`, and
+an interpolation check whose allow-list matched any colon. Both go away
+once the checks read the block bodies instead of the file.
+
+Modes:
+
+* ``code`` — block bodies with whole-line comments dropped. Use when
+  asserting that a construction is *really there*, so a comment quoting it
+  cannot stand in for it.
+* ``raw`` — block bodies verbatim, comments included. Use when asserting
+  something must be *absent*: GitHub substitutes ``${{ }}`` before bash
+  parses the script, and it does that inside comments too.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+BLOCK = re.compile(r"^(\s*)run: [|>]")
+
+
+def run_bodies(text: str, mode: str) -> list[str]:
+    """Lines belonging to `run:` block scalars, in file order."""
+    out: list[str] = []
+    indent: int | None = None
+    for line in text.split("\n"):
+        opened = BLOCK.match(line)
+        if indent is None:
+            if opened:
+                indent = len(opened.group(1))
+            continue
+        if line.strip() == "":
+            continue
+        # A block scalar ends at the first non-blank line indented no
+        # further than the key that introduced it.
+        if len(line) - len(line.lstrip()) <= indent:
+            indent = len(opened.group(1)) if opened else None
+            continue
+        if mode == "code" and line.lstrip().startswith("#"):
+            continue
+        out.append(line)
+    return out
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: extract_run_bodies.py <file> [code|raw]", file=sys.stderr)
+        return 2
+    mode = argv[2] if len(argv) > 2 else "code"
+    if mode not in ("code", "raw"):
+        print(f"unknown mode {mode!r}: expected 'code' or 'raw'", file=sys.stderr)
+        return 2
+    with open(argv[1], encoding="utf-8") as handle:
+        print("\n".join(run_bodies(handle.read(), mode)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

WP16. A composite action at the repo root wrapping `sonda test`, so making an alert rule a required check is three lines of workflow YAML instead of a hand-written install-and-run block in every consumer repo.

```yaml
- uses: davidban77/sonda@v1
  with:
    scenario: examples/alert-lifecycle-test.yaml
    prometheus-url: http://localhost:8428
```

Three steps: resolve the pinned ref to a concrete release → install it → run `sonda test`. The interesting decisions are in what it does **not** reimplement, and in what it **refuses**.

## Release behaviour changes

`release.yml` now force-moves a `vN` tag onto each release, so `uses: davidban77/sonda@v1` tracks the newest `1.x` the way Actions users expect. GitHub does not maintain major tags automatically, so without this `@v1` would break the first time someone used it.

A major tag that moves when it should not silently reassigns everyone pinned to it, so the step is guarded three ways: pre-releases and non-`vX.Y.Z` tags are skipped, the major is derived from the release's own tag (a future `v2.0.0` creates and moves `v2`, leaving `v1` where it is), and the tag never moves backwards onto a backport cut after a newer line. It runs **after** the release is published, so `@v1` can never point at a tag whose assets have not uploaded. The release job also gained a `checkout` it previously did not need.

The `v1` tag comes into existence on the first release after this merges. Until then `uses: davidban77/sonda@main` resolves to the newest published release and says so.

Marketplace listing is a manual step in the GitHub UI and was not attempted here. `action.yml` already carries the required `branding` (icon `activity`, colour purple).

## Three places the spec was wrong about this repo

Measured, not assumed:

| Spec said | Reality |
|---|---|
| "if releases publish no checksum file, ADD one to release.yml" | `SHA256SUMS` is **already** generated and attached; v1.20.0 ships it. No change needed. |
| Asset names are `linux-amd64`-style | They're **target triples** (`sonda-v1.20.0-x86_64-unknown-linux-musl.tar.gz`). `asset_name` in release.yml is the upload-artifact name, never the released filename — an action built to the spec would 404 on every download. |
| Write the download + checksum step | `install.sh` **already does all of it**: uname → triple, tarball name, `SHA256SUMS` fetch, fail-closed verification, driven by `SONDA_VERSION` / `SONDA_INSTALL_DIR`. |

So the action **calls `install.sh`** instead of reimplementing it. One implementation of the supply-chain step, one thing to keep correct, and the action cannot drift from the install path the docs point humans at.

A fourth: the spec says the self-test should boot "the binary stack the Live Infra UAT uses" — that harness uses **docker compose**. The self-test reuses it via a new `live_infra_uat.py --boot-only alerting` flag, so "which backends exist and how long they get to start" keeps one definition.

## What it refuses

Each of these would otherwise surface as a confusing failure somewhere downstream:

- **`alertmanager-url` on a release that predates it.** That input landed in #552, after v1.20.0, and this action installs *released* binaries. Pinning an older version would produce clap's `unexpected argument` — which reads as a bug in the action. Checked **before** download, naming the floor.
- **A tag whose release has no assets yet.** release-please tags before the build uploads, so a real tag with nothing to download is normal and transient. Said so, rather than surfacing a 404.
- **A release with assets but no `SHA256SUMS`** — refused outright rather than installed unverified.
- **`--dry-run` passed through `extra-args`.** It validates and returns before verifying anything, so the step would exit 0 having checked nothing — a green required check that is not checking.

## Injection safety

Every input reaches bash through `env:`, never `${{ }}` interpolation into a `run:` body — interpolation happens *before* bash parses the script, so a scenario name containing `$(...)` would become part of the program rather than a value handed to it. argv is a quoted array; only `extra-args` splits, and it splits with globbing disabled so a bare `*` cannot expand against the workspace.

## Test plan

No Rust changed in this PR, so the usual cargo gates prove almost nothing and the tests are built where the logic actually is:

- **`scripts/resolve_release.py --self-test`** — 34 inline unit tests, no network: major-tag selection including the **v11-must-not-satisfy-v1** trap, drafts and pre-releases skipped, a release candidate not beating its own final release, paginated release listings, the no-assets window, missing checksums, and **numeric-not-lexical** comparison (`v1.20.0 > v1.9.0`).
- **`scripts/tests/action_argv_test.sh`** — 51 checks driving the action's **real** shell against 14 hostile scenario values (spaces, `;`, `$(…)`, backticks, pipes, `&&`, quotes, newlines, globs, UTF-8, emoji, leading dash), asserting on the argv a fake binary receives. Boundaries are NUL-delimited so a newline *inside* an argument is not mistaken for an argument boundary. Every refusal path additionally asserts that **nothing was executed**, not merely that the exit code was 1.
- **`scripts/tests/extract_run_bodies.py`** pulls each `run:` body out of `action.yml` so the suite executes production shell rather than a copy of it, with a completeness check asserting every `run:` key in the file was accounted for.
- **`--check-floor-staleness`** goes red on the release that makes `MIN_ALERTMANAGER_VERSION` stale, so the constant is revisited exactly when it stops gating anything. A network error returns 0: "could not ask" is not "is stale".

**Red-verified.** Every check above was confirmed to fail when the thing it protects is broken, with the mutation asserted present before its result was trusted. Unquoting the scenario turns 8 checks red; interpolating an input into a `run:` body turns 20 red; dropping `set -f`, moving the major-tag step before the release, dropping its `vX.Y.Z` guard, and letting the major tag move backwards each trip their own checks.

**Proven end to end locally** against live VictoriaMetrics + vmalert v1.149.0 + Alertmanager 0.28.1, running the action's three steps in order with the real published binary:

```
=== step 1 ===  Resolved 'v1' to v1.20.0
=== step 2 ===  checksum verified · sonda 1.20.0
=== step 3 ===  PASS HighCpuUsage firing after 10s (within 90s)
                PASS HighCpuUsage resolved after 0s
                positive case exit=0
=== control === FAIL HighCpuUsage did not fire within 20s
                negative control exit=1
=== floor ===   refused v1.20.0 + alertmanager-url, exit=1
```

`action-selftest.yml` repeats all of that in CI with `uses: ./` against the compose stack, path-filtered to action/release/installer changes. The fast contract tests run on **every** PR via a new `action-contract` job in `ci.yml`.

**Gates:** `cargo fmt --all -- --check` clean · `cargo clippy --workspace --all-targets` clean · `validate_docs_commands.py` 155/155 · `validate_docs_scenarios.py` 118 compiled / 0 failed · `mkdocs build --strict` clean · `live_infra_uat.py --self-test` 36 passed.

## Known limitations

- The resolve and install steps are exercised end to end by the live self-test, but no unit test drives their shell directly — only the verify step is covered that way.
- The contract suite's fake binary is named `sonda`, so its "this refusal path executed nothing" assertion would not notice a substitution naming a *different* command. Both constructions it guards invoke `sonda`. Tracked as a follow-up.
- `--boot-only` leaves the compose stack running by design; the CI job relies on the runner being torn down.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)