### PR TITLE
fix(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,9 +871,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

**Main is red.** The Audit job failed on `c92b756` — but not because of what merged there.

```
RUSTSEC-2026-0258 · h2 0.4.14 · "h2 unbounded empty DATA frames"
Date: 2026-08-17 · Solution: Upgrade to >=0.4.16
```

The advisory was published on 2026-08-17. The next push to `main` was simply the first Audit run to see it. Nothing in #565 introduced `h2`.

## Exposure

`h2` is transitive on two paths that matter:

| Path | Reaches |
|---|---|
| `axum` → `hyper` → `h2` | `sonda-server`'s HTTP surface |
| `tonic` → `h2` | the OTLP/gRPC sink, under `sonda-core`'s `otlp` feature |

Not the CLI's default build. The advisory is a resource-exhaustion issue (unbounded empty DATA frames), so the realistic exposure is a long-running `sonda-server` reachable by an untrusted client.

## Why the diff is four lines

`cargo update -p h2` reported "Locking 1 package" but also rewrote **ten unrelated `windows-sys` edges downwards** (0.61.2 → 0.52.0/0.60.2) — resolver churn from my environment rather than anything the advisory requires. Shipping that inside a security fix would be noise a reviewer has to separate from the actual change, so the h2 version and checksum were applied on their own.

`cargo metadata --locked` confirms cargo accepts the hand-narrowed lockfile without wanting to rewrite it — i.e. the result is a lockfile cargo itself considers consistent, not one that merely happens to parse.

## Not the failure

The same job output shows `core2 0.4.0` as **yanked**. That is counted as an allowed warning, predates this change, and is not what fails the job. Left alone deliberately — it belongs in a dependency-hygiene pass, not in a security fix, and bundling it would blur what this PR is for.

## Test plan

- `cargo build -p sonda-core --features otlp` — builds against the vendored h2 0.4.16
- `cargo build -p sonda-server` — builds (axum → hyper → h2)
- `cargo metadata --format-version 1 --locked` — accepted, lockfile unmodified
- `cargo test --workspace --no-fail-fast` — **no new failures.** The same five environmental ones as the previous two PRs, each named rather than counted:
  - `sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message`
  - `tests::sink_file_error_produces_sink_variant`
  - `global_inflight_limit_gates_across_routes`
  - `health_remains_responsive_when_control_plane_is_saturated`
  - `request_timeout_returns_408_with_structured_error`

The first two require `CAP_DAC_OVERRIDE` to fail (this container's root holds it; the reviewer's does not, which is why only three reproduce there — #565 review). The last three are load-sensitive.

**Audit itself cannot be verified locally** — `cargo-audit` is not installed in this environment and installing it needs the advisory DB. CI's Audit job is the proof, and it is the check that must go green for this PR to have done its job.

## Where to attack it

1. **The hand-narrowed lockfile.** I applied two lines of a generated file by hand. `--locked` accepting it is my evidence that it is consistent; check whether that is sufficient, or whether the full `cargo update -p h2` output should have been taken including the `windows-sys` movement.
2. **Scope.** `core2` is left yanked. Judge whether a red-Audit fix should clear everything Audit reports or only the failure.

## Checklist

- [x] `cargo test --workspace` passes (5 environmental failures, each named above, unchanged from before this PR)
- [ ] `cargo clippy --workspace -- -D warnings` — not re-run; no source changed, lockfile only. CI confirms.
- [ ] `cargo fmt --all -- --check` — not re-run, same reason.
- [x] Documentation updated (if applicable) — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bWFJNwscibE4BhmSPbQYU

---
_Generated by [Claude Code](https://claude.ai/code/session_018bWFJNwscibE4BhmSPbQYU)_