### PR TITLE
fix(ci): retire the floor-staleness probe now that v1.21.0 answered it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,10 +481,11 @@ jobs:
     # reaching a shell, and a moving tag resolving to the wrong release.
     # Cheap enough to run on every PR, so they do.
     #
-    # One step makes a single GitHub API call (the floor-staleness check).
-    # It cannot fail this job on an unreachable or rate-limited API — only
-    # on a genuinely stale constant — because every other PR in the repo
-    # would otherwise go red on a question none of them asked.
+    # No step here touches the network. A floor-staleness probe used to,
+    # and it did its job: it went red on v1.21.0, the release that shipped
+    # `--alertmanager-url` and so made the constant a settled fact. With
+    # nothing left to ask it would have reddened every future PR in the
+    # repo, so it was removed rather than muted.
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -499,13 +500,3 @@ jobs:
       # release-please no-assets window, missing checksums, version floors.
       - name: Release resolver unit tests
         run: python3 scripts/resolve_release.py --self-test
-
-      # The alertmanager-url version floor is a constant someone must
-      # remember to revisit. This goes red on the release that makes it
-      # stale, which is exactly when it needs revisiting — and stays green
-      # when the API is simply unreachable, since "could not ask" is not
-      # "is stale".
-      - name: Version floor is not stale
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: python3 scripts/resolve_release.py --check-floor-staleness

--- a/docs/site/docs/test/ci-github-action.md
+++ b/docs/site/docs/test/ci-github-action.md
@@ -39,11 +39,12 @@ Passing both is an error: they verify different hops of the alerting path,
 so there is no sensible way to merge their verdicts. To cover both, add two
 steps — and the one that fails tells you which hop broke.
 
-!!! note "`alertmanager-url` has a version floor"
-    That input needs a Sonda release that has it. If you pin an older
-    version, the action refuses **before** downloading anything and names
-    the floor, rather than installing a binary that would reject the flag
-    with a confusing `unexpected argument`.
+!!! note "`alertmanager-url` needs v1.21.0 or newer"
+    That input first shipped in `v1.21.0`, so `@v1` and `latest` both serve
+    it. Only an explicit older pin cannot. In that case the action refuses
+    **before** downloading anything and names the floor, rather than
+    installing a binary that would reject the flag with a confusing
+    `unexpected argument`.
 
 ## What the action does
 

