### PR TITLE
fix(core): a capture with no recorded silence still owes its rows

### DIFF
--- a/docs/site/docs/build/scheduling.md
+++ b/docs/site/docs/build/scheduling.md
@@ -101,7 +101,9 @@ The two kinds of silence are judged against different clocks, and the difference
 
 **A recurring `gaps:` is a wall-clock interval.** It simulates an exporter that is down from here to here, so a run that has fallen behind is genuinely inside the outage and stays silent for it.
 
-**When a scenario declares both**, the recurring gap is still judged by the wall — but a row it did not cover is emitted late rather than dropped. A recorded row outranks a simulated outage. Rows whose own slot really does sit inside either silence stay suppressed; only rows the run merely owes are caught up.
+**When a scenario has recorded rows and a recurring gap**, the gap is still judged by the wall — but a row it did not cover is emitted late rather than dropped. A recorded row outranks a simulated outage. Rows whose own slot really does sit inside either silence stay suppressed; only rows the run merely owes are caught up.
+
+A scenario counts as having recorded rows if it **replays a capture** (`csv_replay`, or `log_csv_replay` for logs) **or** declares `gap_windows:`. Either is enough. The first covers a capture that happens to contain no silence at all — every cell present, so no windows to declare — which would otherwise be treated as synthetic and lose rows to a slow sink. The second covers a hand-written scenario that describes recorded absence without replaying a file.
 
 This pairs with `csv_replay`: a blank cell in the CSV means the sample was absent, and the window is what turns that absence back into silence. Sonda refuses a scenario where the two disagree in either direction — a blank cell with no window over it, or a window over a row that has a value. Today you write both by hand, or emit them from your own tooling; a `sonda new` importer that captures a Prometheus range and emits the pair is in progress, and this page will say so when it ships.
 

--- a/docs/site/docs/build/scheduling.md
+++ b/docs/site/docs/build/scheduling.md
@@ -101,7 +101,9 @@ The two kinds of silence are judged against different clocks, and the difference
 
 **A recurring `gaps:` is a wall-clock interval.** It simulates an exporter that is down from here to here, so a run that has fallen behind is genuinely inside the outage and stays silent for it.
 
-**When a scenario has recorded rows and a recurring gap**, the gap is still judged by the wall — but a row it did not cover is emitted late rather than dropped. A recorded row outranks a simulated outage. Rows whose own slot really does sit inside either silence stay suppressed; only rows the run merely owes are caught up.
+**When a scenario has recorded rows and a recurring gap**, the gap is still judged by the wall — but a row it did not cover is emitted late rather than dropped. A recorded row outranks a simulated outage: a row the gap did not cover is caught up rather than dropped.
+
+Which rows a *recurring* gap covers is a wall-clock question, though, and that has a consequence worth knowing. `gap_windows:` are judged against the row's own slot, so a row inside one stays silent however late the run is — that is the guarantee a replay depends on. `gaps:` is judged against real time, so a run that has fallen behind can reach a row whose slot sits inside the outage *after* the outage has ended, and emit it. That is the same "an outage is happening now" semantics described above, seen from the other side; if you need silence pinned to particular rows, declare it with `gap_windows:`.
 
 A scenario counts as having recorded rows if it **replays a capture** (`csv_replay`, or `log_csv_replay` for logs) **or** declares `gap_windows:`. Either is enough. The first covers a capture that happens to contain no silence at all — every cell present, so no windows to declare — which would otherwise be treated as synthetic and lose rows to a slow sink. The second covers a hand-written scenario that describes recorded absence without replaying a file.
 

