### PR TITLE
feat(cli): capture a live Prometheus range query as a replayable scenario

### DIFF
--- a/sonda-core/src/acquire/csv_out.rs
+++ b/sonda-core/src/acquire/csv_out.rs
@@ -1,17 +1,12 @@
 //! Write normalized series as a CSV `csv_replay` already knows how to read.
 //!
-//! Pure and feature-free. The header grammar emitted here is the one
-//! [`crate::generator::csv_header`] parses, and the tests round-trip through
-//! that parser rather than a transcription of it.
+//! The header grammar emitted here is the one [`crate::generator::csv_header`]
+//! parses, and the tests round-trip through that parser rather than a copy.
 //!
-//! A column header is a label block nested inside a CSV field, so it passes
-//! through two encoders: the label block backslash-escapes `"` and `\\`, then
-//! the whole thing is RFC 4180 quoted with `"` doubled. Headers are quoted
-//! unconditionally — they always contain `"` and usually `,`.
-//!
-//! Newlines are refused rather than mangled: the label grammar's escape cannot
-//! express one (`\\n` decodes to the letter `n`), and a CSV is read line by
-//! line, so a literal newline would split one column across two rows.
+//! A header passes through two encoders — the label block backslash-escapes
+//! `"` and `\\`, then RFC 4180 doubles the `"` — and is always quoted. A
+//! newline is refused, not mangled: the label escape cannot express one and it
+//! would split a column across two CSV rows.
 
 use super::normalize::{Grid, NormalizedSeries};
 use crate::config::GapWindowConfig;
@@ -20,28 +15,18 @@ use crate::{ConfigError, SondaError};
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
-/// The `gap_windows:` entries describing one column's absent grid points — one
-/// window per maximal run, in row order.
+/// The `gap_windows:` entries for one column's absent grid points — one window
+/// per maximal run, in row order.
 ///
-/// Blanks and windows are one artifact: `cross_check_gap_windows` refuses a
-/// capture where they disagree in either direction.
-///
-/// Both edges sit on the **midpoints** either side of the run — `at = (a-0.5)*step`
-/// clamped to zero at row 0, `end = (b+0.5)*step` — not on the row instants
-/// themselves. Containment is `t*step >= at && t*step < end`, and `at`/`for`
-/// reach that predicate via a decimal string and microsecond truncation while
-/// the predicate recomputes `t*step` directly. Landing an edge on a row instant
-/// puts it a rounding error from the boundary, in either direction; half a step
-/// of margin does not.
-///
-/// Then it checks its own work: re-parses what it built and asks
-/// [`tick_in_window`] — the predicate the cross-check uses — whether it covers
-/// exactly the intended rows.
+/// Both edges sit on the **midpoints** either side of the run: `at`/`for` reach
+/// the containment predicate through microsecond truncation, so an edge on a
+/// row instant would sit a rounding error from the boundary. Verified by
+/// re-parsing the output and driving [`tick_in_window`], the real predicate.
 ///
 /// # Errors
 ///
