### PR TITLE
ci: prune the check surface using the gate audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -30,8 +30,17 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      # Prebuilt binary rather than `cargo install cargo-audit --locked`, which
+      # compiled the tool from source on every push and was ~2.5 of this job's
+      # ~3.1 minutes. Same action and pin the four nextest installs use.
+      #
+      # The per-push cadence is deliberate and stays: this job caught
+      # RUSTSEC-2026-0258 (#566), and an advisory should fail on the PR that
+      # introduces the vulnerable dependency, not on a weekly sweep afterwards.
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        uses: taiki-e/install-action@v2.85.13
+        with:
+          tool: cargo-audit
 
       - name: Audit dependencies
         run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,14 @@ jobs:
       - name: Test (nextest)
         run: cargo nextest run --workspace
 
-      - name: Doctests
-        run: cargo test --workspace --doc
+      # No doctest step here on purpose. Measured: this job's default-feature
+      # run and the all-features job's run enumerate the SAME four doctests, so
+      # the default-feature one proved nothing the all-features one does not.
+      #
+      # The no-default-features job's doctest run is NOT redundant and stays —
+      # it is the only thing asserting those examples compile with no features
+      # at all, which is the boundary sonda-wasm depends on. Same reason the
+      # `schema`-only build next to it exists.
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
@@ -95,26 +101,9 @@ jobs:
         run: cargo nextest run -p sonda-server --test integration --no-capture
         timeout-minutes: 5
 
-  docker-build:
-    name: Docker Build (multi-arch verify)
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build Docker image (amd64)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: linux/amd64
-          push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+# docker-build moved to .github/workflows/docker-build.yml so it can be
+# path-filtered on pull requests. Every job in this file runs on every push;
+# a workflow-level filter here would have skipped all of them.
 
   no-default-features:
     name: Test sonda-core without default features

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,11 +2,14 @@
 # path-filtered on pull requests; unconditional on main, so a break still
 # surfaces within one merge.
 #
