### PR TITLE
fix(server): contain a panic to the operation that panicked

### DIFF
--- a/docs/site/docs/deploy/http-api.md
+++ b/docs/site/docs/deploy/http-api.md
@@ -1075,7 +1075,7 @@ scrape_configs:
 ## Where to next
 
 - [Deploy as a server](server.md) — install, configure, network, and operate the server itself.
-- [Server metrics](server-metrics.md) — the eleven `/metrics` series and the alerts that matter.
+- [Server metrics](server-metrics.md) — the twelve `/metrics` series and the alerts that matter.
 - [Scenario file format](../build/scenario-files.md) — what to put in the body of `POST /scenarios`.
 - [Encoders](../build/encoders.md) and [Sinks](../build/sinks.md) — every encoder/sink option you can declare in a posted body.
 - [Cross-POST `while:` refs (YAML schema)](../build/scenario-files.md#cross-post-while-refs) — the file-side counterpart to the HTTP cross-POST surface.

--- a/docs/site/docs/deploy/kubernetes.md
+++ b/docs/site/docs/deploy/kubernetes.md
@@ -324,7 +324,7 @@ With `server.autostart` enabled, `kubectl rollout status` therefore completes wh
     A sweep that finished but skipped a file still reports ready, so the pod goes into service and the rollout succeeds. That is deliberate. One bad file in a twelve-file ConfigMap must not pull the whole pod out of service. On a node drain, the same rule stops every pod coming back NotReady at once. The counts on [`GET /ready`](server.md#health-and-readiness) and on [`sonda_server_autostart_started`](server-metrics.md#sonda_server_autostart_started) are what surface the skip. This holds when every file is broken too: the pod is Ready with nothing running. Alert on the counts rather than relying on the rollout to fail.
 
 !!! warning "A failed sweep is terminal — the pod stays NotReady and is never restarted"
-    `/ready` reports `status: failed` and keeps answering 503 for the life of the process, so the pod never rejoins the Service. It is not restarted either: the process is alive, so the liveness probe on `/health` keeps passing by design. The pod needs a human. Read the `ERROR` line in the log, then `kubectl delete pod` to start a fresh sweep. Alert on it with [`sonda_server_autostart_started`](server-metrics.md#sonda_server_autostart_started), since a pod that is permanently NotReady is otherwise quiet.
+    A single bad file does not get you here — those are skipped, including one that panics on its way in. `failed` means the sweep itself died. `/ready` then reports `status: failed` and keeps answering 503 for the life of the process, so the pod never rejoins the Service. It is not restarted either: the process is alive, so the liveness probe on `/health` keeps passing by design. The pod needs a human. Read the `ERROR` line in the log, then `kubectl delete pod` to start a fresh sweep. Alert on it with [`sonda_server_autostart_started`](server-metrics.md#sonda_server_autostart_started), since a pod that is permanently NotReady is otherwise quiet.
 
 ## Accessing the server
 
@@ -375,7 +375,7 @@ For example, a Prometheus instance in the same namespace can scrape
 | `GET /scenarios/metrics` | Aggregate scenario data | Per-process scenario view |
 | `GET /metrics` | Server-process RED + saturation | Operational dashboards and alerts |
 
-`GET /scenarios/metrics` and `GET /scenarios/{id}/metrics` are idempotent snapshots — one sample per `(name, labels)` series with no timestamp, like a `node_exporter` scrape. `GET /metrics` returns the server's own RED and saturation telemetry — see [Server metrics](server-metrics.md) for the eleven series and the alerts that go with them. Most Prometheus setups want a job per endpoint; the aggregate `/scenarios/metrics` covers every scenario and you do not need to know scenario IDs in advance. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape) for the `?label=k:v` AND-filter syntax.
+`GET /scenarios/metrics` and `GET /scenarios/{id}/metrics` are idempotent snapshots — one sample per `(name, labels)` series with no timestamp, like a `node_exporter` scrape. `GET /metrics` returns the server's own RED and saturation telemetry — see [Server metrics](server-metrics.md) for the twelve series and the alerts that go with them. Most Prometheus setups want a job per endpoint; the aggregate `/scenarios/metrics` covers every scenario and you do not need to know scenario IDs in advance. See [Aggregate Prometheus scrape](http-api.md#aggregate-prometheus-scrape) for the `?label=k:v` AND-filter syntax.
 
 ### Aggregate scrape config
 
@@ -620,6 +620,6 @@ Add `-n <namespace>` if you installed into a non-default namespace.
 
 - [Synthetic Monitoring guide](../test/synthetic-monitoring.md) -- deploy Sonda on Kubernetes, submit long-running scenarios, scrape with Prometheus, and build Grafana dashboards
 - [Server API](server.md) -- full endpoint reference for `sonda-server`
-- [Server metrics](server-metrics.md) -- the eleven `/metrics` series and the PromQL alerts that matter
+- [Server metrics](server-metrics.md) -- the twelve `/metrics` series and the PromQL alerts that matter
 - [Docker](docker.md) -- Docker image and Compose stacks for local development
 - [Scenario Fields](../reference/scenario-fields.md) -- full YAML schema for scenario configuration

--- a/docs/site/docs/deploy/server-metrics.md
+++ b/docs/site/docs/deploy/server-metrics.md
@@ -1,6 +1,6 @@
 ---
 title: Server metrics
-description: Three Prometheus endpoints on sonda-server, the eleven /metrics series, and PromQL alerts for the load-bearing ones.
+description: Three Prometheus endpoints on sonda-server, the twelve /metrics series, and PromQL alerts for the load-bearing ones.
 ---
 
 # Server metrics
@@ -59,6 +59,14 @@ sonda_server_request_duration_seconds_count{route="/scenarios",method="POST"} 14
 # HELP sonda_server_sink_errors_total Lifetime sink-write failures, summed across scenarios per sink_type.
 # TYPE sonda_server_sink_errors_total counter
 sonda_server_sink_errors_total{sink_type="loki"} 4
+# HELP sonda_server_lock_recoveries_total Poisoned shared-state locks recovered, per lock. Non-zero means a handler panicked while holding it.
+# TYPE sonda_server_lock_recoveries_total counter
+sonda_server_lock_recoveries_total{lock="gate_buses"} 0
+sonda_server_lock_recoveries_total{lock="gate_pending"} 0
+sonda_server_lock_recoveries_total{lock="gate_subscribers"} 0
+sonda_server_lock_recoveries_total{lock="request_counters"} 0
+sonda_server_lock_recoveries_total{lock="request_histograms"} 0
+sonda_server_lock_recoveries_total{lock="scenarios"} 0
 # HELP sonda_server_uptime_seconds Seconds since the server process started.
 # TYPE sonda_server_uptime_seconds gauge
 sonda_server_uptime_seconds 18432.4
@@ -71,7 +79,7 @@ The endpoint is idempotent — two back-to-back scrapes return logically equival
 
 ### Series reference
 
-Eleven series. Operator-tense one-liners and the alerts that matter follow.
+Twelve series. Operator-tense one-liners and the alerts that matter follow.
 
 #### `sonda_server_active_scenarios`
 
@@ -199,6 +207,36 @@ rate(sonda_server_sink_errors_total[5m]) > 0
 ```
 
 This is the single most important alert on the page. Sustained sink errors mean some backend is unreachable or rejecting writes. Drill into individual scenarios with `GET /scenarios` and look at the `degraded` field, then inspect the offenders with `GET /scenarios/{id}/stats` for `last_sink_error`.
+
+#### `sonda_server_lock_recoveries_total`
+
+Counter. Acquisitions of a shared-state lock that had to be recovered because a previous holder panicked while writing to it. Zero on a healthy server, and every lock is reported so the series exist before anything goes wrong.
+
+| `lock` value | What it guards | What one recovery costs |
+|---|---|---|
+| `scenarios` | The map of scenarios the server is running. | A multi-entry `POST /scenarios` may have registered some of its entries and not the others. The ones it had not registered yet are stopped rather than left emitting. |
+| `request_counters`, `request_histograms` | The request counts and durations reported on this endpoint. | One request missing from `sonda_server_requests_total` or from the duration histogram. |
+| `gate_buses`, `gate_subscribers`, `gate_pending` | The cross-POST `while:` wiring. | A downstream scenario can settle in `unresolved` instead of waiting for an upstream that is gone. |
+
+The server keeps serving after a panic: the lock is recovered, the request that panicked is lost — the connection is dropped rather than answered — and everything else carries on. The counter is how you find out it happened at all. A panic marks the lock it was holding as poisoned, and that mark is never cleared while the process runs. Every later acquisition of that lock adds one, so the value climbs with traffic. Only a restart returns it to zero.
+
+```promql title="Alert: a handler panicked while holding shared state"
+sonda_server_lock_recoveries_total > 0
+```
+
+Alert on the level, not on `rate()` or `increase()`. Those measure how often the lock is being acquired, not whether it was ever poisoned. On a server with little traffic the rate falls back to zero while the lock is still poisoned, so the alert resolves itself and then returns with the next burst of requests. `> 0` stays true from the panic until the process restarts, which is exactly as long as the condition lasts.
+
+When it fires:
+
+1. Do not read it as an outage. The server is still answering requests; one request was lost.
+2. Find the panic in the log. The panic message names the code that failed, and a `recovered a poisoned lock` `WARN` names the lock. That `WARN` is written once, at the first recovery, so search back to the start of the incident rather than to the moment the alert fired.
+3. Read the table above for what the lost update was. For `lock="scenarios"`, compare `GET /scenarios` against what you expect to be running.
+4. Restart the process when you want certainty that nothing else was dropped. The mark stays for the life of the process, and the alert clears on restart.
+
+A handler that panics is a bug in the server. Keep the panic message and the `lock` label when you report it.
+
+!!! info "A `POST /scenarios` that panics does not keep the name it claimed"
+    If the panic lands while a POST is registering its entries, the server stops the entries it has not registered yet and frees the `scenario_name` they claimed, with an `admission panicked after launch` `WARN`. The name is available again, so you can re-send the same body without having to `DELETE` anything to free it first.
 
 #### `sonda_server_uptime_seconds`
 

--- a/docs/site/docs/deploy/server.md
+++ b/docs/site/docs/deploy/server.md
@@ -285,7 +285,7 @@ Caused by:
     catalog /catalog contains duplicate entry name "web_traffic": /catalog/a.yaml and /catalog/b.yaml
 ```
 
-Everything else keeps the server up. A file the server cannot use — one it has no permission to open, a v1 body, a compile error, a validation failure, or a file that would push past `--max-scenarios` — is logged and skipped; one bad file never stops the ones after it:
+Everything else keeps the server up. A file the server cannot use — one it has no permission to open, a v1 body, a compile error, a validation failure, or a file that would push past `--max-scenarios` — is logged and skipped; one bad file never stops the ones after it. An entry that panics on its way in is skipped the same way, with a `panicked while starting` `WARN` naming the file:
 
 ```text
 warning: catalog: skipping unreadable file /catalog/locked.yaml: Permission denied (os error 13)
@@ -392,10 +392,10 @@ curl -i http://localhost:8080/ready
 A server without `--autostart` is ready from its first request, so putting a readiness probe on `/ready` is safe whether or not you autostart anything.
 
 !!! warning "`failed` is terminal — the process does not recover on its own"
-    Nothing retries a sweep that died. The status stays `failed` for the life of the process, so `/ready` answers 503 forever and a pod behind a readiness probe stays out of the Service indefinitely. It is not restarted either: the process is still alive and serving, so the liveness probe on `/health` keeps passing by design — a restart would only repeat the sweep that just failed, and the API keeps answering for whatever did start. Treat a `failed` sweep as a page: read the `ERROR` line, then restart the process (`kubectl delete pod`, `docker restart`) once you know why it died. [`sonda_server_autostart_started`](server-metrics.md#sonda_server_autostart_started) sitting below `sonda_server_autostart_expected` is the alertable signal.
+    A single entry does not get you here: an unreadable file, one that does not compile, one the server rejects, and one that panics on its way in are all skipped, and the sweep carries on to the next entry. `failed` means the sweep itself died, which leaves every entry it had not reached unstarted. Nothing retries a sweep that died. The status stays `failed` for the life of the process, so `/ready` answers 503 forever and a pod behind a readiness probe stays out of the Service indefinitely. It is not restarted either: the process is still alive and serving, so the liveness probe on `/health` keeps passing by design — a restart would only repeat the sweep that just failed, and the API keeps answering for whatever did start. Treat a `failed` sweep as a page: read the `ERROR` line, then restart the process (`kubectl delete pod`, `docker restart`) once you know why it died. [`sonda_server_autostart_started`](server-metrics.md#sonda_server_autostart_started) sitting below `sonda_server_autostart_expected` is the alertable signal.
 
 !!! info "A sweep that skipped files is still ready"
-    `status: finished` with `autostart_started` below `autostart_expected` means the sweep ran to the end and skipped something — a file that does not compile, or one that would have pushed past `--max-scenarios`. That is ready. One bad file in a catalog of twelve must not pull the whole server out of service; the skip is logged with the file that caused it, and the difference between the two counts is what you alert on. Both counts are exported as [`sonda_server_autostart_started`](server-metrics.md#sonda_server_autostart_started) and [`sonda_server_autostart_expected`](server-metrics.md#sonda_server_autostart_expected).
+    `status: finished` with `autostart_started` below `autostart_expected` means the sweep ran to the end and skipped something — a file that does not compile, one that would have pushed past `--max-scenarios`, or one that panicked on its way in. That is ready. One bad file in a catalog of twelve must not pull the whole server out of service; the skip is logged with the file that caused it, and the difference between the two counts is what you alert on. Both counts are exported as [`sonda_server_autostart_started`](server-metrics.md#sonda_server_autostart_started) and [`sonda_server_autostart_expected`](server-metrics.md#sonda_server_autostart_expected).
 
     This holds even when every entry is skipped. The server reports ready with nothing running, and a Kubernetes rollout of that catalog succeeds. Readiness answers "did the sweep run", not "was the catalog any good". The counts and the `WARN` line for each skipped entry answer the second question. Alert on those; do not expect a probe to catch a bad catalog. A catalog that yields no runnable entries at all is the one case this comparison cannot show — see [`sonda_server_autostart_expected`](server-metrics.md#sonda_server_autostart_expected).
 
@@ -484,7 +484,7 @@ See [Authentication conventions on HTTP API reference](http-api.md#authenticatio
 ## Where to next
 
 - [HTTP API reference](http-api.md) — every endpoint, request body, and response shape.
-- [Server metrics](server-metrics.md) — the eleven `/metrics` series and the alerts that matter.
+- [Server metrics](server-metrics.md) — the twelve `/metrics` series and the alerts that matter.
 - [Docker](docker.md) — Compose stacks and host-side `docker run` examples.
 - [Kubernetes](kubernetes.md) — Helm chart, Service DNS, cross-namespace access.
 - [Sinks](../build/sinks.md) — every sink type and its `url:` field.

--- a/sonda-server/CLAUDE.md
+++ b/sonda-server/CLAUDE.md
@@ -23,8 +23,11 @@ src/
 ├── autostart.rs        ← --autostart sweep: runnable_entries() enumerates pre-bind (a catalog
 │                         the operator must fix is fatal; transient I/O warns and yields none),
 │                         start_entries() admits each through routes::scenarios::admit_compiled
-│                         and logs+skips per-entry failures. Runs as a spawned task alongside
-│                         axum::serve; takes a CancellationToken that shutdown cancels and joins
+│                         and logs+skips per-entry failures. Each admission runs in its own
+│                         tokio::spawn and is awaited in turn, so an entry that panics is
+│                         skipped like any other failure and the sweep still finishes.
+│                         Runs as a spawned task alongside axum::serve; takes a
+│                         CancellationToken that shutdown cancels and joins
 ├── routes/
 │   ├── mod.rs          ← router_with_config() function: splits three sub-routers — public (/health, /ready),
 │                         protected observability (/scenarios/{id}/stats, /scenarios/{id}/metrics,
@@ -61,7 +64,10 @@ src/
 │                         or post_multi_scenario(), list_scenarios(),
 │                         get_scenario(), get_scenario_stats(),
 │                         get_scenario_metrics(), delete_scenario().
-└── state.rs            ← AppState: Arc<RwLock<HashMap<String, ScenarioHandle>>> + optional api_key
+├── locks.rs            ← RecoveringLock: the RwLock wrapper that owns the poison policy —
+│                         recovers the guard, counts the recovery per lock, and carries the
+│                         per-lock safety argument in its module docs
+└── state.rs            ← AppState: Arc<RecoveringLock<HashMap<String, ScenarioHandle>>> + optional api_key
                         + SweepStatus: lock-free autostart sweep phase (not_configured /
                         in_progress / finished / failed) plus started and expected counts,
                         built before the listener binds so the denominator is never zero
@@ -103,11 +109,23 @@ tests/
 
 ## Error Handling
 
-All handlers use `.map_err()` with the `?` operator for lock acquisition and other fallible
-operations. No handler uses `.expect()` or `.unwrap()` on lock guards. If the `AppState` scenarios
-`RwLock` is poisoned (e.g., because a write handler panicked), all handlers return `500 Internal
-Server Error` with a JSON error body instead of panicking. The per-scenario stats `RwLock` in
-`ScenarioHandle` uses `into_inner()` to recover data from poisoned guards without panicking.
+All handlers use `.map_err()` with the `?` operator for fallible operations. Shared state is held in
+`locks::RecoveringLock`, whose `read()`/`write()` cannot fail: a poisoned lock is recovered, counted
+per lock, and exported as `sonda_server_lock_recoveries_total` on `/metrics`. The per-lock argument
+for why recovery is safe lives in the module docs of `src/locks.rs` — extend it there before putting
+new state behind the type. The per-scenario stats `RwLock` in `ScenarioHandle` is owned by
+sonda-core, which recovers it on its own read paths; the three places the server writes to it
+(`gate_registry.rs`) recover it the same way, so a scenario whose stats lock was poisoned still
+transitions state and still counts resolution attempts.
+
+`admit_compiled` holds its launched handles in an `AdoptionGuard` until they are in the scenario
+map, handing them over one at a time so the guard owns the whole tail it has not yet handed over.
+Dropping it on a panic stops what it still holds and unregisters the scenario name. Two gaps
+remain. The handle in flight at the moment of the panic is already out of the guard and not yet in
+the map, so it escapes still running, and it has dropped its permit — that orphan does not count
+against `--max-scenarios`. And `unregister` is keyed by scenario name alone, so rows the guard had
+already handed over keep running and stay listed but lose their gate buses; their downstreams
+receive `UpstreamGone`.
 
 ## Concurrency Model
 

--- a/sonda-server/src/autostart.rs
+++ b/sonda-server/src/autostart.rs
@@ -1,5 +1,6 @@
 //! Startup sweep that admits every `kind: runnable` catalog entry.
 
+use std::future::Future;
 use std::path::Path;
 
 use sonda_core::catalog::{self, CatalogEntry, CatalogError, EntryKind};
@@ -48,12 +49,24 @@ fn is_misconfiguration(error: &CatalogError) -> bool {
 }
 
 /// Admit every entry through the same path `POST /scenarios` uses, logging and
-/// skipping any entry that fails so one bad file cannot stop the server.
+/// skipping any entry that fails so one bad file cannot stop the server. An entry
+/// whose admission panics is skipped the same way: it runs in its own task, so the
+/// panic ends that entry and not the sweep.
 /// Runs alongside the HTTP server; `cancel` stops it at the next entry boundary
 /// so shutdown never races an admission it would not see.
 pub async fn start_entries(state: &AppState, entries: &[CatalogEntry], cancel: &CancellationToken) {
-    let catalog_dir = state.catalog_dir.as_deref().map(|p| p.as_path());
+    start_entries_with(state, entries, cancel, admit_entry).await
+}
 
+async fn start_entries_with<F, Fut>(
+    state: &AppState,
+    entries: &[CatalogEntry],
+    cancel: &CancellationToken,
+    admit: F,
+) where
+    F: Fn(AppState, CatalogEntry) -> Fut,
+    Fut: Future<Output = bool> + Send + 'static,
+{
     for (index, entry) in entries.iter().enumerate() {
         if cancel.is_cancelled() {
             let started = state.sweep_status.snapshot().started;
@@ -67,27 +80,13 @@ pub async fn start_entries(state: &AppState, entries: &[CatalogEntry], cancel: &
             return;
         }
 
-        let path = entry.source_path.display().to_string();
-
-        let text = match std::fs::read_to_string(&entry.source_path) {
-            Ok(text) => text,
+        match tokio::spawn(admit(state.clone(), entry.clone())).await {
+            Ok(true) => state.sweep_status.record_started(),
+            Ok(false) => {}
             Err(e) => {
-                warn!(origin = %path, reason = %e, "{path}: unreadable, skipping catalog entry");
-                continue;
+                let path = entry.source_path.display().to_string();
+                warn!(origin = %path, reason = %e, "{path}: panicked while starting, skipping catalog entry");
             }
-        };
-
-        let compiled = match compile_v2_text(&text, catalog_dir) {
-            Ok(compiled) => compiled,
-            Err(fail) => {
-                warn!(origin = %path, reason = %fail.message(), "{path}: does not compile, skipping catalog entry");
-                continue;
-            }
-        };
-
-        // admit_compiled logs the reason it rejected an entry, with the same origin.
-        if admit_compiled(state, compiled, &path).await.is_ok() {
-            state.sweep_status.record_started();
         }
     }
 
@@ -100,6 +99,30 @@ pub async fn start_entries(state: &AppState, entries: &[CatalogEntry], cancel: &
         "autostart: started {started} of {} runnable catalog entries",
         entries.len()
     );
+}
+
+async fn admit_entry(state: AppState, entry: CatalogEntry) -> bool {
+    let path = entry.source_path.display().to_string();
+
+    let text = match std::fs::read_to_string(&entry.source_path) {
+        Ok(text) => text,
+        Err(e) => {
+            warn!(origin = %path, reason = %e, "{path}: unreadable, skipping catalog entry");
+            return false;
+        }
+    };
+
+    let catalog_dir = state.catalog_dir.as_deref().map(|p| p.as_path());
+    let compiled = match compile_v2_text(&text, catalog_dir) {
+        Ok(compiled) => compiled,
+        Err(fail) => {
+            warn!(origin = %path, reason = %fail.message(), "{path}: does not compile, skipping catalog entry");
+            return false;
+        }
+    };
+
+    // admit_compiled logs the reason it rejected an entry, with the same origin.
+    admit_compiled(&state, compiled, &path).await.is_ok()
 }
 
 #[cfg(test)]
@@ -142,8 +165,43 @@ scenarios:
         (dir, entries, state)
     }
 
+    fn runnable_named(name: &str) -> String {
+        RUNNABLE
+            .replace("scenario_name: alpha", &format!("scenario_name: {name}"))
+            .replace("name: alpha_cpu", &format!("name: {name}_cpu"))
+    }
+
+    fn catalog_with_three_runnables() -> (TempDir, Vec<CatalogEntry>, AppState) {
+        let dir = TempDir::new().expect("must create temp catalog dir");
+        for name in ["alpha", "beta", "gamma"] {
+            std::fs::write(
+                dir.path().join(format!("{name}.yaml")),
+                runnable_named(name),
+            )
+            .expect("must write catalog file");
+        }
+        let entries = runnable_entries(dir.path()).expect("must enumerate");
+        assert_eq!(
+            entries.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(),
+            vec!["alpha", "beta", "gamma"],
+            "the sweep must reach beta with an entry still behind it"
+        );
+
+        let mut state = AppState::new();
+        state.catalog_dir = Some(Arc::new(dir.path().to_path_buf()));
+        state.sweep_status = Arc::new(SweepStatus::in_progress(entries.len()));
+        (dir, entries, state)
+    }
+
+    async fn admit_but_panic_on_beta(state: AppState, entry: CatalogEntry) -> bool {
+        if entry.name == "beta" {
+            panic!("intentional admission panic");
+        }
+        admit_entry(state, entry).await
+    }
+
     fn admitted(state: &AppState) -> usize {
-        state.scenarios.read().expect("scenarios lock").len()
+        state.scenarios.read().len()
     }
 
     #[tokio::test]
@@ -164,6 +222,49 @@ scenarios:
         let snap = state.sweep_status.snapshot();
         assert_eq!(snap.phase, SweepPhase::Finished);
         assert_eq!((snap.started, snap.expected), (1, 1));
+    }
+
+    #[tokio::test]
+    async fn entries_behind_a_panicking_admission_still_start() {
+        let (_dir, entries, state) = catalog_with_three_runnables();
+
+        start_entries_with(
+            &state,
+            &entries,
+            &CancellationToken::new(),
+            admit_but_panic_on_beta,
+        )
+        .await;
+
+        let names: Vec<String> = state
+            .scenarios
+            .read()
+            .values()
+            .map(|h| h.name.clone())
+            .collect();
+        assert_eq!(names.len(), 2, "got {names:?}");
+        assert!(names.iter().any(|n| n == "alpha_cpu"), "got {names:?}");
+        assert!(names.iter().any(|n| n == "gamma_cpu"), "got {names:?}");
+    }
+
+    #[tokio::test]
+    async fn a_sweep_with_a_panicking_entry_still_finishes_and_reports_ready() {
+        let (_dir, entries, state) = catalog_with_three_runnables();
+
+        start_entries_with(
+            &state,
+            &entries,
+            &CancellationToken::new(),
+            admit_but_panic_on_beta,
+        )
+        .await;
+
+        let snap = state.sweep_status.snapshot();
+        assert_eq!(snap.phase, SweepPhase::Finished);
+        assert_eq!((snap.started, snap.expected), (2, 3));
+
+        let ready = crate::routes::ready::ready(axum::extract::State(state.clone())).await;
+        assert_eq!(ready.status(), axum::http::StatusCode::OK);
     }
 
     #[tokio::test]

--- a/sonda-server/src/gate_registry.rs
+++ b/sonda-server/src/gate_registry.rs
@@ -12,6 +12,8 @@ use sonda_core::schedule::stats::ScenarioStats;
 use sonda_core::ScenarioState;
 use sonda_core::UnresolvedBehavior;
 
+use crate::locks::RecoveringLock;
+
 type BusKey = (String, String);
 
 struct SubscriberRef {
@@ -54,16 +56,37 @@ impl SubscriberRef {
     }
 }
 
-#[derive(Default)]
+const BUSES_LOCK: &str = "gate_buses";
+const SUBSCRIBERS_LOCK: &str = "gate_subscribers";
+const PENDING_LOCK: &str = "gate_pending";
+
 pub struct GateBusRegistry {
-    buses: RwLock<HashMap<BusKey, Arc<GateBus>>>,
-    subscribers: RwLock<HashMap<BusKey, Vec<SubscriberRef>>>,
-    pending: RwLock<HashMap<String, PendingResolution>>,
+    buses: RecoveringLock<HashMap<BusKey, Arc<GateBus>>>,
+    subscribers: RecoveringLock<HashMap<BusKey, Vec<SubscriberRef>>>,
+    pending: RecoveringLock<HashMap<String, PendingResolution>>,
+}
+
+impl Default for GateBusRegistry {
+    fn default() -> Self {
+        Self {
+            buses: RecoveringLock::new(BUSES_LOCK, HashMap::new()),
+            subscribers: RecoveringLock::new(SUBSCRIBERS_LOCK, HashMap::new()),
+            pending: RecoveringLock::new(PENDING_LOCK, HashMap::new()),
+        }
+    }
 }
 
 impl GateBusRegistry {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn lock_recoveries(&self) -> [(&'static str, u64); 3] {
+        [
+            (self.buses.name(), self.buses.recoveries()),
+            (self.subscribers.name(), self.subscribers.recoveries()),
+            (self.pending.name(), self.pending.recoveries()),
+        ]
     }
 
     /// Rewrite tracking keys when the caller assigns a new external handle id
@@ -72,13 +95,13 @@ impl GateBusRegistry {
         if old_id == new_id {
             return;
         }
-        let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
+        let mut pending = self.pending.write();
         if let Some(mut entry) = pending.remove(old_id) {
             entry.handle_id = new_id.to_string();
             pending.insert(new_id.to_string(), entry);
         }
         drop(pending);
-        let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
+        let mut subs = self.subscribers.write();
         for refs in subs.values_mut() {
             for sub in refs.iter_mut() {
                 if sub.handle_id == old_id {
@@ -96,7 +119,7 @@ impl GateBusResolver for GateBusRegistry {
         entry_id: &str,
         bus: Arc<GateBus>,
     ) -> Result<(), RegistryError> {
-        let mut buses = self.buses.write().unwrap_or_else(|p| p.into_inner());
+        let mut buses = self.buses.write();
         let key = (scenario_name.to_string(), entry_id.to_string());
         if buses.contains_key(&key) {
             return Err(RegistryError::DuplicateScenarioName {
@@ -110,7 +133,6 @@ impl GateBusResolver for GateBusRegistry {
     fn lookup(&self, scenario_name: &str, entry_id: &str) -> Option<Arc<GateBus>> {
         self.buses
             .read()
-            .unwrap_or_else(|p| p.into_inner())
             .get(&(scenario_name.to_string(), entry_id.to_string()))
             .cloned()
     }
@@ -127,7 +149,7 @@ impl GateBusResolver for GateBusRegistry {
     }
 
     fn unregister(&self, scenario_name: &str) {
-        let mut buses = self.buses.write().unwrap_or_else(|p| p.into_inner());
+        let mut buses = self.buses.write();
         let removed_keys: Vec<BusKey> = buses
             .keys()
             .filter(|(name, _)| name == scenario_name)
@@ -148,8 +170,8 @@ impl GateBusResolver for GateBusRegistry {
             bus.broadcast_upstream_gone();
         }
 
-        let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
-        let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
+        let mut subs = self.subscribers.write();
+        let mut pending = self.pending.write();
 
         let stale_pending: Vec<String> = pending
             .iter()
@@ -160,10 +182,9 @@ impl GateBusResolver for GateBusRegistry {
             let entry = pending.remove(&handle_id).expect("just snapshotted");
             entry.edge_sender.send(GateEdge::UpstreamGone);
             if let Some(stats_arc) = entry.stats.upgrade() {
-                if let Ok(mut s) = stats_arc.write() {
-                    if s.state != ScenarioState::Finished {
-                        s.transition_state(ScenarioState::Unresolved);
-                    }
+                let mut s = stats_arc.write().unwrap_or_else(|p| p.into_inner());
+                if s.state != ScenarioState::Finished {
+                    s.transition_state(ScenarioState::Unresolved);
                 }
             }
         }
@@ -185,9 +206,9 @@ impl GateBusResolver for GateBusRegistry {
     }
 
     fn sweep_pending(&self) -> usize {
-        let buses = self.buses.read().unwrap_or_else(|p| p.into_inner());
-        let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
-        let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
+        let buses = self.buses.read();
+        let mut pending = self.pending.write();
+        let mut subs = self.subscribers.write();
 
         let mut promoted = 0usize;
         let keys: Vec<String> = pending.keys().cloned().collect();
@@ -206,10 +227,9 @@ impl GateBusResolver for GateBusRegistry {
             let mut entry = pending.remove(&handle_id).expect("just looked up");
             entry.attempts = entry.attempts.saturating_add(1);
             if let Some(stats_arc) = entry.stats.upgrade() {
-                if let Ok(mut s) = stats_arc.write() {
-                    s.cumulative_resolution_attempts =
-                        s.cumulative_resolution_attempts.saturating_add(1);
-                }
+                let mut s = stats_arc.write().unwrap_or_else(|p| p.into_inner());
+                s.cumulative_resolution_attempts =
+                    s.cumulative_resolution_attempts.saturating_add(1);
             }
             bus.subscribe_with_while_sender(entry.spec, entry.edge_sender.clone());
             let (key, sub) = SubscriberRef::from_pending(entry);
@@ -220,12 +240,12 @@ impl GateBusResolver for GateBusRegistry {
     }
 
     fn insert_pending(&self, pending: PendingResolution) {
-        let mut map = self.pending.write().unwrap_or_else(|p| p.into_inner());
+        let mut map = self.pending.write();
         map.insert(pending.handle_id.clone(), pending);
     }
 
     fn pending_for_handle(&self, handle_id: &str) -> Option<PendingRef> {
-        let map = self.pending.read().unwrap_or_else(|p| p.into_inner());
+        let map = self.pending.read();
         let entry = map.get(handle_id)?;
         Some(PendingRef::from_pending(
             entry,
@@ -234,12 +254,12 @@ impl GateBusResolver for GateBusRegistry {
     }
 
     fn scenario_name_in_use(&self, scenario_name: &str) -> bool {
-        let buses = self.buses.read().unwrap_or_else(|p| p.into_inner());
+        let buses = self.buses.read();
         buses.keys().any(|(name, _)| name == scenario_name)
     }
 
     fn track_subscriber(&self, pending: PendingResolution) {
-        let mut subs = self.subscribers.write().unwrap_or_else(|p| p.into_inner());
+        let mut subs = self.subscribers.write();
         let (key, sub) = SubscriberRef::from_pending(pending);
         subs.entry(key).or_default().push(sub);
     }
@@ -249,7 +269,7 @@ impl GateBusResolver for GateBusRegistry {
         scenario_name: &str,
         entry_id: &str,
     ) -> Vec<RegistryError> {
-        let mut pending = self.pending.write().unwrap_or_else(|p| p.into_inner());
+        let mut pending = self.pending.write();
         let matching: Vec<String> = pending
             .iter()
             .filter(|(_, p)| p.scenario_name == scenario_name && p.entry_id == entry_id)
@@ -260,10 +280,9 @@ impl GateBusResolver for GateBusRegistry {
             let entry = pending.remove(&handle_id).expect("just snapshotted");
             entry.edge_sender.send(GateEdge::UpstreamGone);
             if let Some(stats_arc) = entry.stats.upgrade() {
-                if let Ok(mut s) = stats_arc.write() {
-                    if s.state != ScenarioState::Finished {
-                        s.transition_state(ScenarioState::Unresolved);
-                    }
+                let mut s = stats_arc.write().unwrap_or_else(|p| p.into_inner());
+                if s.state != ScenarioState::Finished {
+                    s.transition_state(ScenarioState::Unresolved);
                 }
             }
             errors.push(RegistryError::UpstreamCancelled {
@@ -357,7 +376,7 @@ mod tests {
         let got = reg.subscribe(("post-a", "m"), "h1", weak.clone(), tx.clone());
         assert!(got.is_some());
         reg.track_subscriber(make_pending("h1", "post-a", "m", weak, tx));
-        let subs = reg.subscribers.read().unwrap();
+        let subs = reg.subscribers.read();
         let row = subs
             .get(&("post-a".to_string(), "m".to_string()))
             .expect("subscribers row exists");
@@ -391,7 +410,7 @@ mod tests {
         let promoted = reg.sweep_pending();
         assert_eq!(promoted, 1);
         assert!(reg.pending_for_handle("h1").is_none());
-        let subs = reg.subscribers.read().unwrap();
+        let subs = reg.subscribers.read();
         assert!(subs
             .get(&("upstream".to_string(), "m".to_string()))
             .is_some());
@@ -598,6 +617,91 @@ mod tests {
         assert!(matches!(err, RegistryError::DuplicateScenarioName { .. }));
     }
 
+    fn poison_stats(stats: &Arc<RwLock<ScenarioStats>>) {
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = stats.write().expect("first write must succeed");
+            panic!("intentional poison");
+        }));
+        assert!(panicked.is_err(), "the poisoning panic must have happened");
+        assert!(stats.is_poisoned());
+    }
+
+    fn state_of(stats: &Arc<RwLock<ScenarioStats>>) -> ScenarioState {
+        stats.read().unwrap_or_else(|p| p.into_inner()).state
+    }
+
+    #[test]
+    fn unregister_marks_a_downstream_unresolved_through_its_poisoned_stats_lock() {
+        let reg = GateBusRegistry::new();
+        let (alive, weak) = live_stats();
+        let (tx, _rx) = gate_edge_channel();
+        reg.insert_pending(make_pending("h1", "upstream", "m", weak, tx));
+        poison_stats(&alive);
+
+        reg.unregister("upstream");
+
+        assert_eq!(state_of(&alive), ScenarioState::Unresolved);
+    }
+
+    #[test]
+    fn cancelling_an_upstream_marks_a_downstream_unresolved_through_its_poisoned_stats_lock() {
+        let reg = GateBusRegistry::new();
+        let (alive, weak) = live_stats();
+        let (tx, _rx) = gate_edge_channel();
+        reg.insert_pending(make_pending("h1", "upstream", "m", weak, tx));
+        poison_stats(&alive);
+
+        reg.cancel_pending_for_upstream("upstream", "m");
+
+        assert_eq!(state_of(&alive), ScenarioState::Unresolved);
+    }
+
+    #[test]
+    fn sweep_counts_the_resolution_attempt_through_a_poisoned_stats_lock() {
+        let reg = GateBusRegistry::new();
+        let (alive, weak) = live_stats();
+        let (tx, _rx) = gate_edge_channel();
+        reg.insert_pending(make_pending("h1", "upstream", "m", weak, tx));
+        poison_stats(&alive);
+        let bus = Arc::new(GateBus::new());
+        bus.tick(1.0);
+        reg.register("upstream", "m", bus).expect("register");
+
+        assert_eq!(reg.sweep_pending(), 1);
+
+        let attempts = alive
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .cumulative_resolution_attempts;
+        assert_eq!(attempts, 1);
+    }
+
+    #[test]
+    fn poisoned_registry_locks_still_resolve_a_pending_subscriber() {
+        let reg = GateBusRegistry::new();
+        crate::locks::poison(&reg.buses);
+        crate::locks::poison(&reg.subscribers);
+        crate::locks::poison(&reg.pending);
+
+        let (alive, weak) = live_stats();
+        let (tx, _rx) = gate_edge_channel();
+        reg.insert_pending(make_pending("h1", "upstream", "m", weak, tx));
+        let bus = Arc::new(GateBus::new());
+        bus.tick(1.0);
+        reg.register("upstream", "m", bus).expect("register");
+
+        assert_eq!(reg.sweep_pending(), 1);
+        assert!(reg.pending_for_handle("h1").is_none());
+        assert!(reg
+            .subscribers
+            .read()
+            .contains_key(&("upstream".to_string(), "m".to_string())));
+        for (lock, recoveries) in reg.lock_recoveries() {
+            assert!(recoveries > 0, "{lock} must have counted its recoveries");
+        }
+        drop(alive);
+    }
+
     #[test]
     fn t22_concurrent_subscribe_does_not_deadlock() {
         let reg = Arc::new(GateBusRegistry::new());
@@ -622,7 +726,7 @@ mod tests {
         for t in threads {
             t.join().expect("join");
         }
-        let subs = reg.subscribers.read().unwrap();
+        let subs = reg.subscribers.read();
         assert_eq!(subs.values().map(|v| v.len()).sum::<usize>(), 8);
         drop(kept);
     }

--- a/sonda-server/src/locks.rs
+++ b/sonda-server/src/locks.rs
@@ -1,0 +1,181 @@
+//! Shared-state lock policy: a poisoned lock is recovered, counted, and reported through
+//! `sonda_server_lock_recoveries_total`, so one panicking handler costs the operation it
+//! panicked in rather than every later acquisition for the life of the process.
+//!
+//! Recovery itself is not new for most of this state — the three gate-registry locks and the
+//! two request-metrics locks already recovered in place, each at its own call site. What is new
+//! is that one type states the policy, the `scenarios` map follows it too, and every recovery is
+//! counted.
+//!
+//! Recovery is sound only where no critical section can leave a torn invariant behind. The
+//! argument, per lock:
+//!
+//! - `scenarios` — rows are independent. A panic between two inserts of one batch leaves the
+//!   earlier rows admitted and reachable and `AdoptionGuard` stops the tail it still holds. What
+//!   the map itself holds reads exactly like a batch whose later entries were never admitted.
+//!   Two things survive the guard: the one handle in flight at the panic escapes still running,
+//!   and having dropped its permit it no longer counts against `--max-scenarios`; and the guard's
+//!   `unregister` is keyed by scenario name alone, so the rows it already handed over keep
+//!   running and stay listed but lose their gate buses, and their downstreams see `UpstreamGone`.
+//! - `request_counters`, `request_histograms` — values are atomics and the update run under the
+//!   guard cannot panic, so at worst one observation is lost.
+//! - `gate_buses` — rows are independent and keyed by `(scenario_name, entry_id)`. `unregister`
+//!   removes a pre-collected key set one key at a time, so a panic mid-loop leaves the keys it
+//!   has not reached registered rather than any row half-removed.
+//! - `gate_subscribers`, `gate_pending` — a subscriber moves between the two maps while both
+//!   guards are held, so a panic mid-move can drop an in-flight reference; its edge sender drops
+//!   with it, which the downstream reads as `UpstreamGone` and settles in `unresolved` rather
+//!   than waiting forever. A panic part-way through `unregister` likewise leaves the subscriber
+//!   rows it has not reached in place after their bus is gone: those downstreams have already had
+//!   `UpstreamGone` broadcast to them, and since only `pending` is ever re-resolved they will not
+//!   be re-resolved again while the process lives. Nothing reads a row left behind as something
+//!   it is not.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use tracing::warn;
+
+pub struct RecoveringLock<T> {
+    inner: RwLock<T>,
+    name: &'static str,
+    recoveries: AtomicU64,
+}
+
+impl<T> RecoveringLock<T> {
+    pub fn new(name: &'static str, value: T) -> Self {
+        Self {
+            inner: RwLock::new(value),
+            name,
+            recoveries: AtomicU64::new(0),
+        }
+    }
+
+    pub fn read(&self) -> RwLockReadGuard<'_, T> {
+        match self.inner.read() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                self.record_recovery();
+                poisoned.into_inner()
+            }
+        }
+    }
+
+    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
+        match self.inner.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                self.record_recovery();
+                poisoned.into_inner()
+            }
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    #[cfg(test)]
+    pub fn is_poisoned(&self) -> bool {
+        self.inner.is_poisoned()
+    }
+
+    pub fn recoveries(&self) -> u64 {
+        self.recoveries.load(Ordering::Relaxed)
+    }
+
+    fn record_recovery(&self) {
+        // Poisoning is sticky, so only the first recovery is worth a log line.
+        if self.recoveries.fetch_add(1, Ordering::Relaxed) == 0 {
+            warn!(
+                lock = self.name,
+                "recovered a poisoned lock — a handler panicked while holding it; state guarded by this lock may have lost an update"
+            );
+        }
+    }
+}
+
+/// Leave `lock` poisoned, the way a handler that panics while holding it does.
+#[cfg(test)]
+pub fn poison<T>(lock: &RecoveringLock<T>) {
+    let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _guard = lock.write();
+        panic!("intentional poison");
+    }));
+    assert!(panicked.is_err(), "the poisoning panic must have happened");
+    assert!(lock.is_poisoned(), "the lock must be poisoned afterwards");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn read_returns_the_value_written_under_a_healthy_lock() {
+        let lock = RecoveringLock::new("t", vec![1u8, 2, 3]);
+        lock.write().push(4);
+        assert_eq!(*lock.read(), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn a_healthy_lock_records_no_recoveries() {
+        let lock = RecoveringLock::new("t", 0u8);
+        drop(lock.read());
+        drop(lock.write());
+        assert_eq!(lock.recoveries(), 0);
+    }
+
+    #[test]
+    fn read_after_poisoning_yields_the_state_the_panicking_writer_left() {
+        let lock = RecoveringLock::new("t", vec![1u8]);
+        poison(&lock);
+        assert_eq!(*lock.read(), vec![1]);
+    }
+
+    #[test]
+    fn write_after_poisoning_still_mutates() {
+        let lock = RecoveringLock::new("t", vec![1u8]);
+        poison(&lock);
+        lock.write().push(2);
+        assert_eq!(*lock.read(), vec![1, 2]);
+    }
+
+    #[test]
+    fn every_recovered_acquisition_is_counted() {
+        let lock = RecoveringLock::new("t", 0u8);
+        poison(&lock);
+        drop(lock.read());
+        drop(lock.write());
+        assert_eq!(lock.recoveries(), 2);
+    }
+
+    #[test]
+    fn the_name_is_carried_for_reporting() {
+        assert_eq!(RecoveringLock::new("scenarios", ()).name(), "scenarios");
+    }
+
+    #[test]
+    fn recoveries_from_other_threads_are_visible() {
+        let lock = Arc::new(RecoveringLock::new("t", 0u64));
+        poison(&lock);
+        let readers: Vec<_> = (0..4)
+            .map(|_| {
+                let lock = Arc::clone(&lock);
+                std::thread::spawn(move || {
+                    drop(lock.read());
+                })
+            })
+            .collect();
+        for reader in readers {
+            reader.join().expect("reader must not panic");
+        }
+        assert_eq!(lock.recoveries(), 4);
+    }
+
+    #[test]
+    fn recovering_lock_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<RecoveringLock<Vec<u8>>>();
+    }
+}

--- a/sonda-server/src/main.rs
+++ b/sonda-server/src/main.rs
@@ -6,20 +6,19 @@
 mod auth;
 mod autostart;
 mod gate_registry;
+mod locks;
 mod middleware;
 mod routes;
 mod state;
 
-use std::collections::HashMap;
 use std::env;
 use std::io::Write;
 use std::net::SocketAddr;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{exit, Command};
-use std::sync::atomic::AtomicU64;
-use std::sync::{Arc, RwLock};
-use std::time::{Duration, Instant};
+use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context;
 use clap::Parser;
@@ -205,19 +204,13 @@ async fn run(args: Args, workers: usize, max_inflight_requests: usize) -> anyhow
     };
 
     let state = AppState {
-        scenarios: Arc::new(RwLock::new(HashMap::new())),
         api_key: api_key.map(Arc::new),
         catalog_dir: args.catalog.clone().map(Arc::new),
-        gate_bus_registry: Arc::new(crate::gate_registry::GateBusRegistry::new()),
         scenario_permits: Arc::new(permits),
-        started_at: Instant::now(),
         worker_threads: workers,
         max_scenarios: args.max_scenarios,
-        request_counters: Arc::new(RwLock::new(
-            HashMap::<crate::state::RouteKey, AtomicU64>::new(),
-        )),
-        request_histograms: Arc::new(RwLock::new(HashMap::new())),
         sweep_status,
+        ..AppState::new()
     };
 
     let inflight_semaphore = Arc::new(Semaphore::new(max_inflight_requests));
@@ -376,19 +369,13 @@ async fn shutdown_signal(
         let _ = sweep.await;
     }
 
-    if let Ok(scenarios) = state.scenarios.read() {
-        for handle in scenarios.values() {
-            handle.stop();
-        }
+    for handle in state.scenarios.read().values() {
+        handle.stop();
     }
 
     // Write lock: join consumes the inner JoinHandle.
-    let mut ids_handles: Vec<(String, sonda_core::ScenarioHandle)> = Vec::new();
-    if let Ok(mut scenarios) = state.scenarios.write() {
-        for (id, handle) in scenarios.drain() {
-            ids_handles.push((id, handle));
-        }
-    }
+    let ids_handles: Vec<(String, sonda_core::ScenarioHandle)> =
+        state.scenarios.write().drain().collect();
     for (id, mut handle) in ids_handles {
         match handle.join_async(Some(Duration::from_secs(5))).await {
             Ok(_) => info!(scenario = %id, "scenario task joined"),

--- a/sonda-server/src/middleware/metrics.rs
+++ b/sonda-server/src/middleware/metrics.rs
@@ -36,10 +36,7 @@ pub async fn record_request_metrics(
 fn increment_counter(state: &AppState, route: String, method: String, status: u16) {
     let key = (route, method, status);
     {
-        let guard = match state.request_counters.read() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
+        let guard = state.request_counters.read();
         if let Some(counter) = guard.get(&key) {
             counter.fetch_add(1, Ordering::Relaxed);
             return;
@@ -47,10 +44,7 @@ fn increment_counter(state: &AppState, route: String, method: String, status: u1
     }
     // Slow path: another writer may have created the entry between the read
     // drop and the write acquire — entry().or_insert_with handles both cases.
-    let mut guard = match state.request_counters.write() {
-        Ok(g) => g,
-        Err(p) => p.into_inner(),
-    };
+    let mut guard = state.request_counters.write();
     guard
         .entry(key)
         .or_insert_with(|| AtomicU64::new(0))
@@ -60,19 +54,13 @@ fn increment_counter(state: &AppState, route: String, method: String, status: u1
 fn observe_histogram(state: &AppState, route: String, method: String, seconds: f64) {
     let key = (route, method);
     {
-        let guard = match state.request_histograms.read() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
+        let guard = state.request_histograms.read();
         if let Some(shard) = guard.get(&key) {
             shard.observe(seconds);
             return;
         }
     }
-    let mut guard = match state.request_histograms.write() {
-        Ok(g) => g,
-        Err(p) => p.into_inner(),
-    };
+    let mut guard = state.request_histograms.write();
     guard.entry(key).or_default().observe(seconds);
 }
 
@@ -80,50 +68,37 @@ fn observe_histogram(state: &AppState, route: String, method: String, seconds: f
 mod tests {
     use super::*;
 
-    fn poison<T: Send + Sync>(lock: &std::sync::RwLock<T>) {
-        std::thread::scope(|s| {
-            let _ = s
-                .spawn(|| {
-                    let _g = lock.write().expect("first write must succeed");
-                    panic!("intentional poison");
-                })
-                .join();
-        });
-    }
+    use crate::locks::poison;
 
     #[test]
     fn increment_counter_survives_poisoned_request_counters_lock() {
         let state = AppState::new();
         poison(&state.request_counters);
-        assert!(state.request_counters.is_poisoned());
 
         increment_counter(&state, "/test".to_string(), "GET".to_string(), 200);
         increment_counter(&state, "/test".to_string(), "GET".to_string(), 200);
 
-        let guard = match state.request_counters.read() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
+        let guard = state.request_counters.read();
         let key = ("/test".to_string(), "GET".to_string(), 200u16);
         let counter = guard.get(&key).expect("entry must exist");
         assert_eq!(counter.load(Ordering::Relaxed), 2);
+        drop(guard);
+        assert!(state.request_counters.recoveries() > 0);
     }
 
     #[test]
     fn observe_histogram_survives_poisoned_request_histograms_lock() {
         let state = AppState::new();
         poison(&state.request_histograms);
-        assert!(state.request_histograms.is_poisoned());
 
         observe_histogram(&state, "/test".to_string(), "GET".to_string(), 0.123);
         observe_histogram(&state, "/test".to_string(), "GET".to_string(), 0.456);
 
-        let guard = match state.request_histograms.read() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
+        let guard = state.request_histograms.read();
         let key = ("/test".to_string(), "GET".to_string());
         let snap = guard.get(&key).expect("entry must exist").snapshot();
         assert_eq!(snap.count, 2);
+        drop(guard);
+        assert!(state.request_histograms.recoveries() > 0);
     }
 }

--- a/sonda-server/src/routes/metrics.rs
+++ b/sonda-server/src/routes/metrics.rs
@@ -24,6 +24,7 @@ pub async fn get_metrics(State(state): State<AppState>) -> Result<Response, Resp
     write_requests_total(&state, &mut buf).map_err(internal)?;
     write_request_duration_seconds(&state, &mut buf).map_err(internal)?;
     write_sink_errors_total(&state, &mut buf).map_err(internal)?;
+    write_lock_recoveries(&state, &mut buf).map_err(internal)?;
     write_uptime_seconds(&state, &mut buf).map_err(internal)?;
     write_build_info(&mut buf).map_err(internal)?;
 
@@ -49,10 +50,7 @@ fn write_active_scenarios(state: &AppState, buf: &mut String) -> std::fmt::Resul
         by_state.insert(op.as_label(), 0);
     }
     {
-        let scenarios = match state.scenarios.read() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
+        let scenarios = state.scenarios.read();
         for handle in scenarios.values() {
             let snap = handle.stats_snapshot();
             if snap.state == ScenarioState::Finished {
@@ -82,10 +80,7 @@ fn write_active_scenarios(state: &AppState, buf: &mut String) -> std::fmt::Resul
 fn write_scenarios_finished_total(state: &AppState, buf: &mut String) -> std::fmt::Result {
     let mut finished: u64 = 0;
     {
-        let scenarios = match state.scenarios.read() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
+        let scenarios = state.scenarios.read();
         for handle in scenarios.values() {
             if handle.stats_snapshot().state == ScenarioState::Finished {
                 finished += 1;
@@ -141,10 +136,7 @@ fn write_requests_total(state: &AppState, buf: &mut String) -> std::fmt::Result 
     )?;
     writeln!(buf, "# TYPE sonda_server_requests_total counter")?;
     let snapshot: Vec<((String, String, u16), u64)> = {
-        let guard = match state.request_counters.read() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
+        let guard = state.request_counters.read();
         let mut rows: Vec<_> = guard
             .iter()
             .map(|((r, m, s), c)| ((r.clone(), m.clone(), *s), c.load(Ordering::Relaxed)))
@@ -175,10 +167,7 @@ fn write_request_duration_seconds(state: &AppState, buf: &mut String) -> std::fm
         "# TYPE sonda_server_request_duration_seconds histogram"
     )?;
     let snapshots: Vec<((String, String), _)> = {
-        let guard = match state.request_histograms.read() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
+        let guard = state.request_histograms.read();
         let mut rows: Vec<_> = guard
             .iter()
             .map(|(k, shard)| (k.clone(), shard.snapshot()))
@@ -223,10 +212,7 @@ fn write_sink_errors_total(state: &AppState, buf: &mut String) -> std::fmt::Resu
     writeln!(buf, "# TYPE sonda_server_sink_errors_total counter")?;
     let mut totals: BTreeMap<&'static str, u64> = BTreeMap::new();
     {
-        let scenarios = match state.scenarios.read() {
-            Ok(g) => g,
-            Err(p) => p.into_inner(),
-        };
+        let scenarios = state.scenarios.read();
         for handle in scenarios.values() {
             let snap = handle.stats_snapshot();
             *totals.entry(handle.sink_type()).or_insert(0) += snap.total_sink_failures;
@@ -236,6 +222,21 @@ fn write_sink_errors_total(state: &AppState, buf: &mut String) -> std::fmt::Resu
         writeln!(
             buf,
             "sonda_server_sink_errors_total{{sink_type=\"{sink_type}\"}} {value}"
+        )?;
+    }
+    Ok(())
+}
+
+fn write_lock_recoveries(state: &AppState, buf: &mut String) -> std::fmt::Result {
+    writeln!(
+        buf,
+        "# HELP sonda_server_lock_recoveries_total Poisoned shared-state locks recovered, per lock. Non-zero means a handler panicked while holding it."
+    )?;
+    writeln!(buf, "# TYPE sonda_server_lock_recoveries_total counter")?;
+    for (lock, value) in state.lock_recoveries() {
+        writeln!(
+            buf,
+            "sonda_server_lock_recoveries_total{{lock=\"{lock}\"}} {value}"
         )?;
     }
     Ok(())
@@ -308,6 +309,44 @@ mod tests {
 
         assert!(buf.contains("\nsonda_server_autostart_started 0\n"));
         assert!(buf.contains("\nsonda_server_autostart_expected 0\n"));
+    }
+
+    #[test]
+    fn lock_recoveries_reports_every_lock_at_zero_on_a_healthy_server() {
+        let mut buf = String::new();
+        write_lock_recoveries(&AppState::new(), &mut buf).expect("write must succeed");
+
+        assert!(buf.contains("# TYPE sonda_server_lock_recoveries_total counter"));
+        for lock in [
+            "gate_buses",
+            "gate_pending",
+            "gate_subscribers",
+            "request_counters",
+            "request_histograms",
+            "scenarios",
+        ] {
+            assert!(
+                buf.contains(&format!(
+                    "\nsonda_server_lock_recoveries_total{{lock=\"{lock}\"}} 0\n"
+                )),
+                "{lock} must be reported, got:\n{buf}"
+            );
+        }
+    }
+
+    #[test]
+    fn lock_recoveries_counts_each_recovered_acquisition() {
+        let state = AppState::new();
+        crate::locks::poison(&state.scenarios);
+        drop(state.scenarios.read());
+
+        let mut buf = String::new();
+        write_lock_recoveries(&state, &mut buf).expect("write must succeed");
+
+        assert!(
+            buf.contains("\nsonda_server_lock_recoveries_total{lock=\"scenarios\"} 1\n"),
+            "got:\n{buf}"
+        );
     }
 
     #[test]

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -271,10 +271,9 @@ fn state_string(stats: &ScenarioStats) -> &'static str {
 /// in `pending` / `running` / `paused` state. Finished handles are stale
 /// and skipped. Future `ScenarioState` variants (`#[non_exhaustive]`) must
 /// opt in to blocking explicitly — a stalled or errored handle that the
-/// operator can't DELETE shouldn't lock its name forever. `Err(())`
-/// indicates a poisoned lock.
-fn collect_active_conflicts(state: &AppState, name: &str) -> Result<Vec<ConflictingScenario>, ()> {
-    let scenarios = state.scenarios.read().map_err(|_| ())?;
+/// operator can't DELETE shouldn't lock its name forever.
+fn collect_active_conflicts(state: &AppState, name: &str) -> Vec<ConflictingScenario> {
+    let scenarios = state.scenarios.read();
     let mut conflicts = Vec::new();
     for (id, handle) in scenarios.iter() {
         if handle.scenario_name.as_deref() != Some(name) {
@@ -298,7 +297,7 @@ fn collect_active_conflicts(state: &AppState, name: &str) -> Result<Vec<Conflict
             });
         }
     }
-    Ok(conflicts)
+    conflicts
 }
 
 // ---- Body parsing -----------------------------------------------------------
@@ -613,13 +612,11 @@ fn capacity_exceeded_response(state: &AppState, _needed: usize) -> Response {
     }
     by_state.insert(ScenarioState::Finished.as_label().to_string(), json!(0));
     let mut total = 0u64;
-    if let Ok(scenarios) = state.scenarios.read() {
-        for handle in scenarios.values() {
-            total += 1;
-            let label = handle.stats_snapshot().state.as_label();
-            if let Some(v) = by_state.get_mut(label) {
-                *v = json!(v.as_u64().unwrap_or(0) + 1);
-            }
+    for handle in state.scenarios.read().values() {
+        total += 1;
+        let label = handle.stats_snapshot().state.as_label();
+        if let Some(v) = by_state.get_mut(label) {
+            *v = json!(v.as_u64().unwrap_or(0) + 1);
         }
     }
     let max = state.max_scenarios;
@@ -653,6 +650,44 @@ pub enum AdmissionError {
     Internal(String),
 }
 
+/// Holds scenarios that are launched but not yet reachable through [`AppState`]; dropped without `release` — on a panic — it stops them and frees the scenario name.
+struct AdoptionGuard<'a> {
+    state: &'a AppState,
+    scenario_name: Option<String>,
+    handles: Vec<sonda_core::ScenarioHandle>,
+}
+
+impl<'a> AdoptionGuard<'a> {
+    fn new(
+        state: &'a AppState,
+        scenario_name: Option<String>,
+        handles: Vec<sonda_core::ScenarioHandle>,
+    ) -> Self {
+        Self {
+            state,
+            scenario_name,
+            handles,
+        }
+    }
+
+    fn release(mut self) {
+        self.scenario_name = None;
+        self.handles.clear();
+    }
+}
+
+impl Drop for AdoptionGuard<'_> {
+    fn drop(&mut self) {
+        for handle in &self.handles {
+            handle.stop();
+        }
+        if let Some(name) = self.scenario_name.take() {
+            warn!(scenario_name = %name, stopped = self.handles.len(), "admission panicked after launch — stopped the scenarios it still held and freed the name");
+            self.state.gate_bus_registry.unregister(&name);
+        }
+    }
+}
+
 /// The single admission path: validate a compiled file, launch it, and store the
 /// resulting handles in [`AppState`]. `origin` labels the caller in the logs.
 pub async fn admit_compiled(
@@ -661,10 +696,7 @@ pub async fn admit_compiled(
     origin: &str,
 ) -> Result<Admitted, AdmissionError> {
     if let Some(name) = compiled.scenario_name.as_deref() {
-        let mut conflicts = collect_active_conflicts(state, name).map_err(|()| {
-            warn!(origin = %origin, "{origin}: scenarios lock is poisoned");
-            AdmissionError::Internal("internal state lock is poisoned".to_string())
-        })?;
+        let mut conflicts = collect_active_conflicts(state, name);
         if conflicts.is_empty() && state.gate_bus_registry.scenario_name_in_use(name) {
             conflicts.push(ConflictingScenario {
                 id: String::new(),
@@ -717,8 +749,9 @@ pub async fn admit_compiled(
         }
     };
 
+    let scenario_name = compiled.scenario_name.clone();
     let resolver: Arc<dyn sonda_core::GateBusResolver> = state.gate_bus_registry.clone();
-    let mut handles = launch_multi_compiled(compiled, Some(resolver))
+    let handles = launch_multi_compiled(compiled, Some(resolver))
         .await
         .map_err(|e| {
             warn!(origin = %origin, error = %e, "{origin}: failed to launch scenarios");
@@ -735,8 +768,12 @@ pub async fn admit_compiled(
         ));
     }
 
-    let mut created: Vec<CreatedScenario> = Vec::with_capacity(handles.len());
-    for handle in handles.iter_mut() {
+    let mut launched = AdoptionGuard::new(state, scenario_name, handles);
+    #[cfg(test)]
+    tests::panic_after_launch_if_armed();
+
+    let mut created: Vec<CreatedScenario> = Vec::with_capacity(launched.handles.len());
+    for handle in launched.handles.iter_mut() {
         let new_id = Uuid::new_v4().to_string();
         let old_id = std::mem::replace(&mut handle.id, new_id.clone());
         state.gate_bus_registry.rename_handle(&old_id, &new_id);
@@ -754,17 +791,16 @@ pub async fn admit_compiled(
         });
     }
 
-    let mut scenarios = state.scenarios.write().map_err(|e| {
-        for handle in &handles {
-            handle.stop();
-        }
-        warn!(origin = %origin, error = %e, "{origin}: scenarios lock is poisoned");
-        AdmissionError::Internal("internal state lock is poisoned".to_string())
-    })?;
-    for (created_entry, handle) in created.iter().zip(handles) {
+    let mut scenarios = state.scenarios.write();
+    for created_entry in created.iter() {
+        // Hand one handle over at a time: whatever the guard still holds is what it stops.
+        let handle = launched.handles.remove(0);
+        #[cfg(test)]
+        tests::panic_during_adoption_if_armed();
         scenarios.insert(created_entry.id.clone(), handle);
     }
     drop(scenarios);
+    launched.release();
 
     Ok(Admitted { created, warnings })
 }
@@ -775,10 +811,7 @@ pub async fn admit_compiled(
 /// ID, name, status, and elapsed time. The list includes both running and
 /// stopped scenarios that have not been deleted.
 pub async fn list_scenarios(State(state): State<AppState>) -> Result<impl IntoResponse, Response> {
-    let scenarios = state
-        .scenarios
-        .read()
-        .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
+    let scenarios = state.scenarios.read();
 
     let now_unix_nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -813,10 +846,7 @@ pub async fn get_scenario(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, Response> {
-    let scenarios = state
-        .scenarios
-        .read()
-        .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
+    let scenarios = state.scenarios.read();
 
     let handle = scenarios
         .get(&id)
@@ -863,10 +893,7 @@ pub async fn delete_scenario(
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, Response> {
     let (mut handle, scenario_name_to_unregister) = {
-        let mut scenarios = state
-            .scenarios
-            .write()
-            .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
+        let mut scenarios = state.scenarios.write();
         let handle = scenarios
             .remove(&id)
             .ok_or_else(|| not_found(format!("scenario not found: {id}")))?;
@@ -922,10 +949,7 @@ pub async fn get_scenario_stats(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, Response> {
-    let scenarios = state
-        .scenarios
-        .read()
-        .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
+    let scenarios = state.scenarios.read();
 
     let handle = scenarios
         .get(&id)
@@ -976,10 +1000,7 @@ pub async fn get_scenario_metrics(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Response, Response> {
-    let scenarios = state
-        .scenarios
-        .read()
-        .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
+    let scenarios = state.scenarios.read();
 
     let handle = scenarios
         .get(&id)
@@ -1129,10 +1150,7 @@ pub async fn get_aggregate_metrics(
     let filters = parse_label_filters(raw_query.as_deref()).map_err(bad_request)?;
     let state_filter = parse_include_state(raw_query.as_deref()).map_err(bad_request)?;
 
-    let scenarios = state
-        .scenarios
-        .read()
-        .map_err(|e| internal_error(format!("scenarios lock is poisoned: {e}")))?;
+    let scenarios = state.scenarios.read();
 
     let mut ids: Vec<&String> = scenarios.keys().collect();
     ids.sort();
@@ -1320,12 +1338,236 @@ mod tests {
     fn router_with_handles(handles: Vec<ScenarioHandle>) -> axum::Router {
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             for h in handles {
                 map.insert(h.id.clone(), h);
             }
         }
         router(state)
+    }
+
+    thread_local! {
+        static PANIC_AFTER_LAUNCH: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    }
+
+    pub(super) fn panic_after_launch_if_armed() {
+        if PANIC_AFTER_LAUNCH.with(|armed| armed.replace(false)) {
+            panic!("injected panic between launch and adoption");
+        }
+    }
+
+    fn arm_panic_after_launch() {
+        PANIC_AFTER_LAUNCH.with(|armed| armed.set(true));
+    }
+
+    thread_local! {
+        static PANIC_DURING_ADOPTION: std::cell::Cell<Option<usize>> =
+            const { std::cell::Cell::new(None) };
+    }
+
+    pub(super) fn panic_during_adoption_if_armed() {
+        let fire = PANIC_DURING_ADOPTION.with(|countdown| match countdown.get() {
+            Some(0) => {
+                countdown.set(None);
+                true
+            }
+            Some(remaining) => {
+                countdown.set(Some(remaining - 1));
+                false
+            }
+            None => false,
+        });
+        if fire {
+            panic!("injected panic during adoption");
+        }
+    }
+
+    fn arm_panic_during_adoption(after_handles: usize) {
+        PANIC_DURING_ADOPTION.with(|countdown| countdown.set(Some(after_handles)));
+    }
+
+    fn drive_until_alive_tasks(rt: &tokio::runtime::Runtime, expected: usize) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while rt.metrics().num_alive_tasks() != expected {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "expected {expected} alive tasks, still {}",
+                rt.metrics().num_alive_tasks()
+            );
+            rt.block_on(async { tokio::time::sleep(Duration::from_millis(10)).await });
+        }
+    }
+
+    const ORPHAN_PROBE_YAML: &str = "\
+version: 2
+kind: runnable
+scenario_name: orphan_probe
+defaults:
+  rate: 5
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: memory
+scenarios:
+  - id: cpu
+    signal_type: metrics
+    name: orphan_probe_cpu
+    generator:
+      type: constant
+      value: 1.0
+";
+
+    const ORPHAN_BATCH_YAML: &str = "\
+version: 2
+kind: runnable
+scenario_name: orphan_batch
+defaults:
+  rate: 5
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: memory
+scenarios:
+  - id: first
+    signal_type: metrics
+    name: orphan_batch_first
+    generator:
+      type: constant
+      value: 1.0
+  - id: second
+    signal_type: metrics
+    name: orphan_batch_second
+    generator:
+      type: constant
+      value: 2.0
+  - id: third
+    signal_type: metrics
+    name: orphan_batch_third
+    generator:
+      type: constant
+      value: 3.0
+";
+
+    fn orphan_probe() -> CompiledFile {
+        compile_v2_text(ORPHAN_PROBE_YAML, None).expect("the probe body must compile")
+    }
+
+    fn orphan_batch() -> CompiledFile {
+        compile_v2_text(ORPHAN_BATCH_YAML, None).expect("the batch body must compile")
+    }
+
+    #[test]
+    fn a_panic_between_launch_and_adoption_stops_the_scenarios_and_frees_the_name() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let state = AppState::new();
+
+        arm_panic_after_launch();
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            rt.block_on(admit_compiled(&state, orphan_probe(), "test"))
+        }));
+        assert!(outcome.is_err(), "the injected panic must have propagated");
+
+        assert!(
+            state.scenarios.read().is_empty(),
+            "a scenario that never reached the map must not be listed"
+        );
+        assert!(
+            !state.gate_bus_registry.scenario_name_in_use("orphan_probe"),
+            "the scenario name must not stay held by the registry"
+        );
+        drive_until_alive_tasks(&rt, 0);
+
+        let readmitted = rt.block_on(admit_compiled(&state, orphan_probe(), "test"));
+        assert!(
+            readmitted.is_ok(),
+            "the name must be admissible again, got: {:?}",
+            readmitted.err()
+        );
+        rt.block_on(cleanup_scenarios(&state));
+    }
+
+    #[test]
+    fn a_panic_during_adoption_keeps_the_rows_already_inserted_and_stops_the_tail() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let state = AppState::new();
+
+        arm_panic_during_adoption(1);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            rt.block_on(admit_compiled(&state, orphan_batch(), "test"))
+        }));
+        assert!(outcome.is_err(), "the injected panic must have propagated");
+        assert_eq!(
+            rt.metrics().num_alive_tasks(),
+            3,
+            "all three scenario tasks must still be registered at the panic"
+        );
+
+        let inserted: Vec<Arc<std::sync::atomic::AtomicBool>> = {
+            let map = state.scenarios.read();
+            map.values().map(|h| Arc::clone(&h.alive)).collect()
+        };
+        assert_eq!(
+            inserted.len(),
+            1,
+            "the row inserted before the panic must stay reachable"
+        );
+        assert!(
+            !state.gate_bus_registry.scenario_name_in_use("orphan_batch"),
+            "the scenario name must not stay held by the registry"
+        );
+
+        // Exactly one task exits: the handle the guard still held. The inserted row keeps
+        // running, and the handle in flight at the panic escapes.
+        drive_until_alive_tasks(&rt, 2);
+        assert!(
+            inserted[0].load(std::sync::atomic::Ordering::SeqCst),
+            "an adopted scenario must not be stopped by the guard"
+        );
+    }
+
+    #[tokio::test]
+    async fn dropping_the_adoption_guard_stops_the_scenarios_it_holds() {
+        let state = AppState::new();
+        let resolver: Arc<dyn GateBusResolver> = state.gate_bus_registry.clone();
+        let handles = launch_multi_compiled(orphan_probe(), Some(resolver))
+            .await
+            .expect("launch must succeed");
+        assert!(!handles.is_empty());
+        let alive: Vec<Arc<std::sync::atomic::AtomicBool>> =
+            handles.iter().map(|h| Arc::clone(&h.alive)).collect();
+        assert!(
+            state.gate_bus_registry.scenario_name_in_use("orphan_probe"),
+            "the launch must have taken the name, or this test proves nothing"
+        );
+
+        drop(AdoptionGuard::new(
+            &state,
+            Some("orphan_probe".to_string()),
+            handles,
+        ));
+
+        assert!(
+            !state.gate_bus_registry.scenario_name_in_use("orphan_probe"),
+            "the guard must free the name it took"
+        );
+        for flag in alive {
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+            while flag.load(std::sync::atomic::Ordering::SeqCst) {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "the guard must stop every scenario it holds"
+                );
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
     }
 
     /// Build the router with fresh empty state for test use (returns state for POST tests).
@@ -1348,16 +1590,12 @@ mod tests {
     /// lock to join the threads.
     async fn cleanup_scenarios(state: &AppState) {
         // Phase 1: signal all scenarios to stop (read lock).
-        if let Ok(scenarios) = state.scenarios.read() {
-            for handle in scenarios.values() {
-                handle.stop();
-            }
+        for handle in state.scenarios.read().values() {
+            handle.stop();
         }
         // Phase 2: drain handles under the write lock, then await join_async outside it.
-        let handles: Vec<ScenarioHandle> = match state.scenarios.write() {
-            Ok(mut scenarios) => scenarios.drain().map(|(_, h)| h).collect(),
-            Err(_) => return,
-        };
+        let handles: Vec<ScenarioHandle> =
+            state.scenarios.write().drain().map(|(_, h)| h).collect();
         for mut handle in handles {
             let _ = handle.join_async(Some(Duration::from_secs(2))).await;
         }
@@ -1735,7 +1973,7 @@ scenarios:
         let h = make_handle("id-events", "events_check", 500, Duration::from_millis(10));
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -1855,7 +2093,7 @@ scenarios:
         let created_at = Instant::now();
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -2032,7 +2270,7 @@ scenarios:
 
         // Verify the handle was stored in AppState.
         {
-            let scenarios = state.scenarios.read().expect("lock must not be poisoned");
+            let scenarios = state.scenarios.read();
             let id = body["id"].as_str().unwrap();
             assert!(
                 scenarios.contains_key(id),
@@ -2196,7 +2434,7 @@ scenarios:
 
         // Check that the handle reports is_running() == true.
         {
-            let scenarios = state.scenarios.read().expect("lock must not be poisoned");
+            let scenarios = state.scenarios.read();
             let handle = scenarios
                 .get(&id)
                 .expect("handle must exist in AppState after POST");
@@ -2722,7 +2960,7 @@ scenarios:
         let h = make_handle("id-del-run", "del_running", 1000, Duration::from_millis(50));
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -2752,7 +2990,7 @@ scenarios:
         let h = make_handle("id-del-stats", "del_stats", 1000, Duration::from_millis(10));
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -2782,7 +3020,7 @@ scenarios:
         let h = make_stopped_handle("id-del-stopped", "del_stopped");
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -2837,7 +3075,7 @@ scenarios:
         let h = make_handle("id-del-shape", "del_shape", 1000, Duration::from_millis(50));
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -2876,7 +3114,7 @@ scenarios:
         let h = make_handle("id-del-match", "del_match", 1000, Duration::from_millis(50));
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -2901,7 +3139,7 @@ scenarios:
         let h = make_handle("id-del-twice", "del_twice", 1000, Duration::from_millis(50));
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -2934,13 +3172,13 @@ scenarios:
         let h = make_handle("id-del-map", "del_map", 1000, Duration::from_millis(50));
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
         // Precondition: map has exactly 1 entry.
         assert_eq!(
-            state.scenarios.read().unwrap().len(),
+            state.scenarios.read().len(),
             1,
             "precondition: map must have 1 entry before DELETE"
         );
@@ -2950,7 +3188,7 @@ scenarios:
         assert_eq!(resp.status(), StatusCode::OK);
 
         // After DELETE, the handle must be gone.
-        let map = state.scenarios.read().unwrap();
+        let map = state.scenarios.read();
         assert_eq!(map.len(), 0, "map must be empty after DELETE");
         assert!(
             map.get("id-del-map").is_none(),
@@ -2972,7 +3210,7 @@ scenarios:
         );
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h_keep.id.clone(), h_keep);
             map.insert(h_delete.id.clone(), h_delete);
         }
@@ -3047,7 +3285,7 @@ scenarios:
         let h = make_handle("id-del-ct", "del_ct", 1000, Duration::from_millis(50));
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -3261,7 +3499,7 @@ scenarios:
         );
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -3720,7 +3958,7 @@ scenarios:
         let h = make_handle_with_metrics("id-idem", "idem", events);
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -3969,7 +4207,7 @@ scenarios:
         );
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -3993,7 +4231,7 @@ scenarios:
         );
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -4455,7 +4693,7 @@ scenarios:
         let h = make_unjoinable_handle("id-force", "force_stop");
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -4481,7 +4719,7 @@ scenarios:
         );
 
         // Verify the handle was removed from the map despite being force-stopped.
-        let map = state.scenarios.read().unwrap();
+        let map = state.scenarios.read();
         assert!(
             map.get("id-force").is_none(),
             "force-stopped scenario must still be removed from the map"
@@ -4497,7 +4735,7 @@ scenarios:
         let h = make_panicking_handle("id-panic", "panic_scenario");
         let state = AppState::new();
         {
-            let mut map = state.scenarios.write().unwrap();
+            let mut map = state.scenarios.write();
             map.insert(h.id.clone(), h);
         }
 
@@ -4518,38 +4756,35 @@ scenarios:
         );
 
         // Verify the handle was removed from the map.
-        let map = state.scenarios.read().unwrap();
+        let map = state.scenarios.read();
         assert!(
             map.get("id-panic").is_none(),
             "panicked scenario must be removed from the map"
         );
     }
 
-    // ---- L3: Poisoned map lock returns 500 in read handlers ----------------
-
-    /// Helper: build an AppState with a poisoned scenarios lock.
-    fn make_poisoned_state() -> AppState {
+    fn poisoned_state() -> AppState {
         let state = AppState::new();
-        // Poison the lock by panicking inside a write guard.
-        let scenarios_clone = Arc::clone(&state.scenarios);
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _guard = scenarios_clone.write().unwrap();
-            panic!("intentional panic to poison map lock");
-        }));
-        assert!(result.is_err(), "panic must have occurred");
-        // Verify the lock is actually poisoned.
-        assert!(
-            state.scenarios.read().is_err(),
-            "map lock must be poisoned after panic"
-        );
+        crate::locks::poison(&state.scenarios);
         state
     }
 
-    /// GET /scenarios returns 500 when the map lock is poisoned.
+    fn poisoned_state_holding(handles: Vec<ScenarioHandle>) -> AppState {
+        let state = AppState::new();
+        {
+            let mut map = state.scenarios.write();
+            for h in handles {
+                map.insert(h.id.clone(), h);
+            }
+        }
+        crate::locks::poison(&state.scenarios);
+        state
+    }
+
     #[tokio::test]
-    async fn list_scenarios_poisoned_lock_returns_500() {
-        let state = make_poisoned_state();
-        let app = router(state);
+    async fn list_scenarios_still_serves_the_map_contents_after_the_lock_is_poisoned() {
+        let state = poisoned_state_holding(vec![make_stopped_handle("kept-id", "kept_scenario")]);
+        let app = router(state.clone());
 
         let req = Request::builder()
             .uri("/scenarios")
@@ -4557,25 +4792,38 @@ scenarios:
             .unwrap();
 
         let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(
-            resp.status(),
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "poisoned map lock on list must return 500"
-        );
+        assert_eq!(resp.status(), StatusCode::OK);
 
         let body = body_json(resp).await;
-        assert_eq!(
-            body["error"].as_str().unwrap(),
-            "internal_server_error",
-            "500 response must have error='internal_server_error'"
-        );
+        let listed = body["scenarios"].as_array().expect("scenarios array");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0]["id"], "kept-id");
+        assert!(state.scenarios.recoveries() > 0);
     }
 
-    /// GET /scenarios/{id} returns 500 when the map lock is poisoned.
     #[tokio::test]
-    async fn get_scenario_poisoned_lock_returns_500() {
-        let state = make_poisoned_state();
-        let app = router(state);
+    async fn get_scenario_still_serves_the_map_contents_after_the_lock_is_poisoned() {
+        let state = poisoned_state_holding(vec![make_stopped_handle("kept-id", "kept_scenario")]);
+        let app = router(state.clone());
+
+        let req = Request::builder()
+            .uri("/scenarios/kept-id")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["name"], "kept_scenario");
+        assert!(state.scenarios.recoveries() > 0);
+    }
+
+    #[tokio::test]
+    async fn get_scenario_reports_not_found_for_an_unknown_id_after_the_lock_is_poisoned() {
+        let app = router(poisoned_state_holding(vec![make_stopped_handle(
+            "kept-id",
+            "kept_scenario",
+        )]));
 
         let req = Request::builder()
             .uri("/scenarios/any-id")
@@ -4583,76 +4831,105 @@ scenarios:
             .unwrap();
 
         let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(
-            resp.status(),
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "poisoned map lock on get must return 500"
-        );
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
-    /// GET /scenarios/{id}/stats returns 500 when the map lock is poisoned.
     #[tokio::test]
-    async fn get_scenario_stats_poisoned_lock_returns_500() {
-        let state = make_poisoned_state();
-        let app = router(state);
+    async fn get_scenario_stats_reports_not_found_after_the_map_lock_is_poisoned() {
+        let state = poisoned_state();
+        let app = router(state.clone());
 
         let resp = get_stats_req(app, "any-id").await;
-        assert_eq!(
-            resp.status(),
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "poisoned map lock on stats must return 500"
-        );
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert!(state.scenarios.recoveries() > 0);
     }
 
-    /// GET /scenarios/{id}/metrics returns 500 when the map lock is poisoned.
     #[tokio::test]
-    async fn get_scenario_metrics_poisoned_lock_returns_500() {
-        let state = make_poisoned_state();
-        let app = router(state);
+    async fn get_scenario_metrics_reports_not_found_after_the_map_lock_is_poisoned() {
+        let state = poisoned_state();
+        let app = router(state.clone());
 
         let resp = get_metrics_req(app, "any-id").await;
-        assert_eq!(
-            resp.status(),
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "poisoned map lock on metrics must return 500"
-        );
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert!(state.scenarios.recoveries() > 0);
     }
 
-    /// DELETE /scenarios/{id} returns 500 when the map lock is poisoned.
     #[tokio::test]
-    async fn delete_scenario_poisoned_lock_returns_500() {
-        let state = make_poisoned_state();
-        let app = router(state);
+    async fn delete_scenario_reports_not_found_after_the_map_lock_is_poisoned() {
+        let state = poisoned_state();
+        let app = router(state.clone());
 
         let resp = delete_scenario_req(app, "any-id").await;
-        assert_eq!(
-            resp.status(),
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "poisoned map lock on delete must return 500"
-        );
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert!(state.scenarios.recoveries() > 0);
     }
 
-    /// POST /scenarios returns 500 when the map lock is poisoned (lock
-    /// acquisition for storing the handle fails).
     #[tokio::test]
-    async fn post_scenario_poisoned_lock_returns_500() {
-        let state = make_poisoned_state();
-        let app = router(state);
+    async fn post_scenario_still_admits_after_the_map_lock_is_poisoned() {
+        let state = poisoned_state();
+        let app = router(state.clone());
 
         let response = post_scenarios(app, "application/x-yaml", VALID_METRICS_YAML).await;
-
-        assert_eq!(
-            response.status(),
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "poisoned map lock on post must return 500"
-        );
+        assert_eq!(response.status(), StatusCode::CREATED);
 
         let body = body_json(response).await;
-        assert_eq!(
-            body["error"].as_str().unwrap(),
-            "internal_server_error",
-            "500 response must have error='internal_server_error'"
-        );
+        let id = body["id"]
+            .as_str()
+            .expect("id must be a string")
+            .to_string();
+        assert!(state.scenarios.read().contains_key(&id));
+
+        cleanup_scenarios(&state).await;
+    }
+
+    #[tokio::test]
+    async fn a_poisoned_map_lock_leaves_scenarios_metrics_and_ready_all_serving() {
+        let state = poisoned_state();
+
+        let list = router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/scenarios")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(list.status(), StatusCode::OK);
+
+        let ready = router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(ready.status(), StatusCode::OK);
+
+        let metrics = router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(metrics.status(), StatusCode::OK);
+
+        let text = body_string(metrics).await;
+        let row = text
+            .lines()
+            .find(|l| l.starts_with("sonda_server_lock_recoveries_total{lock=\"scenarios\"}"))
+            .expect("the scenarios lock must have a recoveries series");
+        let value: u64 = row
+            .rsplit(' ')
+            .next()
+            .and_then(|v| v.parse().ok())
+            .expect("the series must carry a numeric value");
+        assert!(value > 0, "recoveries must be reported, got: {row}");
     }
 
     // ========================================================================
@@ -4775,7 +5052,7 @@ scenarios:
         let body = body_json(response).await;
         let scenarios = body["scenarios"].as_array().unwrap();
         {
-            let map = state.scenarios.read().expect("lock must not be poisoned");
+            let map = state.scenarios.read();
             for entry in scenarios {
                 let id = entry["id"].as_str().unwrap();
                 assert!(
@@ -4895,7 +5172,7 @@ scenarios:
         );
 
         // Verify nothing was launched (atomic batch semantics).
-        let map = state.scenarios.read().expect("lock must not be poisoned");
+        let map = state.scenarios.read();
         assert!(
             map.is_empty(),
             "no scenarios must be launched when batch validation fails"
@@ -5023,7 +5300,7 @@ scenarios:
         }
 
         // Verify all are gone.
-        let map = state.scenarios.read().unwrap();
+        let map = state.scenarios.read();
         assert!(
             map.is_empty(),
             "all multi-scenario handles must be removed after DELETE"

--- a/sonda-server/src/state.rs
+++ b/sonda-server/src/state.rs
@@ -3,13 +3,18 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, AtomicU8, AtomicUsize, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Instant;
 
 use sonda_core::ScenarioHandle;
 use tokio::sync::Semaphore;
 
 use crate::gate_registry::GateBusRegistry;
+use crate::locks::RecoveringLock;
+
+const SCENARIOS_LOCK: &str = "scenarios";
+const REQUEST_COUNTERS_LOCK: &str = "request_counters";
+const REQUEST_HISTOGRAMS_LOCK: &str = "request_histograms";
 
 pub type RouteKey = (String, String, u16);
 pub type HistogramKey = (String, String);
@@ -207,7 +212,7 @@ impl SweepStatus {
 #[derive(Clone)]
 pub struct AppState {
     /// Map from scenario ID to its lifecycle handle.
-    pub scenarios: Arc<RwLock<HashMap<String, ScenarioHandle>>>,
+    pub scenarios: Arc<RecoveringLock<HashMap<String, ScenarioHandle>>>,
     /// Optional API key for bearer-token authentication on protected routes.
     pub api_key: Option<Arc<String>>,
     /// Optional catalog directory for resolving `pack:` references in posted bodies.
@@ -223,9 +228,9 @@ pub struct AppState {
     /// Configured `--max-scenarios` value exposed via `sonda_server_max_scenarios`.
     pub max_scenarios: usize,
     /// Per-`(route, method, status)` request counters.
-    pub request_counters: Arc<RwLock<HashMap<RouteKey, AtomicU64>>>,
+    pub request_counters: Arc<RecoveringLock<HashMap<RouteKey, AtomicU64>>>,
     /// Per-`(route, method)` duration histograms.
-    pub request_histograms: Arc<RwLock<HashMap<HistogramKey, HistogramShard>>>,
+    pub request_histograms: Arc<RecoveringLock<HashMap<HistogramKey, HistogramShard>>>,
     /// Progress of the `--autostart` catalog sweep.
     pub sweep_status: Arc<SweepStatus>,
 }
@@ -234,7 +239,7 @@ impl AppState {
     /// Create a new, empty application state with no authentication.
     pub fn new() -> Self {
         Self {
-            scenarios: Arc::new(RwLock::new(HashMap::new())),
+            scenarios: Arc::new(RecoveringLock::new(SCENARIOS_LOCK, HashMap::new())),
             api_key: None,
             catalog_dir: None,
             gate_bus_registry: Arc::new(GateBusRegistry::new()),
@@ -242,8 +247,11 @@ impl AppState {
             started_at: Instant::now(),
             worker_threads: 1,
             max_scenarios: 0,
-            request_counters: Arc::new(RwLock::new(HashMap::new())),
-            request_histograms: Arc::new(RwLock::new(HashMap::new())),
+            request_counters: Arc::new(RecoveringLock::new(REQUEST_COUNTERS_LOCK, HashMap::new())),
+            request_histograms: Arc::new(RecoveringLock::new(
+                REQUEST_HISTOGRAMS_LOCK,
+                HashMap::new(),
+            )),
             sweep_status: Arc::new(SweepStatus::not_configured()),
         }
     }
@@ -252,7 +260,7 @@ impl AppState {
     #[allow(dead_code)]
     pub fn with_api_key(api_key: Option<String>) -> Self {
         Self {
-            scenarios: Arc::new(RwLock::new(HashMap::new())),
+            scenarios: Arc::new(RecoveringLock::new(SCENARIOS_LOCK, HashMap::new())),
             api_key: api_key.map(Arc::new),
             catalog_dir: None,
             gate_bus_registry: Arc::new(GateBusRegistry::new()),
@@ -260,10 +268,31 @@ impl AppState {
             started_at: Instant::now(),
             worker_threads: 1,
             max_scenarios: 0,
-            request_counters: Arc::new(RwLock::new(HashMap::new())),
-            request_histograms: Arc::new(RwLock::new(HashMap::new())),
+            request_counters: Arc::new(RecoveringLock::new(REQUEST_COUNTERS_LOCK, HashMap::new())),
+            request_histograms: Arc::new(RecoveringLock::new(
+                REQUEST_HISTOGRAMS_LOCK,
+                HashMap::new(),
+            )),
             sweep_status: Arc::new(SweepStatus::not_configured()),
         }
+    }
+
+    /// Recovered poisoned-lock acquisitions, per lock, across every lock the server owns.
+    pub fn lock_recoveries(&self) -> Vec<(&'static str, u64)> {
+        let mut rows = vec![
+            (self.scenarios.name(), self.scenarios.recoveries()),
+            (
+                self.request_counters.name(),
+                self.request_counters.recoveries(),
+            ),
+            (
+                self.request_histograms.name(),
+                self.request_histograms.recoveries(),
+            ),
+        ];
+        rows.extend(self.gate_bus_registry.lock_recoveries());
+        rows.sort_by_key(|(name, _)| *name);
+        rows
     }
 }
 
@@ -281,7 +310,7 @@ mod tests {
     #[test]
     fn new_state_has_empty_scenarios() {
         let state = AppState::new();
-        let scenarios = state.scenarios.read().expect("RwLock must not be poisoned");
+        let scenarios = state.scenarios.read();
         assert!(
             scenarios.is_empty(),
             "new AppState must have an empty scenarios map"
@@ -302,7 +331,7 @@ mod tests {
     #[test]
     fn default_produces_empty_state() {
         let state = AppState::default();
-        let scenarios = state.scenarios.read().expect("RwLock must not be poisoned");
+        let scenarios = state.scenarios.read();
         assert!(
             scenarios.is_empty(),
             "default AppState must have an empty scenarios map"
@@ -335,7 +364,7 @@ mod tests {
     #[test]
     fn with_api_key_has_empty_scenarios() {
         let state = AppState::with_api_key(Some("key".to_string()));
-        let scenarios = state.scenarios.read().expect("RwLock must not be poisoned");
+        let scenarios = state.scenarios.read();
         assert!(
             scenarios.is_empty(),
             "with_api_key must produce an empty scenarios map"
@@ -350,7 +379,7 @@ mod tests {
         // Both point to the same Arc.
         assert!(
             Arc::ptr_eq(&state1.scenarios, &state2.scenarios),
-            "cloned AppState must share the same Arc<RwLock<...>>"
+            "cloned AppState must share the same lock"
         );
     }
 

--- a/sonda-server/tests/bounded_scheduler.rs
+++ b/sonda-server/tests/bounded_scheduler.rs
@@ -263,7 +263,7 @@ fn max_scenarios_zero_allows_unlimited_posts() {
 }
 
 #[test]
-fn server_metrics_emits_all_eleven_series_with_zero_state_rows() {
+fn server_metrics_emits_all_twelve_series_with_zero_state_rows() {
     let (port, _guard) = common::start_server();
     let client = common::http_client();
     let base = format!("http://127.0.0.1:{port}");
@@ -285,6 +285,7 @@ fn server_metrics_emits_all_eleven_series_with_zero_state_rows() {
         "sonda_server_requests_total",
         "sonda_server_request_duration_seconds",
         "sonda_server_sink_errors_total",
+        "sonda_server_lock_recoveries_total",
         "sonda_server_uptime_seconds",
         "sonda_server_build_info",
     ] {
@@ -302,9 +303,24 @@ fn server_metrics_emits_all_eleven_series_with_zero_state_rows() {
         );
     }
 
+    for lock in [
+        "gate_buses",
+        "gate_pending",
+        "gate_subscribers",
+        "request_counters",
+        "request_histograms",
+        "scenarios",
+    ] {
+        let needle = format!("sonda_server_lock_recoveries_total{{lock=\"{lock}\"}} 0");
+        assert!(
+            text.contains(&needle),
+            "expected zero-row `{needle}`. Got:\n{text}"
+        );
+    }
+
     assert_eq!(
         text.matches("# TYPE ").count(),
-        11,
+        12,
         "a series was added or removed — update the list above and the count. Got:\n{text}"
     );
 }


### PR DESCRIPTION
A panic while holding shared state poisoned its lock for the life of the process: every later acquisition failed, `/scenarios` and `/metrics` returned 500s, and `/ready` still answered 200 because the startup sweep had succeeded. Nothing surfaced it, and recovery meant a human deleting the pod. Locks now recover instead, and each recovery is counted, so the panic that caused it is visible rather than inferred from the damage.

Recovery is only sound where no critical section can leave a torn invariant, so that argument is made per lock and written down in `locks.rs`. Four of the six locks already recovered inline; what is new is one stated policy, the `scenarios` map joining it, and the counter.

- `RecoveringLock` owns the policy for all six locks
- `sonda_server_lock_recoveries_total{lock=...}` — non-zero means a handler panicked while holding that lock. Alert on the level, not a rate: once poisoned the counter climbs with traffic and a rate-shaped alert never clears
- per-entry admission runs in its own task, so a panic starting one catalog entry skips that entry instead of stopping the sweep
- `AdoptionGuard` stops and unregisters whatever a panic left unadopted between launch and the map. Previously such a scenario emitted forever, was absent from `/scenarios`, could not be DELETEd, and held its `scenario_name` so every later POST under it conflicted. One in-flight handle can still escape, and the docs say so rather than claiming full containment
- stats writes reached through the gate registry recover too, so a scenario whose stats lock is poisoned no longer reports a stale state forever on `/scenarios`, `/stats` and `sonda_server_active_scenarios`

Closes #593