--- a/sonda-core/src/schedule/core_loop.rs
+++ b/sonda-core/src/schedule/core_loop.rs
@@ -422,30 +422,28 @@ pub(crate) async fn run_schedule_loop_with_initial_tick(
             // owed ROW and emits the backlog late; a run that did not starts at
             // the CLOCK and drops it.
             //
-            // The predicate is exactly "`gap_windows:` is non-empty", and the
-            // name says that and nothing more. It is NOT "this run is replaying
-            // a capture", which is what an earlier name claimed and the
-            // scheduler cannot know: `gap_windows` lives on
-            // `BaseScheduleConfig` and any generator may set it. Both
-            // directions, stated because only one of them used to be:
+            // The predicate is a UNION of two facts, and it needs both:
             //
-            //   absence declared  =>  MAY be a capture, may equally be a
-            //                         hand-written synthetic scenario, which
-            //                         then gets catch-up that `gaps:` alone
-            //                         does not. `gap_window_alignment.rs` proves
-            //                         it — its probe drives a `sequence`
-            //                         generator with no capture in sight.
-            //   absence absent    =>  there are certainly no recorded rows for
-            //                         the wall to outrank. This half is sound.
+            //   the generator replays recorded rows  — set by the signal runner
+            //       from the generator itself, which is the only place that is
+            //       knowable. This is the half that protects a FULLY-PRESENT
+            //       capture: it declares no windows, so the other half is false,
+            //       and before this existed a user-added `gaps:` still deleted
+            //       its rows under a stall.
             //
-            // Known limit, stated rather than papered over: a capture with no
-            // recorded absence declares no windows, so its rows get the
-            // synthetic treatment. Closing that needs a compiler-derived flag
-            // saying the generator IS a replay — a different predicate from
-            // this one, not a better implementation of it.
-            let declared_recorded_absence = !schedule.gap_windows.is_empty();
+            //   `gap_windows:` is declared              — a hand-written
+            //       synthetic scenario may declare recorded absence without
+            //       replaying anything, and it keeps the protection. Dropping
+            //       this half to "replay only" would be a behaviour regression
+            //       for scenarios that shipped with it.
+            //
+            // Neither implies the other, which is why it is an OR and not a
+            // rename. `gap_windows` lives on `BaseScheduleConfig` and any
+            // generator may set it; a capture may contain no silence at all.
+            let has_recorded_rows =
+                schedule.replays_recorded_rows || !schedule.gap_windows.is_empty();
             let resumed_at = elapsed + sleep_for;
-            let mut ticks_elapsed = if declared_recorded_absence {
+            let mut ticks_elapsed = if has_recorded_rows {
                 tick - initial_tick
             } else {
                 // Truncation is a LOWER bound, not the answer. When a window
@@ -467,10 +465,13 @@ pub(crate) async fn run_schedule_loop_with_initial_tick(
             // In the synthetic branch that total really is at most two, and
             // this comment twice said otherwise. It does not walk a window it
             // was not slept through: `not_yet` is gated on
-            // `!declared_recorded_absence`, which is true exactly when
-            // `gap_windows` is empty — exactly when there is no one-shot window
-            // for `resumed_at` to land inside. With no windows `sleep_for` is
-            // the periodic gap's end and truncation lands at most one slot low.
+            // `!has_recorded_rows`, and since that predicate is an OR,
+            // `!has_recorded_rows` IMPLIES `gap_windows` is empty — so there is
+            // no one-shot window for `resumed_at` to land inside. (Implies, not
+            // "exactly when": the converse fails for a replay that declares no
+            // windows, which is the case the OR was added to cover.) With no
+            // windows `sleep_for` is the periodic gap's end and truncation
+            // lands at most one slot low.
             //
             // It does not walk the BACKLOG either. The walk starts at the owed
             // row and stops at the first slot that is not silent; the backlog
@@ -482,7 +483,7 @@ pub(crate) async fn run_schedule_loop_with_initial_tick(
             // not how many rows are owed.
             loop {
                 let slot = base_interval.mul_f64(ticks_elapsed as f64);
-                let not_yet = !declared_recorded_absence && slot < resumed_at;
+                let not_yet = !has_recorded_rows && slot < resumed_at;
                 let still_silent = schedule
                     .gap_window
                     .as_ref()
@@ -1696,6 +1697,7 @@ mod tests {
     /// Build a minimal ParsedSchedule for testing.
     fn minimal_schedule(duration: Option<Duration>) -> ParsedSchedule {
         ParsedSchedule {
+            replays_recorded_rows: false,
             gap_windows: Vec::new(),
             total_duration: duration,
             gap_window: None,
@@ -1791,6 +1793,7 @@ mod tests {
     #[tokio::test]
     async fn loop_suppresses_events_during_gap() {
         let schedule = ParsedSchedule {
+            replays_recorded_rows: false,
             gap_windows: Vec::new(),
             total_duration: Some(Duration::from_secs(2)),
             gap_window: Some(GapWindow {
@@ -1842,6 +1845,7 @@ mod tests {
     #[tokio::test]
     async fn loop_increases_rate_during_burst() {
         let schedule = ParsedSchedule {
+            replays_recorded_rows: false,
             gap_windows: Vec::new(),
             total_duration: Some(Duration::from_secs(1)),
             gap_window: None,
@@ -1982,6 +1986,7 @@ mod tests {
         use crate::schedule::CardinalitySpikeWindow;
 
         let schedule = ParsedSchedule {
+            replays_recorded_rows: false,
             gap_windows: Vec::new(),
             total_duration: Some(Duration::from_millis(100)),
             gap_window: None,

--- a/sonda-core/src/schedule/histogram_runner.rs
+++ b/sonda-core/src/schedule/histogram_runner.rs
@@ -40,7 +40,11 @@ pub async fn run_with_sink_gated(
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
 ) -> Result<(), SondaError> {
-    let schedule = ParsedSchedule::from_base_config(&config.base)?;
+    let mut schedule = ParsedSchedule::from_base_config(&config.base)?;
+    // Stated rather than inherited from the default: this signal has no
+    // generator field, so nothing here can replay recorded rows. See
+    // runner.rs, where the value is derived from the generator.
+    schedule.replays_recorded_rows = false;
 
     // Defaults resolution is shared with every other consumer (the wasm
     // playground facade included) via from_config.

--- a/sonda-core/src/schedule/log_runner.rs
+++ b/sonda-core/src/schedule/log_runner.rs
@@ -44,7 +44,11 @@ pub async fn run_logs_with_sink_gated(
     // Parse the schedule (duration, gap/burst/spike windows) from the shared
     // BaseScheduleConfig. This is the single authoritative parsing location —
     // no duplication with the metric runner.
-    let schedule = ParsedSchedule::from_base_config(&config.base)?;
+    let mut schedule = ParsedSchedule::from_base_config(&config.base)?;
+    // Set here and not in `from_base_config`, which never sees the
+    // generator. `core_loop` needs it to know whether a row owed during a
+    // stall may be dropped.
+    schedule.replays_recorded_rows = super::log_generator_replays_recorded_rows(&config.generator);
 
     // Build log generator and encoder from config.
     let generator = create_log_generator(&config.generator)?;

--- a/sonda-core/src/schedule/mod.rs
+++ b/sonda-core/src/schedule/mod.rs
@@ -168,6 +168,47 @@ pub fn time_until_gap_window_end(elapsed: Duration, windows: &[OneShotGap]) -> D
     cursor.saturating_sub(elapsed)
 }
 
+/// Does this generator replay rows that something recorded?
+///
+/// The question `core_loop` needs answered to know whether a row owed during a
+/// stall may be dropped. A recorded row belongs to whoever recorded it and must
+/// be emitted late rather than deleted; tick 2 of a sine is not a thing anyone
+/// recorded, and a recurring `gaps:` is entitled to swallow it.
+///
+/// Exhaustive on purpose — no `_ =>` arm. A new generator that replays captured
+/// data must be added here, and the compiler will say so rather than letting it
+/// inherit the synthetic answer silently.
+pub(crate) fn generator_replays_recorded_rows(gen: &crate::generator::GeneratorConfig) -> bool {
+    use crate::generator::GeneratorConfig as G;
+    match gen {
+        G::CsvReplay { .. } => true,
+        G::Constant { .. }
+        | G::Uniform { .. }
+        | G::Sine { .. }
+        | G::Sawtooth { .. }
+        | G::Sequence { .. }
+        | G::Step { .. }
+        | G::Spike { .. }
+        | G::Flap { .. }
+        | G::Saturation { .. }
+        | G::Leak { .. }
+        | G::Degradation { .. }
+        | G::Steady { .. }
+        | G::SpikeEvent { .. } => false,
+    }
+}
+
+/// The log-signal counterpart of [`generator_replays_recorded_rows`].
+pub(crate) fn log_generator_replays_recorded_rows(
+    gen: &crate::generator::LogGeneratorConfig,
+) -> bool {
+    use crate::generator::LogGeneratorConfig as G;
+    match gen {
+        G::CsvReplay { .. } => true,
+        G::Template { .. } => false,
+    }
+}
+
 /// Resolved configuration for a cardinality spike window.
 ///
 /// Built from a [`CardinalitySpikeConfig`](crate::config::CardinalitySpikeConfig)
@@ -263,6 +304,18 @@ impl DynamicLabel {
 /// Constructed via [`ParsedSchedule::from_base_config`].
 #[derive(Debug, Clone)]
 pub(crate) struct ParsedSchedule {
+    /// Whether this scenario replays rows that something recorded.
+    ///
+    /// Set from the GENERATOR by the signal runners, because that is the only
+    /// place both halves are in scope — `from_base_config` sees the schedule
+    /// and never the generator, so it leaves this `false`.
+    ///
+    /// `core_loop` uses it to decide whether a row owed during a stall is
+    /// emitted late or dropped. Before this existed the decision keyed on
+    /// `gap_windows` being declared, which is a fine proxy for a capture that
+    /// contains silence and no proxy at all for one that does not — a
+    /// fully-present capture under a user-added `gaps:` still lost rows.
+    pub replays_recorded_rows: bool,
     /// Total run duration. `None` means run indefinitely.
     pub total_duration: Option<Duration>,
     /// Optional recurring gap window.
@@ -399,6 +452,8 @@ impl ParsedSchedule {
         };
 
         Ok(Self {
+            // The generator is not in scope here. Signal runners set it.
+            replays_recorded_rows: false,
             total_duration,
             gap_window,
             gap_windows,

--- a/sonda-core/src/schedule/runner.rs
+++ b/sonda-core/src/schedule/runner.rs
@@ -44,7 +44,11 @@ pub async fn run_with_sink_gated(
     upstream_bus: Option<Arc<GateBus>>,
     gate_ctx: Option<GateContext>,
 ) -> Result<(), SondaError> {
-    let schedule = ParsedSchedule::from_base_config(&config.base)?;
+    let mut schedule = ParsedSchedule::from_base_config(&config.base)?;
+    // Set here and not in `from_base_config`, which never sees the
+    // generator. `core_loop` needs it to know whether a row owed during a
+    // stall may be dropped.
+    schedule.replays_recorded_rows = super::generator_replays_recorded_rows(&config.generator);
 
     let generator = create_generator(&config.generator, config.rate)?;
     let generator =

--- a/sonda-core/src/schedule/summary_runner.rs
+++ b/sonda-core/src/schedule/summary_runner.rs
@@ -40,7 +40,11 @@ pub async fn run_with_sink_gated(
     stats: Option<Arc<RwLock<ScenarioStats>>>,
     gate_ctx: Option<GateContext>,
 ) -> Result<(), SondaError> {
-    let schedule = ParsedSchedule::from_base_config(&config.base)?;
+    let mut schedule = ParsedSchedule::from_base_config(&config.base)?;
+    // Stated rather than inherited from the default: this signal has no
+    // generator field, so nothing here can replay recorded rows. See
+    // runner.rs, where the value is derived from the generator.
+    schedule.replays_recorded_rows = false;
 
     // Defaults resolution is shared with every other consumer (the wasm
     // playground facade included) via from_config.

--- a/sonda-core/tests/gap_window_alignment.rs
+++ b/sonda-core/tests/gap_window_alignment.rs
@@ -593,9 +593,22 @@ async fn a_stall_under_both_silences_still_owes_every_row_outside_them() {
 /// `gap_windows` is empty, so this passes only if the predicate consults the
 /// generator.
 ///
-/// Ticks 4 and 5 are deliberately unasserted: their slots sit inside the
-/// simulated outage, and a row the user covered is covered. The claim is
-/// narrower — falling behind is not itself a reason to drop a recorded row.
+/// Only rows 2 and 3 are asserted, and the reason the others are left alone is
+/// worth stating, because the obvious version of it is wrong.
+///
+/// `gaps: every 1s for 200ms` puts the silence at the TAIL of each cycle —
+/// `[800ms, 1000ms)` and `[1800ms, 2000ms)` — so the slots inside a silence are
+/// tick 4 (800ms) and tick 9 (1800ms). Not 5: its slot is 1000ms and the window
+/// is half-open.
+///
+/// And tick 4 is EMITTED anyway. Measured at this head, played is
+/// `[0,1,2,3,4,5,6,7,8,10,11]` — only 9 is missing. A recurring gap is judged
+/// against WALL time on entry, so by the time the stalled loop reaches row 4
+/// real time is past 1000ms and the gap is over. That is `gaps:` doing what it
+/// is documented to do — simulate an outage happening *now* — and not a defect,
+/// but it means "rows whose slot is inside the silence stay suppressed" is a
+/// guarantee only `gap_windows:` makes. Asserting it here would pin behaviour
+/// the wall frame does not promise.
 #[tokio::test]
 async fn a_fully_present_capture_still_owes_its_rows_under_a_recurring_gap() {
     let dir = tempfile::tempdir().expect("tempdir");

--- a/sonda-core/tests/gap_window_alignment.rs
+++ b/sonda-core/tests/gap_window_alignment.rs
@@ -579,6 +579,80 @@ async fn a_stall_under_both_silences_still_owes_every_row_outside_them() {
     );
 }
 
+/// A capture with NO recorded silence still owes its rows under a stall.
+///
+/// The hole #571 shipped with, closed here. The protection used to key on
+/// `gap_windows:` being declared, which is a good proxy for a capture that
+/// contains silence and no proxy at all for one that does not. A fully-present
+/// capture — every cell has a value, so it declares no windows — replayed under
+/// a user-added `gaps:` was treated as synthetic, and a slow sink deleted the
+/// rows owed during the catch-up.
+///
+/// Same shape as the row-frame probe, but the generator is a real
+/// `csv_replay` over a dense CSV and the ONLY silence is the recurring gap.
+/// `gap_windows` is empty, so this passes only if the predicate consults the
+/// generator.
+///
+/// Ticks 4 and 5 are deliberately unasserted: their slots sit inside the
+/// simulated outage, and a row the user covered is covered. The claim is
+/// narrower — falling behind is not itself a reason to drop a recorded row.
+#[tokio::test]
+async fn a_fully_present_capture_still_owes_its_rows_under_a_recurring_gap() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let csv = dir.path().join("dense.csv");
+    // 200ms grid, every slot present. Row n carries value n, so a deleted row
+    // is identifiable by its absence from the played list.
+    let mut body = String::from("timestamp,v\n");
+    for n in 0..12 {
+        body.push_str(&format!("{:.3},{}\n", n as f64 * 0.2, n));
+    }
+    std::fs::write(&csv, body).expect("write csv");
+
+    let mut config = ladder_scenario(
+        "2.4s",
+        Some(GapConfig {
+            every: "1s".to_string(),
+            r#for: "200ms".to_string(),
+        }),
+        None,
+    );
+    config.generator = GeneratorConfig::CsvReplay {
+        file: csv.to_string_lossy().into_owned(),
+        column: Some(1),
+        columns: None,
+        repeat: Some(false),
+        timescale: None,
+        default_metric_name: None,
+    };
+
+    // Premise: the fixture really declares no recorded absence. Without this
+    // the test could pass through the OR's other half and prove nothing.
+    assert!(
+        config.base.gap_windows.is_none(),
+        "premise: this capture must declare NO gap_windows, or the union's \
+         other half satisfies the test and the generator half goes unexercised"
+    );
+
+    let (mut sink, seen) = stalling_sink(2, Duration::from_millis(600));
+    runner::run_with_sink(&config, &mut sink, &CancellationToken::new(), None)
+        .await
+        .expect("run must succeed");
+
+    let seen = seen.lock().expect("timing sink mutex poisoned").clone();
+    let played: Vec<u64> = seen.iter().map(|e| e.value as u64).collect();
+
+    assert!(
+        played.contains(&2),
+        "row 2's slot (400ms) is outside the gap [800ms, 1000ms), so a stall \
+         must not delete it; played {played:?}"
+    );
+    assert!(
+        played.contains(&3),
+        "row 3's slot (600ms) is outside the gap, so a stall must not delete \
+         it; played {played:?}"
+    );
+}
+
 /// WALL FRAME: the same stall, and `gaps:` deliberately behaves the other way.
 ///
 /// This is the other half of the split, and it is what makes the pair


### PR DESCRIPTION


## Summary

The follow-up the design review made binding before WP19, and the hole #571 shipped with by design.

#571 made a recorded row outrank a simulated outage, keyed on `gap_windows:` being declared. That is a good proxy for a capture that *contains* silence and no proxy at all for one that does not. A fully-present capture — every cell has a value, so there are no windows to declare — was treated as synthetic, and under a user-added `gaps:` a slow sink deleted the rows owed during the catch-up.

Both the designer and the adversarial reviewer accepted the hole for #571 (it predates that PR; `csv_replay` + `gaps:` on `main` already deleted rows by the new standard) and required it closed before WP19 certifies the equality claim.

## Changes

**The predicate is now a union of two facts** (`schedule/core_loop.rs`), and it needs both:

| fact | where it comes from | what it covers |
|---|---|---|
| the generator replays recorded rows | set by the signal runner from the generator | a capture with no silence in it — the case this PR adds |
| `gap_windows:` is declared | the schedule, as before | a hand-written scenario describing recorded absence without replaying a file |

Neither implies the other, so it is an OR rather than a rename. Dropping the second half to "replay only" would be a behaviour regression for scenarios that shipped with `gap_windows:`.

**`generator_replays_recorded_rows`** (`schedule/mod.rs`) is the pure predicate, exhaustive with no `_ =>` arm — a future generator that replays captured data has to be classified rather than inheriting the synthetic answer silently. `log_generator_replays_recorded_rows` is its log-signal counterpart.

**The flag lives on `ParsedSchedule`**, set by every signal runner. That is the only place the generator and the schedule are both in scope: `from_base_config` never sees the generator, so it leaves the flag false and the runner decides. The metric and log runners derive it from the generator; the histogram and summary runners set it to `false` explicitly, because those signals have no generator field and nothing there can replay. Stating it beats inheriting it — a reader should not have to go read `from_base_config` to learn what the runner believes.

### No semver break

I told David this follow-up would cost one. It does not. `ParsedSchedule` is `pub(crate)`, so the field is invisible outside the crate and no downstream struct literal can break.

The alternative — a field on `BaseScheduleConfig` — *would* have been breaking: public, all-public fields, no `#[non_exhaustive]`, the same trap `PreparedEntry` was in #583. The runner is the better home regardless, because the generator is in scope there.

## Test plan

**`a_fully_present_capture_still_owes_its_rows_under_a_recurring_gap`** — a real `csv_replay` over a dense 12-row CSV at a 200ms grid, every cell present, with `gaps: every 1s for 200ms` as the only silence and a 600ms sink stall after the second write. `gap_windows` is empty, so this passes only if the predicate consults the generator.

It asserts its premise first: the fixture must declare **no** `gap_windows`, or the union's other half satisfies the test and the generator half goes unexercised.

Red-verified against #571's shipped predicate:

```
let has_recorded_rows = !schedule.gap_windows.is_empty();   // the mutation

played [0, 1, 5, 6, 7, 8, 10, 11]     rows 2, 3 and 4 deleted
11 passed / 1 failed                  every other case in the file stays green
```

So it is the one covering this, not a duplicate of the existing pair.

Only rows 2 and 3 are asserted. The test's docstring now says why, measured rather than reasoned: with `gaps: every 1s for 200ms` the silence sits at the tail of each cycle, so the slots inside it are ticks 4 and 9 — and tick 4 **emits anyway**. Instrumenting the test gives `played = [0,1,2,3,4,5,6,7,8,10,11]`; only 9 is missing, because a recurring gap is judged against wall time on entry and the outage is over by the time the stalled loop reaches row 4. That is `gaps:` doing what it is documented to do. Asserting either row would pin behaviour the wall frame does not promise.

**Also corrected**: the iteration-bound comment said `!has_recorded_rows` is true *"exactly when `gap_windows` is empty"*. With the union it **implies** that but is not equivalent — the converse fails for a replay declaring no windows, which is the case this PR adds. The bound still holds; the wording did not.

Gates: `cargo test --workspace --no-fail-fast` green apart from five failures that reproduce identically on clean `main` in this container — `sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message` and `tests::sink_file_error_produces_sink_variant` (both need a non-root uid), and `global_inflight_limit_gates_across_routes`, `health_remains_responsive_when_control_plane_is_saturated`, `request_timeout_returns_408_with_structured_error` in `sonda-server`. `gap_window_alignment` is 12/12. `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all -- --check` clean, 119 doc fences compiled 0 failed, `mkdocs build --strict` clean, wasm bundle rebuilt and byte-identical.

## Docs

`scheduling.md` states the real rule — a scenario has recorded rows if it **replays a capture or** declares `gap_windows:` — rather than "when a scenario declares both", which was accurate for #571 and is not for this.

It also no longer claims that *"rows whose own slot really does sit inside either silence stay suppressed"*. That guarantee holds for `gap_windows:` and is false for `gaps:`, for the reason the test measured above. The page now presents the asymmetry as a choice: pin silence to particular rows with `gap_windows:`; use `gaps:` when the intent is "an outage is happening now".

No release note. `gap_windows:` and this behaviour both ship in the same release, so no scenario that exists today can observe the change; and for the new half, the alternative it replaces never shipped.

## Known limitations

- The predicate keys on the generator **type**, not on whether that particular capture contains recorded rows the run will actually reach. A `csv_replay` whose file is empty still counts as replaying. That is the conservative direction — it protects rather than deletes — and the cross-check already refuses the configurations where it would matter.
- `generator_replays_recorded_rows` and its log counterpart are exhaustive over the two generator enums that exist. A replay for histogram or summary would arrive as a third enum — `DistributionConfig` — which neither match covers, so those runners would keep returning `false` without a compile error. Whoever adds it needs to classify there too.
