### PR TITLE
feat(server): start catalog scenarios at boot with --autostart

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -290,7 +290,7 @@ tasks:
       negative cases that keep the schema from degenerating into "accepts
       anything".
     cmds:
-      - cargo test -p sonda-core --all-features --lib schema::
+      - "cargo test -p sonda-core --all-features --lib schema::"
       - cargo test -p sonda-core --all-features --test schema_corpus
 
   site:jstest:

--- a/docs/site/docs/build/catalogs-and-packs.md
+++ b/docs/site/docs/build/catalogs-and-packs.md
@@ -26,7 +26,7 @@ sonda --catalog ./my-catalog show @cpu-spike
 sonda --catalog ./my-catalog run @cpu-spike
 ```
 
-Files without a recognized `kind:` header are skipped silently. Files with an unparseable YAML body print a warning to stderr and are skipped. The listing continues.
+Files without a recognized `kind:` header are skipped silently. A file the process cannot open, and a file with an unparseable YAML body, each print a warning to stderr and are skipped. The listing continues — one bad file never costs you the rest of the catalog.
 
 Two files with the same logical name (`name:` field or filename) are a **hard error**. Discovery fails with the conflicting paths. Rename one to disambiguate.
 

--- a/docs/site/docs/deploy/docker.md
+++ b/docs/site/docs/deploy/docker.md
@@ -79,6 +79,56 @@ The image has no built-in catalog. Mount a directory of your own scenario and pa
 !!! warning "Pre-1.9 env vars are gone"
     Earlier releases let the image discover scenarios from `SONDA_PACK_PATH=/packs` and `SONDA_SCENARIO_PATH=/scenarios` environment variables. The image also included companion `/packs` and `/scenarios` directories. Both were removed in 1.9. Discovery is explicit through `--catalog <dir>`. There is no environment variable fallback and no implicit search path. Old recipes built around `docker run … run @scenario` fail with "catalog dir does not exist or is not a directory" or a `@name` resolution error. Add `--catalog /catalog` and mount your catalog volume there.
 
+## Autostarting a mounted catalog
+
+Mounting a catalog makes its files available to `POST /scenarios`; it does not run any of them. Add `SONDA_AUTOSTART` (or the `--autostart` flag) and the container starts every `kind: runnable` file in the mounted directory itself, so a `docker compose up` brings the traffic up with the server and a container restart brings it back:
+
+=== "`docker run`"
+
+    ```bash
+    docker run -p 8080:8080 \
+      -v "$PWD/my-catalog":/catalog:ro \
+      ghcr.io/davidban77/sonda:latest \
+      --catalog /catalog --autostart
+    ```
+
+=== "Docker Compose"
+
+    ```yaml title="docker-compose.yml"
+    services:
+      sonda-server:
+        image: ghcr.io/davidban77/sonda:latest
+        ports:
+          - "8080:8080"
+        volumes:
+          - ./my-catalog:/catalog:ro
+        environment:
+          - SONDA_CATALOG=/catalog
+          - SONDA_AUTOSTART=1
+    ```
+
+The server answers `/health` as soon as the port is open and the entries appear in `GET /scenarios` as they start, so a container health check never waits on the catalog:
+
+```bash
+curl http://localhost:8080/health
+curl http://localhost:8080/scenarios
+
+# One line per started entry, plus a closing count
+docker logs sonda-server
+```
+
+`kind: composable` packs are never started — they stay available for `pack: <name>` references from the runnables next to them. A file the server cannot open, compile, or admit is logged and skipped, so one bad file does not stop the container coming up. Two files claiming the same catalog name is a startup error: the process exits before binding, which under a restart policy shows up as a restart loop rather than a container serving nothing.
+
+!!! warning "`SONDA_AUTOSTART=` in an `.env` file means off"
+    Sonda reads `SONDA_AUTOSTART` like every other boolean env var: an empty value, `0`, `n`, `no`, `f`, `false`, and `off` (any case) all disable it. Compose substitutes an unset variable as empty, so an `.env` entry left blank switches autostart off rather than failing loudly.
+
+    ```bash title=".env"
+    SONDA_CATALOG=/catalog
+    SONDA_AUTOSTART=1
+    ```
+
+See [Server API -- Autostarting a catalog](server.md#autostarting-a-catalog) for the full behaviour, including start order and how skipped files are logged.
+
 ## Authentication
 
 You can protect the server's `/scenarios/*` endpoints with API key authentication.

--- a/docs/site/docs/deploy/kubernetes.md
+++ b/docs/site/docs/deploy/kubernetes.md
@@ -68,6 +68,7 @@ The chart includes default values that work for most installs. Override any valu
 |-------|---------|-------------|
 | `server.port` | `8080` | Port `sonda-server` listens on inside the container |
 | `server.bind` | `0.0.0.0` | Bind address |
+| `server.autostart` | `false` | Start every `kind: runnable` file in the mounted ConfigMap when the pod boots |
 
 ### Service
 
@@ -234,18 +235,23 @@ at `/scenarios` inside the container:
 ```yaml title="my-values.yaml"
 scenarios:
   cpu-metrics.yaml: |
-    name: cpu_usage
-    rate: 100
-    duration: 30s
-    generator:
-      type: sine
-      amplitude: 50
-      period_secs: 60
-      offset: 50
-    encoder:
-      type: prometheus_text
-    sink:
-      type: stdout
+    version: 2
+    kind: runnable
+    defaults:
+      rate: 100
+      duration: 30s
+      encoder:
+        type: prometheus_text
+      sink:
+        type: stdout
+    scenarios:
+      - signal_type: metrics
+        name: cpu_usage
+        generator:
+          type: sine
+          amplitude: 50.0
+          period_secs: 60
+          offset: 50.0
 ```
 
 ```bash
@@ -258,6 +264,31 @@ content in your values file triggers an automatic pod rollout on `helm upgrade`.
 You can place `kind: composable` [metric pack](../build/catalogs-and-packs.md) YAMLs in the same `scenarios` map next to your runnable scenarios. When `scenarios` is populated, the chart points the server's `--catalog` flag at the mounted `/scenarios` directory. `POST /scenarios` bodies that reference a pack by name (`pack: <name>`) then resolve automatically. No extra configuration. See [Pack references over HTTP](http-api.md#pack-references-over-http) for how that resolution works.
 
 See [Scenario Fields](../reference/scenario-fields.md) for the full YAML schema.
+
+#### Starting the ConfigMap scenarios automatically
+
+Mounting scenarios makes them available; it does not run them. Set `server.autostart: true` and the pod starts every `kind: runnable` file in the ConfigMap as soon as the server is listening — no POST, no sidecar re-posting on restart:
+
+```yaml title="my-values.yaml"
+server:
+  autostart: true
+
+scenarios:
+  cpu-metrics.yaml: |
+    version: 2
+    kind: runnable
+    ...
+```
+
+`server.autostart: true` with an empty `scenarios` map is rejected at template time, so the mistake surfaces on `helm install` rather than as a Ready pod serving nothing:
+
+```text
+Error: execution error at (sonda/templates/deployment.yaml:2:4): server.autostart is set but scenarios is empty: there is no catalog to start. Populate .Values.scenarios or set server.autostart=false.
+```
+
+`kind: composable` packs are never started — they stay available for `pack: <name>` references. A scenario file the server cannot admit is logged and skipped, so one bad file cannot keep the pod from coming up; two files claiming the same name is a startup error, because the pod would otherwise come up serving nothing. See [Autostarting a catalog](server.md#autostarting-a-catalog) for the full behaviour, including how skipped files are logged.
+
+Autostarted scenarios run for the `duration:` in their YAML. Once they finish they stay in the scenario list in `finished` state until deleted — set a long `duration:` (or omit it for an unbounded run) when the pod is meant to emit continuously.
 
 ### API (runtime)
 

--- a/docs/site/docs/deploy/server.md
+++ b/docs/site/docs/deploy/server.md
@@ -250,11 +250,13 @@ Press Ctrl+C for graceful shutdown. The server signals all running scenarios to 
 
 ### Autostarting a catalog
 
-By default the server boots empty and waits for you to `POST /scenarios`. Add `--autostart` and it starts every `kind: runnable` file in `--catalog` as soon as it is listening — the same result as POSTing each of those files yourself, without the POST:
+By default the server boots empty and waits for you to `POST /scenarios`. Add `--autostart` and it starts every `kind: runnable` file in `--catalog` itself — the same result as POSTing each of those files yourself, without the POST:
 
 ```bash
 sonda-server --port 8080 --catalog ./catalog --autostart
 ```
+
+The sweep runs alongside the server, not ahead of it. `/health` answers as soon as the port is open, so a readiness probe with a tight `timeoutSeconds` never waits on the catalog, and entries appear in `GET /scenarios` as they start — a large catalog reads as a growing list rather than an empty one. The `INFO` summary below is the point at which the list is complete. A shutdown signal that arrives mid-sweep stops the sweep at the next entry, and every scenario it did start is stopped with the rest.
 
 `--autostart` requires `--catalog`. Passing it alone (or setting `SONDA_AUTOSTART` without `SONDA_CATALOG`) exits before the server binds a port:
 
@@ -283,17 +285,20 @@ Caused by:
     catalog /catalog contains duplicate entry name "web_traffic": /catalog/a.yaml and /catalog/b.yaml
 ```
 
-Everything else keeps the server up. A scenario file the server cannot admit — a v1 body, a compile error, a validation failure, or a file that would push past `--max-scenarios` — is logged as a `WARN` and skipped; one bad file never stops the ones after it:
+Everything else keeps the server up. A file the server cannot use — one it has no permission to open, a v1 body, a compile error, a validation failure, or a file that would push past `--max-scenarios` — is logged and skipped; one bad file never stops the ones after it:
 
 ```text
+warning: catalog: skipping unreadable file /catalog/locked.yaml: Permission denied (os error 13)
 WARN sonda_server::autostart: /catalog/legacy.yaml: does not compile, skipping catalog entry origin=/catalog/legacy.yaml reason=body is not a v2 scenario. ...
 WARN sonda_server::routes::scenarios: /catalog/extra.yaml: scenario cap reached origin=/catalog/extra.yaml needed=1
 ```
 
-If the catalog cannot be read at all — a file the server has no permission to open, a directory that disappears mid-scan — it logs a `WARN`, starts nothing, and keeps serving so you can fix it over the API:
+The first line has a different shape because it comes from the catalog scan rather than the sweep: unreadable and unparseable files are dropped while the catalog is being read, and `sonda list` reports them the same way.
+
+If the catalog *directory* cannot be scanned — its permissions do not allow a listing, or an entry vanishes mid-scan — the server logs a `WARN`, starts nothing, and keeps serving so you can fix it over the API:
 
 ```text
-WARN sonda_server::autostart: autostart: catalog could not be read, starting nothing catalog=/catalog reason=failed to read /catalog/locked.yaml: Permission denied (os error 13)
+WARN sonda_server::autostart: autostart: catalog could not be read, starting nothing catalog=/catalog reason=failed to read catalog dir /catalog: Permission denied (os error 13)
 ```
 
 Every started scenario gets one `INFO` line naming the file it came from, and the sweep closes with a count, so "pod up, serving nothing" is visible in the log rather than only in the API:

--- a/docs/site/docs/deploy/server.md
+++ b/docs/site/docs/deploy/server.md
@@ -225,7 +225,7 @@ The scenario runs in the background inside the server until its `duration` expir
 
 ## Server flags
 
-`sonda-server` accepts nine flags. The first four are the network and addressing surface; the remaining five control resource limits and runtime sizing. Use the `RUST_LOG` environment variable to control log verbosity (default `info`):
+`sonda-server` accepts ten flags. The first five are the network, addressing, and startup surface; the remaining five control resource limits and runtime sizing. Use the `RUST_LOG` environment variable to control log verbosity (default `info`):
 
 ```bash
 RUST_LOG=debug sonda-server --port 8080
@@ -237,6 +237,7 @@ RUST_LOG=debug sonda-server --port 8080
 | `--bind <ADDR>` | -- | `0.0.0.0` | Bind address |
 | `--api-key <KEY>` | `SONDA_API_KEY` | (unset) | Bearer token for `/scenarios/*`, `/events`, and metrics endpoints. See [Authentication](#authentication). |
 | `--catalog <DIR>` | `SONDA_CATALOG` | (unset) | Directory of scenario and pack YAML files. Lets `POST /scenarios` resolve `pack: <name>` references. See [Pack references over HTTP](http-api.md#pack-references-over-http). |
+| `--autostart` | `SONDA_AUTOSTART` | `false` | Start every `kind: runnable` entry in `--catalog` when the server boots. See [Autostarting a catalog](#autostarting-a-catalog). |
 | `--workers <N>` | -- | `min(available_parallelism(), 16)` | Tokio worker thread count. See [Tuning resource limits](#tuning-resource-limits). |
 | `--max-scenarios <N>` | -- | `0` (unlimited) | Maximum concurrent scenario rows. POSTs beyond the cap return [`429 capacity_exceeded`](http-api.md#capacity-and-resource-errors). |
 | `--max-inflight-requests <N>` | -- | `4 * workers` | Maximum concurrent in-flight control-plane HTTP requests. |
@@ -246,6 +247,63 @@ RUST_LOG=debug sonda-server --port 8080
 When you pass `--catalog`, point it at a directory that holds your `kind: composable` pack YAML files. The path must exist. A missing directory makes the server fail at startup with a clear error.
 
 Press Ctrl+C for graceful shutdown. The server signals all running scenarios to stop before exiting.
+
+### Autostarting a catalog
+
+By default the server boots empty and waits for you to `POST /scenarios`. Add `--autostart` and it starts every `kind: runnable` file in `--catalog` as soon as it is listening — the same result as POSTing each of those files yourself, without the POST:
+
+```bash
+sonda-server --port 8080 --catalog ./catalog --autostart
+```
+
+`--autostart` requires `--catalog`. Passing it alone (or setting `SONDA_AUTOSTART` without `SONDA_CATALOG`) exits before the server binds a port:
+
+```text
+Error: --autostart requires --catalog <DIR> (or SONDA_AUTOSTART requires SONDA_CATALOG): there is no scenario catalog to start from
+```
+
+`SONDA_AUTOSTART` reads like every other boolean env var: empty, `0`, `n`, `no`, `f`, `false`, and `off` (any case) disable it; any other value enables it. An empty value is the common one — `env: [{name: SONDA_AUTOSTART, value: ""}]` in a pod spec, or `SONDA_AUTOSTART=` in a Compose `.env` — and it means "off", not "broken".
+
+What starts and what does not:
+
+| Catalog file | Autostart behaviour |
+|---|---|
+| `kind: runnable` | Started. A file with several entries under `scenarios:` starts one scenario per entry. |
+| `kind: composable` | Not started. Packs exist to be referenced by `pack: <name>`, and runnables that reference them resolve against the same catalog directory. |
+| No `kind:` header | Ignored — the file is not a catalog entry at all. |
+
+Entries start in catalog-name order — the `scenario_name:` of the file, or its `name:`, or the filename stem with underscores turned into dashes (`web_traffic.yaml` becomes `web-traffic`), whichever the file declares first. That is the same order `sonda list` shows, so what you see in the catalog listing is the order the sweep uses.
+
+Two things stop the server before it binds, both of them mistakes only you can fix: `--autostart` with no catalog, and a catalog whose entries are not addressable — two files claiming the same name, or a name that cannot be derived from the file. The error names the clash and the files that caused it:
+
+```text
+Error: --autostart: catalog /catalog is not startable
+
+Caused by:
+    catalog /catalog contains duplicate entry name "web_traffic": /catalog/a.yaml and /catalog/b.yaml
+```
+
+Everything else keeps the server up. A scenario file the server cannot admit — a v1 body, a compile error, a validation failure, or a file that would push past `--max-scenarios` — is logged as a `WARN` and skipped; one bad file never stops the ones after it:
+
+```text
+WARN sonda_server::autostart: /catalog/legacy.yaml: does not compile, skipping catalog entry origin=/catalog/legacy.yaml reason=body is not a v2 scenario. ...
+WARN sonda_server::routes::scenarios: /catalog/extra.yaml: scenario cap reached origin=/catalog/extra.yaml needed=1
+```
+
+If the catalog cannot be read at all — a file the server has no permission to open, a directory that disappears mid-scan — it logs a `WARN`, starts nothing, and keeps serving so you can fix it over the API:
+
+```text
+WARN sonda_server::autostart: autostart: catalog could not be read, starting nothing catalog=/catalog reason=failed to read /catalog/locked.yaml: Permission denied (os error 13)
+```
+
+Every started scenario gets one `INFO` line naming the file it came from, and the sweep closes with a count, so "pod up, serving nothing" is visible in the log rather than only in the API:
+
+```text
+INFO sonda_server::routes::scenarios: scenario launched id=6f1c… name=cpu_usage state=running origin=/catalog/cpu.yaml
+INFO sonda_server::autostart: autostart: started 3 of 4 runnable catalog entries started=3 total=4
+```
+
+Autostarted scenarios are ordinary scenarios: they appear in `GET /scenarios`, count against `--max-scenarios`, and are stoppable with `DELETE /scenarios/{id}`. A `while:` clause that points at a scenario in another catalog file resolves when that file's turn comes; until then the scenario sits in `unresolved` or `pending`, exactly as it would if you posted the two files in catalog-name order.
 
 ### Tuning resource limits
 

--- a/docs/site/docs/reference/cli-flags.md
+++ b/docs/site/docs/reference/cli-flags.md
@@ -192,7 +192,7 @@ sonda --catalog ~/sonda-catalog list --kind runnable --tag cpu
 
 `--json` emits a stable array on stdout. Each element has `name`, `kind`, `description`, `tags`, and the resolved `source` path. Use it as the contract when scripting catalog discovery.
 
-Files without a recognized `kind:` header are skipped silently. Files with an unparseable YAML body print a warning to stderr and are also skipped. The listing continues.
+Files without a recognized `kind:` header are skipped silently. A file the process cannot open, and a file with an unparseable YAML body, each print a warning to stderr and are also skipped. The listing continues — one bad file never costs you the rest of the catalog.
 
 ## `sonda show`
 

--- a/helm/sonda/templates/deployment.yaml
+++ b/helm/sonda/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.server.autostart (not .Values.scenarios) }}
+{{- fail "server.autostart is set but scenarios is empty: there is no catalog to start. Populate .Values.scenarios or set server.autostart=false." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,6 +55,9 @@ spec:
             {{- if .Values.scenarios }}
             - "--catalog"
             - "/scenarios"
+            {{- if .Values.server.autostart }}
+            - "--autostart"
+            {{- end }}
             {{- end }}
           ports:
             - name: http

--- a/helm/sonda/values.yaml
+++ b/helm/sonda/values.yaml
@@ -24,6 +24,9 @@ server:
   port: 8080
   # Bind address for the sonda-server.
   bind: "0.0.0.0"
+  # Start every `kind: runnable` file in the mounted catalog at pod startup.
+  # Requires a populated `scenarios` map below.
+  autostart: false
   # API key authentication for /scenarios/* endpoints.
   auth:
     # Enable API key authentication (Bearer token via SONDA_API_KEY).
@@ -74,38 +77,49 @@ securityContext:
 # Each key becomes a file under /scenarios in the container.
 # Composable pack files (kind: composable) can be placed in the same map; they
 # are resolved automatically for `pack: <name>` references in posted scenario
-# bodies.
+# bodies. With server.autostart: true, every kind: runnable file here is
+# started when the pod boots.
 # Example:
 #   scenarios:
 #     basic-metrics.yaml: |
-#       name: cpu_usage
-#       rate: 100
-#       duration: 30s
-#       generator:
-#         type: sine
-#         amplitude: 50
-#         period_secs: 60
-#         offset: 50
-#       encoder:
-#         type: prometheus_text
-#       sink:
-#         type: stdout
+#       version: 2
+#       kind: runnable
+#       defaults:
+#         rate: 100
+#         duration: 30s
+#         encoder:
+#           type: prometheus_text
+#         sink:
+#           type: stdout
+#       scenarios:
+#         - signal_type: metrics
+#           name: cpu_usage
+#           generator:
+#             type: sine
+#             amplitude: 50.0
+#             period_secs: 60
+#             offset: 50.0
 #     app-logs.yaml: |
-#       name: app_logs
-#       rate: 10
-#       duration: 60s
-#       generator:
-#         type: template
-#         templates:
-#           - message: "Request from {ip}"
-#             field_pools:
-#               ip:
-#                 - "10.0.0.1"
-#                 - "10.0.0.2"
-#       encoder:
-#         type: json_lines
-#       sink:
-#         type: stdout
+#       version: 2
+#       kind: runnable
+#       defaults:
+#         rate: 10
+#         duration: 60s
+#         encoder:
+#           type: json_lines
+#         sink:
+#           type: stdout
+#       scenarios:
+#         - signal_type: logs
+#           name: app_logs
+#           log_generator:
+#             type: template
+#             templates:
+#               - message: "Request from {ip}"
+#                 field_pools:
+#                   ip:
+#                     - "10.0.0.1"
+#                     - "10.0.0.2"
 scenarios: {}
 
 # Horizontal Pod Autoscaler configuration.

--- a/sonda-core/src/catalog.rs
+++ b/sonda-core/src/catalog.rs
@@ -28,6 +28,7 @@ pub enum CatalogError {
         source: std::io::Error,
     },
 
+    /// Currently unconstructed: enumeration warns and skips instead. Kept for API stability.
     #[error("failed to read {path}")]
     ReadFile {
         path: String,
@@ -93,7 +94,9 @@ struct CatalogEntryHeader {
 }
 
 /// Walk `dir` and return one [`CatalogEntry`] per YAML file with a
-/// recognized `kind:` header. Files without `kind:` are silently skipped.
+/// recognized `kind:` header. Files without `kind:` are silently skipped;
+/// a file that cannot be read or parsed warns on stderr and is skipped, so
+/// one bad file never costs the rest of the catalog.
 pub fn enumerate(dir: &Path) -> Result<Vec<CatalogEntry>, CatalogError> {
     if !dir.is_dir() {
         return Err(CatalogError::NotADirectory {
@@ -166,10 +169,16 @@ fn is_yaml_file(path: &Path) -> bool {
 }
 
 fn peek_entry(path: &Path) -> Result<Option<CatalogEntry>, CatalogError> {
-    let content = fs::read_to_string(path).map_err(|source| CatalogError::ReadFile {
-        path: path.display().to_string(),
-        source,
-    })?;
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(e) => {
+            eprintln!(
+                "warning: catalog: skipping unreadable file {}: {e}",
+                path.display()
+            );
+            return Ok(None);
+        }
+    };
     let header: CatalogEntryHeader = match serde_yaml_ng::from_str(&content) {
         Ok(h) => h,
         Err(e) => {
@@ -389,6 +398,47 @@ metrics:
         let msg = format!("{err}");
         assert!(msg.contains("missing"), "got: {msg}");
         assert!(msg.contains("cpu-spike"), "must list candidates: {msg}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn enumerate_skips_an_unreadable_file_and_keeps_the_rest() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = temp_catalog();
+        let locked = tmp.path().join("locked.yaml");
+        write(tmp.path(), "locked.yaml", "version: 2\nkind: runnable\n");
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000))
+            .expect("must drop read permission");
+        if fs::File::open(&locked).is_ok() {
+            eprintln!("skipping: this process can open a 0o000 file (running as root?)");
+            return;
+        }
+
+        let entries = enumerate(tmp.path()).expect("one unreadable file must not fail the catalog");
+
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["cpu-spike", "tiny_pack"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_finds_a_readable_entry_next_to_an_unreadable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = temp_catalog();
+        let locked = tmp.path().join("locked.yaml");
+        write(tmp.path(), "locked.yaml", "version: 2\nkind: runnable\n");
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000))
+            .expect("must drop read permission");
+        if fs::File::open(&locked).is_ok() {
+            eprintln!("skipping: this process can open a 0o000 file (running as root?)");
+            return;
+        }
+
+        let resolved = resolve(tmp.path(), "cpu-spike").expect("must resolve");
+
+        assert_eq!(resolved.file_name().unwrap(), "cpu-spike.yaml");
     }
 
     #[test]

--- a/sonda-server/CLAUDE.md
+++ b/sonda-server/CLAUDE.md
@@ -23,7 +23,8 @@ src/
 ├── autostart.rs        ← --autostart sweep: runnable_entries() enumerates pre-bind (a catalog
 │                         the operator must fix is fatal; transient I/O warns and yields none),
 │                         start_entries() admits each through routes::scenarios::admit_compiled
-│                         and logs+skips per-entry failures
+│                         and logs+skips per-entry failures. Runs as a spawned task alongside
+│                         axum::serve; takes a CancellationToken that shutdown cancels and joins
 ├── routes/
 │   ├── mod.rs          ← router_with_config() function: splits three sub-routers — public (/health),
 │                         protected observability (/scenarios/{id}/stats, /scenarios/{id}/metrics,
@@ -137,8 +138,11 @@ Respects `RUST_LOG` env var for log level (default: `info`).
 `{"sonda_server":{"port":N}}` to stdout; tracing logs go to stderr.
 
 `--autostart` (env `SONDA_AUTOSTART`) requires `--catalog` and starts every
-`kind: runnable` catalog entry after the listener is bound, through the same
-admission path `POST /scenarios` uses.
+`kind: runnable` catalog entry through the same admission path `POST /scenarios`
+uses. Catalog validation runs before the bind, so a catalog the operator must fix
+is fatal; the sweep itself runs concurrently with `axum::serve`, so the server
+answers requests while entries are still starting. `shutdown_signal` cancels and
+joins the sweep before draining, so no admission lands after the drain.
 
 ### CLI dispatch shim
 

--- a/sonda-server/CLAUDE.md
+++ b/sonda-server/CLAUDE.md
@@ -20,6 +20,10 @@ src/
 │                         graceful shutdown (Ctrl+C stops all scenarios + joins threads with 5s timeout)
 ├── auth.rs             ← require_api_key middleware (Bearer token), unauthorized() helper,
 │                         extract_bearer_token(), constant-time key comparison via subtle
+├── autostart.rs        ← --autostart sweep: runnable_entries() enumerates pre-bind (a catalog
+│                         the operator must fix is fatal; transient I/O warns and yields none),
+│                         start_entries() admits each through routes::scenarios::admit_compiled
+│                         and logs+skips per-entry failures
 ├── routes/
 │   ├── mod.rs          ← router_with_config() function: splits three sub-routers — public (/health),
 │                         protected observability (/scenarios/{id}/stats, /scenarios/{id}/metrics,
@@ -61,6 +65,9 @@ tests/
 │                         Spawn helpers use `--port 0` + read the stdout announce.
 │                         All test files use `mod common;` for these helpers.
 ├── auth.rs             ← E2E tests: auth via --api-key flag, SONDA_API_KEY env var, no-key backwards compat
+├── autostart.rs        ← --autostart E2E: runnable entries start, packs do not, bad files are
+│                         skipped, SONDA_AUTOSTART value matrix, --autostart without --catalog
+│                         and duplicate catalog names exit before binding
 ├── events.rs           ← POST /events E2E: logs + metrics happy paths, malformed body, unknown
 │                         signal_type, missing fields, invalid sink config (422), sink-push 5xx (502),
 │                         auth (401), loopback warning surfaced on success
@@ -128,6 +135,10 @@ Respects `RUST_LOG` env var for log level (default: `info`).
 
 `--port 0` lets the OS assign a port. The server then prints
 `{"sonda_server":{"port":N}}` to stdout; tracing logs go to stderr.
+
+`--autostart` (env `SONDA_AUTOSTART`) requires `--catalog` and starts every
+`kind: runnable` catalog entry after the listener is bound, through the same
+admission path `POST /scenarios` uses.
 
 ### CLI dispatch shim
 

--- a/sonda-server/src/autostart.rs
+++ b/sonda-server/src/autostart.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 
 use sonda_core::catalog::{self, CatalogEntry, CatalogError, EntryKind};
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::routes::scenarios::{admit_compiled, compile_v2_text};
@@ -10,7 +11,8 @@ use crate::state::AppState;
 
 /// Enumerate the catalog's runnable entries in the order the sweep will start them.
 /// A catalog the operator must fix (duplicate or underivable entry name) is an error;
-/// transient I/O warns and yields no entries, leaving the server free to come up.
+/// a directory that cannot be scanned warns and yields no entries, leaving the server
+/// free to come up.
 pub fn runnable_entries(catalog_dir: &Path) -> anyhow::Result<Vec<CatalogEntry>> {
     let entries = match catalog::enumerate(catalog_dir) {
         Ok(entries) => entries,
@@ -47,11 +49,24 @@ fn is_misconfiguration(error: &CatalogError) -> bool {
 
 /// Admit every entry through the same path `POST /scenarios` uses, logging and
 /// skipping any entry that fails so one bad file cannot stop the server.
-pub async fn start_entries(state: &AppState, entries: &[CatalogEntry]) {
+/// Runs alongside the HTTP server; `cancel` stops it at the next entry boundary
+/// so shutdown never races an admission it would not see.
+pub async fn start_entries(state: &AppState, entries: &[CatalogEntry], cancel: &CancellationToken) {
     let catalog_dir = state.catalog_dir.as_deref().map(|p| p.as_path());
     let mut started = 0usize;
 
-    for entry in entries {
+    for (index, entry) in entries.iter().enumerate() {
+        if cancel.is_cancelled() {
+            warn!(
+                started,
+                total = entries.len(),
+                remaining = entries.len() - index,
+                "autostart: shutdown signalled, stopped after starting {started} of {} runnable catalog entries",
+                entries.len()
+            );
+            return;
+        }
+
         let path = entry.source_path.display().to_string();
 
         let text = match std::fs::read_to_string(&entry.source_path) {
@@ -82,4 +97,68 @@ pub async fn start_entries(state: &AppState, entries: &[CatalogEntry]) {
         "autostart: started {started} of {} runnable catalog entries",
         entries.len()
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+
+    use crate::state::AppState;
+
+    const RUNNABLE: &str = "\
+version: 2
+kind: runnable
+scenario_name: alpha
+defaults:
+  rate: 1
+  duration: 300s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: memory
+scenarios:
+  - signal_type: metrics
+    name: alpha_cpu
+    generator:
+      type: constant
+      value: 1.0
+";
+
+    fn catalog_with_one_runnable() -> (TempDir, Vec<CatalogEntry>, AppState) {
+        let dir = TempDir::new().expect("must create temp catalog dir");
+        std::fs::write(dir.path().join("alpha.yaml"), RUNNABLE).expect("must write catalog file");
+        let entries = runnable_entries(dir.path()).expect("must enumerate");
+        assert_eq!(entries.len(), 1);
+
+        let mut state = AppState::new();
+        state.catalog_dir = Some(Arc::new(dir.path().to_path_buf()));
+        (dir, entries, state)
+    }
+
+    fn admitted(state: &AppState) -> usize {
+        state.scenarios.read().expect("scenarios lock").len()
+    }
+
+    #[tokio::test]
+    async fn sweep_admits_every_runnable_entry() {
+        let (_dir, entries, state) = catalog_with_one_runnable();
+
+        start_entries(&state, &entries, &CancellationToken::new()).await;
+
+        assert_eq!(admitted(&state), 1);
+    }
+
+    #[tokio::test]
+    async fn cancelled_sweep_admits_nothing() {
+        let (_dir, entries, state) = catalog_with_one_runnable();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        start_entries(&state, &entries, &cancel).await;
+
+        assert_eq!(admitted(&state), 0);
+    }
 }

--- a/sonda-server/src/autostart.rs
+++ b/sonda-server/src/autostart.rs
@@ -1,0 +1,85 @@
+//! Startup sweep that admits every `kind: runnable` catalog entry.
+
+use std::path::Path;
+
+use sonda_core::catalog::{self, CatalogEntry, CatalogError, EntryKind};
+use tracing::{info, warn};
+
+use crate::routes::scenarios::{admit_compiled, compile_v2_text};
+use crate::state::AppState;
+
+/// Enumerate the catalog's runnable entries in the order the sweep will start them.
+/// A catalog the operator must fix (duplicate or underivable entry name) is an error;
+/// transient I/O warns and yields no entries, leaving the server free to come up.
+pub fn runnable_entries(catalog_dir: &Path) -> anyhow::Result<Vec<CatalogEntry>> {
+    let entries = match catalog::enumerate(catalog_dir) {
+        Ok(entries) => entries,
+        Err(e) if is_misconfiguration(&e) => {
+            return Err(anyhow::Error::new(e).context(format!(
+                "--autostart: catalog {} is not startable",
+                catalog_dir.display()
+            )))
+        }
+        Err(e) => {
+            let reason = format!("{:#}", anyhow::Error::new(e));
+            warn!(catalog = %catalog_dir.display(), reason = %reason, "autostart: catalog could not be read, starting nothing");
+            return Ok(Vec::new());
+        }
+    };
+
+    Ok(entries
+        .into_iter()
+        .filter(|entry| entry.kind == EntryKind::Runnable)
+        .collect())
+}
+
+fn is_misconfiguration(error: &CatalogError) -> bool {
+    match error {
+        CatalogError::NotADirectory { .. }
+        | CatalogError::InvalidName { .. }
+        | CatalogError::DuplicateName { .. }
+        | CatalogError::UnknownEntry { .. } => true,
+        CatalogError::ReadDir { .. }
+        | CatalogError::ReadEntry { .. }
+        | CatalogError::ReadFile { .. } => false,
+    }
+}
+
+/// Admit every entry through the same path `POST /scenarios` uses, logging and
+/// skipping any entry that fails so one bad file cannot stop the server.
+pub async fn start_entries(state: &AppState, entries: &[CatalogEntry]) {
+    let catalog_dir = state.catalog_dir.as_deref().map(|p| p.as_path());
+    let mut started = 0usize;
+
+    for entry in entries {
+        let path = entry.source_path.display().to_string();
+
+        let text = match std::fs::read_to_string(&entry.source_path) {
+            Ok(text) => text,
+            Err(e) => {
+                warn!(origin = %path, reason = %e, "{path}: unreadable, skipping catalog entry");
+                continue;
+            }
+        };
+
+        let compiled = match compile_v2_text(&text, catalog_dir) {
+            Ok(compiled) => compiled,
+            Err(fail) => {
+                warn!(origin = %path, reason = %fail.message(), "{path}: does not compile, skipping catalog entry");
+                continue;
+            }
+        };
+
+        // admit_compiled logs the reason it rejected an entry, with the same origin.
+        if admit_compiled(state, compiled, &path).await.is_ok() {
+            started += 1;
+        }
+    }
+
+    info!(
+        started,
+        total = entries.len(),
+        "autostart: started {started} of {} runnable catalog entries",
+        entries.len()
+    );
+}

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -24,6 +24,7 @@ use std::time::{Duration, Instant};
 use anyhow::Context;
 use clap::Parser;
 use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::routes::RouterConfig;
@@ -236,13 +237,20 @@ async fn run(args: Args, workers: usize, max_inflight_requests: usize) -> anyhow
 
     info!(addr = %bound_addr, workers, "sonda-server listening");
 
-    if args.autostart {
-        autostart::start_entries(&state, &autostart_entries).await;
-    }
+    let sweep_cancel = CancellationToken::new();
+    let sweep = args.autostart.then(|| {
+        let state = state.clone();
+        let cancel = sweep_cancel.clone();
+        tokio::spawn(
+            async move { autostart::start_entries(&state, &autostart_entries, &cancel).await },
+        )
+    });
 
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(
             state,
+            sweep,
+            sweep_cancel,
             #[cfg(unix)]
             sigterm,
         ))
@@ -305,10 +313,16 @@ fn announce_bound_port(port: u16) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Wait for Ctrl+C or SIGTERM, then stop all running scenarios and signal
-/// shutdown. SIGTERM coverage is what `docker stop` and Kubernetes pod eviction
-/// rely on; without it the process is SIGKILLed after the grace period.
-async fn shutdown_signal(state: AppState, #[cfg(unix)] mut sigterm: tokio::signal::unix::Signal) {
+/// Wait for Ctrl+C or SIGTERM, then cancel and join the autostart sweep before
+/// draining the scenarios it started. SIGTERM coverage is what `docker stop`
+/// and Kubernetes pod eviction rely on; without it the process is SIGKILLed
+/// after the grace period.
+async fn shutdown_signal(
+    state: AppState,
+    sweep: Option<tokio::task::JoinHandle<()>>,
+    sweep_cancel: CancellationToken,
+    #[cfg(unix)] mut sigterm: tokio::signal::unix::Signal,
+) {
     let ctrl_c = async {
         tokio::signal::ctrl_c()
             .await
@@ -328,6 +342,13 @@ async fn shutdown_signal(state: AppState, #[cfg(unix)] mut sigterm: tokio::signa
     }
 
     info!("shutdown signal received — stopping all running scenarios");
+
+    sweep_cancel.cancel();
+    if let Some(sweep) = sweep {
+        if let Err(e) = sweep.await {
+            warn!(error = %e, "autostart sweep did not finish cleanly");
+        }
+    }
 
     if let Ok(scenarios) = state.scenarios.read() {
         for handle in scenarios.values() {

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -4,6 +4,7 @@
 //! stopped over HTTP. All scenario lifecycle logic is delegated to sonda-core.
 
 mod auth;
+mod autostart;
 mod gate_registry;
 mod middleware;
 mod routes;
@@ -64,6 +65,18 @@ struct Args {
     #[arg(long, env = "SONDA_CATALOG")]
     catalog: Option<PathBuf>,
 
+    /// Start every `kind: runnable` entry in `--catalog` at server startup.
+    ///
+    /// Can also be set via the `SONDA_AUTOSTART` environment variable, where
+    /// an empty value and `0` / `no` / `off` / `false` all mean disabled.
+    #[arg(
+        long,
+        env = "SONDA_AUTOSTART",
+        action = clap::ArgAction::SetTrue,
+        value_parser = clap::builder::FalseyValueParser::new()
+    )]
+    autostart: bool,
+
     /// Tokio worker thread count. Defaults to min(available_parallelism(), 16).
     #[arg(long, value_parser = clap::builder::RangedU64ValueParser::<u64>::new().range(1..))]
     workers: Option<u64>,
@@ -93,6 +106,7 @@ impl std::fmt::Debug for Args {
             .field("bind", &self.bind)
             .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
             .field("catalog", &self.catalog)
+            .field("autostart", &self.autostart)
             .field("workers", &self.workers)
             .field("max_scenarios", &self.max_scenarios)
             .field("max_inflight_requests", &self.max_inflight_requests)
@@ -154,6 +168,13 @@ async fn run(args: Args, workers: usize, max_inflight_requests: usize) -> anyhow
         info!("API key authentication disabled — all endpoints are public");
     }
 
+    if args.autostart && args.catalog.is_none() {
+        anyhow::bail!(
+            "--autostart requires --catalog <DIR> (or SONDA_AUTOSTART requires SONDA_CATALOG): \
+             there is no scenario catalog to start from"
+        );
+    }
+
     if let Some(dir) = &args.catalog {
         if !dir.is_dir() {
             anyhow::bail!(
@@ -163,6 +184,11 @@ async fn run(args: Args, workers: usize, max_inflight_requests: usize) -> anyhow
         }
         info!(catalog = %dir.display(), "pack catalog enabled for POST /scenarios");
     }
+
+    let autostart_entries = match args.catalog.as_deref() {
+        Some(dir) if args.autostart => autostart::runnable_entries(dir)?,
+        _ => Vec::new(),
+    };
 
     let permits = if args.max_scenarios == 0 {
         warn!("--max-scenarios 0 — scenario row cap disabled (unlimited)");
@@ -209,6 +235,10 @@ async fn run(args: Args, workers: usize, max_inflight_requests: usize) -> anyhow
     announce_bound_port(bound_addr.port())?;
 
     info!(addr = %bound_addr, workers, "sonda-server listening");
+
+    if args.autostart {
+        autostart::start_entries(&state, &autostart_entries).await;
+    }
 
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -15,7 +15,10 @@
 //! - `DELETE /scenarios/{id}` — stop a running scenario and return final stats.
 //!
 //! All lifecycle logic is delegated to sonda-core. This module is pure HTTP
-//! plumbing: deserialize → compile → launch → store → respond.
+//! plumbing: deserialize → compile → launch → store → respond. The compile and
+//! launch halves — [`compile_v2_text`] and [`admit_compiled`] — are shared with
+//! the `--autostart` catalog sweep, so a posted and an autostarted scenario are
+//! admitted by the same code.
 
 use std::path::Path as FsPath;
 use std::sync::Arc;
@@ -338,13 +341,13 @@ enum ParsedBody {
 /// `while.op`, NaN values, conflicting fields) — surfaced as 422
 /// Unprocessable Entity.
 #[derive(Debug)]
-enum ParseFailure {
+pub enum ParseFailure {
     Syntactic(String),
     Semantic(String),
 }
 
 impl ParseFailure {
-    fn message(&self) -> &str {
+    pub fn message(&self) -> &str {
         match self {
             ParseFailure::Syntactic(m) | ParseFailure::Semantic(m) => m,
         }
@@ -368,21 +371,28 @@ fn parse_body(
     catalog_dir: Option<&FsPath>,
 ) -> Result<ParsedBody, ParseFailure> {
     let text = yaml_body_text(body, headers).map_err(ParseFailure::Syntactic)?;
+    let compiled = compile_v2_text(&text, catalog_dir)?;
+    Ok(ParsedBody::Compiled(Box::new(compiled)))
+}
 
-    let version = detect_version(&text);
-    if version != Some(2) {
+/// Compile v2 YAML text against the catalog pack resolver.
+pub fn compile_v2_text(
+    text: &str,
+    catalog_dir: Option<&FsPath>,
+) -> Result<CompiledFile, ParseFailure> {
+    if detect_version(text) != Some(2) {
         return Err(ParseFailure::Syntactic(format!(
             "body is not a v2 scenario. {V1_REJECTION_HINT}"
         )));
     }
 
     let resolver = sonda_core::catalog::CatalogPackResolver::new(catalog_dir);
-    let compiled = compile_scenario_file_compiled(&text, &resolver).map_err(|e| {
+    let compiled = compile_scenario_file_compiled(text, &resolver).map_err(|e| {
         let detail = format!(
             "v2 scenario body failed to compile: {}",
             format_error_chain(&e)
         );
-        if is_semantic_schema_error(&e, &text) {
+        if is_semantic_schema_error(&e, text) {
             ParseFailure::Semantic(detail)
         } else {
             ParseFailure::Syntactic(detail)
@@ -395,7 +405,7 @@ fn parse_body(
         ));
     }
 
-    Ok(ParsedBody::Compiled(Box::new(compiled)))
+    Ok(compiled)
 }
 
 /// Detect schema-level deserialize failures on otherwise well-formed YAML.
@@ -542,67 +552,38 @@ pub async fn post_scenario(
         }
     }
 
-    if let Some(name) = compiled.scenario_name.as_deref() {
-        let mut conflicts = collect_active_conflicts(&state, name).map_err(|()| {
-            warn!("POST /scenarios: scenarios lock is poisoned");
-            internal_error("internal state lock is poisoned")
-        })?;
-        if conflicts.is_empty() && state.gate_bus_registry.scenario_name_in_use(name) {
-            conflicts.push(ConflictingScenario {
-                id: String::new(),
-                name: name.to_string(),
-                state: "running".to_string(),
-            });
-        }
-        if !conflicts.is_empty() {
-            warn!(
-                scenario_name = %name,
-                count = conflicts.len(),
-                "POST /scenarios: rejected duplicate scenario_name"
-            );
-            return Err(conflict(
+    let Admitted {
+        mut created,
+        warnings,
+    } = admit_compiled(&state, *compiled, "POST /scenarios")
+        .await
+        .map_err(|err| match err {
+            AdmissionError::BadRequest(m) => bad_request(m),
+            AdmissionError::Unprocessable(m) => unprocessable(m),
+            AdmissionError::Conflict { name, conflicts } => conflict(
                 format!("scenario_name '{name}' is already running"),
                 conflicts,
-            ));
-        }
-    }
-
-    // Derive ScenarioEntry values for the loopback warning helper, which
-    // operates on the runtime input shape. prepare_entries doubles as
-    // pre-flight validation — surfacing rate=0, bad phase_offset, etc. as
-    // 422 before any thread spawns.
-    let prepared_entries = sonda_core::compiler::prepare::prepare(compiled.as_ref().clone())
-        .map_err(|e| {
-            warn!(error = %e, "POST /scenarios: prepare failed");
-            unprocessable(e)
+            ),
+            AdmissionError::CapacityExceeded { needed } => {
+                capacity_exceeded_response(&state, needed)
+            }
+            AdmissionError::Internal(m) => internal_error(m),
         })?;
-    let prepared = prepare_entries(prepared_entries).map_err(|e| {
-        warn!(error = %e, "POST /scenarios: validation failed");
-        unprocessable(e)
-    })?;
-    let warning_entries: Vec<ScenarioEntry> = prepared.into_iter().map(|p| p.entry).collect();
-    let mut warnings = sink_loopback_warnings(&warning_entries);
-    warnings.extend(loki_cardinality_warnings(&warning_entries));
-    log_warnings("POST /scenarios", &warnings);
-    drop(warning_entries);
 
-    let needed = compiled.entries.len();
-    let permits = match acquire_permits(&state, needed) {
-        Ok(p) => p,
-        Err(PermitError::CapacityExceeded) => {
-            warn!(
-                needed,
-                "POST /scenarios: scenario cap reached, returning 429"
-            );
-            return Err(capacity_exceeded_response(&state, needed));
-        }
-        Err(PermitError::SemaphoreClosed) => {
-            warn!("POST /scenarios: scenario_permits semaphore is closed");
-            return Err(internal_error("scenario permit semaphore is closed"));
-        }
-    };
-
-    launch_compiled(state, *compiled, warnings, permits).await
+    if created.len() == 1 {
+        let mut single = created.pop().expect("len checked above");
+        single.warnings = warnings;
+        Ok((StatusCode::CREATED, Json(single)).into_response())
+    } else {
+        Ok((
+            StatusCode::CREATED,
+            Json(CreatedScenariosResponse {
+                scenarios: created,
+                warnings,
+            }),
+        )
+            .into_response())
+    }
 }
 
 enum PermitError {
@@ -653,27 +634,104 @@ fn capacity_exceeded_response(state: &AppState, _needed: usize) -> Response {
     (StatusCode::TOO_MANY_REQUESTS, Json(body)).into_response()
 }
 
-async fn launch_compiled(
-    state: AppState,
+pub struct Admitted {
+    pub created: Vec<CreatedScenario>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug)]
+pub enum AdmissionError {
+    BadRequest(String),
+    Unprocessable(String),
+    Conflict {
+        name: String,
+        conflicts: Vec<ConflictingScenario>,
+    },
+    CapacityExceeded {
+        needed: usize,
+    },
+    Internal(String),
+}
+
+/// The single admission path: validate a compiled file, launch it, and store the
+/// resulting handles in [`AppState`]. `origin` labels the caller in the logs.
+pub async fn admit_compiled(
+    state: &AppState,
     compiled: CompiledFile,
-    warnings: Vec<String>,
-    mut permits: Vec<OwnedSemaphorePermit>,
-) -> Result<Response, Response> {
+    origin: &str,
+) -> Result<Admitted, AdmissionError> {
+    if let Some(name) = compiled.scenario_name.as_deref() {
+        let mut conflicts = collect_active_conflicts(state, name).map_err(|()| {
+            warn!(origin = %origin, "{origin}: scenarios lock is poisoned");
+            AdmissionError::Internal("internal state lock is poisoned".to_string())
+        })?;
+        if conflicts.is_empty() && state.gate_bus_registry.scenario_name_in_use(name) {
+            conflicts.push(ConflictingScenario {
+                id: String::new(),
+                name: name.to_string(),
+                state: "running".to_string(),
+            });
+        }
+        if !conflicts.is_empty() {
+            warn!(
+                origin = %origin,
+                scenario_name = %name,
+                count = conflicts.len(),
+                "{origin}: rejected duplicate scenario_name"
+            );
+            return Err(AdmissionError::Conflict {
+                name: name.to_string(),
+                conflicts,
+            });
+        }
+    }
+
+    // prepare_entries doubles as pre-flight validation: rate=0 and friends surface before any thread spawns.
+    let prepared_entries =
+        sonda_core::compiler::prepare::prepare(compiled.clone()).map_err(|e| {
+            warn!(origin = %origin, error = %e, "{origin}: prepare failed");
+            AdmissionError::Unprocessable(e.to_string())
+        })?;
+    let prepared = prepare_entries(prepared_entries).map_err(|e| {
+        warn!(origin = %origin, error = %e, "{origin}: validation failed");
+        AdmissionError::Unprocessable(e.to_string())
+    })?;
+    let warning_entries: Vec<ScenarioEntry> = prepared.into_iter().map(|p| p.entry).collect();
+    let mut warnings = sink_loopback_warnings(&warning_entries);
+    warnings.extend(loki_cardinality_warnings(&warning_entries));
+    log_warnings(origin, &warnings);
+    drop(warning_entries);
+
+    let needed = compiled.entries.len();
+    let mut permits = match acquire_permits(state, needed) {
+        Ok(p) => p,
+        Err(PermitError::CapacityExceeded) => {
+            warn!(origin = %origin, needed, "{origin}: scenario cap reached");
+            return Err(AdmissionError::CapacityExceeded { needed });
+        }
+        Err(PermitError::SemaphoreClosed) => {
+            warn!(origin = %origin, "{origin}: scenario_permits semaphore is closed");
+            return Err(AdmissionError::Internal(
+                "scenario permit semaphore is closed".to_string(),
+            ));
+        }
+    };
+
     let resolver: Arc<dyn sonda_core::GateBusResolver> = state.gate_bus_registry.clone();
     let mut handles = launch_multi_compiled(compiled, Some(resolver))
         .await
         .map_err(|e| {
-            warn!(error = %e, "POST /scenarios: failed to launch scenarios");
+            warn!(origin = %origin, error = %e, "{origin}: failed to launch scenarios");
             match e {
-                sonda_core::SondaError::Config(_) => unprocessable(e),
-                _ => internal_error(e),
+                sonda_core::SondaError::Config(_) => AdmissionError::Unprocessable(e.to_string()),
+                _ => AdmissionError::Internal(e.to_string()),
             }
         })?;
 
     if handles.is_empty() {
-        warn!("POST /scenarios: gated launch produced zero handles");
-        return Err(bad_request(
-            "v2 scenario body produced zero runnable entries",
+        warn!(origin = %origin, "{origin}: gated launch produced zero handles");
+        return Err(AdmissionError::BadRequest(
+            "v2 scenario body produced zero runnable entries".to_string(),
         ));
     }
 
@@ -684,7 +742,7 @@ async fn launch_compiled(
         state.gate_bus_registry.rename_handle(&old_id, &new_id);
         let name = handle.name.clone();
         let state_str = state_string(&handle.stats_snapshot()).to_string();
-        info!(id = %new_id, name = %name, state = %state_str, "scenario launched");
+        info!(id = %new_id, name = %name, state = %state_str, origin = %origin, "scenario launched");
         if let Some(permit) = permits.pop() {
             handle.attach_permit(permit);
         }
@@ -700,28 +758,15 @@ async fn launch_compiled(
         for handle in &handles {
             handle.stop();
         }
-        warn!(error = %e, "POST /scenarios: scenarios lock is poisoned");
-        internal_error("internal state lock is poisoned")
+        warn!(origin = %origin, error = %e, "{origin}: scenarios lock is poisoned");
+        AdmissionError::Internal("internal state lock is poisoned".to_string())
     })?;
     for (created_entry, handle) in created.iter().zip(handles) {
         scenarios.insert(created_entry.id.clone(), handle);
     }
     drop(scenarios);
 
-    if created.len() == 1 {
-        let mut single = created.into_iter().next().expect("len checked above");
-        single.warnings = warnings;
-        Ok((StatusCode::CREATED, Json(single)).into_response())
-    } else {
-        Ok((
-            StatusCode::CREATED,
-            Json(CreatedScenariosResponse {
-                scenarios: created,
-                warnings,
-            }),
-        )
-            .into_response())
-    }
+    Ok(Admitted { created, warnings })
 }
 
 /// `GET /scenarios` — list all scenarios with summary information.

--- a/sonda-server/src/routes/sink_warnings.rs
+++ b/sonda-server/src/routes/sink_warnings.rs
@@ -145,9 +145,9 @@ pub(crate) fn collect_warnings_for_sink(
     }
 }
 
-pub(crate) fn log_warnings(route: &str, warnings: &[String]) {
+pub(crate) fn log_warnings(origin: &str, warnings: &[String]) {
     for message in warnings {
-        warn!(message = %message, route = %route, "{}: sink pre-flight warning", route);
+        warn!(message = %message, origin = %origin, "{origin}: sink pre-flight warning");
     }
 }
 

--- a/sonda-server/tests/autostart.rs
+++ b/sonda-server/tests/autostart.rs
@@ -8,7 +8,10 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::time::Duration;
 
-use common::{http_client, run_server_expecting_exit, spawn_server_with, start_server_with};
+use common::{
+    http_client, run_server_expecting_exit, spawn_server_tailed, start_server_with,
+    terminate_gracefully,
+};
 use tempfile::TempDir;
 
 fn runnable(scenario_name: &str, metric_names: &[&str]) -> String {
@@ -149,10 +152,57 @@ impl Run {
     }
 }
 
+const SWEEP_SUMMARY: &str = "runnable catalog entries";
+const SWEEP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Start the server on `catalog`, wait for the sweep to report its summary, then
+/// read `GET /scenarios`. The sweep runs alongside the server, so a bare GET
+/// races it.
 fn run_catalog(catalog: &Path, extra_args: &[&str], env: &[(&str, &str)]) -> Run {
+    let run = collect_catalog_run(catalog, extra_args, env, Sweep::Expected);
+    assert!(
+        run.count(SWEEP_SUMMARY) > 0,
+        "the sweep never reported a summary: {}",
+        run.stderr
+    );
+    run
+}
+
+/// Same, for a server that must not sweep at all. SIGTERM rather than kill,
+/// because a sweep that had been spawned always reports itself on the way out:
+/// zero `autostart:` lines then proves no sweep ever ran.
+fn run_idle_catalog(catalog: &Path, extra_args: &[&str], env: &[(&str, &str)]) -> Run {
+    let run = collect_catalog_run(catalog, extra_args, env, Sweep::None);
+    assert_eq!(
+        run.count("autostart:"),
+        0,
+        "autostart is off, so no sweep may report anything: {}",
+        run.stderr
+    );
+    run
+}
+
+#[derive(PartialEq, Eq)]
+enum Sweep {
+    Expected,
+    None,
+}
+
+fn collect_catalog_run(
+    catalog: &Path,
+    extra_args: &[&str],
+    env: &[(&str, &str)],
+    sweep: Sweep,
+) -> Run {
     let mut args: Vec<&str> = vec!["--catalog", catalog.to_str().expect("utf-8 temp path")];
     args.extend_from_slice(extra_args);
-    let (port, mut child) = spawn_server_with(&args, env);
+    let mut full_env: Vec<(&str, &str)> = vec![("RUST_LOG", "sonda_server=info")];
+    full_env.extend_from_slice(env);
+    let (port, mut child, tail) = spawn_server_tailed(&args, &full_env);
+
+    if sweep == Sweep::Expected {
+        tail.wait_for(SWEEP_SUMMARY, SWEEP_TIMEOUT);
+    }
 
     let body: serde_json::Value = http_client()
         .get(format!("http://127.0.0.1:{port}/scenarios"))
@@ -173,14 +223,20 @@ fn run_catalog(catalog: &Path, extra_args: &[&str], env: &[(&str, &str)]) -> Run
         })
         .collect();
 
-    child.kill().expect("must kill sonda-server");
-    let output = child
-        .wait_with_output()
-        .expect("must collect sonda-server output");
+    match sweep {
+        Sweep::Expected => {
+            child.kill().expect("must kill sonda-server");
+            child.wait().expect("must reap sonda-server");
+        }
+        Sweep::None => {
+            let code = terminate_gracefully(&mut child);
+            assert_eq!(code, Some(0), "SIGTERM must produce a clean exit");
+        }
+    }
 
     Run {
         metric_names,
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        stderr: tail.finish(),
     }
 }
 
@@ -244,7 +300,7 @@ fn autostart_leaves_composable_packs_alone() {
 fn catalog_without_autostart_starts_nothing() {
     let catalog = catalog_with(&[("alpha.yaml", &runnable("alpha", &["alpha_cpu"]))]);
 
-    let run = run_catalog(catalog.path(), &[], &[]);
+    let run = run_idle_catalog(catalog.path(), &[], &[]);
 
     assert!(
         run.metric_names.is_empty(),
@@ -347,7 +403,7 @@ fn duplicate_entry_names_without_autostart_still_start_the_server() {
         ("beta.yaml", &runnable("shared", &["beta_mem"])),
     ]);
 
-    let run = run_catalog(catalog.path(), &[], &[]);
+    let run = run_idle_catalog(catalog.path(), &[], &[]);
 
     assert!(
         run.metric_names.is_empty(),
@@ -357,33 +413,37 @@ fn duplicate_entry_names_without_autostart_still_start_the_server() {
 }
 
 #[test]
-fn autostart_with_an_unreadable_catalog_file_warns_and_keeps_serving() {
-    if unsafe { libc::geteuid() } == 0 {
-        eprintln!("skipping: file permissions do not constrain root");
-        return;
-    }
-
+fn autostart_skips_an_unreadable_file_and_starts_the_rest() {
     let catalog = catalog_with(&[
         ("alpha.yaml", &runnable("alpha", &["alpha_cpu"])),
         ("locked.yaml", &runnable("locked", &["locked_cpu"])),
     ]);
-    std::fs::set_permissions(
-        catalog.path().join("locked.yaml"),
-        std::fs::Permissions::from_mode(0o000),
-    )
-    .expect("must drop read permission");
+    let locked = catalog.path().join("locked.yaml");
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000))
+        .expect("must drop read permission");
+    if std::fs::File::open(&locked).is_ok() {
+        eprintln!("skipping: this process can open a 0o000 file (running as root?)");
+        return;
+    }
 
     let run = run_catalog(catalog.path(), &["--autostart"], &[]);
 
+    assert_eq!(run.metric_names, BTreeSet::from(["alpha_cpu".to_string()]));
+    assert_eq!(
+        run.count("skipping unreadable file"),
+        1,
+        "the file the server could not open must be reported: {}",
+        run.stderr
+    );
     assert!(
-        run.metric_names.is_empty(),
-        "expected no scenarios, got {:?}",
-        run.metric_names
+        run.stderr.contains("locked.yaml"),
+        "the warning must name the file it skipped: {}",
+        run.stderr
     );
     assert_eq!(
         run.count("catalog could not be read, starting nothing"),
-        1,
-        "starting nothing must never be silent: {}",
+        0,
+        "one unreadable file must not cost the whole catalog: {}",
         run.stderr
     );
 }
@@ -471,7 +531,11 @@ fn autostart_env_var_accepts_the_shapes_operators_actually_set() {
         ("true", true),
         ("True", true),
     ] {
-        let run = run_catalog(catalog.path(), &[], &[("SONDA_AUTOSTART", value)]);
+        let run = if expected_autostart {
+            run_catalog(catalog.path(), &[], &[("SONDA_AUTOSTART", value)])
+        } else {
+            run_idle_catalog(catalog.path(), &[], &[("SONDA_AUTOSTART", value)])
+        };
 
         let expected = if expected_autostart {
             started.clone()
@@ -550,5 +614,129 @@ fn autostart_env_var_without_catalog_fails_before_binding() {
         !exit.announced_a_port(),
         "no port may be bound, stdout was: {}",
         exit.stdout
+    );
+}
+
+#[test]
+fn the_server_answers_while_the_sweep_is_still_starting_entries() {
+    const ENTRIES: usize = 500;
+
+    let files: Vec<(String, String)> = (0..ENTRIES)
+        .map(|i| {
+            (
+                format!("e{i:03}.yaml"),
+                runnable(&format!("e{i:03}"), &[&format!("e{i:03}_cpu")]),
+            )
+        })
+        .collect();
+    let catalog = catalog_with(
+        &files
+            .iter()
+            .map(|(name, body)| (name.as_str(), body.as_str()))
+            .collect::<Vec<_>>(),
+    );
+    let dir = catalog.path().to_str().expect("utf-8 temp path");
+
+    let (port, mut child, tail) = spawn_server_tailed(
+        &["--catalog", dir, "--autostart"],
+        &[("RUST_LOG", "sonda_server=info")],
+    );
+    let client = http_client();
+
+    let during_sweep = scenario_count(&client, port);
+    let swept = tail.wait_for(SWEEP_SUMMARY, SWEEP_TIMEOUT);
+    let after_sweep = scenario_count(&client, port);
+
+    child.kill().expect("must kill sonda-server");
+    child.wait().expect("must reap sonda-server");
+    let stderr = tail.finish();
+
+    assert!(swept, "the sweep never finished: {stderr}");
+    assert!(
+        during_sweep < ENTRIES,
+        "the first request saw all {ENTRIES} entries already started — either the sweep held \
+         the accept loop, or it completed before the request landed (check whether the summary \
+         line precedes the request in the log): during_sweep={during_sweep}\n{stderr}"
+    );
+    assert_eq!(
+        after_sweep, ENTRIES,
+        "every entry must be running once the sweep reports its summary: {stderr}"
+    );
+}
+
+fn scenario_count(client: &reqwest::blocking::Client, port: u16) -> usize {
+    let body: serde_json::Value = client
+        .get(format!("http://127.0.0.1:{port}/scenarios"))
+        .send()
+        .expect("GET /scenarios must succeed")
+        .json()
+        .expect("GET /scenarios must return JSON");
+    body["scenarios"]
+        .as_array()
+        .expect("scenarios must be an array")
+        .len()
+}
+
+#[test]
+fn sigterm_during_the_sweep_exits_cleanly_and_joins_what_it_started() {
+    const ENTRIES: usize = 1000;
+
+    let files: Vec<(String, String)> = (0..ENTRIES)
+        .map(|i| {
+            (
+                format!("e{i:04}.yaml"),
+                runnable(&format!("e{i:04}"), &[&format!("e{i:04}_cpu")]),
+            )
+        })
+        .collect();
+    let catalog = catalog_with(
+        &files
+            .iter()
+            .map(|(name, body)| (name.as_str(), body.as_str()))
+            .collect::<Vec<_>>(),
+    );
+    let dir = catalog.path().to_str().expect("utf-8 temp path");
+
+    let (_port, mut child, tail) = spawn_server_tailed(
+        &["--catalog", dir, "--autostart"],
+        &[("RUST_LOG", "sonda_server=info")],
+    );
+
+    let launched_before_signal =
+        tail.wait_for_lines("scenario launched", ENTRIES / 5, SWEEP_TIMEOUT);
+    let code = terminate_gracefully(&mut child);
+    let stderr = tail.finish();
+
+    assert!(
+        launched_before_signal,
+        "the sweep never got far enough to be interrupted: {stderr}"
+    );
+
+    let sweep_lines = stderr
+        .lines()
+        .filter(|line| line.contains("autostart:"))
+        .count();
+    let launched = stderr
+        .lines()
+        .filter(|line| line.contains("scenario launched"))
+        .count();
+    let accounted_for = stderr
+        .lines()
+        .filter(|line| line.contains("scenario task joined") || line.contains("join failed"))
+        .count();
+
+    assert_eq!(code, Some(0), "SIGTERM must produce a clean exit: {stderr}");
+    assert_eq!(
+        sweep_lines, 1,
+        "the sweep must report itself exactly once, whether it finished or was cut short: {stderr}"
+    );
+    assert_eq!(
+        accounted_for, launched,
+        "shutdown must join every scenario the sweep started, so the sweep has to be joined \
+         before the drain: launched={launched} accounted_for={accounted_for}"
+    );
+    assert!(
+        stderr.contains("sonda-server shut down cleanly"),
+        "the shutdown path must run to the end: {stderr}"
     );
 }

--- a/sonda-server/tests/autostart.rs
+++ b/sonda-server/tests/autostart.rs
@@ -1,0 +1,554 @@
+//! E2E tests for `--autostart`: the catalog sweep that starts every
+//! `kind: runnable` entry at server startup.
+
+mod common;
+
+use std::collections::BTreeSet;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::time::Duration;
+
+use common::{http_client, run_server_expecting_exit, spawn_server_with, start_server_with};
+use tempfile::TempDir;
+
+fn runnable(scenario_name: &str, metric_names: &[&str]) -> String {
+    let mut yaml = format!(
+        "version: 2
+kind: runnable
+scenario_name: {scenario_name}
+defaults:
+  rate: 1
+  duration: 300s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: memory
+scenarios:
+"
+    );
+    for name in metric_names {
+        yaml.push_str(&format!(
+            "  - signal_type: metrics
+    name: {name}
+    generator:
+      type: constant
+      value: 1.0
+"
+        ));
+    }
+    yaml
+}
+
+const COMPOSABLE_PACK: &str = "\
+version: 2
+kind: composable
+name: aaa_test_pack
+description: \"pack that must never be started\"
+metrics:
+  - name: pack_metric
+    generator:
+      type: constant
+      value: 1.0
+";
+
+const V1_SHAPED: &str = "\
+kind: runnable
+name: aaa_legacy
+rate: 1
+duration: 300s
+generator:
+  type: constant
+  value: 1.0
+encoder:
+  type: prometheus_text
+sink:
+  type: stdout
+";
+
+const UNCOMPILABLE: &str = "\
+version: 2
+kind: runnable
+scenario_name: aaa_broken
+defaults:
+  rate: 1
+  duration: 300s
+scenarios:
+  - signal_type: metrics
+    name: broken_metric
+    generator:
+      type: no_such_generator
+";
+
+const CROSS_FILE_BASELINE: &str = "\
+version: 2
+kind: runnable
+scenario_name: baseline_post
+defaults:
+  rate: 5
+  duration: 300s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: memory
+scenarios:
+  - id: baseline_traffic
+    signal_type: metrics
+    name: baseline_traffic
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: cascade_signal
+      op: \">\"
+      value: 0
+      scenario_name: cascade_post
+      if_unresolved: pending
+";
+
+const CROSS_FILE_CASCADE: &str = "\
+version: 2
+kind: runnable
+scenario_name: cascade_post
+defaults:
+  rate: 5
+  duration: 300s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: memory
+scenarios:
+  - id: cascade_signal
+    signal_type: metrics
+    name: cascade_signal
+    generator:
+      type: constant
+      value: 1.0
+";
+
+const UNPARSEABLE_YAML: &str = "kind: runnable\nversion: 2\n  this: [is, not\n   valid yaml\n";
+
+fn catalog_with(files: &[(&str, &str)]) -> TempDir {
+    let dir = TempDir::new().expect("must create temp catalog dir");
+    for (name, contents) in files {
+        std::fs::write(dir.path().join(name), contents).expect("must write catalog file");
+    }
+    dir
+}
+
+struct Run {
+    metric_names: BTreeSet<String>,
+    stderr: String,
+}
+
+impl Run {
+    fn count(&self, needle: &str) -> usize {
+        self.stderr
+            .lines()
+            .filter(|line| line.contains(needle))
+            .count()
+    }
+}
+
+fn run_catalog(catalog: &Path, extra_args: &[&str], env: &[(&str, &str)]) -> Run {
+    let mut args: Vec<&str> = vec!["--catalog", catalog.to_str().expect("utf-8 temp path")];
+    args.extend_from_slice(extra_args);
+    let (port, mut child) = spawn_server_with(&args, env);
+
+    let body: serde_json::Value = http_client()
+        .get(format!("http://127.0.0.1:{port}/scenarios"))
+        .send()
+        .expect("GET /scenarios must succeed")
+        .json()
+        .expect("GET /scenarios must return JSON");
+
+    let metric_names = body["scenarios"]
+        .as_array()
+        .expect("scenarios must be an array")
+        .iter()
+        .map(|s| {
+            s["name"]
+                .as_str()
+                .expect("name must be a string")
+                .to_string()
+        })
+        .collect();
+
+    child.kill().expect("must kill sonda-server");
+    let output = child
+        .wait_with_output()
+        .expect("must collect sonda-server output");
+
+    Run {
+        metric_names,
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+#[test]
+fn autostart_starts_runnable_entries() {
+    let catalog = catalog_with(&[
+        ("alpha.yaml", &runnable("alpha", &["alpha_cpu"])),
+        ("beta.yaml", &runnable("beta", &["beta_mem", "beta_disk"])),
+    ]);
+
+    let run = run_catalog(catalog.path(), &["--autostart"], &[]);
+
+    assert_eq!(
+        run.metric_names,
+        BTreeSet::from([
+            "alpha_cpu".to_string(),
+            "beta_mem".to_string(),
+            "beta_disk".to_string()
+        ])
+    );
+}
+
+#[test]
+fn autostart_logs_one_launch_line_per_started_scenario() {
+    let catalog = catalog_with(&[("beta.yaml", &runnable("beta", &["beta_mem", "beta_disk"]))]);
+
+    let run = run_catalog(
+        catalog.path(),
+        &["--autostart"],
+        &[("RUST_LOG", "sonda_server=info")],
+    );
+
+    assert_eq!(run.count("scenario launched"), 2, "stderr: {}", run.stderr);
+    assert_eq!(
+        run.count("beta.yaml"),
+        2,
+        "each launch line must name the catalog file: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn autostart_leaves_composable_packs_alone() {
+    let catalog = catalog_with(&[
+        ("alpha.yaml", &runnable("alpha", &["alpha_cpu"])),
+        ("pack.yaml", COMPOSABLE_PACK),
+    ]);
+
+    let run = run_catalog(catalog.path(), &["--autostart"], &[]);
+
+    assert_eq!(run.metric_names, BTreeSet::from(["alpha_cpu".to_string()]));
+    assert_eq!(
+        run.count("skipping catalog entry"),
+        0,
+        "a pack is not a candidate, so it must not be reported as skipped: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn catalog_without_autostart_starts_nothing() {
+    let catalog = catalog_with(&[("alpha.yaml", &runnable("alpha", &["alpha_cpu"]))]);
+
+    let run = run_catalog(catalog.path(), &[], &[]);
+
+    assert!(
+        run.metric_names.is_empty(),
+        "expected no scenarios, got {:?}",
+        run.metric_names
+    );
+}
+
+#[test]
+fn autostart_env_var_starts_the_same_scenarios_as_the_flag() {
+    let catalog = catalog_with(&[("alpha.yaml", &runnable("alpha", &["alpha_cpu"]))]);
+
+    let run = run_catalog(catalog.path(), &[], &[("SONDA_AUTOSTART", "true")]);
+
+    assert_eq!(run.metric_names, BTreeSet::from(["alpha_cpu".to_string()]));
+}
+
+#[test]
+fn autostart_skips_uncompilable_file_and_starts_the_rest() {
+    let catalog = catalog_with(&[
+        ("alpha.yaml", &runnable("alpha", &["alpha_cpu"])),
+        ("broken.yaml", UNCOMPILABLE),
+    ]);
+
+    let run = run_catalog(catalog.path(), &["--autostart"], &[]);
+
+    assert_eq!(run.metric_names, BTreeSet::from(["alpha_cpu".to_string()]));
+    assert_eq!(
+        run.count("does not compile, skipping catalog entry"),
+        1,
+        "stderr: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn unparseable_yaml_never_becomes_a_catalog_entry() {
+    let catalog = catalog_with(&[
+        ("alpha.yaml", &runnable("alpha", &["alpha_cpu"])),
+        ("garbage.yaml", UNPARSEABLE_YAML),
+    ]);
+
+    let run = run_catalog(catalog.path(), &["--autostart"], &[]);
+
+    assert_eq!(run.metric_names, BTreeSet::from(["alpha_cpu".to_string()]));
+    assert_eq!(
+        run.count("skipping catalog entry"),
+        0,
+        "enumeration drops the file, so the sweep never sees it: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn autostart_skips_v1_shaped_file_and_starts_the_rest() {
+    let catalog = catalog_with(&[
+        ("alpha.yaml", &runnable("alpha", &["alpha_cpu"])),
+        ("legacy.yaml", V1_SHAPED),
+    ]);
+
+    let run = run_catalog(catalog.path(), &["--autostart"], &[]);
+
+    assert_eq!(run.metric_names, BTreeSet::from(["alpha_cpu".to_string()]));
+    assert!(
+        run.stderr.contains("version: 2"),
+        "the skip reason must carry the v2 migration hint: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn autostart_with_duplicate_entry_names_fails_before_binding() {
+    let catalog = catalog_with(&[
+        ("alpha.yaml", &runnable("shared", &["alpha_cpu"])),
+        ("beta.yaml", &runnable("shared", &["beta_mem"])),
+    ]);
+    let dir = catalog.path().to_str().expect("utf-8 temp path");
+
+    let exit = run_server_expecting_exit(&["--catalog", dir, "--autostart"], &[]);
+
+    assert_eq!(exit.code, Some(1), "stderr was: {}", exit.stderr);
+    assert!(
+        exit.stderr.contains("duplicate entry name")
+            && exit.stderr.contains("alpha.yaml")
+            && exit.stderr.contains("beta.yaml"),
+        "error must name the clash and both files, got: {}",
+        exit.stderr
+    );
+    assert!(
+        !exit.announced_a_port(),
+        "no port may be bound, stdout was: {}",
+        exit.stdout
+    );
+}
+
+#[test]
+fn duplicate_entry_names_without_autostart_still_start_the_server() {
+    let catalog = catalog_with(&[
+        ("alpha.yaml", &runnable("shared", &["alpha_cpu"])),
+        ("beta.yaml", &runnable("shared", &["beta_mem"])),
+    ]);
+
+    let run = run_catalog(catalog.path(), &[], &[]);
+
+    assert!(
+        run.metric_names.is_empty(),
+        "expected no scenarios, got {:?}",
+        run.metric_names
+    );
+}
+
+#[test]
+fn autostart_with_an_unreadable_catalog_file_warns_and_keeps_serving() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: file permissions do not constrain root");
+        return;
+    }
+
+    let catalog = catalog_with(&[
+        ("alpha.yaml", &runnable("alpha", &["alpha_cpu"])),
+        ("locked.yaml", &runnable("locked", &["locked_cpu"])),
+    ]);
+    std::fs::set_permissions(
+        catalog.path().join("locked.yaml"),
+        std::fs::Permissions::from_mode(0o000),
+    )
+    .expect("must drop read permission");
+
+    let run = run_catalog(catalog.path(), &["--autostart"], &[]);
+
+    assert!(
+        run.metric_names.is_empty(),
+        "expected no scenarios, got {:?}",
+        run.metric_names
+    );
+    assert_eq!(
+        run.count("catalog could not be read, starting nothing"),
+        1,
+        "starting nothing must never be silent: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn autostart_resolves_a_cross_file_while_reference() {
+    let catalog = catalog_with(&[
+        ("baseline.yaml", CROSS_FILE_BASELINE),
+        ("cascade.yaml", CROSS_FILE_CASCADE),
+    ]);
+    let dir = catalog.path().to_str().expect("utf-8 temp path");
+    let (port, _guard) = start_server_with(&["--catalog", dir, "--autostart"], &[]);
+    let client = http_client();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let body: serde_json::Value = client
+            .get(format!("http://127.0.0.1:{port}/scenarios"))
+            .send()
+            .expect("GET /scenarios must succeed")
+            .json()
+            .expect("GET /scenarios must return JSON");
+
+        let running: BTreeSet<String> = body["scenarios"]
+            .as_array()
+            .expect("scenarios must be an array")
+            .iter()
+            .filter(|s| s["state"] == "running")
+            .map(|s| s["name"].as_str().unwrap_or_default().to_string())
+            .collect();
+        if running.len() == 2 {
+            assert_eq!(
+                running,
+                BTreeSet::from(["baseline_traffic".to_string(), "cascade_signal".to_string()])
+            );
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "cross-file while: never resolved; last list = {body}"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[test]
+fn autostart_logs_a_summary_even_when_nothing_starts() {
+    let catalog = catalog_with(&[("pack.yaml", COMPOSABLE_PACK)]);
+
+    let run = run_catalog(
+        catalog.path(),
+        &["--autostart"],
+        &[("RUST_LOG", "sonda_server=info")],
+    );
+
+    assert!(
+        run.metric_names.is_empty(),
+        "expected no scenarios, got {:?}",
+        run.metric_names
+    );
+    assert_eq!(
+        run.count("autostart: started 0 of 0 runnable catalog entries"),
+        1,
+        "a sweep that starts nothing must say so: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn autostart_env_var_accepts_the_shapes_operators_actually_set() {
+    let catalog = catalog_with(&[("alpha.yaml", &runnable("alpha", &["alpha_cpu"]))]);
+    let started = BTreeSet::from(["alpha_cpu".to_string()]);
+
+    for (value, expected_autostart) in [
+        ("", false),
+        ("0", false),
+        ("no", false),
+        ("off", false),
+        ("false", false),
+        ("FALSE", false),
+        ("n", false),
+        ("1", true),
+        ("yes", true),
+        ("on", true),
+        ("true", true),
+        ("True", true),
+    ] {
+        let run = run_catalog(catalog.path(), &[], &[("SONDA_AUTOSTART", value)]);
+
+        let expected = if expected_autostart {
+            started.clone()
+        } else {
+            BTreeSet::new()
+        };
+        assert_eq!(
+            run.metric_names,
+            expected,
+            "SONDA_AUTOSTART={value:?} must start the server and {}",
+            if expected_autostart {
+                "autostart"
+            } else {
+                "stay idle"
+            }
+        );
+    }
+}
+
+#[test]
+fn autostart_honours_max_scenarios() {
+    let catalog = catalog_with(&[
+        ("alpha.yaml", &runnable("alpha", &["alpha_cpu"])),
+        ("beta.yaml", &runnable("beta", &["beta_mem"])),
+    ]);
+
+    let run = run_catalog(
+        catalog.path(),
+        &["--autostart", "--max-scenarios", "1"],
+        &[],
+    );
+
+    assert_eq!(run.metric_names, BTreeSet::from(["alpha_cpu".to_string()]));
+    assert_eq!(
+        run.count("scenario cap reached"),
+        1,
+        "the skipped entry must say why, with its own path: {}",
+        run.stderr
+    );
+    assert_eq!(
+        run.count("beta.yaml"),
+        1,
+        "the cap warning must name the file it rejected: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn autostart_without_catalog_fails_before_binding() {
+    let exit = run_server_expecting_exit(&["--autostart"], &[]);
+
+    assert_eq!(exit.code, Some(1), "stderr was: {}", exit.stderr);
+    assert!(
+        exit.stderr.contains("--autostart") && exit.stderr.contains("--catalog"),
+        "error must name both flags, got: {}",
+        exit.stderr
+    );
+    assert!(
+        !exit.announced_a_port(),
+        "no port may be bound, stdout was: {}",
+        exit.stdout
+    );
+}
+
+#[test]
+fn autostart_env_var_without_catalog_fails_before_binding() {
+    let exit = run_server_expecting_exit(&[], &[("SONDA_AUTOSTART", "true")]);
+
+    assert_eq!(exit.code, Some(1), "stderr was: {}", exit.stderr);
+    assert!(
+        exit.stderr.contains("SONDA_CATALOG"),
+        "error must name the env var, got: {}",
+        exit.stderr
+    );
+    assert!(
+        !exit.announced_a_port(),
+        "no port may be bound, stdout was: {}",
+        exit.stdout
+    );
+}

--- a/sonda-server/tests/common/mod.rs
+++ b/sonda-server/tests/common/mod.rs
@@ -5,9 +5,10 @@
 #![allow(dead_code)]
 
 use std::io::{BufRead, BufReader};
-use std::process::{Child, ChildStdout, Command, Stdio};
-use std::sync::mpsc;
-use std::time::Duration;
+use std::process::{Child, ChildStderr, ChildStdout, Command, Stdio};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 const ANNOUNCE_TIMEOUT: Duration = Duration::from_secs(10);
 const EXIT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -36,6 +37,99 @@ pub fn spawn_server_with(extra_args: &[&str], extra_env: &[(&str, &str)]) -> (u1
         .unwrap_or_else(|err| panic!("sonda-server announce failed: {err}"));
 
     (port, child)
+}
+
+/// Reads a running child's stderr into a shared buffer so a test can wait for a
+/// log line instead of guessing how long the server needs to emit it.
+pub struct StderrTail {
+    lines: Arc<Mutex<Vec<String>>>,
+    reader: Option<JoinHandle<()>>,
+}
+
+impl StderrTail {
+    fn spawn(stderr: ChildStderr) -> Self {
+        let lines = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&lines);
+        let reader = std::thread::spawn(move || {
+            for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+                if let Ok(mut buffer) = sink.lock() {
+                    buffer.push(line);
+                }
+            }
+        });
+        Self {
+            lines,
+            reader: Some(reader),
+        }
+    }
+
+    pub fn wait_for(&self, needle: &str, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self.text().contains(needle) {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    /// Wait until `needle` has appeared on at least `count` lines.
+    pub fn wait_for_lines(&self, needle: &str, count: usize, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self.count(needle) >= count {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    pub fn count(&self, needle: &str) -> usize {
+        self.lines
+            .lock()
+            .expect("stderr buffer lock must not be poisoned")
+            .iter()
+            .filter(|line| line.contains(needle))
+            .count()
+    }
+
+    pub fn text(&self) -> String {
+        self.lines
+            .lock()
+            .expect("stderr buffer lock must not be poisoned")
+            .join("\n")
+    }
+
+    /// Drain everything the child wrote. Call once the child has exited.
+    pub fn finish(mut self) -> String {
+        if let Some(reader) = self.reader.take() {
+            reader.join().expect("stderr reader thread must not panic");
+        }
+        self.text()
+    }
+}
+
+/// `spawn_server_with` plus a live view of the child's stderr.
+pub fn spawn_server_tailed(
+    extra_args: &[&str],
+    extra_env: &[(&str, &str)],
+) -> (u16, Child, StderrTail) {
+    let mut child = server_command(extra_args, extra_env)
+        .spawn()
+        .expect("failed to spawn sonda-server binary");
+    let stdout = child.stdout.take().expect("child stdout must be piped");
+    let tail = StderrTail::spawn(child.stderr.take().expect("child stderr must be piped"));
+
+    let port = read_announced_port(stdout)
+        .unwrap_or_else(|err| panic!("sonda-server announce failed: {err}\n{}", tail.text()));
+
+    (port, child, tail)
 }
 
 pub fn spawn_server() -> (u16, Child) {
@@ -92,6 +186,28 @@ pub fn run_server_expecting_exit(extra_args: &[&str], extra_env: &[(&str, &str)]
         code: output.status.code(),
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+/// SIGTERM the child and wait for it to exit, so the server runs its graceful
+/// shutdown path and writes everything it has to say. Kills and panics if it is
+/// still alive after `EXIT_TIMEOUT`.
+pub fn terminate_gracefully(child: &mut Child) -> Option<i32> {
+    unsafe {
+        libc::kill(child.id() as i32, libc::SIGTERM);
+    }
+
+    let deadline = Instant::now() + EXIT_TIMEOUT;
+    loop {
+        match child.try_wait().expect("failed to poll sonda-server") {
+            Some(status) => return status.code(),
+            None if Instant::now() >= deadline => {
+                child.kill().ok();
+                child.wait().ok();
+                panic!("sonda-server did not exit within {EXIT_TIMEOUT:?} of SIGTERM");
+            }
+            None => std::thread::sleep(Duration::from_millis(10)),
+        }
     }
 }
 

--- a/sonda-server/tests/common/mod.rs
+++ b/sonda-server/tests/common/mod.rs
@@ -10,6 +10,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 const ANNOUNCE_TIMEOUT: Duration = Duration::from_secs(10);
+const EXIT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// RAII guard: kills the child on drop.
 pub struct ServerGuard {
@@ -26,25 +27,10 @@ impl Drop for ServerGuard {
 /// Spawn `sonda-server --port 0`, read the announced port, return `(port, child)`.
 /// Strips `SONDA_API_KEY` from the inherited env so a shell-set key doesn't leak in.
 pub fn spawn_server_with(extra_args: &[&str], extra_env: &[(&str, &str)]) -> (u16, Child) {
-    let binary = env!("CARGO_BIN_EXE_sonda-server");
-
-    let mut cmd = Command::new(binary);
-    cmd.args(["--port", "0", "--bind", "127.0.0.1"])
-        .args(extra_args)
-        .env("RUST_LOG", "warn")
-        .env_remove("SONDA_API_KEY")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    for (key, value) in extra_env {
-        cmd.env(key, value);
-    }
-
-    let mut child = cmd.spawn().expect("failed to spawn sonda-server binary");
-    let stdout = child
-        .stdout
-        .take()
-        .expect("child stdout must be piped (Stdio::piped above)");
+    let mut child = server_command(extra_args, extra_env)
+        .spawn()
+        .expect("failed to spawn sonda-server binary");
+    let stdout = child.stdout.take().expect("child stdout must be piped");
 
     let port = read_announced_port(stdout)
         .unwrap_or_else(|err| panic!("sonda-server announce failed: {err}"));
@@ -64,6 +50,66 @@ pub fn start_server() -> (u16, ServerGuard) {
 pub fn start_server_with(extra_args: &[&str], extra_env: &[(&str, &str)]) -> (u16, ServerGuard) {
     let (port, child) = spawn_server_with(extra_args, extra_env);
     (port, ServerGuard { child })
+}
+
+/// Output of a server process that was expected to exit on its own.
+pub struct ServerExit {
+    pub code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl ServerExit {
+    pub fn announced_a_port(&self) -> bool {
+        self.stdout.contains("sonda_server")
+    }
+}
+
+/// Spawn the server with arguments that must be rejected at startup and wait for
+/// it to exit; panics if it is still alive after `EXIT_TIMEOUT`.
+pub fn run_server_expecting_exit(extra_args: &[&str], extra_env: &[(&str, &str)]) -> ServerExit {
+    let mut child = server_command(extra_args, extra_env)
+        .spawn()
+        .expect("failed to spawn sonda-server binary");
+
+    let deadline = std::time::Instant::now() + EXIT_TIMEOUT;
+    loop {
+        match child.try_wait().expect("failed to poll sonda-server") {
+            Some(_) => break,
+            None if std::time::Instant::now() >= deadline => {
+                child.kill().ok();
+                child.wait().ok();
+                panic!("sonda-server did not exit within {EXIT_TIMEOUT:?}");
+            }
+            None => std::thread::sleep(Duration::from_millis(25)),
+        }
+    }
+
+    let output = child
+        .wait_with_output()
+        .expect("failed to collect sonda-server output");
+    ServerExit {
+        code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+fn server_command(extra_args: &[&str], extra_env: &[(&str, &str)]) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sonda-server"));
+    cmd.args(["--port", "0", "--bind", "127.0.0.1"])
+        .args(extra_args)
+        .env("RUST_LOG", "warn")
+        .env_remove("SONDA_API_KEY")
+        .env_remove("SONDA_CATALOG")
+        .env_remove("SONDA_AUTOSTART")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    for (key, value) in extra_env {
+        cmd.env(key, value);
+    }
+    cmd
 }
 
 pub fn http_client() -> reqwest::blocking::Client {

--- a/sonda/tests/cli_list_show.rs
+++ b/sonda/tests/cli_list_show.rs
@@ -220,3 +220,38 @@ fn show_composable_prints_raw_yaml() {
     );
     assert!(stdout.contains("pack_metric_a"));
 }
+
+#[cfg(unix)]
+#[test]
+fn list_skips_an_unreadable_file_and_prints_the_rest() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let cat = write_catalog();
+    let locked = cat.path().join("locked.yaml");
+    std::fs::write(&locked, "version: 2\nkind: runnable\n").expect("write locked entry");
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000))
+        .expect("drop read permission");
+    if std::fs::File::open(&locked).is_ok() {
+        eprintln!("skipping: this process can open a 0o000 file (running as root?)");
+        return;
+    }
+
+    let output = Command::new(sonda_bin())
+        .args(["--catalog"])
+        .arg(cat.path())
+        .args(["list"])
+        .output()
+        .expect("spawn sonda");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stdout.contains("cpu-spike") && stdout.contains("tiny-pack"),
+        "one unreadable file must not cost the catalog, got: {stdout}"
+    );
+    assert!(
+        stderr.contains("locked.yaml"),
+        "the skipped file must be named: {stderr}"
+    );
+}


### PR DESCRIPTION
`sonda-server` held scenarios only in memory, so a pod that mounted a catalog as a ConfigMap and passed `--catalog` came up serving no data until something POSTed to `/scenarios` — the workaround being a sidecar curl loop that re-POSTed after every restart. `--autostart` starts every `kind: runnable` entry in the catalog as the server begins listening, through the same admission path a POSTed body takes, so name conflicts, `--max-scenarios`, sink warnings and gate-bus registration behave identically either way.

- `--autostart` (env `SONDA_AUTOSTART`, default off), requires `--catalog`; falsey env values disable it rather than aborting the process, so `SONDA_AUTOSTART=` in a pod spec or `.env` means off
- a catalog whose entries are not addressable (duplicate or underivable names) fails before the listener binds; a scenario the server cannot admit is logged and skipped, so one bad file never stops the ones after it
- the sweep runs alongside the server rather than holding the accept loop, and shutdown cancels and joins it before draining so nothing starts after the drain
- catalog enumeration now skips a file it cannot read, the way it already skipped one it could not parse — this applies to `sonda list` and `show` too
- entries start in catalog-name order, and the sweep closes with a count so "up but serving nothing" is visible in the log
- chart exposes `server.autostart` and refuses to render when it is set with an empty `scenarios` map; the chart's own scenario examples were v1-shaped and are now runnable
- `Taskfile.yml`'s `schema::` filter is quoted — the trailing `::` made YAML read it as a mapping key, which aborted the whole file and left every `task` target unreachable

Server, Kubernetes and Docker deploy pages cover the flag; `CatalogError::ReadFile` is no longer constructed and is kept for API stability.

## What this changes for `/health`

**Fixed:** `/health` no longer hangs during startup. An earlier revision ran the catalog sweep between binding the listener and starting `axum::serve`, so the kernel accepted connections that nothing answered — a probe saw a hung connection, not a refusal, for as long as the sweep took. The sweep now runs concurrently and the server answers immediately.

**Unchanged, and worth knowing before relying on it:** `/health` is a static handler that reads no state. It returns `{"status":"ok"}` whenever the process is listening, regardless of whether any scenario is running, whether the sweep succeeded, or whether `state.scenarios` is poisoned. It is a liveness signal, not a readiness signal, and the chart currently wires it to both probes. Concretely:

- a pod reports Ready while the sweep is still starting entries — `GET /scenarios` and the `autostart: started N of M` log line are the honest sources for what is actually running
- under #593, a panicking sweep leaves the server returning 500s on `/scenarios` while `/health` still answers 200, so a liveness probe would never restart it

If the goal is "the probe fails when the server has scenarios configured but is not running them", that needs a readiness signal that reflects sweep state, which this PR does not add.

Refs: #591, #592, #593