-# Cost, measured across the last 15 CI runs rather than assumed: this job is
-# bimodal — 12-25s on a warm GitHub Actions cache (9 runs) and 172-241s on a
-# cold one (6 runs), for a mean near 95s. It is not the ~3.5 minutes a single
-# cold sample suggests, but it is not free either, and none of it can be
-# earned back by a docs-only change.
+# Cost, measured on the population the filter actually affects — pull_request
+# runs — rather than on all runs mixed together: 16 samples, median 223s,
+# range 12-286s. Thirteen of the sixteen are cold; the gha cache is rarely
+# warm for a PR. An earlier count here said "median 24s, mean ~95s" and was
+# drawn from a 15-run window that mixed main pushes in and happened to be
+# warm-heavy (#569 review M2). Roughly 3.5 minutes per docs PR is the real
+# saving, and none of it can be earned back by a change that cannot reach the
+# image.
 #
 # The filter is the Dockerfile's own input set: the workspace manifests and
 # the four crate directories it COPYs, plus the Dockerfile and this workflow.

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,58 @@
+# Verifies the container image still builds. Moved out of ci.yml so it can be
+# path-filtered on pull requests; unconditional on main, so a break still
+# surfaces within one merge.
+#
+# Cost, measured across the last 15 CI runs rather than assumed: this job is
+# bimodal — 12-25s on a warm GitHub Actions cache (9 runs) and 172-241s on a
+# cold one (6 runs), for a mean near 95s. It is not the ~3.5 minutes a single
+# cold sample suggests, but it is not free either, and none of it can be
+# earned back by a docs-only change.
+#
+# The filter is the Dockerfile's own input set: the workspace manifests and
+# the four crate directories it COPYs, plus the Dockerfile and this workflow.
+# rust-toolchain.toml is deliberately absent — the image builds `FROM
+# rust:latest` and never reads the pin.
+name: Docker Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'sonda-core/**'
+      - 'sonda/**'
+      - 'sonda-server/**'
+      - 'sonda-wasm/**'
+      - '.github/workflows/docker-build.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-build:
+    name: Docker Build (multi-arch verify)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Docker image (amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/live-infra-uat.yml
+++ b/.github/workflows/live-infra-uat.yml
@@ -11,11 +11,36 @@
 
 name: Live Infra UAT
 
+# Path-filtered on pull requests, unconditional on main. At ~10 minutes it was
+# 29% of a full CI pass and ran on every PR, including docs-only ones that
+# cannot change its answer. Leaving main unfiltered means drift still surfaces
+# within one merge rather than waiting for the next code PR.
+#
+# The list is the harness's real inputs, derived from the script rather than
+# guessed: it builds `-p sonda` (so all of sonda-core and sonda, plus the
+# workspace manifests and toolchain pin), boots the compose stack from
+# examples/ (which mounts ../docker/ for Grafana provisioning), and runs
+# scenarios from examples/ and tests/e2e/.
+#
+# Deliberately NOT listed: docs/site/docs/guides/e2e-testing.md. The matrix is
+# hardcoded in live_infra_uat.py and that page is a hand-maintained parallel
+# copy, so editing the page cannot change what this job does.
 on:
   push:
     branches: [main]
   pull_request:
     branches: ["**"]
+    paths:
+      - 'sonda-core/**'
+      - 'sonda/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'examples/**'
+      - 'docker/**'
+      - 'tests/e2e/**'
+      - 'scripts/live_infra_uat.py'
+      - '.github/workflows/live-infra-uat.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/live-infra-uat.yml
+++ b/.github/workflows/live-infra-uat.yml
@@ -22,6 +22,14 @@ name: Live Infra UAT
 # examples/ (which mounts ../docker/ for Grafana provisioning), and runs
 # scenarios from examples/ and tests/e2e/.
 #
+# Dockerfile and .dockerignore are in the list because the compose stack's
+# `sonda-server` service builds from them (`context: ..`, no `profiles:` key,
+# so it is on the default profile and built on every run). docker-build also
+# lists them, but that job answers "does the image build" — this one answers
+# "does the server come up and serve", which a bad ENTRYPOINT or a dropped
+# runtime file breaks while still building clean. (#569 review W1: this was
+# the one input the derivation missed.)
+#
 # Deliberately NOT listed: docs/site/docs/guides/e2e-testing.md. The matrix is
 # hardcoded in live_infra_uat.py and that page is a hand-maintained parallel
 # copy, so editing the page cannot change what this job does.
@@ -36,6 +44,8 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
+      - 'Dockerfile'
+      - '.dockerignore'
       - 'examples/**'
       - 'docker/**'
       - 'tests/e2e/**'

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -274,6 +274,8 @@ The CLI crate is intentionally thin. Its only responsibilities are:
 - Instantiate the appropriate generator, encoder, and sink from `sonda-core`.
 - Hand control to the `sonda-core` scenario runner.
 
+<!-- verbs:listing -->
+
 Primary CLI surface (six verbs):
 
 ```
@@ -284,6 +286,8 @@ sonda new [--template | --from <csv>] [-o <path>]
 sonda test <file-or-@name> --prometheus-url ...  # verify expect: alerts
 sonda completions <shell>                        # shell completion script
 ```
+
+<!-- /verbs:listing -->
 
 `sonda run` accepts either a filesystem path to a YAML file or a `@name` shorthand that resolves through `--catalog <dir>`. The CLI does not contain signal generation logic. Any behavior that is tested or benchmarked belongs in `sonda-core`.
 

--- a/docs/site/docs/reference/cli-flags.md
+++ b/docs/site/docs/reference/cli-flags.md
@@ -5,7 +5,13 @@ description: Every flag, argument, exit code, and progress line for the sonda bi
 
 # CLI Reference
 
-The `sonda` binary has six verbs: `run`, `list`, `show`, `new`, `test`, and `completions`. `run` executes a [scenario YAML file](../build/scenario-files.md). `list` and `show` browse a catalog directory of scenarios and composable packs. `new` creates a starter file. `test` runs a scenario and verifies its `expect:` alert expectations. `completions` prints a shell completion script.
+<!-- verbs:listing -->
+
+The `sonda` binary has six verbs: `run`, `list`, `show`, `new`, `test`, and `completions`.
+
+<!-- /verbs:listing -->
+
+`run` executes a [scenario YAML file](../build/scenario-files.md). `list` and `show` browse a catalog directory of scenarios and composable packs. `new` creates a starter file. `test` runs a scenario and verifies its `expect:` alert expectations. `completions` prints a shell completion script.
 
 Earlier releases used per-signal subcommands (`metrics`, `logs`, `histogram`, `summary`). These were removed in 1.9. Every signal type is now declared inside the scenario YAML, then run with `sonda run`.
 

--- a/scripts/check_no_raw_html.sh
+++ b/scripts/check_no_raw_html.sh
@@ -26,11 +26,54 @@ PATTERN='\.innerHTML|\.outerHTML|insertAdjacentHTML|document\.write\('
 GENERATED='docs/site/docs/javascripts/sonda-editor.js
 docs/site/docs/javascripts/sonda_wasm.js'
 
+# The roots this gate claims to cover. Keep them here rather than inline in the
+# `find` below, so the corpus assertion and the scan read from one list.
+ROOTS='docs/site/docs/javascripts
+docs/site/tools/editor/src'
+
+# Assert the corpus BEFORE checking it. `find` over a moved or renamed
+# directory prints nothing and exits 0, so without this the gate scans zero
+# files, reports "OK" and reads as coverage — the failure this whole section
+# of CLAUDE.md exists about.
+#
+# Checked per root, not in total: a single count would still be satisfied by
+# one surviving directory while the other had silently stopped being scanned.
+# Counted AFTER the generated-file exemption, because a root holding nothing
+# but build outputs contributes nothing to this gate either.
+corpus=""
+while IFS= read -r root; do
+  [ -n "$root" ] || continue
+  if [ ! -d "$root" ]; then
+    echo "::error::check_no_raw_html.sh: scan root '$root' is not a directory." >&2
+    echo "It was moved, renamed or deleted. Update ROOTS in this script to match —" >&2
+    echo "this gate refuses to pass over a corpus it cannot find." >&2
+    exit 2
+  fi
+  kept=0
+  while IFS= read -r found; do
+    [ -n "$found" ] || continue
+    case "$GENERATED" in
+      *"$found"*) continue ;;
+    esac
+    corpus="$corpus$found
+"
+    kept=$((kept + 1))
+  done < <(find "$root" -name '*.js' -type f | sort)
+  if [ "$kept" -eq 0 ]; then
+    echo "::error::check_no_raw_html.sh: scan root '$root' contributed no hand-written .js files." >&2
+    echo "Either the sources moved, or every file in it is on the GENERATED exemption list." >&2
+    echo "Refusing to report OK over an empty corpus." >&2
+    exit 2
+  fi
+done <<EOF
+$ROOTS
+EOF
+
+checked=0
 status=0
 while IFS= read -r file; do
-  case "$GENERATED" in
-    *"$file"*) continue ;;
-  esac
+  [ -n "$file" ] || continue
+  checked=$((checked + 1))
   if matches=$(grep -nE "$PATTERN" "$file"); then
     if [ "$status" -eq 0 ]; then
       echo "::error::raw-markup assignment found in hand-written docs JS." >&2
@@ -41,9 +84,13 @@ while IFS= read -r file; do
       echo "  $file:$hit" >&2
     done <<<"$matches"
   fi
-done < <(find docs/site/docs/javascripts docs/site/tools/editor/src -name '*.js' -type f | sort)
+done <<EOF
+$corpus
+EOF
 
 if [ "$status" -eq 0 ]; then
-  echo "OK: no raw-markup assignment in hand-written docs JS"
+  # Print the count: a reader can see the corpus was non-empty without
+  # trusting that the assertion above ran.
+  echo "OK: no raw-markup assignment in $checked hand-written docs JS files"
 fi
 exit "$status"

--- a/sonda-core/tests/ci_workflow_test.rs
+++ b/sonda-core/tests/ci_workflow_test.rs
@@ -78,8 +78,9 @@ fn ci_yml_has_test_step() {
     let yaml = load_ci_yaml();
     let steps = ci_steps(&yaml);
     assert!(
-        steps.iter().any(|s| step_run(s).contains("cargo test")),
-        "ci.yml must have a step that runs 'cargo test'"
+        steps.iter().any(runs_tests),
+        "ci.yml's `ci` job must have a step that runs the test suite \
+         ('cargo nextest run' or 'cargo test')"
     );
 }
 
@@ -124,7 +125,10 @@ fn ci_yml_steps_order_build_test_clippy_fmt() {
     };
 
     let build_pos = pos("cargo build");
-    let test_pos = pos("cargo test");
+    let test_pos = steps
+        .iter()
+        .position(runs_tests)
+        .expect("could not find a step running the test suite");
     let clippy_pos = pos("cargo clippy");
     let fmt_pos = pos("cargo fmt");
 
@@ -146,18 +150,40 @@ fn ci_yml_steps_order_build_test_clippy_fmt() {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Return the list of steps from the first (and only expected) job.
+/// Return the steps of the `ci` job — the one running the four gates below.
+///
+/// Selected by key, not by position. The comment here used to say "the CI file
+/// should have exactly one job" and the code took `values().next()`, which was
+/// true when this was written for slice 0.0 and has not been true for a long
+/// time: ci.yml now defines several jobs, and this took whichever one happened
+/// to serialize first. Reordering them — or removing the first one, which is
+/// how this surfaced — would silently move these assertions onto a different
+/// job, or pass them over one that never runs cargo at all.
 fn ci_steps(yaml: &Value) -> Vec<Value> {
-    let jobs = &yaml["jobs"];
-    // The CI file should have exactly one job. Grab the first one regardless of its key name.
-    let job = jobs
-        .as_mapping()
-        .and_then(|m| m.values().next())
-        .expect("ci.yml must define at least one job");
+    let job = &yaml["jobs"]["ci"];
+    assert!(
+        !job.is_null(),
+        "ci.yml must define a job keyed `ci` — these tests assert the build/test/\
+         clippy/fmt gates run there. If it was renamed, update this selector \
+         rather than falling back to whichever job comes first."
+    );
     job["steps"]
         .as_sequence()
-        .expect("job must have a 'steps' sequence")
+        .expect("the `ci` job must have a 'steps' sequence")
         .to_vec()
+}
+
+/// Whether a step runs the workspace test suite.
+///
+/// `cargo nextest run` is how this repo runs tests; plain `cargo test` covers
+/// the doctest steps and any job that has not moved to nextest. Matching only
+/// `cargo test` meant the `ci` job's real test step — nextest — never
+/// satisfied this, and the assertion was being met incidentally by a
+/// `cargo test --workspace --doc` line sitting after it. Removing that
+/// duplicate doctest run is what exposed it.
+fn runs_tests(step: &Value) -> bool {
+    let run = step_run(step);
+    run.contains("cargo nextest run") || run.contains("cargo test")
 }
 
 /// Extract the `run:` string from a step, returning empty string for non-run steps.

--- a/sonda-core/tests/ci_workflow_test.rs
+++ b/sonda-core/tests/ci_workflow_test.rs
@@ -173,16 +173,25 @@ fn ci_steps(yaml: &Value) -> Vec<Value> {
         .to_vec()
 }
 
-/// Whether a step runs the workspace test suite.
+/// Whether a step runs the unit and integration test suite.
 ///
 /// `cargo nextest run` is how this repo runs tests; plain `cargo test` covers
-/// the doctest steps and any job that has not moved to nextest. Matching only
-/// `cargo test` meant the `ci` job's real test step — nextest — never
-/// satisfied this, and the assertion was being met incidentally by a
-/// `cargo test --workspace --doc` line sitting after it. Removing that
-/// duplicate doctest run is what exposed it.
+/// any job that has not moved to nextest. Matching only `cargo test` meant the
+/// `ci` job's real test step — nextest — never satisfied this, and the
+/// assertion was being met incidentally by a `cargo test --workspace --doc`
+/// line sitting after it. Removing that duplicate doctest run is what exposed
+/// it.
+///
+/// A `--doc` run is explicitly NOT a test run for this purpose. Fixing only
+/// today's instance would have left the mechanism in place: re-adding a
+/// doctest step while dropping nextest passed a check whose message says the
+/// job "must have a step that runs the test suite" (#569 review W3). Doctests
+/// compile examples; they execute no unit or integration test.
 fn runs_tests(step: &Value) -> bool {
     let run = step_run(step);
+    if run.contains("--doc") {
+        return false;
+    }
     run.contains("cargo nextest run") || run.contains("cargo test")
 }
 

--- a/sonda/tests/cli_subcommand_parity.rs
+++ b/sonda/tests/cli_subcommand_parity.rs
@@ -41,6 +41,35 @@
 //! it walks every tracked Markdown file and holds any file making a
 //! "<number> verbs" claim to the parser's count. A new document inherits the
 //! gate by existing.
+//!
+//! # Counts are checked. Listings are checked where they say so.
+//!
+//! There are two questions here, and only one of them has an exact answer.
+//!
+//! *Does this stated number match the parser?* is exact: both sides are
+//! integers with one right answer.
+//!
+//! *Is this paragraph a listing of the verbs?* is not. An earlier version of
+//! this file answered it by classifying shapes — inline-list-after-a-colon, or
+//! a fence within a line or two, with a majority rule deciding whether enough
+//! verbs were named to count as an enumeration, over a block whose extent was
+//! itself inferred from blank lines and fence tracking. That classifier drew
+//! six review findings across three rounds of #567 and never caught a real
+//! defect; each fix was correct and revealed another shape. The gate audit
+//! named it the only open-ended heuristic in the repo and recommended
+//! deleting it rather than spending a fourth round.
+//!
+//! It is replaced by declaration. A block that enumerates the CLI surface says
+//! so, between `<!-- verbs:listing -->` and `<!-- /verbs:listing -->`, and the
+//! check over marked blocks is exact: the region is delimited rather than
+//! guessed, and it must name every verb. Nothing is inferred from layout.
+//!
+//! **The limitation, stated rather than papered over:** a listing nobody
+//! marked is not checked. That is a real gap and it is the deliberate trade —
+//! an unmarked listing is a review concern, where an unbounded shape
+//! classifier was a permanent review cost. The count check above still covers
+//! every claim in every Markdown file, marked or not, so a listing that drifts
+//! *and* restates a number is still caught by the exact half.
 
 mod common;
 
@@ -107,62 +136,98 @@ struct VerbCountClaim {
     line_number: usize,
     claimed: usize,
     line: String,
-    /// The claim's own line plus the block it introduces — see [`claim_block`].
-    block: String,
 }
 
-/// The text a verb-count claim is actually making a claim *about*.
-///
-/// The claim line itself, plus the block it introduces: contiguous following
-/// lines, and a fenced code block if one opens within a line or two (the
-/// `Primary CLI surface (six verbs):` / ```` ``` ```` shape). Bounded, so a
-/// document with no blank lines cannot swallow itself whole.
-///
-/// #567 review W1: the previous version searched the WHOLE FILE for each verb.
-/// Five of the six — run, list, show, new, test — are ordinary English
-/// fragments (runner, listing, shows, newline, latest), so only `completions`
-/// discriminated at all. The red-verification passed by luck of the corpus:
-/// `architecture.md` happened to contain that word exactly once, on the line
-/// the mutation deleted. Applied to `cli-flags.md`, where the word survives in
-/// its own section heading, the identical defect was invisible.
-fn claim_block(lines: &[&str], claim_index: usize) -> String {
-    const MAX_BLOCK_LINES: usize = 40;
-    let mut block = vec![lines[claim_index]];
-    let mut in_fence = false;
-    let mut blanks = 0usize;
+/// A region a document declares to be an enumeration of the CLI's verbs.
+struct ListingBlock {
+    path: PathBuf,
+    line_number: usize,
+    text: String,
+}
 
-    for line in lines.iter().skip(claim_index + 1).take(MAX_BLOCK_LINES) {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("```") {
-            block.push(line);
-            if in_fence {
-                break; // the fence this claim introduced has closed
+/// Opens a declared verb listing.
+const LISTING_OPEN: &str = "<!-- verbs:listing -->";
+/// Closes a declared verb listing.
+const LISTING_CLOSE: &str = "<!-- /verbs:listing -->";
+
+/// Every declared verb listing in the repository's Markdown.
+///
+/// The region is what the document delimited: from the line carrying
+/// [`LISTING_OPEN`] to the line carrying [`LISTING_CLOSE`], inclusive. There is
+/// no line budget, no fence tracking and no blank-line counting, because there
+/// is nothing left to infer — that machinery existed only to guess an extent
+/// the author can simply state.
+///
+/// An unbalanced marker is an error, not a skip. A typo'd or missing closer
+/// would otherwise drop a listing out of coverage silently, which is the
+/// vacuous pass this whole file is built to refuse.
+fn listing_blocks() -> Vec<ListingBlock> {
+    let root = repo_root();
+    let mut files = Vec::new();
+    markdown_files(&root, &mut files);
+
+    let mut blocks = Vec::new();
+    for path in files {
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let lines: Vec<&str> = text.lines().collect();
+        let mut open_at: Option<usize> = None;
+        for (index, line) in lines.iter().enumerate() {
+            // Each marker must be alone on its line, because the region is
+            // whole lines. A pair written inline around a clause reads as if
+            // it delimits that clause, and would silently cover the entire
+            // line instead — including the per-verb sentences that follow a
+            // list, which is precisely how #567's whole-file search was
+            // defeated. Rejecting the shape is cheaper than supporting it.
+            for marker in [LISTING_OPEN, LISTING_CLOSE] {
+                assert!(
+                    !line.contains(marker) || line.trim() == marker,
+                    "{}:{} places `{marker}` inline. It must be alone on its line: \
+                     the marked region is whole lines, so an inline pair would cover \
+                     more text than it appears to.\n  {line:?}",
+                    path.display(),
+                    index + 1
+                );
             }
-            in_fence = true;
-            blanks = 0;
-            continue;
-        }
-        if in_fence {
-            block.push(line);
-            continue;
-        }
-        if line.trim().is_empty() {
-            blanks += 1;
-            // One blank line may separate a claim from the fence it
-            // introduces; two means the block is over.
-            if blanks > 1 {
-                break;
+            if line.contains(LISTING_OPEN) {
+                assert!(
+                    open_at.is_none(),
+                    "{}:{} opens a verb listing while one opened at line {} is still \
+                     unclosed. Nested listings are not a thing; this is a missing \
+                     `{LISTING_CLOSE}`.",
+                    path.display(),
+                    index + 1,
+                    open_at.unwrap_or_default() + 1
+                );
+                open_at = Some(index);
+                continue;
             }
-            continue;
+            if line.contains(LISTING_CLOSE) {
+                let start = open_at.take().unwrap_or_else(|| {
+                    panic!(
+                        "{}:{} closes a verb listing that was never opened with \
+                         `{LISTING_OPEN}`.",
+                        path.display(),
+                        index + 1
+                    )
+                });
+                blocks.push(ListingBlock {
+                    path: path.clone(),
+                    line_number: start + 1,
+                    text: lines[start..=index].join("\n"),
+                });
+            }
         }
-        // Reset on content: the comment above says CONSECUTIVE blanks end the
-        // block, and until this line the counter never reset, so two blank
-        // lines anywhere did — one ordinary sentence between a claim and the
-        // fence it introduces was enough to lose the fence (#567 r2 W1).
-        blanks = 0;
-        block.push(line);
+        assert!(
+            open_at.is_none(),
+            "{}:{} opens a verb listing that is never closed. Add `{LISTING_CLOSE}`, \
+             or the block silently stops being checked.",
+            path.display(),
+            open_at.unwrap_or_default() + 1
+        );
     }
-    block.join("\n")
+    blocks
 }
 
 /// Every unexempted "<number> verbs" claim in the repository's Markdown.
@@ -213,7 +278,6 @@ fn verb_count_claims() -> Vec<VerbCountClaim> {
                         line_number: index + 1,
                         claimed,
                         line: line.trim().to_string(),
-                        block: claim_block(&lines, index),
                     });
                 }
             }
@@ -449,119 +513,71 @@ fn every_prose_verb_count_matches_the_parser() {
 }
 
 #[test]
-fn a_block_that_lists_the_verbs_lists_all_of_them() {
+fn the_walk_finds_the_listings_this_test_expects_to_check() {
+    // Same guard, same reason as the two above: a marker that stops being
+    // found makes the check below pass over nothing. Named files rather than a
+    // count, so moving a listing out of one of them is loud.
+    let blocks = listing_blocks();
+    assert!(
+        !blocks.is_empty(),
+        "found no `{LISTING_OPEN}` blocks anywhere in the repo's Markdown — \
+         either the walk broke or the marker was renamed, and both make the \
+         check below vacuous."
+    );
+    let files: Vec<String> = blocks
+        .iter()
+        .map(|b| {
+            b.path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    for expected in ["cli-flags.md", "architecture.md"] {
+        assert!(
+            files.iter().any(|f| f == expected),
+            "expected a declared verb listing in {expected}; found listings in {files:?}"
+        );
+    }
+}
+
+#[test]
+fn every_marked_listing_names_every_verb() {
     // A correct count above a stale list is the same defect one level down.
     //
-    // Scoped to the claim's own block rather than the whole file (#567 review
-    // W1). Whole-file search made this check almost inert: five of the six
-    // verbs are ordinary English fragments, so only `completions` ever
-    // discriminated, and only in a file that happened to contain it once.
-    //
-    // "Is this block a listing?" is decided by how many verbs it already
-    // names. A block naming a MAJORITY of them is enumerating the surface, so
-    // it must name all of them. A block naming few or none is prose that
-    // mentions a count in passing — "the CLI exposes six verbs, all thin
-    // wrappers over sonda-core" is true and useful, and compelling it to
-    // recite the list would be the check being wrong in the other direction
-    // (#567 review M1).
+    // The block is the region the document delimited, so this compares a
+    // declared enumeration against the parser and nothing is inferred. What
+    // replaced the classifier is the marker, not a cleverer rule: see this
+    // file's header for why, and for the gap the marker leaves.
     let mut parser = parser_subcommands();
     parser.retain(|v| v != "help");
 
     let mut problems = Vec::new();
-    for claim in verb_count_claims() {
-        let Some(named) = enumerated_verbs(&claim.line, &claim.block, &parser) else {
-            continue; // a passing mention, not a listing
-        };
+    for block in listing_blocks() {
         let missing: Vec<&str> = parser
             .iter()
-            .filter(|verb| !named.contains(verb))
+            .filter(|verb| !block_names_verb(&block.text, verb))
             .map(|v| v.as_str())
             .collect();
         if !missing.is_empty() {
             problems.push(format!(
-                "{}:{} enumerates {} of the {} verbs, omitting {:?} — {:?}",
-                claim.path.display(),
-                claim.line_number,
-                named.len(),
-                parser.len(),
+                "{}:{} is marked `{LISTING_OPEN}` but omits {:?} of the {} verbs",
+                block.path.display(),
+                block.line_number,
                 missing,
-                claim.line
+                parser.len()
             ));
         }
     }
     assert!(
         problems.is_empty(),
-        "a block that enumerates the CLI's verbs is missing some of them:\n{}",
+        "a block that declares itself an enumeration of the CLI's verbs is \
+         missing some of them:\n{}\n\nEither add the missing verbs, or remove \
+         the `{LISTING_OPEN}` marker if the block was never meant to be a \
+         complete listing.",
         problems.join("\n")
     );
-}
-
-/// The verbs a claim actually *enumerates*, if it enumerates any.
-///
-/// Two shapes occur in this repo, and both attach a list to the count:
-///
-/// ```text
-/// The `sonda` binary has six verbs: `run`, `list`, ... and `completions`.
-///
-/// Primary CLI surface (six verbs):
-/// ```                       <- a fence whose lines are `sonda <verb> ...`
-/// ```
-///
-/// Returns None when the claim carries no enumeration — a passing mention
-/// like "the CLI exposes six verbs, all thin wrappers over sonda-core" has
-/// nothing to be inconsistent with, and demanding a recitation there is the
-/// check being wrong in the other direction (#567 review M1).
-///
-/// This is deliberately narrower than "does the surrounding prose mention the
-/// word somewhere". #567 review W1 defeated that: dropping `completions` from
-/// this very list left the word intact in a later sentence on the same line,
-/// so the paragraph still named all six while the list named five. The count
-/// and the list it introduces have to be compared to each other.
-fn enumerated_verbs(claim_line: &str, block: &str, known: &[String]) -> Option<Vec<String>> {
-    // Shape 1: an inline list introduced by a colon straight after "verbs".
-    if let Some(after) = claim_line.split_once("verbs:").map(|(_, rest)| rest) {
-        // The list ends at the first sentence break.
-        let list = after.split_once(". ").map_or(after, |(head, _)| head);
-        let named: Vec<String> = known
-            .iter()
-            .filter(|verb| block_names_verb(list, verb))
-            .cloned()
-            .collect();
-        if is_enumeration(&named, known) {
-            return Some(named);
-        }
-    }
-
-    // Shape 2: a fenced usage block. Its lines invoke the binary by name, so
-    // the verb is the token straight after `sonda`.
-    let fenced: Vec<String> = block
-        .lines()
-        .filter_map(|line| line.trim().strip_prefix("sonda "))
-        .filter_map(|rest| rest.split_whitespace().next())
-        .filter(|token| known.iter().any(|verb| verb == token))
-        .map(|token| token.to_string())
-        .collect();
-    if is_enumeration(&fenced, known) {
-        return Some(fenced);
-    }
-
-    None
-}
-
-/// Whether a set of named verbs is an enumeration of the surface.
-///
-/// A majority means the text is listing the verbs, so it must list all of
-/// them. Fewer means a passing mention with an example or two, and demanding
-/// a full recitation there is the check being wrong in the other direction.
-///
-/// #567 r2 M1: this rule was stated in a doc comment and implemented as
-/// `!named.is_empty()` — so a passing mention followed by a single
-/// `sonda run scenario.yaml` example was compelled to recite all six. The
-/// rule now lives in one function that both the prose and the callers point
-/// at, because a claim in a comment that the code does not implement is the
-/// defect this repo keeps naming.
-fn is_enumeration(named: &[String], known: &[String]) -> bool {
-    named.len() * 2 > known.len()
 }
 
 /// Whether `block` names `verb` as a verb rather than as a substring.

--- a/sonda/tests/cli_subcommand_parity.rs
+++ b/sonda/tests/cli_subcommand_parity.rs
@@ -61,8 +61,18 @@
 //!
 //! It is replaced by declaration. A block that enumerates the CLI surface says
 //! so, between `<!-- verbs:listing -->` and `<!-- /verbs:listing -->`, and the
-//! check over marked blocks is exact: the region is delimited rather than
-//! guessed, and it must name every verb. Nothing is inferred from layout.
+//! check is exact *over the marked region's text*: the region is delimited
+//! rather than guessed, and every verb must appear in it. Nothing is inferred
+//! from layout.
+//!
+//! That wording is deliberate and was corrected once (#569 review). This is a
+//! **policy** check, not an exact one, in the gate audit's taxonomy: the
+//! parser's verb set is a source of truth, but what it is compared against is
+//! a word-boundary search over prose an author wrote. The vocabulary is closed
+//! and the scope is declared, which is what keeps it from being a classifier —
+//! but "exact" unqualified would be a claim the code does not implement, and
+//! this file is not the place to make one of those. See [`LISTING_OPEN`] for
+//! the authoring convention that carries the difference.
 //!
 //! **The limitation, stated rather than papered over:** a listing nobody
 //! marked is not checked. That is a real gap and it is the deliberate trade —
@@ -146,8 +156,21 @@ struct ListingBlock {
 }
 
 /// Opens a declared verb listing.
+///
+/// **Mark the enumeration only.** Any verb name anywhere inside the region
+/// satisfies the check, for any reason — so prose that repeats the verbs, and
+/// paths like `docs/new/getting-started.md` that happen to contain one, belong
+/// *outside* the markers. Draw the region around the list and nothing else.
+///
+/// This is a convention, and stating it is the point. The check is exact over
+/// the marked region's text; it is not exact about whether the author drew the
+/// region correctly. A region stretched to include the per-verb explanations
+/// would let a shortened list pass, because the explanations name every verb —
+/// which is exactly how #567's whole-file search was defeated, reachable again
+/// purely by where someone puts a marker (#569 review W2). The alternative,
+/// inferring the right extent, is the classifier this replaced.
 const LISTING_OPEN: &str = "<!-- verbs:listing -->";
-/// Closes a declared verb listing.
+/// Closes a declared verb listing. See [`LISTING_OPEN`] for how to draw the region.
 const LISTING_CLOSE: &str = "<!-- /verbs:listing -->";
 
 /// Every declared verb listing in the repository's Markdown.


### PR DESCRIPTION
## What changes

**CI cost**

- `Live Infra UAT` is path-filtered on pull requests, unconditional on `main`. Filter covers the harness's inputs: `sonda-core/**`, `sonda/**`, workspace manifests, `rust-toolchain.toml`, `Dockerfile`, `.dockerignore`, `examples/**`, `docker/**`, `tests/e2e/**`, the script, the workflow. Was ~10 min on every PR.
- `Docker Build` moves from `ci.yml` to its own path-filtered workflow (`docker-build.yml`), filtered to the Dockerfile's input set. Median 223s on PR runs.
- `cargo-audit` installs as a prebuilt binary via `taiki-e/install-action` instead of `cargo install`. 3m13 → 21s. Per-push cadence unchanged.
- The `ci` job's doctest step is removed. It enumerated the same four doctests as the all-features job. The `--no-default-features` doctest run stays — it is the only check that those examples compile with no features.

**Checks**

- `check_no_raw_html.sh` now requires each scan root to exist and contribute at least one non-generated file. Previously a renamed directory meant zero files checked and an `OK`.
- `cli_subcommand_parity.rs` replaces the "is this prose block a CLI listing?" classifier with declared markers. A block that enumerates the verbs is wrapped in `<!-- verbs:listing -->` / `<!-- /verbs:listing -->`; the check runs over marked regions only. Two docs are marked: `docs/architecture.md` and `docs/site/docs/reference/cli-flags.md`.
- `ci_workflow_test.rs` selects the `ci` job by key rather than taking whichever job serialises first, and its test-step predicate now recognises `cargo nextest run` while excluding `--doc` runs.

## Verification

Red-verified, each mutation confirmed present before its result was trusted:

| mutation | result |
|---|---|
| verb dropped from the inline listing | fails, names file and verb |
| verb dropped from the fenced listing | fails, names file and verb |
| unclosed marker | fails, `never closed` |
| inline marker pair | fails, `must be alone on its line` |
| scan root renamed | exit 2, names the root |
| scan root emptied of hand-written files | exit 2, distinct message |
| `ci` job's nextest step replaced by a doctest step | fails |

Also checked: the mkdocs build renders the marked region as normal paragraphs with code spans intact and the markers invisible. `validate_docs_commands.py` 159/159. `validate_docs_scenarios.py` 118 compiled, 0 failed, 60 gallery examples. clippy and fmt clean.

## Limitations

- **An unmarked listing is not checked.** This is a deliberate reduction in coverage: the classifier it replaces produced six review findings across three rounds and caught no real defect. The verb-count check still walks every Markdown file regardless of markers.
- **The marker check is policy, not exact.** It is a word-boundary search over the marked region, so any verb name inside the region satisfies it. The authoring convention — mark the enumeration only — is stated in the test.
- **Neither new filter is exercised by this PR.** Its diff touches `sonda/**` and `sonda-core/**`, so both jobs ran here as before. A docs-only PR is needed to confirm filter behaviour and that no filtered-out check leaves a required status pending.
- Two `sink::file` read-only-directory tests fail as uid 0 and pass unprivileged in CI. Three `sonda-server` `bounded_scheduler` tests fail in the dev container and pass in CI; both sets reproduce on `main` without this branch.
- `audit.yml`, `commitlint.yml`, `docs.yml`, `publish.yml`, `release-please.yml`, `release.yml` and `wasm-drift.yml` still have no job-level `timeout-minutes`.

## Checklist

- [x] `cargo test --workspace --no-fail-fast` — known pre-existing failures listed above
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Documentation updated (if applicable)