### PR TITLE
fix(import): check timestamp monotonicity across the whole file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "sonda"
-version = "1.22.1"
+version = "1.22.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-core"
-version = "1.22.1"
+version = "1.22.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-server"
-version = "1.22.1"
+version = "1.22.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "sonda-wasm"
-version = "1.22.1"
+version = "1.22.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/docs/site/docs/import/grafana-exports.md
+++ b/docs/site/docs/import/grafana-exports.md
@@ -73,6 +73,31 @@ The scenario `name: incident_replay` is replaced with `cpu` because each CSV col
 !!! info "How the derivation works"
     Sonda reads column 0 as a timestamp series. It parses each cell as a number and computes the **median** of consecutive differences across up to the first 100 data rows. Values larger than `1e12` are read as epoch milliseconds. Smaller values are read as epoch seconds. Both Grafana, which exports milliseconds, and VictoriaMetrics, which exports seconds, are covered. The derived rate is `timescale / median_delta`.
 
+### What the timestamp column does, and does not, control
+
+The column has exactly two jobs:
+
+1. **Rate derivation** — the median Δt across the sampled rows, scaled by `timescale`.
+2. **Row alignment** — which row a `gap_windows:` entry covers, checked against the same instants.
+
+It does **not** set a per-event emission time. Replay runs on a **uniform grid** at the derived rate: rows are emitted in file order, evenly spaced, and each event is stamped from the scenario clock (anchored by `start_time:`), not from its row's cell.
+
+!!! warning "Irregular spacing is honored in rate only"
+    If you hand-write a file whose rows are unevenly spaced — say 10s apart for the first half and 60s apart for the second — sonda does not reproduce that pacing. It takes the median of the two, and replays every row at that one interval.
+
+    This is a deliberate limitation, not an oversight. Driving per-event instants from the column would create a second source of truth for emission times that can disagree with the uniform grid the scheduler and the `gap_windows:` cross-check both rely on. Irregular pacing is a scheduling mode, and the capture pipeline does not have one.
+
+    To model a real pause in the data, use [`gap_windows:`](../reference/scenario-fields.md), which the importer emits for you. That expresses absence explicitly rather than implying it through row spacing.
+
+**Timestamps must strictly increase.** A repeated or out-of-order stamp is wrong data — replaying it would silently reorder the capture — so it is refused at load, naming the row:
+
+```
+error: csv_replay: file "capture.csv" has non-monotonic timestamps at data row 120:
+1700000000 is not greater than the previous row's 1700001190
+```
+
+Every row is checked, not just the first 100 the rate derivation samples.
+
 ### Speeding up or slowing down with `timescale`
 
 Use `timescale:` to replay the recording faster or slower without rewriting the CSV.
@@ -273,7 +298,7 @@ Naming rules:
 |---------------|-------|-----|
 | `csv_replay: 'timescale' must be a positive finite number, got 0` | `timescale: 0`, a negative value, or `NaN`/`Inf`. | Set `timescale` to a positive number, or remove it to use the default `1.0`. |
 | `csv_replay: file "..." has fewer than 2 data rows; cannot derive replay rate` | The CSV only has a header and one data row (or zero). | At least two data rows are needed to measure the sample interval. Re-export with a wider time range. |
-| `csv_replay: non-monotonic timestamps in "..." (row N value X <= previous Y)` | A timestamp goes backward or repeats. Common with concatenated exports or paused recordings. | Sort the file by timestamp, deduplicate, or split it at the discontinuity. |
+| `csv_replay: file "..." has non-monotonic timestamps at data row N` | A timestamp goes backward or repeats. Common with concatenated exports or paused recordings. Every row is checked, so this can name a row far into the file. | Sort the file by timestamp, deduplicate, or split it at the discontinuity. |
 | `csv_replay: column N has no metric name (header has labels only with no __name__); set 'default_metric_name' on the generator config` | Auto-discovery found a `{labels...}` header without a metric name. | Add `default_metric_name:` to the generator, or switch to explicit `columns:`. |
 | `generator error: cannot read file "..."` | The CSV path does not exist or is not readable. | Paths are relative to the directory where `sonda` is launched, not to the scenario file. |
 

