### PR TITLE
test(core): tighten the throughput gate's floor to ~500us, and record the ceiling

### DIFF
--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -1135,21 +1135,45 @@ async fn while_runtime_steady_within_10pct_of_baseline() {
     // the knob for resolution, and it costs no wall-clock time.
     //
     // Hence rate 2000 here rather than the 1000 this started at: it halves the
-    // floor to ~500us. It is NOT set higher, and that ceiling is measured
-    // rather than assumed. Raising the rate is only free while the baseline
-    // arm still saturates — once the tick interval approaches what the host
-    // can schedule under load, BOTH arms start losing ticks, the noise stops
-    // being one-sided, and the band's upper half comes alive. Same box, same
-    // 24 spinners, 1s runs, worst deviation over 25 samples:
+    // floor to ~500us. It is NOT set higher, and the reason is a ceiling that
+    // was measured rather than assumed. Raising the rate is only free while the
+    // baseline arm still saturates at rate × duration. Once the tick interval
+    // approaches what the host can schedule under load, BOTH arms start losing
+    // ticks, the noise stops being one-sided, and the band's upper half comes
+    // alive. One session, 24 spinners on 4 cores, 1s runs, 25 samples per rate,
+    // the three rates interleaved so drifting load hits each equally:
     //
-    //   rate 1000   (1000us tick)   4.4%   baseline saturated 25/25
-    //   rate 2000   ( 500us tick)   2.2%   baseline saturated 41/60
-    //   rate 4000   ( 250us tick)   8.7%   baseline saturated 17/25, max ratio 1.0566
+    //   rate 1000  (1000us tick)   base sat 20/25   max ratio 1.0040   worst dev 5.62%
+    //   rate 2000  ( 500us tick)   base sat 16/25   max ratio 1.0106   worst dev 1.20%
+    //   rate 4000  ( 250us tick)   base sat  7/25   max ratio 1.0501   worst dev 5.01%
     //
-    // At 4000 the worst sample was 0.9127 — 1.3 points from failing — which
-    // would have reintroduced exactly the flake this geometry was widened to
-    // remove. 2000 improves both axes at once; 4000 trades one for the other.
-    // Re-measure before moving it again, on the host that will run it.
+    // Read the first two columns, not the third. Baseline saturation falls
+    // monotonically and the maximum ratio rises monotonically: that is the
+    // ceiling, and it reproduces on other hardware. Worst deviation does NOT
+    // order consistently — it is a tail statistic over 25 samples, it puts 1000
+    // worse than 2000 here, and on a quieter host it comes out monotonic
+    // instead. An earlier version of this comment drew its conclusion from that
+    // column while also taking one of its three rows from a different session,
+    // which is how it reached the claim that 2000 beats 1000 on every axis. It
+    // does not. What 2000 buys is half the floor at a cost that is still far
+    // inside the band; at 4000 the upper half of the band is demonstrably live.
+    //
+    // Re-measure before moving it again, on the host that will run it, in one
+    // session, and judge by saturation rather than by the tail.
+    //
+    // Though there is little left to move it to, which is worth knowing before
+    // anyone tries. The loop is deadline-paced (`emit_at = max(next_deadline,
+    // now)`), so for ANY per-tick cost below one tick interval it still meets
+    // every deadline and emits exactly rate × duration events — identically,
+    // not approximately. No rate buys sensitivity below one interval, and the
+    // interval cannot go below what the host schedules under load, which is the
+    // ceiling above. ~500us is therefore at or near the best this instrument
+    // can do here. Timing the run instead would not help either: the pacing is
+    // deadline-driven rather than work-driven, so elapsed time saturates
+    // exactly as the count does. A gate that could see a sub-interval
+    // regression on the `while:` path would have to microbenchmark the wrapped
+    // against the unwrapped `tick_fn` with no scheduler running — a different
+    // instrument, not a further turn of this one.
     async fn run_baseline() -> u64 {
         let entry = metrics_entry("baseline", 2000.0, 1000);
         let cancel = CancellationToken::new();

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -1105,11 +1105,11 @@ async fn while_runtime_steady_within_10pct_of_baseline() {
     //
     // Each run is 1s rather than the 300ms it used to be, and the length is
     // load-bearing rather than incidental. The event count is capped by the
-    // duration, so noise is one-sided: a run never exceeds rate × duration,
-    // it only loses ticks to a scheduler stall, and the band's upper half
-    // never does any work. A longer run divides that loss by a larger
-    // denominator. Measured on a 4-core box under 24 spinning processes,
-    // 25 runs at each length, worst of 25:
+    // duration, so noise is one-sided as long as the baseline arm saturates:
+    // a run never exceeds rate × duration, it only loses ticks to a scheduler
+    // stall, and the band's upper half does no work. A longer run divides that
+    // loss by a larger denominator. Measured on a 4-core box under 24 spinning
+    // processes, 25 runs at each length, worst of 25, at rate 1000:
     //
     //   300ms   7.0%   (279/300)    21 ticks lost
     //   1000ms  4.4%   (956/1000)   44 ticks lost
@@ -1129,15 +1129,29 @@ async fn while_runtime_steady_within_10pct_of_baseline() {
     //
     // What the length does NOT buy is resolution. The smallest per-tick
     // regression this gate can see is set by the tick interval, 1/rate, and
-    // duration does not appear in that floor: at rate 1000 a sweep of added
-    // per-tick cost in the gated arm passes at 1000us and fails at 1200us,
-    // and at rate 4000 it passes at 200us and fails at 300us. So this catches
-    // a gated path that became roughly a millisecond per tick slower, against
-    // a wrapper whose real cost is a closure indirection plus a `try_recv` on
-    // an empty channel — tens of nanoseconds. Rate, not duration, is the knob
-    // that tightens that floor, and raising it costs no wall-clock time.
+    // duration does not appear in that floor: swept with added per-tick cost
+    // in the gated arm, rate 1000 passes at 1000us and fails at 1200us, and
+    // rate 4000 passes at 200us and fails at 300us. Rate, not duration, is
+    // the knob for resolution, and it costs no wall-clock time.
+    //
+    // Hence rate 2000 here rather than the 1000 this started at: it halves the
+    // floor to ~500us. It is NOT set higher, and that ceiling is measured
+    // rather than assumed. Raising the rate is only free while the baseline
+    // arm still saturates — once the tick interval approaches what the host
+    // can schedule under load, BOTH arms start losing ticks, the noise stops
+    // being one-sided, and the band's upper half comes alive. Same box, same
+    // 24 spinners, 1s runs, worst deviation over 25 samples:
+    //
+    //   rate 1000   (1000us tick)   4.4%   baseline saturated 25/25
+    //   rate 2000   ( 500us tick)   2.2%   baseline saturated 41/60
+    //   rate 4000   ( 250us tick)   8.7%   baseline saturated 17/25, max ratio 1.0566
+    //
+    // At 4000 the worst sample was 0.9127 — 1.3 points from failing — which
+    // would have reintroduced exactly the flake this geometry was widened to
+    // remove. 2000 improves both axes at once; 4000 trades one for the other.
+    // Re-measure before moving it again, on the host that will run it.
     async fn run_baseline() -> u64 {
-        let entry = metrics_entry("baseline", 1000.0, 1000);
+        let entry = metrics_entry("baseline", 2000.0, 1000);
         let cancel = CancellationToken::new();
         let mut handle = launch_scenario_with_gates(
             "baseline".to_string(),
@@ -1160,7 +1174,7 @@ async fn while_runtime_steady_within_10pct_of_baseline() {
         let bus = Arc::new(GateBus::new());
         bus.tick(1.0);
         let (rx, init) = bus.subscribe(while_gt_zero());
-        let entry = metrics_entry("gated", 1000.0, 1000);
+        let entry = metrics_entry("gated", 2000.0, 1000);
         let cancel = CancellationToken::new();
         let mut handle = launch_scenario_with_gates(
             "gated".to_string(),

--- a/sonda-core/tests/while_runtime.rs
+++ b/sonda-core/tests/while_runtime.rs
@@ -1143,29 +1143,57 @@ async fn while_runtime_steady_within_10pct_of_baseline() {
     // alive. One session, 24 spinners on 4 cores, 1s runs, 25 samples per rate,
     // the three rates interleaved so drifting load hits each equally:
     //
-    //   rate 1000  (1000us tick)   base sat 20/25   max ratio 1.0040   worst dev 5.62%
-    //   rate 2000  ( 500us tick)   base sat 16/25   max ratio 1.0106   worst dev 1.20%
-    //   rate 4000  ( 250us tick)   base sat  7/25   max ratio 1.0501   worst dev 5.01%
+    //   rate 1000  (1000us tick)   base sat 20/25   min 0.9438   max 1.0040
+    //   rate 2000  ( 500us tick)   base sat 16/25   min 0.9880   max 1.0106
+    //   rate 4000  ( 250us tick)   base sat  7/25   min 0.9885   max 1.0501
     //
-    // Read the first two columns, not the third. Baseline saturation falls
-    // monotonically and the maximum ratio rises monotonically: that is the
-    // ceiling, and it reproduces on other hardware. Worst deviation does NOT
-    // order consistently — it is a tail statistic over 25 samples, it puts 1000
-    // worse than 2000 here, and on a quieter host it comes out monotonic
-    // instead. An earlier version of this comment drew its conclusion from that
-    // column while also taking one of its three rows from a different session,
-    // which is how it reached the claim that 2000 beats 1000 on every axis. It
-    // does not. What 2000 buys is half the floor at a cost that is still far
-    // inside the band; at 4000 the upper half of the band is demonstrably live.
+    // The two ratio bounds are reported separately and deliberately, because
+    // they measure different things and only one of them trends. `max` is
+    // baseline loss — the systematic ceiling effect, rising with rate. `min` is
+    // a gated-arm hiccup — random, no trend. Saturation falls monotonically and
+    // `max` rises monotonically; that is the ceiling, and it reproduces on
+    // other hardware.
+    //
+    // An earlier version of this comment reported a single "worst deviation"
+    // column instead, which is max(1 - min, max - 1) — the larger of those two
+    // unrelated quantities. It cannot order monotonically because it is not
+    // measuring one thing: the low side wins at 1000 and 2000, the high side
+    // wins at 4000. That comment then drew its conclusion from that column
+    // while also taking one of its rows from a different session, and reached
+    // the claim that 2000 beats 1000 on every axis. It does not. What 2000
+    // buys is half the floor at a cost still far inside the band; at 4000 the
+    // upper half of the band is demonstrably live.
     //
     // Re-measure before moving it again, on the host that will run it, in one
-    // session, and judge by saturation rather than by the tail.
+    // session. Judge by saturation and by `max` — but note the power: at 25
+    // samples per rate, saturation resolves a 4x rate change (2000 vs 4000 here
+    // is p=0.006) and does NOT resolve a 2x one (1000 vs 2000 is p=0.20, on
+    // this host and on a quieter one alike). Comparing adjacent rates needs
+    // roughly 120 samples each, about 24 minutes at this geometry.
+    //
+    // One calibration for how unstable a single session is: the geometry table
+    // fifteen lines above reports 4.4% for rate 1000 at 1s under this same load
+    // on this same box, and the sweep here makes the same measurement 5.62%.
+    // Two sessions, one configuration, 1.2 points apart. That spread is the
+    // reason this table is read by trend rather than by any single figure.
     //
     // Though there is little left to move it to, which is worth knowing before
     // anyone tries. The loop is deadline-paced (`emit_at = max(next_deadline,
-    // now)`), so for ANY per-tick cost below one tick interval it still meets
-    // every deadline and emits exactly rate × duration events — identically,
-    // not approximately. No rate buys sensitivity below one interval, and the
+    // now)`), so for any per-tick cost comfortably below one tick interval it
+    // still meets every deadline and emits exactly rate × duration events —
+    // identically, not approximately. "Comfortably" is doing real work in that
+    // sentence: measured at rate 2000 unloaded, injected cost up to 450us is
+    // indistinguishable from zero injection, and at 500us — exactly one
+    // interval — there is a reproducible ~2% loss, because nothing is left for
+    // the sleep and wake path. So it holds to roughly 90% of the interval and
+    // not at 100% of it.
+    //
+    // Two nearby numbers that are not the same quantity: ~500us is where
+    // degradation begins (the interval), and ~600us is where the assertion
+    // fires (about 1.2x the interval — the same ratio held at rate 1000, which
+    // passed at 1000us and failed at 1200us). "~500us floor" labels the former.
+    //
+    // No rate buys sensitivity below one interval, and the
     // interval cannot go below what the host schedules under load, which is the
     // ceiling above. ~500us is therefore at or near the best this instrument
     // can do here. Timing the run instead would not help either: the pacing is


### PR DESCRIPTION


## Summary

The follow-up left open when #585 widened the geometry. That PR established the gate's sensitivity floor is the tick interval, `1/rate`, with duration nowhere in it — so rate is the only knob that buys resolution, and raising it costs no wall-clock time.

Rate goes 1000 → **2000**, halving the floor to ~500µs.

## Why not 4000

"Raise the rate" was the recommendation; "raise it as far as it goes" was the obvious reading, and it's wrong. There is a ceiling.

Raising the rate is only free **while the baseline arm still saturates** at `rate × duration`. Once the tick interval approaches what the host can schedule under load, both arms lose ticks — the noise stops being one-sided and the band's upper half comes alive. One session, 24 spinning processes on 4 cores, 1s runs, 25 samples per rate, the three rates **interleaved** so drifting load hits each equally:

| rate | tick | baseline saturated | min ratio | max ratio |
|---|---|---|---|---|
| 1000 | 1000µs | 20/25 | 0.9438 | 1.0040 |
| **2000** | **500µs** | **16/25** | **0.9880** | **1.0106** |
| 4000 | 250µs | **7/25** | 0.9885 | **1.0501** |

The two ratio bounds are reported separately because they measure different things and only one trends. **`max` is baseline loss** — the systematic ceiling effect, rising with rate. **`min` is a gated-arm hiccup** — random, no trend. Saturation falls monotonically and `max` rises monotonically; that is the ceiling, and it reproduces on other hardware.

So 2000 buys half the floor at a cost still far inside the band, and at 4000 the band's upper half is demonstrably live.

**Power, so the table is not over-read:** at 25 samples per rate, saturation resolves a 4× rate change (2000 vs 4000 is p=0.006) and does **not** resolve a 2× one (1000 vs 2000 is p=0.20, on this host and on a quieter one alike). The comparison this table was built for is the resolved one. Comparing adjacent rates needs roughly 120 samples each, about 24 minutes at this geometry — and the comment says so.

### Corrections made during review

Two rounds, three things withdrawn or fixed:

- **Mixed sessions.** An early revision took the rate-1000 row from #585's session — a different day, different load — while presenting it beside two fresh rows, and its header said "over 25 samples" beside a row reading `41/60`. The claim it produced, that 2000 beats 1000 on every axis, **is withdrawn**. The table above is one interleaved session.
- **A collapsed column.** That revision reported a single `worst dev` figure, which is `max(1 − min, max − 1)` — the larger of two unrelated quantities. It cannot order monotonically because it is not measuring one thing: the low side wins at 1000 and 2000, the high side at 4000. Split into the two bounds above. The reason first given for setting it aside ("a tail statistic over 25 samples") was also wrong — `max ratio` is an extreme order statistic over 25 samples too, and the table asks you to trust that one. The real distinction is that `max` isolates the component with the trend.
- **Calibration, now named rather than left as an apparent contradiction.** The geometry table in the same comment reports 4.4% for rate 1000 at 1s on this box; the sweep here makes the same measurement 5.62%. Two sessions, one configuration, 1.2 points apart. That spread is *why* the table is read by trend rather than by any single figure.

## Where the floor ends

Recorded in the comment so *"re-measure before moving it again"* isn't a pointer at a dead end:

The loop is deadline-paced (`emit_at = max(next_deadline, now)`), so for any per-tick cost **comfortably** below one tick interval it still meets every deadline and emits exactly `rate × duration` events — identically, not approximately. "Comfortably" is load-bearing: measured at rate 2000 unloaded, injection up to 450µs is indistinguishable from none, and at 500µs — exactly one interval — there is a reproducible ~2% loss, because nothing is left for the sleep and wake path. It holds to roughly 90% of the interval and not at 100%.

Two nearby numbers that are **not** the same quantity: ~500µs is where degradation begins (the interval); ~600µs is where the assertion fires (about 1.2× the interval — the same ratio held at rate 1000, which passed at 1000µs and failed at 1200µs).

No rate buys sensitivity below one interval, and the interval cannot drop below what the host schedules under load, which is the ceiling above. Timing the run instead would not help: the pacing is deadline-driven rather than work-driven, so elapsed time saturates exactly as the count does. A gate that could see a sub-interval regression on the `while:` path would have to microbenchmark the wrapped against the unwrapped `tick_fn` with no scheduler running — a different instrument, not a further turn of this one.

## Red-verification

Gated arm cut to 1700 — a 15% regression at the new rate. Mutation confirmed present in the file **before** trusting the result:

```
1177:  let entry = metrics_entry("gated", 1700.0, 1000);

gated/baseline event ratio 0.850 outside [0.90, 1.10]; baseline=2000, gated=1700
test result: FAILED. 0 passed; 1 failed
```

Restored and verified. Same caveat, unchanged: this proves the comparison discriminates, not that the engine's gated path is instrumented — the sabotage lands on the fixture's rate rather than on `core_loop`.

## Test plan

`cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `while_runtime` 24 passed / 0 failed. `cargo test --workspace --no-fail-fast` green except the five failures that reproduce identically on `main` in this container — `sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message` and `tests::sink_file_error_produces_sink_variant` (both need a non-root uid), and `global_inflight_limit_gates_across_routes`, `health_remains_responsive_when_control_plane_is_saturated`, `request_timeout_returns_408_with_structured_error` in `sonda-server`.

Test-only change: one file, no library source, no docs, no wasm bundle. The one-line change is the rate; everything else is the comment explaining why it is that number and not a larger one.