### PR TITLE
docs: complete the stale verb list in the CLI usage line

### DIFF
--- a/docs/site/docs/reference/cli-flags.md
+++ b/docs/site/docs/reference/cli-flags.md
@@ -17,9 +17,13 @@ Earlier releases used per-signal subcommands (`metrics`, `logs`, `histogram`, `s
 
 ## Global options
 
+<!-- verbs:listing -->
+
 ```
-sonda [OPTIONS] <run|list|show|new> [ARGS...]
+sonda [OPTIONS] <run|list|show|new|test|completions> [ARGS...]
 ```
+
+<!-- /verbs:listing -->
 
 | Flag | Short | Description |
 |------|-------|-------------|


### PR DESCRIPTION
## What changes

`docs/site/docs/reference/cli-flags.md` — the usage line under "Global options" read `sonda [OPTIONS] <run|list|show|new> [ARGS...]`, missing `test` and `completions`. Corrected, and wrapped in `<!-- verbs:listing -->` so it is checked from now on.

Nothing caught this: it is a listing with no adjacent count claim, so the verb-count check never saw it, and it carried no marker — the residual gap recorded in #569.

Verified: dropping `completions` from the corrected line now fails `every_marked_listing_names_every_verb` with `cli-flags.md:20 ... omits ["completions"]`. `validate_docs_commands.py` 159/159.

## Second purpose — confirming the #569 path filters

This is also a deliberate docs-only diff, opened as a draft to check how the filters merged in #569 behave. #569 could not test its own filters: its diff touched `sonda/**` and `sonda-core/**`, so both jobs ran on it as before.

This diff touches one file under `docs/site/docs/`. It cannot reach the binary, the image or the compose stack.

**Expected:** `Live Infra UAT (e2e matrix)` and `Docker Build (multi-arch verify)` do not appear in the checks; everything else runs.

**What would be a problem:** either check showing *"Expected — waiting for status to be reported"*. That would mean it is a required status check, and path-filtering it leaves docs PRs unmergeable. `main` is protected and neither I nor the reviewer could read which checks are required, so this is the cheapest way to find out.

If that happens, the filters get reverted rather than the protection loosened, and the finding goes on the record.
