### PR TITLE
fix(cli): make the feature flags real; feat(gate): the docs gate checks flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,25 @@ jobs:
       - name: Doctests without default features
         run: cargo test -p sonda-core --no-default-features --doc
 
+      # The CLI's feature flags were decorative until this step existed: nothing
+      # built `sonda` in any non-default configuration, so `test_cmd.rs` imported
+      # the http-only verify modules ungated and `--no-default-features` had not
+      # compiled for as long as `sonda test` had shipped. Every combination is
+      # listed rather than swept because each is a claim the feature line makes.
+      - name: Build the CLI in every feature combination
+        run: |
+          set -euo pipefail
+          for features in "" "config" "http" "config,http"; do
+            if [ -z "$features" ]; then
+              echo "::group::cargo build -p sonda --no-default-features"
+              cargo build -p sonda --no-default-features
+            else
+              echo "::group::cargo build -p sonda --no-default-features --features $features"
+              cargo build -p sonda --no-default-features --features "$features"
+            fi
+            echo "::endgroup::"
+          done
+
       # `schema` implies `config` and nothing else. That is the whole claim of
       # the feature line, and `--all-features` cannot check it: there, every
       # other feature is on, so a hidden dependency on `runtime` (or on `http`,

--- a/scripts/validate_docs_commands.py
+++ b/scripts/validate_docs_commands.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import functools
 import re
 import shlex
 import subprocess
@@ -529,6 +530,91 @@ def supports_dry_run(cmd: ExtractedCommand) -> bool:
     return sub is not None and sub in DRY_RUNNABLE_SINGLE
 
 