--- a/sonda-core/src/config/mod.rs
+++ b/sonda-core/src/config/mod.rs
@@ -875,8 +875,7 @@ fn read_csv_first_lines(path: &str, max_lines: usize) -> Result<Vec<String>, Son
                 source: e,
             })
         })?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
+        if is_csv_skippable_line(&line) {
             continue;
         }
         out.push(line);
@@ -885,6 +884,85 @@ fn read_csv_first_lines(path: &str, max_lines: usize) -> Result<Vec<String>, Son
         }
     }
     Ok(out)
+}
+
+/// A line carrying no data: blank, or a `#` comment.
+///
+/// One definition because two readers walk the same file and must agree on
+/// which lines are rows — the sampled rate derivation and the full-file
+/// monotonicity check. If they disagreed, the row numbers in an error message
+/// would not point at the row the reader has to fix.
+fn is_csv_skippable_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.is_empty() || trimmed.starts_with('#')
+}
+
+/// Refuse a timestamp column that does not strictly increase.
+///
+/// [`compute_csv_delta_seconds`] reads only [`CSV_DELTA_SAMPLE_ROWS`] rows, so
+/// the monotonicity it enforces covers the head of the file. This walks every
+/// row: a repeated or out-of-order stamp anywhere is wrong data, not a pacing
+/// choice, and replaying it would silently reorder the capture.
+///
+/// Streams rather than collecting — a capture is not bounded in length.
+///
+/// # Errors
+///
+/// Names the first offending row and both stamps. Row numbers count data rows
+/// from 0, matching [`compute_csv_delta_seconds`].
+fn validate_csv_timestamps_monotonic(path: &str, ts_col_idx: usize) -> Result<(), SondaError> {
+    use std::io::BufRead;
+
+    let file = std::fs::File::open(path).map_err(|e| {
+        SondaError::Generator(crate::GeneratorError::FileRead {
+            path: path.to_string(),
+            source: e,
+        })
+    })?;
+
+    let mut prev: Option<f64> = None;
+    let mut row_idx = 0usize;
+    let mut header_checked = false;
+
+    for line_result in std::io::BufReader::new(file).lines() {
+        let line = line_result.map_err(|e| {
+            SondaError::Generator(crate::GeneratorError::FileRead {
+                path: path.to_string(),
+                source: e,
+            })
+        })?;
+        if is_csv_skippable_line(&line) {
+            continue;
+        }
+        if !header_checked {
+            header_checked = true;
+            if is_csv_header_line(&line) {
+                continue;
+            }
+        }
+
+        let cell = line.split(',').nth(ts_col_idx).unwrap_or("");
+        let ts = parse_csv_timestamp(cell).ok_or_else(|| {
+            SondaError::Config(ConfigError::invalid(format!(
+                "csv_replay: failed to parse timestamp at data row {row_idx} column {ts_col_idx}: {cell:?}"
+            )))
+        })?;
+
+        if let Some(previous) = prev {
+            if ts <= previous {
+                return Err(SondaError::Config(ConfigError::invalid(format!(
+                    "csv_replay: file {path:?} has non-monotonic timestamps at data row \
+                     {row_idx}: {ts} is not greater than the previous row's {previous}.\n\n  \
+                     hint: the timestamp column must strictly increase; sonda replays rows in \
+                     file order and derives the rate from it"
+                ))));
+            }
+        }
+        prev = Some(ts);
+        row_idx += 1;
+    }
+
+    Ok(())
 }
 
 fn parse_csv_timestamp(cell: &str) -> Option<f64> {
@@ -1061,6 +1139,7 @@ pub fn expand_scenario(config: ScenarioConfig) -> Result<Vec<ScenarioConfig>, So
         auto_discover_specs(parsed, default_name_opt.as_deref())?
     };
 
+    validate_csv_timestamps_monotonic(&file, 0)?;
     let delta = compute_csv_delta_seconds(&file, 0)?;
     let derived_rate = timescale / delta;
 
