### PR TITLE
test(core): widen the throughput gate's geometry, not its tolerance

### DIFF
--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -1095,12 +1095,31 @@ async fn while_runtime_pending_finishes_when_upstream_gone_before_after_fires() 
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn while_runtime_steady_within_5pct_of_baseline() {
+async fn while_runtime_steady_within_10pct_of_baseline() {
     // Perf-regression gate (A10): a scenario with `while:` open the entire
-    // run must produce within 5% of the event count of the same scenario
-    // without `while:`. Both runs are short (300ms) to keep the test fast.
+    // run must produce within 10% of the event count of the same scenario
+    // without `while:`.
+    //
+    // The spec target is 5%; this asserts 10%, and the name says 10% because
+    // 10% is what it checks. 5% is the lab figure on dedicated hardware.
+    //
+    // Each run is 1s rather than the 300ms it used to be, and the length is
+    // load-bearing rather than incidental. The event count is capped by the
+    // duration, so noise is one-sided: a run never exceeds rate × duration,
+    // it only loses ticks to a scheduler stall. That loss is roughly a fixed
+    // number of ticks regardless of how long the run is, so a longer run
+    // divides the same absolute hiccup by a larger denominator. Measured on
+    // a 4-core box under 24 spinning processes, 25 runs each:
+    //
+    //   300ms   worst deviation 7.0%   (279/300)
+    //   1000ms  worst deviation 4.4%   (956/1000)
+    //
+    // Widening the geometry rather than the band is deliberate: loosening the
+    // tolerance to absorb noise would also absorb the regression this exists
+    // to catch. Do not shorten these runs to speed the suite up without
+    // re-measuring — the margin, not the wall-clock, is the reason for 1s.
     async fn run_baseline() -> u64 {
-        let entry = metrics_entry("baseline", 1000.0, 300);
+        let entry = metrics_entry("baseline", 1000.0, 1000);
         let cancel = CancellationToken::new();
         let mut handle = launch_scenario_with_gates(
             "baseline".to_string(),
@@ -1114,7 +1133,8 @@ async fn while_runtime_steady_within_5pct_of_baseline() {
         )
         .await
         .unwrap();
-        handle.join(Some(Duration::from_secs(2))).unwrap();
+        // Exceeds the 1s run with room for a stalled scheduler to finish.
+        handle.join(Some(Duration::from_secs(5))).unwrap();
         handle.stats_snapshot().total_events
     }
 
@@ -1122,7 +1142,7 @@ async fn while_runtime_steady_within_5pct_of_baseline() {
         let bus = Arc::new(GateBus::new());
         bus.tick(1.0);
         let (rx, init) = bus.subscribe(while_gt_zero());
-        let entry = metrics_entry("gated", 1000.0, 300);
+        let entry = metrics_entry("gated", 1000.0, 1000);
         let cancel = CancellationToken::new();
         let mut handle = launch_scenario_with_gates(
             "gated".to_string(),
@@ -1136,7 +1156,8 @@ async fn while_runtime_steady_within_5pct_of_baseline() {
         )
         .await
         .unwrap();
-        handle.join(Some(Duration::from_secs(2))).unwrap();
+        // Exceeds the 1s run with room for a stalled scheduler to finish.
+        handle.join(Some(Duration::from_secs(5))).unwrap();
         handle.stats_snapshot().total_events
     }
 
@@ -1151,8 +1172,6 @@ async fn while_runtime_steady_within_5pct_of_baseline() {
     let gated_f = gated as f64;
     let ratio = gated_f / baseline_f;
     assert!(baseline > 0, "baseline must produce events: got {baseline}");
-    // spec target is 5%; tightened to 10% to absorb CI noise. < 5% is the
-    // lab-target on dedicated hardware.
     assert!(
         (0.90..=1.10).contains(&ratio),
         "gated/baseline event ratio {ratio:.3} outside [0.90, 1.10]; baseline={baseline}, gated={gated}"

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -1106,18 +1106,36 @@ async fn while_runtime_steady_within_10pct_of_baseline() {
     // Each run is 1s rather than the 300ms it used to be, and the length is
     // load-bearing rather than incidental. The event count is capped by the
     // duration, so noise is one-sided: a run never exceeds rate × duration,
-    // it only loses ticks to a scheduler stall. That loss is roughly a fixed
-    // number of ticks regardless of how long the run is, so a longer run
-    // divides the same absolute hiccup by a larger denominator. Measured on
-    // a 4-core box under 24 spinning processes, 25 runs each:
+    // it only loses ticks to a scheduler stall, and the band's upper half
+    // never does any work. A longer run divides that loss by a larger
+    // denominator. Measured on a 4-core box under 24 spinning processes,
+    // 25 runs at each length, worst of 25:
     //
-    //   300ms   worst deviation 7.0%   (279/300)
-    //   1000ms  worst deviation 4.4%   (956/1000)
+    //   300ms   7.0%   (279/300)    21 ticks lost
+    //   1000ms  4.4%   (956/1000)   44 ticks lost
+    //
+    // Note what those numbers do NOT say. The loss is not a fixed count: if
+    // it were, 21 ticks would be 2.1% at 1000ms rather than 4.4%. A longer
+    // run has more exposure to stalls as well as more samples to absorb one,
+    // and here the second effect only partly outran the first. On other
+    // hardware the loss has measured as strictly fixed (3 ticks at both
+    // lengths, 1.01% -> 0.30%). The improvement holds in both regimes; the
+    // size of it does not transfer, so re-measure rather than re-derive.
     //
     // Widening the geometry rather than the band is deliberate: loosening the
     // tolerance to absorb noise would also absorb the regression this exists
     // to catch. Do not shorten these runs to speed the suite up without
     // re-measuring — the margin, not the wall-clock, is the reason for 1s.
+    //
+    // What the length does NOT buy is resolution. The smallest per-tick
+    // regression this gate can see is set by the tick interval, 1/rate, and
+    // duration does not appear in that floor: at rate 1000 a sweep of added
+    // per-tick cost in the gated arm passes at 1000us and fails at 1200us,
+    // and at rate 4000 it passes at 200us and fails at 300us. So this catches
+    // a gated path that became roughly a millisecond per tick slower, against
+    // a wrapper whose real cost is a closure indirection plus a `try_recv` on
+    // an empty channel — tens of nanoseconds. Rate, not duration, is the knob
+    // that tightens that floor, and raising it costs no wall-clock time.
     async fn run_baseline() -> u64 {
         let entry = metrics_entry("baseline", 1000.0, 1000);
         let cancel = CancellationToken::new();


### PR DESCRIPTION

## Summary

Two tests were carried on the follow-up list as flake-prone in CI. Measurement says one of them is, and the fix is more samples rather than a looser band.

## The throughput gate

`while_runtime_steady_within_5pct_of_baseline` ran a 300ms gated scenario against a 300ms baseline and asserted the ratio sat in `[0.90, 1.10]`.

The event count is capped by the duration, so the noise is **one-sided**: a run never exceeds `rate × duration`, it only loses ticks to a scheduler stall. The band's upper half never does any work. A longer run divides that loss by a larger denominator.

Measured on a 4-core box under 24 spinning processes, 25 runs at each length, worst of 25:

| run length | worst deviation | ticks lost | headroom in a 10% band |
|---|---|---|---|
| 300ms (before) | 7.0% — `279/300` | 21 | 1.4× |
| 1000ms (after) | 4.4% — `956/1000` | 44 | 2.3× |

Each run is now 1s. **The band stays at 10%.** Loosening the tolerance to absorb noise would also absorb the regression the gate exists to catch — the geometry is the part that should move. Join deadlines go 2s → 5s so they still exceed the run they wait on.

### What those numbers do not say

An earlier revision of this PR — and of the comment it ships — claimed the tick loss is "roughly a fixed number of ticks regardless of how long the run is". **The table above disproves that**, and the review caught it: a strictly fixed loss would put the 1s figure at 21/1000 = 2.1%, not the 4.4% measured. A longer run has more exposure to stalls as well as more samples to absorb one, and here the second effect only partly outran the first.

On other hardware the loss does measure as strictly fixed — 3 ticks at both lengths, 1.01% → 0.30%. The improvement holds in both regimes; its size does not transfer. The comment now says so, and says to re-measure rather than re-derive.

### The length buys margin, not resolution

The smallest per-tick regression this gate can see is the tick interval, `1/rate`, and **duration does not appear in that floor**. Swept against added per-tick cost in the gated arm:

```
rate 1000 (tick interval 1000us)    1000us added  PASSES    1200us added  FAILS
rate 4000 (tick interval  250us)     200us added  PASSES     300us added  FAILS
```

So this gate registers a regression only once the `while:` path is roughly a millisecond per tick slower — against a wrapper whose real cost is a closure indirection plus a `try_recv` on an empty channel, order tens of nanoseconds. That is now recorded beside the noise measurements, with rate named as the knob that tightens it.

**The rate stays at 1000 here.** Moving it changes *what the gate catches* rather than *how reliably it reports*, which is a separate decision from the flake fix this PR is.

## The name did not match the assertion

The test was called `_within_5pct_` and asserted 10%, and the comment described going 5% → 10% as *"tightened"*. Renamed to `while_runtime_steady_within_10pct_of_baseline`, and the rationale rewritten to state what the code actually checks.

## Red-verification

The gated arm's rate cut to 850 — a simulated 15% throughput regression. Mutation confirmed present in the file **before** trusting the result:

```
1145:  let entry = metrics_entry("gated", 850.0, 1000);

gated/baseline event ratio 0.850 outside [0.90, 1.10]; baseline=1000, gated=850
test result: FAILED. 0 passed; 1 failed
```

Restored, then re-run 20× under the same 24-spinner load: 0 failures.

It proves the comparison still discriminates — the widened test is not vacuous. It does not prove the engine's gated path is instrumented, because the sabotage lands on the fixture's rate rather than on `core_loop`; the sensitivity sweep above is the number behind that caveat.

## The other test is not flaky

`a_stalled_sink_is_still_judged_by_the_wall_for_a_recurring_gap` was on the same list. It stalls the sink 600ms after two writes and requires tick 2 to stay suppressed; the failure mode would be total delay overrunning the gap's 1000ms end, leaving ~200ms of margin.

80 runs at up to 6× oversubscription produced **0 failures**. The margin is not the problem it was assumed to be, so it is unchanged — widening it would weaken a gate that is holding, for a flake measurement does not support.

## Test plan

`cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `while_runtime` 24 passed / 0 failed. `cargo test --workspace --no-fail-fast` green except the five failures that reproduce identically on `main` in this container — `sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message` and `tests::sink_file_error_produces_sink_variant` (both need a non-root uid), and `global_inflight_limit_gates_across_routes`, `health_remains_responsive_when_control_plane_is_saturated`, `request_timeout_returns_408_with_structured_error` in `sonda-server`.

Test-only change: no library source, no docs, no wasm bundle.
