### PR TITLE
fix(docs): gate prose verb counts and waveform SVG drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,35 @@ jobs:
         env:
           SONDA_BIN: ./target/release/sonda
 
+      # The generator waveform SVGs on build/generators.md are a committed
+      # build output of `sonda-core/examples/waveform_gallery.rs`, and until
+      # now the only committed build output with no drift gate — the editor
+      # bundle has one here, the wasm bundle has its own workflow, these had
+      # nothing. A change to a generator's shape, or to the renderer, left the
+      # published pictures showing the old curve with nothing to say so.
+      #
+      # Unlike the wasm bundle this needs no platform precondition: the
+      # example is pure Rust writing text, and all 13 files reproduce
+      # byte-identically from a plain `cargo run`.
+      #
+      # THE DELETION IS THE POINT. Regenerating over the top and diffing would
+      # pass vacuously if the example ever stopped writing — no output, no
+      # difference, green. Removing the files first makes the check depend on
+      # the generator actually producing them: silence now shows up as 13
+      # deletions rather than as success.
+      - name: Committed waveform SVGs match their generator
+        run: |
+          set -euo pipefail
+          rm -f docs/site/docs/build/img/generators/*.svg
+          cargo run -q -p sonda-core --example waveform_gallery
+          if ! git diff --exit-code --stat -- docs/site/docs/build/img/generators/; then
+            echo "::error::the committed waveform SVGs do not match a fresh run of" \
+              "the waveform_gallery example. Run 'task site:waveforms' and commit" \
+              "the result. If files are shown as deleted rather than modified, the" \
+              "example did not write them at all."
+            exit 1
+          fi
+
   # The docs site's JS is exercised here and nowhere else. The pure-helper
   # harness covers functions that are plain functions of their arguments; this
   # job covers what only a browser can: the wasm engine actually loading, the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,25 +349,54 @@ jobs:
       # nothing. A change to a generator's shape, or to the renderer, left the
       # published pictures showing the old curve with nothing to say so.
       #
-      # Unlike the wasm bundle this needs no platform precondition: the
-      # example is pure Rust writing text, and all 13 files reproduce
-      # byte-identically from a plain `cargo run`.
+      # Unlike the wasm bundle this needs no platform precondition — but the
+      # reason is the ROUNDING, not the language (#567 r3 M2). The gallery
+      # calls `.sin()`, `.ln()` and `.cos()`, whose last ULP is not guaranteed
+      # identical across platforms and libm versions; every coordinate is then
+      # emitted as `{:.1}`, which swamps a ULP difference by orders of
+      # magnitude. Seeded RNGs (42, 7, 11) close the other degree of freedom.
+      # If that precision is ever widened for smoother curves, this claim has
+      # to be re-measured across hosts before it can be repeated.
       #
       # THE DELETION IS THE POINT. Regenerating over the top and diffing would
       # pass vacuously if the example ever stopped writing — no output, no
       # difference, green. Removing the files first makes the check depend on
-      # the generator actually producing them: silence now shows up as 13
+      # the generator actually producing them: silence shows up as 13
       # deletions rather than as success.
       - name: Committed waveform SVGs match their generator
         run: |
           set -euo pipefail
-          rm -f docs/site/docs/build/img/generators/*.svg
+          dir=docs/site/docs/build/img/generators
+
+          # Assert the corpus exists BEFORE deleting it. `rm -f` succeeds on a
+          # glob that matches nothing and git reports nothing for a path it
+          # does not track, so a renamed directory would leave both halves of
+          # this step green forever while checking nothing (#567 r3 M1) —
+          # the same vacuous-pass shape the parity test already guards twice.
+          # `|| true` because pipefail would otherwise kill the step on a
+          # missing directory before the message below can explain why.
+          before=$(find "$dir" -maxdepth 1 -name '*.svg' 2>/dev/null | wc -l || true)
+          if [ "$before" -eq 0 ]; then
+            echo "::error::no SVGs found under ${dir} — the directory moved or" \
+              "the glob is wrong. Refusing to 'verify' an empty corpus."
+            exit 1
+          fi
+
+          rm -f "$dir"/*.svg
           cargo run -q -p sonda-core --example waveform_gallery
-          if ! git diff --exit-code --stat -- docs/site/docs/build/img/generators/; then
+
+          # `git status --porcelain`, not `git diff`: diff compares the worktree
+          # to the index and so cannot see UNTRACKED files. Adding a 14th
+          # generator, regenerating, and forgetting to `git add` the new SVG is
+          # precisely the workflow this gate exists to protect, and it was
+          # invisible to the diff form (#567 r3 W1).
+          drift=$(git status --porcelain -- "$dir")
+          if [ -n "$drift" ]; then
             echo "::error::the committed waveform SVGs do not match a fresh run of" \
               "the waveform_gallery example. Run 'task site:waveforms' and commit" \
-              "the result. If files are shown as deleted rather than modified, the" \
-              "example did not write them at all."
+              "the result. '??' means a generated file is not tracked at all;" \
+              "' D' means the example did not write it."
+            echo "$drift"
             exit 1
           fi
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -274,13 +274,15 @@ The CLI crate is intentionally thin. Its only responsibilities are:
 - Instantiate the appropriate generator, encoder, and sink from `sonda-core`.
 - Hand control to the `sonda-core` scenario runner.
 
-Primary CLI surface (four verbs):
+Primary CLI surface (six verbs):
 
 ```
 sonda run <file-or-@name> [OPTIONS]              # launch a v2 scenario
 sonda list --catalog <dir> [--kind ...] [--tag ...]
 sonda show <@name> --catalog <dir>               # print the raw YAML
 sonda new [--template | --from <csv>] [-o <path>]
+sonda test <file-or-@name> --prometheus-url ...  # verify expect: alerts
+sonda completions <shell>                        # shell completion script
 ```
 
 `sonda run` accepts either a filesystem path to a YAML file or a `@name` shorthand that resolves through `--catalog <dir>`. The CLI does not contain signal generation logic. Any behavior that is tested or benchmarked belongs in `sonda-core`.
@@ -342,7 +344,7 @@ Portability is a primary constraint. Sonda must run on bare metal, in Docker, an
 
 ## 11. MVP Scope
 
-The MVP is complete when the following criteria are met. (Historical wording — the CLI surface collapsed to the four verbs documented in §7 for 1.9; today the equivalent is `sonda run <file>` against a v2 YAML.)
+The MVP is complete when the following criteria are met. <!-- verbs:historical --> (Historical wording — the CLI surface collapsed to the four verbs documented in §7 for 1.9; today the equivalent is `sonda run <file>` against a v2 YAML.)
 
 - `sonda metrics --name <n> --rate <r> --duration <d>` generates valid Prometheus text to stdout.
 - Value generators: constant, uniform random (seeded), sine, sawtooth.

--- a/sonda-core/src/verify/prometheus.rs
+++ b/sonda-core/src/verify/prometheus.rs
@@ -132,6 +132,41 @@ impl PrometheusClient {
         })
     }
 
+    /// [`Self::alert_state`] plus the label sets of the firing series.
+    ///
+    /// Same request, same parse; the caller keeps the labels so provenance
+    /// survives a fall back to the live poll timeline.
+    pub fn alert_probe(
+        &self,
+        expectation: &AlertExpectation,
+    ) -> Result<(AlertState, Vec<BTreeMap<String, String>>), SondaError> {
+        let query = alerts_query(expectation);
+        let body = self
+            .agent
+            .get(&self.query_url)
+            .query("query", &query)
+            .call()
+            .map_err(|e| {
+                SondaError::Verify(VerifyError::Query {
+                    url: self.query_url.clone(),
+                    reason: e.to_string(),
+                })
+            })?
+            .into_string()
+            .map_err(|e| {
+                SondaError::Verify(VerifyError::BadResponse {
+                    url: self.query_url.clone(),
+                    reason: format!("response could not be read: {e}"),
+                })
+            })?;
+        parse_alert_probe(&body).map_err(|reason| {
+            SondaError::Verify(VerifyError::BadResponse {
+                url: self.query_url.clone(),
+                reason,
+            })
+        })
+    }
+
     /// Measure the server's clock with an instant `time()` query,
     /// bracketing the request with local readings so the offset is taken
     /// against the request's midpoint.
@@ -379,6 +414,22 @@ fn escape_label_value(value: &str) -> String {
 /// Returns a human-readable reason on failure; the caller wraps it with the
 /// query URL into a [`VerifyError::BadResponse`].
 pub fn parse_alert_state(body: &str) -> Result<AlertState, String> {
+    parse_alert_probe(body).map(|(state, _)| state)
+}
+
+/// An instant query's state **and** the label sets of its firing series.
+///
+/// The labels are in the response either way; returning only the state
+/// discarded them, and the discard had a consequence. The verdict timeline
+/// normally comes from a range query, which collects firing-series labels
+/// for the provenance check — but when no stored sample exists yet (an alert
+/// that fires faster than one `--query-step`) or the range API errors, the
+/// verdict falls back to the live poll timeline, and the provenance check
+/// then had nothing to inspect. The advisory disappeared precisely when the
+/// run was fastest, silently (#567 r4).
+pub fn parse_alert_probe(
+    body: &str,
+) -> Result<(AlertState, Vec<BTreeMap<String, String>>), String> {
     let parsed: serde_json::Value =
         serde_json::from_str(body).map_err(|e| format!("not valid JSON: {e}"))?;
     if parsed["status"] != "success" {
@@ -387,16 +438,29 @@ pub fn parse_alert_state(body: &str) -> Result<AlertState, String> {
     let empty = Vec::new();
     let results = parsed["data"]["result"].as_array().unwrap_or(&empty);
     if results.is_empty() {
-        return Ok(AlertState::Inactive);
+        return Ok((AlertState::Inactive, Vec::new()));
     }
-    let firing = results
-        .iter()
-        .any(|series| series["metric"]["alertstate"] == "firing");
-    Ok(if firing {
-        AlertState::Firing
-    } else {
+    let mut firing_series = Vec::new();
+    for series in results {
+        if series["metric"]["alertstate"] != "firing" {
+            continue;
+        }
+        let Some(metric) = series["metric"].as_object() else {
+            continue;
+        };
+        firing_series.push(
+            metric
+                .iter()
+                .filter_map(|(k, v)| v.as_str().map(|v| (k.clone(), v.to_string())))
+                .collect(),
+        );
+    }
+    let state = if firing_series.is_empty() {
         AlertState::Pending
-    })
+    } else {
+        AlertState::Firing
+    };
+    Ok((state, firing_series))
 }
 
 #[cfg(test)]

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -70,6 +70,7 @@ sonda [GLOBAL FLAGS] run <SCENARIO> [OPTIONS]
 sonda [GLOBAL FLAGS] list --catalog <DIR> [--kind <runnable|composable>] [--tag <TAG>] [--json]
 sonda [GLOBAL FLAGS] show <@NAME> --catalog <DIR>
 sonda [GLOBAL FLAGS] new [--template | --from <CSV>] [-o <PATH>]
+sonda [GLOBAL FLAGS] test <SCENARIO> --prometheus-url <URL> | --alertmanager-url <URL>
 sonda completions <bash|zsh|fish|powershell|elvish>
 ```
 

--- a/sonda/src/test_cmd.rs
+++ b/sonda/src/test_cmd.rs
@@ -103,8 +103,11 @@ enum Source {
 }
 
 /// What one poll of one expectation yielded, in the shape both acquisitions
-/// can produce. The Prometheus path leaves `series` and `started_at` empty
-/// — it recovers matched series from its range query instead.
+/// can produce. Both fill `series`: Prometheus normally recovers matched
+/// series from its range query, but that query can be unusable — no stored
+/// sample yet for an alert that fires inside one `--query-step`, or an API
+/// error — and the poll's own labels are what keep the provenance check
+/// working when it is (#567 r4). `started_at` stays Alertmanager-only.
 #[derive(Default)]
 struct Poll {
     series: Vec<BTreeMap<String, String>>,
@@ -157,10 +160,16 @@ impl Source {
     /// rest is evidence the caller accumulates.
     fn poll(&self, expectation: &AlertExpectation) -> (Result<AlertState, String>, Poll) {
         match self {
-            Source::Prometheus(client) => (
-                client.alert_state(expectation).map_err(|e| e.to_string()),
-                Poll::default(),
-            ),
+            Source::Prometheus(client) => match client.alert_probe(expectation) {
+                Ok((state, series)) => (
+                    Ok(state),
+                    Poll {
+                        series,
+                        ..Poll::default()
+                    },
+                ),
+                Err(e) => (Err(e.to_string()), Poll::default()),
+            },
             Source::Alertmanager(client) => match client.alerts(expectation) {
                 Ok(snapshot) => (
                     Ok(snapshot.state),
@@ -414,7 +423,16 @@ pub fn run(
                 evidence[index].series.clone(),
             ),
         };
-        matched_firing_series.extend(series);
+        // An empty `series` here means the range query produced no verdict
+        // timeline and the live poll one was used instead. The live poll saw
+        // the same alerts, so its labels answer the provenance question just
+        // as well — without this the advisory vanished exactly when the alert
+        // fired fastest (#567 r4).
+        if series.is_empty() {
+            matched_firing_series.extend(evidence[index].series.clone());
+        } else {
+            matched_firing_series.extend(series);
+        }
         firing_outcomes.push(evaluate_firing(&timeline, deadline));
     }
 

--- a/sonda/tests/cli_subcommand_parity.rs
+++ b/sonda/tests/cli_subcommand_parity.rs
@@ -107,6 +107,57 @@ struct VerbCountClaim {
     line_number: usize,
     claimed: usize,
     line: String,
+    /// The claim's own line plus the block it introduces — see [`claim_block`].
+    block: String,
+}
+
+/// The text a verb-count claim is actually making a claim *about*.
+///
+/// The claim line itself, plus the block it introduces: contiguous following
+/// lines, and a fenced code block if one opens within a line or two (the
+/// `Primary CLI surface (six verbs):` / ```` ``` ```` shape). Bounded, so a
+/// document with no blank lines cannot swallow itself whole.
+///
+/// #567 review W1: the previous version searched the WHOLE FILE for each verb.
+/// Five of the six — run, list, show, new, test — are ordinary English
+/// fragments (runner, listing, shows, newline, latest), so only `completions`
+/// discriminated at all. The red-verification passed by luck of the corpus:
+/// `architecture.md` happened to contain that word exactly once, on the line
+/// the mutation deleted. Applied to `cli-flags.md`, where the word survives in
+/// its own section heading, the identical defect was invisible.
+fn claim_block(lines: &[&str], claim_index: usize) -> String {
+    const MAX_BLOCK_LINES: usize = 40;
+    let mut block = vec![lines[claim_index]];
+    let mut in_fence = false;
+    let mut blanks = 0usize;
+
+    for line in lines.iter().skip(claim_index + 1).take(MAX_BLOCK_LINES) {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") {
+            block.push(line);
+            if in_fence {
+                break; // the fence this claim introduced has closed
+            }
+            in_fence = true;
+            blanks = 0;
+            continue;
+        }
+        if in_fence {
+            block.push(line);
+            continue;
+        }
+        if line.trim().is_empty() {
+            blanks += 1;
+            // One blank line may separate a claim from the fence it
+            // introduces; two means the block is over.
+            if blanks > 1 {
+                break;
+            }
+            continue;
+        }
+        block.push(line);
+    }
+    block.join("\n")
 }
 
 /// Every unexempted "<number> verbs" claim in the repository's Markdown.
@@ -138,7 +189,8 @@ fn verb_count_claims() -> Vec<VerbCountClaim> {
         let Ok(text) = std::fs::read_to_string(&path) else {
             continue;
         };
-        for (index, line) in text.lines().enumerate() {
+        let lines: Vec<&str> = text.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
             if line.contains("<!-- verbs:historical -->") {
                 continue;
             }
@@ -156,6 +208,7 @@ fn verb_count_claims() -> Vec<VerbCountClaim> {
                         line_number: index + 1,
                         claimed,
                         line: line.trim().to_string(),
+                        block: claim_block(&lines, index),
                     });
                 }
             }
@@ -391,27 +444,129 @@ fn every_prose_verb_count_matches_the_parser() {
 }
 
 #[test]
-fn a_document_that_counts_the_verbs_also_names_them() {
-    // A correct count with a stale list is the same defect one level down:
-    // `cli-flags.md` would have said "six verbs" while listing four.
+fn a_block_that_lists_the_verbs_lists_all_of_them() {
+    // A correct count above a stale list is the same defect one level down.
+    //
+    // Scoped to the claim's own block rather than the whole file (#567 review
+    // W1). Whole-file search made this check almost inert: five of the six
+    // verbs are ordinary English fragments, so only `completions` ever
+    // discriminated, and only in a file that happened to contain it once.
+    //
+    // "Is this block a listing?" is decided by how many verbs it already
+    // names. A block naming a MAJORITY of them is enumerating the surface, so
+    // it must name all of them. A block naming few or none is prose that
+    // mentions a count in passing — "the CLI exposes six verbs, all thin
+    // wrappers over sonda-core" is true and useful, and compelling it to
+    // recite the list would be the check being wrong in the other direction
+    // (#567 review M1).
     let mut parser = parser_subcommands();
     parser.retain(|v| v != "help");
 
-    let mut missing = Vec::new();
+    let mut problems = Vec::new();
     for claim in verb_count_claims() {
-        let Ok(text) = std::fs::read_to_string(&claim.path) else {
-            continue;
+        let Some(named) = enumerated_verbs(&claim.line, &claim.block, &parser) else {
+            continue; // a passing mention, not a listing
         };
-        for verb in &parser {
-            if !text.contains(verb.as_str()) {
-                missing.push(format!(
-                    "{} counts the verbs but never names `{verb}`",
-                    claim.path.display()
-                ));
-            }
+        let missing: Vec<&str> = parser
+            .iter()
+            .filter(|verb| !named.contains(verb))
+            .map(|v| v.as_str())
+            .collect();
+        if !missing.is_empty() {
+            problems.push(format!(
+                "{}:{} enumerates {} of the {} verbs, omitting {:?} — {:?}",
+                claim.path.display(),
+                claim.line_number,
+                named.len(),
+                parser.len(),
+                missing,
+                claim.line
+            ));
         }
     }
-    missing.sort();
-    missing.dedup();
-    assert!(missing.is_empty(), "{}", missing.join("\n"));
+    assert!(
+        problems.is_empty(),
+        "a block that enumerates the CLI's verbs is missing some of them:\n{}",
+        problems.join("\n")
+    );
+}
+
+/// The verbs a claim actually *enumerates*, if it enumerates any.
+///
+/// Two shapes occur in this repo, and both attach a list to the count:
+///
+/// ```text
+/// The `sonda` binary has six verbs: `run`, `list`, ... and `completions`.
+///
+/// Primary CLI surface (six verbs):
+/// ```                       <- a fence whose lines are `sonda <verb> ...`
+/// ```
+///
+/// Returns None when the claim carries no enumeration — a passing mention
+/// like "the CLI exposes six verbs, all thin wrappers over sonda-core" has
+/// nothing to be inconsistent with, and demanding a recitation there is the
+/// check being wrong in the other direction (#567 review M1).
+///
+/// This is deliberately narrower than "does the surrounding prose mention the
+/// word somewhere". #567 review W1 defeated that: dropping `completions` from
+/// this very list left the word intact in a later sentence on the same line,
+/// so the paragraph still named all six while the list named five. The count
+/// and the list it introduces have to be compared to each other.
+fn enumerated_verbs(claim_line: &str, block: &str, known: &[String]) -> Option<Vec<String>> {
+    // Shape 1: an inline list introduced by a colon straight after "verbs".
+    if let Some(after) = claim_line.split_once("verbs:").map(|(_, rest)| rest) {
+        // The list ends at the first sentence break.
+        let list = after.split_once(". ").map_or(after, |(head, _)| head);
+        let named: Vec<String> = known
+            .iter()
+            .filter(|verb| block_names_verb(list, verb))
+            .cloned()
+            .collect();
+        if !named.is_empty() {
+            return Some(named);
+        }
+    }
+
+    // Shape 2: a fenced usage block. Its lines invoke the binary by name, so
+    // the verb is the token straight after `sonda`.
+    let fenced: Vec<String> = block
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("sonda "))
+        .filter_map(|rest| rest.split_whitespace().next())
+        .filter(|token| known.iter().any(|verb| verb == token))
+        .map(|token| token.to_string())
+        .collect();
+    if !fenced.is_empty() {
+        return Some(fenced);
+    }
+
+    None
+}
+
+/// Whether `block` names `verb` as a verb rather than as a substring.
+///
+/// `run`, `list`, `show`, `new` and `test` all occur inside ordinary words —
+/// runner, listing, shows, newline, latest — which is exactly why the
+/// whole-file `contains` this replaces could not discriminate. Requiring a
+/// non-alphanumeric boundary on both sides is what makes the check mean
+/// "names the verb".
+fn block_names_verb(block: &str, verb: &str) -> bool {
+    let boundary =
+        |c: Option<char>| !c.is_some_and(|c| c.is_alphanumeric() || c == '_' || c == '-');
+    let bytes = block.as_bytes();
+    let mut from = 0usize;
+    while let Some(found) = block[from..].find(verb) {
+        let start = from + found;
+        let end = start + verb.len();
+        let before = block[..start].chars().next_back();
+        let after = block[end..].chars().next();
+        if boundary(before) && boundary(after) {
+            return true;
+        }
+        from = start + 1;
+        if from >= bytes.len() {
+            break;
+        }
+    }
+    false
 }

--- a/sonda/tests/cli_subcommand_parity.rs
+++ b/sonda/tests/cli_subcommand_parity.rs
@@ -1,6 +1,16 @@
 //! Every copy of "which verbs does the CLI have" must agree with the parser.
 //!
-//! There are three, and the `Commands` enum is the only one that is real:
+//! The `Commands` enum is the only one that is real. Two machine-readable
+//! copies and an open-ended set of prose claims are checked against it here.
+//!
+//! Deliberately no count is stated in this sentence. An earlier version said
+//! "there are three", `sonda-server`'s comment said "a fourth", and #565's PR
+//! body said "a fifth" — three hand-maintained tallies of the hand-maintained
+//! copies, disagreeing with each other, in the file arguing that hand-
+//! maintained lists drift (#565 review M2). The tests below enumerate; this
+//! comment does not.
+//!
+//! The machine-readable copies:
 //!
 //! * `sonda-server`'s `SONDA_SUBCOMMANDS` — it shells out to the sibling
 //!   `sonda` binary for anything in that list, so a verb missing from it is
@@ -22,11 +32,137 @@
 //! either constant is restructured, this fails loudly — which is correct. A
 //! silent pass on a constant it can no longer find would be the exact failure
 //! it exists to prevent, so both parses assert they found something.
+//!
+//! The prose claims are handled differently, and the difference is the point.
+//! #565 enumerated the copies BY HAND and missed one: `docs/architecture.md`
+//! had said "four verbs" since `sonda test` shipped, unnoticed because it sits
+//! outside the docs gate's root. Naming three files here would repeat that
+//! mistake with a larger three. So the prose check does not take a file list:
+//! it walks every tracked Markdown file and holds any file making a
+//! "<number> verbs" claim to the parser's count. A new document inherits the
+//! gate by existing.
 
 mod common;
 
 use common::sonda_bin;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+
+/// Number words a prose verb-count claim might spell out, plus digits.
+fn spelled_number(word: &str) -> Option<usize> {
+    const WORDS: [&str; 13] = [
+        "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+        "eleven", "twelve",
+    ];
+    let lower = word.to_ascii_lowercase();
+    if let Some(index) = WORDS.iter().position(|w| *w == lower) {
+        return Some(index);
+    }
+    lower.parse::<usize>().ok()
+}
+
+/// Repo root, derived from this crate's manifest directory.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("the sonda crate must live inside the workspace")
+        .to_path_buf()
+}
+
+/// Every Markdown file in the repository, skipping build and vendor trees.
+fn markdown_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            // Build output, vendored JS, git internals and virtualenvs are not
+            // ours to gate.
+            //
+            // Note `docs/site/site/` — mkdocs' build output per .gitignore —
+            // and NOT any directory merely named `site`: excluding that name
+            // outright silently swallowed `docs/site/docs/**`, which is where
+            // the user-facing reference lives. The guard test below caught it
+            // on the first run by naming a file it expects to find, which is
+            // the whole reason that guard exists.
+            let is_mkdocs_output = name == "site" && dir.file_name().is_some_and(|d| d == "site");
+            if is_mkdocs_output
+                || matches!(name.as_ref(), "target" | "node_modules" | ".git" | ".venv")
+            {
+                continue;
+            }
+            markdown_files(&path, out);
+        } else if name.ends_with(".md") {
+            out.push(path);
+        }
+    }
+}
+
+/// A prose claim of the form "<number> verbs", with where it was found.
+struct VerbCountClaim {
+    path: PathBuf,
+    line_number: usize,
+    claimed: usize,
+    line: String,
+}
+
+/// Every unexempted "<number> verbs" claim in the repository's Markdown.
+///
+/// Two exemptions, both narrow and both visible in the source they exempt:
+///
+/// * `CHANGELOG.md` — an append-only record of what was true at each release.
+///   Rewriting past entries to match today would falsify history, so the file
+///   is skipped wholesale rather than line by line.
+/// * Any line carrying `<!-- verbs:historical -->` — prose that deliberately
+///   describes an earlier surface. This is an opt-out a human must type, and
+///   it is visible in the diff when they do; it is not a silent exemption.
+fn verb_count_claims() -> Vec<VerbCountClaim> {
+    let root = repo_root();
+    let mut files = Vec::new();
+    markdown_files(&root, &mut files);
+    assert!(
+        !files.is_empty(),
+        "found no Markdown files under {} — the walk is broken, and an empty \
+         set would make this gate pass vacuously",
+        root.display()
+    );
+
+    let mut claims = Vec::new();
+    for path in files {
+        if path.file_name().is_some_and(|n| n == "CHANGELOG.md") {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        for (index, line) in text.lines().enumerate() {
+            if line.contains("<!-- verbs:historical -->") {
+                continue;
+            }
+            let mut words = line.split_whitespace().peekable();
+            while let Some(word) = words.next() {
+                let next_is_verbs = words
+                    .peek()
+                    .is_some_and(|w| w.trim_end_matches([':', '.', ',', ')']) == "verbs");
+                if !next_is_verbs {
+                    continue;
+                }
+                if let Some(claimed) = spelled_number(word.trim_start_matches('(')) {
+                    claims.push(VerbCountClaim {
+                        path: path.clone(),
+                        line_number: index + 1,
+                        claimed,
+                        line: line.trim().to_string(),
+                    });
+                }
+            }
+        }
+    }
+    claims
+}
 
 /// The verbs `sonda --help` advertises, read from the live parser.
 fn parser_subcommands() -> Vec<String> {
@@ -191,4 +327,91 @@ fn the_docs_validator_accepts_every_verb_the_cli_defines() {
          that is actually correct; a verb here that the CLI does not define \
          lets a typo through as a real command."
     );
+}
+
+#[test]
+fn the_walk_finds_the_claims_this_test_expects_to_check() {
+    // Guards the walk itself, for the same reason `help_lists_the_verbs…`
+    // guards the help parse: if the traversal or the phrase match silently
+    // stops finding anything, every assertion below passes on an empty set.
+    let claims = verb_count_claims();
+    assert!(
+        !claims.is_empty(),
+        "found no '<number> verbs' claims anywhere in the repo's Markdown. \
+         Either the walk broke or the phrasing changed — both make the gate \
+         below vacuous."
+    );
+    let files: Vec<String> = claims
+        .iter()
+        .map(|c| {
+            c.path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    for expected in ["cli-flags.md", "CLAUDE.md", "architecture.md"] {
+        assert!(
+            files.iter().any(|f| f == expected),
+            "expected a verb-count claim in {expected}; found claims in {files:?}"
+        );
+    }
+}
+
+#[test]
+fn every_prose_verb_count_matches_the_parser() {
+    let mut parser = parser_subcommands();
+    parser.retain(|v| v != "help");
+    parser.sort();
+    parser.dedup();
+
+    let mut wrong = Vec::new();
+    for claim in verb_count_claims() {
+        if claim.claimed != parser.len() {
+            wrong.push(format!(
+                "{}:{} claims {} verbs, parser has {} — {:?}",
+                claim.path.display(),
+                claim.line_number,
+                claim.claimed,
+                parser.len(),
+                claim.line
+            ));
+        }
+    }
+    assert!(
+        wrong.is_empty(),
+        "prose verb counts have drifted from the CLI.\n{}\n\nThis is what \
+         #565 missed: docs/architecture.md had said \"four verbs\" since \
+         `sonda test` shipped, because nothing checked it and it sits outside \
+         the docs gate's root. If a claim is deliberately describing an older \
+         surface, mark that line `<!-- verbs:historical -->`.",
+        wrong.join("\n")
+    );
+}
+
+#[test]
+fn a_document_that_counts_the_verbs_also_names_them() {
+    // A correct count with a stale list is the same defect one level down:
+    // `cli-flags.md` would have said "six verbs" while listing four.
+    let mut parser = parser_subcommands();
+    parser.retain(|v| v != "help");
+
+    let mut missing = Vec::new();
+    for claim in verb_count_claims() {
+        let Ok(text) = std::fs::read_to_string(&claim.path) else {
+            continue;
+        };
+        for verb in &parser {
+            if !text.contains(verb.as_str()) {
+                missing.push(format!(
+                    "{} counts the verbs but never names `{verb}`",
+                    claim.path.display()
+                ));
+            }
+        }
+    }
+    missing.sort();
+    missing.dedup();
+    assert!(missing.is_empty(), "{}", missing.join("\n"));
 }

--- a/sonda/tests/cli_subcommand_parity.rs
+++ b/sonda/tests/cli_subcommand_parity.rs
@@ -155,6 +155,11 @@ fn claim_block(lines: &[&str], claim_index: usize) -> String {
             }
             continue;
         }
+        // Reset on content: the comment above says CONSECUTIVE blanks end the
+        // block, and until this line the counter never reset, so two blank
+        // lines anywhere did — one ordinary sentence between a claim and the
+        // fence it introduces was enough to lose the fence (#567 r2 W1).
+        blanks = 0;
         block.push(line);
     }
     block.join("\n")
@@ -522,7 +527,7 @@ fn enumerated_verbs(claim_line: &str, block: &str, known: &[String]) -> Option<V
             .filter(|verb| block_names_verb(list, verb))
             .cloned()
             .collect();
-        if !named.is_empty() {
+        if is_enumeration(&named, known) {
             return Some(named);
         }
     }
@@ -536,11 +541,27 @@ fn enumerated_verbs(claim_line: &str, block: &str, known: &[String]) -> Option<V
         .filter(|token| known.iter().any(|verb| verb == token))
         .map(|token| token.to_string())
         .collect();
-    if !fenced.is_empty() {
+    if is_enumeration(&fenced, known) {
         return Some(fenced);
     }
 
     None
+}
+
+/// Whether a set of named verbs is an enumeration of the surface.
+///
+/// A majority means the text is listing the verbs, so it must list all of
+/// them. Fewer means a passing mention with an example or two, and demanding
+/// a full recitation there is the check being wrong in the other direction.
+///
+/// #567 r2 M1: this rule was stated in a doc comment and implemented as
+/// `!named.is_empty()` — so a passing mention followed by a single
+/// `sonda run scenario.yaml` example was compelled to recite all six. The
+/// rule now lives in one function that both the prose and the callers point
+/// at, because a claim in a comment that the code does not implement is the
+/// defect this repo keeps naming.
+fn is_enumeration(named: &[String], known: &[String]) -> bool {
+    named.len() * 2 > known.len()
 }
 
 /// Whether `block` names `verb` as a verb rather than as a substring.

--- a/sonda/tests/cli_test_cmd.rs
+++ b/sonda/tests/cli_test_cmd.rs
@@ -16,7 +16,6 @@ use common::sonda_bin;
 use tempfile::TempDir;
 
 const EMPTY_RESULT: &str = r#"{"status":"success","data":{"resultType":"vector","result":[]}}"#;
-const FIRING_RESULT: &str = r#"{"status":"success","data":{"resultType":"vector","result":[{"metric":{"alertname":"HighCpuUsage","alertstate":"firing"},"value":[1,"1"]}]}}"#;
 
 /// Serve scripted query responses. `respond(n, request_line)` picks the
 /// body and an artificial delay for the n-th request (0-based); the raw
@@ -195,8 +194,16 @@ fn skewed_alert_world(
             let offset = mono0.elapsed().as_secs_f64();
             let firing =
                 fire_at.is_some_and(|f| offset >= f) && resolve_at.is_none_or(|r| offset < r);
+            // Carry the same labels the matrix body does. Real Prometheus
+            // returns a series' full label set on an instant ALERTS query;
+            // a fixture that returns only alertname/alertstate cannot
+            // exercise anything that reads labels off the live poll.
             (
-                (if firing { FIRING_RESULT } else { EMPTY_RESULT }).to_string(),
+                (if firing {
+                    firing_result(host)
+                } else {
+                    EMPTY_RESULT.to_string()
+                }),
                 NO_STALL,
             )
         }
@@ -220,6 +227,13 @@ type RequestLog = Arc<std::sync::Mutex<Vec<String>>>;
 /// response headers + artificial delay out.
 type Responder =
     dyn Fn(usize, &str) -> (String, Vec<(String, String)>, std::time::Duration) + Send + Sync;
+
+/// An instant-query vector for a firing `ALERTS` series carrying `host`.
+fn firing_result(host: &str) -> String {
+    format!(
+        r#"{{"status":"success","data":{{"resultType":"vector","result":[{{"metric":{{"alertname":"HighCpuUsage","alertstate":"firing","severity":"critical","host":"{host}"}},"value":[1,"1"]}}]}}}}"#
+    )
+}
 
 /// Format an instant as Alertmanager renders `startsAt` / `endsAt`.
 fn rfc3339(unix: f64) -> String {
@@ -848,6 +862,72 @@ fn verdicts_survive_a_server_clock_running_behind() {
     assert!(
         stderr.contains("did not fire within 1s"),
         "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn provenance_survives_a_fall_back_to_the_live_poll_timeline() {
+    // #567 r4. The verdict timeline normally comes from a range query, which
+    // collects firing-series labels for the provenance check. When that query
+    // is unusable — no stored sample yet for an alert that fires inside one
+    // --query-step, or an API error — the verdict falls back to the live poll
+    // timeline, and the provenance check used to have nothing to inspect: the
+    // run passed clean while matching an alert from a foreign series.
+    //
+    // Forcing the range query to fail reproduces that state deterministically,
+    // without depending on the race that made it a CI flake.
+    let inner = alert_world(Some(0.0), None, "intruder-host");
+    let (url, _hits) = mock_prometheus(move |n, line| {
+        if line.contains("/api/v1/query_range") {
+            return (
+                "{\"status\":\"error\"}".to_string(),
+                std::time::Duration::ZERO,
+            );
+        }
+        inner(n, line)
+    });
+    let dir = TempDir::new().expect("tempdir");
+    let yaml = "version: 2
+kind: runnable
+defaults:
+  rate: 10
+  duration: 300ms
+  encoder:
+    type: prometheus_text
+  sink:
+    type: memory
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: cpu_usage
+    generator:
+      type: constant
+      value: 95.0
+    labels:
+      host: sonda-test
+expect:
+  alerts:
+    - alert: HighCpuUsage
+      firing_within: 5s
+";
+    let path = write_scenario(&dir, yaml);
+    let output = Command::new(sonda_bin())
+        .args(["test", path.to_str().expect("utf8 path")])
+        .args(["--prometheus-url", &url, "--interval", "100ms"])
+        .args(["--query-step", "200ms"])
+        .output()
+        .expect("run sonda test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Guards the fixture: if the fallback is not taken, this test proves
+    // nothing about the fallback.
+    assert!(
+        stderr.contains("uses the live poll timeline"),
+        "fixture did not force the fallback: {stderr}"
+    );
+    assert!(
+        stderr.contains("WARN") && stderr.contains("host=\"intruder-host\""),
+        "the provenance advisory must survive the fallback: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

Two documentation drift gates, plus the two stale docs they found.

## What ships

**1. Prose verb counts are checked against the parser.**

`sonda/tests/cli_subcommand_parity.rs` walks every Markdown file in the repo. Any `<number> verbs` claim must match the verb count `sonda --help` reports, and any claim that *enumerates* the verbs must enumerate all of them.

It takes no file list — a new document inherits the gate by existing.

Two exemptions: `CHANGELOG.md` wholesale (an append-only record of what was true at each release), and any line carrying `<!-- verbs:historical -->` (an opt-out a human types, visible in the diff).

**2. The committed waveform SVGs are checked against their generator.**

A new `docs-commands` step regenerates the 13 generator SVGs and fails if the committed files differ. These were the last committed build output with no drift gate; the editor bundle and the wasm bundle already have theirs.

The step deletes the SVGs before regenerating, so a generator that stops writing shows up as 13 deletions rather than as a vacuous green, and compares with `git status --porcelain` rather than `git diff` so an untracked new SVG is in scope.

**3. Two documentation fixes the gates surfaced.**

- `docs/architecture.md` presented the CLI surface as current and said "four verbs" — stale since `sonda test` shipped in 1.20. Now six, with `test` and `completions` listed.
- `sonda/CLAUDE.md`'s CLI Surface block omitted `sonda test`.

## How the verb gate decides

| Input | Treatment |
|---|---|
| `six verbs: \`run\`, \`list\`, …` | inline enumeration — must name all six |
| `Primary CLI surface (six verbs):` + fence of `sonda <verb>` lines | fenced enumeration — must name all six |
| "the CLI exposes six verbs, all thin wrappers over sonda-core" | passing mention — count checked, no list required |

A block naming a majority of the verbs is an enumeration; fewer is a passing mention. Verb matching is word-boundary aware, so `newline` is not `new`.

## Test plan

Six tests in `cli_subcommand_parity.rs`, all mutations asserted present in the file before their result was trusted:

| Mutation | Result |
|---|---|
| `architecture.md` reverted to "four verbs" | `every_prose_verb_count_matches_the_parser` fails, alone |
| `cli-flags.md` claims six, lists five (word survives elsewhere in the file) | `a_block_that_lists_the_verbs_lists_all_of_them` fails, naming the omission |
| `completions` dropped from `architecture.md`'s fence | same test fails, at that file's line |
| a sentence between a claim and its fence, five verbs listed | caught |
| passing mention + one `sonda run` example | passes |
| `<!-- verbs:historical -->` stripped | the exempted line is caught |
| verb removed from `SONDA_SUBCOMMANDS` / `KNOWN_SUBCOMMANDS` | each list's own parity test fails, alone |

SVG gate:

| Mutation | Result |
|---|---|
| a wrong SVG committed | RED |
| the renderer changed (path precision 1dp → 2dp) | RED |
| the example writes nothing | RED, as 13 deletions |
| an untracked SVG from a 14th generator | RED |
| the image directory renamed | RED, refusing to verify an empty corpus |

**Gates:** `cargo test --workspace --no-fail-fast` — five environmental failures, unchanged from `main`, no new ones · `cargo clippy --workspace --all-targets -- -D warnings` clean · `cargo fmt --all -- --check` clean · `validate_docs_commands.py` 159/159 · `validate_docs_scenarios.py` 118 compiled / 0 failed · `mkdocs build --strict` clean.

The five: `sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message` and `tests::sink_file_error_produces_sink_variant` (need `CAP_DAC_OVERRIDE` to fail), plus `global_inflight_limit_gates_across_routes`, `health_remains_responsive_when_control_plane_is_saturated`, `request_timeout_returns_408_with_structured_error` (load-sensitive).

## Known limitations

- The verb gate recognises two enumeration shapes. Bullet lists, tables, `$`-prefixed fence lines, and a list wrapping to the line after the claim are treated as passing mentions — their **count** is still checked, only count-vs-list consistency is not.
- A document that lists the CLI surface without stating a count is ungated. There is nothing to compare against, and requiring every `sonda` example to be exhaustive would break tutorial pages. `sonda/CLAUDE.md`'s usage block is this case, which is why that fix needed a human.
- The SVG gate's byte-exact reproducibility rests on the generator's `{:.1}` coordinate rounding and its seeded RNGs, not on the language. Widening that precision requires re-measuring the claim across hosts.

## Checklist

- [x] `cargo test --workspace` passes (five environmental failures, named above)
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)