@@ -1409,6 +1488,7 @@ pub fn expand_log_scenario(
     let timescale = validate_csv_timescale(timescale_opt)?;
     let ts_col_idx =
         crate::generator::log_csv_replay::resolve_timestamp_column_index(&file, columns.as_ref())?;
+    validate_csv_timestamps_monotonic(&file, ts_col_idx)?;
     let delta = compute_csv_delta_seconds(&file, ts_col_idx)?;
     let derived_rate = timescale / delta;
     let user_rate = config.base.rate;
@@ -5063,5 +5143,94 @@ generator:
             msg.contains("non-monotonic"),
             "error message must mention non-monotonic, got: {msg}"
         );
+    }
+
+    // ======================================================================
+    // Timestamp column monotonicity (full file, not just the sampled head)
+    // ======================================================================
+
+    /// Write a CSV whose timestamps are a clean 10s grid, then overwrite one
+    /// row's stamp with `bad_ts` — returning the path and the row's index.
+    fn csv_with_bad_row(rows: usize, bad_row: usize, bad_ts: f64) -> tempfile::NamedTempFile {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
+        writeln!(tmp, "timestamp,cpu").expect("write header");
+        for i in 0..rows {
+            let ts = if i == bad_row {
+                bad_ts
+            } else {
+                1_700_000_000.0 + (i as f64) * 10.0
+            };
+            writeln!(tmp, "{ts},42.5").expect("write row");
+        }
+        tmp.flush().expect("flush");
+        tmp
+    }
+
+    #[test]
+    fn monotonic_timestamps_are_accepted() {
+        let tmp = csv_with_bad_row(150, usize::MAX, 0.0);
+        validate_csv_timestamps_monotonic(&tmp.path().to_string_lossy(), 0)
+            .expect("a strictly increasing column must be accepted");
+    }
+
+    #[test]
+    fn repeated_timestamp_is_refused_naming_the_row() {
+        // Row 4 repeats row 3's stamp.
+        let tmp = csv_with_bad_row(20, 4, 1_700_000_030.0);
+        let err = validate_csv_timestamps_monotonic(&tmp.path().to_string_lossy(), 0)
+            .expect_err("a repeated timestamp must be refused");
+        let msg = err.to_string();
+        assert!(msg.contains("non-monotonic"), "got: {msg}");
+        assert!(msg.contains("data row 4"), "must name the row, got: {msg}");
+    }
+
+    #[test]
+    fn out_of_order_timestamp_is_refused_naming_the_row() {
+        // Row 7 jumps backwards behind row 6.
+        let tmp = csv_with_bad_row(20, 7, 1_700_000_000.0);
+        let err = validate_csv_timestamps_monotonic(&tmp.path().to_string_lossy(), 0)
+            .expect_err("an out-of-order timestamp must be refused");
+        let msg = err.to_string();
+        assert!(msg.contains("non-monotonic"), "got: {msg}");
+        assert!(msg.contains("data row 7"), "must name the row, got: {msg}");
+    }
+
+    /// The gap this check exists to close.
+    ///
+    /// `compute_csv_delta_seconds` reads only `CSV_DELTA_SAMPLE_ROWS` rows, so
+    /// its own monotonicity guard cannot see a defect past that window. Row 120
+    /// is beyond it by construction: the assertion below pins that, so shrinking
+    /// the sample constant cannot quietly turn this case into a duplicate of the
+    /// head-of-file ones above.
+    #[test]
+    fn non_monotonic_row_beyond_the_sample_window_is_refused() {
+        let bad_row = CSV_DELTA_SAMPLE_ROWS + 20;
+        assert!(
+            bad_row > CSV_DELTA_SAMPLE_ROWS,
+            "the defect must sit outside the sampled window for this to test anything"
+        );
+
+        let tmp = csv_with_bad_row(bad_row + 30, bad_row, 1_700_000_000.0);
+        let path = tmp.path().to_string_lossy().into_owned();
+
+        // The sampled derivation is blind to it — that is the defect.
+        compute_csv_delta_seconds(&path, 0)
+            .expect("the sampled head is clean, so rate derivation still succeeds");
+
+        let err = validate_csv_timestamps_monotonic(&path, 0)
+            .expect_err("a defect past the sample window must still be refused");
+        assert!(
+            err.to_string().contains(&format!("data row {bad_row}")),
+            "must name the row, got: {err}"
+        );
+    }
+
+    #[test]
+    fn importer_output_passes_the_monotonicity_check() {
+        // The emitter writes a uniform grid; its own output must load.
+        let tmp = write_temp_timing_csv("Time,cpu,mem,disk,net", 200);
+        validate_csv_timestamps_monotonic(&tmp.path().to_string_lossy(), 0)
+            .expect("importer-emitted CSV must pass");
     }
 }