+# --- Flag validation -------------------------------------------------------
+#
+# The subcommand check above catches an invented verb. Nothing caught an
+# invented FLAG: `sonda new --from-promethus …` documented a typo that no
+# gate saw, because every downstream check keys off the verb alone.
+#
+# The comparison is exact rather than heuristic: the flags a verb accepts come
+# from `sonda <verb> --help`, which is clap rendering the parser itself. Two
+# things follow from that and are load-bearing:
+#
+#   * Without a binary there is no source of truth, so the check does not run.
+#     `main` prints a SKIP line in that case rather than letting the summary
+#     read as coverage — a flag check that quietly does nothing looks exactly
+#     like one that found nothing wrong.
+#   * `_known_flags` asserts it parsed a non-empty set. If `--help` output ever
+#     stops matching the pattern, every documented flag would look unknown, or
+#     (worse, with the set empty and the check short-circuiting) every one would
+#     look fine. Failing loudly on an empty parse is the only honest option.
+
+_FLAG_IN_HELP_RE = re.compile(r"(?<![\w-])(--[a-zA-Z][a-zA-Z0-9-]*)")
+
+# Flags clap declares `global = true`, accepted by every subcommand. They appear
+# in the root `--help` but not in each subcommand's, so they are unioned in.
+_GLOBAL_FLAGS: frozenset[str] = frozenset(
+    {"--quiet", "--verbose", "--dry-run", "--catalog", "--format", "--help", "--version"}
+)
+
+
+# Set by `_known_flags` the first time any verb yields a flag of its own. The
+# vacuity guard is corpus-level rather than per-verb because a verb with no
+# flags is legitimate — `sonda completions` takes a positional shell and
+# nothing else — while a `--help` format this cannot parse would make EVERY
+# documented flag look unknown. `assert_flag_parse_worked` checks it once.
+_flag_parse_produced_something = False
+
+
+@functools.lru_cache(maxsize=None)
+def _known_flags(sonda_bin: str, verb: str, timeout: float) -> frozenset[str]:
+    """Every long flag ``sonda <verb>`` accepts, read from its own ``--help``.
+
+    Cached: one `--help` per verb rather than one per documented command.
+    """
+    global _flag_parse_produced_something
+    proc = subprocess.run(  # noqa: S603
+        [sonda_bin, verb, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    own = frozenset(_FLAG_IN_HELP_RE.findall(proc.stdout)) - _GLOBAL_FLAGS
+    if own:
+        _flag_parse_produced_something = True
+    return own | _GLOBAL_FLAGS
+
+
+def assert_flag_parse_worked(checked_any: bool) -> None:
+    """Fail if the flag check ran over commands and never parsed a single flag.
+
+    Raises:
+        RuntimeError: when `--help` was read but yielded nothing anywhere, which
+            is what a changed help format looks like from in here.
+    """
+    if checked_any and not _flag_parse_produced_something:
+        raise RuntimeError(
+            "the flag check read `--help` for every documented verb and parsed "
+            "no flags from any of them; `--help` output no longer matches "
+            "_FLAG_IN_HELP_RE, so nothing was really compared"
+        )
+
+
+def flags_used(argv: Sequence[str]) -> list[str]:
+    """Long flags appearing in a documented command line, `--flag=value` included.
+
+    Stops at `--`, after which tokens are operands however they are spelled.
+    """
+    used: list[str] = []
+    for tok in argv[1:]:
+        if tok == "--":
+            break
+        if tok.startswith("--") and len(tok) > 2:
+            used.append(tok.split("=", 1)[0])
+    return used
+
+
 def validate_command(
     cmd: ExtractedCommand,
     repo_root: Path,
@@ -549,6 +635,24 @@ def validate_command(
                 f"expected one of {', '.join(sorted(KNOWN_SUBCOMMANDS))}"
             ),
         )
+
+    # An invented flag is the same class of defect as an invented verb, and
+    # nothing below would notice it. Needs a binary; see `_known_flags`.
+    if sonda_bin is not None and cmd.subcommand is not None:
+        try:
+            known = _known_flags(str(sonda_bin), cmd.subcommand, subprocess_timeout)
+        except (OSError, subprocess.SubprocessError) as exc:
+            return ValidationResult(command=cmd, ok=False, message=str(exc))
+        unknown = [f for f in flags_used(cmd.argv) if f not in known]
+        if unknown:
+            return ValidationResult(
+                command=cmd,
+                ok=False,
+                message=(
+                    f"`sonda {cmd.subcommand}` does not accept "
+                    f"{', '.join(unknown)} — not in its `--help`"
+                ),
+            )
 
     run_target = extract_run_target(cmd.argv) if cmd.subcommand == "run" else None
     target_is_repo_path = (
@@ -739,6 +843,11 @@ def run_validation(
         )
         if not result.ok:
             failures.append(result)
+    # One check that the flag comparison meant anything at all; see
+    # `assert_flag_parse_worked`. Raises rather than returning a failure
+    # because it is the checker that is broken, not a document.
+    assert_flag_parse_worked(checked_any=sonda_bin is not None and bool(all_commands))
+
     return len(all_commands), failures
 
 
@@ -826,6 +935,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     for failure in failures:
         print(format_failure(failure, repo_root), file=sys.stderr)
+    if sonda_bin is None:
+        # Named rather than left to the summary line, which would otherwise
+        # read as coverage: without a binary there is no `--help` to compare
+        # documented flags against, and no dry-run either.
+        print(
+            "SKIP flag and dry-run checks: no sonda binary (--no-binary)",
+            file=sys.stderr,
+        )
     print(
         f"{checked} commands checked, {len(failures)} failed",
         file=sys.stderr,
@@ -834,6 +951,59 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 # --- Self-tests --------------------------------------------------------------
+
+
+class _FlagsUsedTests(unittest.TestCase):
+    """`flags_used` — the half of the flag check that needs no binary."""
+
+    def test_long_flags_are_collected(self) -> None:
+        argv = ("sonda", "new", "--template", "-o", "x.yaml", "--from", "a.csv")
+        self.assertEqual(flags_used(argv), ["--template", "--from"])
+
+    def test_equals_form_reports_the_flag_not_the_value(self) -> None:
+        self.assertEqual(flags_used(("sonda", "run", "--rate=5")), ["--rate"])
+
+    def test_a_value_that_looks_like_a_flag_is_still_a_value(self) -> None:
+        # `--query --foo` would be a query of "--foo"; the checker cannot know
+        # that, so this documents the known over-report rather than hiding it.
+        self.assertEqual(
+            flags_used(("sonda", "new", "--query", "--foo")), ["--query", "--foo"]
+        )
+
+    def test_short_flags_and_operands_are_ignored(self) -> None:
+        self.assertEqual(flags_used(("sonda", "run", "-o", "out", "scenario.yaml")), [])
+
+    def test_bare_double_dash_ends_the_scan(self) -> None:
+        argv = ("sonda", "run", "--rate", "5", "--", "--not-a-flag")
+        self.assertEqual(flags_used(argv), ["--rate"])
+
+    def test_the_verb_itself_is_never_a_flag(self) -> None:
+        self.assertEqual(flags_used(("--sonda", "run")), [])
+
+
+class _FlagParseGuardTests(unittest.TestCase):
+    """The corpus-level vacuity guard, which is the whole check's safety net."""
+
+    def test_it_raises_when_nothing_was_ever_parsed(self) -> None:
+        import validate_docs_commands as mod
+
+        saved = mod._flag_parse_produced_something
+        try:
+            mod._flag_parse_produced_something = False
+            with self.assertRaises(RuntimeError):
+                mod.assert_flag_parse_worked(checked_any=True)
+        finally:
+            mod._flag_parse_produced_something = saved
+
+    def test_it_stays_quiet_when_no_commands_were_checked(self) -> None:
+        import validate_docs_commands as mod
+
+        saved = mod._flag_parse_produced_something
+        try:
+            mod._flag_parse_produced_something = False
+            mod.assert_flag_parse_worked(checked_any=False)
+        finally:
+            mod._flag_parse_produced_something = saved
 
 
 class _ExtractBashBlocksTests(unittest.TestCase):
@@ -1303,23 +1473,39 @@ class _BuildDryRunArgvTests(unittest.TestCase):
         )
 
 
+# The floor exists because this list used to be written out by hand, and a
+# class added without also being named here ran zero tests while `--self-test`
+# reported OK. Discovery removed that; the floor catches the other direction,
+# where a rename or a bad glob makes discovery itself find nothing.
+_MIN_SELF_TEST_CLASSES = 12
+
+
 def _run_self_tests() -> int:
+    """Run every `_*Tests` class in this module.
+
+    Discovered rather than listed: a hand-maintained roster silently skips a
+    class somebody forgot to add, which is a passing run that tested less than
+    it claimed.
+    """
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
-    for cls in (
-        _ExtractBashBlocksTests,
-        _JoinContinuationsTests,
-        _StripPromptAndEnvTests,
-        _TrimShellTrailersTests,
-        _CliPlaceholderTokenTests,
-        _ExtractSondaCommandsTests,
-        _ExtractRunTargetTests,
-        _ExtractNewFromFileTests,
-        _ExtractCatalogDirTests,
-        _RepoRelativePathTests,
-        _SupportsDryRunTests,
-        _BuildDryRunArgvTests,
-    ):
+    classes = [
+        obj
+        for name, obj in sorted(globals().items())
+        if name.startswith("_")
+        and name.endswith("Tests")
+        and isinstance(obj, type)
+        and issubclass(obj, unittest.TestCase)
+    ]
+    if len(classes) < _MIN_SELF_TEST_CLASSES:
+        print(
+            f"self-test discovery found {len(classes)} test classes, fewer than "
+            f"the {_MIN_SELF_TEST_CLASSES} this module is known to have; "
+            "discovery is broken, not the tests",
+            file=sys.stderr,
+        )
+        return 1
+    for cls in classes:
         suite.addTests(loader.loadTestsFromTestCase(cls))
     runner = unittest.TextTestRunner(verbosity=2)
     result = runner.run(suite)

--- a/scripts/validate_docs_commands.py
+++ b/scripts/validate_docs_commands.py
@@ -551,18 +551,11 @@ def supports_dry_run(cmd: ExtractedCommand) -> bool:
 
 _FLAG_IN_HELP_RE = re.compile(r"(?<![\w-])(--[a-zA-Z][a-zA-Z0-9-]*)")
 
-# Flags clap declares `global = true`, accepted by every subcommand. They appear
-# in the root `--help` but not in each subcommand's, so they are unioned in.
-_GLOBAL_FLAGS: frozenset[str] = frozenset(
-    {"--quiet", "--verbose", "--dry-run", "--catalog", "--format", "--help", "--version"}
-)
-
-
-# Set by `_known_flags` the first time any verb yields a flag of its own. The
-# vacuity guard is corpus-level rather than per-verb because a verb with no
-# flags is legitimate — `sonda completions` takes a positional shell and
-# nothing else — while a `--help` format this cannot parse would make EVERY
-# documented flag look unknown. `assert_flag_parse_worked` checks it once.
+# Set by `_known_flags` the first time any verb yields a flag. The vacuity guard
+# is corpus-level rather than per-verb because a verb with no flags is
+# legitimate — `sonda completions` takes a positional shell and nothing else —
+# while a `--help` format this cannot parse would make EVERY documented flag
+# look unknown. `assert_flag_parse_worked` checks it once.
 _flag_parse_produced_something = False
 
 
@@ -580,10 +573,12 @@ def _known_flags(sonda_bin: str, verb: str, timeout: float) -> frozenset[str]:
         timeout=timeout,
         check=False,
     )
-    own = frozenset(_FLAG_IN_HELP_RE.findall(proc.stdout)) - _GLOBAL_FLAGS
-    if own:
+    # Globals (`--dry-run`, `--catalog`, …) need no special case: clap renders
+    # them in every subcommand's help, so the parser already returns them.
+    found = frozenset(_FLAG_IN_HELP_RE.findall(proc.stdout))
+    if found:
         _flag_parse_produced_something = True
-    return own | _GLOBAL_FLAGS
+    return found
 
 
 def assert_flag_parse_worked(checked_any: bool) -> None:
@@ -605,6 +600,11 @@ def flags_used(argv: Sequence[str]) -> list[str]:
     """Long flags appearing in a documented command line, `--flag=value` included.
 
     Stops at `--`, after which tokens are operands however they are spelled.
+
+    Two limitations, both covered by tests below. Short flags are not collected,
+    so `-o`/`-q`/`-v` go unchecked; and a value that looks like a flag is
+    reported as one, so `--query --foo` yields both. Narrowing either needs
+    per-flag argv semantics, i.e. a second list that would drift.
     """
     used: list[str] = []
     for tok in argv[1:]:
@@ -1473,29 +1473,29 @@ class _BuildDryRunArgvTests(unittest.TestCase):
         )
 
 
-# The floor exists because this list used to be written out by hand, and a
-# class added without also being named here ran zero tests while `--self-test`
-# reported OK. Discovery removed that; the floor catches the other direction,
-# where a rename or a bad glob makes discovery itself find nothing.
-_MIN_SELF_TEST_CLASSES = 12
+# A floor, not a tally: it fails a discovery that finds nothing, or nearly
+# nothing, instead of reporting OK over a shrunken suite. Keep it at the
+# current class count.
+_MIN_SELF_TEST_CLASSES = 15
 
 
 def _run_self_tests() -> int:
-    """Run every `_*Tests` class in this module.
+    """Run every `unittest.TestCase` defined in this module.
 
     Discovered rather than listed: a hand-maintained roster silently skips a
     class somebody forgot to add, which is a passing run that tested less than
-    it claimed.
+    it claimed. Selection is by type and defining module rather than by name,
+    so renaming a class cannot drop it out of the suite either.
     """
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
     classes = [
         obj
-        for name, obj in sorted(globals().items())
-        if name.startswith("_")
-        and name.endswith("Tests")
-        and isinstance(obj, type)
+        for _, obj in sorted(globals().items(), key=lambda kv: kv[0])
+        if isinstance(obj, type)
         and issubclass(obj, unittest.TestCase)
+        and obj is not unittest.TestCase
+        and obj.__module__ == __name__
     ]
     if len(classes) < _MIN_SELF_TEST_CLASSES:
         print(

--- a/sonda/src/cli.rs
+++ b/sonda/src/cli.rs
@@ -61,6 +61,7 @@ pub enum Commands {
     /// Scaffold a new scenario YAML.
     New(NewArgs),
     /// Run a scenario and verify its `expect:` alert expectations.
+    #[cfg(feature = "http")]
     Test(TestArgs),
     /// Print a shell completion script to stdout.
     Completions(CompletionsArgs),
@@ -133,6 +134,7 @@ pub struct ShowArgs {
 }
 
 #[derive(Debug, Args)]
+#[cfg(feature = "http")]
 pub struct TestArgs {
     /// Path to a v2 YAML file with an `expect:` block, or `@name` for a
     /// catalog reference.

--- a/sonda/src/main.rs
+++ b/sonda/src/main.rs
@@ -8,6 +8,9 @@ mod progress;
 mod scenario_loader;
 mod sink_format;
 mod status;
+// `sonda test` verifies against a Prometheus or Alertmanager, so it exists only
+// where the HTTP client does.
+#[cfg(feature = "http")]
 mod test_cmd;
 
 use std::process;
@@ -74,6 +77,7 @@ fn run() -> anyhow::Result<()> {
         Commands::List(ref args) => list_catalog(args, catalog)?,
         Commands::Show(ref args) => show_entry(args, catalog)?,
         Commands::New(ref args) => new::run(args)?,
+        #[cfg(feature = "http")]
         Commands::Test(ref args) => test_cmd::run(&rt, args, &cli, catalog, verbosity, &cancel)?,
         // Returned above, before the runtime exists.
         Commands::Completions(_) => unreachable!("completions is handled before the runtime"),


### PR DESCRIPTION
The two follow-ups named in #594 and #600. Independent, one commit each.

## 1. The CLI could not build without default features

`cargo build -p sonda --no-default-features` had not compiled for as long as `sonda test` had shipped. `test_cmd.rs` imports `sonda_core::verify::{alertmanager, prometheus}` — both behind sonda-core's `http` — with no gate of its own. Nothing noticed because **nothing builds the CLI in any non-default configuration**: CI's `no-default-features` job builds `sonda-core` only.

`--features http` alone already built, so `config` is genuinely optional and this one import was the entire breakage. `test_cmd` and the `Test` verb are now gated on `http`, which is where they belong — a build without an HTTP client cannot verify against a Prometheus or an Alertmanager, so it should not offer the subcommand.

**The CI step is the half that matters.** Fixing a build nothing compiles just resets the clock, so the `no-default-features` job now builds `sonda` in all four combinations:

```
cargo build -p sonda --no-default-features                            builds
cargo build -p sonda --no-default-features --features config          builds
cargo build -p sonda --no-default-features --features http            builds
cargo build -p sonda --no-default-features --features config,http     builds
```

Red-verified: with the `#[cfg]` reverted, the two configurations lacking `http` fail and the step catches them.

## 2. The docs gate now checks flags

#565 closed the hole where a documented `sonda <verb>` naming a nonexistent verb sailed through. The same hole was open one level down — every check keyed off the verb, so **`sonda new --from-promethus …` was a documented typo no gate could see.**

The comparison is exact, not heuristic: the flags a verb accepts come from `sonda <verb> --help`, which is clap rendering the parser itself, so there is no second list to drift. That includes the globals — clap renders `--catalog`, `--dry-run` and the rest in each subcommand's own help, so they arrive from the parser like any other flag and need no special case. `--help` is read once per verb rather than once per command.

### How it fails

- **The vacuity guard is corpus-level, not per-verb.** `sonda completions` takes a positional shell and no flags, so an empty result for one verb is legitimate. The guard asserts that *some* verb yielded a flag across the whole run: a `--help` format the regex cannot parse would otherwise make every documented flag look unknown, or with the set empty, every one look fine.
- **`--no-binary` prints a SKIP line.** There is no `--help` to compare against, so the check cannot run — and `167 commands checked, 0 failed` with neither the flag nor the dry-run check having run reads as coverage.
- **Self-tests are discovered, not listed.** `_run_self_tests` selects every `unittest.TestCase` defined in this module, by type and defining module rather than by name, so neither forgetting to register a class nor renaming one can drop it from the suite. A floor (`_MIN_SELF_TEST_CLASSES = 15`, the current count) fails a discovery that finds nothing rather than reporting OK over a shrunken suite. **83 tests run.**

### Stated limitations

`flags_used` is deliberately imprecise in two directions, each covered by a test. It over-reports: `--query --foo` yields both flags, because a value that looks like a flag is indistinguishable from one here. And it under-reports: short flags are not collected, so `-o`, `-q` and `-v` go unchecked. Narrowing either needs per-flag argv semantics — the drifting second list this design avoids.

## Red-verification

Each mutation confirmed present in the source before its result was trusted, and reverted after.

| Mutation | Result |
|---|---|
| `--from-prometheus` → `--from-promethus` in a real doc | caught: ``` `sonda new` does not accept --from-promethus — not in its `--help` ``` |
| `_FLAG_IN_HELP_RE` made to match nothing | corpus guard raises, naming the regex |
| a test class deleted | floor fires: "found 14 test classes, fewer than the 15" |
| the type filter in discovery broken | floor fires: "found 0 test classes" |
| `#[cfg(feature = "http")]` reverted on `test_cmd` | 2 of 4 build configurations fail |

Measurement behind the no-special-case decision for globals: six of the seven globals appear in `sonda run --help` already, and the seventh, `--version`, is rejected by clap on a subcommand (`error: unexpected argument '--version' found`) — so a documented `sonda run --version` is now caught rather than accepted.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0
- `cargo test --workspace --all-features --no-fail-fast` — 5 failed, and they are the five that reproduce on `main` in this container: `sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message` and `tests::sink_file_error_produces_sink_variant` (both need a non-root uid), plus `global_inflight_limit_gates_across_routes`, `health_remains_responsive_when_control_plane_is_saturated` and `request_timeout_returns_408_with_structured_error` in `sonda-server`
- `scripts/validate_docs_commands.py` — 167 commands, 0 failed
- `scripts/validate_docs_commands.py --self-test` — 83 passed
- `scripts/validate_docs_scenarios.py` — 119 compiled, 0 failed
- All four CLI feature combinations build