--- a/scripts/resolve_release.py
+++ b/scripts/resolve_release.py
@@ -46,11 +46,18 @@ FULL_TAG = re.compile(r"^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
 # A moving major tag: v1, v2 — the shape Actions users expect to pin.
 MAJOR_TAG = re.compile(r"^v(\d+)$")
 
-# `sonda test --alertmanager-url` landed in #552, after v1.20.0 shipped. The
-# action installs *released* binaries, so an older pin cannot serve that
-# input — and the failure it would otherwise produce is clap's "unexpected
-# argument", which reads like a bug in the action rather than a version
-# floor. Bump this when the flag's release changes.
+# `sonda test --alertmanager-url` landed in #552 and first shipped in
+# v1.21.0. The action installs *released* binaries, so an older pin cannot
+# serve that input — and the failure it would otherwise produce is clap's
+# "unexpected argument", which reads like a bug in the action rather than a
+# version floor.
+#
+# This is now a historical fact rather than a pending decision: the release
+# that introduced the flag has happened, so the value is fixed and there is
+# nothing left to bump. It was accompanied by a `--check-floor-staleness`
+# probe that went red on the release making it stale — that release was
+# v1.21.0, the probe fired exactly as designed, and it has been removed
+# because a check with no remaining question to ask is noise on every PR.
 MIN_ALERTMANAGER_VERSION = (1, 21, 0)
 
 
@@ -293,22 +300,34 @@ def resolve(
     return tag
 
 
+def alertmanager_floor_error(tag: str) -> str | None:
+    """Why ``tag`` cannot serve ``alertmanager-url``, or None if it can.
+
+    Pure, so the refusal itself is testable rather than only the comparison
+    underneath it. Previously the floor's only tests were on
+    :func:`at_least`, with the refusal — the message a user actually reads,
+    and the branch that decides whether a run proceeds — covered by nothing.
+    That is the shape #554 round 1 found in the selection path: a guard
+    placed on the helper beside the decision instead of on the decision.
+    """
+    if at_least(tag, MIN_ALERTMANAGER_VERSION):
+        return None
+    floor = "v" + ".".join(str(p) for p in MIN_ALERTMANAGER_VERSION)
+    return (
+        f"the alertmanager-url input needs sonda {floor} or newer, but this "
+        f"run resolved to {tag}. `sonda test --alertmanager-url` does not "
+        f"exist in {tag}, so the run would fail with an 'unexpected argument' "
+        f"error that looks like an action bug. Pin version: {floor} or newer, "
+        "or use prometheus-url."
+    )
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Resolve a sonda-action version reference to a concrete release tag.",
     )
     parser.add_argument("--ref", default="", help="Version input, or github.action_ref.")
     parser.add_argument("--repo", default=DEFAULT_REPO, help="owner/repo to resolve against.")
-    parser.add_argument(
-        "--check-floor-staleness",
-        action="store_true",
-        help=(
-            "Network check for CI: fail once MIN_ALERTMANAGER_VERSION is "
-            "stale — i.e. once a release at or above the floor exists, at "
-            "which point the constant no longer needs to gate anything and "
-            "someone must revisit it."
-        ),
-    )
     parser.add_argument(
         "--needs-alertmanager",
         action="store_true",
@@ -328,58 +347,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         result = unittest.TextTestRunner(verbosity=2).run(suite)
         return 0 if result.wasSuccessful() else 1
 
-    if args.check_floor_staleness:
-        # The floor is a constant someone has to remember to revisit. This
-        # turns that into a red check at exactly the moment it matters —
-        # the release that makes it stale — rather than relying on memory
-        # (#554 review, question 3). Deriving it from the binary is not an
-        # option: the only honest source is the installed `--help`, which
-        # means downloading first, which is the thing the floor exists to
-        # avoid.
-        floor = "v" + ".".join(str(p) for p in MIN_ALERTMANAGER_VERSION)
-        # Deliberately NOT via resolve(): that ends in check_downloadable,
-        # so during the release-please window — tag created, assets still
-        # uploading, which this module documents as normal and transient —
-        # every open PR in the repo would go red on a question about a
-        # constant (#554 round 2, W3). Staleness needs the newest published
-        # *tag*, not something downloadable.
-        try:
-            token = os.environ.get("GITHUB_TOKEN")
-            newest = newest_published(_api_get(f"{GITHUB_API}/repos/{args.repo}/releases", token))
-        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
-            # "Could not ask" is not "is stale". Failing here would take
-            # every open PR down with a GitHub 5xx or a rate limit, and
-            # protect nothing: the constant is either stale or it is not,
-            # and this run simply does not know.
-            print(f"note: could not check floor staleness ({e}); skipping", file=sys.stderr)
-            return 0
-        if newest is None:
-            print("note: no published releases to compare the floor against; skipping")
-            return 0
-        if at_least(newest, MIN_ALERTMANAGER_VERSION):
-            print(
-                f"error: MIN_ALERTMANAGER_VERSION ({floor}) is stale — {newest} is "
-                "released and at or above it, so the floor no longer gates "
-                "anything. Confirm `--alertmanager-url` shipped in that release "
-                "and either drop the guard or move the floor.",
-                file=sys.stderr,
-            )
-            return 1
-        print(f"floor {floor} still ahead of the newest release ({newest})")
-        return 0
-
     try:
         tag = resolve(args.ref, args.repo, os.environ.get("GITHUB_TOKEN"))
-        if args.needs_alertmanager and not at_least(tag, MIN_ALERTMANAGER_VERSION):
-            floor = "v" + ".".join(str(p) for p in MIN_ALERTMANAGER_VERSION)
-            raise ResolveError(
-                f"the alertmanager-url input needs sonda {floor} or newer, but "
-                f"this run resolved to {tag}. `sonda test --alertmanager-url` "
-                f"does not exist in {tag}, so the run would fail with an "
-                "'unexpected argument' error that looks like an action bug. "
-                f"Pin version: {floor} once it is released, or use "
-                "prometheus-url."
-            )
+        if args.needs_alertmanager:
+            refusal = alertmanager_floor_error(tag)
+            if refusal is not None:
+                raise ResolveError(refusal)
         print(tag)
     except ResolveError as e:
         print(f"error: {e}", file=sys.stderr)
@@ -447,6 +420,48 @@ class VersionFloorTests(unittest.TestCase):
         # Fail open against the user, not closed: the tag already resolved
         # to something installable.
         self.assertTrue(at_least("weird", (1, 21, 0)))
+
+
+class AlertmanagerRefusalTests(unittest.TestCase):
+    """The refusal itself, not just the comparison it rests on.
+
+    These are the tests that go red if the floor guard is deleted along
+    with the staleness probe it shipped beside — the two were introduced
+    together, and only one of them had a reason to be removed.
+    """
+
+    def test_a_release_below_the_floor_is_refused(self):
+        message = alertmanager_floor_error("v1.20.0")
+        self.assertIsNotNone(message)
+        assert message is not None
+        # The message must name BOTH the floor and what this run actually
+        # resolved to. Naming only the floor leaves the reader guessing
+        # which of their pins produced it.
+        self.assertIn("v1.21.0", message)
+        self.assertIn("v1.20.0", message)
+        self.assertIn("prometheus-url", message)
+
+    def test_the_floor_release_itself_is_accepted(self):
+        self.assertIsNone(alertmanager_floor_error("v1.21.0"))
+
+    def test_a_newer_release_is_accepted(self):
+        for tag in ("v1.22.0", "v1.21.1", "v2.0.0"):
+            self.assertIsNone(alertmanager_floor_error(tag))
+
+    def test_an_unrecognized_shape_is_not_refused(self):
+        # parse_version returns None for anything that is not vX.Y.Z, and
+        # at_least treats that as satisfying the floor. Refusing here would
+        # block resolution on a shape this module does not understand,
+        # which is a worse failure than letting clap report the truth.
+        self.assertIsNone(alertmanager_floor_error("nightly"))
+
+    def test_the_message_no_longer_promises_a_future_release(self):
+        # The old wording said "Pin version: v1.21.0 once it is released".
+        # It is released; telling someone to wait for it sends them after a
+        # cause that no longer exists.
+        message = alertmanager_floor_error("v1.20.0")
+        assert message is not None
+        self.assertNotIn("once it is released", message)
 
 
 class SelectionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

The v1.21.0 release makes `MIN_ALERTMANAGER_VERSION` a settled fact, which means the check that was watching for exactly that moment has fired and has nothing left to ask. Left in place it turns one check red on **every** future PR in this repo, so it is removed rather than muted.

This is time-sensitive: `main` is currently green only because the contract job ran nine seconds before the release published.

| | |
|---|---|
| contract job started | `2026-08-17T07:17:51Z` — passed |
| v1.21.0 published | `2026-08-17T07:18:00Z` |
| same check, run now | `error: MIN_ALERTMANAGER_VERSION (v1.21.0) is stale`, exit 1 |

## What changed, and what deliberately did not

**Removed:** `--check-floor-staleness` and its `ci.yml` step. It was added in #554 round 1 as the answer to "can the floor be derived rather than remembered?" — the middle option: go red at the moment the constant stops gating anything. That moment was v1.21.0. It worked, and it is done.

**Kept:** the `--needs-alertmanager` guard. An explicit `version: v1.20.0` pin can still ask for `alertmanager-url`, and clap's raw `unexpected argument` is a worse answer than naming the floor. The constant stays as a historical fact — the flag's first release — with nothing left to bump.

**Also:** the refusal message said *"Pin version: v1.21.0 once it is released"*. It is released. Telling someone to wait for it now sends them after a cause that no longer exists.

## The part worth reviewing

Removing one and keeping the other exposed that the guard had no test of its own. The floor's only coverage was on `at_least` — the comparison — leaving the refusal itself asserted by nothing: not the branch that decides whether a run proceeds, and not the message a user reads.

That is the same shape #554 round 1 found in the selection path: a guard placed on the helper *beside* the decision instead of on the decision, in a file that already contained a test proving the hazard was understood. Two occurrences now, so the refusal became a pure function — `alertmanager_floor_error` — with tests over the decision and the wording.

## Test plan

Resolver self-test **39 passed** (was 34). Discriminating tests verified RED before green, with each mutation asserted present in the file before its result was trusted:

| Mutation | Result |
|---|---|
| comparison neutered to `if True: return None` — how a careless "delete the floor stuff" would land | `test_a_release_below_the_floor_is_refused` **and** `test_the_message_no_longer_promises_a_future_release` fail |
| old *"once it is released"* wording restored, guard intact | `test_the_message_no_longer_promises_a_future_release` fails **alone**, proving it discriminates on wording independently of the guard |

Verified live against this repo, exit codes measured directly rather than through a pipe:

```
--ref v1          --needs-alertmanager  ->  v1.21.0, exit 0
--ref v1.20.0     --needs-alertmanager  ->  exit 1, names both v1.21.0 and v1.20.0
--check-floor-staleness                 ->  exit 2, flag no longer exists
```

**Gates run:** action argv suite 51 checks passed · `validate_docs_commands.py` 155/155 · `validate_docs_scenarios.py` 118 compiled / 0 failed · `cargo fmt --all -- --check` clean.

`action-contract` now makes **no network calls at all**, which is a small independent win: the job's only remaining failure modes are the things it actually tests.

## How the surviving guard is covered

Two layers, and it matters which is which:

- **The refusal decision and its message** — `alertmanager_floor_error`, five unit tests in the resolver self-test.
- **The wiring** — the `if args.needs_alertmanager:` branch in `main()` that calls it. This has **no unit test**: deleting the branch leaves all 39 tests green while `--ref v1.20.0 --needs-alertmanager` exits 0. It is covered instead by `action-selftest.yml`, which pins `version: v1.20.0` with `alertmanager-url` on purpose and asserts the refusal — and whose `pull_request` path filter includes `scripts/resolve_release.py`, so it runs on any PR touching this file. It ran on this one: job `95326895154`, `version floor enforced as required`.

So `alertmanager_floor_error` is now itself a helper beside a decision, one level up from the gap this PR fixes. That is a real observation about the shape, not a claim of full coverage at the fast layer. Adding `main(["--ref", "v1.20.0", "--needs-alertmanager"])` with `resolve` stubbed would close it in about five lines; not done here, so this PR's merged commit stays the reviewed commit.

*(An earlier version of this section claimed no CI job pins an old version on purpose. That was wrong — the job it overlooked is one this repo already had, added in #554. Corrected on review, no code change.)*

## Known limitations

- Nothing warns if `--alertmanager-url` is ever removed or renamed, which would make the constant wrong in the other direction. Judged not worth a probe: the floor's message names the flag, so a rename that missed it would surface as a stale string in a refusal path the live self-test executes on every action-affecting PR.
- The fast layer does not cover the wiring, as described above.

## Checklist

- [ ] `cargo test --workspace` — **not re-run.** No Rust changed in this PR, so the outcome is unchanged from `5d2e3e7`, which is green. This PR's CI confirms it rather than my word.
- [ ] `cargo clippy --workspace -- -D warnings` — not re-run, same reason.
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)
