### PR TITLE
feat(server): add /ready so probes can tell alive from doing its job

### DIFF
--- a/docs/site/docs/deploy/docker.md
+++ b/docs/site/docs/deploy/docker.md
@@ -107,15 +107,31 @@ Mounting a catalog makes its files available to `POST /scenarios`; it does not r
           - SONDA_AUTOSTART=1
     ```
 
-The server answers `/health` as soon as the port is open and the entries appear in `GET /scenarios` as they start, so a container health check never waits on the catalog:
+The server answers `/health` as soon as the port is open and the entries appear in `GET /scenarios` as they start. `/ready` is the one that waits: it returns 503 until the sweep has been through every entry, then 200.
 
 ```bash
-curl http://localhost:8080/health
+curl http://localhost:8080/health   # 200 as soon as the port is open
+curl http://localhost:8080/ready    # 503 until the sweep is done, then 200
 curl http://localhost:8080/scenarios
 
 # One line per started entry, plus a closing count
 docker logs sonda-server
 ```
+
+Gate anything that depends on the scenarios on `/ready`, not on the port being open. A script that starts the stack and immediately asserts on data will otherwise run against a half-started catalog:
+
+```bash
+# Wait for the catalog to be up before doing anything that depends on it
+until curl -sf http://localhost:8080/ready > /dev/null; do sleep 1; done
+docker compose up -d prometheus grafana
+```
+
+!!! warning "Do not add a Compose `healthcheck:` — nothing in the image can run it"
+    The published image is built `FROM scratch`. It has no shell, no `curl`, and no `wget` — only the two Sonda binaries. A `healthcheck:` therefore has no command to run the request with, and `depends_on: condition: service_healthy` has nothing to wait on. A healthcheck added anyway does not fall back to something that works: it fails every time, and the container settles into `unhealthy` while serving normally. Poll from the host as shown above instead.
+
+    Kubernetes does not have this limitation. The kubelet performs the HTTP GET itself, which is why the [Helm chart](kubernetes.md#health-probes) points its readiness probe straight at `/ready`.
+
+A sweep that finished but skipped a file still reports ready; see [Health and readiness](server.md#health-and-readiness) for the response shape and the counts that surface the skip.
 
 `kind: composable` packs are never started — they stay available for `pack: <name>` references from the runnables next to them. A file the server cannot open, compile, or admit is logged and skipped, so one bad file does not stop the container coming up. Two files claiming the same catalog name is a startup error: the process exits before binding, which under a restart policy shows up as a restart loop rather than a container serving nothing.
 
@@ -155,16 +171,17 @@ way as the `--api-key` CLI flag.
           - SONDA_API_KEY=my-secret-key
     ```
 
-Once enabled, all `/scenarios/*` requests require a `Bearer` token. The `/health`
-endpoint stays public so health probes keep working.
+Once enabled, all `/scenarios/*` requests require a `Bearer` token. The `/health` and
+`/ready` endpoints stay public so health and readiness probes keep working.
 
 ```bash
 # Authenticated request
 curl -H "Authorization: Bearer my-secret-key" \
   http://localhost:8080/scenarios
 
-# Health check (no auth needed)
+# Health and readiness checks (no auth needed)
 curl http://localhost:8080/health
+curl http://localhost:8080/ready
 ```
 
 !!! warning "Don't embed secrets in plain text"

--- a/docs/site/docs/deploy/http-api.md
+++ b/docs/site/docs/deploy/http-api.md
@@ -11,7 +11,7 @@ description: REST endpoints exposed by sonda-server — scenarios, events, metri
 
 ### Authentication
 