### PR DESCRIPTION
#535 O1 residual. Two parts: one exact check, and the column's contract written down.

## The check

`median_delta_seconds` already refused a non-monotonic pair and named the row — but it only ever saw what `compute_csv_delta_seconds` read, which is the first `CSV_DELTA_SAMPLE_ROWS` (100) rows. A repeated or out-of-order stamp past that window was invisible, and replaying it silently reorders the capture.

`validate_csv_timestamps_monotonic` now streams **every** row ahead of both expansion paths (`expand_scenario`, `expand_log_scenario`):

```
error: csv_replay: file "capture.csv" has non-monotonic timestamps at data row 120:
1700000000 is not greater than the previous row's 1700001190

  hint: the timestamp column must strictly increase; sonda replays rows in file order
  and derives the rate from it
```

It streams rather than collecting — a capture is not bounded in length. The sampling stays as it is for rate derivation: widening it would change derived rates and break the emitter/engine agreement `median_delta_seconds` exists to hold.

Strict monotonicity is the whole rule. No spacing-regularity heuristic, no threshold anyone can tune — a stamp that does not increase is wrong data, not a pacing choice.

The blank/comment skip rule is now one function both readers call. They walk the same file and must agree on which lines are rows, or the row number in the error would not point at the row the reader has to fix.

## The contract: document, don't drive

Per the replay-only ruling, the column's two jobs are now stated where it is described:

1. **Rate derivation** — median Δt across the sampled rows, scaled by `timescale`.
2. **Row alignment** — which row a `gap_windows:` entry covers.

It does **not** set a per-event emission time. Replay runs on a uniform grid; each event is stamped from the scenario clock anchored by `start_time:`, not from its row's cell. Irregular spacing in a hand-written file is honored in rate only — sonda takes the median and replays every row at that one interval.

Written as a stated limitation rather than fixed. Driving per-event instants from the column would create a second source of truth for emission times that can disagree with the grid the scheduler and the `gap_windows:` cross-check both rely on. Irregular pacing is a scheduling mode, and the capture pipeline does not have one — `gap_windows:` already expresses absence explicitly, and the importer emits it.

## Verification

Red-verified with the mutation confirmed present in the file: disabling the comparison fails all three new rejection tests, while the two pre-existing head-of-file tests (`non_monotonic_timestamps_return_clear_error`, `expand_log_scenario_rejects_non_monotonic_timestamps`) stay green — the two checks cover different rows, which is the point.

The first attempt at that sabotage was a no-op — `if false { } else if ts <= previous` still evaluates the `else if`. It surfaced as every test staying green and was redone. Worth stating, since a sabotage that fails to apply looks exactly like a passing gate.

`non_monotonic_row_beyond_the_sample_window_is_refused` is the case that covers the actual gap. It asserts its defect sits outside `CSV_DELTA_SAMPLE_ROWS`, and that `compute_csv_delta_seconds` still *succeeds* on that same file — so shrinking the constant cannot quietly turn it into a duplicate of the head-of-file cases.

The importer's own 200-row output passes (`importer_output_passes_the_monotonicity_check`).

## Gates

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0
- `cargo test --workspace --all-features --no-fail-fast` — 51 result lines, 5 failed: the five that reproduce on `main` in this container (`sink::file::tests::write_to_readonly_dir_returns_sink_error_with_path_in_message` and `tests::sink_file_error_produces_sink_variant`, both needing a non-root uid; `global_inflight_limit_gates_across_routes`, `health_remains_responsive_when_control_plane_is_saturated`, `request_timeout_returns_408_with_structured_error` in sonda-server)

## Release note

A capture with a repeated or out-of-order timestamp past row 100 previously loaded and replayed reordered; it now fails at load naming the row.
