### PR TITLE
fix(core): a finishing entry no longer tears down its siblings' gate refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-wasm"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/docs/site/docs/build/scenario-files.md
+++ b/docs/site/docs/build/scenario-files.md
@@ -711,8 +711,17 @@ A cross-POST-gated scenario adds one state to the `while:` lifecycle: **`unresol
 
 - **Initial POST**: the downstream lands in `unresolved`. Its [`pending_ref` field on `GET /scenarios/{id}`](../deploy/http-api.md#pending_ref-field-on-get-scenariosid) shows the upstream it is waiting on.
 - **Upstream POSTs**: the downstream resolves automatically. The server's resolver wires the subscription and the downstream transitions to `running` (or to `paused` if the predicate is already false). No client orchestration is needed.
-- **Upstream is DELETEd, or finishes its duration**: the downstream transitions back to `unresolved` and applies the `if_unresolved:` mode again. `open` keeps it emitting, `closed` pauses, `pending` halts.
-- **A new POST arrives with the same `scenario_name:`**: the downstream re-resolves to the new upstream automatically. The downstream keeps its accumulated state across the gap; counters preserve their value through pause/resume cycles.
+- **The upstream entry is DELETEd, or finishes its duration**: the downstream transitions back to `unresolved` and applies the `if_unresolved:` mode again. `open` keeps it emitting, `closed` pauses, `pending` halts.
+- **A new POST arrives with the same `scenario_name:`**: the downstream re-resolves automatically, as long as that body carries an entry whose `id:` matches the downstream's `ref:`. The downstream keeps its accumulated state across the gap; counters preserve their value through pause/resume cycles.
+
+Each of those bullets is about the one upstream **entry** named by `ref:`, not about the whole upstream body. An upstream body can hold several entries under a single `scenario_name:`, and every entry carries its own gate signal. A downstream is connected to exactly one of them.
+
+!!! info "What entries of one body share, and what they do not"
+    Entries in the same POST body share the `scenario_name:` that addresses them, and the [409 Conflict rule](../deploy/http-api.md#duplicate-scenario_name-returns-409) that protects that name. They do not share gate lifetimes.
+
+    - Another entry of the upstream body finishing its `duration:`, or being DELETEd, leaves your downstream connected. Only the entry named by `ref:` sends it back to `unresolved`.
+    - A downstream still waiting for an upstream that has never been POSTed keeps waiting. Entries of that `scenario_name:` starting and ending in the meantime do not cancel the wait. The downstream resolves when an entry with a matching `ref:` arrives.
+    - The `scenario_name:` itself stays taken while any one entry of that body is still live. It frees when the last one finishes or is DELETEd. A new POST with that name then returns `201`.
 
 `GET /scenarios/{id}` exposes the wait target as `pending_ref` whenever `state` is `unresolved`. The field is omitted in every other state.
 

--- a/docs/site/docs/deploy/http-api.md
+++ b/docs/site/docs/deploy/http-api.md
@@ -506,7 +506,7 @@ Without `--catalog`, a body that references a pack by name is rejected with `400
 
 When a request body sets a top-level `scenario_name`, the server scans the active scenario map for a matching handle. A match is any handle with the same `scenario_name` in `pending`, `running`, `paused`, `held`, or `unresolved` state. If at least one match is found, the POST is rejected with `409 Conflict`. Nothing is launched. The rule is explicit: the operator must `DELETE` the conflicting scenarios first, then re-send the body. There is no `?force=true` override. The explicit DELETE is the only way to free the name.
 
-Anonymous bodies (no top-level `scenario_name`) skip this check entirely. Two consecutive POSTs of the same anonymous body both return 201. Finished handles do not block a new POST. Once every prior cascade with the same name reaches `finished` state, a new cascade with the same name returns 201.
+Anonymous bodies (no top-level `scenario_name`) skip this check entirely. Two consecutive POSTs of the same anonymous body both return 201. Finished handles do not block a new POST. A body with several entries holds its name while any one of them is still live. Once all of them have finished or been DELETEd, a new body with the same name returns 201.
 
 The conflict check is best-effort. The server scans the active scenarios before launching the new one. Two simultaneous POSTs of the same `scenario_name` can both pass the check if they race within the launch window. Both register and their Prometheus streams will collide on duplicate timestamps. Sequential operator use is unaffected. High-concurrency callers should serialize POSTs that share a `scenario_name`.
 
@@ -583,7 +583,7 @@ A scenario with a cross-POST `while:` clause may have no registered upstream yet
 | `unresolved` | Cross-POST `while.scenario_name:` has not been received yet (with `if_unresolved: pending`), or its upstream was deleted. |
 | `finished` | `duration:` elapsed or shutdown signalled. Terminal. |
 
