### PR TITLE
fix(cli): --dry-run must refuse what run refuses

### DIFF
--- a/docs/site/docs/javascripts/livegen-presets.js
+++ b/docs/site/docs/javascripts/livegen-presets.js
@@ -193,20 +193,33 @@ export const WIDGETS = {
    * the same sine underneath for exactly that reason: hold the signal still
    * and the schedule becomes the only variable.
    *
-   * `for` reaches past `every` on purpose. The engine accepts that (verified:
-   * `sonda --dry-run run` compiles gaps and bursts at every corner of these
-   * ranges, including for=15s against every=5s), and the compile gate proves
-   * it on every CI run; the shading stays legible because scheduleWindows
-   * clips each window to its own cycle rather than painting one long band.
-   * Ranges chosen so the default shows three or four whole cycles in the
-   * 60-second sample — a period the eye can count.
+   * `for` never reaches `every`. The engine refuses `for >= every` for gaps
+   * and bursts alike (`gaps.for (..) must be less than gaps.every (..)`,
+   * config/validate.rs) — an open window that outlives its own cycle has no
+   * meaning to the scheduler. These are two INDEPENDENT range inputs, so the
+   * widget has no way to express a constraint that couples them; the ranges
+   * are therefore chosen DISJOINT instead: max(`for`) = 9 < min(`every`) = 10,
+   * which makes every point in the space runnable rather than only the
+   * corners the compile gate samples. `PAIR_RULES` in pure.test.mjs asserts
+   * that disjointness against the ranges, because a corner grid over
+   * {min, value, max} cannot see an interior pair that violates it.
+   *
+   * An earlier version of this comment claimed the opposite ("the engine
+   * accepts that, verified") and cited the compile gate as proof. The gate was
+   * running `sonda --dry-run run`, which at the time returned before
+   * validation ran — so it compiled nothing and agreed with whatever it was
+   * told. Do not restore the wider ranges without a run that actually fails.
+   *
+   * The shading stays legible because scheduleWindows clips each window to its
+   * own cycle rather than painting one long band. Ranges keep the default at
+   * four whole cycles in the 60-second sample — a period the eye can count.
    */
   gaps: {
     rate: 4,
     durationSecs: 60,
     sliders: [
-      { key: "every", min: 5, max: 30, step: 1, value: 15, unit: "s" },
-      { key: "for", min: 1, max: 15, step: 1, value: 5, unit: "s" },
+      { key: "every", min: 10, max: 30, step: 1, value: 15, unit: "s" },
+      { key: "for", min: 1, max: 9, step: 1, value: 5, unit: "s" },
     ],
     yaml(p) {
       return `${head(this.rate, this.durationSecs)}
@@ -222,8 +235,8 @@ export const WIDGETS = {
     rate: 4,
     durationSecs: 60,
     sliders: [
-      { key: "every", min: 5, max: 30, step: 1, value: 15, unit: "s" },
-      { key: "for", min: 1, max: 15, step: 1, value: 4, unit: "s" },
+      { key: "every", min: 10, max: 30, step: 1, value: 15, unit: "s" },
+      { key: "for", min: 1, max: 9, step: 1, value: 4, unit: "s" },
       { key: "multiplier", min: 1, max: 10, step: 0.5, value: 3, unit: "x" },
     ],
     yaml(p) {

--- a/docs/site/docs/javascripts/livegen-presets.js
+++ b/docs/site/docs/javascripts/livegen-presets.js
@@ -199,10 +199,10 @@ export const WIDGETS = {
    * meaning to the scheduler. These are two INDEPENDENT range inputs, so the
    * widget has no way to express a constraint that couples them; the ranges
    * are therefore chosen DISJOINT instead: max(`for`) = 9 < min(`every`) = 10,
-   * which makes every point in the space runnable rather than only the
-   * corners the compile gate samples. `PAIR_RULES` in pure.test.mjs asserts
-   * that disjointness against the ranges, because a corner grid over
-   * {min, value, max} cannot see an interior pair that violates it.
+   * which makes every point in the space runnable. `PAIR_RULES` in
+   * pure.test.mjs asserts that disjointness against the ranges; the compile
+   * gate catches it too, because `cornerParams` crosses the sliders and so
+   * always contains the worst pair.
    *
    * An earlier version of this comment claimed the opposite ("the engine
    * accepts that, verified") and cited the compile gate as proof. The gate was

--- a/docs/site/docs/reference/cli-flags.md
+++ b/docs/site/docs/reference/cli-flags.md
@@ -72,7 +72,7 @@ sonda [--catalog <DIR>] [--dry-run] [--format text|json] run <SCENARIO> [OVERRID
 | `--on-sink-error warn\|fail` | Override `defaults.on_sink_error`. |
 
 !!! info "`--dry-run` reads the data files your scenario references"
-    Validation runs the same pipeline `run` does, and some rules are facts about the data rather than the YAML — a `csv_replay` derives its rate from the capture's own timestamps, and cross-checks blank cells against declared `gap_windows:`. So a dry-run opens the CSV. If you validate in CI on a machine that has the scenario but not the capture, `--dry-run` will fail there. That is the check working: a config pointing at data that is not present is a finding, not a false alarm.
+    Validation runs the same pipeline `run` does, and some rules are facts about the data rather than the YAML — a `csv_replay` derives its rate from the capture's own timestamps. So a dry-run opens the CSV. If you validate in CI on a machine that has the scenario but not the capture, `--dry-run` will fail there. That is the check working: a config pointing at data that is not present is a finding, not a false alarm.
 
 ### Run a file
 

--- a/docs/site/docs/reference/cli-flags.md
+++ b/docs/site/docs/reference/cli-flags.md
@@ -71,6 +71,9 @@ sonda [--catalog <DIR>] [--dry-run] [--format text|json] run <SCENARIO> [OVERRID
 | `--label k=v` | Add a static label. Repeatable. |
 | `--on-sink-error warn\|fail` | Override `defaults.on_sink_error`. |
 
+!!! info "`--dry-run` reads the data files your scenario references"
+    Validation runs the same pipeline `run` does, and some rules are facts about the data rather than the YAML — a `csv_replay` derives its rate from the capture's own timestamps, and cross-checks blank cells against declared `gap_windows:`. So a dry-run opens the CSV. If you validate in CI on a machine that has the scenario but not the capture, `--dry-run` will fail there. That is the check working: a config pointing at data that is not present is a finding, not a false alarm.
+
 ### Run a file
 
 ```bash title="examples/cpu-spike.yaml"

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -508,19 +508,59 @@ test("duration-coupled slider floors cover the scenario duration (review #534 M1
   }
 });
 
-test("every min/max slider pair is non-crossable by range construction", () => {
-  // Generalises the baseline/ceiling rule above to the pairs WP13 added.
-  // The engine rejects `min >= max`, so a pair whose ranges OVERLAP ships a
-  // widget that compiles at rest and throws under the reader's hand — the
-  // failure only appears for the readers who actually play with it, which is
-  // everyone the widget is for. Disjoint ranges make it unreachable rather
-  // than merely untested.
-  for (const [gen, widget] of Object.entries(WIDGETS)) {
-    const lo = (widget.sliders || []).find((s) => s.key === "min");
-    const hi = (widget.sliders || []).find((s) => s.key === "max");
-    if (lo && hi) {
-      assert.ok(lo.max < hi.min, `${gen}: min range [${lo.min},${lo.max}] must sit below max range [${hi.min},${hi.max}]`);
+/* The cross-slider constraints the ENGINE enforces, checked against the slider
+ * RANGES rather than against sampled points.
+ *
+ * `lo` must stay strictly below `hi` for every combination a reader can drag
+ * to. Two sliders move independently, so the widget has no way to express that
+ * coupling — the only way to make it unreachable is to keep the two ranges
+ * disjoint, and disjointness is a property of the ranges themselves.
+ *
+ * Checking the ranges rather than sampling is the whole point. Every other
+ * gate over these presets samples: `cornerParams` takes each slider at
+ * {min, value, max} INDEPENDENTLY, so a pair that violates its constraint only
+ * at an interior combination is invisible to the corner grid and to the
+ * compile gate built on it. Comparing max(lo) to min(hi) covers the entire
+ * space in one comparison.
+ *
+ * `expected` is the anti-vacuity half. A renamed slider key, or a widget
+ * dropped from WIDGETS, would otherwise leave the loop matching nothing and
+ * reporting success — a check that covers zero widgets reads exactly like a
+ * check that covers all of them. Update the count deliberately.
+ */
+const PAIR_RULES = [
+  { lo: "min", hi: "max", expected: 2, engine: "the engine rejects min >= max" },
+  {
+    lo: "for",
+    hi: "every",
+    expected: 2,
+    engine: "the engine rejects for >= every for gaps, bursts and cardinality_spikes (config/validate.rs)",
+  },
+];
+
+test("cross-slider constraints are unreachable by range construction", () => {
+  // A pair whose ranges OVERLAP ships a widget that compiles at rest and
+  // throws under the reader's hand — the failure only appears for the readers
+  // who actually play with it, which is everyone the widget is for.
+  for (const rule of PAIR_RULES) {
+    let matched = 0;
+    for (const [gen, widget] of Object.entries(WIDGETS)) {
+      const lo = (widget.sliders || []).find((s) => s.key === rule.lo);
+      const hi = (widget.sliders || []).find((s) => s.key === rule.hi);
+      if (!lo || !hi) continue;
+      matched += 1;
+      assert.ok(
+        lo.max < hi.min,
+        `${gen}: ${rule.lo} range [${lo.min},${lo.max}] must sit below ` +
+          `${rule.hi} range [${hi.min},${hi.max}] — ${rule.engine}`
+      );
     }
+    assert.equal(
+      matched,
+      rule.expected,
+      `expected ${rule.expected} widgets pairing ${rule.lo}/${rule.hi}, found ${matched} — ` +
+        `a slider was renamed or a widget removed and this rule stopped covering it`
+    );
   }
 });
 

--- a/docs/site/tools/tests/pure.test.mjs
+++ b/docs/site/tools/tests/pure.test.mjs
@@ -508,20 +508,30 @@ test("duration-coupled slider floors cover the scenario duration (review #534 M1
   }
 });
 
-/* The cross-slider constraints the ENGINE enforces, checked against the slider
- * RANGES rather than against sampled points.
+/* Two-slider constraints, checked against the slider RANGES.
  *
  * `lo` must stay strictly below `hi` for every combination a reader can drag
  * to. Two sliders move independently, so the widget has no way to express that
- * coupling — the only way to make it unreachable is to keep the two ranges
+ * coupling — the only way to make a bad pair unreachable is to keep the ranges
  * disjoint, and disjointness is a property of the ranges themselves.
  *
- * Checking the ranges rather than sampling is the whole point. Every other
- * gate over these presets samples: `cornerParams` takes each slider at
- * {min, value, max} INDEPENDENTLY, so a pair that violates its constraint only
- * at an interior combination is invisible to the corner grid and to the
- * compile gate built on it. Comparing max(lo) to min(hi) covers the entire
- * space in one comparison.
+ * What this does NOT buy, stated because an earlier version of this comment
+ * claimed it and review #583 W3 disproved it by execution: it is not stronger
+ * than the compile gate for the `for`/`every` rule. `cornerParams` builds the
+ * full CROSS PRODUCT of each slider's {min, value, max}, so the worst pair
+ * (max lo, min hi) is always in the grid — and for a monotone constraint like
+ * this one, a violation exists if and only if that pair violates it. Restoring
+ * the old ranges makes the compile gate fail 3/648 on gaps alone. The two
+ * checks are equally strong there; this one is merely faster, needs no built
+ * binary, and names the ranges rather than one combination.
+ *
+ * Where it IS load-bearing is rule 1, and for the opposite reason: the engine
+ * does not reject `min >= max` for either widget that pairs them. A sawtooth
+ * with min 50 / max 10 compiles and runs, emitting a descending ramp; a uniform
+ * with the same pair emits values inside [10,50]. Both measured. So no compile
+ * gate can catch that one, and the reason to hold it is the widget's own
+ * coherence — a slider that lets a reader set a minimum above a maximum
+ * teaches a wrong shape — not an engine rule.
  *
  * `expected` is the anti-vacuity half. A renamed slider key, or a widget
  * dropped from WIDGETS, would otherwise leave the loop matching nothing and
@@ -529,19 +539,26 @@ test("duration-coupled slider floors cover the scenario duration (review #534 M1
  * check that covers all of them. Update the count deliberately.
  */
 const PAIR_RULES = [
-  { lo: "min", hi: "max", expected: 2, engine: "the engine rejects min >= max" },
+  {
+    lo: "min",
+    hi: "max",
+    expected: 2,
+    why: "widget coherence — the engine accepts min >= max here, so nothing else catches it",
+  },
   {
     lo: "for",
     hi: "every",
     expected: 2,
-    engine: "the engine rejects for >= every for gaps, bursts and cardinality_spikes (config/validate.rs)",
+    why: "the engine rejects for >= every for gaps, bursts and cardinality_spikes (config/validate.rs)",
   },
 ];
 
 test("cross-slider constraints are unreachable by range construction", () => {
   // A pair whose ranges OVERLAP ships a widget that compiles at rest and
-  // throws under the reader's hand — the failure only appears for the readers
-  // who actually play with it, which is everyone the widget is for.
+  // misbehaves under the reader's hand — either refused by the engine or
+  // silently drawing the wrong shape, depending on the rule. Either way the
+  // failure only reaches the readers who actually play with it, which is
+  // everyone the widget is for.
   for (const rule of PAIR_RULES) {
     let matched = 0;
     for (const [gen, widget] of Object.entries(WIDGETS)) {
@@ -552,7 +569,7 @@ test("cross-slider constraints are unreachable by range construction", () => {
       assert.ok(
         lo.max < hi.min,
         `${gen}: ${rule.lo} range [${lo.min},${lo.max}] must sit below ` +
-          `${rule.hi} range [${hi.min},${hi.max}] — ${rule.engine}`
+          `${rule.hi} range [${hi.min},${hi.max}] — ${rule.why}`
       );
     }
     assert.equal(

--- a/sonda-core/src/lib.rs
+++ b/sonda-core/src/lib.rs
@@ -69,7 +69,9 @@ pub use schedule::gate_bus::{
 #[cfg(feature = "runtime")]
 pub use schedule::handle::ScenarioHandle;
 #[cfg(feature = "runtime")]
-pub use schedule::launch::{launch_scenario, prepare_entries, validate_entry, PreparedEntry};
+pub use schedule::launch::{
+    launch_scenario, prepare_entries, prepare_entries_grouped, validate_entry, PreparedEntry,
+};
 #[cfg(feature = "runtime")]
 pub use schedule::stats::{ScenarioState, ScenarioStats};
 #[cfg(feature = "runtime")]

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -75,6 +75,16 @@ pub struct PreparedEntry {
     pub while_clause: Option<WhileClause>,
     /// Open / close debounce windows applied to `while:` transitions.
     pub delay_clause: Option<DelayClause>,
+    /// Index of the AUTHORED entry this one came from, into the slice passed to
+    /// [`prepare_entries`].
+    ///
+    /// Not always 1:1: a multi-column `csv_replay` fans one authored entry out
+    /// into one entry per series, and every one of them reports the same index.
+    /// `sonda --dry-run run` needs that mapping to show what will actually run
+    /// while still rendering the authored-only fields (`while:`, `after:`,
+    /// `clock_group`) that live on the compiled entry and do not survive
+    /// expansion.
+    pub source_index: usize,
 }
 
 /// Expand, validate, and resolve phase offsets for a batch of scenario entries.
@@ -158,6 +168,7 @@ pub fn prepare_entries(entries: Vec<ScenarioEntry>) -> Result<Vec<PreparedEntry>
             id: None,
             while_clause: None,
             delay_clause: None,
+            source_index: orig_idx,
         });
     }
 

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -75,16 +75,6 @@ pub struct PreparedEntry {
     pub while_clause: Option<WhileClause>,
     /// Open / close debounce windows applied to `while:` transitions.
     pub delay_clause: Option<DelayClause>,
-    /// Index of the AUTHORED entry this one came from, into the slice passed to
-    /// [`prepare_entries`].
-    ///
-    /// Not always 1:1: a multi-column `csv_replay` fans one authored entry out
-    /// into one entry per series, and every one of them reports the same index.
-    /// `sonda --dry-run run` needs that mapping to show what will actually run
-    /// while still rendering the authored-only fields (`while:`, `after:`,
-    /// `clock_group`) that live on the compiled entry and do not survive
-    /// expansion.
-    pub source_index: usize,
 }
 
 /// Expand, validate, and resolve phase offsets for a batch of scenario entries.
@@ -109,9 +99,34 @@ pub struct PreparedEntry {
 /// or phase-offset parsing. The error message includes the entry index for
 /// diagnostics.
 pub fn prepare_entries(entries: Vec<ScenarioEntry>) -> Result<Vec<PreparedEntry>, SondaError> {
+    Ok(prepare_entries_grouped(entries)?
+        .into_iter()
+        .flatten()
+        .collect())
+}
+
+/// [`prepare_entries`], with each authored entry's results kept together.
+///
+/// `result[i]` holds every entry that authored entry `i` expanded into, in
+/// order. Usually one; a multi-column `csv_replay` produces one per series, and
+/// an entry that expands to nothing produces an empty inner `Vec` — so the
+/// outer length always equals the input length and index `i` is always the
+/// authored entry `i`.
+///
+/// This exists because a caller that has to render an expanded entry alongside
+/// something only the AUTHORED entry knows — `sonda --dry-run run` and the
+/// `while:` / `after:` / `clock_group` fields the compiler resolves — needs the
+/// mapping, and flattening throws it away. Returning the grouping rather than
+/// stamping an index onto [`PreparedEntry`] keeps that struct's shape: it has
+/// all-public fields and no `#[non_exhaustive]`, so adding one would break
+/// every downstream struct literal (review #583 r2 M1).
+pub fn prepare_entries_grouped(
+    entries: Vec<ScenarioEntry>,
+) -> Result<Vec<Vec<PreparedEntry>>, SondaError> {
     // Phase 1: expand csv_replay multi-column entries, tracking the original
     // input index for each expanded entry so error messages reference the
     // index the caller provided rather than the post-expansion position.
+    let group_count = entries.len();
     let mut expanded: Vec<(usize, ScenarioEntry)> = Vec::new();
     for (i, entry) in entries.into_iter().enumerate() {
         let batch = expand_entry(entry).map_err(|e| {
@@ -142,8 +157,10 @@ pub fn prepare_entries(entries: Vec<ScenarioEntry>) -> Result<Vec<PreparedEntry>
         })
         .collect::<Result<Vec<_>, SondaError>>()?;
 
-    // Phase 2: validate all entries and resolve phase offsets.
-    let mut prepared = Vec::with_capacity(expanded.len());
+    // Phase 2: validate all entries and resolve phase offsets, keeping each
+    // authored entry's results in its own bucket.
+    let mut prepared: Vec<Vec<PreparedEntry>> = Vec::with_capacity(group_count);
+    prepared.resize_with(group_count, Vec::new);
     for (orig_idx, entry) in expanded {
         validate_entry(&entry).map_err(|e| {
             SondaError::Config(ConfigError::invalid(format!(
@@ -162,13 +179,12 @@ pub fn prepare_entries(entries: Vec<ScenarioEntry>) -> Result<Vec<PreparedEntry>
             None => None,
         };
 
-        prepared.push(PreparedEntry {
+        prepared[orig_idx].push(PreparedEntry {
             entry,
             start_delay,
             id: None,
             while_clause: None,
             delay_clause: None,
-            source_index: orig_idx,
         });
     }
 

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -62,6 +62,73 @@ pub async fn run_multi(
     }
 }
 
+/// Prepare one compiled entry for the **gated** launch path: translate, expand,
+/// desugar, validate.
+///
+/// This is the gated counterpart to [`prepare_entries`], and the single
+/// definition of what [`launch_multi_compiled`] will accept. It is not the same
+/// rulebook: multi-column `csv_replay` fan-out is legal in the ungated pipeline
+/// and refused here, because a gate needs one entry per gated signal and the
+/// fan-out produces several.
+///
+/// That difference is why this is a function rather than a loop body.
+/// [`validate_compiled_gated`] calls it so `sonda --dry-run run` asks the gated
+/// question about a gated file instead of the ungated one — a dry-run that
+/// validated against the wrong rulebook would bless a file `run` refuses, which
+/// is the defect the flag exists to catch.
+///
+/// `Ok(None)` means the entry expanded to nothing and the caller should skip it.
+#[cfg(feature = "config")]
+fn prepare_gated_entry(
+    compiled_entry: crate::compiler::compile_after::CompiledEntry,
+) -> Result<Option<ScenarioEntry>, SondaError> {
+    let id = compiled_entry.id.clone();
+
+    let translated = translate_entry(compiled_entry).map_err(|e| {
+        SondaError::Config(crate::ConfigError::invalid(format!("compile prepare: {e}")))
+    })?;
+
+    // Mirror the expand → desugar → validate pipeline that `prepare_entries`
+    // runs for non-gated launches. Skipping it here would let operational
+    // aliases (flap, saturation, etc.) reach `create_generator()` un-desugared
+    // and panic at runtime.
+    let mut expanded = expand_entry(translated)?;
+    let translated = match expanded.len() {
+        0 => return Ok(None),
+        1 => expanded.remove(0),
+        _ => {
+            return Err(SondaError::Config(crate::ConfigError::invalid(format!(
+                "scenario id {:?}: csv_replay multi-column expansion is not supported \
+                 when `while:` is in use; specify a single column or remove the gate",
+                id.as_deref().unwrap_or("(anonymous)"),
+            ))));
+        }
+    };
+    let translated = desugar_entry(translated)?;
+    validate_entry(&translated)?;
+    Ok(Some(translated))
+}
+
+/// Validate a compiled file through the **gated** pipeline without launching it.
+///
+/// Runs the same per-entry preparation [`launch_multi_compiled`] runs, and
+/// discards the result. `sonda --dry-run run` calls this for any file carrying a
+/// `while:` clause, so the two verbs decide from one rulebook rather than two.
+///
+/// Scope, stated because a validator that looks broader than it is would be
+/// worse than none: this covers per-entry preparation only. Gate-bus wiring and
+/// cross-POST resolution are not exercised, and do not need to be — a
+/// `while.scenario_name` on the CLI is refused at parse, and a `while.ref`
+/// naming an id that does not exist is refused at `compile_after`, so both
+/// already reach `--dry-run` through the compile step.
+#[cfg(feature = "config")]
+pub fn validate_compiled_gated(file: CompiledFile) -> Result<(), SondaError> {
+    for compiled_entry in file.entries.into_iter() {
+        prepare_gated_entry(compiled_entry)?;
+    }
+    Ok(())
+}
+
 /// Launch a compiled scenario file with `while:` / `after:` gating wired in.
 /// Each handle owns an independent cancellation token; see [`run_multi_compiled`]
 /// for the master-stop-all path.
@@ -111,28 +178,10 @@ pub async fn launch_multi_compiled(
         let delay_clause = compiled_entry.delay_clause.clone();
         let phase_offset = compiled_entry.phase_offset.clone();
 
-        let translated = translate_entry(compiled_entry).map_err(|e| {
-            SondaError::Config(crate::ConfigError::invalid(format!("compile prepare: {e}")))
-        })?;
-
-        // Mirror the expand → desugar → validate pipeline that
-        // `prepare_entries` runs for non-gated launches. Skipping it
-        // here would let operational aliases (flap, saturation, etc.)
-        // reach `create_generator()` un-desugared and panic at runtime.
-        let mut expanded = expand_entry(translated)?;
-        let translated = match expanded.len() {
-            0 => continue,
-            1 => expanded.remove(0),
-            _ => {
-                return Err(SondaError::Config(crate::ConfigError::invalid(format!(
-                    "scenario id {:?}: csv_replay multi-column expansion is not supported \
-                     when `while:` is in use; specify a single column or remove the gate",
-                    id.as_deref().unwrap_or("(anonymous)"),
-                ))));
-            }
+        let translated = match prepare_gated_entry(compiled_entry)? {
+            Some(entry) => entry,
+            None => continue,
         };
-        let translated = desugar_entry(translated)?;
-        validate_entry(&translated)?;
 
         let upstream_bus = id.as_ref().and_then(|name| buses.get(name).cloned());
 

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -109,11 +109,18 @@ fn prepare_gated_entry(
     Ok(Some(translated))
 }
 
-/// Validate a compiled file through the **gated** pipeline without launching it.
+/// Validate a compiled file through the **gated** pipeline without launching it,
+/// returning the entries that would run.
 ///
-/// Runs the same per-entry preparation [`launch_multi_compiled`] runs, and
-/// discards the result. `sonda --dry-run run` calls this for any file carrying a
-/// `while:` clause, so the two verbs decide from one rulebook rather than two.
+/// Runs the same per-entry preparation [`launch_multi_compiled`] runs.
+/// `sonda --dry-run run` calls this for any file carrying a `while:` clause, so
+/// the two verbs decide from one rulebook rather than two — and prints what
+/// comes back, so the view it shows is post-expansion rather than as-authored.
+///
+/// Each returned entry is paired with the index of the authored entry it came
+/// from. On this path that is always 1:1 (fan-out is refused above), but the
+/// pairing is what lets a caller render the authored-only fields — `while:`,
+/// `after:`, `clock_group` — which do not survive translation.
 ///
 /// Scope, stated because a validator that looks broader than it is would be
 /// worse than none: this covers per-entry preparation only. Gate-bus wiring and
@@ -122,11 +129,16 @@ fn prepare_gated_entry(
 /// naming an id that does not exist is refused at `compile_after`, so both
 /// already reach `--dry-run` through the compile step.
 #[cfg(feature = "config")]
-pub fn validate_compiled_gated(file: CompiledFile) -> Result<(), SondaError> {
-    for compiled_entry in file.entries.into_iter() {
-        prepare_gated_entry(compiled_entry)?;
+pub fn validate_compiled_gated(
+    file: CompiledFile,
+) -> Result<Vec<(usize, ScenarioEntry)>, SondaError> {
+    let mut out = Vec::with_capacity(file.entries.len());
+    for (index, compiled_entry) in file.entries.into_iter().enumerate() {
+        if let Some(entry) = prepare_gated_entry(compiled_entry)? {
+            out.push((index, entry));
+        }
     }
-    Ok(())
+    Ok(out)
 }
 
 /// Launch a compiled scenario file with `while:` / `after:` gating wired in.

--- a/sonda/src/dry_run.rs
+++ b/sonda/src/dry_run.rs
@@ -61,10 +61,19 @@ pub fn print_dry_run_compiled(
     Ok(())
 }
 
-/// Surface alias-validation and sink-config errors that would otherwise only
-/// fire inside `prepare_entries` (which dry-run never calls) or the sink
-/// factory at run time. Extend here for any future invariant that should
-/// reach operators at dry-run time.
+/// Surface alias-validation and sink-config errors that fire late — inside the
+/// sink factory at run time, or in a shape `prepare_entries` reports less
+/// clearly.
+///
+/// **Do not extend this with engine rules.** The sentence that used to be here
+/// said "which dry-run never calls" and invited exactly that; dry-run now calls
+/// the real pipelines (`prepare_entries`, or `validate_compiled_gated` for a
+/// gated file), so every invariant they enforce already reaches operators here
+/// without being written down twice. A transcribed rule diverges on whichever
+/// rule someone adds last, which is the failure this file's callers argue
+/// against four files away. What is left below earns its place only by
+/// producing a better message than the engine does, for a check the engine
+/// makes anyway or makes too late.
 fn validate_alias_invariants(compiled: &CompiledFile) -> anyhow::Result<()> {
     for entry in &compiled.entries {
         if let Some(GeneratorConfig::Flap {

--- a/sonda/src/dry_run.rs
+++ b/sonda/src/dry_run.rs
@@ -39,23 +39,47 @@ pub fn parse_format(value: Option<&str>) -> anyhow::Result<DryRunFormat> {
     }
 }
 
-/// Print the dry-run output for a [`CompiledFile`].
+/// One thing that will actually run, paired with the entry that authored it.
+///
+/// The two halves carry different truths and neither is sufficient alone.
+///
+/// * `runnable` is post-expansion. It is where a multi-column `csv_replay`
+///   becomes one entry per series, where that series' own metric name and
+///   per-column labels live, and where the rate a capture derives from its own
+///   timestamps replaces the authored one.
+/// * `source` is the authored [`CompiledEntry`]. `while:`, `after:`,
+///   `clock_group` and `phase_offset` are resolved by the compiler and do not
+///   survive translation into a runnable entry, so they can only be read here.
+///
+/// Printing only `source` is what review #583 W2 found: `--dry-run` said
+/// "2 scenarios" for a file that launches 3 series, and `--format json` listed
+/// two. A CI job counting scenarios got the authored count under a flag whose
+/// whole job is to answer "what would happen".
+pub struct RunnableView<'a> {
+    /// The entry as it will be launched.
+    pub runnable: &'a sonda_core::config::ScenarioEntry,
+    /// The authored entry it expanded from.
+    pub source: &'a CompiledEntry,
+}
+
+/// Print the dry-run output for a compiled file and the entries it expands to.
 ///
 /// Text output goes to stderr; JSON output goes to stdout.
 pub fn print_dry_run_compiled(
     source_label: &str,
     compiled: &CompiledFile,
+    runnable: &[RunnableView<'_>],
     format: DryRunFormat,
 ) -> anyhow::Result<()> {
     validate_alias_invariants(compiled)?;
     match format {
         DryRunFormat::Text => {
             let mut out = io::stderr().lock();
-            write_text_compiled(&mut out, source_label, compiled)?;
+            write_text_compiled(&mut out, source_label, compiled, runnable)?;
         }
         DryRunFormat::Json => {
             let mut out = io::stdout().lock();
-            write_json_compiled(&mut out, source_label, compiled)?;
+            write_json_compiled(&mut out, source_label, compiled, runnable)?;
         }
     }
     Ok(())
@@ -274,20 +298,23 @@ fn write_text_compiled<W: Write>(
     out: &mut W,
     source_label: &str,
     compiled: &CompiledFile,
+    runnable: &[RunnableView<'_>],
 ) -> io::Result<()> {
-    let entries = &compiled.entries;
-    let total = entries.len();
+    // The count is the RUNNABLE count, not the authored one. They differ
+    // whenever a multi-column csv_replay fans out, and the runnable count is
+    // what the flag is being asked about.
+    let total = runnable.len();
     let scenario_word = if total == 1 { "scenario" } else { "scenarios" };
     writeln!(
         out,
         "[config] file: {source_label} (version: 2, {total} {scenario_word})"
     )?;
 
-    let upstream_index = build_upstream_index(entries);
+    let upstream_index = build_upstream_index(&compiled.entries);
 
-    for (i, entry) in entries.iter().enumerate() {
+    for (i, view) in runnable.iter().enumerate() {
         writeln!(out)?;
-        write_compiled_entry_text(out, entry, &upstream_index, i + 1, total)?;
+        write_compiled_entry_text(out, view, &upstream_index, i + 1, total)?;
         if i + 1 < total {
             writeln!(out, "---")?;
         }
@@ -300,16 +327,31 @@ fn write_text_compiled<W: Write>(
 
 fn write_compiled_entry_text<W: Write>(
     out: &mut W,
-    entry: &CompiledEntry,
+    view: &RunnableView<'_>,
     upstream: &HashMap<&str, &CompiledEntry>,
     index: usize,
     total: usize,
 ) -> io::Result<()> {
-    writeln!(out, "[config] [{index}/{total}] {}", entry.name)?;
+    let entry = view.source;
+    let base = view.runnable.base();
+
+    // `name`, `rate` and `labels` come from the RUNNABLE half: expansion renames
+    // each fanned-out series, merges that column's own labels, and lets a
+    // csv_replay derive its rate from the capture's timestamps. Those three are
+    // exactly what W2 was about.
+    //
+    // Everything else stays on the AUTHORED half, including `generator:`.
+    // Expansion does not change what `generator_display` renders — the column
+    // index is not in it, and the series is already identified by `name:` — but
+    // DESUGARING does, and destructively: an entry written as `type: flap`
+    // prints as `sequence (90 values)` once desugared, which is true of the
+    // machine and useless to the person who wrote `flap`. Truthful about what
+    // runs is the goal; unrecognisable is not the same thing as truthful.
+    writeln!(out, "[config] [{index}/{total}] {}", base.name)?;
     writeln!(out)?;
-    write_field(out, "name:", &entry.name)?;
+    write_field(out, "name:", &base.name)?;
     write_field(out, "signal:", &entry.signal_type)?;
-    write_field(out, "rate:", &format!("{}/s", format_rate(entry.rate)))?;
+    write_field(out, "rate:", &format!("{}/s", format_rate(base.rate)))?;
     write_field(
         out,
         "duration:",
@@ -337,12 +379,21 @@ fn write_compiled_entry_text<W: Write>(
 
     write_field(out, "encoder:", &encoder_display(&entry.encoder))?;
     write_field(out, "sink:", &sink_display(&entry.sink))?;
-    write_labels_btree(out, entry.labels.as_ref())?;
+    write_labels_btree(out, sorted_labels(base.labels.as_ref()).as_ref())?;
+    // Authored-only from here down: the compiler resolves these and they do not
+    // survive translation, so `view.source` is the only place they exist.
     write_phase_offset_or_after_first_fire(out, entry)?;
     write_clock_group(out, &entry.clock_group, Some(entry.clock_group_is_auto))?;
     write_while_block(out, entry, upstream)?;
     write_delay_block(out, entry.delay_clause.as_ref())?;
     Ok(())
+}
+
+/// Labels on a runnable entry are a `HashMap`; the printer wants stable order.
+fn sorted_labels(
+    labels: Option<&std::collections::HashMap<String, String>>,
+) -> Option<std::collections::BTreeMap<String, String>> {
+    labels.map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
 }
 
 fn write_phase_offset_or_after_first_fire<W: Write>(
@@ -652,13 +703,13 @@ fn write_json_compiled<W: Write>(
     out: &mut W,
     source_label: &str,
     compiled: &CompiledFile,
+    runnable: &[RunnableView<'_>],
 ) -> io::Result<()> {
     let upstream = build_upstream_index(&compiled.entries);
-    let scenarios = compiled
-        .entries
+    let scenarios = runnable
         .iter()
         .enumerate()
-        .map(|(i, entry)| to_compiled_scenario_dto(i + 1, entry, &upstream))
+        .map(|(i, view)| to_compiled_scenario_dto(i + 1, view, &upstream))
         .collect();
 
     let dto = DryRunDto {
@@ -675,9 +726,12 @@ fn write_json_compiled<W: Write>(
 
 fn to_compiled_scenario_dto<'a>(
     index: usize,
-    entry: &'a CompiledEntry,
+    view: &RunnableView<'a>,
     upstream: &HashMap<&str, &CompiledEntry>,
 ) -> ScenarioDto<'a> {
+    let entry = view.source;
+    let base = view.runnable.base();
+
     let signal: &'static str = match entry.signal_type.as_str() {
         "metrics" => "metrics",
         "logs" => "logs",
@@ -685,6 +739,7 @@ fn to_compiled_scenario_dto<'a>(
         "summary" => "summary",
         _ => "unknown",
     };
+    // Authored, for the same reason the text printer uses it — see there.
     let generator = if let Some(ref g) = entry.generator {
         generator_display(g)
     } else if let Some(ref g) = entry.log_generator {
@@ -694,10 +749,14 @@ fn to_compiled_scenario_dto<'a>(
     } else {
         "unknown".to_string()
     };
-    let labels = entry
+    let labels = base
         .labels
         .as_ref()
-        .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        .map(|m| {
+            m.iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect::<std::collections::BTreeMap<_, _>>()
+        })
         .unwrap_or_default();
     let while_clause = entry.while_clause.as_ref().map(while_clause_display);
     let delay_clause = entry.delay_clause.as_ref().map(delay_clause_display);
@@ -708,14 +767,16 @@ fn to_compiled_scenario_dto<'a>(
 
     ScenarioDto {
         index,
-        name: entry.name.as_str(),
+        // Post-expansion: one DTO per series, each under its own metric name.
+        name: base.name.as_str(),
         signal,
-        rate: entry.rate,
+        rate: base.rate,
         duration: entry.duration.as_deref(),
         generator,
         encoder: encoder_display(&entry.encoder),
         sink: sink_display(&entry.sink),
         labels,
+        // Authored-only, read from the compiled entry.
         phase_offset: entry.phase_offset.as_deref(),
         clock_group: entry.clock_group.as_deref(),
         clock_group_is_auto: Some(entry.clock_group_is_auto),
@@ -728,6 +789,34 @@ fn to_compiled_scenario_dto<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build the printer's input by running the REAL expansion pipeline.
+    ///
+    /// Not a transcription of it: these tests exist to pin what `--dry-run`
+    /// shows, and a helper that constructed runnable entries by hand would
+    /// diverge from the launch path on exactly the field a bug is in.
+    fn runnable_of(compiled: &CompiledFile) -> Vec<(usize, sonda_core::config::ScenarioEntry)> {
+        let entries =
+            sonda_core::compiler::prepare::prepare(compiled.clone()).expect("prepare must succeed");
+        sonda_core::prepare_entries(entries)
+            .expect("prepare_entries must succeed")
+            .into_iter()
+            .map(|p| (p.source_index, p.entry))
+            .collect()
+    }
+
+    fn views<'a>(
+        compiled: &'a CompiledFile,
+        runnable: &'a [(usize, sonda_core::config::ScenarioEntry)],
+    ) -> Vec<RunnableView<'a>> {
+        runnable
+            .iter()
+            .map(|(i, entry)| RunnableView {
+                runnable: entry,
+                source: &compiled.entries[*i],
+            })
+            .collect()
+    }
     use sonda_core::compile_scenario_file_compiled;
     use sonda_core::compiler::expand::InMemoryPackResolver;
 
@@ -775,10 +864,87 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_text_compiled(&mut buf, "scn.yaml", &compiled).unwrap();
+        let runnable = runnable_of(&compiled);
+        let views = views(&compiled, &runnable);
+        write_text_compiled(&mut buf, "scn.yaml", &compiled, &views).unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(out.contains("[config] file: scn.yaml (version: 2, 1 scenario)"));
         assert!(out.contains("Validation: OK (1 scenario)"));
+    }
+
+    #[test]
+    fn dry_run_counts_the_series_that_will_run_not_the_blocks_authored() {
+        // Review #583 W2. One authored `csv_replay` block with two columns
+        // launches two series. Dry-run validated the expansion and then printed
+        // the file that went in, so it said "1 scenario" for a run that starts
+        // two — under a flag whose whole job is to answer "what would happen".
+        let dir = tempfile::tempdir().expect("tempdir");
+        let csv = dir.path().join("cap.csv");
+        std::fs::write(&csv, "timestamp,cpu,mem\n0.000,10,50\n1.000,20,60\n").expect("write csv");
+
+        let compiled = compile(&format!(
+            r#"version: 2
+kind: runnable
+defaults:
+  rate: 1
+  duration: 2s
+scenarios:
+  - id: replay
+    signal_type: metrics
+    name: capture
+    generator:
+      type: csv_replay
+      file: {}
+      columns:
+        - index: 1
+          name: cpu_percent
+        - index: 2
+          name: mem_percent
+"#,
+            csv.display()
+        ));
+
+        // Premise: the file really does author ONE block. Without this the
+        // assertions below would pass against a two-block file that never
+        // exercised fan-out at all.
+        assert_eq!(
+            compiled.entries.len(),
+            1,
+            "premise: the fixture must author exactly one entry"
+        );
+
+        let mut buf = Vec::new();
+        let runnable = runnable_of(&compiled);
+        let views = views(&compiled, &runnable);
+        write_text_compiled(&mut buf, "fanout.yaml", &compiled, &views).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+
+        assert!(
+            out.contains("(version: 2, 2 scenarios)")
+                && out.contains("Validation: OK (2 scenarios)"),
+            "the count must be the series that will run, not the blocks authored, got:\n{out}"
+        );
+        assert!(
+            out.contains("cpu_percent") && out.contains("mem_percent"),
+            "each expanded series must appear under its own metric name, got:\n{out}"
+        );
+
+        // And the JSON a CI job parses must agree with the text.
+        let mut json = Vec::new();
+        write_json_compiled(&mut json, "fanout.yaml", &compiled, &views).unwrap();
+        let dto: serde_json::Value =
+            serde_json::from_slice(&json).expect("dry-run JSON must parse");
+        let scenarios = dto["scenarios"].as_array().expect("scenarios array");
+        assert_eq!(
+            scenarios.len(),
+            2,
+            "--format json must list one entry per series, got:\n{dto:#}"
+        );
+        let names: Vec<&str> = scenarios
+            .iter()
+            .filter_map(|s| s["name"].as_str())
+            .collect();
+        assert_eq!(names, vec!["cpu_percent", "mem_percent"], "got:\n{dto:#}");
     }
 
     #[test]
@@ -805,7 +971,9 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_text_compiled(&mut buf, "multi.yaml", &compiled).unwrap();
+        let runnable = runnable_of(&compiled);
+        let views = views(&compiled, &runnable);
+        write_text_compiled(&mut buf, "multi.yaml", &compiled, &views).unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(out.contains("(version: 2, 2 scenarios)"));
         assert!(out.contains("Validation: OK (2 scenarios)"));
@@ -844,11 +1012,23 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_text_compiled(&mut buf, "link-failover.yaml", &compiled).unwrap();
+        let runnable = runnable_of(&compiled);
+        let views = views(&compiled, &runnable);
+        write_text_compiled(&mut buf, "link-failover.yaml", &compiled, &views).unwrap();
         let out = String::from_utf8(buf).unwrap();
+        // Assert the phase_offset LINE, not two substrings that can match in
+        // different places. The previous form was `contains("phase_offset:")
+        // && contains("60")`, and the "60" it matched was in the *generator*
+        // line of the *other* entry — `flap (up_duration: 60s, ...)`. Rendering
+        // the desugared generator instead made that incidental match vanish and
+        // the test fail for a reason unrelated to what it is named for.
+        let offset_line = out
+            .lines()
+            .find(|l| l.trim_start().starts_with("phase_offset:"))
+            .unwrap_or_else(|| panic!("phase_offset line must render, got:\n{out}"));
         assert!(
-            out.contains("phase_offset:") && out.contains("60"),
-            "phase_offset line must render, got:\n{out}"
+            offset_line.contains("1m"),
+            "the after-chain resolves to a 60s offset, which renders as `1m`; got: {offset_line:?}\n{out}"
         );
         assert!(
             out.contains("chain_backup_util"),
@@ -880,7 +1060,9 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_json_compiled(&mut buf, "scn.yaml", &compiled).unwrap();
+        let runnable = runnable_of(&compiled);
+        let views = views(&compiled, &runnable);
+        write_json_compiled(&mut buf, "scn.yaml", &compiled, &views).unwrap();
         let json: serde_json::Value = serde_json::from_slice(&buf).expect("json parses");
         assert_eq!(json["file"], "scn.yaml");
         assert_eq!(json["version"], 2);
@@ -921,7 +1103,9 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_text_compiled(&mut buf, "while-analytical.yaml", &compiled).unwrap();
+        let runnable = runnable_of(&compiled);
+        let views = views(&compiled, &runnable);
+        write_text_compiled(&mut buf, "while-analytical.yaml", &compiled, &views).unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.contains("while:"),
@@ -968,7 +1152,9 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_text_compiled(&mut buf, "while-non-analytical.yaml", &compiled).unwrap();
+        let runnable = runnable_of(&compiled);
+        let views = views(&compiled, &runnable);
+        write_text_compiled(&mut buf, "while-non-analytical.yaml", &compiled, &views).unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.contains("<indeterminate — non-analytical generator>"),
@@ -1010,7 +1196,9 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_text_compiled(&mut buf, "while-delay.yaml", &compiled).unwrap();
+        let runnable = runnable_of(&compiled);
+        let views = views(&compiled, &runnable);
+        write_text_compiled(&mut buf, "while-delay.yaml", &compiled, &views).unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.contains("delay:") && out.contains("open=5s") && out.contains("close=10s"),
@@ -1105,7 +1293,9 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_text_compiled(&mut buf, "mixed-upstream.yaml", &compiled).unwrap();
+        let runnable = runnable_of(&compiled);
+        let views = views(&compiled, &runnable);
+        write_text_compiled(&mut buf, "mixed-upstream.yaml", &compiled, &views).unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.contains("after_first_fire:") && out.contains("(ref: trigger)"),
@@ -1159,7 +1349,9 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_json_compiled(&mut buf, "while-json.yaml", &compiled).unwrap();
+        let runnable = runnable_of(&compiled);
+        let views = views(&compiled, &runnable);
+        write_json_compiled(&mut buf, "while-json.yaml", &compiled, &views).unwrap();
         let json: serde_json::Value = serde_json::from_slice(&buf).unwrap();
         let traffic = json["scenarios"]
             .as_array()
@@ -1196,7 +1388,9 @@ scenarios:
 "#,
         );
         let mut buf = Vec::new();
-        write_json_compiled(&mut buf, "no-clauses.yaml", &compiled).unwrap();
+        let runnable = runnable_of(&compiled);
+        let views = views(&compiled, &runnable);
+        write_json_compiled(&mut buf, "no-clauses.yaml", &compiled, &views).unwrap();
         let body = String::from_utf8(buf).unwrap();
         assert!(
             !body.contains("while_clause"),

--- a/sonda/src/dry_run.rs
+++ b/sonda/src/dry_run.rs
@@ -796,12 +796,29 @@ mod tests {
     /// shows, and a helper that constructed runnable entries by hand would
     /// diverge from the launch path on exactly the field a bug is in.
     fn runnable_of(compiled: &CompiledFile) -> Vec<(usize, sonda_core::config::ScenarioEntry)> {
+        // Pick the pipeline `main.rs` would pick for this file. Always calling
+        // the ungated one left the gated pairing with no unit coverage at all
+        // (review #583 r2 M2) — and "the two pipelines produce identical
+        // entries for anything the gated one accepts" is exactly the kind of
+        // reasoning this helper's own docstring argues against relying on.
+        let has_gates = compiled.entries.iter().any(|e| e.while_clause.is_some());
+        if has_gates {
+            return sonda_core::schedule::multi_runner::validate_compiled_gated(compiled.clone())
+                .expect("validate_compiled_gated must succeed");
+        }
+
         let entries =
             sonda_core::compiler::prepare::prepare(compiled.clone()).expect("prepare must succeed");
-        sonda_core::prepare_entries(entries)
-            .expect("prepare_entries must succeed")
+        assert_eq!(
+            entries.len(),
+            compiled.entries.len(),
+            "`prepare` must stay a 1:1 order-preserving map for the pairing below"
+        );
+        sonda_core::prepare_entries_grouped(entries)
+            .expect("prepare_entries_grouped must succeed")
             .into_iter()
-            .map(|p| (p.source_index, p.entry))
+            .enumerate()
+            .flat_map(|(i, group)| group.into_iter().map(move |p| (i, p.entry)))
             .collect()
     }
 

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -106,6 +106,29 @@ fn run_scenario(
 
     if cli_opts.dry_run {
         let format = dry_run::parse_format(cli_opts.format.as_deref())?;
+        // Validate through the pipeline the runtime uses, not a second list of
+        // its rules.
+        //
+        // `--dry-run` returned here before doing this, which meant it never ran
+        // `prepare_entries` — and therefore never ran `expand_scenario`, where
+        // csv_replay derives its rate from the file's timestamps, fans a
+        // multi-column capture out into one entry per series, and rejects a
+        // file it cannot replay. So a scenario `sonda run` refuses printed
+        // "Validation: OK", which is worse than saying nothing: the whole point
+        // of the flag is to answer "would this run?" without running it, and CI
+        // users reach for it precisely to catch this class before a deploy.
+        //
+        // The fix is to call the real thing rather than teach this path to
+        // recognise the same failures — a transcription would diverge on
+        // exactly the rule that was added last. `prepare` and `prepare_entries`
+        // are the same two calls the non-dry-run path makes immediately below;
+        // the only difference is that nothing is launched afterwards.
+        //
+        // The clone is because `prepare` consumes the file and the printer
+        // still needs it. It happens once, on a path that is about to exit.
+        let entries = sonda_core::compiler::prepare::prepare(compiled.clone())
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        sonda_core::prepare_entries(entries).map_err(|e| anyhow::anyhow!("{}", e))?;
         dry_run::print_dry_run_compiled(&args.scenario, &compiled, format)?;
         return Ok(());
     }

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -135,15 +135,48 @@ fn run_scenario(
         //
         // The clone is because both pipelines consume the file and the printer
         // still needs it. It happens once, on a path that is about to exit.
-        if has_gates {
+        //
+        // And what it prints is what came BACK from that pipeline, not the file
+        // that went in. Validating and then rendering the pre-expansion view
+        // fixed the refusal half of parity and left the reporting half wrong:
+        // a multi-column `csv_replay` launches one series per column, so
+        // "Validation: OK (2 scenarios)" for a file that runs three is the same
+        // flag telling the same CI job the same kind of untruth.
+        let runnable: Vec<(usize, sonda_core::config::ScenarioEntry)> = if has_gates {
             sonda_core::schedule::multi_runner::validate_compiled_gated(compiled.clone())
-                .map_err(|e| anyhow::anyhow!("{}", e))?;
+                .map_err(|e| anyhow::anyhow!("{}", e))?
         } else {
             let entries = sonda_core::compiler::prepare::prepare(compiled.clone())
                 .map_err(|e| anyhow::anyhow!("{}", e))?;
-            sonda_core::prepare_entries(entries).map_err(|e| anyhow::anyhow!("{}", e))?;
-        }
-        dry_run::print_dry_run_compiled(&args.scenario, &compiled, format)?;
+            sonda_core::prepare_entries(entries)
+                .map_err(|e| anyhow::anyhow!("{}", e))?
+                .into_iter()
+                .map(|p| (p.source_index, p.entry))
+                .collect()
+        };
+
+        // Pair each runnable entry with the entry that authored it. `while:`,
+        // `after:`, `clock_group` and `phase_offset` are resolved by the
+        // compiler and do not survive translation, so they can only be read
+        // from the compiled side.
+        let views: Vec<dry_run::RunnableView<'_>> = runnable
+            .iter()
+            .map(|(source_index, entry)| {
+                let source = compiled.entries.get(*source_index).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "internal: expanded entry reports source index {source_index}, \
+                         but the compiled file has {} entries",
+                        compiled.entries.len()
+                    )
+                })?;
+                Ok(dry_run::RunnableView {
+                    runnable: entry,
+                    source,
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        dry_run::print_dry_run_compiled(&args.scenario, &compiled, &views, format)?;
         return Ok(());
     }
 

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -120,15 +120,29 @@ fn run_scenario(
         //
         // The fix is to call the real thing rather than teach this path to
         // recognise the same failures — a transcription would diverge on
-        // exactly the rule that was added last. `prepare` and `prepare_entries`
-        // are the same two calls the non-dry-run path makes immediately below;
-        // the only difference is that nothing is launched afterwards.
+        // exactly the rule that was added last.
         //
-        // The clone is because `prepare` consumes the file and the printer
+        // AND IT HAS TO BE THE RIGHT REAL THING. `run` has two launch paths and
+        // they do not share a rulebook: a file with a `while:` clause goes to
+        // `launch_multi_compiled`, whose per-entry preparation refuses things
+        // the ungated `prepare_entries` accepts — multi-column `csv_replay`
+        // fan-out most of all, because a gate needs one entry per gated signal.
+        // Calling only the ungated pipeline restored most of parity and left
+        // the gated branch blessing files `run` refuses, which is worse than
+        // the original bug: the flag now looks trustworthy. So dry-run
+        // dispatches on `has_gates` exactly as the launch below does, and the
+        // two branches call the two pipelines.
+        //
+        // The clone is because both pipelines consume the file and the printer
         // still needs it. It happens once, on a path that is about to exit.
-        let entries = sonda_core::compiler::prepare::prepare(compiled.clone())
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
-        sonda_core::prepare_entries(entries).map_err(|e| anyhow::anyhow!("{}", e))?;
+        if has_gates {
+            sonda_core::schedule::multi_runner::validate_compiled_gated(compiled.clone())
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+        } else {
+            let entries = sonda_core::compiler::prepare::prepare(compiled.clone())
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
+            sonda_core::prepare_entries(entries).map_err(|e| anyhow::anyhow!("{}", e))?;
+        }
         dry_run::print_dry_run_compiled(&args.scenario, &compiled, format)?;
         return Ok(());
     }
@@ -145,7 +159,7 @@ fn run_scenario(
         sonda_core::compiler::prepare::prepare(compiled).map_err(|e| anyhow::anyhow!("{}", e))?;
     let prepared = sonda_core::prepare_entries(entries).map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    if handle_pre_launch(&prepared, verbosity, cli_opts.dry_run) {
+    if handle_pre_launch(&prepared, verbosity) {
         return Ok(());
     }
 
@@ -225,19 +239,18 @@ fn show_entry(args: &cli::ShowArgs, catalog: Option<&std::path::Path>) -> anyhow
     Ok(())
 }
 
-fn handle_pre_launch(prepared: &[PreparedEntry], verbosity: Verbosity, dry_run: bool) -> bool {
+/// Print the pre-launch banner, and report whether the caller should stop.
+///
+/// It always returns `false` now. It used to carry a second `--dry-run`
+/// implementation — printing the entries and a second "Validation: OK" — which
+/// became unreachable when the dry-run branch in `run_scenario` started
+/// returning before this call. `dry_run.rs` owns that output and is the only
+/// thing that prints it. The `bool` stays because the shape is the useful one:
+/// a future pre-launch check that should abort has somewhere to say so.
+fn handle_pre_launch(prepared: &[PreparedEntry], verbosity: Verbosity) -> bool {
     if verbosity == Verbosity::Verbose {
         status::print_version();
-    }
-    let total = prepared.len();
-    if dry_run {
-        for (i, p) in prepared.iter().enumerate() {
-            status::print_config(&p.entry, i + 1, total);
-        }
-        status::print_dry_run_ok(total);
-        return true;
-    }
-    if verbosity == Verbosity::Verbose {
+        let total = prepared.len();
         for (i, p) in prepared.iter().enumerate() {
             status::print_config(&p.entry, i + 1, total);
         }

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -148,10 +148,29 @@ fn run_scenario(
         } else {
             let entries = sonda_core::compiler::prepare::prepare(compiled.clone())
                 .map_err(|e| anyhow::anyhow!("{}", e))?;
-            sonda_core::prepare_entries(entries)
+
+            // The pairing below indexes `compiled.entries` with a position from
+            // the slice handed to `prepare_entries_grouped`. Those are the same
+            // index only because `prepare` is a strict order-preserving 1:1 map.
+            // It is today, and nothing states it — so state it here, where a
+            // future `prepare` that filtered would trip loudly instead of
+            // silently handing one series another entry's `while:` block
+            // (review #583 r2).
+            anyhow::ensure!(
+                entries.len() == compiled.entries.len(),
+                "internal: `prepare` returned {} entries for {} compiled entries. \
+                 The dry-run view pairs them by position and can no longer do so.",
+                entries.len(),
+                compiled.entries.len(),
+            );
+
+            sonda_core::prepare_entries_grouped(entries)
                 .map_err(|e| anyhow::anyhow!("{}", e))?
                 .into_iter()
-                .map(|p| (p.source_index, p.entry))
+                .enumerate()
+                .flat_map(|(source_index, group)| {
+                    group.into_iter().map(move |p| (source_index, p.entry))
+                })
                 .collect()
         };
 
@@ -192,9 +211,7 @@ fn run_scenario(
         sonda_core::compiler::prepare::prepare(compiled).map_err(|e| anyhow::anyhow!("{}", e))?;
     let prepared = sonda_core::prepare_entries(entries).map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    if handle_pre_launch(&prepared, verbosity) {
-        return Ok(());
-    }
+    handle_pre_launch(&prepared, verbosity);
 
     if prepared.len() == 1 {
         let p = prepared.into_iter().next().expect("len checked above");
@@ -272,15 +289,16 @@ fn show_entry(args: &cli::ShowArgs, catalog: Option<&std::path::Path>) -> anyhow
     Ok(())
 }
 
-/// Print the pre-launch banner, and report whether the caller should stop.
+/// Print the pre-launch banner.
 ///
-/// It always returns `false` now. It used to carry a second `--dry-run`
-/// implementation — printing the entries and a second "Validation: OK" — which
-/// became unreachable when the dry-run branch in `run_scenario` started
-/// returning before this call. `dry_run.rs` owns that output and is the only
-/// thing that prints it. The `bool` stays because the shape is the useful one:
-/// a future pre-launch check that should abort has somewhere to say so.
-fn handle_pre_launch(prepared: &[PreparedEntry], verbosity: Verbosity) -> bool {
+/// It used to return a `bool` saying whether the caller should stop, for a
+/// second `--dry-run` implementation that printed the entries and its own
+/// "Validation: OK". That became unreachable when the dry-run branch in
+/// `run_scenario` started returning above this call, so the flag was always
+/// `false` and the caller's `if … { return }` was dead code that read like a
+/// live branch. `dry_run.rs` owns that output and is the only thing that
+/// prints it.
+fn handle_pre_launch(prepared: &[PreparedEntry], verbosity: Verbosity) {
     if verbosity == Verbosity::Verbose {
         status::print_version();
         let total = prepared.len();
@@ -288,7 +306,6 @@ fn handle_pre_launch(prepared: &[PreparedEntry], verbosity: Verbosity) -> bool {
             status::print_config(&p.entry, i + 1, total);
         }
     }
-    false
 }
 
 fn run_single_scenario(

--- a/sonda/src/status.rs
+++ b/sonda/src/status.rs
@@ -8,7 +8,6 @@
 //! complete in the `run` subcommand. [`print_version`] displays the crate
 //! version and enabled features. [`print_show_header`] prints a styled header
 //! for the `scenarios show` subcommand.
-//! hint message for contextual help on errors.
 //!
 //! The dry-run validation result is NOT printed from here — `dry_run.rs` owns
 //! that output. This module used to carry a second printer for it, reached

--- a/sonda/src/status.rs
+++ b/sonda/src/status.rs
@@ -7,9 +7,13 @@
 //! [`print_summary`] function prints an aggregate summary after all scenarios
 //! complete in the `run` subcommand. [`print_version`] displays the crate
 //! version and enabled features. [`print_show_header`] prints a styled header
-//! for the `scenarios show` subcommand. [`print_dry_run_ok`] shows the
-//! validation result with a scenario count.
+//! for the `scenarios show` subcommand.
 //! hint message for contextual help on errors.
+//!
+//! The dry-run validation result is NOT printed from here — `dry_run.rs` owns
+//! that output. This module used to carry a second printer for it, reached
+//! from a branch that became unreachable once the dry-run path started
+//! returning before the launch banner.
 
 use std::time::Duration;
 
@@ -493,21 +497,6 @@ fn print_clock_group_line(clock_group: &Option<String>) {
         let label = label.if_supports_color(Stderr, |t| t.bold());
         eprintln!("  {label} {group}");
     }
-}
-
-/// Print the dry-run validation result to stderr.
-///
-/// Called after all entries are printed in dry-run mode to confirm that
-/// validation passed. The `scenario_count` is displayed alongside the OK
-/// status (e.g. `"Validation: OK (3 scenarios)"`).
-pub fn print_dry_run_ok(scenario_count: usize) {
-    let ok_label = "OK".if_supports_color(Stderr, |t| t.green());
-    let noun = if scenario_count == 1 {
-        "scenario"
-    } else {
-        "scenarios"
-    };
-    eprintln!("Validation: {ok_label} ({scenario_count} {noun})");
 }
 
 /// Build the version string displayed by [`print_version`].
@@ -1645,25 +1634,6 @@ mod tests {
             },
         });
         print_config(&entry, 1, 1);
-    }
-
-    // -----------------------------------------------------------------------
-    // print_dry_run_ok: does not panic, correct pluralization
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn print_dry_run_ok_single_scenario_does_not_panic() {
-        print_dry_run_ok(1);
-    }
-
-    #[test]
-    fn print_dry_run_ok_multiple_scenarios_does_not_panic() {
-        print_dry_run_ok(3);
-    }
-
-    #[test]
-    fn print_dry_run_ok_zero_scenarios_does_not_panic() {
-        print_dry_run_ok(0);
     }
 
     // -----------------------------------------------------------------------

--- a/sonda/tests/cli_run_dispatch.rs
+++ b/sonda/tests/cli_run_dispatch.rs
@@ -321,15 +321,31 @@ fn both_verdicts(path: &std::path::Path) -> (std::process::Output, std::process:
 }
 
 fn assert_verdicts_agree(run: &std::process::Output, dry: &std::process::Output) {
+    let run_err = String::from_utf8_lossy(&run.stderr);
+    let dry_err = String::from_utf8_lossy(&dry.stderr);
+
     assert_eq!(
         dry.status.success(),
         run.status.success(),
         "`--dry-run` and `run` must agree. run={:?} dry-run={:?}\n\
-         run stderr:\n{}\ndry-run stderr:\n{}\ndry-run stdout:\n{}",
+         run stderr:\n{run_err}\ndry-run stderr:\n{dry_err}\ndry-run stdout:\n{}",
         run.status.code(),
         dry.status.code(),
-        String::from_utf8_lossy(&run.stderr),
-        String::from_utf8_lossy(&dry.stderr),
         String::from_utf8_lossy(&dry.stdout),
     );
+
+    // Agreeing on the exit code is weaker than it looks: two paths could refuse
+    // the same file for DIFFERENT reasons and every parity test would still
+    // pass (review #583 r2). The stronger property held in every divergence
+    // probe either of us ran, so assert it rather than leave it a coincidence.
+    //
+    // Refusal side only. When both accept, `run` goes on to emit events and its
+    // stderr carries banners and a summary `--dry-run` has no reason to print;
+    // requiring those to match would be asserting the wrong thing.
+    if !run.status.success() {
+        assert_eq!(
+            run_err, dry_err,
+            "both verbs refused, so they must refuse for the same stated reason"
+        );
+    }
 }

--- a/sonda/tests/cli_run_dispatch.rs
+++ b/sonda/tests/cli_run_dispatch.rs
@@ -201,16 +201,7 @@ fn dry_run_refuses_what_run_refuses() {
     .expect("write YAML");
     yaml.flush().expect("flush");
 
-    let run = Command::new(sonda_bin())
-        .args(["--quiet", "run"])
-        .arg(yaml.path())
-        .output()
-        .expect("must spawn sonda");
-    let dry = Command::new(sonda_bin())
-        .args(["--quiet", "--dry-run", "run"])
-        .arg(yaml.path())
-        .output()
-        .expect("must spawn sonda");
+    let (run, dry) = both_verdicts(yaml.path());
 
     // The premise: if `run` ever stops refusing this file, the comparison below
     // would pass vacuously with both succeeding.
@@ -219,7 +210,117 @@ fn dry_run_refuses_what_run_refuses() {
         "premise: `run` must refuse a non-monotonic capture; stderr:\n{}",
         String::from_utf8_lossy(&run.stderr)
     );
+    assert_verdicts_agree(&run, &dry);
+}
 
+/// The other direction: a scenario `run` accepts must still dry-run cleanly.
+///
+/// Without this, the parity above could be satisfied by making `--dry-run`
+/// refuse everything.
+///
+/// The fixture is gated (`while:`), so this is also the accept-side coverage of
+/// the gated dispatch — but only because it spawns BOTH verbs. It did not, and
+/// that is precisely how the gated branch shipped unvalidated: a test named for
+/// a comparison it never made, asserting that one verb exits 0.
+#[test]
+fn dry_run_still_accepts_what_run_accepts() {
+    let fixture = cli_fixtures_dir().join("while-cascade.v2.yaml");
+    let (run, dry) = both_verdicts(&fixture);
+
+    assert!(
+        run.status.success(),
+        "premise: `run` must accept this fixture, or the comparison below is \
+         vacuous; stderr:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_verdicts_agree(&run, &dry);
+}
+
+/// The gated launch path has its own rulebook, and `--dry-run` must ask it.
+///
+/// `run` dispatches a file carrying a `while:` clause to `launch_multi_compiled`,
+/// whose per-entry preparation refuses things the ungated `prepare_entries`
+/// accepts. Multi-column `csv_replay` fan-out is the sharpest case: legal
+/// ungated, refused here because a gate needs one entry per gated signal.
+///
+/// Measured before the dispatch fix, both binaries at the PR head:
+///
+/// ```text
+/// $ sonda run gated-multicol.yaml
+/// error: configuration error: scenario id "replay": csv_replay multi-column
+///        expansion is not supported when `while:` is in use; ...
+/// exit=1
+/// $ sonda --dry-run run gated-multicol.yaml
+/// Validation: OK (2 scenarios)
+/// exit=0
+/// ```
+///
+/// The premise assertion matters more than usual here: if the gated runner ever
+/// starts accepting the fan-out, this test must fail loudly rather than quietly
+/// comparing two zeros.
+#[test]
+fn dry_run_refuses_what_the_gated_run_refuses() {
+    use std::io::Write;
+
+    let mut csv = tempfile::Builder::new()
+        .prefix("gated_multicol_")
+        .suffix(".csv")
+        .tempfile()
+        .expect("create temp CSV");
+    writeln!(csv, "timestamp,cpu,mem").expect("write header");
+    writeln!(csv, "0.000,10,50").expect("write row");
+    writeln!(csv, "1.000,20,60").expect("write row");
+    writeln!(csv, "2.000,30,70").expect("write row");
+    csv.flush().expect("flush");
+
+    let mut yaml = tempfile::Builder::new()
+        .prefix("gated_parity_")
+        .suffix(".v2.yaml")
+        .tempfile()
+        .expect("create temp YAML");
+    write!(
+        yaml,
+        "version: 2\nkind: runnable\ndefaults:\n  duration: 2s\n  encoder:\n    \
+         type: prometheus_text\n  sink:\n    type: stdout\nscenarios:\n  \
+         - id: src\n    signal_type: metrics\n    name: src\n    rate: 1\n    \
+         generator:\n      type: constant\n      value: 1\n  \
+         - id: replay\n    signal_type: metrics\n    name: capture\n    rate: 1\n    \
+         generator:\n      type: csv_replay\n      file: {}\n      columns:\n        \
+         - index: 1\n          name: cpu_percent\n        - index: 2\n          \
+         name: mem_percent\n    while:\n      ref: src\n      op: '>'\n      value: 0\n",
+        csv.path().display()
+    )
+    .expect("write YAML");
+    yaml.flush().expect("flush");
+
+    let (run, dry) = both_verdicts(yaml.path());
+
+    assert!(
+        !run.status.success(),
+        "premise: the gated runner must refuse multi-column fan-out, or this \
+         comparison is vacuous; stderr:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_verdicts_agree(&run, &dry);
+}
+
+/// Drive both verbs over one file. The comparison has one definition so a test
+/// cannot accidentally be named for a comparison it does not make.
+fn both_verdicts(path: &std::path::Path) -> (std::process::Output, std::process::Output) {
+    let run = Command::new(sonda_bin())
+        .args(["--quiet", "run"])
+        .arg(path)
+        .output()
+        .expect("must spawn sonda");
+    let dry = Command::new(sonda_bin())
+        .args(["--quiet", "--dry-run", "run"])
+        .arg(path)
+        .output()
+        .expect("must spawn sonda");
+    (run, dry)
+}
+
+fn assert_verdicts_agree(run: &std::process::Output, dry: &std::process::Output) {
     assert_eq!(
         dry.status.success(),
         run.status.success(),
@@ -230,25 +331,5 @@ fn dry_run_refuses_what_run_refuses() {
         String::from_utf8_lossy(&run.stderr),
         String::from_utf8_lossy(&dry.stderr),
         String::from_utf8_lossy(&dry.stdout),
-    );
-}
-
-/// The other direction: a scenario `run` accepts must still dry-run cleanly.
-///
-/// Without this, the parity above could be satisfied by making `--dry-run`
-/// refuse everything.
-#[test]
-fn dry_run_still_accepts_what_run_accepts() {
-    let fixture = cli_fixtures_dir().join("while-cascade.v2.yaml");
-    let output = Command::new(sonda_bin())
-        .args(["--quiet", "--dry-run", "run"])
-        .arg(&fixture)
-        .output()
-        .expect("must spawn sonda");
-
-    assert!(
-        output.status.success(),
-        "a valid scenario must still dry-run cleanly; stderr:\n{}",
-        String::from_utf8_lossy(&output.stderr)
     );
 }

--- a/sonda/tests/cli_run_dispatch.rs
+++ b/sonda/tests/cli_run_dispatch.rs
@@ -154,3 +154,101 @@ fn v2_compile_error_surfaces_with_context() {
         "error must identify the source file or the self-reference, got:\n{stderr}"
     );
 }
+
+// ---- `--dry-run` and `run` must agree on what they refuse --------------------
+
+/// `--dry-run` must refuse every scenario `run` refuses.
+///
+/// It used to return before `prepare_entries`, so it never ran
+/// `expand_scenario` — where csv_replay derives its rate from the file's
+/// timestamps and rejects a file it cannot replay. A scenario `sonda run`
+/// errors on printed "Validation: OK", which is the opposite of what the flag
+/// is for: CI reaches for `--dry-run` precisely to catch this class before a
+/// deploy.
+///
+/// The test drives both verbs over the same file and compares their verdicts
+/// rather than asserting a message, so it keeps holding as rules are added to
+/// the expansion path — which is the failure mode a transcribed list of rules
+/// would have.
+#[test]
+fn dry_run_refuses_what_run_refuses() {
+    use std::io::Write;
+
+    let mut csv = tempfile::Builder::new()
+        .prefix("nonmono_")
+        .suffix(".csv")
+        .tempfile()
+        .expect("create temp CSV");
+    // Timestamps run backwards, so the replay rate cannot be derived. This is
+    // rejected inside `expand_scenario`, which is the step `--dry-run` skipped.
+    writeln!(csv, "Time,cpu").expect("write header");
+    writeln!(csv, "1700000010,1").expect("write row");
+    writeln!(csv, "1700000000,2").expect("write row");
+    csv.flush().expect("flush");
+
+    let mut yaml = tempfile::Builder::new()
+        .prefix("dry_run_parity_")
+        .suffix(".v2.yaml")
+        .tempfile()
+        .expect("create temp YAML");
+    write!(
+        yaml,
+        "version: 2\nkind: runnable\nscenarios:\n  - signal_type: metrics\n    \
+         name: cpu\n    rate: 1\n    duration: 5s\n    generator:\n      \
+         type: csv_replay\n      file: {}\n",
+        csv.path().display()
+    )
+    .expect("write YAML");
+    yaml.flush().expect("flush");
+
+    let run = Command::new(sonda_bin())
+        .args(["--quiet", "run"])
+        .arg(yaml.path())
+        .output()
+        .expect("must spawn sonda");
+    let dry = Command::new(sonda_bin())
+        .args(["--quiet", "--dry-run", "run"])
+        .arg(yaml.path())
+        .output()
+        .expect("must spawn sonda");
+
+    // The premise: if `run` ever stops refusing this file, the comparison below
+    // would pass vacuously with both succeeding.
+    assert!(
+        !run.status.success(),
+        "premise: `run` must refuse a non-monotonic capture; stderr:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+
+    assert_eq!(
+        dry.status.success(),
+        run.status.success(),
+        "`--dry-run` and `run` must agree. run={:?} dry-run={:?}\n\
+         run stderr:\n{}\ndry-run stderr:\n{}\ndry-run stdout:\n{}",
+        run.status.code(),
+        dry.status.code(),
+        String::from_utf8_lossy(&run.stderr),
+        String::from_utf8_lossy(&dry.stderr),
+        String::from_utf8_lossy(&dry.stdout),
+    );
+}
+
+/// The other direction: a scenario `run` accepts must still dry-run cleanly.
+///
+/// Without this, the parity above could be satisfied by making `--dry-run`
+/// refuse everything.
+#[test]
+fn dry_run_still_accepts_what_run_accepts() {
+    let fixture = cli_fixtures_dir().join("while-cascade.v2.yaml");
+    let output = Command::new(sonda_bin())
+        .args(["--quiet", "--dry-run", "run"])
+        .arg(&fixture)
+        .output()
+        .expect("must spawn sonda");
+
+    assert!(
+        output.status.success(),
+        "a valid scenario must still dry-run cleanly; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION

## Summary

`sonda --dry-run run` returned before validating. A scenario `sonda run` refuses printed `Validation: OK`, which is worse than the flag saying nothing — its whole purpose is to answer *"would this run?"* without running it, and CI reaches for it precisely to catch that class before a deploy.

Closing it turned out to have three parts, each found by the one before:

1. **It never validated at all.** It returned before `prepare_entries`, so it never reached `expand_scenario`.
2. **`run` has two launch paths and they do not share a rulebook.** Validating through only the ungated one left gated files blessed that `run` refuses.
3. **It validated and then printed the file that went in.** The refusal half of parity was fixed and the reporting half stayed wrong.

Plus the widget defect the fix exposed once the docs compile gate became truthful.

## Changes

**`sonda/src/main.rs`** — the dry-run branch runs the same pipeline the launch does, dispatching on `has_gates` exactly as the launch below it does, and prints what came back rather than what went in.

Deliberately *not* done: teaching the dry-run path to recognise the same failures. A transcribed list of rules diverges on exactly the rule someone added last — the shape #565 already fixed once, for retry policy.

**`sonda-core/src/schedule/multi_runner.rs`** — the gated per-entry pipeline (translate → expand → desugar → validate) is now `prepare_gated_entry`, called by both `launch_multi_compiled` and the new `validate_compiled_gated`, so the two verbs share one definition rather than a transcription. It is not the same rulebook as `prepare_entries`: multi-column `csv_replay` fan-out is legal ungated and refused here, because a gate needs one entry per gated signal. That is the divergence that let a gated file pass dry-run and fail `run`.

`validate_compiled_gated` is scoped to per-entry preparation and says so in its doc comment. Gate-bus wiring and cross-POST resolution are not exercised and do not need to be — a `while.scenario_name` on the CLI is refused at parse, and a `while.ref` naming a missing id at `compile_after`, so both already reach dry-run through the compile step.

**`sonda-core/src/schedule/launch.rs`** — new `prepare_entries_grouped`, returning one inner `Vec` per **authored** entry; `prepare_entries` becomes a flatten over it. Purely additive: `PreparedEntry` is unchanged. The grouping is the relationship the printer needs — an earlier revision stamped a `source_index` field onto `PreparedEntry` instead, which breaks every downstream struct literal, since that struct is public with all-public fields and no `#[non_exhaustive]` and the crate publishes to crates.io.

`main.rs` asserts the invariant that makes the pairing sound: it indexes `compiled.entries` by a position from the slice handed to `prepare_entries_grouped`, and those coincide only because `compiler::prepare` is a strict order-preserving 1:1 map. A future `prepare` that filtered would now trip loudly rather than hand one series another entry's `while:` block.

**`sonda/src/dry_run.rs`** — the printer takes `RunnableView` pairs instead of the compiled file alone. Which half each field comes from is the design:

| from the **runnable** half | from the **authored** half |
|---|---|
| `name`, `rate`, `labels`, and the scenario count | `generator`, `encoder`, `sink`, `duration`, `phase_offset`, `clock_group`, `while:`, `delay:` |
| expansion renames each series, merges that column's labels, and lets a csv_replay derive its rate from the capture's timestamps | the compiler resolves the last four and they do not survive translation at all |

`generator:` is on the authored side deliberately, and I had it wrong first: rendering the runnable generator turns an entry written as `type: flap` into `sequence (90 values)` — true of the machine, useless to whoever wrote `flap` — and expansion does not change what the display renders anyway, since the column index is not in it and the series is already identified by `name:`.

**`docs/site/docs/javascripts/livegen-presets.js`** — the `gaps` and `bursts` widgets offered `every` 5..30 against `for` 1..15, and the engine rejects `for >= every` for both. A reader could drag one slider from its default into a configuration that cannot run. The ranges are now disjoint (`for` 1..9 below `every` 10..30, both defaults unchanged). The comment above them claimed the opposite and cited the compile gate as proof — a claim verified against the check that wasn't checking.

## Test plan

**Parity, in `sonda/tests/cli_run_dispatch.rs`.** All three tests drive both verbs through one `both_verdicts` helper and compare through one `assert_verdicts_agree`, so a parity test cannot again be named for a comparison it does not make. Each asserts its premise first, so none can pass vacuously. And the comparison is stronger than exit codes: when both verbs refuse, their stderr must match, so two paths cannot refuse the same file for different reasons with every test green.

- `dry_run_refuses_what_run_refuses` — ungated, a capture whose timestamps run backwards. Red-verified by removing the fix: `run=Some(1) dry-run=Some(0)`.
- `dry_run_refuses_what_the_gated_run_refuses` — multi-column `csv_replay` behind a `while:` gate. Red-verified by reverting the dispatch alone, with both validation calls left in place: `run=Some(1) dry-run=Some(0)`, and the other two parity tests stay green, so this is the one covering the gated branch rather than a duplicate.
- `dry_run_still_accepts_what_run_accepts` — the other direction. Parity alone would also be satisfied by making `--dry-run` refuse everything.

**Reporting, in `sonda/src/dry_run.rs`.** `dry_run_counts_the_series_that_will_run_not_the_blocks_authored` asserts the fixture authors exactly one block, then that the text count, both series names, and the `--format json` array all report two. Red-verified by reverting the count to `compiled.entries.len()`.

Measured end to end on a two-column capture — dry-run and the real run now agree:

```
$ sonda --dry-run run ungated-multicol.yaml
  (version: 2, 2 scenarios)    name: cpu_percent    name: mem_percent
$ sonda --dry-run --format json run ungated-multicol.yaml
  2 ['cpu_percent', 'mem_percent']
$ sonda -v run ungated-multicol.yaml
  2 [config] blocks
```

**Widget ranges.** `PAIR_RULES` in `pure.test.mjs` checks the ranges rather than sampled points. Red-verified three ways, each mutation confirmed present before its result was trusted: widening `gaps.for` back to 15, renaming the `bursts` `for` key, and overlapping the `sawtooth` min/max pair.

**Three checks that were weaker than they looked**, all fixed here:

- The `dry_run` unit tests called the writers with a hand-built `CompiledFile`. They now build the printer's input by running the real pipeline — **and the same pipeline `main.rs` would pick for that file**, so the gated pairing has coverage rather than being assumed equivalent to the ungated one.
- `text_prints_phase_offset_and_clock_group_for_after_chain` asserted `contains("phase_offset:") && contains("60")`. The `"60"` it matched lived in the *generator* line of the *other* entry (`flap (up_duration: 60s, ...)`) — two independent substrings satisfied in two different places, neither the line the test is named for. It now finds the `phase_offset:` line and asserts on that line.
- `assert_verdicts_agree` compared two booleans. See above.

Gates: `cargo test --workspace --no-fail-fast` green apart from five failures that reproduce identically on clean `main` in this container — `sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message` and `tests::sink_file_error_produces_sink_variant` (both need a non-root uid), and `global_inflight_limit_gates_across_routes`, `health_remains_responsive_when_control_plane_is_saturated`, `request_timeout_returns_408_with_structured_error` in `sonda-server`. `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all -- --check` clean, 118 doc fences compiled 0 failed, `mkdocs build --strict` clean, 648 slider combinations compile, 197 pure-helper tests.

**One flake observed, not swept up.** `while_runtime_steady_within_5pct_of_baseline` failed on the first full-workspace run and passed on the next two, plus 5/5 in isolation on this tree and 5/5 in isolation on the unmodified tree. It compares event counts of two 300ms runs within 5% while a dozen other test binaries compete for CPU, and it drives `launch_scenario_with_gates` directly rather than any pipeline this diff touches. Load-sensitive and pre-existing — but it can fail in CI, so it is written down rather than left to be rediscovered.

## Known limitations

- **Scenarios that were passing `--dry-run` while being unrunnable now fail it.** That is the point, but it is a behaviour change for anyone relying on the looser check.
- **`--dry-run` now opens the data files a scenario references.** Rate derivation is a fact about the CSV, not the YAML. Validating in CI on a machine that has the scenario and not the capture will now fail there — a config pointing at data that is not present is a finding, not a false alarm. Named in the CLI flag reference where a CI user would look.
- **`--dry-run --format json` now lists one entry per series rather than per authored block**, so a job counting scenarios sees a different number. It is the number that will run.
- **The two scheduling widgets lose the ranges `every` 5..9 and `for` 10..15.** Sliders are independent range inputs, so a constraint coupling them cannot be expressed without new widget machinery; disjointness is the established pattern in this same file (sawtooth, uniform, saturation, leak and step all pair sliders this way).
- The config types have no `deny_unknown_fields` on nested blocks, so a typo inside `generator:` or `sink:` is still silently ignored. Unknown fields at the scenario-entry and file-top levels *are* rejected. Pre-existing, repo-wide, untouched here.

## Merge ordering with #571

Neither has merged; `origin/main` is still this PR's base. Whichever lands second needs `main` merged in and CI re-run — and for #571 that matters more than ordinary hygiene, because its fixtures have never been dry-run through a `--dry-run` that validates, and the docs compile gate only acquired teeth in this PR. A green CI run on #571's current head is a green run of the toothless gate.