### PR TITLE
docs: how to add a check, and a timeout on every CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   ci:
     name: Build, Test, Clippy, Fmt
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -62,6 +63,7 @@ jobs:
   sonda-server:
     name: sonda-server Build & Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -96,6 +98,7 @@ jobs:
   docker-build:
     name: Docker Build (multi-arch verify)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -116,6 +119,7 @@ jobs:
   no-default-features:
     name: Test sonda-core without default features
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -159,6 +163,7 @@ jobs:
   all-features:
     name: Build, Test, Clippy (all features)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -200,6 +205,7 @@ jobs:
   docs-commands:
     name: Validate sonda commands in user-facing docs
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -410,6 +416,7 @@ jobs:
   docs-browser-smoke:
     name: Docs site browser smoke suite
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -508,6 +515,7 @@ jobs:
   release-pin-check:
     name: release.yml rust-toolchain pin matches rust-toolchain.toml
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -532,6 +540,7 @@ jobs:
   action-contract:
     name: sonda-action contract (argv safety + release resolution)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     # Deliberately NOT path-filtered, unlike the live self-test. These are
     # seconds of shell and Python with no containers, and they guard the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,10 +46,50 @@ Every commit must pass:
 
 ```bash
 cargo build --workspace
-cargo test --workspace
+cargo test --workspace --no-fail-fast
 cargo clippy --workspace -- -D warnings
 cargo fmt --all -- --check
 ```
+
+`--no-fail-fast` is not optional. `cargo test --workspace` stops at the first failing *binary*,
+so a failure in `sonda-core` means `sonda-server` and the CLI integration tests never run at all.
+A run that aborted early has been reported as "everything passes" more than once. Name the
+failing tests individually; a count is not a result.
+
+## Writing a Check
+
+Most defects this repo has shipped were in its *checks*, not its code. Before adding one, answer
+these four. Each is here because it already went wrong.
+
+1. **Can it pass vacuously?** An empty corpus, a renamed directory, a generator that writes
+   nothing, a parse that returns nothing — all produce "no differences found". Assert the input
+   exists *before* checking it. `cli_subcommand_parity.rs` does this twice; the SVG gate in
+   `ci.yml` deletes its corpus first so silence surfaces as deletions rather than success.
+
+2. **Does the red-verification depend on an accident?** Confirm the mutation is present in the
+   file before trusting its result — a sabotage that silently fails to apply is indistinguishable
+   from a passing gate. Then ask *why* it went red: a check once passed only because the corpus
+   happened to contain the needle exactly once, on the line the mutation deleted. The same defect
+   elsewhere was invisible.
+
+3. **Is the exemption something a human types?** An opt-out that appears in a diff
+   (`<!-- verbs:historical -->`) is honest. Silently skipping anything the check does not
+   recognise is not — it reads as coverage.
+
+4. **Does the comment describe what the code does?** A doc comment claiming a majority rule sat
+   above `!named.is_empty()`; a comment saying "two consecutive blanks" sat above a counter that
+   never reset. If a comment states a rule, the rule belongs in one function both the prose and
+   the callers point at.
+
+Two further rules of thumb, earned the expensive way:
+
+- **Prefer exact checks to heuristic ones.** Comparing a value to its source of truth converges.
+  Pattern-matching over prose or layout has an unbounded tail of shapes: every round finds
+  another, and each fix is genuinely correct. If a check cannot be made exact, ship it with its
+  limitations written down rather than iterating toward completeness.
+- **A test that copies the code it tests will diverge on exactly the line the bug is on.** Drive
+  the real thing — `scripts/tests/extract_run_bodies.py` exists so the action's contract tests
+  execute `action.yml`'s own shell rather than a transcription of it.
 
 ## How to Build
 


### PR DESCRIPTION
## Summary

Two things:

1. `CLAUDE.md` gains a **Writing a Check** section, and the Quality Gates block gains `--no-fail-fast` with the reason.
2. Every job in `ci.yml` gains a **`timeout-minutes`**.

## Writing a Check

Most defects this repo shipped recently were in its *checks*, not its code. That knowledge lived only in review threads, so each new gate rediscovered the same failures. Four questions before adding one, each earned by a check that went wrong here:

1. Can it pass vacuously? (empty corpus, renamed directory, generator that writes nothing)
2. Does the red-verification depend on an accident? (assert the mutation applied; then ask *why* it went red)
3. Is the exemption something a human types? (an opt-out in a diff is honest; a silent skip reads as coverage)
4. Does the comment describe what the code does?

Plus two rules of thumb: **prefer exact checks to heuristic ones** — comparing a value to its source of truth converges, pattern-matching over prose has an unbounded tail — and **a test that copies the code it tests will diverge on exactly the line the bug is on**.

`--no-fail-fast` is now mandatory and the file says why: the plain form stops at the first failing *binary*, so a `sonda-core` failure means `sonda-server` and the CLI integration tests never run at all.

## CI timeouts

Two `Docs site browser smoke suite` jobs on this PR hung on the Playwright browser download for 3h49m, on two independent runners. That step normally takes ~30s. No job in `ci.yml` had a `timeout-minutes`, so the ceiling was GitHub's 6-hour job limit — a stall reads as "still running" for most of a working day instead of failing with a legible cause.

All nine jobs get one, not only the one that hung: a bound on a single job while eight others can sit for six hours is the same defect with a smaller blast radius. Limits are at least 4.9× the worst duration observed across the last 8 CI runs.

| job | worst observed | limit |
|---|---|---|
| Build, Test, Clippy, Fmt | 4.4m | 30m |
| Build, Test, Clippy (all features) | 3.4m | 30m |
| Docker Build (multi-arch verify) | 4.1m | 20m |
| Docs site browser smoke suite | 3.2m | 20m |
| Validate sonda commands in user-facing docs | 2.9m | 20m |
| sonda-server Build &amp; Integration Tests | 1.8m | 20m |
| Test sonda-core without default features | 1.4m | 20m |
| release.yml rust-toolchain pin check | 0.1m | 10m |
| sonda-action contract | 0.1m | 10m |

The Rust jobs carry the 20–30m limits because a cold cargo cache lands on them.

## Verification

- Both Quality Gates commands were run. `--no-fail-fast` is a `cargo test` flag; `cargo build` rejects it. **The first draft of this file put it on `cargo build`** — the exact mistake point 4 is about, caught by running it.
- The three files cited as examples were checked to do what the text says: `cli_subcommand_parity.rs` guards against vacuous passes, `ci.yml`'s SVG gate deletes its corpus before regenerating, `action_argv_test.sh` extracts and runs `action.yml`'s own shell.
- The timeouts were verified by parsing `ci.yml` and asserting all 9 jobs carry the key, not by eye. Deliberately **not** red-verified: the semantics relied on are GitHub's own, so a sabotage would exercise Actions rather than anything in this repo.
- `validate_docs_commands.py` 159/159 · `cargo fmt --all -- --check` clean.

## Not included

A gate asserting that *future* jobs carry a timeout. It would be an exact check and cheap to write, but this PR's own thesis is that each check carries ongoing review cost — worth deciding on deliberately rather than bundling here. The other nine workflow files are also unbounded except `action-selftest.yml` and `live-infra-uat.yml`, which already set their own.

## Checklist

- [x] `cargo test --workspace --no-fail-fast` passes — no code touched
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)