-When the server starts with `--api-key <key>` (or `SONDA_API_KEY=<key>`), every request to `/scenarios/*`, `/events`, `/metrics`, and `/scenarios/metrics` must include `Authorization: Bearer <key>`. The `/health` endpoint is always public. When no key is configured, all endpoints are public.
+When the server starts with `--api-key <key>` (or `SONDA_API_KEY=<key>`), every request to `/scenarios/*`, `/events`, `/metrics`, and `/scenarios/metrics` must include `Authorization: Bearer <key>`. The `/health` and `/ready` endpoints are always public. When no key is configured, all endpoints are public.
 
 ```bash title="Authenticated request"
 curl -X POST http://localhost:8080/scenarios \
@@ -54,7 +54,7 @@ Most error responses share the format `{"error": "<short_code>", "detail": "<mes
 
 ### Capacity and resource errors
 
-Three status codes signal that a request was rejected by the server's resource-limit guards rather than by validation. They apply only to the control-plane sub-router (`POST /scenarios`, `DELETE /scenarios/{id}`, `POST /events`, list/inspect). The observability endpoints (`/metrics`, `/scenarios/metrics`, `/scenarios/{id}/metrics`, `/scenarios/{id}/stats`, `/health`) are not subject to these limits and stay reachable under saturation. Every rejection is counted on [`sonda_server_requests_total{status="..."}`](server-metrics.md#sonda_server_requests_total).
+Three status codes signal that a request was rejected by the server's resource-limit guards rather than by validation. They apply only to the control-plane sub-router (`POST /scenarios`, `DELETE /scenarios/{id}`, `POST /events`, list/inspect). The observability endpoints (`/metrics`, `/scenarios/metrics`, `/scenarios/{id}/metrics`, `/scenarios/{id}/stats`, `/health`, `/ready`) are not subject to these limits and stay reachable under saturation. Every rejection is counted on [`sonda_server_requests_total{status="..."}`](server-metrics.md#sonda_server_requests_total).
 
 #### `429 Too Many Requests` — capacity_exceeded
 
@@ -100,7 +100,30 @@ curl http://localhost:8080/health
 # {"status":"ok"}
 ```
 
-Returns 200 OK with `{"status":"ok"}` when the server process is alive.
+Returns 200 OK with `{"status":"ok"}` when the server process is alive. It reads no server state, so it answers as soon as the port is open and keeps answering regardless of what the scenarios are doing.
+
+### `GET /ready`
+
+Readiness probe. Always public. No `Authorization` header required.
+
+```bash
+curl -i http://localhost:8080/ready
+# HTTP/1.1 200 OK
+# {"autostart_expected":12,"autostart_started":12,"status":"finished"}
+```
+
+Returns 200 when the [`--autostart`](server.md#autostarting-a-catalog) sweep has nothing left to start, and 503 while it is still running or after it failed. Every response carries the sweep status and both counts.
+
+| `status` | HTTP | Meaning |
+|---|---|---|
+| `not_configured` | 200 | The server was started without `--autostart`. |
+| `in_progress` | 503 | The sweep is still starting catalog entries. |
+| `finished` | 200 | The sweep has been through every entry. |
+| `failed` | 503 | The sweep died before it finished; an `ERROR` line names the cause. |
+
+`finished` with `autostart_started` below `autostart_expected` is still ready — the sweep ran to the end and logged the entries it skipped. Use the two counts (also exported as [`sonda_server_autostart_started`](server-metrics.md#sonda_server_autostart_started) and [`sonda_server_autostart_expected`](server-metrics.md#sonda_server_autostart_expected)) to detect skips; do not gate traffic on them.
+
+Use `/health` for liveness and `/ready` for readiness: the first says the process is alive, the second says it is doing what it was configured to do. See [Health and readiness](server.md#health-and-readiness).
 
 ### `GET /scenarios/{id}/stats`
 
@@ -1037,7 +1060,8 @@ scrape_configs:
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/health` | Health check |
+| GET | `/health` | Liveness check — 200 whenever the process is up |
+| GET | `/ready` | Readiness check — 200 when the `--autostart` sweep has nothing left to start, 503 while it runs |
 | POST | `/scenarios` | Start one or more scenarios from YAML/JSON body |
 | GET | `/scenarios` | List all running scenarios |
 | GET | `/scenarios/{id}` | Inspect a scenario: config, stats, elapsed |
@@ -1051,7 +1075,7 @@ scrape_configs:
 ## Where to next
 
 - [Deploy as a server](server.md) — install, configure, network, and operate the server itself.
-- [Server metrics](server-metrics.md) — the nine `/metrics` series and the alerts that matter.
+- [Server metrics](server-metrics.md) — the eleven `/metrics` series and the alerts that matter.
 - [Scenario file format](../build/scenario-files.md) — what to put in the body of `POST /scenarios`.
 - [Encoders](../build/encoders.md) and [Sinks](../build/sinks.md) — every encoder/sink option you can declare in a posted body.
 - [Cross-POST `while:` refs (YAML schema)](../build/scenario-files.md#cross-post-while-refs) — the file-side counterpart to the HTTP cross-POST surface.

--- a/docs/site/docs/deploy/kubernetes.md
+++ b/docs/site/docs/deploy/kubernetes.md
@@ -306,15 +306,25 @@ See [Server API](server.md) for the full endpoint reference and the
 
 ## Health probes
 
-The Deployment configures both liveness and readiness probes against `GET /health`:
+The Deployment configures a liveness probe against `GET /health` and a readiness probe against `GET /ready`:
 
-| Probe | Initial delay | Period | Timeout | Failure threshold |
-|-------|--------------|--------|---------|-------------------|
-| Liveness | 5s | 10s | 3s | 3 |
-| Readiness | 2s | 5s | 3s | 3 |
+| Probe | Path | Initial delay | Period | Timeout | Failure threshold |
+|-------|------|--------------|--------|---------|-------------------|
+| Liveness | `/health` | 5s | 10s | 3s | 3 |
+| Readiness | `/ready` | 2s | 5s | 3s | 3 |
 
-The `/health` endpoint returns `{"status":"ok"}` with HTTP 200 when the server is running.
-Pods restart automatically if the server becomes unresponsive.
+The two answer different questions. `/health` returns `{"status":"ok"}` with HTTP 200 whenever the process is up, and a failing liveness probe restarts the pod. `/ready` returns 503 while the [`server.autostart`](#starting-the-configmap-scenarios-automatically) sweep is still starting catalog entries, and 200 once it has finished. A pod only joins the Service endpoints once the scenarios it was deployed to run are actually running. A pod that is not ready is taken out of the Service without being restarted, which is what you want while a large catalog is still starting.
+
+With `server.autostart` enabled, `kubectl rollout status` therefore completes when the catalog is running, not when the port opens. With `server.autostart` disabled — the default — `/ready` answers 200 from the first request, so the readiness probe behaves exactly as it did against `/health`.
+
+??? warning "A pinned `image.tag` older than `/ready` leaves the pod permanently NotReady"
+    The chart's default `image.tag` follows its own `appVersion`, so a `helm upgrade` that takes this chart takes a matching image and there is nothing to do. If you pin `image.tag` to a release that does not serve `/ready`, the probe gets a 404 and the pod never becomes Ready. Move the pin forward, or stay on the chart version you were running.
+
+!!! info "A sweep that skipped files is still ready"
+    A sweep that finished but skipped a file still reports ready, so the pod goes into service and the rollout succeeds. That is deliberate. One bad file in a twelve-file ConfigMap must not pull the whole pod out of service. On a node drain, the same rule stops every pod coming back NotReady at once. The counts on [`GET /ready`](server.md#health-and-readiness) and on [`sonda_server_autostart_started`](server-metrics.md#sonda_server_autostart_started) are what surface the skip. This holds when every file is broken too: the pod is Ready with nothing running. Alert on the counts rather than relying on the rollout to fail.
+
+!!! warning "A failed sweep is terminal — the pod stays NotReady and is never restarted"
+    `/ready` reports `status: failed` and keeps answering 503 for the life of the process, so the pod never rejoins the Service. It is not restarted either: the process is alive, so the liveness probe on `/health` keeps passing by design. The pod needs a human. Read the `ERROR` line in the log, then `kubectl delete pod` to start a fresh sweep. Alert on it with [`sonda_server_autostart_started`](server-metrics.md#sonda_server_autostart_started), since a pod that is permanently NotReady is otherwise quiet.
 
 ## Accessing the server
 
@@ -331,6 +341,9 @@ Then interact with the API at `http://localhost:8080`:
 ```bash
 # Health check
 curl http://localhost:8080/health
+
+# Readiness check
+curl http://localhost:8080/ready
 
 # Start a scenario
 curl -X POST -H "Content-Type: text/yaml" \
@@ -362,7 +375,7 @@ For example, a Prometheus instance in the same namespace can scrape
 | `GET /scenarios/metrics` | Aggregate scenario data | Per-process scenario view |
 | `GET /metrics` | Server-process RED + saturation | Operational dashboards and alerts |
 
-`GET /scenarios/metrics` and `GET /scenarios/{id}/metrics` are idempotent snapshots — one sample per `(name, labels)` series with no timestamp, like a `node_exporter` scrape. `GET /metrics` returns the server's own RED and saturation telemetry — see [Server metrics](server-metrics.md) for the nine series and the alerts that go with them. Most Prometheus setups want a job per endpoint; the aggregate `/scenarios/metrics` covers every scenario and you do not need to know scenario IDs in advance. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape) for the `?label=k:v` AND-filter syntax.
+`GET /scenarios/metrics` and `GET /scenarios/{id}/metrics` are idempotent snapshots — one sample per `(name, labels)` series with no timestamp, like a `node_exporter` scrape. `GET /metrics` returns the server's own RED and saturation telemetry — see [Server metrics](server-metrics.md) for the eleven series and the alerts that go with them. Most Prometheus setups want a job per endpoint; the aggregate `/scenarios/metrics` covers every scenario and you do not need to know scenario IDs in advance. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape) for the `?label=k:v` AND-filter syntax.
 
 ### Aggregate scrape config
 
@@ -439,7 +452,7 @@ The `port: http` field matches the named port on the Sonda Service. Each `endpoi
 
 Sonda-server supports optional bearer token authentication on `/scenarios/*`, `/scenarios/metrics`, and
 `/events`. When enabled, clients must include an `Authorization: Bearer <key>` header. The
-`/health` endpoint stays public so liveness and readiness probes work without credentials.
+`/health` and `/ready` endpoints stay public so liveness and readiness probes work without credentials.
 
 For the full authentication behavior (error responses, protected vs. public endpoints), see the
 [Server API Authentication](server.md#authentication) section.
@@ -510,8 +523,9 @@ curl -X POST \
   --data-binary @examples/basic-metrics.yaml \
   http://localhost:8080/scenarios
 
-# Health check (always public)
+# Health and readiness checks (always public)
 curl http://localhost:8080/health
+curl http://localhost:8080/ready
 ```
 
 ### Prometheus scraping with auth
@@ -606,6 +620,6 @@ Add `-n <namespace>` if you installed into a non-default namespace.
 
 - [Synthetic Monitoring guide](../test/synthetic-monitoring.md) -- deploy Sonda on Kubernetes, submit long-running scenarios, scrape with Prometheus, and build Grafana dashboards
 - [Server API](server.md) -- full endpoint reference for `sonda-server`
-- [Server metrics](server-metrics.md) -- the nine `/metrics` series and the PromQL alerts that matter
+- [Server metrics](server-metrics.md) -- the eleven `/metrics` series and the PromQL alerts that matter
 - [Docker](docker.md) -- Docker image and Compose stacks for local development
 - [Scenario Fields](../reference/scenario-fields.md) -- full YAML schema for scenario configuration

--- a/docs/site/docs/deploy/server-metrics.md
+++ b/docs/site/docs/deploy/server-metrics.md
@@ -1,6 +1,6 @@
 ---
 title: Server metrics
-description: Three Prometheus endpoints on sonda-server, the nine /metrics series, and PromQL alerts for the load-bearing ones.
+description: Three Prometheus endpoints on sonda-server, the eleven /metrics series, and PromQL alerts for the load-bearing ones.
 ---
 
 # Server metrics
@@ -40,6 +40,12 @@ sonda_server_worker_threads 8
 # HELP sonda_server_max_scenarios Configured scenario row cap (0 means unlimited).
 # TYPE sonda_server_max_scenarios gauge
 sonda_server_max_scenarios 500
+# HELP sonda_server_autostart_started Catalog entries the startup sweep has started.
+# TYPE sonda_server_autostart_started gauge
+sonda_server_autostart_started 12
+# HELP sonda_server_autostart_expected Runnable catalog entries the startup sweep set out to start.
+# TYPE sonda_server_autostart_expected gauge
+sonda_server_autostart_expected 12
 # HELP sonda_server_requests_total HTTP requests served, per matched route, method, and status.
 # TYPE sonda_server_requests_total counter
 sonda_server_requests_total{route="/scenarios",method="POST",status="201"} 14
@@ -65,7 +71,7 @@ The endpoint is idempotent — two back-to-back scrapes return logically equival
 
 ### Series reference
 
-Nine series. Operator-tense one-liners and the alerts that matter follow.
+Eleven series. Operator-tense one-liners and the alerts that matter follow.
 
 #### `sonda_server_active_scenarios`
 
@@ -100,6 +106,41 @@ Gauge. The tokio multi-thread worker count configured at startup — that is, th
 #### `sonda_server_max_scenarios`
 
 Gauge. The configured value of [`--max-scenarios`](server.md#tuning-resource-limits). Reports `0` when the cap is disabled (unlimited).
+
+#### `sonda_server_autostart_started`
+
+Gauge. Catalog entries the [`--autostart`](server.md#autostarting-a-catalog) sweep has started so far. Rises during the sweep and then stays flat for the life of the process. Reports `0` on a server started without `--autostart`.
+
+#### `sonda_server_autostart_expected`
+
+Gauge. Runnable catalog entries the sweep set out to start, fixed when the catalog is enumerated at startup. Reports `0` on a server started without `--autostart`, and also when `--autostart` found nothing to start.
+
+```promql title="Alert: the sweep skipped catalog entries"
+sonda_server_autostart_started < sonda_server_autostart_expected
+```
+
+A `started` count that stays below `expected` means the sweep either skipped entries — a file that does not compile, one the server could not read, or one that would have pushed past `--max-scenarios` — or died partway through. The server stays [ready](server.md#health-and-readiness) when entries are skipped, on purpose, so this alert is how you find out; the `WARN` line for each skipped entry names the file, and a sweep that died logs an `ERROR` and flips `GET /ready` to `status: failed`.
+
+The expression is also briefly true while a large catalog is still starting, so pair it with a `for:` clause longer than your sweep takes:
+
+```yaml
+- alert: SondaAutostartIncomplete
+  expr: sonda_server_autostart_started < sonda_server_autostart_expected
+  for: 5m
+```
+
+!!! warning "This alert cannot see an empty catalog"
+    `started < expected` is false when both counts are `0`, and both are `0` whenever the sweep found no runnable entries. Three cases produce that:
+
+    - the catalog directory is empty
+    - it holds only `kind: composable` packs, which are never started
+    - the server could not read it, and logged a `WARN` naming the directory
+
+    In all three the server reports [ready](server.md#health-and-readiness) with nothing running, because the sweep did run and had nothing to do. On a deployment you expect to autostart something, alert on the count itself:
+
+    ```promql
+    sonda_server_autostart_expected == 0
+    ```
 
 #### `sonda_server_requests_total`
 

--- a/docs/site/docs/deploy/server.md
+++ b/docs/site/docs/deploy/server.md
@@ -256,7 +256,7 @@ By default the server boots empty and waits for you to `POST /scenarios`. Add `-
 sonda-server --port 8080 --catalog ./catalog --autostart
 ```
 
-The sweep runs alongside the server, not ahead of it. `/health` answers as soon as the port is open, so a readiness probe with a tight `timeoutSeconds` never waits on the catalog, and entries appear in `GET /scenarios` as they start — a large catalog reads as a growing list rather than an empty one. The `INFO` summary below is the point at which the list is complete. A shutdown signal that arrives mid-sweep stops the sweep at the next entry, and every scenario it did start is stopped with the rest.
+The sweep runs alongside the server, not ahead of it. `/health` answers as soon as the port is open, and entries appear in `GET /scenarios` as they start — a large catalog reads as a growing list rather than an empty one. [`GET /ready`](#health-and-readiness) is the endpoint that tells you when that list is complete: it returns 503 while the sweep is starting entries and 200 once it is done. It has already flipped to 200 by the time the `INFO` summary below is logged, so waiting on that line and waiting on `/ready` never disagree. A shutdown signal that arrives mid-sweep stops the sweep at the next entry, and every scenario it did start is stopped with the rest.
 
 `--autostart` requires `--catalog`. Passing it alone (or setting `SONDA_AUTOSTART` without `SONDA_CATALOG`) exits before the server binds a port:
 
@@ -357,9 +357,53 @@ The maximum request body size on control-plane routes. Bodies above the limit re
 
 The flag does not apply to the observability sub-router.
 
+## Health and readiness
+
+Two public endpoints answer two different questions. `/health` says the process is alive; `/ready` says it is doing what it was configured to do.
+
+| Endpoint | Question it answers | Use it for |
+|---|---|---|
+| `GET /health` | Is the process up and serving HTTP? | Liveness probes, load-balancer checks |
+| `GET /ready` | Has the [`--autostart`](#autostarting-a-catalog) sweep finished starting the catalog? | Readiness probes, deploy gates, scripts that wait before asserting on data |
+
+`/health` is static. It returns `{"status":"ok"}` with 200 as soon as the port is open and never reads server state — which is exactly what you want from a liveness probe, since a restart is the only thing a failing liveness check can do.
+
+`/ready` reports the state of the startup sweep and the two counts behind it:
+
+```bash
+# While the sweep is starting entries
+curl -i http://localhost:8080/ready
+# HTTP/1.1 503 Service Unavailable
+# {"autostart_expected":120,"autostart_started":38,"status":"in_progress"}
+
+# Once it has finished
+curl -i http://localhost:8080/ready
+# HTTP/1.1 200 OK
+# {"autostart_expected":120,"autostart_started":120,"status":"finished"}
+```
+
+| `status` | HTTP | Meaning |
+|---|---|---|
+| `not_configured` | 200 | The server was started without `--autostart`, so there is nothing to wait for. |
+| `in_progress` | 503 | The sweep is still starting catalog entries. |
+| `finished` | 200 | The sweep has been through every entry. |
+| `failed` | 503 | The sweep died before it finished. An `ERROR` line names the cause; the scenarios it had not reached will not start. |
+
+A server without `--autostart` is ready from its first request, so putting a readiness probe on `/ready` is safe whether or not you autostart anything.
+
+!!! warning "`failed` is terminal — the process does not recover on its own"
+    Nothing retries a sweep that died. The status stays `failed` for the life of the process, so `/ready` answers 503 forever and a pod behind a readiness probe stays out of the Service indefinitely. It is not restarted either: the process is still alive and serving, so the liveness probe on `/health` keeps passing by design — a restart would only repeat the sweep that just failed, and the API keeps answering for whatever did start. Treat a `failed` sweep as a page: read the `ERROR` line, then restart the process (`kubectl delete pod`, `docker restart`) once you know why it died. [`sonda_server_autostart_started`](server-metrics.md#sonda_server_autostart_started) sitting below `sonda_server_autostart_expected` is the alertable signal.
+
+!!! info "A sweep that skipped files is still ready"
+    `status: finished` with `autostart_started` below `autostart_expected` means the sweep ran to the end and skipped something — a file that does not compile, or one that would have pushed past `--max-scenarios`. That is ready. One bad file in a catalog of twelve must not pull the whole server out of service; the skip is logged with the file that caused it, and the difference between the two counts is what you alert on. Both counts are exported as [`sonda_server_autostart_started`](server-metrics.md#sonda_server_autostart_started) and [`sonda_server_autostart_expected`](server-metrics.md#sonda_server_autostart_expected).
+
+    This holds even when every entry is skipped. The server reports ready with nothing running, and a Kubernetes rollout of that catalog succeeds. Readiness answers "did the sweep run", not "was the catalog any good". The counts and the `WARN` line for each skipped entry answer the second question. Alert on those; do not expect a probe to catch a bad catalog. A catalog that yields no runnable entries at all is the one case this comparison cannot show — see [`sonda_server_autostart_expected`](server-metrics.md#sonda_server_autostart_expected).
+
+Both endpoints stay public when [API key authentication](#authentication) is enabled, so probes work without credentials.
+
 ## Authentication
 
-You can protect scenario endpoints with API key authentication. When enabled, all `/scenarios/*` requests, `GET /metrics`, `GET /scenarios/metrics`, and `POST /events` must include a bearer token. The `/health` endpoint is always public, so health probes and load balancer checks work without credentials.
+You can protect scenario endpoints with API key authentication. When enabled, all `/scenarios/*` requests, `GET /metrics`, `GET /scenarios/metrics`, and `POST /events` must include a bearer token. The `/health` and `/ready` endpoints are always public, so health and readiness probes work without credentials.
 
 ### Enabling authentication
 
@@ -391,6 +435,7 @@ INFO sonda_server: API key authentication enabled for /scenarios/*, /events, /me
 | Endpoint | Auth required |
 |----------|---------------|
 | `GET /health` | No -- always public |
+| `GET /ready` | No -- always public |
 | `POST /scenarios` | Yes |
 | `GET /scenarios` | Yes |
 | `GET /scenarios/{id}` | Yes |
@@ -439,7 +484,7 @@ See [Authentication conventions on HTTP API reference](http-api.md#authenticatio
 ## Where to next
 
 - [HTTP API reference](http-api.md) — every endpoint, request body, and response shape.
-- [Server metrics](server-metrics.md) — the nine `/metrics` series and the alerts that matter.
+- [Server metrics](server-metrics.md) — the eleven `/metrics` series and the alerts that matter.
 - [Docker](docker.md) — Compose stacks and host-side `docker run` examples.
 - [Kubernetes](kubernetes.md) — Helm chart, Service DNS, cross-namespace access.
 - [Sinks](../build/sinks.md) — every sink type and its `url:` field.

--- a/docs/site/docs/test/synthetic-monitoring.md
+++ b/docs/site/docs/test/synthetic-monitoring.md
@@ -133,7 +133,7 @@ Wait for the pod to become ready:
 kubectl get pods -l app.kubernetes.io/name=sonda -w
 ```
 
-You should see `1/1 Running` within 15 to 20 seconds. The Deployment configures liveness and readiness probes against `GET /health`. Kubernetes restarts the pod automatically if the server stops responding.
+You should see `1/1 Running` within 15 to 20 seconds. The Deployment configures a liveness probe against `GET /health` and a readiness probe against `GET /ready`. `/health` says the process is alive, so Kubernetes restarts the pod automatically if the server stops responding. `/ready` says the scenarios it was deployed to run have started — see [Health probes](../deploy/kubernetes.md#health-probes).
 
 ??? info "Customizing the deployment"
     Override common settings with `--set`:
@@ -500,7 +500,8 @@ The pod alert fires fast and signals an infrastructure issue. The metric-absent 
 | Check scenario stats | `curl http://localhost:8080/scenarios/<id>/stats` |
 | Scrape metrics | `curl http://localhost:8080/scenarios/<id>/metrics` |
 | Stop a scenario | `curl -X DELETE http://localhost:8080/scenarios/<id>` |
-| Health check | `curl http://localhost:8080/health` |
+| Health check (process alive) | `curl http://localhost:8080/health` |
+| Readiness check (catalog started) | `curl http://localhost:8080/ready` |
 
 ## Related pages
 

--- a/helm/sonda/templates/deployment.yaml
+++ b/helm/sonda/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: http
             initialDelaySeconds: 2
             periodSeconds: 5

--- a/sonda-server/CLAUDE.md
+++ b/sonda-server/CLAUDE.md
@@ -26,13 +26,17 @@ src/
 │                         and logs+skips per-entry failures. Runs as a spawned task alongside
 │                         axum::serve; takes a CancellationToken that shutdown cancels and joins
 ├── routes/
-│   ├── mod.rs          ← router_with_config() function: splits three sub-routers — public (/health),
+│   ├── mod.rs          ← router_with_config() function: splits three sub-routers — public (/health, /ready),
 │                         protected observability (/scenarios/{id}/stats, /scenarios/{id}/metrics,
 │                         /scenarios/metrics, /metrics), and protected control (/scenarios POST/GET,
 │                         /scenarios/{id} GET/DELETE, /events). Auth + request-metrics middleware
 │                         applied per protected sub-router; the control sub-router additionally
 │                         carries the timeout + body-limit + global-concurrency tower stack.
-│   ├── health.rs       ← GET /health → {"status": "ok"}
+│   ├── health.rs       ← GET /health → {"status": "ok"} (static liveness signal)
+│   ├── ready.rs        ← GET /ready → sweep phase + started/expected counts. 200 when the
+│                         autostart sweep has nothing pending (not configured, or finished —
+│                         including a run that skipped entries), 503 while it runs or after
+│                         it failed.
 │   ├── events.rs       ← POST /events: synchronous single-event emission. Tagged-enum
 │                         request body, dispatches on signal_type, builds LogEvent/MetricEvent,
 │                         awaits sonda_core::emit::{emit_log, emit_metric} directly.
@@ -58,6 +62,9 @@ src/
 │                         get_scenario(), get_scenario_stats(),
 │                         get_scenario_metrics(), delete_scenario().
 └── state.rs            ← AppState: Arc<RwLock<HashMap<String, ScenarioHandle>>> + optional api_key
+                        + SweepStatus: lock-free autostart sweep phase (not_configured /
+                        in_progress / finished / failed) plus started and expected counts,
+                        built before the listener binds so the denominator is never zero
 
 tests/
 ├── common/
@@ -73,6 +80,9 @@ tests/
 │                         signal_type, missing fields, invalid sink config (422), sink-push 5xx (502),
 │                         auth (401), loopback warning surfaced on success
 ├── health.rs           ← server startup, GET /health, unknown routes, SIGTERM shutdown
+├── ready.rs            ← GET /ready E2E: 503 during a 500-entry sweep then 200 after, ready
+│                         without autostart, ready despite a skipped file, autostart counters
+│                         on /metrics
 ├── integration.rs      ← full lifecycle: POST metrics + logs → GET list → stats → DELETE → verify stopped
 └── scenarios.rs        ← POST /scenarios unit-level tests (valid/invalid YAML, JSON, validation errors)
 ```
@@ -81,7 +91,8 @@ tests/
 
 | Method | Path                    | Description                                             |
 |--------|-------------------------|---------------------------------------------------------|
-| GET    | /health                 | Health check — always returns 200 OK                    |
+| GET    | /health                 | Liveness check — always returns 200 OK                  |
+| GET    | /ready                  | Readiness check — 200 when the autostart sweep has nothing left to start (or was never configured), 503 while it is in progress or after it failed. Body carries `status`, `autostart_started`, `autostart_expected`. Public, like /health. |
 | POST   | /scenarios              | Start scenario(s) from a v2 YAML or JSON body. Every body is compiled through `sonda_core::compile_scenario_file`; v1 YAML shapes are rejected with a 400 + migration hint. When the compilation produces exactly one entry the response is `{id, name, status}`; otherwise it is `{scenarios: [{id, name, status}, ...]}`. |
 | GET    | /scenarios              | List all scenarios with id, name, status, elapsed       |
 | GET    | /scenarios/{id}         | Inspect a scenario: detail + live stats                 |
@@ -113,7 +124,7 @@ worker threads.
 ## Authentication
 
 API key authentication is opt-in. When configured, all `/scenarios/*` endpoints require a
-`Authorization: Bearer <key>` header. The `/health` endpoint is always public.
+`Authorization: Bearer <key>` header. The `/health` and `/ready` endpoints are always public.
 
 ```
 # Via CLI flag:
@@ -142,7 +153,13 @@ Respects `RUST_LOG` env var for log level (default: `info`).
 uses. Catalog validation runs before the bind, so a catalog the operator must fix
 is fatal; the sweep itself runs concurrently with `axum::serve`, so the server
 answers requests while entries are still starting. `shutdown_signal` cancels and
-joins the sweep before draining, so no admission lands after the drain.
+joins the sweep before draining, so no admission lands after the drain. The sweep is
+spawned through spawn_supervised_sweep(): a supervisor task awaits its JoinHandle, so a
+sweep that panics is logged at ERROR and flips SweepStatus to failed at once and /ready
+reports 503 without waiting for shutdown. The failed phase is terminal — nothing retries
+the sweep, and liveness stays on the static /health, so recovery is a process restart.
+Shutdown joins the supervisor rather than the sweep and no longer reports the outcome
+itself; report_sweep_outcome() is the only place that does.
 
 ### CLI dispatch shim
 

--- a/sonda-server/src/autostart.rs
+++ b/sonda-server/src/autostart.rs
@@ -53,10 +53,10 @@ fn is_misconfiguration(error: &CatalogError) -> bool {
 /// so shutdown never races an admission it would not see.
 pub async fn start_entries(state: &AppState, entries: &[CatalogEntry], cancel: &CancellationToken) {
     let catalog_dir = state.catalog_dir.as_deref().map(|p| p.as_path());
-    let mut started = 0usize;
 
     for (index, entry) in entries.iter().enumerate() {
         if cancel.is_cancelled() {
+            let started = state.sweep_status.snapshot().started;
             warn!(
                 started,
                 total = entries.len(),
@@ -87,10 +87,13 @@ pub async fn start_entries(state: &AppState, entries: &[CatalogEntry], cancel: &
 
         // admit_compiled logs the reason it rejected an entry, with the same origin.
         if admit_compiled(state, compiled, &path).await.is_ok() {
-            started += 1;
+            state.sweep_status.record_started();
         }
     }
 
+    // Finish before the summary line, so anything that waits on the log sees a ready /ready.
+    state.sweep_status.finish();
+    let started = state.sweep_status.snapshot().started;
     info!(
         started,
         total = entries.len(),
@@ -106,7 +109,7 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use crate::state::AppState;
+    use crate::state::{AppState, SweepPhase, SweepStatus};
 
     const RUNNABLE: &str = "\
 version: 2
@@ -135,6 +138,7 @@ scenarios:
 
         let mut state = AppState::new();
         state.catalog_dir = Some(Arc::new(dir.path().to_path_buf()));
+        state.sweep_status = Arc::new(SweepStatus::in_progress(entries.len()));
         (dir, entries, state)
     }
 
@@ -152,6 +156,17 @@ scenarios:
     }
 
     #[tokio::test]
+    async fn a_completed_sweep_reports_finished_with_its_counts() {
+        let (_dir, entries, state) = catalog_with_one_runnable();
+
+        start_entries(&state, &entries, &CancellationToken::new()).await;
+
+        let snap = state.sweep_status.snapshot();
+        assert_eq!(snap.phase, SweepPhase::Finished);
+        assert_eq!((snap.started, snap.expected), (1, 1));
+    }
+
+    #[tokio::test]
     async fn cancelled_sweep_admits_nothing() {
         let (_dir, entries, state) = catalog_with_one_runnable();
         let cancel = CancellationToken::new();
@@ -160,5 +175,16 @@ scenarios:
         start_entries(&state, &entries, &cancel).await;
 
         assert_eq!(admitted(&state), 0);
+    }
+
+    #[tokio::test]
+    async fn a_cancelled_sweep_never_reports_itself_finished() {
+        let (_dir, entries, state) = catalog_with_one_runnable();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        start_entries(&state, &entries, &cancel).await;
+
+        assert_eq!(state.sweep_status.snapshot().phase, SweepPhase::InProgress);
     }
 }

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -25,10 +25,10 @@ use anyhow::Context;
 use clap::Parser;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::routes::RouterConfig;
-use crate::state::AppState;
+use crate::state::{AppState, SweepStatus};
 
 /// Subcommands the dispatch shim forwards to the sibling `sonda` binary.
 /// Mirror of `sonda`'s clap definition.
@@ -52,8 +52,8 @@ struct Args {
     /// API key for bearer-token authentication on `/scenarios/*`, `/events`, `/metrics`, and `/scenarios/metrics` endpoints.
     ///
     /// When set, requests to these endpoints must include an
-    /// `Authorization: Bearer <key>` header. The `/health` endpoint remains
-    /// public regardless of this setting.
+    /// `Authorization: Bearer <key>` header. The `/health` and `/ready`
+    /// endpoints remain public regardless of this setting.
     ///
     /// Can also be set via the `SONDA_API_KEY` environment variable.
     #[arg(long, env = "SONDA_API_KEY")]
@@ -191,6 +191,12 @@ async fn run(args: Args, workers: usize, max_inflight_requests: usize) -> anyhow
         _ => Vec::new(),
     };
 
+    let sweep_status = Arc::new(if args.autostart {
+        SweepStatus::in_progress(autostart_entries.len())
+    } else {
+        SweepStatus::not_configured()
+    });
+
     let permits = if args.max_scenarios == 0 {
         warn!("--max-scenarios 0 — scenario row cap disabled (unlimited)");
         Semaphore::new(Semaphore::MAX_PERMITS)
@@ -211,6 +217,7 @@ async fn run(args: Args, workers: usize, max_inflight_requests: usize) -> anyhow
             HashMap::<crate::state::RouteKey, AtomicU64>::new(),
         )),
         request_histograms: Arc::new(RwLock::new(HashMap::new())),
+        sweep_status,
     };
 
     let inflight_semaphore = Arc::new(Semaphore::new(max_inflight_requests));
@@ -239,10 +246,11 @@ async fn run(args: Args, workers: usize, max_inflight_requests: usize) -> anyhow
 
     let sweep_cancel = CancellationToken::new();
     let sweep = args.autostart.then(|| {
-        let state = state.clone();
+        let sweep_state = state.clone();
         let cancel = sweep_cancel.clone();
-        tokio::spawn(
-            async move { autostart::start_entries(&state, &autostart_entries, &cancel).await },
+        spawn_supervised_sweep(
+            async move { autostart::start_entries(&sweep_state, &autostart_entries, &cancel).await },
+            state.sweep_status.clone(),
         )
     });
 
@@ -259,6 +267,24 @@ async fn run(args: Args, workers: usize, max_inflight_requests: usize) -> anyhow
 
     info!("sonda-server shut down cleanly");
     Ok(())
+}
+
+/// Run the sweep under a task that observes how it ended. The returned handle is
+/// the supervisor's: awaiting it joins the sweep and its outcome report.
+fn spawn_supervised_sweep<F>(sweep: F, status: Arc<SweepStatus>) -> tokio::task::JoinHandle<()>
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    let sweeping = tokio::spawn(sweep);
+    tokio::spawn(report_sweep_outcome(sweeping, status))
+}
+
+/// Report a sweep that ended without finishing when it happens, not at shutdown.
+async fn report_sweep_outcome(sweeping: tokio::task::JoinHandle<()>, status: Arc<SweepStatus>) {
+    if let Err(error) = sweeping.await {
+        status.fail();
+        error!(%error, "autostart: sweep ended without finishing — the catalog entries it had not reached will not be started");
+    }
 }
 
 /// If `argv[1]` is a sonda subcommand, exec the sibling `sonda` binary and
@@ -345,9 +371,9 @@ async fn shutdown_signal(
 
     sweep_cancel.cancel();
     if let Some(sweep) = sweep {
-        if let Err(e) = sweep.await {
-            warn!(error = %e, "autostart sweep did not finish cleanly");
-        }
+        // report_sweep_outcome already reported anything worth reporting; this join
+        // only orders the sweep ahead of the drain.
+        let _ = sweep.await;
     }
 
     if let Ok(scenarios) = state.scenarios.read() {
@@ -422,6 +448,73 @@ mod tests {
             sorted.len(),
             "SONDA_SUBCOMMANDS contains duplicates"
         );
+    }
+
+    #[tokio::test]
+    async fn a_spawned_sweep_that_panics_is_reported_as_failed_without_waiting_for_shutdown() {
+        let status = Arc::new(SweepStatus::in_progress(3));
+
+        spawn_supervised_sweep(async { panic!("sweep exploded") }, Arc::clone(&status))
+            .await
+            .expect("the supervisor must not panic with the sweep");
+
+        assert_eq!(status.snapshot().phase, crate::state::SweepPhase::Failed);
+    }
+
+    #[tokio::test]
+    async fn a_spawned_sweep_that_finishes_stays_ready() {
+        let status = Arc::new(SweepStatus::in_progress(1));
+        let sweep_status = Arc::clone(&status);
+
+        spawn_supervised_sweep(
+            async move {
+                sweep_status.record_started();
+                sweep_status.finish();
+            },
+            Arc::clone(&status),
+        )
+        .await
+        .expect("the supervisor must not panic");
+
+        let snap = status.snapshot();
+        assert_eq!(snap.phase, crate::state::SweepPhase::Finished);
+        assert_eq!((snap.started, snap.expected), (1, 1));
+    }
+
+    #[tokio::test]
+    async fn a_panicking_sweep_is_reported_as_failed_without_waiting_for_shutdown() {
+        let status = Arc::new(SweepStatus::in_progress(3));
+        status.record_started();
+        let sweeping = tokio::spawn(async { panic!("sweep exploded") });
+
+        report_sweep_outcome(sweeping, Arc::clone(&status)).await;
+
+        let snap = status.snapshot();
+        assert_eq!(snap.phase, crate::state::SweepPhase::Failed);
+        assert!(!snap.phase.is_ready());
+        assert_eq!((snap.started, snap.expected), (1, 3));
+    }
+
+    #[tokio::test]
+    async fn an_aborted_sweep_is_reported_as_failed() {
+        let status = Arc::new(SweepStatus::in_progress(3));
+        let sweeping = tokio::spawn(std::future::pending::<()>());
+        sweeping.abort();
+
+        report_sweep_outcome(sweeping, Arc::clone(&status)).await;
+
+        assert_eq!(status.snapshot().phase, crate::state::SweepPhase::Failed);
+    }
+
+    #[tokio::test]
+    async fn a_sweep_that_returns_normally_keeps_the_status_it_set_itself() {
+        let status = Arc::new(SweepStatus::in_progress(3));
+        let sweep_status = Arc::clone(&status);
+        let sweeping = tokio::spawn(async move { sweep_status.finish() });
+
+        report_sweep_outcome(sweeping, Arc::clone(&status)).await;
+
+        assert_eq!(status.snapshot().phase, crate::state::SweepPhase::Finished);
     }
 
     #[test]

--- a/sonda-server/src/routes/health.rs
+++ b/sonda-server/src/routes/health.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 
 /// `GET /health` — returns `{"status": "ok"}` with HTTP 200.
 ///
-/// Used by load balancers and readiness probes to confirm the server is up.
+/// Liveness only — it reads no state. Readiness lives on `/ready`.
 pub async fn health() -> Json<Value> {
     Json(json!({ "status": "ok" }))
 }

--- a/sonda-server/src/routes/metrics.rs
+++ b/sonda-server/src/routes/metrics.rs
@@ -20,6 +20,7 @@ pub async fn get_metrics(State(state): State<AppState>) -> Result<Response, Resp
     write_scenarios_finished_total(&state, &mut buf).map_err(internal)?;
     write_worker_threads(&state, &mut buf).map_err(internal)?;
     write_max_scenarios(&state, &mut buf).map_err(internal)?;
+    write_autostart_progress(&state, &mut buf).map_err(internal)?;
     write_requests_total(&state, &mut buf).map_err(internal)?;
     write_request_duration_seconds(&state, &mut buf).map_err(internal)?;
     write_sink_errors_total(&state, &mut buf).map_err(internal)?;
@@ -115,6 +116,22 @@ fn write_max_scenarios(state: &AppState, buf: &mut String) -> std::fmt::Result {
     )?;
     writeln!(buf, "# TYPE sonda_server_max_scenarios gauge")?;
     writeln!(buf, "sonda_server_max_scenarios {}", state.max_scenarios)
+}
+
+fn write_autostart_progress(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    let sweep = state.sweep_status.snapshot();
+    writeln!(
+        buf,
+        "# HELP sonda_server_autostart_started Catalog entries the startup sweep has started."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_autostart_started gauge")?;
+    writeln!(buf, "sonda_server_autostart_started {}", sweep.started)?;
+    writeln!(
+        buf,
+        "# HELP sonda_server_autostart_expected Runnable catalog entries the startup sweep set out to start."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_autostart_expected gauge")?;
+    writeln!(buf, "sonda_server_autostart_expected {}", sweep.expected)
 }
 
 fn write_requests_total(state: &AppState, buf: &mut String) -> std::fmt::Result {
@@ -266,6 +283,32 @@ fn escape_label(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn autostart_progress_reports_started_and_expected() {
+        let mut state = AppState::new();
+        let status = crate::state::SweepStatus::in_progress(4);
+        status.record_started();
+        status.finish();
+        state.sweep_status = std::sync::Arc::new(status);
+
+        let mut buf = String::new();
+        write_autostart_progress(&state, &mut buf).expect("write must succeed");
+
+        assert!(buf.contains("# TYPE sonda_server_autostart_started gauge"));
+        assert!(buf.contains("\nsonda_server_autostart_started 1\n"));
+        assert!(buf.contains("# TYPE sonda_server_autostart_expected gauge"));
+        assert!(buf.contains("\nsonda_server_autostart_expected 4\n"));
+    }
+
+    #[test]
+    fn autostart_progress_is_zeroed_when_autostart_is_off() {
+        let mut buf = String::new();
+        write_autostart_progress(&AppState::new(), &mut buf).expect("write must succeed");
+
+        assert!(buf.contains("\nsonda_server_autostart_started 0\n"));
+        assert!(buf.contains("\nsonda_server_autostart_expected 0\n"));
+    }
 
     #[test]
     fn escape_label_handles_backslash_quote_and_newline() {

--- a/sonda-server/src/routes/mod.rs
+++ b/sonda-server/src/routes/mod.rs
@@ -3,6 +3,7 @@
 pub mod events;
 pub mod health;
 pub mod metrics;
+pub mod ready;
 pub mod scenarios;
 pub mod sink_warnings;
 
@@ -47,7 +48,9 @@ pub fn router(state: AppState) -> Router {
 }
 
 pub fn router_with_config(state: AppState, cfg: RouterConfig) -> Router {
-    let public = Router::new().route("/health", get(health::health));
+    let public = Router::new()
+        .route("/health", get(health::health))
+        .route("/ready", get(ready::ready));
 
     let protected_observability = Router::new()
         .route("/scenarios/{id}/stats", get(scenarios::get_scenario_stats))
@@ -313,6 +316,22 @@ mod tests {
             response.status(),
             StatusCode::OK,
             "GET /health must return 200 even when auth is enabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_enabled_ready_remains_public() {
+        let app = test_router_with_key("secret");
+        let request = Request::builder()
+            .uri("/ready")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "GET /ready must answer without a bearer token"
         );
     }
 

--- a/sonda-server/src/routes/ready.rs
+++ b/sonda-server/src/routes/ready.rs
@@ -1,0 +1,144 @@
+//! Readiness endpoint.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json, Response};
+use serde_json::json;
+
+use crate::state::AppState;
+
+/// `GET /ready` — 200 once the startup sweep has nothing left to start, 503 while
+/// it is still running or after it failed.
+pub async fn ready(State(state): State<AppState>) -> Response {
+    let sweep = state.sweep_status.snapshot();
+    let status = if sweep.phase.is_ready() {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    (
+        status,
+        Json(json!({
+            "status": sweep.phase.as_str(),
+            "autostart_started": sweep.started,
+            "autostart_expected": sweep.expected,
+        })),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::SweepStatus;
+    use http_body_util::BodyExt;
+    use std::sync::Arc;
+
+    async fn probe(status: SweepStatus) -> (StatusCode, serde_json::Value) {
+        let mut state = AppState::new();
+        state.sweep_status = Arc::new(status);
+        let response = ready(State(state)).await;
+        let code = response.status();
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("body must collect")
+            .to_bytes();
+        (
+            code,
+            serde_json::from_slice(&bytes).expect("body must be JSON"),
+        )
+    }
+
+    #[tokio::test]
+    async fn no_autostart_is_ready() {
+        let (code, body) = probe(SweepStatus::not_configured()).await;
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(
+            body,
+            json!({
+                "status": "not_configured",
+                "autostart_started": 0,
+                "autostart_expected": 0,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn a_running_sweep_is_not_ready() {
+        let status = SweepStatus::in_progress(12);
+        status.record_started();
+
+        let (code, body) = probe(status).await;
+
+        assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            body,
+            json!({
+                "status": "in_progress",
+                "autostart_started": 1,
+                "autostart_expected": 12,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn a_finished_sweep_is_ready() {
+        let status = SweepStatus::in_progress(2);
+        status.record_started();
+        status.record_started();
+        status.finish();
+
+        let (code, body) = probe(status).await;
+
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(
+            body,
+            json!({
+                "status": "finished",
+                "autostart_started": 2,
+                "autostart_expected": 2,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn a_sweep_that_skipped_entries_is_still_ready() {
+        let status = SweepStatus::in_progress(12);
+        status.record_started();
+        status.finish();
+
+        let (code, body) = probe(status).await;
+
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(
+            body,
+            json!({
+                "status": "finished",
+                "autostart_started": 1,
+                "autostart_expected": 12,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_sweep_is_not_ready() {
+        let status = SweepStatus::in_progress(4);
+        status.record_started();
+        status.fail();
+
+        let (code, body) = probe(status).await;
+
+        assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            body,
+            json!({
+                "status": "failed",
+                "autostart_started": 1,
+                "autostart_expected": 4,
+            })
+        );
+    }
+}

--- a/sonda-server/src/state.rs
+++ b/sonda-server/src/state.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
@@ -96,6 +96,104 @@ pub struct HistogramSnapshot {
     pub count: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SweepPhase {
+    NotConfigured,
+    InProgress,
+    Finished,
+    Failed,
+}
+
+impl SweepPhase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SweepPhase::NotConfigured => "not_configured",
+            SweepPhase::InProgress => "in_progress",
+            SweepPhase::Finished => "finished",
+            SweepPhase::Failed => "failed",
+        }
+    }
+
+    pub fn is_ready(self) -> bool {
+        matches!(self, SweepPhase::NotConfigured | SweepPhase::Finished)
+    }
+
+    fn code(self) -> u8 {
+        match self {
+            SweepPhase::NotConfigured => 0,
+            SweepPhase::InProgress => 1,
+            SweepPhase::Finished => 2,
+            SweepPhase::Failed => 3,
+        }
+    }
+
+    fn from_code(code: u8) -> Self {
+        match code {
+            0 => SweepPhase::NotConfigured,
+            1 => SweepPhase::InProgress,
+            2 => SweepPhase::Finished,
+            _ => SweepPhase::Failed,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SweepSnapshot {
+    pub phase: SweepPhase,
+    pub started: usize,
+    pub expected: usize,
+}
+
+/// Progress of the `--autostart` catalog sweep. `expected` is fixed when the catalog
+/// is enumerated, before the listener binds, so probes never read a zero denominator.
+pub struct SweepStatus {
+    phase: AtomicU8,
+    started: AtomicUsize,
+    expected: usize,
+}
+
+impl SweepStatus {
+    pub fn not_configured() -> Self {
+        Self {
+            phase: AtomicU8::new(SweepPhase::NotConfigured.code()),
+            started: AtomicUsize::new(0),
+            expected: 0,
+        }
+    }
+
+    pub fn in_progress(expected: usize) -> Self {
+        Self {
+            phase: AtomicU8::new(SweepPhase::InProgress.code()),
+            started: AtomicUsize::new(0),
+            expected,
+        }
+    }
+
+    pub fn record_started(&self) {
+        self.started.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn finish(&self) {
+        self.phase
+            .store(SweepPhase::Finished.code(), Ordering::Release);
+    }
+
+    pub fn fail(&self) {
+        self.phase
+            .store(SweepPhase::Failed.code(), Ordering::Release);
+    }
+
+    pub fn snapshot(&self) -> SweepSnapshot {
+        // Acquire pairs with finish()'s Release: seeing Finished implies the final count.
+        let phase = SweepPhase::from_code(self.phase.load(Ordering::Acquire));
+        SweepSnapshot {
+            phase,
+            started: self.started.load(Ordering::Relaxed),
+            expected: self.expected,
+        }
+    }
+}
+
 /// Shared application state for the HTTP server.
 ///
 /// Holds a map of running [`ScenarioHandle`]s keyed by scenario ID, the
@@ -128,6 +226,8 @@ pub struct AppState {
     pub request_counters: Arc<RwLock<HashMap<RouteKey, AtomicU64>>>,
     /// Per-`(route, method)` duration histograms.
     pub request_histograms: Arc<RwLock<HashMap<HistogramKey, HistogramShard>>>,
+    /// Progress of the `--autostart` catalog sweep.
+    pub sweep_status: Arc<SweepStatus>,
 }
 
 impl AppState {
@@ -144,6 +244,7 @@ impl AppState {
             max_scenarios: 0,
             request_counters: Arc::new(RwLock::new(HashMap::new())),
             request_histograms: Arc::new(RwLock::new(HashMap::new())),
+            sweep_status: Arc::new(SweepStatus::not_configured()),
         }
     }
 
@@ -161,6 +262,7 @@ impl AppState {
             max_scenarios: 0,
             request_counters: Arc::new(RwLock::new(HashMap::new())),
             request_histograms: Arc::new(RwLock::new(HashMap::new())),
+            sweep_status: Arc::new(SweepStatus::not_configured()),
         }
     }
 }
@@ -324,6 +426,83 @@ mod tests {
         let after = Instant::now();
         assert!(state.started_at >= before);
         assert!(state.started_at <= after);
+    }
+
+    #[test]
+    fn not_configured_status_is_ready_with_zero_counts() {
+        let snap = SweepStatus::not_configured().snapshot();
+        assert_eq!(snap.phase, SweepPhase::NotConfigured);
+        assert!(snap.phase.is_ready());
+        assert_eq!((snap.started, snap.expected), (0, 0));
+    }
+
+    #[test]
+    fn in_progress_status_carries_the_expected_count_before_anything_starts() {
+        let snap = SweepStatus::in_progress(12).snapshot();
+        assert_eq!(snap.phase, SweepPhase::InProgress);
+        assert!(!snap.phase.is_ready());
+        assert_eq!((snap.started, snap.expected), (0, 12));
+    }
+
+    #[test]
+    fn record_started_counts_up_to_finish() {
+        let status = SweepStatus::in_progress(3);
+        status.record_started();
+        status.record_started();
+        status.finish();
+
+        let snap = status.snapshot();
+        assert_eq!(snap.phase, SweepPhase::Finished);
+        assert!(snap.phase.is_ready());
+        assert_eq!((snap.started, snap.expected), (2, 3));
+    }
+
+    #[test]
+    fn a_failed_sweep_is_not_ready_and_keeps_its_counts() {
+        let status = SweepStatus::in_progress(4);
+        status.record_started();
+        status.fail();
+
+        let snap = status.snapshot();
+        assert_eq!(snap.phase, SweepPhase::Failed);
+        assert!(!snap.phase.is_ready());
+        assert_eq!((snap.started, snap.expected), (1, 4));
+    }
+
+    #[test]
+    fn phase_labels_are_stable() {
+        assert_eq!(SweepPhase::NotConfigured.as_str(), "not_configured");
+        assert_eq!(SweepPhase::InProgress.as_str(), "in_progress");
+        assert_eq!(SweepPhase::Finished.as_str(), "finished");
+        assert_eq!(SweepPhase::Failed.as_str(), "failed");
+    }
+
+    #[test]
+    fn phase_codes_round_trip() {
+        for phase in [
+            SweepPhase::NotConfigured,
+            SweepPhase::InProgress,
+            SweepPhase::Finished,
+            SweepPhase::Failed,
+        ] {
+            assert_eq!(SweepPhase::from_code(phase.code()), phase);
+        }
+    }
+
+    #[test]
+    fn new_state_reports_no_autostart_sweep() {
+        assert_eq!(
+            AppState::new().sweep_status.snapshot().phase,
+            SweepPhase::NotConfigured
+        );
+    }
+
+    #[test]
+    fn clone_shares_the_same_sweep_status() {
+        let state = AppState::new();
+        let clone = state.clone();
+        state.sweep_status.record_started();
+        assert_eq!(clone.sweep_status.snapshot().started, 1);
     }
 
     #[test]

--- a/sonda-server/tests/bounded_scheduler.rs
+++ b/sonda-server/tests/bounded_scheduler.rs
@@ -263,7 +263,7 @@ fn max_scenarios_zero_allows_unlimited_posts() {
 }
 
 #[test]
-fn server_metrics_emits_all_nine_series_with_zero_state_rows() {
+fn server_metrics_emits_all_eleven_series_with_zero_state_rows() {
     let (port, _guard) = common::start_server();
     let client = common::http_client();
     let base = format!("http://127.0.0.1:{port}");
@@ -280,6 +280,8 @@ fn server_metrics_emits_all_nine_series_with_zero_state_rows() {
         "sonda_server_scenarios_finished_total",
         "sonda_server_worker_threads",
         "sonda_server_max_scenarios",
+        "sonda_server_autostart_started",
+        "sonda_server_autostart_expected",
         "sonda_server_requests_total",
         "sonda_server_request_duration_seconds",
         "sonda_server_sink_errors_total",
@@ -299,6 +301,12 @@ fn server_metrics_emits_all_nine_series_with_zero_state_rows() {
             "expected zero-row `{needle}`. Got:\n{text}"
         );
     }
+
+    assert_eq!(
+        text.matches("# TYPE ").count(),
+        11,
+        "a series was added or removed — update the list above and the count. Got:\n{text}"
+    );
 }
 
 #[test]

--- a/sonda-server/tests/ready.rs
+++ b/sonda-server/tests/ready.rs
@@ -1,0 +1,270 @@
+//! E2E tests for `GET /ready`: the readiness signal that reports whether the
+//! `--autostart` sweep has anything left to start.
+
+mod common;
+
+use std::path::Path;
+use std::time::Duration;
+
+use common::{http_client, spawn_server_tailed, start_server, start_server_with};
+use tempfile::TempDir;
+
+const SWEEP_SUMMARY: &str = "runnable catalog entries";
+const SWEEP_TIMEOUT: Duration = Duration::from_secs(30);
+
+const UNCOMPILABLE: &str = "\
+version: 2
+kind: runnable
+scenario_name: broken
+defaults:
+  rate: 1
+  duration: 300s
+scenarios:
+  - signal_type: metrics
+    name: broken_metric
+    generator:
+      type: no_such_generator
+";
+
+fn runnable(scenario_name: &str) -> String {
+    format!(
+        "version: 2
+kind: runnable
+scenario_name: {scenario_name}
+defaults:
+  rate: 1
+  duration: 300s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: memory
+scenarios:
+  - signal_type: metrics
+    name: {scenario_name}_cpu
+    generator:
+      type: constant
+      value: 1.0
+"
+    )
+}
+
+fn catalog_with(files: &[(String, String)]) -> TempDir {
+    let dir = TempDir::new().expect("must create temp catalog dir");
+    for (name, contents) in files {
+        std::fs::write(dir.path().join(name), contents).expect("must write catalog file");
+    }
+    dir
+}
+
+fn catalog_of(entries: usize) -> TempDir {
+    let files: Vec<(String, String)> = (0..entries)
+        .map(|i| (format!("e{i:03}.yaml"), runnable(&format!("e{i:03}"))))
+        .collect();
+    catalog_with(&files)
+}
+
+fn dir_arg(catalog: &TempDir) -> &str {
+    catalog.path().to_str().expect("utf-8 temp path")
+}
+
+#[derive(Debug)]
+struct Probe {
+    status: u16,
+    body: serde_json::Value,
+}
+
+fn probe_ready(client: &reqwest::blocking::Client, port: u16) -> Probe {
+    let response = client
+        .get(format!("http://127.0.0.1:{port}/ready"))
+        .send()
+        .expect("GET /ready must succeed");
+    Probe {
+        status: response.status().as_u16(),
+        body: response.json().expect("GET /ready must return JSON"),
+    }
+}
+
+fn health_status(client: &reqwest::blocking::Client, port: u16) -> u16 {
+    client
+        .get(format!("http://127.0.0.1:{port}/health"))
+        .send()
+        .expect("GET /health must succeed")
+        .status()
+        .as_u16()
+}
+
+fn scrape(client: &reqwest::blocking::Client, port: u16) -> String {
+    client
+        .get(format!("http://127.0.0.1:{port}/metrics"))
+        .send()
+        .expect("GET /metrics must succeed")
+        .text()
+        .expect("GET /metrics must return a body")
+}
+
+/// Start the server on `catalog` with `--autostart` and wait for the sweep summary.
+fn swept_server(catalog: &Path) -> (u16, std::process::Child, common::StderrTail) {
+    let (port, child, tail) = spawn_server_tailed(
+        &[
+            "--catalog",
+            catalog.to_str().expect("utf-8 temp path"),
+            "--autostart",
+        ],
+        &[("RUST_LOG", "sonda_server=info")],
+    );
+    assert!(
+        tail.wait_for(SWEEP_SUMMARY, SWEEP_TIMEOUT),
+        "the sweep never reported a summary: {}",
+        tail.text()
+    );
+    (port, child, tail)
+}
+
+#[test]
+fn a_server_with_no_catalog_is_ready_at_once() {
+    let (port, _guard) = start_server();
+
+    let probe = probe_ready(&http_client(), port);
+
+    assert_eq!(probe.status, 200, "got {probe:?}");
+    assert_eq!(probe.body["status"], "not_configured");
+    assert_eq!(probe.body["autostart_started"], 0);
+    assert_eq!(probe.body["autostart_expected"], 0);
+}
+
+#[test]
+fn a_catalog_without_autostart_is_ready_at_once() {
+    let catalog = catalog_of(3);
+    let (port, _guard) = start_server_with(&["--catalog", dir_arg(&catalog)], &[]);
+
+    let probe = probe_ready(&http_client(), port);
+
+    assert_eq!(probe.status, 200, "got {probe:?}");
+    assert_eq!(probe.body["status"], "not_configured");
+    assert_eq!(
+        probe.body["autostart_expected"], 0,
+        "nothing is expected when the catalog is only there for pack: refs"
+    );
+}
+
+#[test]
+fn ready_is_503_while_the_sweep_runs_and_200_once_it_finishes() {
+    const ENTRIES: usize = 500;
+    let catalog = catalog_of(ENTRIES);
+    let client = http_client();
+    let (port, mut child, tail) = spawn_server_tailed(
+        &["--catalog", dir_arg(&catalog), "--autostart"],
+        &[("RUST_LOG", "sonda_server=info")],
+    );
+
+    let during = probe_ready(&client, port);
+    let health_during = health_status(&client, port);
+    let swept = tail.wait_for(SWEEP_SUMMARY, SWEEP_TIMEOUT);
+    let after = probe_ready(&client, port);
+    let health_after = health_status(&client, port);
+
+    child.kill().expect("must kill sonda-server");
+    child.wait().expect("must reap sonda-server");
+    let stderr = tail.finish();
+
+    assert!(swept, "the sweep never finished: {stderr}");
+    assert_eq!(
+        during.body["autostart_expected"], ENTRIES,
+        "the denominator must be known before the listener binds, not filled in later: {during:?}"
+    );
+    assert_eq!(
+        during.status, 503,
+        "the first request landed after the sweep had already finished — check whether the \
+         summary line precedes it in the log: {during:?}\n{stderr}"
+    );
+    assert_eq!(during.body["status"], "in_progress");
+    assert!(
+        during.body["autostart_started"]
+            .as_u64()
+            .expect("autostart_started must be a number")
+            <= ENTRIES as u64,
+        "the sweep starts each entry at most once, so it can never overshoot its own \
+         denominator: {during:?}"
+    );
+    assert_eq!(
+        health_during, 200,
+        "/health is the liveness signal: it answers while the sweep is still running"
+    );
+
+    assert_eq!(after.status, 200, "got {after:?}\n{stderr}");
+    assert_eq!(after.body["status"], "finished");
+    assert_eq!(after.body["autostart_started"], ENTRIES);
+    assert_eq!(after.body["autostart_expected"], ENTRIES);
+    assert_eq!(health_after, 200);
+}
+
+#[test]
+fn a_sweep_that_skipped_a_bad_file_is_still_ready() {
+    let catalog = catalog_with(&[
+        ("alpha.yaml".to_string(), runnable("alpha")),
+        ("broken.yaml".to_string(), UNCOMPILABLE.to_string()),
+    ]);
+    let (port, mut child, tail) = swept_server(catalog.path());
+
+    let probe = probe_ready(&http_client(), port);
+
+    child.kill().expect("must kill sonda-server");
+    child.wait().expect("must reap sonda-server");
+    let stderr = tail.finish();
+
+    assert_eq!(
+        probe.status, 200,
+        "one file that does not compile must not pull the whole server out of service: \
+         {probe:?}\n{stderr}"
+    );
+    assert_eq!(probe.body["status"], "finished");
+    assert_eq!(probe.body["autostart_started"], 1);
+    assert_eq!(
+        probe.body["autostart_expected"], 2,
+        "the gap between started and expected is what reports the skip"
+    );
+}
+
+#[test]
+fn metrics_report_what_the_sweep_started_and_what_it_expected() {
+    let catalog = catalog_with(&[
+        ("alpha.yaml".to_string(), runnable("alpha")),
+        ("broken.yaml".to_string(), UNCOMPILABLE.to_string()),
+    ]);
+    let (port, mut child, tail) = swept_server(catalog.path());
+
+    let text = scrape(&http_client(), port);
+
+    child.kill().expect("must kill sonda-server");
+    child.wait().expect("must reap sonda-server");
+    let stderr = tail.finish();
+
+    for line in [
+        "# TYPE sonda_server_autostart_started gauge",
+        "sonda_server_autostart_started 1",
+        "# TYPE sonda_server_autostart_expected gauge",
+        "sonda_server_autostart_expected 2",
+    ] {
+        assert!(
+            text.contains(line),
+            "/metrics must contain `{line}`. Got:\n{text}\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn metrics_report_zero_autostart_counts_when_autostart_is_off() {
+    let (port, _guard) = start_server();
+
+    let text = scrape(&http_client(), port);
+
+    for line in [
+        "sonda_server_autostart_started 0",
+        "sonda_server_autostart_expected 0",
+    ] {
+        assert!(
+            text.contains(line),
+            "/metrics must contain `{line}`. Got:\n{text}"
+        );
+    }
+}


### PR DESCRIPTION
`/health` is a static handler that reads no state, and the chart wired it to both probes — so a pod reported Ready while the autostart sweep was still starting entries, and kept reporting Ready if the sweep died. `/ready` answers from the sweep instead: 503 while it runs or after it fails, 200 once there is nothing left to start. `/health` is unchanged and stays the liveness signal.

- `GET /ready` on the public router, unauthenticated like `/health`, and outside the concurrency and timeout layers so it still answers under saturation
- sweep status is fixed pre-bind from the catalog count, so `autostart_expected` is honest on the very first request rather than filling in later
- a sweep that finished but skipped entries is **ready** — failing readiness over one bad file would take the whole pod out of the Service, and on a node drain every pod would come back NotReady at once
- a panicking sweep is reported when it happens rather than at shutdown, and moves `/ready` to 503; that phase is terminal and the docs say so plainly
- `sonda_server_autostart_started` / `_expected`, documented with the alert for the case where `expected` is 0 and the obvious comparison cannot fire
- chart puts liveness on `/health` and readiness on `/ready`; a release that does not set `server.autostart` is Ready immediately, so the probe change is safe to upgrade into

Docker gets a host-side readiness wait rather than a Compose `healthcheck:` — the published image is `FROM scratch`, so nothing in it can run an in-container check.

Refs: #593