-/// [`SondaError::Config`] if the window fails that round-trip, which now needs a
-/// step whose half-width is under a microsecond.
+/// [`SondaError::Config`] if that round-trip fails, which needs a step whose
+/// half-width is under a microsecond.
 pub fn gap_windows_for(
     values: &[Option<f64>],
     step_secs: f64,
@@ -125,15 +110,11 @@ fn verify_window(
 /// Build one column header for a series' label set, unquoted —
 /// [`csv_quote_field`] applies the CSV layer.
 ///
-/// `{__name__="m", k="v"}` when the series kept its metric name, `{k="v"}` when
-/// the query dropped it. In the latter case the caller must set
-/// `default_metric_name`, which `auto_discover_specs` requires for a nameless
-/// column.
+/// `{__name__="m", k="v"}`, or `{k="v"}` when the query dropped the name.
 ///
 /// # Errors
 ///
-/// [`SondaError::Config`] when a key or value contains a newline, or a key
-/// contains `=`; neither is representable in this grammar.
+/// [`SondaError::Config`] for a newline in either half, or `=` in a key.
 pub fn column_header(labels: &BTreeMap<String, String>) -> Result<String, SondaError> {
     for (k, v) in labels {
         for (what, s) in [("key", k), ("value", v)] {
@@ -146,23 +127,10 @@ pub fn column_header(labels: &BTreeMap<String, String>) -> Result<String, SondaE
             }
         }
 
-        // Values are escaped on the way out, keys are not — the `{k="v"}`
-        // grammar has nowhere to put an escape left of the `=`. A key containing
-        // the delimiter therefore reads back as a different label: `a=b` with
-        // value `v` emits `a=b="v"`, which the parser splits into label `a` with
-        // value `b="v"`. Silent, and wrong data in the file.
-        //
-        // Only `=` needs refusing; against the real parser, keys containing `"`,
-        // `{`, `}`, space or comma all round-trip unharmed, so refusing
-        // them "for symmetry" would reject captures that work today. The tests
-        // below pin that, so the narrowness of this guard is checked rather than
-        // asserted.
-        //
-        // Refused rather than escaped: a conforming Prometheus label name is
-        // `[a-zA-Z_][a-zA-Z0-9_]*`, so this cannot arrive from a well-behaved
-        // server — but acquisition reads a remote TSDB, which is the trust
-        // boundary this whole module polices, and failing at capture time is
-        // more honest than writing a header that reads back as something else.
+        // Keys are not escaped — the `{k="v"}` grammar has nowhere to put an
+        // escape left of the `=` — so a key containing one reads back as a
+        // different label. Only `=` needs refusing; the tests below pin that
+        // `"`, `{`, `}`, space and comma all round-trip through the real parser.
         if k.contains('=') {
             return Err(SondaError::Config(ConfigError::invalid(format!(
                 "csv capture: label key {k:?} contains '=', which is the delimiter this \
@@ -221,27 +189,18 @@ pub fn csv_quote_field(field: &str) -> String {
 /// Render one grid instant as the timestamp cell for its row.
 ///
 /// `{:.3}` rather than `{}` keeps scientific notation out of the file, which
-/// `parse_csv_timestamp` rejects.
-///
-/// A function rather than an inline format string because this precision decides
-/// the step the engine replays at — `csv_replay` derives its interval from these
-/// timestamps — so [`super::yaml_out`] calls it to reduce the same numbers the
-/// file will carry.
+/// `parse_csv_timestamp` rejects. A function because this precision decides the
+/// replay step, so [`super::yaml_out`] reduces the same numbers.
 pub fn format_timestamp(instant: f64) -> String {
     format!("{instant:.3}")
 }
 
-/// Render the whole capture as CSV text.
+/// Render the whole capture as CSV text. Column 0 is the timestamp in unix
+/// seconds, which `csv_replay` derives its rate from; the rest are series.
 ///
-/// Column 0 is the timestamp in unix seconds — `csv_replay` derives its replay
-/// rate from the delta between the first two, and `auto_discover_specs` skips
-/// column 0 when mapping columns to series. Every other column is one series.
-///
-/// This writes every series' blanks, while [`gap_windows_for`] speaks for one
-/// column. `gap_windows:` is scenario-level, so a caller writing a multi-column
-/// capture must group columns by identical absence pattern and emit one block
-/// per group — see [`super::yaml_out`]. Nothing here can check that, because
-/// nothing here knows which column the windows will be paired with.
+/// Writes every series' blanks, while [`gap_windows_for`] speaks for one
+/// column — so a caller must group columns by absence pattern and emit one
+/// block per group ([`super::yaml_out`] does). Nothing here can check that.
 ///
 /// # Errors
 ///
@@ -631,20 +590,10 @@ mod tests {
 
     #[test]
     fn the_window_boundary_survives_steps_that_break_the_obvious_encoding() {
-        // These eleven (step, run) pairs are the ones where `for = (b+1-a)*step`
-        // — the obvious encoding — puts row b+1 inside the window after
-        // microsecond truncation. They are named individually because they are
-        // rare: a sweep of short runs at common steps passes under BOTH
-        // encodings, so a test built from round numbers would not discriminate.
-        // Verified by mutation: reverting the emitter to (b+1) fails on these.
-        // The leading edge has its own failing set, and it is a different one.
-        // With `at = a*step` the run's own FIRST row falls outside its window,
-        // because `at` reaches the predicate via a decimal string and
-        // microsecond quantisation while the predicate recomputes `a * step`
-        // directly — and `trunc(x * 1e6) / 1e6` can land marginally ABOVE `x`
-        // when the multiply rounds up onto an integer. Containment at the start
-        // is `>=`, so marginally above is enough. All of these are steps within
-        // a millionth of one second; none appear in the trailing-edge set.
+        // The (step, run) pairs where the midpoint encoding is load-bearing:
+        // under `for = (b+1-a)*step` row b+1 falls inside the window, and under
+        // `at = a*step` the run's own first row falls outside it. Listed rather
+        // than swept because round steps pass under both encodings.
         const SQUARE_LEADING_EDGE_FAILS_HERE: &[(f64, usize, usize)] = &[
             (0.999_999, 13, 13),
             (0.999_999, 13, 14),

--- a/sonda-core/src/acquire/mod.rs
+++ b/sonda-core/src/acquire/mod.rs
@@ -1,19 +1,14 @@
 //! Capture a signal out of a Prometheus-compatible TSDB and replay it exactly.
 //!
-//! It fetches a PromQL range query, resamples the result onto the requested
-//! step grid, and hands back data the CSV writer turns into a `csv_replay`
-//! scenario.
+//! Fetches a PromQL range query, resamples it onto the requested grid, and
+//! hands back what the CSV writer turns into a `csv_replay` scenario. Reached
+//! from `sonda new --from-prometheus`.
 //!
-//! No CLI surface reaches this yet; do not name a flag here until one exists.
+//! **Replay-only:** no classifier, no generator inference, no `--fit`. The case
+//! this closes is alert regression, where the alert must fire on what actually
+//! happened. Pattern fitting stays in `--from <csv>`, which promises a guess.
 //!
-//! **Replay-only.** Nothing here inspects the shape of a signal — no
-//! classifier, no generator inference, no `--fit`. Recorded values are written
-//! and replayed verbatim, because the case this closes is alert regression,
-//! where the alert must fire on what actually happened. Pattern fitting stays
-//! in the `--from <csv>` wizard, where the promise is "a guess to edit".
-//!
-//! Everything is pure and feature-free except [`tsdb`], which owns the HTTP
-//! client and sits behind the `http` feature.
+//! Pure and feature-free except [`tsdb`], which is behind `http`.
 
 #[cfg(feature = "http")]
 pub mod tsdb;

--- a/sonda-core/src/acquire/normalize.rs
+++ b/sonda-core/src/acquire/normalize.rs
@@ -1,18 +1,12 @@
 //! Resample fetched series onto the requested step grid.
 //!
-//! Pure and feature-free, and one rule: **a grid point takes the value the TSDB
-//! reported at that instant, or `None` if it reported nothing there.** Values
-//! are never interpolated, averaged or carried forward — that is what makes
-//! this path exact rather than a fit.
+//! One rule: **a grid point takes the value the TSDB reported at that instant,
+//! or `None` if it reported nothing there.** Never interpolated, averaged or
+//! carried forward — that is what makes this exact rather than a fit.
 //!
-//! `Option<f64>` rather than a `NaN` sentinel because absence and value are
-//! separate facts: [`super::response`] keeps a reported `NaN` or infinity
-//! verbatim, and the capture path turns absence into a declared `gap_windows:`
-//! entry, so conflating them would emit silence the database never reported.
-//!
-//! Nothing is written here. [`crate::acquire::csv_out`] turns each `None` into
-//! a blank cell and derives the matching windows from the same entries, so the
-//! two halves of that pair come from one source.
+//! `Option<f64>` rather than a `NaN` sentinel: a reported `NaN` is data and
+//! absence is not, and conflating them would emit silence the database never
+//! reported.
 
 use super::FetchedSeries;
 use std::collections::BTreeMap;
@@ -91,15 +85,9 @@ impl NormalizedSeries {
 
 /// Resample one fetched series onto `grid`.
 ///
-/// A sample counts for grid point `n` when its timestamp is within half a
-/// millisecond of `grid.point(n)`. Prometheus aligns range-query samples to
-/// the requested grid, so in practice this is an exact match; the tolerance
-/// exists because the timestamps arrive as JSON floats, not because the
-/// values are being snapped to somewhere they did not come from.
-///
-/// Samples that match no grid point are dropped: they are outside the
-/// requested window, and inventing a grid point for them would move data the
-/// caller did not ask for.
+/// A sample counts for grid point `n` within half a millisecond of
+/// `grid.point(n)` — a tolerance for JSON float error, not a snap. Samples
+/// matching no grid point are dropped rather than given one.
 pub fn normalize(series: &FetchedSeries, grid: Grid) -> NormalizedSeries {
     // Half a millisecond, the finest resolution the Prometheus API expresses.
     const TOLERANCE_SECS: f64 = 0.0005;

--- a/sonda-core/src/acquire/tsdb.rs
+++ b/sonda-core/src/acquire/tsdb.rs
@@ -1,25 +1,12 @@
 //! The HTTP half of TSDB capture: fetch one range query.
 //!
-//! Deliberately thin. Every decision that can be made without a socket —
-//! parsing the response, resampling, writing CSV — lives in a feature-free
-//! sibling module and is tested there. What is left here is building a
-//! request, applying auth, and handing the body to
-//! [`super::response::parse_matrix_response`].
+//! Deliberately thin — everything decidable without a socket lives in a
+//! feature-free sibling. Modelled on [`crate::verify::prometheus`]: one agent,
+//! a mandatory timeout, errors that name their URL.
 //!
-//! Modelled on [`crate::verify::prometheus`], which was hardened in #528: one
-//! agent, a mandatory overall timeout so a stalled endpoint fails rather than
-//! hangs, and errors that name the URL they came from.
-//!
-//! # Credentials never reach an artifact
-//!
-//! [`Auth`] deliberately has no `Display`, no `Debug` that prints the secret,
-//! and no accessor returning the token. It exists only to be applied to a
-//! request. The emitted CSV and YAML are built from labels and values, and
-//! never see this type — asserted by a test rather than by inspection.
-//!
-//! A base URL is the other way a credential arrives: `http://user:pass@host`.
-//! That one *is* stored, so the rule is that only [`scrub_userinfo`]'s output
-//! is ever formatted — into an error, into a `Debug`, anywhere but the wire.
+//! Two credential rules. [`Auth`] has no `Display`, no revealing `Debug` and no
+//! accessor, so it can only be applied to a request. A `user:pass@` base URL is
+//! stored, so only [`scrub_userinfo`]'s output is ever formatted.
 
 use super::response::parse_matrix_response;
 use super::FetchedSeries;
@@ -28,17 +15,9 @@ use std::time::Duration;
 
 /// How to authenticate to the TSDB.
 ///
-/// The secret is protected structurally rather than by convention: `Debug` is
-/// written by hand so a token cannot reach a log line, a panic message, or an
-/// error report through a derived formatter, and there is deliberately no
-/// `Serialize`, so it cannot reach an emitted CSV or YAML even by accident.
-///
-/// `#[non_exhaustive]` is here for the remaining hole. The variants are public,
-/// so `if let Auth::Bearer(t) = auth` is an accessor any future caller could
-/// write — the type had no method returning the token, but destructuring did
-/// not need one. Outside this crate the enum can no longer be matched
-/// exhaustively, so reaching the secret is a deliberate act rather than the
-/// obvious one.
+/// Protected structurally: a hand-written `Debug`, no `Serialize`, and
+/// `#[non_exhaustive]` so an outside caller cannot destructure the secret out
+/// without meaning to.
 #[derive(Clone, Default)]
 #[non_exhaustive]
 pub enum Auth {

--- a/sonda-core/src/acquire/yaml_out.rs
+++ b/sonda-core/src/acquire/yaml_out.rs
@@ -1,27 +1,12 @@
-//! Emit the scenario file that replays a capture.
+//! Emit the scenario that replays a capture. [`super::csv_out`] writes the data.
 //!
-//! The companion to [`super::csv_out`]. That module writes the data — values,
-//! blanks, one row per grid point — and this one writes the scenario that
-//! plays it back at the cadence it was captured at, with the recorded silence
-//! declared as `gap_windows:`.
+//! Builds the compiler's own [`ScenarioFile`] and serialises it, so nothing
+//! writes YAML by hand. Three rules a block keeps, each enforced below:
 //!
-//! Feature-gated on `config`: it builds the compiler's own [`ScenarioFile`] and
-//! serialises that, so the emitted grammar is whatever serde produces for the
-//! types the compiler already reads. Nothing writes YAML by hand.
-//!
-//! Three rules the emitted scenarios keep:
-//!
-//! * **One block per distinct absence pattern.** `gap_windows:` is
-//!   scenario-level, so a block speaks for every column it lists; columns whose
-//!   silence falls on different rows cannot share one.
-//! * **No two columns in a block share a metric name.** `expand_scenario` makes
-//!   a column name into a scenario name and refuses duplicates, so one metric
-//!   across several label sets — `up{job="api"}` and `up{job="db"}`, the
-//!   ordinary result of a range query — has to span blocks.
-//! * **`repeat: false` on every block**, silence or not. The generator defaults
-//!   to `true`, so omitting it would loop a dense capture — and for a capture
-//!   with silence the engine refuses the combination outright, since
-//!   `gap_windows:` describe a single pass.
+//! * One block per distinct absence pattern — `gap_windows:` is scenario-level.
+//! * No two columns in a block share a metric name — `expand_scenario` turns a
+//!   column name into a scenario name and refuses duplicates.
+//! * `repeat: false` always — the generator defaults to `true` and would loop.
 
 use super::normalize::{Grid, NormalizedSeries};
 use crate::compiler::{Entry, Kind, ScenarioFile};
@@ -29,29 +14,18 @@ use crate::config::GapWindowConfig;
 use crate::generator::{CsvColumnSpec, GeneratorConfig};
 use crate::{ConfigError, SondaError};
 
-/// Build the scenario file that replays `series` from `csv_path`.
+/// Build the scenario that replays `series` from `csv_path`, written verbatim.
 ///
-/// `csv_path` is written into the emitted `file:` field verbatim; the caller
-/// decides whether it is absolute or relative to the scenario, and nothing here
-/// touches the filesystem.
+/// `timescale` is the replay speed. It divides the step rate, duration and the
+/// windows are all derived from, because the engine recomputes
+/// `rate = timescale / Δt` on load and the other two must agree with it.
 ///
-/// `timescale` is the replay speed: `1.0` replays at the captured cadence, `2.0`
-/// twice as fast. It divides the step every emitted value is derived from, so
-/// rate, duration and the gap windows describe the same accelerated timeline —
-/// the engine derives `rate = timescale / Δt` on load, and a duration or a
-/// window left on the captured timeline would disagree with it.
-///
-/// Column indices are 1-based in the emitted spec because column 0 of the file
-/// [`super::csv_out::write_csv`] wrote is the timestamp — series `i` is CSV
-/// column `i + 1`. Getting that off by one would silently replay the timestamps
-/// as values.
+/// Emitted column indices are 1-based: column 0 of the CSV is the timestamp.
 ///
 /// # Errors
 ///
-/// Returns [`SondaError::Config`] when the grid cannot be expressed as a rate,
-/// when `timescale` is not positive and finite, when a series carries no metric
-/// name to build a scenario name from, or when
-/// [`super::csv_out::gap_windows_for`] cannot express a column's silence.
+/// [`SondaError::Config`] for a grid that is not a rate, a non-positive
+/// `timescale`, a series with no `__name__`, or silence with no window.
 pub fn scenario_for(
     csv_path: &str,
     grid: Grid,
@@ -202,19 +176,11 @@ pub fn scenario_for(
     })
 }
 
-/// The step the engine will replay at, given the file [`super::csv_out::write_csv`]
-/// will write.
+/// The step the engine will read back, which is not `grid.step`: the CSV
+/// carries millisecond timestamps, so `1/7` returns as `0.143`.
 ///
-/// Not `grid.step`: the CSV carries millisecond timestamps, so `1/7` reaches the
-/// engine as `0.143`, and windows built from the caller's step drift against the
-/// replay until the capture stops loading.
-///
-/// Both halves are borrowed rather than modelled —
-/// [`super::csv_out::format_timestamp`] renders the instants the file will
-/// carry, and [`crate::config::median_delta_seconds`] reduces them over
-/// [`crate::config::CSV_DELTA_SAMPLE_ROWS`] rows, which is exactly what
-/// `compute_csv_delta_seconds` does on the way back in. Any model of that
-/// reduction disagrees with it somewhere.
+/// Drives the real formatter and the real reduction rather than modelling
+/// either, so this cannot disagree with `compute_csv_delta_seconds`.
 fn file_step(grid: Grid) -> Result<f64, SondaError> {
     // A single-row capture has no delta to read, so nothing rounds it and the
     // caller's step stands.
@@ -246,8 +212,7 @@ fn file_step(grid: Grid) -> Result<f64, SondaError> {
 ///
 /// # Errors
 ///
-/// Returns [`SondaError::Config`] if serialisation fails, which would mean a
-/// config type stopped being representable in YAML.
+/// [`SondaError::Config`] if a config type stopped being representable in YAML.
 pub fn to_yaml(file: &ScenarioFile) -> Result<String, SondaError> {
     let mut value: serde_yaml_ng::Value = serde_yaml_ng::to_value(file).map_err(|e| {
         SondaError::Config(ConfigError::invalid(format!(
@@ -611,16 +576,10 @@ mod tests {
 
     #[test]
     fn a_step_that_is_not_a_whole_millisecond_still_round_trips_at_length() {
-        // The capture file carries millisecond timestamps and `csv_replay`
-        // takes its interval from them, so a step like 1/7 reaches the engine
-        // rounded. Windows built from the caller's exact step drift against
-        // that by a fixed amount per row, and the error accumulates until a
-        // window misses the row it was built for.
-        //
-        // Short captures at round steps do not reach it — every other test in
-        // this file passes under the drifting version — so the length and the
-        // steps here are the point. Measured against the old behaviour: 1/7
-        // and 1/3 failed from roughly 600 rows, 0.123456789 from roughly 200.
+        // `csv_replay` takes its interval from the file's millisecond
+        // timestamps, so a step like 1/7 reaches the engine rounded and windows
+        // built from the caller's exact step drift a fixed amount per row. The
+        // length and the odd steps are the point: round steps never reach it.
         const ROWS: usize = 1400;
         // The last three are the ones a first-delta model gets wrong: a step
         // whose millisecond value is a clean half rounds one way as a single

--- a/sonda-core/src/acquire/yaml_out.rs
+++ b/sonda-core/src/acquire/yaml_out.rs
@@ -31,6 +31,12 @@ use crate::{ConfigError, SondaError};
 /// decides whether it is absolute or relative to the scenario, and nothing here
 /// touches the filesystem.
 ///
+/// `timescale` is the replay speed: `1.0` replays at the captured cadence, `2.0`
+/// twice as fast. It divides the step every emitted value is derived from, so
+/// rate, duration and the gap windows describe the same accelerated timeline —
+/// the engine derives `rate = timescale / Δt` on load, and a duration or a
+/// window left on the captured timeline would disagree with it.
+///
 /// Column indices are 1-based in the emitted spec because column 0 of the file
 /// [`super::csv_out::write_csv`] wrote is the timestamp — series `i` is CSV
 /// column `i + 1`. Getting that off by one would silently replay the timestamps
@@ -39,12 +45,14 @@ use crate::{ConfigError, SondaError};
 /// # Errors
 ///
 /// Returns [`SondaError::Config`] when the grid cannot be expressed as a rate,
-/// when a series carries no metric name to build a scenario name from, or when
+/// when `timescale` is not positive and finite, when a series carries no metric
+/// name to build a scenario name from, or when
 /// [`super::csv_out::gap_windows_for`] cannot express a column's silence.
 pub fn scenario_for(
     csv_path: &str,
     grid: Grid,
     series: &[NormalizedSeries],
+    timescale: f64,
 ) -> Result<ScenarioFile, SondaError> {
     if series.is_empty() {
         return Err(SondaError::Config(ConfigError::invalid(
@@ -57,10 +65,15 @@ pub fn scenario_for(
             grid.step
         ))));
     }
+    if !timescale.is_finite() || timescale <= 0.0 {
+        return Err(SondaError::Config(ConfigError::invalid(format!(
+            "acquire: timescale must be a positive finite number, got {timescale}"
+        ))));
+    }
 
-    // The engine's step, not the caller's — see `file_step`. Windows, rate and
-    // duration all come from this one value.
-    let step = file_step(grid)?;
+    // The engine's step, not the caller's — see `file_step` — divided by the
+    // replay speed. Windows, rate and duration all come from this one value.
+    let step = file_step(grid)? / timescale;
     let rate = 1.0 / step;
     let duration = format!("{}s", grid.len as f64 * step);
 
@@ -122,7 +135,8 @@ pub fn scenario_for(
                 columns: Some(columns),
                 // Explicit, and never true — see the module docs.
                 repeat: Some(false),
-                timescale: None,
+                // Omitted at 1.0 so an untimescaled capture reads as one.
+                timescale: (timescale != 1.0).then_some(timescale),
                 default_metric_name: None,
             }),
             log_generator: None,
@@ -287,7 +301,7 @@ mod tests {
         let csv_path = dir.path().join("capture.csv");
         std::fs::write(&csv_path, write_csv(grid, series).expect("csv")).expect("write csv");
 
-        let file = scenario_for(csv_path.to_str().expect("utf8 path"), grid, series)
+        let file = scenario_for(csv_path.to_str().expect("utf8 path"), grid, series, 1.0)
             .expect("scenario must build");
         let yaml = to_yaml(&file).expect("yaml");
         let entries = crate::compile_scenario_file(&yaml, &InMemoryPackResolver::default())
@@ -318,7 +332,7 @@ mod tests {
             norm("b", &[], &[Some(9.0), None, Some(7.0), Some(6.0)]),
             norm("c", &[], &[Some(1.0), Some(2.0), None, Some(4.0)]),
         ];
-        let file = scenario_for("capture.csv", grid, &series).expect("scenario");
+        let file = scenario_for("capture.csv", grid, &series, 1.0).expect("scenario");
         assert_eq!(
             file.scenarios.len(),
             2,
@@ -347,10 +361,104 @@ mod tests {
     }
 
     #[test]
+    fn a_timescale_moves_rate_duration_and_windows_together() {
+        // 10s grid, silence on row 2. At 1.0 the engine replays one row per
+        // 10s; at 4.0, one per 2.5s — and every emitted value has to say so.
+        let grid = Grid::new(0.0, 30.0, 10.0).expect("grid");
+        let series = [norm("m", &[], &[Some(1.0), None, Some(3.0), Some(4.0)])];
+
+        let at = |t: f64| {
+            let e = scenario_for("capture.csv", grid, &series, t)
+                .expect("scenario")
+                .scenarios
+                .remove(0);
+            let w = e.gap_windows.clone().expect("silence to declare");
+            (
+                e.rate.expect("rate"),
+                e.duration.clone().expect("duration"),
+                w[0].at.clone(),
+                w[0].r#for.clone(),
+            )
+        };
+
+        let (rate1, dur1, at1, for1) = at(1.0);
+        let (rate4, dur4, at4, for4) = at(4.0);
+
+        assert_eq!((rate1, dur1.as_str()), (0.1, "40s"));
+        assert_eq!((at1.as_str(), for1.as_str()), ("5s", "10s"));
+
+        assert_eq!(rate4, 0.4, "four times the rate");
+        assert_eq!(dur4, "10s", "and a quarter of the wall clock");
+        assert_eq!(
+            (at4.as_str(), for4.as_str()),
+            ("1.25s", "2.5s"),
+            "the window has to land on the accelerated timeline too"
+        );
+    }
+
+    #[test]
+    fn a_timescale_is_emitted_only_when_it_is_not_one() {
+        let grid = Grid::new(0.0, 2.0, 1.0).expect("grid");
+        let series = [norm("m", &[], &[Some(1.0), Some(2.0), Some(3.0)])];
+        let timescale_of = |t: f64| match scenario_for("capture.csv", grid, &series, t)
+            .expect("scenario")
+            .scenarios[0]
+            .generator
+            .as_ref()
+            .expect("generator")
+        {
+            GeneratorConfig::CsvReplay { timescale, .. } => *timescale,
+            other => panic!("expected csv_replay, got {other:?}"),
+        };
+        assert_eq!(timescale_of(1.0), None, "the default is not written out");
+        assert_eq!(timescale_of(2.5), Some(2.5));
+    }
+
+    #[test]
+    fn a_timescaled_capture_still_compiles_and_loads_its_own_file() {
+        // The engine derives `rate = timescale / Δt` on load, overriding the
+        // emitted rate. If the two disagree the replay runs at a cadence the
+        // duration and windows were not written for, so drive the real thing.
+        let grid = Grid::new(0.0, 4.0, 1.0).expect("grid");
+        let series = [norm(
+            "m",
+            &[],
+            &[Some(1.0), None, Some(3.0), Some(4.0), None],
+        )];
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let csv_path = dir.path().join("capture.csv");
+        std::fs::write(&csv_path, write_csv(grid, &series).expect("csv")).expect("write csv");
+
+        let file = scenario_for(csv_path.to_str().expect("utf8 path"), grid, &series, 3.0)
+            .expect("scenario must build");
+        let yaml = to_yaml(&file).expect("yaml");
+        let entries = crate::compile_scenario_file(&yaml, &InMemoryPackResolver::default())
+            .unwrap_or_else(|e| panic!("the compiler rejected a timescaled capture: {e}\n{yaml}"));
+        for e in entries {
+            crate::config::expand_entry(e).expect("the emitted columns must expand");
+        }
+    }
+
+    #[test]
+    fn a_timescale_that_is_not_a_positive_number_is_refused() {
+        let grid = Grid::new(0.0, 2.0, 1.0).expect("grid");
+        let series = [norm("m", &[], &[Some(1.0), Some(2.0), Some(3.0)])];
+        for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let err = scenario_for("capture.csv", grid, &series, bad)
+                .expect_err(&format!("timescale {bad} must be refused"));
+            assert!(
+                err.to_string().contains("timescale"),
+                "the error should name the field: {err}"
+            );
+        }
+    }
+
+    #[test]
     fn every_block_sets_repeat_false_even_with_no_silence_to_declare() {
         let grid = Grid::new(0.0, 2.0, 1.0).expect("grid");
         let series = [norm("dense", &[], &[Some(1.0), Some(2.0), Some(3.0)])];
-        let file = scenario_for("capture.csv", grid, &series).expect("scenario");
+        let file = scenario_for("capture.csv", grid, &series, 1.0).expect("scenario");
         let entry = &file.scenarios[0];
         assert!(
             entry.gap_windows.is_none(),
@@ -373,7 +481,7 @@ mod tests {
         // reproduce it exactly.
         let grid = Grid::new(0.0, 2.0, 1.0).expect("grid");
         let series = [norm("m", &[], &[Some(1.0), None, Some(3.0)])];
-        let file = scenario_for("capture.csv", grid, &series).expect("scenario");
+        let file = scenario_for("capture.csv", grid, &series, 1.0).expect("scenario");
         for e in &file.scenarios {
             assert!(e.jitter.is_none() && e.jitter_seed.is_none(), "no jitter");
         }
@@ -390,7 +498,7 @@ mod tests {
             norm("first", &[], &[Some(1.0), Some(2.0)]),
             norm("second", &[], &[Some(3.0), Some(4.0)]),
         ];
-        let file = scenario_for("capture.csv", grid, &series).expect("scenario");
+        let file = scenario_for("capture.csv", grid, &series, 1.0).expect("scenario");
         match file.scenarios[0].generator.as_ref().expect("generator") {
             GeneratorConfig::CsvReplay { columns, .. } => {
                 let idx: Vec<usize> = columns
@@ -457,7 +565,7 @@ mod tests {
             labels: BTreeMap::new(),
             values: vec![Some(1.0), Some(2.0)],
         };
-        let err = scenario_for("capture.csv", grid, &[nameless]).expect_err("must refuse");
+        let err = scenario_for("capture.csv", grid, &[nameless], 1.0).expect_err("must refuse");
         assert!(
             err.to_string().contains("__name__"),
             "the error names the missing label: {err}"
@@ -467,7 +575,7 @@ mod tests {
     #[test]
     fn zero_series_is_refused_rather_than_emitting_an_empty_scenario() {
         let grid = Grid::new(0.0, 1.0, 1.0).expect("grid");
-        let err = scenario_for("capture.csv", grid, &[]).expect_err("must refuse");
+        let err = scenario_for("capture.csv", grid, &[], 1.0).expect_err("must refuse");
         assert!(err.to_string().contains("matched nothing"), "{err}");
     }
 }

--- a/sonda-core/src/acquire/yaml_out.rs
+++ b/sonda-core/src/acquire/yaml_out.rs
@@ -9,11 +9,15 @@
 //! serialises that, so the emitted grammar is whatever serde produces for the
 //! types the compiler already reads. Nothing writes YAML by hand.
 //!
-//! Two rules the emitted scenarios keep:
+//! Three rules the emitted scenarios keep:
 //!
 //! * **One block per distinct absence pattern.** `gap_windows:` is
 //!   scenario-level, so a block speaks for every column it lists; columns whose
 //!   silence falls on different rows cannot share one.
+//! * **No two columns in a block share a metric name.** `expand_scenario` makes
+//!   a column name into a scenario name and refuses duplicates, so one metric
+//!   across several label sets — `up{job="api"}` and `up{job="db"}`, the
+//!   ordinary result of a range query — has to span blocks.
 //! * **`repeat: false` on every block**, silence or not. The generator defaults
 //!   to `true`, so omitting it would loop a dense capture — and for a capture
 //!   with silence the engine refuses the combination outright, since
@@ -87,7 +91,19 @@ pub fn scenario_for(
             w.iter().map(|g| (g.at.clone(), g.r#for.clone())).collect()
         };
         let this = key(&windows);
-        match blocks.iter_mut().find(|(_, w)| key(w) == this) {
+        // ...and only when their metric names differ. `expand_scenario` turns
+        // each column name into a scenario name, so it refuses duplicates
+        // within a block — and one metric across several label sets, which is
+        // what `up{job="api"}` and `up{job="db"}` are, is the ordinary thing a
+        // range query returns.
+        let name = s.labels.get("__name__");
+        let fits = |(members, w): &&mut (Vec<usize>, Vec<GapWindowConfig>)| {
+            key(w) == this
+                && !members
+                    .iter()
+                    .any(|&j| series[j].labels.get("__name__") == name)
+        };
+        match blocks.iter_mut().find(fits) {
             Some((members, _)) => members.push(i),
             None => blocks.push((vec![i], windows)),
         }
@@ -358,6 +374,82 @@ mod tests {
             runnables, 3,
             "and the three columns fan out to three runnables at launch"
         );
+    }
+
+    #[test]
+    fn one_metric_across_several_label_sets_splits_rather_than_colliding() {
+        // The shape `--query up` returns from any Prometheus with two healthy
+        // targets, and the one a fixture hides whenever its series happen to
+        // differ in absence pattern or in name. `expand_scenario` turns a
+        // column name into a scenario name and refuses duplicates, so two
+        // columns called `up` in one block is a file that will not load.
+        let grid = Grid::new(0.0, 3.0, 1.0).expect("grid");
+        let series = [
+            norm("up", &[("job", "api")], &[Some(1.0); 4]),
+            norm("up", &[("job", "db")], &[Some(1.0); 4]),
+        ];
+        let file = scenario_for("capture.csv", grid, &series, 1.0).expect("scenario");
+        assert_eq!(
+            file.scenarios.len(),
+            2,
+            "same name and same (empty) absence pattern still needs two blocks: {:#?}",
+            file.scenarios
+        );
+
+        // Drive the real compiler: the emitted file has to load, which is the
+        // property the block split exists for.
+        let (_dir, entries) = compile_emitted(grid, &series);
+        let runnables: usize = entries
+            .into_iter()
+            .map(|e| {
+                crate::config::expand_entry(e)
+                    .expect("the emitted columns must expand")
+                    .len()
+            })
+            .sum();
+        assert_eq!(runnables, 2, "one runnable per series");
+    }
+
+    #[test]
+    fn columns_split_by_name_keep_their_own_silence() {
+        // Splitting must not smear one series' windows onto another's block.
+        let grid = Grid::new(0.0, 3.0, 1.0).expect("grid");
+        let series = [
+            norm(
+                "up",
+                &[("job", "api")],
+                &[Some(1.0), None, Some(3.0), Some(4.0)],
+            ),
+            norm(
+                "up",
+                &[("job", "db")],
+                &[Some(1.0), None, Some(3.0), Some(4.0)],
+            ),
+        ];
+        let file = scenario_for("capture.csv", grid, &series, 1.0).expect("scenario");
+        assert_eq!(file.scenarios.len(), 2, "same name, so two blocks");
+        for (n, entry) in file.scenarios.iter().enumerate() {
+            let w = entry
+                .gap_windows
+                .as_ref()
+                .unwrap_or_else(|| panic!("block {n} lost its silence"));
+            assert_eq!(w.len(), 1, "block {n}: one hole, one window");
+            assert_eq!((w[0].at.as_str(), w[0].r#for.as_str()), ("0.5s", "1s"));
+        }
+        let (_dir, _entries) = compile_emitted(grid, &series);
+    }
+
+    #[test]
+    fn distinct_names_sharing_an_absence_pattern_still_share_a_block() {
+        // The split is by name collision only — it must not undo the grouping
+        // that `columns_sharing_an_absence_pattern_share_a_block` pins.
+        let grid = Grid::new(0.0, 3.0, 1.0).expect("grid");
+        let series = [
+            norm("a", &[], &[Some(1.0), None, Some(3.0), Some(4.0)]),
+            norm("b", &[], &[Some(9.0), None, Some(7.0), Some(6.0)]),
+        ];
+        let file = scenario_for("capture.csv", grid, &series, 1.0).expect("scenario");
+        assert_eq!(file.scenarios.len(), 1, "different names, one block");
     }
 
     #[test]

--- a/sonda-core/tests/acquire_capture.rs
+++ b/sonda-core/tests/acquire_capture.rs
@@ -91,7 +91,7 @@ fn a_capture_taken_over_http_replays_through_the_real_compiler() {
     )
     .expect("write");
 
-    let file = yaml_out::scenario_for(csv_path.to_str().expect("utf8"), grid, &normalized)
+    let file = yaml_out::scenario_for(csv_path.to_str().expect("utf8"), grid, &normalized, 1.0)
         .expect("scenario");
     let yaml = yaml_out::to_yaml(&file).expect("yaml");
 
@@ -128,7 +128,7 @@ fn a_bearer_token_is_sent_and_never_reaches_an_emitted_artifact() {
     let normalized: Vec<_> = series.iter().map(|s| normalize(s, grid)).collect();
 
     let csv = csv_out::write_csv(grid, &normalized).expect("csv");
-    let file = yaml_out::scenario_for("capture.csv", grid, &normalized).expect("scenario");
+    let file = yaml_out::scenario_for("capture.csv", grid, &normalized, 1.0).expect("scenario");
     let yaml = yaml_out::to_yaml(&file).expect("yaml");
 
     for (what, text) in [("csv", &csv), ("yaml", &yaml)] {
@@ -209,7 +209,7 @@ fn basic_auth_credentials_do_not_reach_an_artifact_in_either_form() {
     let normalized: Vec<_> = series.iter().map(|s| normalize(s, grid)).collect();
     let csv = csv_out::write_csv(grid, &normalized).expect("csv");
     let yaml = yaml_out::to_yaml(
-        &yaml_out::scenario_for("capture.csv", grid, &normalized).expect("scenario"),
+        &yaml_out::scenario_for("capture.csv", grid, &normalized, 1.0).expect("scenario"),
     )
     .expect("yaml");
 
@@ -289,7 +289,7 @@ fn hostile_labels_from_the_server_survive_into_a_loadable_capture() {
     .expect("write");
 
     let yaml = yaml_out::to_yaml(
-        &yaml_out::scenario_for(csv_path.to_str().expect("utf8"), grid, &normalized)
+        &yaml_out::scenario_for(csv_path.to_str().expect("utf8"), grid, &normalized, 1.0)
             .expect("scenario"),
     )
     .expect("yaml");

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -48,8 +48,10 @@ src/
 │   ├── csv_reader.rs   ← CSV file reading for `--from <csv>`: header parsing,
 │   │                      numeric column extraction
 │   ├── tsdb_reader.rs  ← `--from-prometheus`: resolves the capture window from
-│   │                      --range or --start/--end, builds the credential from
-│   │                      --header and SONDA_PROM_TOKEN, and hands off to
+│   │                      --range or --start/--end, validates every flag-only
+│   │                      input before the network call, builds the credential
+│   │                      from --header and SONDA_PROM_TOKEN, names series the
+│   │                      query left unnamed, and hands off to
 │   │                      sonda_core::acquire. Caps the result at 20 series.
 │   │                      Behind the `http` feature, with the rest of acquire.
 │   └── yaml_gen.rs     ← YAML rendering: minimal_template(), render_from_answers(),
@@ -119,11 +121,18 @@ the single discovery surface. The verbosity model is captured in the `Verbosity`
   `--from-prometheus <url>` captures a live PromQL range query and emits a scenario that
   replays it **verbatim** — no pattern detection, no generator inference, no `--fit`. It
   requires `--query`, `--step` and `--out` (the CSV path the emitted scenario references), plus
-  a window from either `--range` or `--start`/`--end` (unix seconds or RFC 3339). `--timescale`
-  sets the replay speed and moves rate, duration and gap windows together. Credentials come
-  from `SONDA_PROM_TOKEN` or `--header Name: value`, never from a flag value that would land in
-  a shell history; neither reaches the emitted CSV or YAML. A query matching more than 20
-  series is refused with the aggregation hint rather than emitting an unreadable scenario.
+  a window from either `--range` or `--start`/`--end` (unix seconds or RFC 3339). Every capture
+  flag requires `--from-prometheus` in turn, so one on its own is a typo rather than a no-op.
+  `--timescale` sets the replay speed and moves rate, duration and gap windows together.
+
+  `--metric-name <NAME>` supplies a name for series the query left without one. PromQL
+  aggregations drop `__name__`, and aggregating is the usual way under the 20-series cap, so
+  the cap's advice and this flag go together — without it an aggregated capture is refused.
+
+  Credentials come from `SONDA_PROM_TOKEN` or `--header Name: value`, never from a flag value
+  that would land in a shell history; neither reaches the emitted CSV or YAML. An explicit
+  `--header Authorization:` wins over the environment token, with a note on stderr rather than
+  silently.
 
 - **`sonda test`** — run a scenario and verify its top-level `expect:` alert expectations
   against **exactly one** acquisition source: a Prometheus-compatible API

--- a/sonda/CLAUDE.md
+++ b/sonda/CLAUDE.md
@@ -41,12 +41,17 @@ src/
 │                          the "start" banner agree on how a sink prints).
 ├── new/
 │   ├── mod.rs          ← `sonda new` subcommand: dispatches between --template,
-│   │                      --from <csv>, and interactive flow; writes to -o <path>
-│   │                      or stdout
+│   │                      --from <csv>, --from-prometheus <url>, and the
+│   │                      interactive flow; writes to -o <path> or stdout
 │   ├── prompts.rs      ← interactive prompt logic using dialoguer: signal type,
 │   │                      scenario id, generator (metrics only), rate, duration, sink
 │   ├── csv_reader.rs   ← CSV file reading for `--from <csv>`: header parsing,
 │   │                      numeric column extraction
+│   ├── tsdb_reader.rs  ← `--from-prometheus`: resolves the capture window from
+│   │                      --range or --start/--end, builds the credential from
+│   │                      --header and SONDA_PROM_TOKEN, and hands off to
+│   │                      sonda_core::acquire. Caps the result at 20 series.
+│   │                      Behind the `http` feature, with the rest of acquire.
 │   └── yaml_gen.rs     ← YAML rendering: minimal_template(), render_from_answers(),
 │                          spec_from_pattern() — maps detected patterns to v2 YAML
 │                          using operational vocabulary aliases (steady, spike_event,
@@ -69,7 +74,7 @@ requires multiple tightly-coupled files.
 sonda [GLOBAL FLAGS] run <SCENARIO> [OPTIONS]
 sonda [GLOBAL FLAGS] list --catalog <DIR> [--kind <runnable|composable>] [--tag <TAG>] [--json]
 sonda [GLOBAL FLAGS] show <@NAME> --catalog <DIR>
-sonda [GLOBAL FLAGS] new [--template | --from <CSV>] [-o <PATH>]
+sonda [GLOBAL FLAGS] new [--template | --from <CSV> | --from-prometheus <URL>] [-o <PATH>]
 sonda [GLOBAL FLAGS] test <SCENARIO> --prometheus-url <URL> | --alertmanager-url <URL>
 sonda completions <bash|zsh|fish|powershell|elvish>
 ```
@@ -110,6 +115,15 @@ the single discovery surface. The verbosity model is captured in the `Verbosity`
   with no prompts. `--from <csv>` scaffolds from a CSV using `sonda_core::analysis::pattern`
   and maps detected patterns to operational vocabulary aliases. `-o <path>` writes to a file;
   otherwise the YAML is printed to stdout.
+
+  `--from-prometheus <url>` captures a live PromQL range query and emits a scenario that
+  replays it **verbatim** — no pattern detection, no generator inference, no `--fit`. It
+  requires `--query`, `--step` and `--out` (the CSV path the emitted scenario references), plus
+  a window from either `--range` or `--start`/`--end` (unix seconds or RFC 3339). `--timescale`
+  sets the replay speed and moves rate, duration and gap windows together. Credentials come
+  from `SONDA_PROM_TOKEN` or `--header Name: value`, never from a flag value that would land in
+  a shell history; neither reaches the emitted CSV or YAML. A query matching more than 20
+  series is refused with the aggregation hint rather than emitting an unreadable scenario.
 
 - **`sonda test`** — run a scenario and verify its top-level `expect:` alert expectations
   against **exactly one** acquisition source: a Prometheus-compatible API
@@ -185,5 +199,7 @@ This crate depends on:
 - `anyhow` for error handling
 - `owo-colors` for colored terminal output (with `supports-colors` feature for auto-detection)
 - `dialoguer` for interactive terminal prompts in `sonda new` (pure Rust, musl-compatible)
+- `chrono` (optional, enabled by the `http` feature) for RFC 3339 window bounds on
+  `sonda new --from-prometheus`
 
 It depends on `tokio` (runtime construction in `main` to drive the async `launch_scenario` API). It should NOT depend on: `axum`, `hyper`, or any server-specific HTTP crate.

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 [features]
 default = ["config", "http"]
 config = ["sonda-core/config"]
-http = ["sonda-core/http"]
+http = ["sonda-core/http", "dep:chrono"]
 remote-write = ["sonda-core/remote-write"]
 kafka = ["sonda-core/kafka"]
 otlp = ["sonda-core/otlp"]
@@ -37,6 +37,9 @@ dialoguer = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tokio-util = { version = "0.7", default-features = false }
+# Only the `--from-prometheus` capture path parses RFC 3339 window bounds, and
+# that path is behind `http`.
+chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/sonda/src/cli.rs
+++ b/sonda/src/cli.rs
@@ -181,6 +181,67 @@ pub struct NewArgs {
     /// Output file path. When omitted, the YAML is printed to stdout.
     #[arg(short, long, value_name = "PATH")]
     pub output: Option<PathBuf>,
+
+    /// Capture a live range query from a Prometheus-compatible TSDB and replay it
+    /// verbatim. Values are recorded, never fitted to a generator.
+    #[arg(
+        long,
+        value_name = "URL",
+        conflicts_with_all = ["template", "from"],
+        requires_all = ["query", "step", "out"],
+        help_heading = "Capture"
+    )]
+    pub from_prometheus: Option<String>,
+
+    /// PromQL range query to capture.
+    #[arg(long, value_name = "PROMQL", help_heading = "Capture")]
+    pub query: Option<String>,
+
+    /// Capture the window ending now (e.g. `1h`, `30m`). Alternative to --start/--end.
+    #[arg(long, value_name = "DURATION", help_heading = "Capture")]
+    pub range: Option<String>,
+
+    /// Window start, as unix seconds or RFC 3339. Use with --end.
+    #[arg(long, value_name = "INSTANT", help_heading = "Capture")]
+    pub start: Option<String>,
+
+    /// Window end, as unix seconds or RFC 3339. Use with --start.
+    #[arg(long, value_name = "INSTANT", help_heading = "Capture")]
+    pub end: Option<String>,
+
+    /// Sample step for the range query (e.g. `15s`, `1m`).
+    #[arg(long, value_name = "DURATION", help_heading = "Capture")]
+    pub step: Option<String>,
+
+    /// Where to write the captured CSV. The emitted scenario references this path.
+    #[arg(long, value_name = "PATH", help_heading = "Capture")]
+    pub out: Option<PathBuf>,
+
+    /// Replay speed: 1.0 is the captured cadence, 2.0 is twice as fast.
+    #[arg(long, value_name = "FACTOR", help_heading = "Capture")]
+    pub timescale: Option<f64>,
+
+    /// Add a request header as `Name: value`. Repeat for multiple. A bearer token
+    /// is better passed as `SONDA_PROM_TOKEN` so it stays out of the command line.
+    #[arg(
+        long = "header",
+        value_parser = parse_header,
+        value_name = "NAME:VALUE",
+        help_heading = "Capture"
+    )]
+    pub headers: Vec<(String, String)>,
+}
+
+/// Parse a `Name: value` request header.
+fn parse_header(raw: &str) -> Result<(String, String), String> {
+    let (name, value) = raw
+        .split_once(':')
+        .ok_or_else(|| format!("expected `Name: value`, got {raw:?}"))?;
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(format!("header name is empty in {raw:?}"));
+    }
+    Ok((name.to_string(), value.trim().to_string()))
 }
 
 fn clap_styles() -> clap::builder::styling::Styles {

--- a/sonda/src/cli.rs
+++ b/sonda/src/cli.rs
@@ -194,31 +194,66 @@ pub struct NewArgs {
     pub from_prometheus: Option<String>,
 
     /// PromQL range query to capture.
-    #[arg(long, value_name = "PROMQL", help_heading = "Capture")]
+    #[arg(
+        long,
+        value_name = "PROMQL",
+        requires = "from_prometheus",
+        help_heading = "Capture"
+    )]
     pub query: Option<String>,
 
     /// Capture the window ending now (e.g. `1h`, `30m`). Alternative to --start/--end.
-    #[arg(long, value_name = "DURATION", help_heading = "Capture")]
+    #[arg(
+        long,
+        value_name = "DURATION",
+        requires = "from_prometheus",
+        help_heading = "Capture"
+    )]
     pub range: Option<String>,
 
     /// Window start, as unix seconds or RFC 3339. Use with --end.
-    #[arg(long, value_name = "INSTANT", help_heading = "Capture")]
+    #[arg(
+        long,
+        value_name = "INSTANT",
+        requires = "from_prometheus",
+        help_heading = "Capture"
+    )]
     pub start: Option<String>,
 
     /// Window end, as unix seconds or RFC 3339. Use with --start.
-    #[arg(long, value_name = "INSTANT", help_heading = "Capture")]
+    #[arg(
+        long,
+        value_name = "INSTANT",
+        requires = "from_prometheus",
+        help_heading = "Capture"
+    )]
     pub end: Option<String>,
 
     /// Sample step for the range query (e.g. `15s`, `1m`).
-    #[arg(long, value_name = "DURATION", help_heading = "Capture")]
+    #[arg(
+        long,
+        value_name = "DURATION",
+        requires = "from_prometheus",
+        help_heading = "Capture"
+    )]
     pub step: Option<String>,
 
     /// Where to write the captured CSV. The emitted scenario references this path.
-    #[arg(long, value_name = "PATH", help_heading = "Capture")]
+    #[arg(
+        long,
+        value_name = "PATH",
+        requires = "from_prometheus",
+        help_heading = "Capture"
+    )]
     pub out: Option<PathBuf>,
 
     /// Replay speed: 1.0 is the captured cadence, 2.0 is twice as fast.
-    #[arg(long, value_name = "FACTOR", help_heading = "Capture")]
+    #[arg(
+        long,
+        value_name = "FACTOR",
+        requires = "from_prometheus",
+        help_heading = "Capture"
+    )]
     pub timescale: Option<f64>,
 
     /// Add a request header as `Name: value`. Repeat for multiple. A bearer token
@@ -227,9 +262,20 @@ pub struct NewArgs {
         long = "header",
         value_parser = parse_header,
         value_name = "NAME:VALUE",
+        requires = "from_prometheus",
         help_heading = "Capture"
     )]
     pub headers: Vec<(String, String)>,
+
+    /// Metric name for series the query left without one. PromQL aggregations
+    /// drop `__name__`, so `sum by (job) (...)` needs this.
+    #[arg(
+        long,
+        value_name = "NAME",
+        requires = "from_prometheus",
+        help_heading = "Capture"
+    )]
+    pub metric_name: Option<String>,
 }
 
 /// Parse a `Name: value` request header.

--- a/sonda/src/new/mod.rs
+++ b/sonda/src/new/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod csv_reader;
 pub mod prompts;
+#[cfg(feature = "http")]
+pub mod tsdb_reader;
 pub mod yaml_gen;
 
 use std::fs;
@@ -15,6 +17,8 @@ use crate::cli::NewArgs;
 pub fn run(args: &NewArgs) -> Result<()> {
     let yaml = if args.template {
         yaml_gen::minimal_template()
+    } else if args.from_prometheus.is_some() {
+        capture(args)?
     } else if let Some(ref csv_path) = args.from {
         scaffold_from_csv(csv_path)?
     } else {
@@ -39,6 +43,25 @@ pub fn run(args: &NewArgs) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Capture a live range query. `acquire::tsdb` is behind sonda-core's `http`
+/// feature, so a build without it refuses at runtime rather than silently
+/// scaffolding something else.
+#[cfg(feature = "http")]
+fn capture(args: &NewArgs) -> Result<String> {
+    // Read the wall clock once, so a `--range` window and anything reported
+    // about it agree on when "now" was.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0);
+    tsdb_reader::capture(args, now)
+}
+
+#[cfg(not(feature = "http"))]
+fn capture(_args: &NewArgs) -> Result<String> {
+    anyhow::bail!("this build of sonda has no HTTP support, so it cannot capture")
 }
 
 fn scaffold_from_csv(path: &Path) -> Result<String> {

--- a/sonda/src/new/tsdb_reader.rs
+++ b/sonda/src/new/tsdb_reader.rs
@@ -1,0 +1,271 @@
+//! `sonda new --from-prometheus` — capture a live range query as a replayable scenario.
+//!
+//! Every decision belongs to `sonda_core::acquire`: this module resolves the
+//! time window from the flags, builds the auth, and writes the two files core
+//! produced. It does not parse PromQL, inspect the shape of a signal, or pick a
+//! generator — a capture replays what the database reported.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use sonda_core::acquire::normalize::{normalize, Grid};
+use sonda_core::acquire::tsdb::{Auth, TsdbClient};
+use sonda_core::acquire::{csv_out, yaml_out};
+
+use crate::cli::NewArgs;
+
+/// Past this many series a capture stops being a scenario anyone can read, and
+/// the CSV grows a column per series. The number is a judgement, not a limit of
+/// the format; the error says how to get under it.
+const MAX_SERIES: usize = 20;
+
+/// A bearer token is read from the environment so it never reaches a shell
+/// history, a process listing, or a CI log of the command line.
+const TOKEN_ENV: &str = "SONDA_PROM_TOKEN";
+
+/// Overall budget for the one range query. Generous, because a wide range at a
+/// fine step is slow server-side, but finite so an unreachable endpoint fails.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Fetch the query, write the CSV to `--out`, and return the scenario YAML.
+pub fn capture(args: &NewArgs, now_unix: f64) -> Result<String> {
+    let url = args
+        .from_prometheus
+        .as_deref()
+        .expect("caller checked --from-prometheus is set");
+    let query = args
+        .query
+        .as_deref()
+        .context("--query is required with --from-prometheus")?;
+    let csv_path = args.out.as_deref().context(
+        "--out is required with --from-prometheus: the emitted scenario \
+                  references the CSV by path, so it has to be written somewhere",
+    )?;
+
+    let step_text = args
+        .step
+        .as_deref()
+        .context("--step is required with --from-prometheus")?;
+    let step = sonda_core::config::validate::parse_duration(step_text)
+        .with_context(|| format!("--step {step_text:?} is not a duration"))?;
+
+    let (start, end) = resolve_window(args, now_unix)?;
+    let timescale = args.timescale.unwrap_or(1.0);
+
+    let client = TsdbClient::new(url, auth_from(args)?, FETCH_TIMEOUT);
+    let series = client
+        .fetch_range(query, start, end, step)
+        .context("the range query failed")?;
+
+    if series.is_empty() {
+        bail!("the query matched no series over that range; widen --range or check --query");
+    }
+    if series.len() > MAX_SERIES {
+        bail!(
+            "the query matched {} series, over the cap of {MAX_SERIES}. Aggregate \
+             (`sum by (job) (...)`) or add matchers to narrow it.",
+            series.len()
+        );
+    }
+
+    let grid = Grid::new(start, end, step.as_secs_f64()).with_context(|| {
+        format!(
+            "start {start}, end {end} and step {}s do not describe a grid",
+            step.as_secs_f64()
+        )
+    })?;
+    let normalized: Vec<_> = series.iter().map(|s| normalize(s, grid)).collect();
+
+    let csv = csv_out::write_csv(grid, &normalized).context("building the capture CSV")?;
+    write_file(csv_path, &csv)?;
+
+    let file = yaml_out::scenario_for(&path_for_yaml(csv_path)?, grid, &normalized, timescale)
+        .context("building the scenario for the capture")?;
+    let yaml = yaml_out::to_yaml(&file).context("rendering the scenario")?;
+
+    let gaps: usize = normalized.iter().map(|s| s.gap_count()).sum();
+    eprintln!(
+        "captured {} series over {} points to {} ({gaps} missing sample{})",
+        normalized.len(),
+        grid.len,
+        csv_path.display(),
+        if gaps == 1 { "" } else { "s" }
+    );
+    Ok(yaml)
+}
+
+/// Resolve `--range` or `--start`/`--end` into a unix-seconds window.
+///
+/// `--range` is relative to `now_unix`, which the caller reads once so a
+/// capture and its log line agree on when "now" was.
+fn resolve_window(args: &NewArgs, now_unix: f64) -> Result<(f64, f64)> {
+    match (&args.range, &args.start, &args.end) {
+        (Some(range), None, None) => {
+            let span = sonda_core::config::validate::parse_duration(range)
+                .with_context(|| format!("--range {range:?} is not a duration"))?;
+            Ok((now_unix - span.as_secs_f64(), now_unix))
+        }
+        (None, Some(start), Some(end)) => {
+            let (s, e) = (parse_instant(start)?, parse_instant(end)?);
+            if e <= s {
+                bail!("--end ({end}) must be after --start ({start})");
+            }
+            Ok((s, e))
+        }
+        (None, Some(_), None) | (None, None, Some(_)) => {
+            bail!("--start and --end go together; pass both, or use --range")
+        }
+        (Some(_), _, _) => bail!("--range and --start/--end are alternatives; pass one"),
+        (None, None, None) => {
+            bail!("a capture needs a window: pass --range, or --start and --end")
+        }
+    }
+}
+
+/// Parse an instant as unix seconds or as RFC 3339.
+fn parse_instant(text: &str) -> Result<f64> {
+    if let Ok(secs) = text.parse::<f64>() {
+        if secs.is_finite() {
+            return Ok(secs);
+        }
+    }
+    let stamp = chrono::DateTime::parse_from_rfc3339(text)
+        .with_context(|| format!("{text:?} is neither unix seconds nor an RFC 3339 timestamp"))?;
+    Ok(stamp.timestamp() as f64 + f64::from(stamp.timestamp_subsec_millis()) / 1000.0)
+}
+
+/// Build the credential from `--header` and the token environment variable.
+///
+/// Both may be set: the token becomes an `Authorization` header alongside the
+/// rest. Neither the value nor the [`Auth`] carrying it is ever printed — see
+/// that type's docs.
+fn auth_from(args: &NewArgs) -> Result<Auth> {
+    let token = std::env::var(TOKEN_ENV).ok().filter(|t| !t.is_empty());
+    if args.headers.is_empty() {
+        return Ok(match token {
+            Some(t) => Auth::Bearer(t),
+            None => Auth::None,
+        });
+    }
+    let mut headers = Vec::with_capacity(args.headers.len() + 1);
+    if let Some(t) = token {
+        headers.push(("Authorization".to_string(), format!("Bearer {t}")));
+    }
+    headers.extend(args.headers.iter().cloned());
+    Ok(Auth::Headers(headers))
+}
+
+/// The CSV path as the emitted scenario should carry it.
+fn path_for_yaml(csv_path: &Path) -> Result<String> {
+    csv_path
+        .to_str()
+        .map(str::to_string)
+        .with_context(|| format!("--out {} is not valid UTF-8", csv_path.display()))
+}
+
+fn write_file(path: &Path, contents: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create parent dir {}", parent.display()))?;
+        }
+    }
+    std::fs::write(path, contents).with_context(|| format!("failed to write {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args() -> NewArgs {
+        NewArgs {
+            template: false,
+            from: None,
+            output: None,
+            from_prometheus: Some("http://localhost:9090".to_string()),
+            query: Some("up".to_string()),
+            range: None,
+            start: None,
+            end: None,
+            step: Some("15s".to_string()),
+            out: None,
+            timescale: None,
+            headers: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_range_is_measured_back_from_the_caller_s_now() {
+        let mut a = args();
+        a.range = Some("1h".to_string());
+        assert_eq!(
+            resolve_window(&a, 10_000.0).expect("window"),
+            (6_400.0, 10_000.0)
+        );
+    }
+
+    #[test]
+    fn explicit_bounds_accept_unix_seconds_and_rfc3339() {
+        let mut a = args();
+        a.start = Some("100".to_string());
+        a.end = Some("200.5".to_string());
+        assert_eq!(resolve_window(&a, 0.0).expect("window"), (100.0, 200.5));
+
+        a.start = Some("1970-01-01T00:01:40Z".to_string());
+        a.end = Some("1970-01-01T00:03:20Z".to_string());
+        assert_eq!(resolve_window(&a, 0.0).expect("window"), (100.0, 200.0));
+    }
+
+    /// One rejected window: the flags as a caller would type them, and the
+    /// phrase the error has to carry.
+    struct Rejected {
+        range: Option<&'static str>,
+        start: Option<&'static str>,
+        end: Option<&'static str>,
+        needle: &'static str,
+    }
+
+    #[test]
+    fn a_window_that_is_missing_ambiguous_or_inverted_is_refused() {
+        let case = |range, start, end, needle| Rejected {
+            range,
+            start,
+            end,
+            needle,
+        };
+        let cases = [
+            case(None, None, None, "needs a window"),
+            case(None, Some("100"), None, "go together"),
+            case(None, None, Some("200"), "go together"),
+            case(Some("1h"), Some("100"), Some("200"), "alternatives"),
+            case(None, Some("200"), Some("100"), "must be after"),
+        ];
+        for c in cases {
+            let mut a = args();
+            a.range = c.range.map(str::to_string);
+            a.start = c.start.map(str::to_string);
+            a.end = c.end.map(str::to_string);
+            let err = resolve_window(&a, 0.0).expect_err(&format!(
+                "{:?}/{:?}/{:?} must be refused",
+                c.range, c.start, c.end
+            ));
+            assert!(
+                err.to_string().contains(c.needle),
+                "expected {:?} in: {err}",
+                c.needle
+            );
+        }
+    }
+
+    #[test]
+    fn an_unparseable_instant_says_both_forms_it_accepts() {
+        let mut a = args();
+        a.start = Some("yesterday".to_string());
+        a.end = Some("200".to_string());
+        let err = resolve_window(&a, 0.0).expect_err("must be refused");
+        let text = format!("{err:#}");
+        assert!(text.contains("unix seconds"), "{text}");
+        assert!(text.contains("RFC 3339"), "{text}");
+    }
+}

--- a/sonda/src/new/tsdb_reader.rs
+++ b/sonda/src/new/tsdb_reader.rs
@@ -9,11 +9,22 @@ use std::path::Path;
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
-use sonda_core::acquire::normalize::{normalize, Grid};
+use sonda_core::acquire::normalize::{normalize, Grid, NormalizedSeries};
 use sonda_core::acquire::tsdb::{Auth, TsdbClient};
 use sonda_core::acquire::{csv_out, yaml_out};
+use sonda_core::SondaError;
 
 use crate::cli::NewArgs;
+
+/// Flatten a [`SondaError`] into one message.
+///
+/// Its `Display` already contains the source's text *and* `#[from]` exposes
+/// that source, so anyhow's `{:#}` walks the chain and prints the same sentence
+/// twice. Flattening here keeps every error this path reports readable; the
+/// duplication itself is core's and predates this module.
+fn flat(e: SondaError) -> anyhow::Error {
+    anyhow::anyhow!("{e}")
+}
 
 /// Past this many series a capture stops being a scenario anyone can read, and
 /// the CSV grows a column per series. The number is a judgement, not a limit of
@@ -48,14 +59,25 @@ pub fn capture(args: &NewArgs, now_unix: f64) -> Result<String> {
         .as_deref()
         .context("--step is required with --from-prometheus")?;
     let step = sonda_core::config::validate::parse_duration(step_text)
+        .map_err(flat)
         .with_context(|| format!("--step {step_text:?} is not a duration"))?;
 
+    // Everything that can be rejected from the flags alone is rejected here,
+    // before the network call and before anything is written. `scenario_for`
+    // validates the timescale too, but that runs after the CSV has landed —
+    // which would leave a capture on disk with no scenario beside it.
     let (start, end) = resolve_window(args, now_unix)?;
-    let timescale = args.timescale.unwrap_or(1.0);
+    let timescale = resolve_timescale(args)?;
+    if let Some(name) = args.metric_name.as_deref() {
+        sonda_core::ValidatedMetricName::new(name)
+            .map_err(flat)
+            .context("--metric-name")?;
+    }
 
-    let client = TsdbClient::new(url, auth_from(args)?, FETCH_TIMEOUT);
+    let client = TsdbClient::new(url, auth_from(args), FETCH_TIMEOUT);
     let series = client
         .fetch_range(query, start, end, step)
+        .map_err(flat)
         .context("the range query failed")?;
 
     if series.is_empty() {
@@ -63,8 +85,9 @@ pub fn capture(args: &NewArgs, now_unix: f64) -> Result<String> {
     }
     if series.len() > MAX_SERIES {
         bail!(
-            "the query matched {} series, over the cap of {MAX_SERIES}. Aggregate \
-             (`sum by (job) (...)`) or add matchers to narrow it.",
+            "the query matched {} series, over the cap of {MAX_SERIES}. Add matchers to narrow \
+             it, or aggregate — `sum by (job) (...)` drops the metric name, so an aggregated \
+             query needs --metric-name <NAME> to supply one.",
             series.len()
         );
     }
@@ -75,14 +98,20 @@ pub fn capture(args: &NewArgs, now_unix: f64) -> Result<String> {
             step.as_secs_f64()
         )
     })?;
-    let normalized: Vec<_> = series.iter().map(|s| normalize(s, grid)).collect();
+    let mut normalized: Vec<_> = series.iter().map(|s| normalize(s, grid)).collect();
+    name_unnamed_series(&mut normalized, args.metric_name.as_deref())?;
 
-    let csv = csv_out::write_csv(grid, &normalized).context("building the capture CSV")?;
+    let csv = csv_out::write_csv(grid, &normalized)
+        .map_err(flat)
+        .context("building the capture CSV")?;
     write_file(csv_path, &csv)?;
 
     let file = yaml_out::scenario_for(&path_for_yaml(csv_path)?, grid, &normalized, timescale)
+        .map_err(flat)
         .context("building the scenario for the capture")?;
-    let yaml = yaml_out::to_yaml(&file).context("rendering the scenario")?;
+    let yaml = yaml_out::to_yaml(&file)
+        .map_err(flat)
+        .context("rendering the scenario")?;
 
     let gaps: usize = normalized.iter().map(|s| s.gap_count()).sum();
     eprintln!(
@@ -95,6 +124,43 @@ pub fn capture(args: &NewArgs, now_unix: f64) -> Result<String> {
     Ok(yaml)
 }
 
+/// The replay speed, refused here rather than deep in the emitter.
+fn resolve_timescale(args: &NewArgs) -> Result<f64> {
+    let t = args.timescale.unwrap_or(1.0);
+    if !t.is_finite() || t <= 0.0 {
+        bail!("--timescale must be a positive finite number, got {t}");
+    }
+    Ok(t)
+}
+
+/// Give `--metric-name` to every series the query left without one.
+///
+/// PromQL aggregations drop `__name__`, and `sum by (job) (...)` is the usual
+/// way to get under the series cap — so the two would otherwise contradict each
+/// other: take the cap's advice and the capture is refused for having no name.
+fn name_unnamed_series(series: &mut [NormalizedSeries], name: Option<&str>) -> Result<()> {
+    let missing = series
+        .iter()
+        .filter(|s| !s.labels.contains_key("__name__"))
+        .count();
+    if missing == 0 {
+        return Ok(());
+    }
+    let Some(name) = name else {
+        bail!(
+            "{missing} of {} series carry no metric name. PromQL aggregations such as \
+             `sum by (job) (...)` drop __name__; pass --metric-name <NAME> to supply one.",
+            series.len()
+        );
+    };
+    for s in series.iter_mut() {
+        s.labels
+            .entry("__name__".to_string())
+            .or_insert_with(|| name.to_string());
+    }
+    Ok(())
+}
+
 /// Resolve `--range` or `--start`/`--end` into a unix-seconds window.
 ///
 /// `--range` is relative to `now_unix`, which the caller reads once so a
@@ -103,6 +169,7 @@ fn resolve_window(args: &NewArgs, now_unix: f64) -> Result<(f64, f64)> {
     match (&args.range, &args.start, &args.end) {
         (Some(range), None, None) => {
             let span = sonda_core::config::validate::parse_duration(range)
+                .map_err(flat)
                 .with_context(|| format!("--range {range:?} is not a duration"))?;
             Ok((now_unix - span.as_secs_f64(), now_unix))
         }
@@ -137,23 +204,34 @@ fn parse_instant(text: &str) -> Result<f64> {
 
 /// Build the credential from `--header` and the token environment variable.
 ///
-/// Both may be set: the token becomes an `Authorization` header alongside the
-/// rest. Neither the value nor the [`Auth`] carrying it is ever printed — see
-/// that type's docs.
-fn auth_from(args: &NewArgs) -> Result<Auth> {
+/// Both may be set and the token joins the headers — except when one of them is
+/// itself an `Authorization`, where the explicit flag wins and the token is
+/// dropped with a note. Silently sending one of two credentials is the part
+/// worth avoiding. Neither the value nor the [`Auth`] carrying it is ever
+/// printed — see that type's docs.
+fn auth_from(args: &NewArgs) -> Auth {
     let token = std::env::var(TOKEN_ENV).ok().filter(|t| !t.is_empty());
     if args.headers.is_empty() {
-        return Ok(match token {
+        return match token {
             Some(t) => Auth::Bearer(t),
             None => Auth::None,
-        });
+        };
     }
+
+    let explicit_auth = args
+        .headers
+        .iter()
+        .any(|(name, _)| name.eq_ignore_ascii_case("Authorization"));
     let mut headers = Vec::with_capacity(args.headers.len() + 1);
-    if let Some(t) = token {
-        headers.push(("Authorization".to_string(), format!("Bearer {t}")));
+    match token {
+        Some(_) if explicit_auth => eprintln!(
+            "note: --header Authorization overrides {TOKEN_ENV}; the environment token is unused"
+        ),
+        Some(t) => headers.push(("Authorization".to_string(), format!("Bearer {t}"))),
+        None => {}
     }
     headers.extend(args.headers.iter().cloned());
-    Ok(Auth::Headers(headers))
+    Auth::Headers(headers)
 }
 
 /// The CSV path as the emitted scenario should carry it.
@@ -192,7 +270,66 @@ mod tests {
             out: None,
             timescale: None,
             headers: Vec::new(),
+            metric_name: None,
         }
+    }
+
+    fn series(name: Option<&str>) -> NormalizedSeries {
+        let mut labels = std::collections::BTreeMap::new();
+        if let Some(n) = name {
+            labels.insert("__name__".to_string(), n.to_string());
+        }
+        labels.insert("job".to_string(), "api".to_string());
+        NormalizedSeries {
+            labels,
+            values: vec![Some(1.0)],
+        }
+    }
+
+    #[test]
+    fn a_metric_name_fills_in_only_the_series_that_lack_one() {
+        let mut s = [series(None), series(Some("kept"))];
+        name_unnamed_series(&mut s, Some("supplied")).expect("named");
+        assert_eq!(
+            s[0].labels.get("__name__").map(String::as_str),
+            Some("supplied")
+        );
+        assert_eq!(
+            s[1].labels.get("__name__").map(String::as_str),
+            Some("kept"),
+            "an existing name is not overwritten"
+        );
+    }
+
+    #[test]
+    fn a_nameless_series_without_the_flag_says_which_flag_supplies_one() {
+        let mut s = [series(None), series(Some("kept"))];
+        let err = name_unnamed_series(&mut s, None).expect_err("must refuse");
+        let text = err.to_string();
+        assert!(text.contains("1 of 2"), "it counts them: {text}");
+        assert!(text.contains("--metric-name"), "and names the flag: {text}");
+        assert!(text.contains("sum by"), "and why it happened: {text}");
+    }
+
+    #[test]
+    fn a_fully_named_result_needs_no_flag() {
+        let mut s = [series(Some("a")), series(Some("b"))];
+        name_unnamed_series(&mut s, None).expect("nothing to fill in");
+    }
+
+    #[test]
+    fn a_timescale_that_is_not_positive_is_refused_before_anything_is_written() {
+        for bad in ["0", "-1", "nan", "inf"] {
+            let mut a = args();
+            a.timescale = Some(bad.parse().expect("f64"));
+            let err =
+                resolve_timescale(&a).expect_err(&format!("--timescale {bad} must be refused"));
+            assert!(err.to_string().contains("--timescale"), "{err}");
+        }
+        let mut a = args();
+        a.timescale = Some(4.0);
+        assert_eq!(resolve_timescale(&a).expect("valid"), 4.0);
+        assert_eq!(resolve_timescale(&args()).expect("default"), 1.0);
     }
 
     #[test]

--- a/sonda/tests/cli_new_capture.rs
+++ b/sonda/tests/cli_new_capture.rs
@@ -43,7 +43,7 @@ fn mock_tsdb(status: &str, body: &str) -> (String, mpsc::Receiver<String>) {
     (base, rx)
 }
 
-/// Three series over a 10s grid, the middle one with a hole in it.
+/// Two series over a 10s grid, the second with a hole in it.
 fn matrix_body() -> String {
     r#"{"status":"success","data":{"resultType":"matrix","result":[
         {"metric":{"__name__":"up","job":"api"},"values":[[0,"1"],[10,"1"],[20,"1"],[30,"1"]]},
@@ -235,6 +235,245 @@ fn a_timescaled_capture_says_so_and_still_loads() {
         "a timescaled capture must load; stderr:\n{}\nyaml:\n{yaml_text}",
         String::from_utf8_lossy(&dry.stderr)
     );
+}
+
+/// B1: the ordinary result of `--query up` — one metric, several label sets.
+#[test]
+fn one_metric_across_label_sets_emits_a_scenario_that_loads() {
+    // Both dense and both named `up`. The PR's original fixture hid this by
+    // giving one series a hole, which put it in its own block.
+    let body = r#"{"status":"success","data":{"resultType":"matrix","result":[
+        {"metric":{"__name__":"up","job":"api"},"values":[[0,"1"],[10,"1"],[20,"1"],[30,"1"]]},
+        {"metric":{"__name__":"up","job":"db"},"values":[[0,"1"],[10,"1"],[20,"1"],[30,"1"]]},
+        {"metric":{"__name__":"up","job":"web"},"values":[[0,"1"],[10,"1"],[20,"1"],[30,"1"]]}
+    ]}}"#;
+    let (base, _rx) = mock_tsdb("200 OK", body);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let csv = dir.path().join("capture.csv");
+    let yaml = dir.path().join("capture.yaml");
+
+    let out = Command::new(sonda_bin())
+        .args(["new", "--from-prometheus", &base])
+        .args(["--query", "up"])
+        .args(["--start", "0", "--end", "30", "--step", "10s"])
+        .arg("--out")
+        .arg(&csv)
+        .arg("-o")
+        .arg(&yaml)
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        out.status.success(),
+        "capture must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let yaml_text = std::fs::read_to_string(&yaml).expect("written");
+    let dry = Command::new(sonda_bin())
+        .arg("--dry-run")
+        .arg("run")
+        .arg(&yaml)
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        dry.status.success(),
+        "three series of one metric must load; stderr:\n{}\nyaml:\n{yaml_text}",
+        String::from_utf8_lossy(&dry.stderr)
+    );
+}
+
+/// W2: the advice the cap gives has to lead somewhere that works.
+#[test]
+fn an_aggregated_query_captures_once_it_is_given_a_metric_name() {
+    // What `sum by (job) (...)` returns: no __name__ anywhere.
+    let body = r#"{"status":"success","data":{"resultType":"matrix","result":[
+        {"metric":{"job":"api"},"values":[[0,"1"],[10,"2"],[20,"3"],[30,"4"]]},
+        {"metric":{"job":"db"},"values":[[0,"5"],[10,"6"],[20,"7"],[30,"8"]]}
+    ]}}"#;
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // Without the flag: refused, and the refusal names the flag that fixes it.
+    let (base, _rx) = mock_tsdb("200 OK", body);
+    let bare = Command::new(sonda_bin())
+        .args(["new", "--from-prometheus", &base])
+        .args(["--query", "sum by (job) (rate(errors[5m]))"])
+        .args(["--start", "0", "--end", "30", "--step", "10s"])
+        .arg("--out")
+        .arg(dir.path().join("bare.csv"))
+        .output()
+        .expect("spawn sonda");
+    assert!(!bare.status.success(), "a nameless result must be refused");
+    let stderr = String::from_utf8_lossy(&bare.stderr);
+    assert!(
+        stderr.contains("--metric-name"),
+        "the refusal must name the flag: {stderr}"
+    );
+
+    // With it: captures, and the scenario loads.
+    let (base, _rx) = mock_tsdb("200 OK", body);
+    let csv = dir.path().join("agg.csv");
+    let yaml = dir.path().join("agg.yaml");
+    let out = Command::new(sonda_bin())
+        .args(["new", "--from-prometheus", &base])
+        .args(["--query", "sum by (job) (rate(errors[5m]))"])
+        .args(["--start", "0", "--end", "30", "--step", "10s"])
+        .args(["--metric-name", "errors_per_second"])
+        .arg("--out")
+        .arg(&csv)
+        .arg("-o")
+        .arg(&yaml)
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        out.status.success(),
+        "--metric-name must make it capture; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let yaml_text = std::fs::read_to_string(&yaml).expect("written");
+    assert!(
+        yaml_text.contains("errors_per_second"),
+        "the supplied name is in the scenario:\n{yaml_text}"
+    );
+    let dry = Command::new(sonda_bin())
+        .arg("--dry-run")
+        .arg("run")
+        .arg(&yaml)
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        dry.status.success(),
+        "an aggregated capture must load; stderr:\n{}\nyaml:\n{yaml_text}",
+        String::from_utf8_lossy(&dry.stderr)
+    );
+}
+
+/// W3: a refusal from the flags alone must not leave half a capture behind.
+#[test]
+fn a_flag_only_refusal_writes_nothing_and_never_reaches_the_network() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let csv = dir.path().join("capture.csv");
+
+    // Port 1 is not listening: if the check ran after the fetch, this would
+    // fail with a connection error instead of the timescale message.
+    let out = Command::new(sonda_bin())
+        .args(["new", "--from-prometheus", "http://127.0.0.1:1"])
+        .args(["--query", "up"])
+        .args(["--start", "0", "--end", "30", "--step", "10s"])
+        .args(["--timescale", "0"])
+        .arg("--out")
+        .arg(&csv)
+        .output()
+        .expect("spawn sonda");
+    assert!(!out.status.success(), "--timescale 0 must be refused");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--timescale"),
+        "the refusal names the flag rather than the socket: {stderr}"
+    );
+    assert!(
+        !csv.exists(),
+        "nothing is written when the capture is refused from its flags"
+    );
+}
+
+/// W4: an error from this path says its piece once.
+#[test]
+fn an_error_is_not_printed_twice() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = Command::new(sonda_bin())
+        .args(["new", "--from-prometheus", "http://127.0.0.1:1"])
+        .args(["--query", "up"])
+        .args(["--range", "1h", "--step", "10s"])
+        .arg("--out")
+        .arg(dir.path().join("capture.csv"))
+        .output()
+        .expect("spawn sonda");
+    assert!(!out.status.success(), "a refused connection must fail");
+
+    // Count the sentence, not the URL: `ureq` quotes the endpoint again inside
+    // its own reason, so the URL legitimately appears twice in one message.
+    // What doubled was the whole "query against ... failed" clause, once per
+    // link in the error chain.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let seen = stderr.matches("query against").count();
+    assert_eq!(
+        seen, 1,
+        "the error should say its piece once, not once per link in the chain:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("/api/v1/query_range"),
+        "and it still names the endpoint: {stderr}"
+    );
+}
+
+/// N5: an explicit Authorization wins, and does not do so silently.
+#[test]
+fn an_explicit_authorization_header_overrides_the_env_token_and_says_so() {
+    const TOKEN: &str = "env-token-that-loses";
+
+    let (base, rx) = mock_tsdb("200 OK", &matrix_body());
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let out = Command::new(sonda_bin())
+        .env("SONDA_PROM_TOKEN", TOKEN)
+        .args(["new", "--from-prometheus", &base])
+        .args(["--query", "up"])
+        .args(["--range", "1h", "--step", "10s"])
+        .args(["--header", "Authorization: Basic dXNlcjpwYXNz"])
+        .arg("--out")
+        .arg(dir.path().join("capture.csv"))
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        out.status.success(),
+        "capture must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let request = rx.recv_timeout(Duration::from_secs(5)).expect("request");
+    let auth: Vec<&str> = request
+        .lines()
+        .filter(|l| l.starts_with("Authorization:"))
+        .collect();
+    assert_eq!(
+        auth,
+        vec!["Authorization: Basic dXNlcjpwYXNz"],
+        "exactly the explicit one goes out:\n{request}"
+    );
+    assert!(
+        !request.contains(TOKEN),
+        "and not the env token:\n{request}"
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("overrides SONDA_PROM_TOKEN"),
+        "the override is announced rather than silent: {stderr}"
+    );
+}
+
+/// N6: a capture flag without --from-prometheus is a typo, not a no-op.
+#[test]
+fn capture_flags_without_from_prometheus_are_rejected() {
+    let cases: [&[&str]; 3] = [
+        &["new", "--from", "a.csv", "--out", "scenario.yaml"],
+        &["new", "--template", "--timescale", "9"],
+        &["new", "--template", "--query", "up"],
+    ];
+    for args in cases {
+        let out = Command::new(sonda_bin())
+            .args(args)
+            .output()
+            .expect("spawn sonda");
+        assert!(!out.status.success(), "{args:?} must be rejected");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("--from-prometheus"),
+            "{args:?} should point at the flag it needs: {stderr}"
+        );
+    }
 }
 
 #[test]

--- a/sonda/tests/cli_new_capture.rs
+++ b/sonda/tests/cli_new_capture.rs
@@ -1,0 +1,344 @@
+//! `sonda new --from-prometheus` driven as a real process against a real socket.
+//!
+//! The unit tests in `new/tsdb_reader.rs` cover window resolution. What only a
+//! spawned binary can show is that the flags clap accepts reach the capture,
+//! that both files land, that the emitted scenario is one `sonda run` will
+//! take — and that the token in the environment never reaches either file.
+
+mod common;
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::process::Command;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use common::sonda_bin;
+
+/// Serve one canned response and hand back the request that asked for it.
+fn mock_tsdb(status: &str, body: &str) -> (String, mpsc::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
+    let base = format!("http://{}", listener.local_addr().expect("addr"));
+    let (tx, rx) = mpsc::channel();
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept");
+        let mut seen = Vec::new();
+        let mut byte = [0u8; 1];
+        while stream.read(&mut byte).unwrap_or(0) == 1 {
+            seen.push(byte[0]);
+            if seen.ends_with(b"\r\n\r\n") {
+                break;
+            }
+        }
+        let _ = stream.write_all(response.as_bytes());
+        let _ = stream.flush();
+        let _ = tx.send(String::from_utf8_lossy(&seen).into_owned());
+    });
+
+    (base, rx)
+}
+
+/// Three series over a 10s grid, the middle one with a hole in it.
+fn matrix_body() -> String {
+    r#"{"status":"success","data":{"resultType":"matrix","result":[
+        {"metric":{"__name__":"up","job":"api"},"values":[[0,"1"],[10,"1"],[20,"1"],[30,"1"]]},
+        {"metric":{"__name__":"up","job":"db"},"values":[[0,"1"],[30,"0"]]}
+    ]}}"#
+        .to_string()
+}
+
+#[test]
+fn a_capture_writes_both_files_and_the_scenario_runs() {
+    let (base, _rx) = mock_tsdb("200 OK", &matrix_body());
+    let dir = tempfile::tempdir().expect("tempdir");
+    let csv = dir.path().join("capture.csv");
+    let yaml = dir.path().join("capture.yaml");
+
+    let out = Command::new(sonda_bin())
+        .args(["new", "--from-prometheus", &base])
+        .args(["--query", "up"])
+        .args(["--start", "0", "--end", "30"])
+        .args(["--step", "10s"])
+        .arg("--out")
+        .arg(&csv)
+        .arg("-o")
+        .arg(&yaml)
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        out.status.success(),
+        "capture must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let csv_text = std::fs::read_to_string(&csv).expect("the CSV was written");
+    assert!(
+        csv_text.lines().count() == 5,
+        "a header and four grid points:\n{csv_text}"
+    );
+    // The header is one quoted CSV field per column, so the label quotes are
+    // doubled inside it — this is the escaped form, not a second convention.
+    assert!(
+        csv_text.contains(r#"job=""api"""#) && csv_text.contains(r#"job=""db"""#),
+        "both series became columns:\n{csv_text}"
+    );
+    assert!(
+        csv_text.contains("10.000,1,\n"),
+        "and the db series' silence is a blank cell, not a zero:\n{csv_text}"
+    );
+
+    let yaml_text = std::fs::read_to_string(&yaml).expect("the scenario was written");
+    assert!(
+        yaml_text.contains("gap_windows:"),
+        "the silence in the db series is declared:\n{yaml_text}"
+    );
+
+    // The real acceptance test: the binary loads what the binary wrote.
+    let dry = Command::new(sonda_bin())
+        .arg("--dry-run")
+        .arg("run")
+        .arg(&yaml)
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        dry.status.success(),
+        "the emitted scenario must load; stderr:\n{}\nyaml:\n{yaml_text}",
+        String::from_utf8_lossy(&dry.stderr)
+    );
+}
+
+#[test]
+fn a_token_in_the_environment_is_sent_and_reaches_neither_file() {
+    const TOKEN: &str = "cli-token-must-not-be-written";
+
+    let (base, rx) = mock_tsdb("200 OK", &matrix_body());
+    let dir = tempfile::tempdir().expect("tempdir");
+    let csv = dir.path().join("capture.csv");
+    let yaml = dir.path().join("capture.yaml");
+
+    let out = Command::new(sonda_bin())
+        .env("SONDA_PROM_TOKEN", TOKEN)
+        .args(["new", "--from-prometheus", &base])
+        .args(["--query", "up"])
+        .args(["--range", "1h", "--step", "10s"])
+        .arg("--out")
+        .arg(&csv)
+        .arg("-o")
+        .arg(&yaml)
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        out.status.success(),
+        "capture must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Vacuity guard: absence in the files proves nothing unless the token was
+    // actually sent. Without this the assertions below pass just as well when
+    // the CLI never reads the environment variable at all.
+    let request = rx.recv_timeout(Duration::from_secs(5)).expect("request");
+    assert!(
+        request.contains(&format!("Authorization: Bearer {TOKEN}")),
+        "the env token must reach the wire, or the leak checks prove nothing:\n{request}"
+    );
+
+    for (what, path) in [("csv", &csv), ("yaml", &yaml)] {
+        let text = std::fs::read_to_string(path).expect("written");
+        assert!(
+            !text.contains(TOKEN),
+            "the {what} carries the token:\n{text}"
+        );
+    }
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains(TOKEN),
+        "the log carries the token:\n{stderr}"
+    );
+}
+
+#[test]
+fn explicit_headers_are_sent_alongside_the_env_token() {
+    const TOKEN: &str = "env-token-alongside-headers";
+
+    let (base, rx) = mock_tsdb("200 OK", &matrix_body());
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let out = Command::new(sonda_bin())
+        .env("SONDA_PROM_TOKEN", TOKEN)
+        .args(["new", "--from-prometheus", &base])
+        .args(["--query", "up"])
+        .args(["--range", "1h", "--step", "10s"])
+        .args(["--header", "X-Scope-OrgID: tenant-7"])
+        .arg("--out")
+        .arg(dir.path().join("capture.csv"))
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        out.status.success(),
+        "capture must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let request = rx.recv_timeout(Duration::from_secs(5)).expect("request");
+    assert!(
+        request.contains("X-Scope-OrgID: tenant-7"),
+        "the explicit header was sent:\n{request}"
+    );
+    assert!(
+        request.contains(&format!("Authorization: Bearer {TOKEN}")),
+        "and the env token was not dropped by adding one:\n{request}"
+    );
+}
+
+#[test]
+fn a_timescaled_capture_says_so_and_still_loads() {
+    let (base, _rx) = mock_tsdb("200 OK", &matrix_body());
+    let dir = tempfile::tempdir().expect("tempdir");
+    let csv = dir.path().join("capture.csv");
+    let yaml = dir.path().join("capture.yaml");
+
+    let out = Command::new(sonda_bin())
+        .args(["new", "--from-prometheus", &base])
+        .args(["--query", "up"])
+        .args(["--start", "0", "--end", "30", "--step", "10s"])
+        .args(["--timescale", "4"])
+        .arg("--out")
+        .arg(&csv)
+        .arg("-o")
+        .arg(&yaml)
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        out.status.success(),
+        "capture must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let yaml_text = std::fs::read_to_string(&yaml).expect("written");
+    assert!(
+        yaml_text.contains("timescale: 4"),
+        "the replay speed is in the scenario:\n{yaml_text}"
+    );
+    let dry = Command::new(sonda_bin())
+        .arg("--dry-run")
+        .arg("run")
+        .arg(&yaml)
+        .output()
+        .expect("spawn sonda");
+    assert!(
+        dry.status.success(),
+        "a timescaled capture must load; stderr:\n{}\nyaml:\n{yaml_text}",
+        String::from_utf8_lossy(&dry.stderr)
+    );
+}
+
+#[test]
+fn too_many_series_says_how_to_narrow_the_query() {
+    // 21 series, one over the cap.
+    let results: Vec<String> = (0..21)
+        .map(|i| {
+            format!(r#"{{"metric":{{"__name__":"up","pod":"p{i}"}},"values":[[0,"1"],[10,"1"]]}}"#)
+        })
+        .collect();
+    let body = format!(
+        r#"{{"status":"success","data":{{"resultType":"matrix","result":[{}]}}}}"#,
+        results.join(",")
+    );
+
+    let (base, _rx) = mock_tsdb("200 OK", &body);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let csv = dir.path().join("capture.csv");
+
+    let out = Command::new(sonda_bin())
+        .args(["new", "--from-prometheus", &base])
+        .args(["--query", "up"])
+        .args(["--start", "0", "--end", "10", "--step", "10s"])
+        .arg("--out")
+        .arg(&csv)
+        .output()
+        .expect("spawn sonda");
+    assert!(!out.status.success(), "over the cap must fail");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("21 series"), "it says how many: {stderr}");
+    assert!(
+        stderr.contains("sum by") || stderr.contains("Aggregate"),
+        "and how to narrow it: {stderr}"
+    );
+    assert!(
+        !csv.exists(),
+        "and nothing is written when the capture is refused"
+    );
+}
+
+#[test]
+fn the_capture_flags_that_go_together_are_enforced_by_the_parser() {
+    let cases: [(&[&str], &str); 4] = [
+        (
+            &["new", "--from-prometheus", "http://x:9090"],
+            "required arguments were not provided",
+        ),
+        (
+            &[
+                "new",
+                "--from-prometheus",
+                "http://x:9090",
+                "--query",
+                "up",
+                "--step",
+                "10s",
+            ],
+            "required arguments were not provided",
+        ),
+        (
+            &["new", "--template", "--from-prometheus", "http://x:9090"],
+            "cannot be used with",
+        ),
+        (
+            &[
+                "new",
+                "--from",
+                "a.csv",
+                "--from-prometheus",
+                "http://x:9090",
+            ],
+            "cannot be used with",
+        ),
+    ];
+    for (args, needle) in cases {
+        let out = Command::new(sonda_bin())
+            .args(args)
+            .output()
+            .expect("spawn sonda");
+        assert!(!out.status.success(), "{args:?} must be rejected");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains(needle),
+            "{args:?} should say {needle:?}, got: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn a_window_the_parser_accepts_but_the_capture_cannot_use_is_reported() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Parses fine — no --range and no --start/--end is a clap-legal command.
+    let out = Command::new(sonda_bin())
+        .args(["new", "--from-prometheus", "http://127.0.0.1:1"])
+        .args(["--query", "up", "--step", "10s"])
+        .arg("--out")
+        .arg(dir.path().join("capture.csv"))
+        .output()
+        .expect("spawn sonda");
+    assert!(!out.status.success(), "a capture with no window must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--range") && stderr.contains("--start"),
+        "the error names both ways to give one: {stderr}"
+    );
+}


### PR DESCRIPTION
## What ships

`sonda new --from-prometheus <url>` — the CLI surface over the `acquire` path from #586–#589. It fetches a PromQL range query and writes the two files that replay it: the CSV of recorded values, and the scenario that plays them back.

```
sonda new --from-prometheus http://prom:9090 \
  --query 'sum by (job) (rate(http_errors_total[5m]))' --metric-name http_errors_per_second \
  --range 1h --step 15s --out incident.csv -o incident.yaml
```

Replay-only: no pattern detection, no generator inference, no `--fit`. The case this closes is alert regression, where the alert has to fire on what actually happened.

| Flag | |
|---|---|
| `--from-prometheus <URL>` | requires `--query`, `--step`, `--out`; conflicts with `--template` and `--from` |
| `--query <PROMQL>` | the range query |
| `--range <DUR>` *or* `--start`/`--end` | window; bounds take unix seconds or RFC 3339 |
| `--step <DUR>` | sample step, and the replay grid |
| `--out <PATH>` | the CSV; the emitted scenario references this path |
| `--metric-name <NAME>` | name for series the query left without one |
| `--timescale <F>` | replay speed |
| `--header 'Name: value'`, `SONDA_PROM_TOKEN` | credentials |

Every capture flag requires `--from-prometheus` in turn, so one on its own is a rejected typo rather than a silent no-op — `sonda new --from data.csv --out scenario.yaml` fails instead of printing to stdout.

## One metric across several label sets

`scenario_for` groups columns into blocks by absence pattern and names each from its `__name__`. `expand_scenario` turns a column name into a **scenario name** and refuses duplicates — so `up{job="api"}` and `up{job="db"}` in one block emit two columns called `up`, and the file will not load. That is `--query up` against any Prometheus with two healthy targets.

A block now takes a column only when the windows match **and** no member already carries that metric name — the same shape as the rule it already enforced. Relaxing the compiler's uniqueness rule was the alternative and is wrong: the name is an identity, not just a metric name.

## `--metric-name`, and why the cap needed it

The 20-series cap advises aggregating. PromQL aggregations drop `__name__`, and a nameless result was then refused for having no metric name — two messages shipping pointed at each other, with no route between them. `--metric-name` supplies one, and the cap's advice now names the flag.

## `--timescale` is not a passthrough

The engine derives `rate = timescale / Δt` when it loads a `csv_replay`, overriding the file's declared rate. A scenario that set `timescale` but left `duration` and `gap_windows` on the *captured* timeline would replay at a cadence neither was written for. `scenario_for` takes the timescale and divides the step all three derive from:

```
                 rate    duration   first gap window
timescale 1.0     0.1        40s     at 5s    for 10s
timescale 4.0     0.4        10s     at 1.25s for 2.5s
```

A timescale of `1.0` is omitted rather than written as a default.

## Credentials and failure behaviour

`SONDA_PROM_TOKEN` rather than a flag value, so the token stays out of shell history, process listings and CI logs. `--header` composes with it — except when the header *is* an `Authorization`, where the explicit flag wins and says so on stderr rather than silently discarding one of two credentials.

Everything decidable from the flags alone — window, timescale, metric name — is validated **before** the network call, so a refusal never leaves a CSV on disk with no scenario beside it. And errors from this path print once: `SondaError`'s Display restates its source *and* `#[from]` exposes it, so anyhow's `{:#}` printed the same clause twice; flattened at this boundary (the duplication is core's and predates this path).

Leak tests use the guard shape from #589: assert the credential reached the wire **before** asserting it is absent from the CSV, the YAML and the log.

## Red-verification

Each mutation was confirmed present in the source before its result was trusted, and reverted after.

| Mutation | Result |
|---|---|
| ignore a name collision when grouping | 2 core tests fail; the emitted file is one the compiler refuses |
| never apply `--metric-name` | the aggregated capture fails |
| drop the flattening on the fetch error | the clause count goes 1 → 2 |
| make the `Authorization` check never match | the env token goes out alongside the explicit one |
| ignore `SONDA_PROM_TOKEN` | 2 tests fail on the vacuity guard, which names the reason |
| ignore `--timescale` | the emitted scenario carries no timescale |
| remove the 20-series cap | the over-cap capture succeeds |
| accept a capture with no window | the window table fires |

The doubling test counts the `query against` clause, not the URL: `ureq` quotes the endpoint inside its own reason, so the URL legitimately appears twice in one message. Counting the URL would have made the test pass for the wrong reason.

## On the two gates

Measured, neither needs to change:

- **`cli_subcommand_parity`** checks *verbs*; `--from-prometheus` is a flag on the existing `new` verb. All 7 tests pass untouched.
- **`validate_docs_commands.py`** already distinguishes the flags: `extract_new_from_file` returns `None` for `--from-prometheus`, so a documented capture command is not mistaken for a `--from <file>` that must exist. Probed directly.

A real gap neither covers, left as a follow-up rather than widening this PR: **the docs gate validates subcommands but not flags**, so a `--from-promethus` typo in documentation would pass. Same class as the invented-subcommand hole #565 closed, and it has an exact fix available (compare against `sonda new --help`).

## Limitations

- One range query per invocation; no chunking of a window too large for the server to answer at once.
- The emitted scenario references `--out` verbatim, so a relative path resolves against the working directory at run time, not against the scenario file.
- `--start`/`--end` accept unix seconds and RFC 3339, not relative expressions like `now-1h`.
- The 20-series cap is a judgement about readability, not a limit of the format.
- One metric across N label sets emits N scenario blocks. Correct, and more verbose than one block would be.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0
- `cargo test --workspace --all-features --no-fail-fast` — 3318 passed, 5 failed: the five that reproduce on `main` in this container (`sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message` and `tests::sink_file_error_produces_sink_variant`, both needing a non-root uid; `global_inflight_limit_gates_across_routes`, `health_remains_responsive_when_control_plane_is_saturated`, `request_timeout_returns_408_with_structured_error` in `sonda-server`)
- `scripts/validate_docs_commands.py` — 159 commands, 0 failed

`yaml_out` is behind `config`, which `sonda-wasm` does build with — so the bundle was rebuilt on the reference platform (wasm-bindgen 0.2.117, binaryen 119, Linux x86_64) and compared: `sonda_wasm.js` and `sonda_wasm_bg.wasm` both byte-identical.
