### PR TITLE
docs: the capture page, and let --timescale -1 reach its own error

### DIFF
--- a/docs/site/docs/import/from-csv.md
+++ b/docs/site/docs/import/from-csv.md
@@ -190,7 +190,7 @@ sonda run scenario.yaml --rate 10 --duration 5m
 ## CLI reference
 
 ```
-sonda new [--template] [--from <CSV>] [-o <PATH>]
+sonda new [--template] [--from <CSV>] [--from-prometheus <URL> ...] [-o <PATH>]
 ```
 
 | Flag | Description |
@@ -198,6 +198,7 @@ sonda new [--template] [--from <CSV>] [-o <PATH>]
 | (no flags) | Interactive flow. Asks for signal type, generator, rate, duration, sink type, and output path. |
 | `--template` | Print a minimal valid YAML to stdout and exit. No prompts. |
 | `--from <CSV>` | Generate a scenario from a CSV file. Runs pattern detection on each numeric column. |
+| `--from-prometheus <URL>` | Capture a live PromQL range query and replay it verbatim — no pattern detection. Takes its own flags; see [From a live Prometheus](from-prometheus.md). |
 | `-o <PATH>` | Write the result to a file instead of stdout. |
 
 See [CLI Reference: sonda new](../reference/cli-flags.md#sonda-new) for the full reference.

--- a/docs/site/docs/import/from-prometheus.md
+++ b/docs/site/docs/import/from-prometheus.md
@@ -1,0 +1,208 @@
+---
+title: From a live Prometheus
+description: Capture a PromQL range query with sonda new --from-prometheus and replay it verbatim — recorded values, recorded gaps, no pattern fitting.
+---
+
+# Capture from a live Prometheus
+
+`sonda new --from-prometheus` runs one PromQL range query against a live
+Prometheus-compatible TSDB and writes the two files that replay it: a CSV of the
+values it recorded, and a scenario that plays them back at the cadence they were
+captured at.
+
+The case this closes is **alert regression**. An alert fired during an incident;
+you want it to fire again, in CI, on the same numbers — not on a synthetic curve
+that resembles them. So the values are replayed verbatim, and the gaps in the
+data are replayed as gaps.
+
+---
+
+## The recipe
+
+```bash
+sonda new --from-prometheus http://localhost:9090 \
+  --query 'up{job="api"}' \
+  --range 1h --step 15s \
+  --out incident.csv -o incident.yaml
+```
+
+That writes two files and prints a line to stderr saying what it captured:
+
+```text title="stderr"
+captured 1 series over 241 points to incident.csv (1 missing sample)
+wrote incident.yaml
+```
+
+Then replay it like any other scenario:
+
+```bash
+sonda run incident.yaml
+```
+
+`incident.yaml` references `incident.csv` by the path you gave `--out`, so keep
+the pair together — or pass an absolute path if the scenario will run from
+somewhere else.
+
+### The window
+
+Either a duration ending now:
+
+```bash
+sonda new --from-prometheus http://localhost:9090 --query up \
+  --range 30m --step 15s --out capture.csv
+```
+
+…or explicit bounds, as unix seconds or RFC 3339:
+
+```bash
+sonda new --from-prometheus http://localhost:9090 --query up \
+  --start 2026-05-14T09:00:00Z --end 2026-05-14T10:00:00Z \
+  --step 15s --out capture.csv
+```
+
+`--step` is the sample step of the query *and* the replay grid: one CSV row per
+step, one replay tick per row.
+
+### Credentials
+
+Pass a bearer token through the environment, never a flag — a flag value lands in
+shell history, process listings and CI logs:
+
+```bash
+SONDA_PROM_TOKEN=… sonda new --from-prometheus https://prom.example.com \
+  --query up --range 1h --step 15s --out capture.csv
+```
+
+For anything else, `--header` (repeatable):
+
+```bash
+sonda new --from-prometheus https://prom.example.com \
+  --header 'X-Scope-OrgID: tenant-7' \
+  --query up --range 1h --step 15s --out capture.csv
+```
+
+Both can be set at once. An explicit `--header Authorization:` wins over
+`SONDA_PROM_TOKEN`, and says so on stderr rather than quietly dropping one of the
+two. Neither ever reaches the emitted CSV or YAML.
+
+---
+
+## Aggregated queries need `--metric-name`
+
+A query matching more than 20 series is refused — past that a capture stops being
+a scenario anyone can read. The usual way under the cap is to aggregate, and
+**PromQL aggregations drop `__name__`**, so the emitted scenario would have no
+metric name to use. Supply one:
+
+```bash
+sonda new --from-prometheus http://localhost:9090 \
+  --query 'sum by (job) (rate(http_errors_total[5m]))' \
+  --metric-name http_errors_per_second \
+  --range 1h --step 15s --out errors.csv -o errors.yaml
+```
+
+`--metric-name` fills in only the series that lack a name; one the query kept is
+never overwritten.
+
+## Replaying faster than real time
+
+`--timescale 4` replays a one-hour capture in fifteen minutes. It moves the rate,
+the duration and the gap windows together, so the accelerated scenario describes
+one consistent timeline:
+
+```bash
+sonda new --from-prometheus http://localhost:9090 --query up \
+  --range 1h --step 15s --timescale 4 --out capture.csv -o fast.yaml
+```
+
+## Gaps are data
+
+A grid point the database had no sample for becomes a blank cell in the CSV and a
+[`gap_windows:`](../build/scheduling.md) entry in the scenario, so the replay goes
+silent exactly where the original did. A scrape gap that made an alert fire is
+part of the incident, and a capture that filled it in would not reproduce it.
+
+Values are never interpolated, averaged or carried forward. A `NaN` the database
+reported is a sample; a point it reported nothing for is a gap. They are
+different facts and the capture keeps them apart.
+
+---
+
+## What this is not
+
+Three fences worth stating plainly, because each one is a thing people reasonably
+expect and none of them is here.
+
+**Not a PromQL engine.** Sonda sends your query to Prometheus and reads the
+result. It does not parse, rewrite, optimise or validate PromQL — a syntax error
+comes back from the server, in the server's words. Anything your Prometheus can
+answer, this can capture; anything it cannot, neither can this.
+
+**Not backfill.** This reads *out* of a TSDB and writes files. It never writes
+into one. If you need historical samples loaded into Prometheus, that is
+`promtool tsdb create-blocks-from` or your vendor's import path, not Sonda.
+
+**Not decomposition.** A capture is not analysed. Nothing here classifies the
+shape of a signal, fits a generator to it, or hands you tunable parameters —
+there is no `--fit`. You get the recorded numbers back.
+
+If you want the *pattern* rather than the recording — a portable scenario with
+knobs you can turn, that runs without the original file — that is
+[`sonda new --from <csv>`](from-csv.md), which does classify and does fit. The
+two answer different questions:
+
+| | `--from-prometheus` | `--from <csv>` |
+|---|---|---|
+| Output | the recorded values | a fitted generator |
+| Needs the data file at run time | yes | no |
+| Parameterised afterwards | no | yes |
+| Reproduces an incident exactly | yes | approximately |
+
+---
+
+## What gets written
+
+The CSV carries one timestamp column and one column per series, with the label
+set in the header:
+
+```text title="incident.csv"
+timestamp,"{__name__=""up"", job=""api""}"
+1747213200.000,1
+1747213215.000,1
+1747213230.000,
+1747213245.000,1
+```
+
+The scenario points at it, one entry per group of columns that share an absence
+pattern and carry different metric names:
+
+```yaml title="incident.yaml"
+version: 2
+kind: runnable
+tags: []
+scenarios:
+- id: capture_0
+  signal_type: metrics
+  name: capture_0
+  rate: 0.06666666666666667
+  duration: 3615s
+  generator:
+    type: csv_replay
+    file: incident.csv
+    columns:
+    - index: 1
+      name: up
+      labels:
+        job: api
+    repeat: false
+  gap_windows:
+  - at: 22.5s
+    for: 15s
+```
+
+`repeat: false` is always written: a capture is a single pass, and looping one
+that declares `gap_windows:` is refused by the engine.
+
+One metric across several label sets — `up{job="api"}` and `up{job="db"}`, the
+ordinary result of a range query — becomes one entry each, because a column name
+becomes a scenario name and those must be unique.

--- a/docs/site/docs/import/index.md
+++ b/docs/site/docs/import/index.md
@@ -5,9 +5,13 @@ description: Convert CSV exports, Grafana panels, and log files into replayable 
 
 # Import real data
 
-This section covers three ways to turn real telemetry into a Sonda scenario. Each page handles one input format: a CSV file, a Grafana panel export, or a structured log file. The result is a YAML scenario you can replay for incident reproduction, regression tests, or dashboard validation.
+This section covers four ways to turn real telemetry into a Sonda scenario: a live Prometheus, a CSV file, a Grafana panel export, or a structured log file. The result is a YAML scenario you can replay for incident reproduction, regression tests, or dashboard validation.
 
 <div class="grid cards" markdown>
+
+-   :material-database-arrow-down-outline: __[From a live Prometheus](from-prometheus.md)__
+
+    `sonda new --from-prometheus` captures a PromQL range query and replays the recorded values verbatim — gaps included. For alert regression.
 
 -   :material-file-table-outline: __[From a CSV file](from-csv.md)__
 

--- a/docs/site/docs/reference/cli-flags.md
+++ b/docs/site/docs/reference/cli-flags.md
@@ -216,10 +216,10 @@ sonda --dry-run run /tmp/snap.yaml
 
 ## `sonda new`
 
-Create a new scenario YAML. Three modes are available. Pick the one that matches how much you already know about the scenario you want.
+Create a new scenario YAML. Four modes are available. Pick the one that matches how much you already know about the scenario you want.
 
 ```
-sonda new [--template] [--from <CSV>] [-o <PATH>]
+sonda new [--template] [--from <CSV>] [--from-prometheus <URL> ...] [-o <PATH>]
 ```
 
 | Flag | Description |
@@ -227,7 +227,29 @@ sonda new [--template] [--from <CSV>] [-o <PATH>]
 | (no flags) | Interactive [dialoguer](https://crates.io/crates/dialoguer) flow. Walks through signal type, generator, rate, duration, sink type, and output path. Requires a TTY on stdin. |
 | `--template` | Print a minimal valid YAML to stdout and exit. No prompts. |
 | `--from <CSV>` | Seed the file from a CSV file. Pattern detection runs on each numeric column and chooses an operational alias (`steady`, `spike_event`, `leak`, `saturation`, `flap`) per column. |
+| `--from-prometheus <URL>` | Capture a live PromQL range query and replay it verbatim — no pattern detection. See the capture flags below. Conflicts with `--template` and `--from`. |
 | `-o <PATH>` | Write the result to a file instead of stdout. Parent directories are created if missing. |
+
+### Capture flags
+
+Every flag in this table requires `--from-prometheus`, and `--from-prometheus`
+requires `--query`, `--step` and `--out`. Full guide:
+[From a live Prometheus](../import/from-prometheus.md).
+
+| Flag | Description |
+|------|-------------|
+| `--query <PROMQL>` | The range query to capture. Sent to the server as written. |
+| `--range <DURATION>` | Capture the window ending now (`1h`, `30m`). Alternative to `--start`/`--end`. |
+| `--start <INSTANT>` / `--end <INSTANT>` | Explicit bounds, as unix seconds or RFC 3339. Both or neither. |
+| `--step <DURATION>` | Sample step of the query, and the replay grid. |
+| `--out <PATH>` | Where to write the captured CSV. The emitted scenario references this path. |
+| `--metric-name <NAME>` | Name for series the query left without one — PromQL aggregations drop `__name__`. Never overwrites a name the query kept. |
+| `--timescale <FACTOR>` | Replay speed. `4` replays an hour in fifteen minutes, moving rate, duration and gap windows together. |
+| `--header <NAME:VALUE>` | Extra request header, repeatable. An explicit `Authorization:` overrides `SONDA_PROM_TOKEN`, with a note on stderr. |
+
+| Environment variable | Description |
+|---|---|
+| `SONDA_PROM_TOKEN` | Bearer token for the capture. Read from the environment so it stays out of shell history and process listings. |
 
 ### Minimal template
 

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -232,6 +232,7 @@ nav:
   - Import real data:
       - import/index.md
       - From a CSV file: import/from-csv.md
+      - From a live Prometheus: import/from-prometheus.md
       - Grafana exports: import/grafana-exports.md
       - Log files: import/log-files.md
   - Deploy:

--- a/sonda/src/cli.rs
+++ b/sonda/src/cli.rs
@@ -248,10 +248,13 @@ pub struct NewArgs {
     pub out: Option<PathBuf>,
 
     /// Replay speed: 1.0 is the captured cadence, 2.0 is twice as fast.
+    // `allow_negative_numbers` so `--timescale -1` reaches the capture's own
+    // check and gets its message, not clap's "unexpected argument".
     #[arg(
         long,
         value_name = "FACTOR",
         requires = "from_prometheus",
+        allow_negative_numbers = true,
         help_heading = "Capture"
     )]
     pub timescale: Option<f64>,

--- a/sonda/tests/cli_new_capture.rs
+++ b/sonda/tests/cli_new_capture.rs
@@ -378,6 +378,30 @@ fn a_flag_only_refusal_writes_nothing_and_never_reaches_the_network() {
     );
 }
 
