### PR TITLE
test(core): drive the capture path over a socket, and close two credential leaks

### DIFF
--- a/sonda-core/src/acquire/tsdb.rs
+++ b/sonda-core/src/acquire/tsdb.rs
@@ -16,6 +16,10 @@
 //! and no accessor returning the token. It exists only to be applied to a
 //! request. The emitted CSV and YAML are built from labels and values, and
 //! never see this type — asserted by a test rather than by inspection.
+//!
+//! A base URL is the other way a credential arrives: `http://user:pass@host`.
+//! That one *is* stored, so the rule is that only [`scrub_userinfo`]'s output
+//! is ever formatted — into an error, into a `Debug`, anywhere but the wire.
 
 use super::response::parse_matrix_response;
 use super::FetchedSeries;
@@ -101,12 +105,46 @@ fn base64_encode(input: &[u8]) -> String {
     out
 }
 
+/// The `user:pass@` prefix of a URL's authority, if it has one.
+///
+/// The last `@` before the path ends the userinfo: RFC 3986 requires an `@`
+/// inside it to be percent-encoded, so a later one cannot belong to it.
+fn userinfo_of(url: &str) -> Option<String> {
+    let (_, rest) = url.split_once("://")?;
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let at = rest[..authority_end].rfind('@')?;
+    Some(rest[..=at].to_string())
+}
+
+/// Replace a URL credential wherever it appears in `text`.
+///
+/// Every occurrence, because `ureq` builds its error messages from the URL it
+/// was handed and quotes it more than once.
+fn scrub_userinfo(text: &str, userinfo: Option<&str>) -> String {
+    match userinfo {
+        Some(u) => text.replace(u, "<redacted>@"),
+        None => text.to_string(),
+    }
+}
+
 /// A client for one TSDB's range-query endpoint.