-A scenario can transition `unresolved → pending → running` once the upstream registers. It returns to `unresolved` when the upstream is deleted or finishes its own duration. Re-sending the same `scenario_name:` re-resolves the downstream automatically. No client orchestration is required. See [Cross-POST `while:` refs](../build/scenario-files.md#cross-post-while-refs) for the YAML schema and the `if_unresolved:` mode reference.
+A scenario can transition `unresolved → pending → running` once the upstream registers. It returns to `unresolved` when the upstream **entry** it names is deleted or finishes its own duration. Other entries of that upstream body starting or ending do not affect it. Re-sending the same `scenario_name:` re-resolves the downstream automatically. No client orchestration is required. See [Cross-POST `while:` refs](../build/scenario-files.md#cross-post-while-refs) for the YAML schema and the `if_unresolved:` mode reference. [Lifecycle](../build/scenario-files.md#lifecycle) covers what entries of one body share.
 
 !!! warning "Add `unresolved` and `held` to your dashboards"
     If you maintain Prometheus recording rules or Grafana dashboards that enumerate `state=~"pending|running|paused|finished"`, add `unresolved` and `held` to the alternation (`state=~"pending|running|paused|held|unresolved|finished"`). Or rewrite the matcher as a negation (`state!="finished"`). A matcher that lists every known state drops scenarios in `unresolved` or `held` silently.

--- a/sonda-core/src/schedule/gate_bus.rs
+++ b/sonda-core/src/schedule/gate_bus.rs
@@ -606,7 +606,10 @@ pub trait GateBusResolver: Send + Sync {
         edge_sender: GateEdgeSender,
     ) -> Option<Arc<GateBus>>;
 
-    fn unregister(&self, scenario_name: &str);
+    /// Remove the gate buses of `entry_ids` under `scenario_name`, leaving that name's other
+    /// entries registered. Pending waiters are left in place: an entry that has not registered
+    /// yet may still do so.
+    fn unregister_entries(&self, scenario_name: &str, entry_ids: &[&str]);
 
     /// Discard pending entries whose downstream stats handle has been dropped.
     fn sweep_pending(&self) -> usize;
@@ -617,7 +620,7 @@ pub trait GateBusResolver: Send + Sync {
 
     fn scenario_name_in_use(&self, scenario_name: &str) -> bool;
 
-    /// Record an active subscriber so [`unregister`](Self::unregister) can
+    /// Record an active subscriber so [`unregister_entries`](Self::unregister_entries) can
     /// re-pend it for cross-POST re-resolution. Default impl is a no-op for
     /// resolvers that do not implement re-resolution tracking.
     fn track_subscriber(&self, _pending: PendingResolution) {}
@@ -964,7 +967,7 @@ mod tests {
             None
         }
 
-        fn unregister(&self, _scenario_name: &str) {}
+        fn unregister_entries(&self, _scenario_name: &str, _entry_ids: &[&str]) {}
 
         fn sweep_pending(&self) -> usize {
             0

--- a/sonda-core/src/schedule/handle.rs
+++ b/sonda-core/src/schedule/handle.rs
@@ -30,6 +30,8 @@ impl std::error::Error for JoinTimeout {}
 #[non_exhaustive]
 pub struct ScenarioHandle {
     pub id: String,
+    /// Compiler entry id this scenario's gate bus is keyed by; never rewritten when `id` is.
+    pub entry_id: String,
     pub name: String,
     pub scenario_name: Option<String>,
     /// Per-handle cancellation token. `stop()` on one handle never affects another.
@@ -68,6 +70,7 @@ impl ScenarioHandle {
         cleaned_up: Arc<AtomicBool>,
     ) -> Self {
         Self {
+            entry_id: id.clone(),
             id,
             name,
             scenario_name,

--- a/sonda-core/src/schedule/launch.rs
+++ b/sonda-core/src/schedule/launch.rs
@@ -237,8 +237,9 @@ pub async fn launch_scenario_with_gates(
     let cleaned_up_for_task = Arc::clone(&cleaned_up);
     let resolver_for_task = resolver.clone();
     let scenario_name_for_task = scenario_name.clone();
+    let entry_id_for_task = id.clone();
 
-    // Cross-POST scenarios broadcast via resolver.unregister; broadcasting
+    // Cross-POST scenarios broadcast via resolver.unregister_entries; broadcasting
     // here too races the registry's subscriber migration.
     let bus_for_finish_guard = if scenario_name_for_task.is_some() && resolver_for_task.is_some() {
         None
@@ -254,11 +255,12 @@ pub async fn launch_scenario_with_gates(
             flag: alive_for_task,
         };
 
-        // Marks Finished on drop; unregisters when a resolver is wired.
+        // Marks Finished on drop; unregisters this entry's bus when a resolver is wired.
         let _state_guard = StateGuard {
             stats: Arc::clone(&stats_for_state),
             resolver: resolver_for_task,
             scenario_name: scenario_name_for_task,
+            entry_id: entry_id_for_task,
             cleaned_up: cleaned_up_for_task,
         };
 
@@ -429,6 +431,7 @@ struct StateGuard {
     stats: Arc<RwLock<ScenarioStats>>,
     resolver: Option<Arc<dyn GateBusResolver>>,
     scenario_name: Option<String>,
+    entry_id: String,
     cleaned_up: Arc<AtomicBool>,
 }
 
@@ -446,7 +449,7 @@ impl Drop for StateGuard {
         if let (Some(name), Some(resolver)) =
             (self.scenario_name.as_deref(), self.resolver.as_ref())
         {
-            resolver.unregister(name);
+            resolver.unregister_entries(name, &[self.entry_id.as_str()]);
         }
     }
 }
@@ -1624,6 +1627,7 @@ mod tests {
                 stats: Arc::clone(&stats),
                 resolver: None,
                 scenario_name: None,
+                entry_id: String::new(),
                 cleaned_up: Arc::new(AtomicBool::new(false)),
             };
         }
@@ -1642,6 +1646,7 @@ mod tests {
                     stats: stats_for_thread,
                     resolver: None,
                     scenario_name: None,
+                    entry_id: String::new(),
                     cleaned_up: Arc::new(AtomicBool::new(false)),
                 };
                 panic!("intentional panic for StateGuard test");

--- a/sonda-core/src/schedule/multi_runner.rs
+++ b/sonda-core/src/schedule/multi_runner.rs
@@ -1404,11 +1404,11 @@ scenarios:
                     .cloned()
             }
 
-            fn unregister(&self, scenario_name: &str) {
+            fn unregister_entries(&self, scenario_name: &str, entry_ids: &[&str]) {
                 let mut buses = self.buses.lock().unwrap();
                 let keys: Vec<_> = buses
                     .keys()
-                    .filter(|(s, _)| s == scenario_name)
+                    .filter(|(s, e)| s == scenario_name && entry_ids.contains(&e.as_str()))
                     .cloned()
                     .collect();
                 for key in keys {
@@ -1612,10 +1612,10 @@ scenarios:
             stop_and_join(upstream_handles);
         }
 
-        // Re-resolution after `unregister` (so a downstream Unresolved can pick up a fresh
-        // upstream with the same scenario_name) requires the registry to push affected
-        // downstreams back into `pending` on unregister — that mechanism lives with the
-        // production `GateBusRegistry` implementation, not the test resolver.
+        // Re-resolution after the upstream's bus is retired (so a downstream Unresolved can
+        // pick up a fresh upstream with the same scenario_name) requires the registry to push
+        // affected downstreams back into `pending` — that mechanism lives with the production
+        // `GateBusRegistry` implementation, not the test resolver.
         #[tokio::test(flavor = "multi_thread")]
         async fn t10_unregister_drives_downstream_back_to_unresolved() {
             let registry = TestRegistry::new();
@@ -1642,7 +1642,7 @@ scenarios:
                 Duration::from_secs(2),
             );
 
-            resolver.unregister("upstream_post");
+            resolver.unregister_entries("upstream_post", &["upstream_metric"]);
             wait_for_state(
                 &downstream_handles[0],
                 ScenarioState::Unresolved,
@@ -1666,6 +1666,131 @@ scenarios:
             );
 
             stop_and_join(downstream_handles);
+        }
+
+        fn sibling_batch_yaml() -> String {
+            r#"
+version: 2
+kind: runnable
+scenario_name: sibling_batch
+defaults:
+  rate: 50
+  encoder:
+    type: prometheus_text
+  sink:
+    type: stdout
+scenarios:
+  - id: shortlived
+    signal_type: metrics
+    name: shortlived
+    duration: 300ms
+    generator:
+      type: constant
+      value: 1.0
+  - id: upstream
+    signal_type: metrics
+    name: upstream
+    duration: 30s
+    generator:
+      type: constant
+      value: 1.0
+  - id: downstream
+    signal_type: metrics
+    name: downstream
+    duration: 30s
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: upstream
+      op: ">"
+      value: 0
+"#
+            .to_string()
+        }
+
+        fn handle_for<'h>(handles: &'h [ScenarioHandle], id: &str) -> &'h ScenarioHandle {
+            handles
+                .iter()
+                .find(|h| h.entry_id == id)
+                .unwrap_or_else(|| panic!("no handle for entry '{id}'"))
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn a_finished_entry_retires_only_its_own_bus_leaving_its_siblings_registered() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+            let compiled =
+                compile_scenario_file_compiled(&sibling_batch_yaml(), &InMemoryPackResolver::new())
+                    .expect("compile batch");
+            let handles = launch_multi_compiled(compiled, Some(resolver))
+                .await
+                .expect("launch batch");
+
+            wait_for_state(
+                handle_for(&handles, "shortlived"),
+                ScenarioState::Finished,
+                Duration::from_secs(5),
+            );
+
+            assert!(
+                registry.lookup("sibling_batch", "shortlived").is_none(),
+                "the entry that finished must retire its own bus"
+            );
+            assert!(
+                registry.lookup("sibling_batch", "upstream").is_some(),
+                "a sibling that is still running must keep its bus"
+            );
+            assert!(
+                registry.lookup("sibling_batch", "downstream").is_some(),
+                "a sibling that is still running must keep its bus"
+            );
+            stop_and_join(handles);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn a_gated_entry_survives_a_sibling_finishing_and_stops_only_with_its_upstream() {
+            let registry = TestRegistry::new();
+            let resolver: Arc<dyn GateBusResolver> = registry.clone();
+            let compiled =
+                compile_scenario_file_compiled(&sibling_batch_yaml(), &InMemoryPackResolver::new())
+                    .expect("compile batch");
+            let handles = launch_multi_compiled(compiled, Some(resolver))
+                .await
+                .expect("launch batch");
+
+            wait_for_state(
+                handle_for(&handles, "downstream"),
+                ScenarioState::Running,
+                Duration::from_secs(5),
+            );
+            wait_for_state(
+                handle_for(&handles, "shortlived"),
+                ScenarioState::Finished,
+                Duration::from_secs(5),
+            );
+
+            let downstream = handle_for(&handles, "downstream");
+            let before = downstream.stats_snapshot().total_events;
+            thread::sleep(Duration::from_millis(300));
+            let after = downstream.stats_snapshot().total_events;
+            assert_eq!(
+                downstream.stats_snapshot().state,
+                ScenarioState::Running,
+                "a sibling finishing must not close the gate on an unrelated upstream"
+            );
+            assert!(
+                after > before,
+                "the gated entry must keep emitting after its sibling finished: {before} -> {after}"
+            );
+
+            handle_for(&handles, "upstream").stop();
+            wait_for_state(
+                handle_for(&handles, "downstream"),
+                ScenarioState::Finished,
+                Duration::from_secs(5),
+            );
+            stop_and_join(handles);
         }
 
         #[tokio::test(flavor = "multi_thread")]

--- a/sonda-server/CLAUDE.md
+++ b/sonda-server/CLAUDE.md
@@ -114,18 +114,14 @@ All handlers use `.map_err()` with the `?` operator for fallible operations. Sha
 per lock, and exported as `sonda_server_lock_recoveries_total` on `/metrics`. The per-lock argument
 for why recovery is safe lives in the module docs of `src/locks.rs` — extend it there before putting
 new state behind the type. The per-scenario stats `RwLock` in `ScenarioHandle` is owned by
-sonda-core, which recovers it on its own read paths; the three places the server writes to it
+sonda-core, which recovers it on its own read paths; the two places the server writes to it
 (`gate_registry.rs`) recover it the same way, so a scenario whose stats lock was poisoned still
-transitions state and still counts resolution attempts.
+counts its resolution attempts. Only one of those two is on a live path — `cancel_pending_for_upstream`
+has no production caller.
 
-`admit_compiled` holds its launched handles in an `AdoptionGuard` until they are in the scenario
-map, handing them over one at a time so the guard owns the whole tail it has not yet handed over.
-Dropping it on a panic stops what it still holds and unregisters the scenario name. Two gaps
-remain. The handle in flight at the moment of the panic is already out of the guard and not yet in
-the map, so it escapes still running, and it has dropped its permit — that orphan does not count
-against `--max-scenarios`. And `unregister` is keyed by scenario name alone, so rows the guard had
-already handed over keep running and stay listed but lose their gate buses; their downstreams
-receive `UpstreamGone`.
+`admit_compiled` holds its launched handles in an `AdoptionGuard` until they are in the scenario map, handing them over one at a time through the guard's `in_flight` slot so the guard owns every handle it has not yet inserted. Dropping it on a panic stops what it still holds, claims their registry cleanup so the stopping tasks do not tear down their buses twice, and removes only those entries' gate buses — rows already handed over keep running, stay listed, and keep the buses their downstreams' `while:` refs are subscribed to. Nothing escapes still running, so no orphan keeps a `--max-scenarios` slot it is no longer reachable through.
+
+Gate-bus teardown is per entry everywhere. `GateBusResolver::unregister_entries` is the only teardown verb: `StateGuard` in sonda-core passes the single entry the finishing task owns, `DELETE /scenarios/{id}` passes the deleted row's `ScenarioHandle::entry_id`, and `AdoptionGuard` passes the entries it never handed over. `entry_id` is the compiler entry id the bus is keyed by and survives the UUID rewrite `admit_compiled` applies to `handle.id`. A `scenario_name` therefore stays in use until the last entry under it is gone.
 
 ## Concurrency Model
 

--- a/sonda-server/src/gate_registry.rs
+++ b/sonda-server/src/gate_registry.rs
@@ -110,6 +110,53 @@ impl GateBusRegistry {
             }
         }
     }
+
+    fn retire_buses(&self, scenario_name: &str, entry_ids: &[&str]) -> Vec<BusKey> {
+        let mut buses = self.buses.write();
+        let keys: Vec<BusKey> = buses
+            .keys()
+            .filter(|(name, entry_id)| {
+                name == scenario_name && entry_ids.contains(&entry_id.as_str())
+            })
+            .cloned()
+            .collect();
+        let mut removed: Vec<BusKey> = Vec::with_capacity(keys.len());
+        let mut retired: Vec<Arc<GateBus>> = Vec::with_capacity(keys.len());
+        for key in keys {
+            if let Some(bus) = buses.remove(&key) {
+                removed.push(key);
+                retired.push(bus);
+            }
+        }
+        drop(buses);
+
+        // Broadcast on the bus first so in-flight subscribers (those that called
+        // subscribe_with_while_sender but whose track_subscriber has not yet landed
+        // in the registry) still receive UpstreamGone.
+        for bus in retired {
+            bus.broadcast_upstream_gone();
+        }
+        removed
+    }
+
+    fn requeue_subscribers(&self, keys: &[BusKey]) {
+        let mut subs = self.subscribers.write();
+        let mut pending = self.pending.write();
+        for key in keys {
+            let Some(refs) = subs.remove(key) else {
+                continue;
+            };
+            for sub in refs {
+                if sub.stats.strong_count() == 0 {
+                    continue;
+                }
+                sub.sender.send(GateEdge::UpstreamGone);
+                let handle_id = sub.handle_id.clone();
+                let pending_entry = sub.into_pending(key.0.clone(), key.1.clone());
+                pending.insert(handle_id, pending_entry);
+            }
+        }
+    }
 }
 
 impl GateBusResolver for GateBusRegistry {
@@ -148,61 +195,9 @@ impl GateBusResolver for GateBusRegistry {
         self.lookup(upstream.0, upstream.1)
     }
 
-    fn unregister(&self, scenario_name: &str) {
-        let mut buses = self.buses.write();
-        let removed_keys: Vec<BusKey> = buses
-            .keys()
-            .filter(|(name, _)| name == scenario_name)
-            .cloned()
-            .collect();
-        let mut removed_buses: Vec<(BusKey, Arc<GateBus>)> = Vec::with_capacity(removed_keys.len());
-        for key in &removed_keys {
-            if let Some(bus) = buses.remove(key) {
-                removed_buses.push((key.clone(), bus));
-            }
-        }
-        drop(buses);
-
-        // Broadcast on the bus first so in-flight subscribers (those that called
-        // subscribe_with_while_sender but whose track_subscriber has not yet landed
-        // in the registry) still receive UpstreamGone.
-        for (_, bus) in &removed_buses {
-            bus.broadcast_upstream_gone();
-        }
-
-        let mut subs = self.subscribers.write();
-        let mut pending = self.pending.write();
-
-        let stale_pending: Vec<String> = pending
-            .iter()
-            .filter(|(_, entry)| entry.scenario_name == scenario_name)
-            .map(|(k, _)| k.clone())
-            .collect();
-        for handle_id in stale_pending {
-            let entry = pending.remove(&handle_id).expect("just snapshotted");
-            entry.edge_sender.send(GateEdge::UpstreamGone);
-            if let Some(stats_arc) = entry.stats.upgrade() {
-                let mut s = stats_arc.write().unwrap_or_else(|p| p.into_inner());
-                if s.state != ScenarioState::Finished {
-                    s.transition_state(ScenarioState::Unresolved);
-                }
-            }
-        }
-
-        for key in removed_keys {
-            let Some(refs) = subs.remove(&key) else {
-                continue;
-            };
-            for sub in refs {
-                if sub.stats.strong_count() == 0 {
-                    continue;
-                }
-                sub.sender.send(GateEdge::UpstreamGone);
-                let handle_id = sub.handle_id.clone();
-                let pending_entry = sub.into_pending(key.0.clone(), key.1.clone());
-                pending.insert(handle_id, pending_entry);
-            }
-        }
+    fn unregister_entries(&self, scenario_name: &str, entry_ids: &[&str]) {
+        let removed = self.retire_buses(scenario_name, entry_ids);
+        self.requeue_subscribers(&removed);
     }
 
     fn sweep_pending(&self) -> usize {
@@ -418,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn t_reg_5_unregister_moves_subscribers_to_pending_and_signals_gone() {
+    fn t_reg_5_unregister_entries_moves_subscribers_to_pending_and_signals_gone() {
         let reg = GateBusRegistry::new();
         let bus = Arc::new(GateBus::new());
         reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
@@ -428,7 +423,7 @@ mod tests {
             .expect("sub");
         reg.track_subscriber(make_pending("h1", "post-a", "m", weak, tx));
 
-        reg.unregister("post-a");
+        reg.unregister_entries("post-a", &["m"]);
         let edge =
             recv_timeout(&mut rx, Duration::from_millis(200)).expect("UpstreamGone within 200ms");
         assert_eq!(edge, GateEdge::UpstreamGone);
@@ -441,7 +436,97 @@ mod tests {
     }
 
     #[test]
-    fn t_reg_6_re_register_after_unregister_re_wires_existing_sender() {
+    fn unregister_entries_removes_only_the_named_entries_buses() {
+        let reg = GateBusRegistry::new();
+        reg.register("post-a", "m1", Arc::new(GateBus::new()))
+            .expect("reg a/m1");
+        reg.register("post-a", "m2", Arc::new(GateBus::new()))
+            .expect("reg a/m2");
+        reg.register("post-b", "m1", Arc::new(GateBus::new()))
+            .expect("reg b/m1");
+
+        reg.unregister_entries("post-a", &["m1"]);
+
+        assert!(reg.lookup("post-a", "m1").is_none());
+        assert!(
+            reg.lookup("post-a", "m2").is_some(),
+            "an entry of the same scenario name that was not named must stay registered"
+        );
+        assert!(reg.lookup("post-b", "m1").is_some());
+        assert!(reg.scenario_name_in_use("post-a"));
+    }
+
+    #[test]
+    fn unregister_entries_requeues_only_the_removed_entrys_subscribers() {
+        let reg = GateBusRegistry::new();
+        let bus_1 = Arc::new(GateBus::new());
+        let bus_2 = Arc::new(GateBus::new());
+        reg.register("post-a", "m1", Arc::clone(&bus_1))
+            .expect("reg m1");
+        reg.register("post-a", "m2", Arc::clone(&bus_2))
+            .expect("reg m2");
+        let (tx_1, mut rx_1) = gate_edge_channel();
+        let (tx_2, mut rx_2) = gate_edge_channel();
+        let (alive_1, weak_1) = live_stats();
+        let (alive_2, weak_2) = live_stats();
+        reg.subscribe(("post-a", "m1"), "h1", weak_1.clone(), tx_1.clone())
+            .expect("sub m1");
+        reg.subscribe(("post-a", "m2"), "h2", weak_2.clone(), tx_2.clone())
+            .expect("sub m2");
+        reg.track_subscriber(make_pending("h1", "post-a", "m1", weak_1, tx_1));
+        reg.track_subscriber(make_pending("h2", "post-a", "m2", weak_2, tx_2));
+
+        reg.unregister_entries("post-a", &["m1"]);
+
+        assert_eq!(
+            recv_timeout(&mut rx_1, Duration::from_millis(200)),
+            Ok(GateEdge::UpstreamGone)
+        );
+        assert!(reg.pending_for_handle("h1").is_some());
+        assert!(
+            recv_timeout(&mut rx_2, Duration::from_millis(50)).is_err(),
+            "a subscriber of an entry that stays registered must not be signalled"
+        );
+        assert!(reg.pending_for_handle("h2").is_none());
+        drop((alive_1, alive_2));
+    }
+
+    #[test]
+    fn unregister_entries_leaves_pending_waiters_on_other_entries_of_the_same_name() {
+        let reg = GateBusRegistry::new();
+        reg.register("post-a", "m1", Arc::new(GateBus::new()))
+            .expect("reg m1");
+        let (tx, mut rx) = gate_edge_channel();
+        let (alive, weak) = live_stats();
+        reg.insert_pending(make_pending("h-waiting", "post-a", "m2", weak, tx));
+
+        reg.unregister_entries("post-a", &["m1"]);
+
+        assert!(
+            reg.pending_for_handle("h-waiting").is_some(),
+            "a waiter on an entry that was never removed must keep waiting"
+        );
+        assert!(
+            recv_timeout(&mut rx, Duration::from_millis(50)).is_err(),
+            "a waiter on an entry that was never removed must not be signalled"
+        );
+        drop(alive);
+    }
+
+    #[test]
+    fn unregister_entries_with_no_entry_ids_removes_nothing() {
+        let reg = GateBusRegistry::new();
+        reg.register("post-a", "m1", Arc::new(GateBus::new()))
+            .expect("reg m1");
+
+        reg.unregister_entries("post-a", &[]);
+        reg.unregister_entries("post-a", &["not-an-entry"]);
+
+        assert!(reg.lookup("post-a", "m1").is_some());
+    }
+
+    #[test]
+    fn t_reg_6_re_register_after_unregister_entries_re_wires_existing_sender() {
         let reg = GateBusRegistry::new();
         let bus_a = Arc::new(GateBus::new());
         bus_a.tick(1.0);
@@ -453,7 +538,7 @@ mod tests {
             .expect("sub");
         reg.track_subscriber(make_pending("h1", "post-a", "m", weak, tx));
 
-        reg.unregister("post-a");
+        reg.unregister_entries("post-a", &["m"]);
         let _ = recv_timeout(&mut rx, Duration::from_millis(200));
 
         let bus_b = Arc::new(GateBus::new());
@@ -480,7 +565,7 @@ mod tests {
     }
 
     #[test]
-    fn t_reg_8_dead_weak_is_silently_skipped_on_unregister_and_sweep() {
+    fn t_reg_8_dead_weak_is_silently_skipped_on_unregister_entries_and_sweep() {
         let reg = GateBusRegistry::new();
         let bus = Arc::new(GateBus::new());
         reg.register("post-a", "m", Arc::clone(&bus)).expect("reg");
@@ -492,7 +577,7 @@ mod tests {
             reg.track_subscriber(make_pending("h-dead", "post-a", "m", weak, tx));
             drop(alive_local);
         }
-        reg.unregister("post-a");
+        reg.unregister_entries("post-a", &["m"]);
         let _ = recv_timeout(&mut rx, Duration::from_millis(100));
         assert!(reg.pending_for_handle("h-dead").is_none());
     }
@@ -580,24 +665,23 @@ mod tests {
     }
 
     #[test]
-    fn unregister_signals_pending_downstreams_waiting_on_that_upstream() {
+    fn unregister_entries_leaves_an_unresolved_waiter_on_the_removed_entry_pending() {
         let reg = GateBusRegistry::new();
+        reg.register("post-a", "m1", Arc::new(GateBus::new()))
+            .expect("reg m1");
         let (tx, mut rx) = gate_edge_channel();
         let (alive, weak) = live_stats();
-        reg.insert_pending(make_pending("h-pending", "nope", "entry-x", weak, tx));
+        reg.insert_pending(make_pending("h-pending", "post-a", "m1", weak, tx));
+
+        reg.unregister_entries("post-a", &["m1"]);
+
         assert!(
             reg.pending_for_handle("h-pending").is_some(),
-            "pending entry must be present before unregister"
+            "a waiter that never resolved must keep waiting for a re-POST of the same name"
         );
-
-        reg.unregister("nope");
-
-        let edge = recv_timeout(&mut rx, Duration::from_millis(200))
-            .expect("waiter must receive UpstreamGone within 200ms");
-        assert_eq!(edge, GateEdge::UpstreamGone);
         assert!(
-            reg.pending_for_handle("h-pending").is_none(),
-            "pending entry must be removed after unregister"
+            recv_timeout(&mut rx, Duration::from_millis(50)).is_err(),
+            "a waiter that never resolved must not be signalled"
         );
         drop(alive);
     }
@@ -628,19 +712,6 @@ mod tests {
 
     fn state_of(stats: &Arc<RwLock<ScenarioStats>>) -> ScenarioState {
         stats.read().unwrap_or_else(|p| p.into_inner()).state
-    }
-
-    #[test]
-    fn unregister_marks_a_downstream_unresolved_through_its_poisoned_stats_lock() {
-        let reg = GateBusRegistry::new();
-        let (alive, weak) = live_stats();
-        let (tx, _rx) = gate_edge_channel();
-        reg.insert_pending(make_pending("h1", "upstream", "m", weak, tx));
-        poison_stats(&alive);
-
-        reg.unregister("upstream");
-
-        assert_eq!(state_of(&alive), ScenarioState::Unresolved);
     }
 
     #[test]

--- a/sonda-server/src/locks.rs
+++ b/sonda-server/src/locks.rs
@@ -11,21 +11,20 @@
 //! argument, per lock:
 //!
 //! - `scenarios` — rows are independent. A panic between two inserts of one batch leaves the
-//!   earlier rows admitted and reachable and `AdoptionGuard` stops the tail it still holds. What
-//!   the map itself holds reads exactly like a batch whose later entries were never admitted.
-//!   Two things survive the guard: the one handle in flight at the panic escapes still running,
-//!   and having dropped its permit it no longer counts against `--max-scenarios`; and the guard's
-//!   `unregister` is keyed by scenario name alone, so the rows it already handed over keep
-//!   running and stay listed but lose their gate buses, and their downstreams see `UpstreamGone`.
+//!   earlier rows admitted and reachable, and `AdoptionGuard` stops every handle it has not yet
+//!   inserted — the tail plus the one in flight — unregistering the gate buses of those entries
+//!   alone, so the rows already handed over keep running with their gate buses and their
+//!   downstreams' `while:` wiring intact. What the map itself holds reads exactly like a batch
+//!   whose later entries were never admitted, and nothing escapes still running.
 //! - `request_counters`, `request_histograms` — values are atomics and the update run under the
 //!   guard cannot panic, so at worst one observation is lost.
-//! - `gate_buses` — rows are independent and keyed by `(scenario_name, entry_id)`. `unregister`
-//!   removes a pre-collected key set one key at a time, so a panic mid-loop leaves the keys it
-//!   has not reached registered rather than any row half-removed.
+//! - `gate_buses` — rows are independent and keyed by `(scenario_name, entry_id)`.
+//!   `unregister_entries` removes a pre-collected key set one key at a time, so a panic mid-loop
+//!   leaves the keys it has not reached registered rather than any row half-removed.
 //! - `gate_subscribers`, `gate_pending` — a subscriber moves between the two maps while both
 //!   guards are held, so a panic mid-move can drop an in-flight reference; its edge sender drops
 //!   with it, which the downstream reads as `UpstreamGone` and settles in `unresolved` rather
-//!   than waiting forever. A panic part-way through `unregister` likewise leaves the subscriber
+//!   than waiting forever. A panic part-way through `unregister_entries` likewise leaves the subscriber
 //!   rows it has not reached in place after their bus is gone: those downstreams have already had
 //!   `UpstreamGone` broadcast to them, and since only `pending` is ever re-resolved they will not
 //!   be re-resolved again while the process lives. Nothing reads a row left behind as something

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -650,11 +650,13 @@ pub enum AdmissionError {
     Internal(String),
 }
 
-/// Holds scenarios that are launched but not yet reachable through [`AppState`]; dropped without `release` — on a panic — it stops them and frees the scenario name.
+/// Holds scenarios that are launched but not yet reachable through [`AppState`]; dropped without `release` — on a panic — it stops them and unregisters their gate buses.
 struct AdoptionGuard<'a> {
     state: &'a AppState,
     scenario_name: Option<String>,
-    handles: Vec<sonda_core::ScenarioHandle>,
+    held: Vec<sonda_core::ScenarioHandle>,
+    // The one handle between leaving `held` and entering the scenario map.
+    in_flight: Option<sonda_core::ScenarioHandle>,
 }
 
 impl<'a> AdoptionGuard<'a> {
@@ -666,24 +668,37 @@ impl<'a> AdoptionGuard<'a> {
         Self {
             state,
             scenario_name,
-            handles,
+            held: handles,
+            in_flight: None,
         }
+    }
+
+    fn owned(&self) -> impl Iterator<Item = &sonda_core::ScenarioHandle> {
+        self.held.iter().chain(self.in_flight.iter())
     }
 
     fn release(mut self) {
         self.scenario_name = None;
-        self.handles.clear();
+        self.held.clear();
+        self.in_flight = None;
     }
 }
 
 impl Drop for AdoptionGuard<'_> {
     fn drop(&mut self) {
-        for handle in &self.handles {
+        for handle in self.owned() {
+            // Claim the cleanup before stopping so the task's own teardown does not race this one.
+            handle
+                .cleaned_up
+                .store(true, std::sync::atomic::Ordering::SeqCst);
             handle.stop();
         }
         if let Some(name) = self.scenario_name.take() {
-            warn!(scenario_name = %name, stopped = self.handles.len(), "admission panicked after launch — stopped the scenarios it still held and freed the name");
-            self.state.gate_bus_registry.unregister(&name);
+            let entry_ids: Vec<&str> = self.owned().map(|h| h.entry_id.as_str()).collect();
+            warn!(scenario_name = %name, stopped = entry_ids.len(), "admission panicked after launch — stopped the scenarios it still held and unregistered their gate buses");
+            self.state
+                .gate_bus_registry
+                .unregister_entries(&name, &entry_ids);
         }
     }
 }
@@ -772,8 +787,8 @@ pub async fn admit_compiled(
     #[cfg(test)]
     tests::panic_after_launch_if_armed();
 
-    let mut created: Vec<CreatedScenario> = Vec::with_capacity(launched.handles.len());
-    for handle in launched.handles.iter_mut() {
+    let mut created: Vec<CreatedScenario> = Vec::with_capacity(launched.held.len());
+    for handle in launched.held.iter_mut() {
         let new_id = Uuid::new_v4().to_string();
         let old_id = std::mem::replace(&mut handle.id, new_id.clone());
         state.gate_bus_registry.rename_handle(&old_id, &new_id);
@@ -793,11 +808,15 @@ pub async fn admit_compiled(
 
     let mut scenarios = state.scenarios.write();
     for created_entry in created.iter() {
-        // Hand one handle over at a time: whatever the guard still holds is what it stops.
-        let handle = launched.handles.remove(0);
+        // Via in_flight, so the guard owns every handle it has not yet inserted.
+        let row_id = created_entry.id.clone();
+        launched.in_flight = Some(launched.held.remove(0));
         #[cfg(test)]
         tests::panic_during_adoption_if_armed();
-        scenarios.insert(created_entry.id.clone(), handle);
+        scenarios.insert(
+            row_id,
+            launched.in_flight.take().expect("in_flight was just set"),
+        );
     }
     drop(scenarios);
     launched.release();
@@ -922,7 +941,9 @@ pub async fn delete_scenario(
     let final_stats = handle.stats_snapshot();
 
     if let Some(name) = scenario_name_to_unregister {
-        state.gate_bus_registry.unregister(&name);
+        state
+            .gate_bus_registry
+            .unregister_entries(&name, &[handle.entry_id.as_str()]);
     }
 
     info!(id = %id, status = %status, total_events = final_stats.total_events, "scenario deleted");
@@ -1450,12 +1471,42 @@ scenarios:
       value: 3.0
 ";
 
+    const ORPHAN_BATCH_WATCHER_YAML: &str = "\
+version: 2
+kind: runnable
+scenario_name: orphan_batch_watcher
+defaults:
+  rate: 5
+  duration: 60s
+  encoder:
+    type: prometheus_text
+  sink:
+    type: memory
+scenarios:
+  - id: watcher
+    signal_type: metrics
+    name: orphan_batch_watcher
+    generator:
+      type: constant
+      value: 1.0
+    while:
+      ref: first
+      op: \">\"
+      value: 0
+      scenario_name: orphan_batch
+      if_unresolved: pending
+";
+
     fn orphan_probe() -> CompiledFile {
         compile_v2_text(ORPHAN_PROBE_YAML, None).expect("the probe body must compile")
     }
 
     fn orphan_batch() -> CompiledFile {
         compile_v2_text(ORPHAN_BATCH_YAML, None).expect("the batch body must compile")
+    }
+
+    fn orphan_batch_watcher() -> CompiledFile {
+        compile_v2_text(ORPHAN_BATCH_WATCHER_YAML, None).expect("the watcher body must compile")
     }
 
     #[test]
@@ -1519,18 +1570,249 @@ scenarios:
             1,
             "the row inserted before the panic must stay reachable"
         );
-        assert!(
-            !state.gate_bus_registry.scenario_name_in_use("orphan_batch"),
-            "the scenario name must not stay held by the registry"
-        );
-
-        // Exactly one task exits: the handle the guard still held. The inserted row keeps
-        // running, and the handle in flight at the panic escapes.
-        drive_until_alive_tasks(&rt, 2);
+        // Only the adopted row survives: the guard owns the tail and the handle in flight.
+        drive_until_alive_tasks(&rt, 1);
         assert!(
             inserted[0].load(std::sync::atomic::Ordering::SeqCst),
             "an adopted scenario must not be stopped by the guard"
         );
+        assert!(
+            state
+                .gate_bus_registry
+                .lookup("orphan_batch", "first")
+                .is_some(),
+            "an adopted row must keep its gate bus"
+        );
+        for orphan in ["second", "third"] {
+            assert!(
+                state
+                    .gate_bus_registry
+                    .lookup("orphan_batch", orphan)
+                    .is_none(),
+                "the guard must unregister '{orphan}': the tail it held and the handle in flight"
+            );
+        }
+    }
+
+    #[test]
+    fn a_panic_during_adoption_leaves_a_downstream_of_an_adopted_row_subscribed() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let state = AppState::new();
+
+        let watcher = rt
+            .block_on(admit_compiled(&state, orphan_batch_watcher(), "test"))
+            .expect("the watcher must be admitted");
+        let watcher_id = watcher.created[0].id.clone();
+        assert!(
+            state
+                .gate_bus_registry
+                .pending_for_handle(&watcher_id)
+                .is_some(),
+            "the watcher must start out waiting for an upstream that does not exist yet"
+        );
+
+        arm_panic_during_adoption(1);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            rt.block_on(admit_compiled(&state, orphan_batch(), "test"))
+        }));
+        assert!(outcome.is_err(), "the injected panic must have propagated");
+
+        let attempts = state
+            .scenarios
+            .read()
+            .get(&watcher_id)
+            .expect("the watcher must still be listed")
+            .stats_snapshot()
+            .cumulative_resolution_attempts;
+        assert!(
+            attempts >= 1,
+            "the batch launch must have resolved the watcher onto the adopted row's bus, \
+             otherwise this test proves nothing"
+        );
+        drive_until_alive_tasks(&rt, 2);
+        assert!(
+            state
+                .gate_bus_registry
+                .lookup("orphan_batch", "first")
+                .is_some(),
+            "the adopted row must keep its gate bus once the stopped tail has finished"
+        );
+        assert!(
+            state
+                .gate_bus_registry
+                .pending_for_handle(&watcher_id)
+                .is_none(),
+            "a downstream of an adopted row must stay subscribed, not be sent back to pending"
+        );
+    }
+
+    #[test]
+    fn the_batch_name_stays_conflicted_after_an_adoption_panic_until_the_adopted_row_is_deleted() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let state = AppState::new();
+
+        arm_panic_during_adoption(1);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            rt.block_on(admit_compiled(&state, orphan_batch(), "test"))
+        }));
+        assert!(outcome.is_err(), "the injected panic must have propagated");
+
+        let rejected = rt.block_on(admit_compiled(&state, orphan_batch(), "test"));
+        assert!(
+            matches!(&rejected, Err(AdmissionError::Conflict { .. })),
+            "the name must stay conflicted while the adopted row runs, got: {:?}",
+            rejected.err()
+        );
+        assert!(
+            state
+                .gate_bus_registry
+                .lookup("orphan_batch", "first")
+                .is_some(),
+            "the adopted row is the only thing that may still hold the name"
+        );
+        for orphan in ["second", "third"] {
+            assert!(
+                state
+                    .gate_bus_registry
+                    .lookup("orphan_batch", orphan)
+                    .is_none(),
+                "'{orphan}' was never adopted, so nothing must hold its bus"
+            );
+        }
+
+        let adopted: Vec<String> = state.scenarios.read().keys().cloned().collect();
+        assert_eq!(adopted.len(), 1, "one row must have been adopted");
+        for id in adopted {
+            assert!(
+                rt.block_on(delete_scenario(State(state.clone()), Path(id)))
+                    .is_ok(),
+                "deleting an adopted row must succeed"
+            );
+        }
+
+        assert!(
+            !state.gate_bus_registry.scenario_name_in_use("orphan_batch"),
+            "deleting the last row under the name must leave no bus behind"
+        );
+        let readmitted = rt.block_on(admit_compiled(&state, orphan_batch(), "test"));
+        assert!(
+            readmitted.is_ok(),
+            "the name must be admissible once the adopted rows are deleted, got: {:?}",
+            readmitted.err()
+        );
+        rt.block_on(cleanup_scenarios(&state));
+    }
+
+    fn row_id_for_entry(state: &AppState, entry_id: &str) -> String {
+        state
+            .scenarios
+            .read()
+            .iter()
+            .find(|(_, h)| h.entry_id == entry_id)
+            .map(|(id, _)| id.clone())
+            .unwrap_or_else(|| panic!("no row for entry '{entry_id}'"))
+    }
+
+    #[test]
+    fn deleting_one_row_of_a_batch_leaves_its_siblings_bus_and_downstream_alone() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let state = AppState::new();
+
+        rt.block_on(admit_compiled(&state, orphan_batch(), "test"))
+            .expect("the batch must be admitted");
+        let watcher = rt
+            .block_on(admit_compiled(&state, orphan_batch_watcher(), "test"))
+            .expect("the watcher must be admitted");
+        let watcher_id = watcher.created[0].id.clone();
+        assert!(
+            state
+                .gate_bus_registry
+                .pending_for_handle(&watcher_id)
+                .is_none(),
+            "the watcher must have resolved onto 'first', or this test proves nothing"
+        );
+
+        let third = row_id_for_entry(&state, "third");
+        rt.block_on(delete_scenario(State(state.clone()), Path(third)))
+            .expect("deleting one row must succeed");
+
+        assert!(
+            state
+                .gate_bus_registry
+                .lookup("orphan_batch", "third")
+                .is_none(),
+            "the deleted row must retire its own bus"
+        );
+        for sibling in ["first", "second"] {
+            assert!(
+                state
+                    .gate_bus_registry
+                    .lookup("orphan_batch", sibling)
+                    .is_some(),
+                "'{sibling}' is still running and must keep its bus"
+            );
+        }
+        assert!(
+            state
+                .gate_bus_registry
+                .pending_for_handle(&watcher_id)
+                .is_none(),
+            "a downstream of a sibling that was not deleted must stay subscribed"
+        );
+        rt.block_on(cleanup_scenarios(&state));
+    }
+
+    #[test]
+    fn the_batch_name_frees_only_once_its_last_row_is_deleted() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let state = AppState::new();
+
+        rt.block_on(admit_compiled(&state, orphan_batch(), "test"))
+            .expect("the batch must be admitted");
+
+        for entry_id in ["first", "second"] {
+            let row = row_id_for_entry(&state, entry_id);
+            rt.block_on(delete_scenario(State(state.clone()), Path(row)))
+                .expect("deleting a row must succeed");
+            assert!(
+                state.gate_bus_registry.scenario_name_in_use("orphan_batch"),
+                "the name must stay held while entries after '{entry_id}' are running"
+            );
+            let rejected = rt.block_on(admit_compiled(&state, orphan_batch(), "test"));
+            assert!(
+                matches!(&rejected, Err(AdmissionError::Conflict { .. })),
+                "the name must stay conflicted after deleting '{entry_id}', got: {:?}",
+                rejected.err()
+            );
+        }
+
+        let last = row_id_for_entry(&state, "third");
+        rt.block_on(delete_scenario(State(state.clone()), Path(last)))
+            .expect("deleting the last row must succeed");
+
+        assert!(
+            !state.gate_bus_registry.scenario_name_in_use("orphan_batch"),
+            "the name must free once the last entry under it is gone"
+        );
+        let readmitted = rt.block_on(admit_compiled(&state, orphan_batch(), "test"));
+        assert!(
+            readmitted.is_ok(),
+            "the name must be admissible again, got: {:?}",
+            readmitted.err()
+        );
+        rt.block_on(cleanup_scenarios(&state));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Entries in one file share a `scenario_name`, and every teardown removed the gate buses for that whole name rather than its own entry. Each entry owns exactly one, so whichever finished first destroyed the refs its still-running siblings were watching — those downstreams saw their upstream disappear and stopped, with the upstream still running.

The failure is silent: the row stays listed, the state reads `finished`, nothing is logged. Reproduced on 1.22.0 with a three-entry file — `shortlived` (3s) beside `upstream` (flap, 120s) and `downstream` (120s, gated on `upstream`):

```
t+2s:  downstream=running   shortlived=running   upstream=running
t+4s:  downstream=finished  shortlived=finished  upstream=running   <-- gone
```

Delete `shortlived`, change nothing else, and `downstream` oscillates correctly for the full run. No panic is involved, and any multi-entry file with non-uniform durations reaches it — the ordinary shape for a `while:` cascade.

Teardown is now per entry everywhere. `GateBusResolver::unregister` is replaced by `unregister_entries`, so the name-wide form no longer exists to reach for, and a `scenario_name` frees exactly when its last entry goes.

- `ScenarioHandle` carries the entry id the bus is keyed by, so `DELETE` can find it past the id the server swaps in for the API
- `AdoptionGuard` holds the handle in flight as well as the tail, closing the one window where a handle belonged to neither the guard nor the map
- retiring an entry no longer cancels waiters queued for an entry it does not own — a downstream waiting on an upstream that has not been posted yet now survives to resolve when it arrives, which is what `scenario-files.md` already promised and the old sweep made impossible
- the gate lifetime is documented: when a downstream loses its upstream, what entries in one file do and do not share, and when a name frees

Verified against a real 8-entry workshop cascade (7 gated on one flapping upstream, 4-minute run): gating cycles correctly throughout and all 8 finish together.

Closes #604
Closes #602