+/// N7: both spellings of a negative timescale get the capture's own message,
+/// not clap's "unexpected argument". The unit test parses `"-1"` directly, which
+/// never passes through clap, so only a spawned binary shows what a user sees.
+#[test]
+fn a_negative_timescale_is_refused_the_same_way_however_it_is_spelled() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for spelling in [vec!["--timescale", "-1"], vec!["--timescale=-1"]] {
+        let out = Command::new(sonda_bin())
+            .args(["new", "--from-prometheus", "http://127.0.0.1:1"])
+            .args(["--query", "up", "--range", "1h", "--step", "10s"])
+            .args(&spelling)
+            .arg("--out")
+            .arg(dir.path().join("capture.csv"))
+            .output()
+            .expect("spawn sonda");
+        assert!(!out.status.success(), "{spelling:?} must be refused");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("--timescale must be a positive finite number"),
+            "{spelling:?} should get the capture's message, got: {stderr}"
+        );
+    }
+}
+
 /// W4: an error from this path says its piece once.
 #[test]
 fn an_error_is_not_printed_twice() {


### PR DESCRIPTION
## What ships

**`docs/site/docs/import/from-prometheus.md`** — the guide for `sonda new --from-prometheus`, beside its three siblings in the import section. The recipe, the two window forms, credentials, `--metric-name` for aggregated queries, `--timescale`, why gaps are data, and what the emitted pair looks like. Wired into the nav and the section index card.

### The three scope fences

Stated plainly, because each is something people reasonably expect and none is here:

- **Not a PromQL engine.** The query goes to the server as written. Sonda does not parse, rewrite, optimise or validate it — a syntax error comes back in the server's words.
- **Not backfill.** This reads *out* of a TSDB and writes files. It never writes into one. Historical samples into Prometheus is `promtool tsdb create-blocks-from`, not Sonda.
- **Not decomposition.** No classifier, no fitted generator, no `--fit`. You get the recorded numbers back.

The page points at `--from <csv>` for the fitting path, with a table of which question each answers — the two are genuinely different tools and the page says so rather than implying one supersedes the other.

### The examples are generated, not written

A mock TSDB served an hour of `up{job="api"}` at 15s with one sample missing; the real binary captured it; the fences carry those bytes. I diffed the page's YAML fence against the emission line by line, which caught two things I had wrong by hand:

- the emitted file carries `tags: []`, which I had omitted
- my stderr sample said `(0 missing samples)` beside a CSV example that shows a blank cell

Both corrected. The fence is now byte-identical to real output apart from the `file:` path.

## Also: the N7 note from #594's round-2 review

`--timescale -1` was caught by clap as `unexpected argument '-1'` (exit 2) while `--timescale=-1` reached the capture's own check and got the useful message (exit 1). `allow_negative_numbers` sends both to the same place.

The fair half of that note was about the test, not the code: the existing unit test iterates `"-1".parse()`, which never passes through clap, so it proved the check without proving the message a user sees. The new test spawns the binary with **both spellings**. It was red before the attribute and green after — verified in that order.

## `reference/cli-flags.md` and `import/from-csv.md`

Both gain `--from-prometheus`; `cli-flags.md` gains the full capture-flag table and `SONDA_PROM_TOKEN`. Its `sonda new` section said *"Three modes are available"*; there are four.

These synopsis lines are hand-maintained and **no gate covers them** — `cli_subcommand_parity` checks verb counts across all Markdown, not per-subcommand modes or flags. The first pass caught one of the two by reading and missed the other; both are now confirmed by sweeping every `^sonda new [` line in the docs tree, 2 of 2.

## What the docs gate does and does not check here

`validate_docs_commands.py` goes from 159 to **167 commands, 0 failed**. To be precise about what that means: it confirms `new` and `run` are real subcommands and that referenced input files exist. It does **not execute** any of this page's commands — `DRY_RUNNABLE_SINGLE` is `{"run", "test"}`, so no `sonda new` is ever spawned, and the one `sonda run incident.yaml` is skipped because the page's `title="incident.yaml"` fence registers that name as a tutorial-created file.

So the eight added commands are counted and shape-checked, not run. Making that claim true would need `new` to grow a validation mode the gate can invoke, which is bigger than this PR — noted alongside the flag-validation gap raised on #594.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0
- `cargo test --workspace --all-features --no-fail-fast` — 3348 passed, 5 failed: the five that reproduce on `main` in this container (`sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message` and `tests::sink_file_error_produces_sink_variant`, both needing a non-root uid; `global_inflight_limit_gates_across_routes`, `health_remains_responsive_when_control_plane_is_saturated`, `request_timeout_returns_408_with_structured_error` in `sonda-server`)
- `scripts/validate_docs_commands.py` — 167 commands, 0 failed (see the scope note above)
- `scripts/validate_docs_scenarios.py` — 119 compiled, 0 failed
- `cli_subcommand_parity` — 7 passed
- `cli_new_capture` — 14 passed