-#[derive(Debug)]
 pub struct TsdbClient {
     range_url: String,
+    /// `range_url` with any credential removed. The only form that is printed.
+    display_url: String,
+    userinfo: Option<String>,
     agent: ureq::Agent,
     auth: Auth,
+}
+
+/// Written by hand so a `user:pass@` base URL cannot reach a log line.
+impl std::fmt::Debug for TsdbClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TsdbClient")
+            .field("range_url", &self.display_url)
+            .field("auth", &self.auth)
+            .finish_non_exhaustive()
+    }
 }
 
 impl TsdbClient {
@@ -116,11 +154,20 @@ impl TsdbClient {
     /// against an unreachable endpoint must fail, not hang.
     pub fn new(base_url: &str, auth: Auth, timeout: Duration) -> Self {
         let base = base_url.trim_end_matches('/');
+        let range_url = format!("{base}/api/v1/query_range");
+        let userinfo = userinfo_of(&range_url);
         TsdbClient {
-            range_url: format!("{base}/api/v1/query_range"),
+            display_url: scrub_userinfo(&range_url, userinfo.as_deref()),
+            userinfo,
+            range_url,
             agent: ureq::AgentBuilder::new().timeout(timeout).build(),
             auth,
         }
+    }
+
+    /// Strip the URL credential from anything this client reports.
+    fn scrub(&self, text: &str) -> String {
+        scrub_userinfo(text, self.userinfo.as_deref())
     }
 
     /// Run `query` over `start..=end` at `step` and return the series.
@@ -162,22 +209,22 @@ impl TsdbClient {
             .call()
             .map_err(|e| {
                 SondaError::Verify(VerifyError::Query {
-                    url: self.range_url.clone(),
-                    reason: e.to_string(),
+                    url: self.display_url.clone(),
+                    reason: self.scrub(&e.to_string()),
                 })
             })?
             .into_string()
             .map_err(|e| {
                 SondaError::Verify(VerifyError::BadResponse {
-                    url: self.range_url.clone(),
-                    reason: format!("response could not be read: {e}"),
+                    url: self.display_url.clone(),
+                    reason: self.scrub(&format!("response could not be read: {e}")),
                 })
             })?;
 
         parse_matrix_response(&body).map_err(|reason| {
             SondaError::Verify(VerifyError::BadResponse {
-                url: self.range_url.clone(),
-                reason,
+                url: self.display_url.clone(),
+                reason: self.scrub(&reason),
             })
         })
     }
@@ -241,5 +288,51 @@ mod tests {
     fn base_url_trailing_slashes_do_not_double_up() {
         let c = TsdbClient::new("http://x:9090/", Auth::None, Duration::from_secs(1));
         assert_eq!(c.range_url, "http://x:9090/api/v1/query_range");
+    }
+
+    #[test]
+    fn userinfo_is_found_only_in_the_authority() {
+        assert_eq!(
+            userinfo_of("http://admin:s3cret@host:9090/api"),
+            Some("admin:s3cret@".to_string())
+        );
+        assert_eq!(userinfo_of("http://tok@host/api"), Some("tok@".to_string()));
+        assert_eq!(userinfo_of("http://host:9090/api"), None);
+        // An `@` in the path is not a credential.
+        assert_eq!(userinfo_of("http://host:9090/api/a@b"), None);
+        assert_eq!(userinfo_of("http://host:9090/?q=a@b"), None);
+        assert_eq!(userinfo_of("not-a-url"), None);
+    }
+
+    #[test]
+    fn a_url_credential_is_kept_for_the_wire_and_stripped_from_everything_else() {
+        let c = TsdbClient::new(
+            "http://admin:urlsecret@127.0.0.1:9090",
+            Auth::None,
+            Duration::from_secs(1),
+        );
+        assert!(
+            c.range_url.contains("admin:urlsecret@"),
+            "the request itself still needs the credential: {}",
+            c.range_url
+        );
+        assert_eq!(
+            c.display_url,
+            "http://<redacted>@127.0.0.1:9090/api/v1/query_range"
+        );
+
+        let shown = format!("{c:?}");
+        assert!(!shown.contains("urlsecret"), "client Debug leaked: {shown}");
+
+        // ureq quotes the URL more than once in one message.
+        let doubled = format!("{0} failed: {0}", c.range_url);
+        assert!(!c.scrub(&doubled).contains("urlsecret"), "{doubled}");
+    }
+
+    #[test]
+    fn a_url_without_a_credential_is_reported_verbatim() {
+        let c = TsdbClient::new("http://127.0.0.1:9090", Auth::None, Duration::from_secs(1));
+        assert_eq!(c.display_url, c.range_url);
+        assert_eq!(c.scrub("nothing to strip"), "nothing to strip");
     }
 }

--- a/sonda-core/tests/acquire_capture.rs
+++ b/sonda-core/tests/acquire_capture.rs
@@ -1,0 +1,270 @@
+//! Drive the capture path end to end against a real socket.
+//!
+//! Everything else in `acquire` is unit-tested without a network, which leaves
+//! one seam untested: the HTTP client itself, and what it does with a
+//! credential. These tests stand a throwaway TCP server in front of it so the
+//! request is inspectable and the whole chain — fetch, normalize, CSV, scenario,
+//! compile — runs on data that arrived over the wire.
+
+#![cfg(all(feature = "http", feature = "config"))]
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use sonda_core::acquire::normalize::{normalize, Grid};
+use sonda_core::acquire::tsdb::{Auth, TsdbClient};
+use sonda_core::acquire::{csv_out, yaml_out, FetchedSeries};
+use sonda_core::compiler::expand::InMemoryPackResolver;
+
+/// Serve `body` to exactly one request and hand back what that request was.
+///
+/// The captured text is what makes the leak tests non-vacuous: asserting a token
+/// is absent from an artifact proves nothing unless the token was actually sent.
+fn mock_tsdb(status: &str, body: &str) -> (String, mpsc::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
+    let base = format!("http://{}", listener.local_addr().expect("addr"));
+    let (tx, rx) = mpsc::channel();
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept");
+        // Read until the header terminator; the client sends no body.
+        let mut seen = Vec::new();
+        let mut byte = [0u8; 1];
+        while stream.read(&mut byte).unwrap_or(0) == 1 {
+            seen.push(byte[0]);
+            if seen.ends_with(b"\r\n\r\n") {
+                break;
+            }
+        }
+        let _ = stream.write_all(response.as_bytes());
+        let _ = stream.flush();
+        let _ = tx.send(String::from_utf8_lossy(&seen).into_owned());
+    });
+
+    (base, rx)
+}
+
+fn matrix(label_block: &str, samples: &str) -> String {
+    format!(
+        r#"{{"status":"success","data":{{"resultType":"matrix","result":[
+             {{"metric":{label_block},"values":[{samples}]}}]}}}}"#
+    )
+}
+
+fn fetch(base: &str, auth: Auth) -> Result<Vec<FetchedSeries>, sonda_core::SondaError> {
+    TsdbClient::new(base, auth, Duration::from_secs(5)).fetch_range(
+        "up",
+        0.0,
+        30.0,
+        Duration::from_secs(10),
+    )
+}
+
+/// Fetch, normalize, write both halves, and load them with the real compiler.
+#[test]
+fn a_capture_taken_over_http_replays_through_the_real_compiler() {
+    let body = matrix(
+        r#"{"__name__":"up","job":"api"}"#,
+        // 10s grid over 0..=30 with the sample at 10 missing.
+        r#"[0,"1"],[20,"3"],[30,"4"]"#,
+    );
+    let (base, _rx) = mock_tsdb("200 OK", &body);
+
+    let series = fetch(&base, Auth::None).expect("fetch must succeed");
+    assert_eq!(series.len(), 1, "one series came back");
+
+    let grid = Grid::new(0.0, 30.0, 10.0).expect("grid");
+    let normalized: Vec<_> = series.iter().map(|s| normalize(s, grid)).collect();
+    assert_eq!(normalized[0].gap_count(), 1, "the missing sample is a gap");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let csv_path = dir.path().join("capture.csv");
+    std::fs::write(
+        &csv_path,
+        csv_out::write_csv(grid, &normalized).expect("csv"),
+    )
+    .expect("write");
+
+    let file = yaml_out::scenario_for(csv_path.to_str().expect("utf8"), grid, &normalized)
+        .expect("scenario");
+    let yaml = yaml_out::to_yaml(&file).expect("yaml");
+
+    let entries = sonda_core::compile_scenario_file(&yaml, &InMemoryPackResolver::default())
+        .unwrap_or_else(|e| panic!("the compiler rejected the capture: {e}\n{yaml}"));
+    for e in entries {
+        sonda_core::config::expand_entry(e).expect("the emitted columns must expand");
+    }
+}
+
+/// The credential reaches the server and appears in nothing this path writes.
+#[test]
+fn a_bearer_token_is_sent_and_never_reaches_an_emitted_artifact() {
+    const TOKEN: &str = "s3cr3t-bearer-value-do-not-emit";
+
+    let body = matrix(r#"{"__name__":"up","job":"api"}"#, r#"[0,"1"],[10,"2"]"#);
+    let (base, rx) = mock_tsdb("200 OK", &body);
+
+    let series = fetch(&base, Auth::Bearer(TOKEN.to_string())).expect("fetch");
+
+    // Vacuity guard. Without this the assertions below pass just as well when
+    // the client forgets to send the credential at all.
+    let request = rx.recv_timeout(Duration::from_secs(5)).expect("request");
+    assert!(
+        request.contains(TOKEN),
+        "the token must actually have been sent, or the leak checks prove nothing:\n{request}"
+    );
+    assert!(
+        request.contains(&format!("Bearer {TOKEN}")),
+        "and sent as a Bearer header:\n{request}"
+    );
+
+    let grid = Grid::new(0.0, 10.0, 10.0).expect("grid");
+    let normalized: Vec<_> = series.iter().map(|s| normalize(s, grid)).collect();
+
+    let csv = csv_out::write_csv(grid, &normalized).expect("csv");
+    let file = yaml_out::scenario_for("capture.csv", grid, &normalized).expect("scenario");
+    let yaml = yaml_out::to_yaml(&file).expect("yaml");
+
+    for (what, text) in [("csv", &csv), ("yaml", &yaml)] {
+        assert!(
+            !text.contains(TOKEN),
+            "the {what} artifact carries the credential:\n{text}"
+        );
+    }
+
+    // The client's own Debug is the other place a credential escapes to a log.
+    let client = TsdbClient::new(
+        &base,
+        Auth::Bearer(TOKEN.to_string()),
+        Duration::from_secs(1),
+    );
+    assert!(!format!("{client:?}").contains(TOKEN));
+}
+
+/// A failing fetch reports the URL, not the credential.
+#[test]
+fn an_error_response_does_not_quote_the_credential_back() {
+    const TOKEN: &str = "s3cr3t-in-an-error-path";
+    let (base, rx) = mock_tsdb(
+        "500 Internal Server Error",
+        r#"{"status":"error","errorType":"internal","error":"boom"}"#,
+    );
+
+    let err = fetch(&base, Auth::Bearer(TOKEN.to_string())).expect_err("a 500 must be an error");
+
+    let request = rx.recv_timeout(Duration::from_secs(5)).expect("request");
+    assert!(request.contains(TOKEN), "the token was sent");
+
+    let text = err.to_string();
+    assert!(
+        !text.contains(TOKEN),
+        "the error quotes the credential: {text}"
+    );
+    assert!(
+        text.contains("/api/v1/query_range"),
+        "and it should still name the endpoint: {text}"
+    );
+}
+
+/// Basic auth is base64-encoded, so the raw password must be checked for too —
+/// and so must the encoding, which is what would actually appear in a header.
+#[test]
+fn basic_auth_credentials_do_not_reach_an_artifact_in_either_form() {
+    const PASSWORD: &str = "hunter2-plaintext";
+
+    let body = matrix(r#"{"__name__":"up"}"#, r#"[0,"1"],[10,"2"]"#);
+    let (base, rx) = mock_tsdb("200 OK", &body);
+
+    let series = fetch(
+        &base,
+        Auth::Basic {
+            user: "admin".to_string(),
+            password: PASSWORD.to_string(),
+        },
+    )
+    .expect("fetch");
+
+    let request = rx.recv_timeout(Duration::from_secs(5)).expect("request");
+    let encoded = request
+        .lines()
+        .find_map(|l| l.strip_prefix("Authorization: Basic "))
+        .expect("a Basic header was sent")
+        .trim()
+        .to_string();
+    assert!(!encoded.is_empty(), "the encoded credential is non-empty");
+
+    let grid = Grid::new(0.0, 10.0, 10.0).expect("grid");
+    let normalized: Vec<_> = series.iter().map(|s| normalize(s, grid)).collect();
+    let csv = csv_out::write_csv(grid, &normalized).expect("csv");
+    let yaml = yaml_out::to_yaml(
+        &yaml_out::scenario_for("capture.csv", grid, &normalized).expect("scenario"),
+    )
+    .expect("yaml");
+
+    for (what, text) in [("csv", &csv), ("yaml", &yaml)] {
+        assert!(!text.contains(PASSWORD), "{what} carries the password");
+        assert!(
+            !text.contains(&encoded),
+            "{what} carries the encoded header"
+        );
+    }
+}
+
+/// Labels chosen to break the header grammar, arriving over the wire.
+#[test]
+fn hostile_labels_from_the_server_survive_into_a_loadable_capture() {
+    // Quote, backslash, brace, comma and a unicode value — each one is a
+    // character the label block or the CSV field has to escape.
+    let body = matrix(
+        r#"{"__name__":"up","quote":"a\"b","backslash":"a\\b","brace":"{v}","comma":"a,b","unicode":"héllo → ✓"}"#,
+        r#"[0,"1"],[10,"2"],[20,"3"]"#,
+    );
+    let (base, _rx) = mock_tsdb("200 OK", &body);
+
+    let series = fetch(&base, Auth::None).expect("fetch");
+    let grid = Grid::new(0.0, 20.0, 10.0).expect("grid");
+    let normalized: Vec<_> = series.iter().map(|s| normalize(s, grid)).collect();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let csv_path = dir.path().join("hostile.csv");
+    std::fs::write(
+        &csv_path,
+        csv_out::write_csv(grid, &normalized).expect("csv"),
+    )
+    .expect("write");
+
+    let yaml = yaml_out::to_yaml(
+        &yaml_out::scenario_for(csv_path.to_str().expect("utf8"), grid, &normalized)
+            .expect("scenario"),
+    )
+    .expect("yaml");
+
+    let entries = sonda_core::compile_scenario_file(&yaml, &InMemoryPackResolver::default())
+        .unwrap_or_else(|e| panic!("hostile labels broke the capture: {e}\n{yaml}"));
+    let runnables: usize = entries
+        .into_iter()
+        .map(|e| sonda_core::config::expand_entry(e).expect("expand").len())
+        .sum();
+    assert_eq!(runnables, 1, "one series, one runnable");
+
+    // And the values survived the two escaping layers intact.
+    for (k, v) in [
+        ("quote", "a\"b"),
+        ("backslash", "a\\b"),
+        ("brace", "{v}"),
+        ("comma", "a,b"),
+        ("unicode", "héllo → ✓"),
+    ] {
+        assert_eq!(
+            normalized[0].labels.get(k).map(String::as_str),
+            Some(v),
+            "label {k} arrived intact"
+        );
+    }
+}

--- a/sonda-core/tests/acquire_capture.rs
+++ b/sonda-core/tests/acquire_capture.rs
@@ -197,7 +197,13 @@ fn basic_auth_credentials_do_not_reach_an_artifact_in_either_form() {
         .expect("a Basic header was sent")
         .trim()
         .to_string();
-    assert!(!encoded.is_empty(), "the encoded credential is non-empty");
+    // Vacuity guard, and it has to be this exact value: a header that is merely
+    // present and non-empty is satisfied by base64("admin:"), so the plaintext
+    // check below would pass with the password never leaving the process.
+    assert_eq!(
+        encoded, "YWRtaW46aHVudGVyMi1wbGFpbnRleHQ=",
+        "the password must actually have been sent, or the plaintext leak check proves nothing"
+    );
 
     let grid = Grid::new(0.0, 10.0, 10.0).expect("grid");
     let normalized: Vec<_> = series.iter().map(|s| normalize(s, grid)).collect();
@@ -214,6 +220,49 @@ fn basic_auth_credentials_do_not_reach_an_artifact_in_either_form() {
             "{what} carries the encoded header"
         );
     }
+}
+
+/// `http://user:pass@host` is the other way a credential reaches this client,
+/// and it is the one that is stored rather than applied and dropped.
+#[test]
+fn a_credential_in_the_base_url_reaches_neither_the_error_nor_the_debug() {
+    const PASSWORD: &str = "urlsecret9999";
+
+    let (base, rx) = mock_tsdb(
+        "500 Internal Server Error",
+        r#"{"status":"error","error":"boom"}"#,
+    );
+    let with_credential = base.replace("http://", &format!("http://admin:{PASSWORD}@"));
+
+    let err = fetch(&with_credential, Auth::None).expect_err("a 500 must be an error");
+
+    // The credential still has to be on the wire, or nothing below is a test.
+    let request = rx.recv_timeout(Duration::from_secs(5)).expect("request");
+    assert!(
+        request.starts_with("GET "),
+        "the request was actually made:\n{request}"
+    );
+
+    let text = err.to_string();
+    assert!(!text.contains(PASSWORD), "the error quotes it: {text}");
+    // Same trap as the basic-auth guard: absence proves nothing if the URL
+    // never carried a credential. The marker says one was there and was cut.
+    assert!(
+        text.contains("<redacted>@"),
+        "a credential was redacted, rather than there being none: {text}"
+    );
+    assert!(
+        text.contains("/api/v1/query_range"),
+        "and it still names the endpoint: {text}"
+    );
+
+    let client = TsdbClient::new(&with_credential, Auth::None, Duration::from_secs(1));
+    let shown = format!("{client:?}");
+    assert!(!shown.contains(PASSWORD), "Debug carries it: {shown}");
+    assert!(
+        shown.contains("<redacted>@"),
+        "Debug shows the cut: {shown}"
+    );
 }
 
 /// Labels chosen to break the header grammar, arriving over the wire.


### PR DESCRIPTION
## What ships

**A socket-backed test harness for the capture path.** `sonda-core/tests/acquire_capture.rs`
stands a throwaway `TcpListener` in front of `TsdbClient`, so the outbound HTTP request is
inspectable and the whole chain (fetch → normalize → CSV → scenario → `compile_scenario_file`
→ `expand_entry`) runs on data that arrived over a real socket rather than on a hand-built
`FetchedSeries`. No new dependency; the mock is ~25 lines of `std::net`. Until now every
`acquire` test constructed its input in-process, which left the HTTP client and what it does
with a credential untested.

**Two credential leaks closed in `acquire/tsdb.rs`.** `http://user:pass@host` is a way a
credential reaches this client that `Auth` does not cover, and unlike `Auth` it is *stored*
rather than applied and dropped. It was appearing verbatim in the query error — twice, once
as the reported URL and once inside `ureq`'s own message — and in the derived `Debug`.

- `userinfo_of` locates the credential once at construction; `scrub_userinfo` is the single
  definition of the removal, used both for the stored display form and for every string this
  client reports. The wire still gets the credentialed URL; only what is *formatted* is cut.
- The derived `Debug` is replaced with a hand-written one, matching what `Auth` already does
  a few lines above. The derived form leaked three ways at once: `range_url`, the `userinfo`
  field, and the raw value.

| Test | Asserts |
|---|---|
| `a_capture_taken_over_http_replays_through_the_real_compiler` | a capture with a hole in it round-trips into a scenario the compiler accepts and `expand_entry` expands |
| `a_bearer_token_is_sent_and_never_reaches_an_emitted_artifact` | the token is in neither the CSV, the YAML, nor `TsdbClient`'s `Debug` |
| `an_error_response_does_not_quote_the_credential_back` | a 500 produces an error naming `/api/v1/query_range` and not the token |
| `basic_auth_credentials_do_not_reach_an_artifact_in_either_form` | plaintext password *and* the base64 header value, read back off the captured request |
| `a_credential_in_the_base_url_reaches_neither_the_error_nor_the_debug` | a `user:pass@` base URL is redacted from the error and the `Debug`, and still on the wire |
| `hostile_labels_from_the_server_survive_into_a_loadable_capture` | quote, backslash, brace, comma and unicode label values survive both escaping layers and load through the compiler intact |

Plus unit tests in `tsdb.rs` for `userinfo_of` (an `@` in a path or query is not a credential)
and for the wire-keeps-it / display-cuts-it split.

## Why none of the leak checks are vacuous

Asserting a credential is *absent* proves nothing unless it was *present* first, and there are
two ways to get that wrong. Both are guarded:

- **The credential was never sent.** Each `Auth` test reads the captured request off a channel
  and asserts the credential is in it before checking the artifacts. For basic auth this has to
  be an exact comparison — a header that is merely present and non-empty is satisfied by
  `base64("admin:")`, which would let the plaintext check pass with the password never leaving
  the process.
- **There was no credential to redact.** The URL test asserts the error and the `Debug` contain
  the `<redacted>@` marker, so a test URL that quietly stopped carrying a credential fails
  rather than passing by testing nothing.

## Red-verification

Each mutation was confirmed present in the source before its result was trusted, and reverted
after.

| Mutation | Result |
|---|---|
| drop the `Bearer` header from `Auth::Bearer` | vacuity guard fires with its own message; 2 tests fail |
| replace `Auth`'s redacting `Debug` with one that prints the credential | 1 test fails |
| send an empty basic password (`"{user}:"`) | the exact-encoding assert fires: got `YWRtaW46`, wanted the full encoding |
| `#[derive(Debug)]` on `TsdbClient` | 2 tests fail, showing the credential three ways |
| raw `range_url` and unscrubbed reason in the query error | the URL test fails, showing the credential twice in one message |
| the test URL embeds no credential at all | the `<redacted>@` guard fires |

## Limitations

- One canned response per mock server; no retry, redirect or chunked-transfer coverage. This
  exercises the credential and parse paths, not connection behaviour.
- Leak checking is substring containment over the emitted CSV and YAML. It catches a credential
  written through verbatim or base64-encoded; it would not catch one transformed some other way.
- Redaction covers the credential this client was constructed with. A secret that reaches an
  error by some other route — a server echoing it in a response body, say — is not in scope.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features --no-fail-fast` — 3266 passed, 5 failed. The five are
  the ones that reproduce on `main` in this container:
  `sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message` and
  `tests::sink_file_error_produces_sink_variant` (both need a non-root uid), plus
  `global_inflight_limit_gates_across_routes`,
  `health_remains_responsive_when_control_plane_is_saturated` and
  `request_timeout_returns_408_with_structured_error` in `sonda-server`.

`tsdb.rs` is behind the `http` feature and `sonda-wasm` builds `sonda-core` with `config` only,
so the wasm bundle is unaffected.
