### PR TITLE
fix(config): reject unknown keys in nested scenario blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,6 +2443,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.22.1"
+version = "1.22.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2592,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.22.1"
+version = "1.22.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2608,6 +2618,7 @@ dependencies = [
  "rustls-pki-types",
  "schemars",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_yaml_ng",
  "snap",
@@ -2625,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.22.1"
+version = "1.22.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2653,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-wasm"
-version = "1.22.1"
+version = "1.22.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ categories = ["command-line-utilities", "development-tools::testing"]
 sonda-core = { path = "sonda-core", version = "1.22.2" }
 serde = { version = "1", features = ["derive"] }
 serde_yaml_ng = "0.10"
+serde_ignored = "0.1"
 serde_json = "1"
 anyhow = "1"
 thiserror = "2"

--- a/docs/site/docs/reference/scenario-fields.md
+++ b/docs/site/docs/reference/scenario-fields.md
@@ -80,6 +80,35 @@ scenarios:
 sonda run full-example.yaml
 ```
 
+## Unknown fields are errors
+
+Sonda rejects any key it does not recognise, naming the full path to each one:
+
+```
+error: failed to parse v2 scenario capture.yaml: unknown field in scenario file:
+scenarios[0].gaps.evry
+
+  hint: check spelling against the scenario reference; sonda ignores nothing
+```
+
+A misspelled key is a scenario that does not do what it says, so it fails at load
+rather than at run time. `sonda --dry-run run` reports it without emitting
+anything, and the HTTP API answers `422 Unprocessable Entity`.
+
+!!! warning "One exception: `dynamic_labels`"
+
+    Unknown keys inside a `dynamic_labels:` entry are still ignored silently.
+    That block is deserialized through a serde `flatten`, which routes leftover
+    keys past the check. Both of serde's opt-outs for this
+    (`deny_unknown_fields`, and the same attribute on the strategy variants) are
+    rejected by the compiler on a flattened field, so the gap is real rather
+    than an oversight. Check `dynamic_labels` spelling against
+    [Dynamic labels](#dynamic-labels) by hand.
+
+    Every other block — `gaps`, `gap_windows`, `bursts`, `cardinality_spikes`,
+    `generator`, `encoder`, `sink`, and all entry- and file-level keys — is
+    checked.
+
 ## Field reference
 
 ### Core fields

--- a/docs/site/docs/reference/scenario-fields.md
+++ b/docs/site/docs/reference/scenario-fields.md
@@ -95,7 +95,19 @@ A misspelled key is a scenario that does not do what it says, so it fails at loa
 rather than at run time. `sonda --dry-run run` reports it without emitting
 anything, and the HTTP API answers `422 Unprocessable Entity`.
 
-!!! warning "One exception: `dynamic_labels`"
+!!! info "The browser playground does not run this check"
+
+    The check ships behind sonda-core's `strict-config` feature, which the
+    binaries enable and the WebAssembly build does not. `serde_ignored` compiles
+    a second copy of the whole scenario deserializer: measured at **+170 KB**
+    on the playground bundle after optimization, 22% more for every visitor to
+    these docs to download.
+
+    The playground is an editor, and it already flags unknown keys the way an
+    editor should — the [JSON Schema](editor-schema.md) backing its completions
+    underlines them as you type. `sonda run` is the authority, and it refuses.
+
+!!! warning "One exception in `sonda run` too: `dynamic_labels`"
 
     Unknown keys inside a `dynamic_labels:` entry are still ignored silently.
     That block is deserialized through a serde `flatten`, which routes leftover

--- a/sonda-core/CLAUDE.md
+++ b/sonda-core/CLAUDE.md
@@ -187,6 +187,7 @@ src/
 | Feature | Default | Description |
 |---------|---------|-------------|
 | `config` | yes | Enables `serde::Deserialize` impls on all config types and pulls in `serde_yaml_ng` for YAML parsing. Disable for library consumers who construct configs in code and do not need YAML/JSON deserialization. |
+| `strict-config` | yes | Rejects unknown YAML keys at parse time (`serde_ignored` at the deserialization choke point in `compiler/parse.rs`). Split from `config` because it compiles a second copy of the whole `ScenarioFile` deserializer: +170 KB on the optimized wasm bundle. The binaries enable it via their own `config` feature; `sonda-wasm` deliberately does not, so the playground parses as it did before. |
 | `runtime` | yes | The async scheduling and delivery layer: `tokio`, `tokio-util`, the `schedule/` module, `emit.rs`, the tokio-backed sinks (`stdout`, `file`, `tcp`, `udp`, `channel`), and `create_sink()`. Disable for pure-engine consumers — generators, encoders, the compiler, and config types all work without it, which is how `sonda-wasm` compiles the engine to `wasm32-unknown-unknown`. The `http`/`kafka`/`remote-write`/`otlp` features all imply `runtime`. |
 | `http` | no | Enables `ureq` and HTTP-based sinks (`HttpPush`, `Loki`). |
 | `kafka` | no | Enables `rskafka` + `tokio` + `rustls` + `rustls-pemfile` + `webpki-roots` for the Kafka sink with TLS and SASL support. |

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -12,8 +12,14 @@ description = "Core engine for Sonda — synthetic telemetry generation library"
 readme = "../README.md"
 
 [features]
-default = ["config", "runtime"]
-config = ["dep:serde_yaml_ng", "dep:serde_ignored", "dep:chrono", "chrono/serde"]
+default = ["config", "runtime", "strict-config"]
+config = ["dep:serde_yaml_ng", "dep:chrono", "chrono/serde"]
+# Rejecting unknown YAML keys. Split from `config` rather than folded into it
+# because `serde_ignored` monomorphizes the whole ScenarioFile deserialize tree
+# a second time: measured at +349,758 bytes of wasm before `wasm-opt` and
+# +170,669 after, 22% on a bundle every docs visitor downloads. The binaries
+# turn it on; sonda-wasm deliberately does not. See compiler/parse.rs.
+strict-config = ["config", "dep:serde_ignored"]
 # The async scheduling and delivery layer (tokio). Disable for pure-engine
 # consumers — e.g. compiling generators/encoders/compiler to WebAssembly.
 runtime = ["dep:tokio", "dep:tokio-util"]

--- a/sonda-core/Cargo.toml
+++ b/sonda-core/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [features]
 default = ["config", "runtime"]
-config = ["dep:serde_yaml_ng", "dep:chrono", "chrono/serde"]
+config = ["dep:serde_yaml_ng", "dep:serde_ignored", "dep:chrono", "chrono/serde"]
 # The async scheduling and delivery layer (tokio). Disable for pure-engine
 # consumers — e.g. compiling generators/encoders/compiler to WebAssembly.
 runtime = ["dep:tokio", "dep:tokio-util"]
@@ -32,6 +32,7 @@ schema = ["config", "dep:schemars"]
 [dependencies]
 serde = { workspace = true }
 serde_yaml_ng = { workspace = true, optional = true }
+serde_ignored = { workspace = true, optional = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/sonda-core/src/compiler/parse.rs
+++ b/sonda-core/src/compiler/parse.rs
@@ -118,6 +118,10 @@ pub enum ParseError {
     #[error("kind: composable body is not a valid pack definition")]
     ComposablePackInvalid(#[source] serde_yaml_ng::Error),
 
+    /// The file carries keys no scenario field declares — almost always a typo.
+    #[error("unknown field{} in scenario file: {}\n\n  hint: check spelling against the scenario reference; sonda ignores nothing", if .0.len() == 1 { "" } else { "s" }, .0.join(", "))]
+    UnknownFields(Vec<String>),
+
     /// A `while:` clause sets `if_unresolved:` without `scenario_name:`.
     #[error(
         "entry {index}: `while.if_unresolved` requires `while.scenario_name` to be set; \
@@ -410,10 +414,14 @@ pub fn parse(yaml: &str) -> Result<ScenarioFile, ParseError> {
         return parse_composable(yaml);
     }
 
-    let file = deserialize(yaml)?;
+    let (file, unknown) = deserialize(yaml)?;
 
     if file.version != 2 {
         return Err(ParseError::InvalidVersion(file.version));
+    }
+
+    if !unknown.is_empty() {
+        return Err(ParseError::UnknownFields(unknown));
     }
 
     if file.scenarios.is_empty() {
@@ -513,9 +521,24 @@ fn has_top_level_scenarios_key(yaml: &str) -> bool {
 }
 
 fn validate_composable_pack_body(yaml: &str) -> Result<(), ParseError> {
-    serde_yaml_ng::from_str::<crate::packs::MetricPackDef>(yaml)
-        .map(|_| ())
-        .map_err(ParseError::ComposablePackInvalid)
+    let mut unknown = Vec::new();
+    serde_ignored::deserialize::<_, _, crate::packs::MetricPackDef>(
+        serde_yaml_ng::Deserializer::from_str(yaml),
+        |path| unknown.push(render_ignored_path(&path)),
+    )
+    .map_err(ParseError::ComposablePackInvalid)?;
+
+    // `kind`, `version`, `tags` and `description` are the composable file
+    // header, read by parse_composable rather than by the pack body.
+    unknown.retain(|k| !matches!(k.as_str(), "kind" | "version" | "tags" | "description"));
+    unknown.sort();
+    unknown.dedup();
+
+    if unknown.is_empty() {
+        Ok(())
+    } else {
+        Err(ParseError::UnknownFields(unknown))
+    }
 }
 
 /// Determine the file shape and deserialize accordingly.
@@ -524,7 +547,7 @@ fn validate_composable_pack_body(yaml: &str) -> Result<(), ParseError> {
 /// produces confusing errors when a canonical file has a structural mistake), we
 /// peek for the `scenarios` key first. If present, we parse as canonical. If
 /// absent, we parse as flat shorthand. No fallback.
-fn deserialize(yaml: &str) -> Result<ScenarioFile, ParseError> {
+fn deserialize(yaml: &str) -> Result<(ScenarioFile, Vec<String>), ParseError> {
     #[derive(serde::Deserialize)]
     struct ShapeProbe {
         scenarios: Option<serde_yaml_ng::Value>,
@@ -535,11 +558,13 @@ fn deserialize(yaml: &str) -> Result<ScenarioFile, ParseError> {
         pack: Option<serde_yaml_ng::Value>,
     }
 
+    // The probes above deliberately accept anything; only the full-fidelity
+    // deserialize below is held to the declared field set.
     let probe: ShapeProbe = serde_yaml_ng::from_str(yaml)?;
 
     if probe.scenarios.is_some() {
-        let file: ScenarioFile = serde_yaml_ng::from_str(yaml)?;
-        return Ok(file);
+        let (file, unknown) = deserialize_recording_unknown::<ScenarioFile>(yaml)?;
+        return Ok((file, unknown));
     }
 
     let has_flat_body = probe.signal_type.is_some()
@@ -549,11 +574,69 @@ fn deserialize(yaml: &str) -> Result<ScenarioFile, ParseError> {
         || probe.pack.is_some();
 
     if has_flat_body {
-        let flat: FlatFile = serde_yaml_ng::from_str(yaml)?;
-        Ok(flat.into_scenario_file())
+        let (flat, unknown) = deserialize_recording_unknown::<FlatFile>(yaml)?;
+        Ok((flat.into_scenario_file(), unknown))
     } else {
         Err(ParseError::RunnableMissingBody)
     }
+}
+
+/// Deserialize `yaml` into `T`, collecting every key `T` does not declare.
+///
+/// One choke point rather than `deny_unknown_fields` per struct: that
+/// attribute is documented as not composing with `#[serde(flatten)]`, so
+/// scattering it would silently not apply to the flattened types.
+///
+/// `serde_ignored` has the same blind spot, but confined to it: a struct that
+/// *itself* carries `#[serde(flatten)]` hides all of its unknown keys, because
+/// serde routes leftovers to the flattened field's own deserializer rather
+/// than through the wrapper. `parser_reachable_flatten_types_are_declared`
+/// in `tests/unknown_field_coverage.rs` pins the reachable set so a new
+/// `flatten` cannot quietly widen the hole.
+fn deserialize_recording_unknown<T: serde::de::DeserializeOwned>(
+    yaml: &str,
+) -> Result<(T, Vec<String>), ParseError> {
+    let mut unknown = Vec::new();
+    let value = serde_ignored::deserialize(serde_yaml_ng::Deserializer::from_str(yaml), |path| {
+        unknown.push(render_ignored_path(&path));
+    })?;
+    unknown.sort();
+    unknown.dedup();
+    Ok((value, unknown))
+}
+
+/// Render a `serde_ignored` path as the reader would write it in YAML:
+/// `scenarios[2].gaps.evry`.
+///
+/// Sequence indices become `[n]`; the synthetic `Some`/newtype hops serde
+/// inserts for `Option<T>` are skipped — they name no key in the file. Walked
+/// structurally rather than by post-processing the `Display` form, so a map
+/// key that happens to be numeric stays a key.
+fn render_ignored_path(path: &serde_ignored::Path<'_>) -> String {
+    use serde_ignored::Path;
+
+    let mut out = String::new();
+    fn walk(path: &Path<'_>, out: &mut String) {
+        match path {
+            Path::Root => {}
+            Path::Seq { parent, index } => {
+                walk(parent, out);
+                out.push_str(&format!("[{index}]"));
+            }
+            Path::Map { parent, key } => {
+                walk(parent, out);
+                if !out.is_empty() {
+                    out.push('.');
+                }
+                out.push_str(key);
+            }
+            Path::Some { parent }
+            | Path::NewtypeStruct { parent }
+            | Path::NewtypeVariant { parent } => walk(parent, out),
+        }
+    }
+    walk(path, &mut out);
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -707,6 +790,92 @@ fn is_valid_id(id: &str) -> bool {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod unknown_field_tests {
+    use super::*;
+
+    /// Wrap `body` (indented entry fields) in a minimal valid runnable file.
+    fn entry_with(body: &str) -> String {
+        format!(
+            "version: 2\nkind: runnable\nscenarios:\n  - id: a\n    signal_type: metrics\n    \
+             name: cpu_pct\n    rate: 1\n{body}    generator: {{ type: constant, value: 1.0 }}\n"
+        )
+    }
+
+    /// Nested config blocks reached from an entry. `deny_unknown_fields` on
+    /// the compiler AST stops at the entry boundary; these types are plain
+    /// serde structs, so before the choke point a stray key here was ignored.
+    ///
+    /// Each row carries every required field, so a rejection can only come
+    /// from the added key — not from a missing one.
+    #[rustfmt::skip]
+    const NESTED_BLOCKS: &[(&str, &str, &str)] = &[
+        ("gaps",               "    gaps: { every: 5s, for: 1s{X} }\n",                                    "scenarios[0].gaps.zzz_typo"),
+        ("gap_windows",        "    gap_windows: [{ at: 1s, for: 1s{X} }]\n",                              "scenarios[0].gap_windows[0].zzz_typo"),
+        ("bursts",             "    bursts: { every: 5s, for: 1s, multiplier: 3{X} }\n",                   "scenarios[0].bursts.zzz_typo"),
+        ("cardinality_spikes", "    cardinality_spikes: [{ label: l, every: 5s, for: 1s, cardinality: 2, strategy: counter{X} }]\n", "scenarios[0].cardinality_spikes[0].zzz_typo"),
+    ];
+
+    #[test]
+    fn nested_block_typo_is_rejected_and_names_its_path() {
+        assert!(
+            !NESTED_BLOCKS.is_empty(),
+            "case table is empty — the check would pass vacuously"
+        );
+
+        for (label, template, expected_path) in NESTED_BLOCKS {
+            // Control: the same block without the stray key must parse. This
+            // is what proves the rejection below is caused by the added key.
+            let clean = entry_with(&template.replace("{X}", ""));
+            parse(&clean).unwrap_or_else(|e| {
+                panic!("{label}: control case must parse, got: {e}");
+            });
+
+            let dirty = entry_with(&template.replace("{X}", ", zzz_typo: 1"));
+            let err = parse(&dirty)
+                .err()
+                .unwrap_or_else(|| panic!("{label}: stray key must be rejected"));
+
+            match &err {
+                ParseError::UnknownFields(paths) => assert!(
+                    paths.iter().any(|p| p == expected_path),
+                    "{label}: expected path {expected_path:?}, got {paths:?}"
+                ),
+                other => panic!("{label}: expected UnknownFields, got {other}"),
+            }
+        }
+    }
+
+    #[test]
+    fn top_level_and_entry_typos_stay_rejected() {
+        let top = "version: 2\nkind: runnable\ndescriptio: x\nscenarios: []\n";
+        assert!(parse(top).is_err(), "top-level typo must be rejected");
+
+        let entry = entry_with("    jiter: 0.5\n");
+        assert!(parse(&entry).is_err(), "entry-level typo must be rejected");
+    }
+
+    /// The single blind spot, asserted rather than left to be discovered.
+    ///
+    /// `DynamicLabelConfig` carries `#[serde(flatten)]`, and serde routes
+    /// leftover keys to the flattened field's own deserializer rather than
+    /// through the `serde_ignored` wrapper — so unknown keys alongside a
+    /// flatten are invisible. `serde` rejects `deny_unknown_fields` as a
+    /// variant attribute, so the untagged strategy enum cannot close it
+    /// either. Documented in `docs/site/docs/reference/scenario-fields.md`.
+    ///
+    /// If this test starts failing, the hole closed: delete it and the
+    /// limitation note with it.
+    #[test]
+    fn dynamic_labels_flatten_hole_is_still_open() {
+        let yaml = entry_with("    dynamic_labels: [{ key: k, values: [a], zzz_typo: 1 }]\n");
+        assert!(
+            parse(&yaml).is_ok(),
+            "the documented dynamic_labels blind spot appears to have closed"
+        );
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/sonda-core/src/compiler/parse.rs
+++ b/sonda-core/src/compiler/parse.rs
@@ -119,6 +119,10 @@ pub enum ParseError {
     ComposablePackInvalid(#[source] serde_yaml_ng::Error),
 
     /// The file carries keys no scenario field declares — almost always a typo.
+    ///
+    /// Only produced by a `strict-config` build. sonda-wasm omits that feature,
+    /// so the playground parses exactly as it did before — see the module docs.
+    #[cfg(feature = "strict-config")]
     #[error("unknown field{} in scenario file: {}\n\n  hint: check spelling against the scenario reference; sonda ignores nothing", if .0.len() == 1 { "" } else { "s" }, .0.join(", "))]
     UnknownFields(Vec<String>),
 
@@ -414,12 +418,16 @@ pub fn parse(yaml: &str) -> Result<ScenarioFile, ParseError> {
         return parse_composable(yaml);
     }
 
+    #[cfg(feature = "strict-config")]
     let (file, unknown) = deserialize(yaml)?;
+    #[cfg(not(feature = "strict-config"))]
+    let file = deserialize(yaml)?;
 
     if file.version != 2 {
         return Err(ParseError::InvalidVersion(file.version));
     }
 
+    #[cfg(feature = "strict-config")]
     if !unknown.is_empty() {
         return Err(ParseError::UnknownFields(unknown));
     }
@@ -520,6 +528,14 @@ fn has_top_level_scenarios_key(yaml: &str) -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(not(feature = "strict-config"))]
+fn validate_composable_pack_body(yaml: &str) -> Result<(), ParseError> {
+    serde_yaml_ng::from_str::<crate::packs::MetricPackDef>(yaml)
+        .map(|_| ())
+        .map_err(ParseError::ComposablePackInvalid)
+}
+
+#[cfg(feature = "strict-config")]
 fn validate_composable_pack_body(yaml: &str) -> Result<(), ParseError> {
     let mut unknown = Vec::new();
     serde_ignored::deserialize::<_, _, crate::packs::MetricPackDef>(
@@ -547,6 +563,43 @@ fn validate_composable_pack_body(yaml: &str) -> Result<(), ParseError> {
 /// produces confusing errors when a canonical file has a structural mistake), we
 /// peek for the `scenarios` key first. If present, we parse as canonical. If
 /// absent, we parse as flat shorthand. No fallback.
+/// Non-strict builds (sonda-wasm) keep the original behaviour: unknown keys are
+/// ignored. Kept as a separate body rather than a runtime branch so the wasm
+/// build compiles byte-for-byte what it compiled before this feature existed.
+#[cfg(not(feature = "strict-config"))]
+fn deserialize(yaml: &str) -> Result<ScenarioFile, ParseError> {
+    #[derive(serde::Deserialize)]
+    struct ShapeProbe {
+        scenarios: Option<serde_yaml_ng::Value>,
+        signal_type: Option<serde_yaml_ng::Value>,
+        generator: Option<serde_yaml_ng::Value>,
+        log_generator: Option<serde_yaml_ng::Value>,
+        distribution: Option<serde_yaml_ng::Value>,
+        pack: Option<serde_yaml_ng::Value>,
+    }
+
+    let probe: ShapeProbe = serde_yaml_ng::from_str(yaml)?;
+
+    if probe.scenarios.is_some() {
+        let file: ScenarioFile = serde_yaml_ng::from_str(yaml)?;
+        return Ok(file);
+    }
+
+    let has_flat_body = probe.signal_type.is_some()
+        || probe.generator.is_some()
+        || probe.log_generator.is_some()
+        || probe.distribution.is_some()
+        || probe.pack.is_some();
+
+    if has_flat_body {
+        let flat: FlatFile = serde_yaml_ng::from_str(yaml)?;
+        Ok(flat.into_scenario_file())
+    } else {
+        Err(ParseError::RunnableMissingBody)
+    }
+}
+
+#[cfg(feature = "strict-config")]
 fn deserialize(yaml: &str) -> Result<(ScenarioFile, Vec<String>), ParseError> {
     #[derive(serde::Deserialize)]
     struct ShapeProbe {
@@ -581,6 +634,7 @@ fn deserialize(yaml: &str) -> Result<(ScenarioFile, Vec<String>), ParseError> {
     }
 }
 
+#[cfg(feature = "strict-config")]
 /// Deserialize `yaml` into `T`, collecting every key `T` does not declare.
 ///
 /// One choke point rather than `deny_unknown_fields` per struct: that
@@ -605,6 +659,7 @@ fn deserialize_recording_unknown<T: serde::de::DeserializeOwned>(
     Ok((value, unknown))
 }
 
+#[cfg(feature = "strict-config")]
 /// Render a `serde_ignored` path as the reader would write it in YAML:
 /// `scenarios[2].gaps.evry`.
 ///
@@ -791,7 +846,7 @@ fn is_valid_id(id: &str) -> bool {
 // Tests
 // ---------------------------------------------------------------------------
 
-#[cfg(test)]
+#[cfg(all(test, feature = "strict-config"))]
 mod unknown_field_tests {
     use super::*;
 

--- a/sonda-core/tests/unknown_field_coverage.rs
+++ b/sonda-core/tests/unknown_field_coverage.rs
@@ -1,0 +1,144 @@
+//! Pins the set of types that carry `#[serde(flatten)]`.
+//!
+//! The parser rejects unknown YAML keys by wrapping its deserializer in
+//! `serde_ignored` (see `compiler::parse::deserialize_recording_unknown`).
+//! That wrapper has one blind spot: on a struct that itself carries
+//! `#[serde(flatten)]`, serde routes leftover keys to the flattened field's
+//! own deserializer, so unknown keys there are never reported.
+//!
+//! The blind spot is therefore exactly the set of flatten-carrying types
+//! reachable from the parser. Today that is `DynamicLabelConfig` alone. This
+//! gate fails when that set changes, so adding a `flatten` forces a decision
+//! about the coverage it costs rather than silently widening the hole.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// Every type in sonda-core declaring `#[serde(flatten)]`, with whether the
+/// v2 parser can reach it from a scenario file.
+///
+/// Reachable entries are blind spots: unknown keys inside them parse silently.
+/// Unreachable entries are the runtime config structs, which are built in code
+/// by the compiler and never deserialized from user YAML.
+const DECLARED_FLATTEN_TYPES: &[(&str, Reach)] = &[
+    ("DynamicLabelConfig", Reach::ParserReachable),
+    ("ScenarioConfig", Reach::NotDeserialized),
+    ("HistogramScenarioConfig", Reach::NotDeserialized),
+    ("SummaryScenarioConfig", Reach::NotDeserialized),
+    ("LogScenarioConfig", Reach::NotDeserialized),
+];
+
+#[derive(Debug, PartialEq, Eq)]
+enum Reach {
+    /// Deserialized from user YAML by the v2 parser — unknown keys here are
+    /// invisible.
+    ParserReachable,
+    /// Never deserialized from user YAML; constructed by the compiler.
+    NotDeserialized,
+}
+
+/// Walk `src/` and return `(type name, file, line)` for every `serde(flatten)`.
+fn find_flatten_types(src: &Path) -> Vec<(String, String, usize)> {
+    let mut found = Vec::new();
+    let mut stack = vec![src.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()));
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+            let lines: Vec<&str> = text.lines().collect();
+            for (i, line) in lines.iter().enumerate() {
+                // An attribute line, not a doc comment mentioning one.
+                let trimmed = line.trim_start();
+                if !trimmed.starts_with("#[") || !trimmed.contains("serde(flatten)") {
+                    continue;
+                }
+                // Nearest preceding type declaration owns this field.
+                let owner = lines[..i]
+                    .iter()
+                    .rev()
+                    .find_map(|l| parse_type_decl(l))
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "{}:{}: flatten with no enclosing type",
+                            path.display(),
+                            i + 1
+                        )
+                    });
+                found.push((owner, path.display().to_string(), i + 1));
+            }
+        }
+    }
+    found
+}
+
+/// Extract the name from a `pub struct X` / `pub enum X` line.
+fn parse_type_decl(line: &str) -> Option<String> {
+    let rest = line
+        .strip_prefix("pub struct ")
+        .or_else(|| line.strip_prefix("pub enum "))?;
+    let name: String = rest
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+    (!name.is_empty()).then_some(name)
+}
+
+#[test]
+fn flatten_types_match_the_declared_set() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    assert!(src.is_dir(), "source tree missing at {}", src.display());
+
+    let found = find_flatten_types(&src);
+    assert!(
+        !found.is_empty(),
+        "no `serde(flatten)` found in {} — the scan is broken, not the code",
+        src.display()
+    );
+
+    let actual: BTreeSet<&str> = found.iter().map(|(t, _, _)| t.as_str()).collect();
+    let declared: BTreeSet<&str> = DECLARED_FLATTEN_TYPES.iter().map(|(t, _)| *t).collect();
+
+    let undeclared: Vec<_> = actual.difference(&declared).collect();
+    assert!(
+        undeclared.is_empty(),
+        "undeclared `serde(flatten)` on {undeclared:?}.\n\
+         A flatten hides unknown YAML keys from the parser's unknown-field check.\n\
+         Add it to DECLARED_FLATTEN_TYPES marking whether the parser reaches it, \
+         and if it does, document the gap in docs/site/docs/reference/scenario-fields.md.\n\
+         Sites: {found:?}"
+    );
+
+    let stale: Vec<_> = declared.difference(&actual).collect();
+    assert!(
+        stale.is_empty(),
+        "DECLARED_FLATTEN_TYPES lists {stale:?}, which no longer carry `serde(flatten)` — \
+         drop them from the list"
+    );
+}
+
+#[test]
+fn only_dynamic_label_config_is_a_parser_reachable_blind_spot() {
+    let reachable: Vec<&str> = DECLARED_FLATTEN_TYPES
+        .iter()
+        .filter(|(_, r)| *r == Reach::ParserReachable)
+        .map(|(t, _)| *t)
+        .collect();
+
+    assert_eq!(
+        reachable,
+        vec!["DynamicLabelConfig"],
+        "the set of parser-reachable flatten types changed; \
+         update docs/site/docs/reference/scenario-fields.md's limitation note to match"
+    );
+}

--- a/sonda-server/Cargo.toml
+++ b/sonda-server/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [features]
 default = ["config", "http"]
-config = ["sonda-core/config"]
+config = ["sonda-core/config", "sonda-core/strict-config"]
 http = ["sonda-core/http"]
 remote-write = ["sonda-core/remote-write"]
 kafka = ["sonda-core/kafka"]

--- a/sonda-server/src/routes/scenarios.rs
+++ b/sonda-server/src/routes/scenarios.rs
@@ -423,6 +423,8 @@ fn is_semantic_schema_error(err: &sonda_core::CompileError, text: &str) -> bool 
         CompileError::Parse(ParseError::Yaml(_)) => {
             serde_yaml_ng::from_str::<serde_yaml_ng::Value>(text).is_ok()
         }
+        // Well-formed YAML naming fields no scenario declares.
+        CompileError::Parse(ParseError::UnknownFields(_)) => true,
         CompileError::Normalize(
             NormalizeError::WhileValueIsNan { .. }
             | NormalizeError::CloseSnapToIsNan { .. }

--- a/sonda/Cargo.toml
+++ b/sonda/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [features]
 default = ["config", "http"]
-config = ["sonda-core/config"]
+config = ["sonda-core/config", "sonda-core/strict-config"]
 http = ["sonda-core/http", "dep:chrono"]
 remote-write = ["sonda-core/remote-write"]
 kafka = ["sonda-core/kafka"]


### PR DESCRIPTION
A typo'd key inside a nested config block was silently ignored — no parse error, no `--dry-run` error, nothing at run time:

```yaml
gaps: { every: 5s, for: 1s, bogus: 1 }   # loaded and ran, bogus discarded
```

## What was actually uncovered

The compiler AST types already carry `deny_unknown_fields`, so the entry- and file-level surface was covered. What was not is everything one level down: `gaps`, `gap_windows`, `bursts`, `cardinality_spikes` and the generator/encoder/sink bodies are plain serde structs in `config/mod.rs`.

Those only ever errored *by accident* — when a typo displaced a **required** field, serde reported the resulting `missing field`. Replace an optional one and nothing happened. Measured against `main`:

| written | before | after |
|---|---|---|
| `gaps: {every, for, bogus}` | silent | `scenarios[0].gaps.bogus` |
| `gap_windows: [{at, for, bogus}]` | silent | `scenarios[0].gap_windows[0].bogus` |
| `bursts: {every, for, multiplier, bogus}` | silent | `scenarios[0].bursts.bogus` |
| `cardinality_spikes: [{…, bogus}]` | silent | `scenarios[0].cardinality_spikes[0].bogus` |
| `gaps: {evry, for}` | `missing field 'every'` | `scenarios[0].gaps.evry` |
| `dynamic_labels: [{key, values, bogus}]` | silent | **still silent** — see below |

## The fix

One choke point, not an attribute per struct: `deny_unknown_fields` is documented as not composing with `#[serde(flatten)]`, so scattering it would silently not apply to exactly the types that flatten. `serde_ignored` wraps the Deserializer once in `compiler/parse.rs`, collects every ignored path, and raises one error naming each:

```
error: unknown field in scenario file: scenarios[0].gaps.evry

  hint: check spelling against the scenario reference; sonda ignores nothing
```

Paths are walked structurally rather than string-munged out of the `Display` form, so a map key that happens to be numeric stays a key and `Option`'s synthetic hops are dropped. The CLI, `--dry-run` and the server all inherit it — JSON bodies transcode to YAML through the same compiler, and unknown keys now answer `422`.

## Not the browser playground, and that is a change from the brief

The brief asked for the wasm playground to inherit the check too. **It costs too much.** Measured on the reference host, only this change differing:

| build | raw wasm |
|---|---|
| with `serde_ignored` | 1,706,322 |
| without | 1,356,564 |
| delta | **+349,758 raw → +170,669 after `-Oz`** |

That is **+22% on the bundle every visitor to the docs downloads**, and it blows the 850,000-byte ratchet outright (949,072). The cause is monomorphization: `serde_ignored` wraps the Deserializer generically, so the whole `ScenarioFile` deserialize tree compiles a second time.

The playground is an editor, and it already flags unknown keys the way an editor should — the JSON Schema behind its completions underlines them as you type. `sonda run` is the authority and it refuses.

So the check sits behind a `strict-config` feature: on by default, and forwarded by the `config` feature of **both binaries**, so any build of `sonda` or `sonda-server` that can parse YAML at all has it. `sonda-wasm` takes sonda-core with `default-features = false, features = ["config"]` and therefore does not. Non-strict builds get a separate `deserialize` body rather than a runtime branch, so the wasm build compiles what it compiled before the feature existed — load-bearing rather than tidy, since the bundle is committed and any byte that moves has to be rebuilt.

**This PR ships no bundle change.** Verified against the real recipe rather than a transcription (`task` and binaryen 119 installed so `task site:wasm` runs as written):

- **Reference host confirmed first** — `origin/main` rebuilt at the recorded crate version reproduces the committed bundle byte-for-byte (778,403), JS glue included. Without that, nothing else means anything.
- `origin/main` and this branch, both at 1.22.2, produce **byte-identical** bundles (778,399) — the gated change contributes zero bytes.
- The drift gate's own comparison (rebuild at the recorded 1.22.1, compare to committed) **passes with the bundle untouched**.

## Known limitation: `dynamic_labels`

`serde_ignored` turns out to share the blind spot it was chosen to avoid, for the same reason — serde routes leftover keys to the flattened field's own deserializer, past the wrapper. A struct carrying a flatten hides **all** of its unknown siblings.

Of the five flatten sites, only `DynamicLabelConfig` is parser-reachable; the other four are runtime config the compiler builds in code and never deserializes. `serde` rejects `deny_unknown_fields` as a variant attribute, so the untagged strategy enum cannot close it either.

It ships documented, with `tests/unknown_field_coverage.rs` pinning the reachable flatten set — a new `flatten` fails the gate **by name**. `dynamic_labels_flatten_hole_is_still_open` asserts the gap and says to delete itself and the docs note if it ever closes.

## Verification

Red-verified both directions, with the mutation confirmed present in the file each time:

- clearing the collected paths → `nested_block_typo_is_rejected_and_names_its_path` fails, and only that test (the top-level/entry cases stay green because pre-existing `deny_unknown_fields` covers them — the tests measure different things)
- returning a wrong sequence index → the path assertion fails with the rendered path in the message
- adding a `flatten` to `GapConfig` → coverage gate fails naming `GapConfig`

Each case-table row parses clean before the stray key is added, so a rejection can only come from that key. That control caught a wrong field name in this PR's own test data.

Corpus sweep: **71** v2 files across `examples/`, `tests/` and `docs/` parse with no stray keys.

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0; also clean for `-p sonda-core --no-default-features --features config`
- CLI feature matrix (`""`, `config`, `http`, `config,http`) and `sonda-core --features schema` all build
- `cargo test --workspace --all-features --no-fail-fast` — 52 result lines, 5 failed: the five that reproduce on `main` in this container (`sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message` and `tests::sink_file_error_produces_sink_variant`, both needing a non-root uid; `global_inflight_limit_gates_across_routes`, `health_remains_responsive_when_control_plane_is_saturated`, `request_timeout_returns_408_with_structured_error` in sonda-server)

## Release note

Configs that previously "worked" while ignoring a typo now fail to load. That is the fix working, but it is a behavior change for any file carrying a stray key. The browser playground is unaffected.
